### PR TITLE
Implement X-CORS-Status

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -22,8 +22,22 @@ export function fetch(token, _path, _options) {
       Accept: 'application/json',
       Authorization: `token ${token}`,
       'Content-Type': 'application/json',
+      'X-CORS-Status': 'true',
     },
   };
   const path = API_ROOT + _path;
-  return fetchRef(path, options);
+  const promise = fetchRef(path, options);
+  return new Promise((accept, reject) => {
+    promise.then(response => {
+      const _status = response.headers.get('X-Status');
+      const status = _status ? parseInt(_status, 10) : response.status;
+      // eslint-disable-next-line no-param-reassign
+      response.statusCode = status;
+      if (status >= 400) {
+        reject(response);
+      } else {
+        accept(response);
+      }
+    }, reject);
+  });
 }

--- a/test/fetch.spec.js
+++ b/test/fetch.spec.js
@@ -21,13 +21,14 @@ describe('fetch', () => {
     },
   };
 
-  const getFetchStub = () => sandbox.stub(fetch, 'rawFetch')
+  const getFetchStub = (status = 200) => sandbox.stub(fetch, 'rawFetch')
     .returns(new Promise((accept) => accept({
       headers: {
         get() {
-          return 200;
+          return status;
         },
       },
+      status: 200,
     })));
 
   it('should default to cors mode and headers for token', async () => {
@@ -62,5 +63,21 @@ describe('fetch', () => {
         ...data,
       }
     ));
+  });
+
+  it('should handle X-Status', async () => {
+    getFetchStub(201);
+    const resp = await fetch.fetch(token, 'path');
+    expect(resp.statusCode).to.equal(201);
+  });
+
+  it('should handle X-Status errors', async () => {
+    getFetchStub(400);
+    try {
+      await fetch.fetch(token, 'path');
+      expect(true).to.equal(false);
+    } catch (resp) {
+      expect(resp.statusCode).to.equal(400);
+    }
   });
 });

--- a/test/fetch.spec.js
+++ b/test/fetch.spec.js
@@ -17,10 +17,18 @@ describe('fetch', () => {
       Accept: 'application/json',
       Authorization: `token ${token}`,
       'Content-Type': 'application/json',
+      'X-CORS-Status': 'true',
     },
   };
 
-  const getFetchStub = (rsp) => sandbox.stub(fetch, 'rawFetch').returns(rsp);
+  const getFetchStub = () => sandbox.stub(fetch, 'rawFetch')
+    .returns(new Promise((accept) => accept({
+      headers: {
+        get() {
+          return 200;
+        },
+      },
+    })));
 
   it('should default to cors mode and headers for token', async () => {
     const fetchStub = getFetchStub();


### PR DESCRIPTION
The API allows us to specify the X-CORS-Status header, which will
instruct it to return all responses with the 200 status code and place
the real status code in X-Status.