### PR TITLE
Set min Node version to 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "5"
+    - "6"
 script:
     - |
         cat <<EOF > src/secrets.js

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following buzzwords are involved in this project:
 
     git clone https://github.com/Linode/manager.git
     cd manager
-    node --version # should be 5.x or better
+    node --version # should be 6.x or better
     npm install
 
 Currently the codebase is hardcoded to point to our [alpha


### PR DESCRIPTION
Considering the [LTS](https://github.com/nodejs/LTS#lts_schedule) schedule - and if we aren't set on using stable already - is there any reason not to track v6 if not latest for development?