### PR TITLE
Add error handling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
     "import/no-unresolved": 0,
     "no-underscore-dangle": 0,
     "no-unused-expressions": 0,
+    "no-confusing-arrow": 0,
     "react/no-multi-comp": 0,
     "dot-notation": [
       "error", {

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,9 @@
     "no-unused-expressions": 0,
     "react/no-multi-comp": 0,
     "dot-notation": [
-      "error", { "allowKeywords": false }
+      "error", {
+        "allowPattern": "^(default|public|private|return)$"
+      }
     ]
   }
 }

--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -51,19 +51,45 @@
         .edit-details {
             font-size: 2.2rem;
             display: inline-block;
+            width: 70%;
+            position: relative;
+
+            button {
+                margin: 0 0.5rem;
+            }
 
             input {
                 background: transparent;
-                margin: 0 0.5rem;
                 padding: 0;
-                width: 12rem;
                 border: none;
                 border-bottom: $linode-border;
+                display: block;
+                width: 100%;
 
                 &:focus {
                     outline: none;
                     border-bottom-color: $linode-dark-gray;
                 }
+
+                &.has-error {
+                    border-bottom-color: $linode-red;
+                }
+            }
+
+            .alert {
+                font-size: $font-size;
+                line-height: $font-size * 1.5;
+
+                ul {
+                    @extend .list-unstyled;
+                }
+            }
+
+            .errors {
+                position: absolute;
+                z-index: 99999;
+                // Constant from bootstrap
+                width: calc(100% + 1.875rem);
             }
         }
     }

--- a/scss/manager.scss
+++ b/scss/manager.scss
@@ -327,6 +327,10 @@ hr {
     border: $linode-border;
     background: $linode-light-gray;
 
+    &.btn-default {
+        color: $linode-black;
+    }
+
     .fa {
         line-height: $input-height;
     }
@@ -473,6 +477,10 @@ input[type=checkbox] {
 
 .text-danger {
     color: $linode-red;
+}
+
+.centered {
+    text-align: center;
 }
 
 @-moz-keyframes pulse {

--- a/src/actions/errors.js
+++ b/src/actions/errors.js
@@ -1,0 +1,22 @@
+export const SET_ERROR = '@@errors/SET_ERROR';
+export const TOGGLE_DETAILS = '@@errors/TOGGLE_DETAILS';
+
+export function setError(response) {
+  return async (dispatch) => {
+    const type = response.headers.get('Content-Type');
+    let json = 'fubar';
+    if (type === 'application/json') {
+      json = await response.json();
+    }
+    dispatch({
+      type: SET_ERROR,
+      status: response.statusCode,
+      statusText: response.statusText,
+      json,
+    });
+  };
+}
+
+export function toggleDetails() {
+  return { type: TOGGLE_DETAILS };
+}

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,5 +1,8 @@
 import { API_ROOT } from './constants';
 import * as isomorphicFetch from 'isomorphic-fetch';
+import store from '~/store';
+import checkLogin from '~/session';
+import { setToken } from '~/actions/authentication';
 
 /*
  * Sinon cannot stub out a function in a function-only module.
@@ -7,6 +10,12 @@ import * as isomorphicFetch from 'isomorphic-fetch';
  */
 export function rawFetch(...args) {
   return isomorphicFetch['default'](...args);
+}
+
+function expireSession() {
+  const next = { location: window.location };
+  store.dispatch(setToken(null, null, null, null));
+  checkLogin(next);
 }
 
 export function fetch(token, _path, _options) {
@@ -34,6 +43,9 @@ export function fetch(token, _path, _options) {
       // eslint-disable-next-line no-param-reassign
       response.statusCode = status;
       if (status >= 400) {
+        if (status === 401) {
+          expireSession();
+        }
         reject(response);
       } else {
         accept(response);

--- a/src/index.js
+++ b/src/index.js
@@ -7,12 +7,10 @@ import { Router, Route, IndexRedirect, browserHistory } from 'react-router';
 import DevTools from './components/DevTools';
 import { syncHistoryWithStore } from 'react-router-redux';
 
+import checkLogin from './session';
+
 // eslint-disable-next-line no-unused-vars
 import styles from '../scss/manager.scss';
-
-import { clientId } from './secrets';
-import { APP_ROOT, LOGIN_ROOT } from './constants';
-import checkLogin from './session';
 
 const history = syncHistoryWithStore(browserHistory, store);
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
-import configureStore from './store/configureStore';
+import store from './store';
 import { Router, Route, IndexRedirect, browserHistory } from 'react-router';
 import DevTools from './components/DevTools';
 import { syncHistoryWithStore } from 'react-router-redux';
@@ -12,8 +12,8 @@ import styles from '../scss/manager.scss';
 
 import { clientId } from './secrets';
 import { APP_ROOT, LOGIN_ROOT } from './constants';
+import checkLogin from './session';
 
-const store = configureStore();
 const history = syncHistoryWithStore(browserHistory, store);
 
 import Layout from './layouts/Layout';
@@ -22,25 +22,6 @@ import NotFound from './layouts/NotFound';
 import Linodes from './linodes';
 
 const init = () => {
-  const state = store.getState();
-  function checkLogin(next) {
-    if (next.location.pathname !== '/oauth/callback' && state.authentication.token === null) {
-      const query = Object.keys(next.location.query)
-              .reduce((a, k) => [
-                ...a,
-                `${k}=${encodeURIComponent(next.location.query[k])}`,
-              ], []).join('%26');
-      /* eslint-disable prefer-template */
-      window.location = `${LOGIN_ROOT}/oauth/authorize?` +
-        `client_id=${clientId}` +
-        '&scopes=*' +
-        `&redirect_uri=${encodeURIComponent(APP_ROOT)}/oauth/callback?return=` +
-              encodeURIComponent(next.location.pathname + (query ? '%3F' + query : ''));
-      /* eslint-enable prefer-template */
-      return;
-    }
-  }
-
   render(
     <Provider store={store}>
       <div>

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -31,7 +31,7 @@ export class Layout extends Component {
             style={{ margin: '0 0.51rem' }}
             className="btn btn-default"
             onClick={() => window.location.reload(true)}
-          >Refresh</button>
+          >Reload</button>
           <a
             style={{ margin: '0 0.5rem' }}
             href={`mailto:support@linode.com?subject=${
@@ -50,6 +50,7 @@ export class Layout extends Component {
         </div>
         <div style={{ marginTop: '1rem' }}>
           <a
+            className="toggle-error-response"
             href="#"
             onClick={e => {
               e.preventDefault();

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -3,18 +3,71 @@ import { connect } from 'react-redux';
 import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
 import Modal from '../components/Modal';
+import { toggleDetails } from '~/actions/errors';
 
 function Layout(props) {
-  const { username } = props;
+  const { dispatch, username, errors } = props;
   return (
     <div className="layout">
       <Header username={username} />
       <Sidebar />
       <div className="main">
-        <div className="container">
-          <Modal />
-          {props.children}
-        </div>
+        {errors.status === null ?
+          <div className="container">
+            <Modal />
+            {props.children}
+          </div>
+          :
+          <div
+            className="container centered"
+            style={{ marginTop: '5rem' }}
+          >
+            <h1>{errors.status} {errors.statusText}</h1>
+            <p>
+              Something broke. Sorry about that.
+            </p>
+            <div>
+              <button
+                style={{ margin: '0 0.51rem' }}
+                className="btn btn-default"
+                onClick={() => window.location.reload(true)}
+              >Refresh</button>
+              <a
+                style={{ margin: '0 0.5rem' }}
+                href={`mailto:support@linode.com?subject=${
+                  encodeURIComponent(`${errors.status} ${errors.statusText}`)
+                }&body=${
+                  encodeURIComponent(
+                    `I'm getting the following error on ${
+                      window.location.href
+                    }:\n\n${
+                      JSON.stringify(errors.json, null, 4)
+                    }`
+                  )
+                }`}
+                className="btn btn-default"
+              >Contact Support</a>
+            </div>
+            <div style={{ marginTop: '1rem' }}>
+              <a
+                href="#"
+                onClick={e => {
+                  e.preventDefault();
+                  dispatch(toggleDetails());
+                }}
+              >{errors.details ? 'Hide' : 'Show'} Response JSON</a>
+              {errors.details ?
+                <pre
+                  style={{
+                    textAlign: 'left',
+                    maxHeight: '20rem',
+                    width: '40rem',
+                    margin: '0 auto',
+                  }}
+                >{JSON.stringify(errors.json, null, 4)}</pre>
+              : null}
+            </div>
+          </div>}
       </div>
     </div>
   );
@@ -23,10 +76,15 @@ function Layout(props) {
 Layout.propTypes = {
   username: PropTypes.string,
   children: PropTypes.node.isRequired,
+  errors: PropTypes.object.isRequired,
+  dispatch: PropTypes.func.isRequired,
 };
 
 function select(state) {
-  return { username: state.authentication.username };
+  return {
+    username: state.authentication.username,
+    errors: state.errors,
+  };
 }
 
 export default connect(select)(Layout);

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -1,76 +1,91 @@
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Component } from 'react';
 import { connect } from 'react-redux';
 import Header from '../components/Header';
 import Sidebar from '../components/Sidebar';
 import Modal from '../components/Modal';
 import { toggleDetails } from '~/actions/errors';
+import NotFound from './NotFound';
 
-function Layout(props) {
-  const { dispatch, username, errors } = props;
-  return (
-    <div className="layout">
-      <Header username={username} />
-      <Sidebar />
-      <div className="main">
-        {errors.status === null ?
-          <div className="container">
-            <Modal />
-            {props.children}
-          </div>
-          :
-          <div
-            className="container centered"
-            style={{ marginTop: '5rem' }}
-          >
-            <h1>{errors.status} {errors.statusText}</h1>
-            <p>
-              Something broke. Sorry about that.
-            </p>
-            <div>
-              <button
-                style={{ margin: '0 0.51rem' }}
-                className="btn btn-default"
-                onClick={() => window.location.reload(true)}
-              >Refresh</button>
-              <a
-                style={{ margin: '0 0.5rem' }}
-                href={`mailto:support@linode.com?subject=${
-                  encodeURIComponent(`${errors.status} ${errors.statusText}`)
-                }&body=${
-                  encodeURIComponent(
-                    `I'm getting the following error on ${
-                      window.location.href
-                    }:\n\n${
-                      JSON.stringify(errors.json, null, 4)
-                    }`
-                  )
-                }`}
-                className="btn btn-default"
-              >Contact Support</a>
-            </div>
-            <div style={{ marginTop: '1rem' }}>
-              <a
-                href="#"
-                onClick={e => {
-                  e.preventDefault();
-                  dispatch(toggleDetails());
-                }}
-              >{errors.details ? 'Hide' : 'Show'} Response JSON</a>
-              {errors.details ?
-                <pre
-                  style={{
-                    textAlign: 'left',
-                    maxHeight: '20rem',
-                    width: '40rem',
-                    margin: '0 auto',
-                  }}
-                >{JSON.stringify(errors.json, null, 4)}</pre>
-              : null}
-            </div>
-          </div>}
+export class Layout extends Component {
+  constructor() {
+    super();
+    this.renderError = this.renderError.bind(this);
+  }
+
+  renderError() {
+    const { dispatch, errors } = this.props;
+    if (errors.status === 404) {
+      return <div className="container"><NotFound /></div>;
+    }
+    return (
+      <div
+        className="container centered"
+        style={{ marginTop: '5rem' }}
+      >
+        <h1>{errors.status} {errors.statusText}</h1>
+        <p>
+          Something broke. Sorry about that.
+        </p>
+        <div>
+          <button
+            style={{ margin: '0 0.51rem' }}
+            className="btn btn-default"
+            onClick={() => window.location.reload(true)}
+          >Refresh</button>
+          <a
+            style={{ margin: '0 0.5rem' }}
+            href={`mailto:support@linode.com?subject=${
+              encodeURIComponent(`${errors.status} ${errors.statusText}`)
+            }&body=${
+              encodeURIComponent(
+                `I'm getting the following error on ${
+                  window.location.href
+                }:\n\n${
+                  JSON.stringify(errors.json, null, 4)
+                }`
+              )
+            }`}
+            className="btn btn-default"
+          >Contact Support</a>
+        </div>
+        <div style={{ marginTop: '1rem' }}>
+          <a
+            href="#"
+            onClick={e => {
+              e.preventDefault();
+              dispatch(toggleDetails());
+            }}
+          >{errors.details ? 'Hide' : 'Show'} Response JSON</a>
+          {errors.details ?
+            <pre
+              style={{
+                textAlign: 'left',
+                maxHeight: '20rem',
+                width: '40rem',
+                margin: '0 auto',
+              }}
+            >{JSON.stringify(errors.json, null, 4)}</pre>
+          : null}
+        </div>
+      </div>);
+  }
+
+  render() {
+    const { username, errors } = this.props;
+    return (
+      <div className="layout">
+        <Header username={username} />
+        <Sidebar />
+        <div className="main">
+          {errors.status === null ?
+            <div className="container">
+              <Modal />
+              {this.props.children}
+            </div> : this.renderError()}
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
 }
 
 Layout.propTypes = {

--- a/src/linodes/actions/detail/index.js
+++ b/src/linodes/actions/detail/index.js
@@ -41,7 +41,10 @@ export function commitChanges(id) {
       dispatch(toggleEditMode());
     } catch (resp) {
       if (resp.statusCode !== 400) {
-        dispatch({ SET_ERRORS, _: `Error: ${resp.statusCode} ${resp.statusText}` });
+        dispatch({
+          type: SET_ERRORS,
+          _: [`Error: ${resp.statusCode} ${resp.statusText}`],
+        });
       } else {
         const json = await resp.json();
         const reducer = f => (s, e) => {

--- a/src/linodes/actions/detail/index.js
+++ b/src/linodes/actions/detail/index.js
@@ -5,6 +5,7 @@ export const TOGGLE_EDIT_MODE = '@@linodes@@detail/TOGGLE_EDIT_MODE';
 export const SET_LINODE_LABEL = '@@linodes@@detail/SET_LINODE_LABEL';
 export const SET_LINODE_GROUP = '@@linodes@@detail/SET_LINODE_GROUP';
 export const TOGGLE_LOADING = '@@linodes@@detail/TOGGLE_LOADING';
+export const SET_ERRORS = '@@linodes@@detail/SET_ERRORS';
 
 export function toggleEditMode() {
   return { type: TOGGLE_EDIT_MODE };
@@ -18,20 +19,45 @@ export function setLinodeGroup(group) {
   return { type: SET_LINODE_GROUP, group };
 }
 
+export function clearErrors() {
+  return { type: SET_ERRORS, label: null, group: null, _: null };
+}
+
 export function commitChanges(id) {
   return async (dispatch, getState) => {
     const state = getState();
     const { label, group } = state.linodes.detail.index;
     const { token } = state.authentication;
     dispatch({ type: TOGGLE_LOADING });
-    // TODO: Error handling
-    const resp = await fetch(token, `/linodes/${id}`, {
-      method: 'PUT',
-      body: JSON.stringify({ label, group }),
-    });
-    const json = await resp.json();
-    dispatch({ type: UPDATE_LINODE, linode: json });
-    dispatch({ type: TOGGLE_LOADING });
-    dispatch(toggleEditMode());
+    dispatch(clearErrors());
+    try {
+      const resp = await fetch(token, `/linodes/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify({ label, group }),
+      });
+      const json = await resp.json();
+      dispatch({ type: UPDATE_LINODE, linode: json });
+      dispatch({ type: TOGGLE_LOADING });
+      dispatch(toggleEditMode());
+    } catch (resp) {
+      if (resp.statusCode !== 400) {
+        dispatch({ SET_ERRORS, _: `Error: ${resp.statusCode} ${resp.statusText}` });
+      } else {
+        const json = await resp.json();
+        const reducer = f => (s, e) => {
+          if (e.field === f) {
+            return s ? [...s, e.reason] : [e.reason];
+          }
+          return s;
+        };
+        dispatch({
+          type: SET_ERRORS,
+          label: json.errors.reduce(reducer('label'), null),
+          group: json.errors.reduce(reducer('group'), null),
+          _: json.errors.reduce((s, e) => e.field ? s : [...s, e.reason], null),
+        });
+        dispatch({ type: TOGGLE_LOADING });
+      }
+    }
   };
 }

--- a/src/linodes/layouts/CreateLinodePage.js
+++ b/src/linodes/layouts/CreateLinodePage.js
@@ -8,16 +8,23 @@ import OrderSummary from '../components/OrderSummary';
 import { fetchDistros } from '~/actions/api/distros';
 import { fetchDatacenters } from '~/actions/api/datacenters';
 import { fetchServices } from '~/actions/api/services';
+import { setError } from '~/actions/errors';
 import { changeSourceTab, selectSource } from '~/linodes/actions/create/source';
 import { selectDatacenter } from '~/linodes/actions/create/datacenter';
 import { selectService } from '~/linodes/actions/create/service';
 
 export class CreateLinodePage extends Component {
-  componentDidMount() {
+  async componentDidMount() {
     const { dispatch } = this.props;
-    dispatch(fetchDistros());
-    dispatch(fetchDatacenters());
-    dispatch(fetchServices());
+    try {
+      await Promise.all([
+        dispatch(fetchDistros()),
+        dispatch(fetchDatacenters()),
+        dispatch(fetchServices()),
+      ]);
+    } catch (response) {
+      dispatch(setError(response));
+    }
   }
 
   render() {

--- a/src/linodes/layouts/IndexPage.js
+++ b/src/linodes/layouts/IndexPage.js
@@ -5,7 +5,8 @@ import { push } from 'react-router-redux';
 import { Linode } from '../components/Linode';
 import Dropdown from '~/components/Dropdown';
 import { LinodeStates } from '~/constants';
-import _ from 'underscore';
+import { setError } from '~/actions/errors';
+import _ from 'lodash';
 import {
   fetchLinodes,
   updateLinodeUntil,
@@ -36,11 +37,15 @@ export class IndexPage extends Component {
     this.handleScroll = this.handleScroll.bind(this);
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     const { dispatch } = this.props;
-    dispatch(fetchLinodes());
     window.addEventListener('scroll', this.handleScroll);
     this.componentDidUpdate();
+    try {
+      await dispatch(fetchLinodes());
+    } catch (response) {
+      dispatch(setError(response));
+    }
   }
 
   componentDidUpdate() {

--- a/src/linodes/layouts/LinodeDetailPage.js
+++ b/src/linodes/layouts/LinodeDetailPage.js
@@ -23,13 +23,16 @@ export function getLinode() {
   return linodes[linodeId];
 }
 
-export function loadLinode() {
+export async function updateLinode() {
   const { dispatch } = this.props;
   const linode = this.getLinode();
   if (!linode) {
     const { linodeId } = this.props.params;
-    dispatch(updateLinode(linodeId))
-      .catch(response => dispatch(setError(response)));
+    try {
+      await dispatch(updateLinode(linodeId));
+    } catch (response) {
+      dispatch(setError(response));
+    }
   }
 }
 

--- a/src/linodes/layouts/LinodeDetailPage.js
+++ b/src/linodes/layouts/LinodeDetailPage.js
@@ -24,7 +24,7 @@ export function getLinode() {
   return linodes[linodeId];
 }
 
-export async function updateLinode() {
+export async function loadLinode() {
   const { dispatch } = this.props;
   const linode = this.getLinode();
   if (!linode) {

--- a/src/linodes/layouts/LinodeDetailPage.js
+++ b/src/linodes/layouts/LinodeDetailPage.js
@@ -6,6 +6,7 @@ import { push } from 'react-router-redux';
 
 import Dropdown from '~/components/Dropdown';
 import { LinodeStates, LinodeStatesReadable } from '~/constants';
+import { setError } from '~/actions/errors';
 import {
   toggleEditMode,
   setLinodeLabel,
@@ -27,7 +28,8 @@ export function loadLinode() {
   const linode = this.getLinode();
   if (!linode) {
     const { linodeId } = this.props.params;
-    dispatch(updateLinode(linodeId));
+    dispatch(updateLinode(linodeId))
+      .catch(response => dispatch(setError(response)));
   }
 }
 

--- a/src/linodes/layouts/LinodeDetailPage.js
+++ b/src/linodes/layouts/LinodeDetailPage.js
@@ -12,6 +12,7 @@ import {
   setLinodeLabel,
   setLinodeGroup,
   commitChanges,
+  clearErrors,
 } from '../actions/detail/index';
 import {
   updateLinode, powerOnLinode, powerOffLinode, rebootLinode,
@@ -100,35 +101,65 @@ export class LinodeDetailPage extends Component {
   }
 
   renderEditUI(linode) {
-    const { label, group, loading } = this.props.detail;
+    const { label, group, loading, errors } = this.props.detail;
     const { dispatch } = this.props;
+    const hasErrors = errors.label || errors.group || errors._;
     return (
       <div className="edit-details">
-        <input
-          type="text"
-          value={group}
-          placeholder="Group..."
-          onChange={e => dispatch(setLinodeGroup(e.target.value))}
-          onKeyUp={e => this.handleLabelKeyUp(e, linode)}
-        />
-        <span>/</span>
-        <input
-          type="text"
-          value={label}
-          placeholder="Label..."
-          onChange={e => dispatch(setLinodeLabel(e.target.value))}
-          onKeyUp={e => this.handleLabelKeyUp(e, linode)}
-        />
-        <button
-          className="btn btn-primary"
-          onClick={() => dispatch(commitChanges(linode.id))}
-          disabled={loading}
-        >Save</button>
-        <button
-          className="btn btn-secondary"
-          onClick={() => dispatch(toggleEditMode())}
-          disabled={loading}
-        >Cancel</button>
+        <div className="row">
+          <div className="col-md-4">
+            <input
+              type="text"
+              value={group}
+              placeholder="Group..."
+              onChange={e => dispatch(setLinodeGroup(e.target.value))}
+              onKeyUp={e => this.handleLabelKeyUp(e, linode)}
+              className={errors.group ? 'has-error' : ''}
+            />
+          </div>
+          <div className="col-md-1 centered">/</div>
+          <div className="col-md-4">
+            <input
+              type="text"
+              value={label}
+              placeholder="Label..."
+              onChange={e => dispatch(setLinodeLabel(e.target.value))}
+              onKeyUp={e => this.handleLabelKeyUp(e, linode)}
+              className={errors.label ? 'has-error' : ''}
+            />
+          </div>
+          <div className="col-md-3">
+            <button
+              className="btn btn-primary"
+              onClick={() => dispatch(commitChanges(linode.id))}
+              disabled={loading}
+            >Save</button>
+            <button
+              className="btn btn-secondary"
+              onClick={() => dispatch(toggleEditMode())}
+              disabled={loading}
+            >Cancel</button>
+          </div>
+        </div>
+        {hasErrors ?
+          <div className="row errors">
+            <div className="col-md-4">
+              {errors.group ?
+                <div className="alert alert-danger">
+                  <ul>
+                    {errors.group.map(e => <li>{e}</li>)}
+                  </ul>
+                </div> : null}
+            </div>
+            <div className="col-md-4 col-md-offset-1">
+              {errors.label ?
+                <div className="alert alert-danger">
+                  <ul>
+                    {errors.label.map(e => <li>{e}</li>)}
+                  </ul>
+                </div> : null}
+            </div>
+          </div> : null}
       </div>
     );
   }
@@ -149,6 +180,7 @@ export class LinodeDetailPage extends Component {
               e.preventDefault();
               dispatch(setLinodeLabel(linode.label));
               dispatch(setLinodeGroup(linode.group));
+              dispatch(clearErrors());
               dispatch(toggleEditMode());
             }}
           >

--- a/src/linodes/layouts/LinodeDetailPage.js
+++ b/src/linodes/layouts/LinodeDetailPage.js
@@ -147,7 +147,7 @@ export class LinodeDetailPage extends Component {
               {errors.group ?
                 <div className="alert alert-danger">
                   <ul>
-                    {errors.group.map(e => <li>{e}</li>)}
+                    {errors.group.map(e => <li key={e}>{e}</li>)}
                   </ul>
                 </div> : null}
             </div>
@@ -155,7 +155,7 @@ export class LinodeDetailPage extends Component {
               {errors.label ?
                 <div className="alert alert-danger">
                   <ul>
-                    {errors.label.map(e => <li>{e}</li>)}
+                    {errors.label.map(e => <li key={e}>{e}</li>)}
                   </ul>
                 </div> : null}
             </div>

--- a/src/linodes/reducers/detail/index.js
+++ b/src/linodes/reducers/detail/index.js
@@ -4,6 +4,7 @@ import {
   SET_LINODE_LABEL,
   SET_LINODE_GROUP,
   TOGGLE_LOADING,
+  SET_ERRORS,
 } from '../../actions/detail/index';
 import backups from './backups';
 
@@ -12,6 +13,11 @@ const defaultState = {
   label: '',
   group: '',
   loading: false,
+  errors: {
+    label: null,
+    group: null,
+    _: null,
+  },
 };
 
 export function detail(state = defaultState, action) {
@@ -24,6 +30,15 @@ export function detail(state = defaultState, action) {
       return { ...state, group: action.group };
     case TOGGLE_LOADING:
       return { ...state, loading: !state.loading };
+    case SET_ERRORS:
+      return {
+        ...state,
+        errors: {
+          label: action.label,
+          group: action.group,
+          _: action._,
+        },
+      };
     default:
       return state;
   }

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -1,0 +1,21 @@
+import { SET_ERROR, TOGGLE_DETAILS } from '~/actions/errors';
+
+const defaultState = {
+  json: null,
+  status: null,
+  statusText: null,
+  details: false,
+};
+
+export default function errors(state = defaultState, action) {
+  switch (action.type) {
+    case SET_ERROR: {
+      const { json, status, statusText } = action;
+      return { ...state, json, status, statusText };
+    }
+    case TOGGLE_DETAILS:
+      return { ...state, details: !state.details };
+    default:
+      return state;
+  }
+}

--- a/src/reducers/errors.js
+++ b/src/reducers/errors.js
@@ -1,4 +1,5 @@
 import { SET_ERROR, TOGGLE_DETAILS } from '~/actions/errors';
+import { LOCATION_CHANGE } from 'react-router-redux';
 
 const defaultState = {
   json: null,
@@ -15,6 +16,8 @@ export default function errors(state = defaultState, action) {
     }
     case TOGGLE_DETAILS:
       return { ...state, details: !state.details };
+    case LOCATION_CHANGE:
+      return { ...state, json: null, status: null, statusText: null };
     default:
       return state;
   }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,6 +3,7 @@ import { routerReducer } from 'react-router-redux';
 import authentication from './authentication';
 import modal from './modal';
 import api from './api';
+import errors from './errors';
 import linodes from '../linodes/reducers';
 
 const rootReducer = combineReducers({
@@ -11,6 +12,7 @@ const rootReducer = combineReducers({
   modal,
   api,
   linodes,
+  errors,
 });
 
 export default rootReducer;

--- a/src/session.js
+++ b/src/session.js
@@ -1,0 +1,22 @@
+import store from '~/store';
+import { APP_ROOT, LOGIN_ROOT } from './constants';
+import { clientId } from './secrets';
+
+export default function checkLogin(next) {
+  const state = store.getState();
+  if (next.location.pathname !== '/oauth/callback'
+      && state.authentication.token === null) {
+    const query = Object.keys(next.location.query)
+            .reduce((a, k) => [
+              ...a,
+              `${k}=${encodeURIComponent(next.location.query[k])}`,
+            ], []).join('%26');
+    /* eslint-disable prefer-template */
+    window.location = `${LOGIN_ROOT}/oauth/authorize?` +
+      `client_id=${clientId}` +
+      '&scopes=*' +
+      `&redirect_uri=${encodeURIComponent(APP_ROOT)}/oauth/callback?return=` +
+            encodeURIComponent(next.location.pathname + (query ? '%3F' + query : ''));
+    /* eslint-enable prefer-template */
+  }
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -11,7 +11,7 @@ const createStoreWithMiddleware = compose(
   DevTools.instrument()
 )(createStore);
 
-export default function configureStore(initialState) {
+export function configureStore(initialState) {
   const store = createStoreWithMiddleware(reducer, initialState);
 
   if (module.hot) {
@@ -23,3 +23,7 @@ export default function configureStore(initialState) {
 
   return store;
 }
+
+const store = configureStore();
+
+export default store;

--- a/test/actions/errors.spec.js
+++ b/test/actions/errors.spec.js
@@ -1,0 +1,59 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import * as actions from '../../src/actions/errors';
+
+describe('actions/errors', () => {
+  describe('toggleDetails', () => {
+    it('should return a TOGGLE_DETAILS action', () => {
+      expect(actions.toggleDetails())
+        .to.deep.equal({ type: actions.TOGGLE_DETAILS });
+    });
+  });
+
+  describe('setError', () => {
+    const sandbox = sinon.sandbox.create();
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should return a thunk', () => {
+      expect(actions.setError({})).to.be.a('function');
+    });
+
+    it('retrieve the body for JSON responses', async () => {
+      const json = sandbox.stub();
+      json.returns({ foo: 'bar' });
+      const response = {
+        headers: {
+          get: () => 'application/json',
+        },
+        json,
+      };
+      const thunk = actions.setError(response);
+      await thunk(() => {});
+      expect(json.calledOnce).to.equal(true);
+    });
+
+    it('dispatches a SET_ERROR action', async () => {
+      const response = {
+        headers: {
+          get: () => 'application/json',
+        },
+        json: () => ({ foo: 'bar' }),
+        statusCode: 400,
+        statusText: 'Bad Request',
+      };
+      const thunk = actions.setError(response);
+      const dispatch = sandbox.spy();
+      await thunk(dispatch);
+      expect(dispatch.calledOnce).to.equal(true);
+      expect(dispatch.calledWith({
+        type: actions.SET_ERROR,
+        status: 400,
+        statusText: 'Bad Request',
+        json: { foo: 'bar' },
+      })).to.equal(true);
+    });
+  });
+});

--- a/test/layouts/Layout.spec.js
+++ b/test/layouts/Layout.spec.js
@@ -1,0 +1,111 @@
+import React from 'react';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { Layout } from '../../src/layouts/Layout';
+
+describe('layouts/Layout', () => {
+  const sandbox = sinon.sandbox.create();
+  let dispatch = sandbox.spy();
+
+  afterEach(() => {
+    sandbox.restore();
+    dispatch = sandbox.spy();
+  });
+
+  const errors = {
+    json: null,
+    status: null,
+    statusText: null,
+    details: false,
+  };
+
+  it('renders its children', () => {
+    const component = shallow(
+      <Layout
+        dispatch={dispatch}
+        errors={errors}
+      ><p>Hello world!</p></Layout>);
+    expect(component.contains(<p>Hello world!</p>))
+      .to.equal(true);
+  });
+
+  it('renders a sidebar', () => {
+    const component = shallow(
+      <Layout
+        dispatch={dispatch}
+        errors={errors}
+      ><p>Hello world!</p></Layout>);
+    expect(component.find('Sidebar')).to.exist;
+  });
+
+  it('renders a header', () => {
+    const component = shallow(
+      <Layout
+        dispatch={dispatch}
+        errors={errors}
+      ><p>Hello world!</p></Layout>);
+    expect(component.find('Header')).to.exist;
+  });
+
+  it('renders a modal', () => {
+    const component = shallow(
+      <Layout
+        dispatch={dispatch}
+        errors={errors}
+      ><p>Hello world!</p></Layout>);
+    expect(component.find('Modal')).to.exist;
+  });
+
+  const errorsPopulated = {
+    json: {
+      errors: [
+        { reason: 'You done fucked up' },
+      ],
+    },
+    status: 400,
+    statusText: 'Invalid Request',
+    details: false,
+  };
+
+  it('does not render children on error', () => {
+    const component = shallow(
+      <Layout
+        dispatch={dispatch}
+        errors={errorsPopulated}
+      ><p>Hello world!</p></Layout>);
+    expect(component.contains(<p>Hello world!</p>))
+      .to.equal(false);
+  });
+
+  it('renders a 404 page when appropriate', () => {
+    const component = shallow(
+      <Layout
+        dispatch={dispatch}
+        errors={{ ...errorsPopulated, status: 404 }}
+      ><p>Hello world!</p></Layout>);
+    expect(component.find('NotFound')).to.exist;
+  });
+
+  it('renders error status code and text', () => {
+    const component = shallow(
+      <Layout
+        dispatch={dispatch}
+        errors={errorsPopulated}
+      ><p>Hello world!</p></Layout>);
+    expect(component.contains(
+      <h1>{errorsPopulated.status} {errorsPopulated.statusText}</h1>
+    )).to.equal(true);
+  });
+
+  it('renders response JSON', () => {
+    const component = shallow(
+      <Layout
+        dispatch={dispatch}
+        errors={{ ...errorsPopulated, details: true }}
+      ><p>Hello world!</p></Layout>);
+    const pre = component.find('pre');
+    expect(pre).to.exist;
+    expect(JSON.parse(pre.text())).to.deep.equal(errorsPopulated.json);
+  });
+});

--- a/test/layouts/Layout.spec.js
+++ b/test/layouts/Layout.spec.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { Layout } from '../../src/layouts/Layout';
+import { toggleDetails } from '~/actions/errors';
 
 describe('layouts/Layout', () => {
   const sandbox = sinon.sandbox.create();
@@ -107,5 +108,19 @@ describe('layouts/Layout', () => {
     const pre = component.find('pre');
     expect(pre).to.exist;
     expect(JSON.parse(pre.text())).to.deep.equal(errorsPopulated.json);
+  });
+
+  it('toggles response JSON when link is clicked', () => {
+    const component = shallow(
+      <Layout
+        dispatch={dispatch}
+        errors={{ ...errorsPopulated, details: true }}
+      ><p>Hello world!</p></Layout>);
+    const link = component.find('.toggle-error-response');
+    expect(link).to.exist;
+    dispatch.reset();
+    link.simulate('click', { preventDefault: () => {} });
+    expect(dispatch.calledOnce).to.equal(true);
+    expect(dispatch.calledWith(toggleDetails())).to.equal(true);
   });
 });

--- a/test/linodes/actions/detail/index.spec.js
+++ b/test/linodes/actions/detail/index.spec.js
@@ -93,6 +93,51 @@ describe('linodes/actions/detail/index', () => {
         })).to.equal(true);
     });
 
+    it('handles non-400 errors', async () => {
+      const action = actions.commitChanges('linode_1234');
+      expect(action).to.be.a('function');
+      const dispatch = getDispatch();
+      const getState = getGetState(state);
+      sandbox.stub(fetch, 'fetch')
+        .throws({
+          json: () => ({}),
+          statusCode: 401,
+          statusText: 'Unauthorized',
+        });
+      await action(dispatch, getState);
+      expect(dispatch.calledWith({
+        type: actions.SET_ERRORS,
+        _: ['Error: 401 Unauthorized'],
+      })).to.equal(true);
+    });
+
+    it('handles 400 errors', async () => {
+      const action = actions.commitChanges('linode_1234');
+      expect(action).to.be.a('function');
+      const dispatch = getDispatch();
+      const getState = getGetState(state);
+      sandbox.stub(fetch, 'fetch')
+        .throws({
+          json: () => ({
+            errors: [
+              {
+                field: 'label',
+                reason: 'This is a silly name for a Linode',
+              },
+            ],
+          }),
+          statusCode: 400,
+          statusText: 'Bad Request',
+        });
+      await action(dispatch, getState);
+      expect(dispatch.calledWith({
+        type: actions.SET_ERRORS,
+        label: ['This is a silly name for a Linode'],
+        group: null,
+        _: null,
+      })).to.equal(true);
+    });
+
     it('dispatches an UPDATE_LINODE action with the new linode details', async () => {
       const action = actions.commitChanges('linode_1234');
       expect(action).to.be.a('function');

--- a/test/linodes/layouts/IndexPage.spec.js
+++ b/test/linodes/layouts/IndexPage.spec.js
@@ -4,11 +4,12 @@ import { mount, shallow } from 'enzyme';
 import { expect } from 'chai';
 import { push } from 'react-router-redux';
 import { IndexPage } from '~/linodes/layouts/IndexPage';
-import { UPDATE_LINODES } from '~/actions/api/linodes';
+import * as linodeActions from '~/actions/api/linodes';
 import { TOGGLE_SELECTED, CHANGE_VIEW } from '~/linodes/actions/index';
 import * as fetch from '~/fetch';
 import { testLinode } from '~/../test/data';
 import Dropdown from '~/components/Dropdown';
+import { SET_ERROR } from '~/actions/errors';
 
 describe('linodes/layouts/IndexPage', () => {
   const sandbox = sinon.sandbox.create();
@@ -52,7 +53,29 @@ describe('linodes/layouts/IndexPage', () => {
     expect(fetchStub.calledOnce).to.equal(true);
     expect(fetchStub.firstCall.args[1]).to.equal('/linodes?page=1');
     expect(dispatch.calledOnce).to.equal(true);
-    expect(dispatch.firstCall.args[0].type).to.equal(UPDATE_LINODES);
+    expect(dispatch.firstCall.args[0].type).to.equal(linodeActions.UPDATE_LINODES);
+  });
+
+  it('handles errors from fetchLinodes', async () => {
+    sandbox.stub(linodeActions, 'fetchLinodes').throws({
+      json: () => ({ foo: 'bar' }),
+      headers: { get() { return 'application/json'; } },
+      statusCode: 400,
+      statusText: 'Bad Request',
+    });
+    mount(
+      <IndexPage
+        dispatch={dispatch}
+        view={'grid'}
+        selected={{}}
+        linodes={linodes}
+      />);
+    expect(dispatch.calledWith({
+      type: SET_ERROR,
+      json: { foo: 'bar' },
+      status: 400,
+      statusText: 'Bad Request',
+    }));
   });
 
   it('redirects to /linodes/create when you have no Linodes', async () => {

--- a/test/linodes/layouts/IndexPage.spec.js
+++ b/test/linodes/layouts/IndexPage.spec.js
@@ -56,7 +56,7 @@ describe('linodes/layouts/IndexPage', () => {
     expect(dispatch.firstCall.args[0].type).to.equal(linodeActions.UPDATE_LINODES);
   });
 
-  it('handles errors from fetchLinodes', async () => {
+  it('handles errors from fetchLinodes', () => {
     sandbox.stub(linodeActions, 'fetchLinodes').throws({
       json: () => ({ foo: 'bar' }),
       headers: { get() { return 'application/json'; } },

--- a/test/linodes/layouts/LinodeDetailPage.spec.js
+++ b/test/linodes/layouts/LinodeDetailPage.spec.js
@@ -62,7 +62,7 @@ describe('linodes/layouts/LinodeDetailPage/loadLinode', async () => {
     expect(dispatch.firstCall.args[0].type).to.equal(linodeActions.UPDATE_LINODE);
   });
 
-  it('handles errors from updateLinode', async () => {
+  it('handles errors from updateLinode', () => {
     sandbox.stub(linodeActions, 'updateLinode').throws({
       json: () => ({ foo: 'bar' }),
       headers: { get() { return 'application/json'; } },

--- a/test/linodes/layouts/LinodeDetailPage.spec.js
+++ b/test/linodes/layouts/LinodeDetailPage.spec.js
@@ -145,6 +145,11 @@ describe('linodes/layouts/LinodeDetailPage', () => {
     label: '',
     group: '',
     loading: false,
+    errors: {
+      label: null,
+      group: null,
+      _: null,
+    },
   };
 
   it('calls loadLinode during mount', () => {

--- a/test/linodes/layouts/LinodeDetailPage.spec.js
+++ b/test/linodes/layouts/LinodeDetailPage.spec.js
@@ -6,10 +6,11 @@ import { expect } from 'chai';
 import * as fetch from '~/fetch';
 import { testLinode, linodes } from '~/../test/data';
 import * as LinodeDetailPageWrapper from '~/linodes/layouts/LinodeDetailPage';
-import { UPDATE_LINODE } from '~/actions/api/linodes';
+import * as linodeActions from '~/actions/api/linodes';
 import { Tabs, Tab } from 'react-tabs';
 import * as actions from '~/linodes/actions/detail/index';
 import Dropdown from '~/components/Dropdown';
+import { SET_ERROR } from '~/actions/errors';
 
 const {
   LinodeDetailPage,
@@ -58,7 +59,28 @@ describe('linodes/layouts/LinodeDetailPage/loadLinode', async () => {
     expect(fetchStub.calledOnce).to.equal(true);
     expect(fetchStub.firstCall.args[1]).to.equal('/linodes/linode_1234');
     expect(dispatch.calledOnce).to.equal(true);
-    expect(dispatch.firstCall.args[0].type).to.equal(UPDATE_LINODE);
+    expect(dispatch.firstCall.args[0].type).to.equal(linodeActions.UPDATE_LINODE);
+  });
+
+  it('handles errors from updateLinode', async () => {
+    sandbox.stub(linodeActions, 'updateLinode').throws({
+      json: () => ({ foo: 'bar' }),
+      headers: { get() { return 'application/json'; } },
+      statusCode: 400,
+      statusText: 'Bad Request',
+    });
+    mount(
+      <Test
+        dispatch={dispatch}
+        linodes={{ linodes: { } }}
+        params={{ linodeId: 'linode_1234' }}
+      />);
+    expect(dispatch.calledWith({
+      type: SET_ERROR,
+      json: { foo: 'bar' },
+      status: 400,
+      statusText: 'Bad Request',
+    }));
   });
 
   it('does not fetch when mounted with a known linode', async () => {

--- a/test/linodes/reducers/detail/index.spec.js
+++ b/test/linodes/reducers/detail/index.spec.js
@@ -71,4 +71,20 @@ describe('linodes/reducers/detail/index', () => {
     expect(detail(stateLoading, { type: actions.TOGGLE_LOADING }))
       .to.have.property('loading').that.equals(false);
   });
+
+  it('should handle SET_ERRORS', () => {
+    const state = { };
+    deepFreeze(state);
+
+    expect(detail(state, {
+      type: actions.SET_ERRORS,
+      label: ['a', 'b', 'c'],
+      group: ['a', 'b', 'c'],
+      _: null,
+    })).to.have.property('errors').that.deep.equals({
+      label: ['a', 'b', 'c'],
+      group: ['a', 'b', 'c'],
+      _: null,
+    });
+  });
 });

--- a/test/linodes/reducers/detail/index.spec.js
+++ b/test/linodes/reducers/detail/index.spec.js
@@ -12,6 +12,11 @@ describe('linodes/reducers/detail/index', () => {
       label: '',
       group: '',
       loading: false,
+      errors: {
+        label: null,
+        group: null,
+        _: null,
+      },
     });
   });
 

--- a/test/reducers/errors.spec.js
+++ b/test/reducers/errors.spec.js
@@ -13,7 +13,6 @@ describe('reducers/errors', () => {
   deepFreeze(defaultState);
 
   it('should handle initial state', () => {
-    window.localStorage.clear();
     expect(
       errors(undefined, {})
     ).to.deep.equal(defaultState);

--- a/test/reducers/errors.spec.js
+++ b/test/reducers/errors.spec.js
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import deepFreeze from 'deep-freeze';
+import errors from '../../src/reducers/errors';
+import * as actions from '../../src/actions/errors';
+
+describe('reducers/errors', () => {
+  const defaultState = {
+    json: null,
+    status: null,
+    statusText: null,
+    details: false,
+  };
+  deepFreeze(defaultState);
+
+  it('should handle initial state', () => {
+    window.localStorage.clear();
+    expect(
+      errors(undefined, {})
+    ).to.deep.equal(defaultState);
+  });
+
+  it('should handle SET_ERROR', () => {
+    expect(
+      errors(defaultState, {
+        type: actions.SET_ERROR,
+        status: 400,
+        statusText: 'Bad Request',
+        json: { },
+      })
+    ).to.deep.equal({
+      ...defaultState,
+      status: 400,
+      statusText: 'Bad Request',
+      json: { },
+    });
+  });
+
+  it('should handle TOGGLE_DETAILS', () => {
+    expect(
+      errors(defaultState, { type: actions.TOGGLE_DETAILS })
+    ).to.deep.equal({
+      ...defaultState,
+      details: !defaultState.details,
+    });
+  });
+});


### PR DESCRIPTION
* [x] Redirect to oauth flow on auth error
* [ ] Tests

Show error page on error for:
* [x] GET /linodes
* [x] GET /linodes/:id
* [x] GET /distributions
* [x] Handle 404 errors appropriately
* [ ] Handle uncaught exceptions

Show error response inline (overall error and/or per-field error) for:
* [x] Alerts form
* [x] Edit group / label

Closes #71 