### PR TITLE
Add PropTypes to all of our React components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ node_js:
 script:
     - |
         cat <<EOF > src/secrets.js
-        export const client_id = "placeholder";
-        export const client_secret = "placeholder";
+        export const clientId = 'placeholder';
+        export const clientSecret = 'placeholder';
         EOF
     - npm test
     - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script:
         EOF
     - npm test
     - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls
+    - npm run lint

--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 export default function Dropdown(props) {
   const { elements } = props;
@@ -27,3 +27,10 @@ export default function Dropdown(props) {
     </span>
   );
 }
+
+Dropdown.propTypes = {
+  elements: PropTypes.arrayOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    action: PropTypes.func,
+  })).isRequired,
+};

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import Navigation from './Navigation';
 
 export default function Header(props) {
@@ -11,3 +11,8 @@ export default function Header(props) {
     </div>
   );
 }
+
+Header.propTypes = {
+  username: PropTypes.string,
+  style: PropTypes.object,
+};

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 import logo from 'file!../../assets/linode-logo.svg';
 
@@ -49,3 +49,5 @@ export default function Navigation(props) {
     </nav>
   );
 }
+
+Navigation.propTypes = { username: PropTypes.string };

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
@@ -17,6 +17,11 @@ function Layout(props) {
     </div>
   );
 }
+
+Layout.propTypes = {
+  username: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
 
 function select(state) {
   return { username: state.authentication.username };

--- a/src/layouts/OAuth.js
+++ b/src/layouts/OAuth.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { setToken } from '../actions/authentication';
 import { clientId, clientSecret } from '../secrets';
@@ -31,4 +31,9 @@ class OAuthCallbackPage extends Component {
   }
 }
 
-export default connect(() => ({}))(OAuthCallbackPage);
+OAuthCallbackPage.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+  location: PropTypes.string.isRequired,
+};
+
+export default connect()(OAuthCallbackPage);

--- a/src/linodes/components/DatacenterSelection.js
+++ b/src/linodes/components/DatacenterSelection.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { flags } from '~/assets';
 
 // TODO: This is lame, we should extend the API to include country code
@@ -86,3 +86,11 @@ export default class DatacenterSelection extends Component {
     );
   }
 }
+
+DatacenterSelection.propTypes = {
+  datacenters: PropTypes.object.isRequired,
+  selected: PropTypes.string,
+  ui: PropTypes.object.isRequired,
+  onBack: PropTypes.func,
+  onSelection: PropTypes.func,
+};

--- a/src/linodes/components/DistroSelection.js
+++ b/src/linodes/components/DistroSelection.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { distros as distroAssets } from '~/assets';
 import _ from 'underscore';
 
@@ -48,3 +48,9 @@ export default class DistroSelection extends Component {
     );
   }
 }
+
+DistroSelection.propTypes = {
+  distros: PropTypes.object.isRequired,
+  selected: PropTypes.string,
+  onSelection: PropTypes.func,
+};

--- a/src/linodes/components/Linode.js
+++ b/src/linodes/components/Linode.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 import { LinodeStatesReadable } from '~/constants';
 
@@ -16,6 +16,12 @@ function renderPowerButton(props) {
   return powerIcon === '' ? <span /> :
     <span className={`linode-power fa ${powerIcon} pull-right`} onClick={powerActionF} />;
 }
+
+renderPowerButton.propTypes = {
+  linode: PropTypes.object.isRequired,
+  powerOn: PropTypes.func,
+  reboot: PropTypes.func,
+};
 
 function renderCard(props) {
   const { linode, onSelect, isSelected } = props;
@@ -64,6 +70,12 @@ function renderCard(props) {
   );
 }
 
+renderCard.propTypes = {
+  linode: PropTypes.object.isRequired,
+  onSelect: PropTypes.func,
+  isSelected: PropTypes.bool.isRequired,
+};
+
 function renderRow(props) {
   const { linode, onSelect, isSelected } = props;
   const select = () => onSelect(linode);
@@ -105,7 +117,22 @@ function renderRow(props) {
   );
 }
 
+renderRow.propTypes = {
+  linode: PropTypes.object.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  onSelect: PropTypes.func,
+};
+
 export function Linode(props) {
   const { isCard } = props;
   return isCard ? renderCard(props) : renderRow(props);
 }
+
+Linode.propTypes = {
+  isCard: PropTypes.bool,
+  ...renderPowerButton.propTypes,
+  ...renderCard.propTypes,
+  ...renderRow.propTypes,
+};
+
+Linode.defaultProps = { isCard: true };

--- a/src/linodes/components/LinodePower.js
+++ b/src/linodes/components/LinodePower.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 export function LinodePower({
   linode,
@@ -45,3 +45,12 @@ export function LinodePower({
         </div>);
   }
 }
+
+LinodePower.propTypes = {
+  linode: PropTypes.object.isRequired,
+  pending: PropTypes.bool.isRequired,
+  cols: PropTypes.number.isRequired,
+  onPowerOn: PropTypes.func,
+  onPowerOff: PropTypes.func,
+  onReboot: PropTypes.func,
+};

--- a/src/linodes/components/OrderSummary.js
+++ b/src/linodes/components/OrderSummary.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
 import { distros as distroAssets, flags } from '~/assets';
 import Service from './Service';
@@ -144,3 +144,14 @@ export default class Summary extends Component {
     </div>);
   }
 }
+
+Summary.propTypes = {
+  ui: PropTypes.object.isRequired,
+  services: PropTypes.array.isRequired,
+  distros: PropTypes.object.isRequired,
+  datacenters: PropTypes.object.isRequired,
+  onBack: PropTypes.func,
+  onLabelChange: PropTypes.func,
+  onShowRootPassword: PropTypes.func,
+  onCreate: PropTypes.func,
+};

--- a/src/linodes/components/Service.js
+++ b/src/linodes/components/Service.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 
 export default class Service extends Component {
   constructor() {
@@ -39,3 +39,8 @@ export default class Service extends Component {
     );
   }
 }
+
+Service.propTypes = {
+  service: PropTypes.object.isRequired,
+  onSelection: PropTypes.func,
+};

--- a/src/linodes/components/ServiceSelection.js
+++ b/src/linodes/components/ServiceSelection.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { toggleAllPlans } from '../actions/create';
 import Service from './Service';
 
@@ -175,3 +175,11 @@ export default class ServiceSelection extends Component {
     );
   }
 }
+
+ServiceSelection.propTypes = {
+  onBack: PropTypes.func,
+  onSelection: PropTypes.func,
+  ui: PropTypes.object.isRequired,
+  services: PropTypes.array.isRequired,
+  dispatch: PropTypes.func.isRequired,
+};

--- a/src/linodes/components/SourceSelection.js
+++ b/src/linodes/components/SourceSelection.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import DistroSelection from './DistroSelection';
 import { changeSourceTab, selectSource } from '../actions/create';
@@ -75,3 +75,8 @@ export default class SourceSelection extends Component {
     );
   }
 }
+
+SourceSelection.propTypes = {
+  ui: PropTypes.object.isRequired,
+  distros: PropTypes.object.isRequired,
+};

--- a/src/linodes/layouts/CreateLinodePage.js
+++ b/src/linodes/layouts/CreateLinodePage.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import SourceSelection from '../components/SourceSelection';
 import ServiceSelection from '../components/ServiceSelection';
@@ -73,6 +73,14 @@ class CreateLinodePage extends Component {
     );
   }
 }
+
+CreateLinodePage.propTypes = {
+  dispatch: PropTypes.func.isRequired,
+  ui: PropTypes.object.isRequired,
+  distros: PropTypes.object.isRequired,
+  datacenters: PropTypes.object.isRequired,
+  services: PropTypes.array.isRequired,
+};
 
 function select(state) {
   return {

--- a/src/linodes/layouts/IndexPage.js
+++ b/src/linodes/layouts/IndexPage.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { Linode } from '../components/Linode';
@@ -174,8 +174,8 @@ class IndexPage extends Component {
     };
 
     const selectAllCheckbox = allSelected ?
-      <input type="checkbox" onClick={selectAll} checked="checked" /> :
-      <input type="checkbox" onClick={selectAll} />;
+      <input type="checkbox" onChange={selectAll} checked="checked" /> :
+      <input type="checkbox" onChange={selectAll} />;
 
     const { view } = this.props;
     const gridListToggle = (
@@ -221,6 +221,13 @@ class IndexPage extends Component {
     );
   }
 }
+
+IndexPage.propTypes = {
+  dispatch: PropTypes.func,
+  linodes: PropTypes.object,
+  view: PropTypes.oneOf(['list', 'grid']),
+  selected: PropTypes.object,
+};
 
 function select(state) {
   return {

--- a/src/linodes/layouts/LinodeDetailPage.js
+++ b/src/linodes/layouts/LinodeDetailPage.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import {
@@ -140,6 +140,14 @@ class LinodeDetailPage extends Component {
     );
   }
 }
+
+LinodeDetailPage.propTypes = {
+  dispatch: PropTypes.func,
+  linodes: PropTypes.object,
+  params: PropTypes.shape({
+    linodeId: PropTypes.string,
+  }),
+};
 
 function select(state) {
   return { linodes: state.api.linodes };


### PR DESCRIPTION
This brings our linter errors down to zero - so this PR also turns on linting during the Travis build and will fail builds for introducing linter errors.