### PR TITLE
Implement routing for Linode detail page

### DIFF
--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -24,6 +24,11 @@
                 background: white;
                 border-bottom: 0;
             }
+
+            a {
+                color: inherit;
+                text-decoration: inherit;
+            }
         }
 
         [role=tabpanel] {

--- a/src/linodes/actions/detail.js
+++ b/src/linodes/actions/detail.js
@@ -1,15 +1,10 @@
 import { fetch } from '~/fetch';
 import { UPDATE_LINODE } from '~/actions/api/linodes';
 
-export const CHANGE_DETAIL_TAB = '@@linodes@@detail/CHANGE_DETAIL_TAB';
 export const TOGGLE_EDIT_MODE = '@@linodes@@detail/TOGGLE_EDIT_MODE';
 export const SET_LINODE_LABEL = '@@linodes@@detail/SET_LINODE_LABEL';
 export const SET_LINODE_GROUP = '@@linodes@@detail/SET_LINODE_GROUP';
 export const TOGGLE_LOADING = '@@linodes@@detail/TOGGLE_LOADING';
-
-export function changeDetailTab(index) {
-  return { type: CHANGE_DETAIL_TAB, index };
-}
 
 export function toggleEditMode() {
   return { type: TOGGLE_EDIT_MODE };

--- a/src/linodes/index.js
+++ b/src/linodes/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Route, IndexRoute } from 'react-router';
 
 import IndexPage from './layouts/IndexPage';
@@ -6,16 +6,9 @@ import LinodeDetailPage from './layouts/LinodeDetailPage';
 import CreateLinodePage from './layouts/CreateLinodePage';
 
 /* eslint-disable react/prop-types */
-class Placeholder extends Component {
-  constructor() {
-    super();
-    this.render = this.render.bind(this);
-  }
-
-  render() {
-    const { pathname } = this.props.location;
-    return <div>{pathname} placeholder</div>;
-  }
+function Placeholder(props) {
+  const { pathname } = props.location;
+  return <div>{pathname} placeholder</div>;
 }
 
 export default (

--- a/src/linodes/index.js
+++ b/src/linodes/index.js
@@ -1,14 +1,34 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Route, IndexRoute } from 'react-router';
 
 import IndexPage from './layouts/IndexPage';
 import LinodeDetailPage from './layouts/LinodeDetailPage';
 import CreateLinodePage from './layouts/CreateLinodePage';
 
+/* eslint-disable react/prop-types */
+class Placeholder extends Component {
+  constructor() {
+    super();
+    this.render = this.render.bind(this);
+  }
+
+  render() {
+    const { pathname } = this.props.location;
+    return <div>{pathname} placeholder</div>;
+  }
+}
+
 export default (
   <Route path="/linodes">
     <IndexRoute component={IndexPage} />
     <Route path="create" component={CreateLinodePage} />
-    <Route path=":linodeId" component={LinodeDetailPage} />
+    <Route path=":linodeId" component={LinodeDetailPage}>
+      <IndexRoute component={Placeholder} />
+      <Route path="networking" component={Placeholder} />
+      <Route path="resize" component={Placeholder} />
+      <Route path="repair" component={Placeholder} />
+      <Route path="backups" component={Placeholder} />
+      <Route path="settings" component={Placeholder} />
+    </Route>
   </Route>
 );

--- a/src/linodes/layouts/LinodeDetailPage.js
+++ b/src/linodes/layouts/LinodeDetailPage.js
@@ -203,7 +203,7 @@ LinodeDetailPage.propTypes = {
   }),
   detail: PropTypes.object,
   children: PropTypes.node,
-  location: PropTypes.object.optional,
+  location: PropTypes.object,
 };
 
 function select(state) {

--- a/src/linodes/layouts/LinodeDetailPage.js
+++ b/src/linodes/layouts/LinodeDetailPage.js
@@ -1,10 +1,11 @@
 import React, { Component, PropTypes } from 'react';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import { connect } from 'react-redux';
+import { Link } from 'react-router';
+import { pushPath } from 'redux-simple-router';
 import Dropdown from '~/components/Dropdown';
 import { LinodeStates, LinodeStatesReadable } from '~/constants';
 import {
-  changeDetailTab,
   toggleEditMode,
   setLinodeLabel,
   setLinodeGroup,
@@ -147,42 +148,46 @@ export class LinodeDetailPage extends Component {
   render() {
     const linode = this.getLinode();
     if (!linode) return <span></span>;
-    const { dispatch, detail } = this.props;
+    const { dispatch, location } = this.props;
+    const tabList = [
+      { name: 'General', link: '' },
+      { name: 'Networking', link: '/networking' },
+      { name: 'Resize', link: '/resize' },
+      { name: 'Repair', link: '/repair' },
+      { name: 'Backups', link: '/backups' },
+      { name: 'Settings', link: '/settings' },
+    ].map(t => ({ ...t, link: `/linodes/${linode.id}${t.link}` }));
+
+    const pathname = location ? location.pathname : tabList[0].link;
+
+    let selected = tabList[0];
+    for (let i = 1; i < tabList.length; ++i) {
+      if (pathname === tabList[i].link) {
+        selected = tabList[i];
+        break;
+      }
+    }
 
     return (
       <div className="details-page">
         <div className="card">
           {this.renderHeader(linode)}
           <Tabs
-            onSelect={ix => dispatch(changeDetailTab(ix))}
-            selectedIndex={detail.tab}
+            onSelect={ix => dispatch(pushPath(tabList[ix].link))}
+            selectedIndex={tabList.indexOf(selected)}
           >
             <TabList>
-              <Tab>General</Tab>
-              <Tab>Networking</Tab>
-              <Tab>Resize</Tab>
-              <Tab>Repair</Tab>
-              <Tab>Backups</Tab>
-              <Tab>Settings</Tab>
+              {tabList.map(t => (
+                <Tab key={t.name}>
+                  <Link to={t.link} onClick={e => e.preventDefault()}>{t.name}</Link>
+                </Tab>
+              ))}
             </TabList>
-            <TabPanel>
-              <h2>Summary</h2>
-            </TabPanel>
-            <TabPanel>
-              Networking Tab
-            </TabPanel>
-            <TabPanel>
-              Resize Tab
-            </TabPanel>
-            <TabPanel>
-              Repair Tab
-            </TabPanel>
-            <TabPanel>
-              Backups Tab
-            </TabPanel>
-            <TabPanel>
-              Settings Tab
-            </TabPanel>
+            {tabList.map(t => (
+              <TabPanel key={t.name}>
+                {t === selected ? this.props.children : null}
+              </TabPanel>
+            ))}
           </Tabs>
         </div>
       </div>
@@ -197,6 +202,8 @@ LinodeDetailPage.propTypes = {
     linodeId: PropTypes.string,
   }),
   detail: PropTypes.object,
+  children: PropTypes.node,
+  location: PropTypes.object.optional,
 };
 
 function select(state) {

--- a/src/linodes/layouts/LinodeDetailPage.js
+++ b/src/linodes/layouts/LinodeDetailPage.js
@@ -159,14 +159,8 @@ export class LinodeDetailPage extends Component {
     ].map(t => ({ ...t, link: `/linodes/${linode.id}${t.link}` }));
 
     const pathname = location ? location.pathname : tabList[0].link;
-
-    let selected = tabList[0];
-    for (let i = 1; i < tabList.length; ++i) {
-      if (pathname === tabList[i].link) {
-        selected = tabList[i];
-        break;
-      }
-    }
+    const selected = tabList.reduce((last, current) =>
+      (pathname === current.link ? current : last));
 
     return (
       <div className="details-page">

--- a/src/linodes/reducers/detail.js
+++ b/src/linodes/reducers/detail.js
@@ -1,5 +1,4 @@
 import {
-  CHANGE_DETAIL_TAB,
   TOGGLE_EDIT_MODE,
   SET_LINODE_LABEL,
   SET_LINODE_GROUP,
@@ -7,7 +6,6 @@ import {
 } from '../actions/detail';
 
 const defaultState = {
-  tab: 0,
   editing: false,
   label: '',
   group: '',
@@ -16,8 +14,6 @@ const defaultState = {
 
 export default function detail(state = defaultState, action) {
   switch (action.type) {
-    case CHANGE_DETAIL_TAB:
-      return { ...state, tab: action.index };
     case TOGGLE_EDIT_MODE:
       return { ...state, editing: !state.editing };
     case SET_LINODE_LABEL:

--- a/test/linodes/actions/detail.spec.js
+++ b/test/linodes/actions/detail.spec.js
@@ -5,16 +5,6 @@ import { UPDATE_LINODE } from '~/actions/api/linodes';
 import * as fetch from '~/fetch';
 
 describe('linodes/actions/detail', () => {
-  describe('changeDetailTab', () => {
-    it('should return a CHANGE_DETAIL_TAB action', () => {
-      expect(actions.changeDetailTab(1))
-        .to.deep.equal({
-          type: actions.CHANGE_DETAIL_TAB,
-          index: 1,
-        });
-    });
-  });
-
   describe('toggleEditMode', () => {
     it('should return a TOGGLE_EDIT_MODE action', () => {
       expect(actions.toggleEditMode())

--- a/test/linodes/layouts/LinodeDetailPage.spec.js
+++ b/test/linodes/layouts/LinodeDetailPage.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
+import { pushPath } from 'redux-simple-router';
 import { mount, shallow } from 'enzyme';
 import { expect } from 'chai';
 import * as fetch from '~/fetch';
@@ -34,7 +35,6 @@ describe('linodes/layouts/LinodeDetailPage', () => {
   };
 
   const detail = {
-    tab: 0,
     editing: false,
     label: '',
     group: '',
@@ -113,10 +113,11 @@ describe('linodes/layouts/LinodeDetailPage', () => {
     const expectedTabs = [
       'General', 'Networking', 'Resize', 'Repair', 'Backups', 'Settings',
     ];
-    expectedTabs.map(t => expect(tabs.contains(<Tab>{t}</Tab>)).to.equal(true));
+    expect(tabs.find(Tab).length).to.equal(expectedTabs.length);
+    expect(tabs.find(Tab).filter(t => t.text() === t)).to.exist;
   });
 
-  it('dispatches a tab change action when tabs are clicked', () => {
+  it('dispatches a pushPath action when tabs are clicked', () => {
     const page = shallow(
       <LinodeDetailPage
         dispatch={dispatch}
@@ -126,7 +127,7 @@ describe('linodes/layouts/LinodeDetailPage', () => {
       />);
     const tabs = page.find(Tabs);
     tabs.props().onSelect(2);
-    expect(dispatch.calledWith(actions.changeDetailTab(2))).to.equal(true);
+    expect(dispatch.calledWith(pushPath('/linodes/linode_1234/resize'))).to.equal(true);
   });
 
   it('renders a power management dropdown', () => {

--- a/test/linodes/reducers/detail.spec.js
+++ b/test/linodes/reducers/detail.spec.js
@@ -8,7 +8,6 @@ describe('linodes/detail reducer', () => {
     expect(
       detail(undefined, {})
     ).to.be.eql({
-      tab: 0,
       editing: false,
       label: '',
       group: '',
@@ -17,19 +16,11 @@ describe('linodes/detail reducer', () => {
   });
 
   it('should no-op on arbitrary actions', () => {
-    const state = { tab: 0 };
+    const state = { };
     deepFreeze(state);
 
     expect(detail(state, { type: 'foobar' }))
       .to.deep.equal(state);
-  });
-
-  it('should handle CHANGE_DETAIL_TAB', () => {
-    const state = { tab: 0 };
-    deepFreeze(state);
-
-    expect(detail(state, actions.changeDetailTab(3)))
-      .to.have.property('tab').that.equals(3);
   });
 
   it('should handle TOGGLE_EDIT_MODE', () => {


### PR DESCRIPTION
Note that the components for each tab need to be added in
src/linodes/index.js now instead of directly in the detail page.

Closes #86.