### PR TITLE
Nested stores

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,10 +15,13 @@
     "babel/object-shorthand": 2,
     "babel/flow-object-type": 2,
     "babel/no-await-in-loop": 0,
+    "babel/arrow-parens": 0,
     "import/no-unresolved": 0,
     "no-underscore-dangle": 0,
     "no-unused-expressions": 0,
     "no-confusing-arrow": 0,
+    "array-callback-return": 0,
+    "consistent-return": 0,
     "react/no-multi-comp": 0,
     "dot-notation": [
       "error", {

--- a/src/actions/api/linodes.js
+++ b/src/actions/api/linodes.js
@@ -1,8 +1,8 @@
 import { fetch } from '~/fetch';
 import {
   makeFetchPage,
-  makeUpdateItem,
-  makeUpdateUntil,
+  makeFetchItem,
+  makeFetchUntil,
   makeDeleteItem,
   makePutItem,
 } from '~/api-store';
@@ -21,8 +21,8 @@ export const UPDATE_LINODE_DISKS = '@@linodes/UPDATE_LINODE_DISKS ';
 export const DELETE_LINODE_DISK = '@@linodes/DELETE_LINODE_DISK ';
 
 export const fetchLinodes = makeFetchPage(UPDATE_LINODES, 'linodes');
-export const updateLinode = makeUpdateItem(UPDATE_LINODE, 'linode', 'linodes');
-export const updateLinodeUntil = makeUpdateUntil(UPDATE_LINODE, 'linodes', 'linode');
+export const updateLinode = makeFetchItem(UPDATE_LINODE, 'linode', 'linodes');
+export const updateLinodeUntil = makeFetchUntil(UPDATE_LINODE, 'linodes', 'linode');
 export const deleteLinode = makeDeleteItem(DELETE_LINODE, 'linodes');
 export const putLinode = makePutItem(PUT_LINODE, 'linodes');
 

--- a/src/actions/api/linodes.js
+++ b/src/actions/api/linodes.js
@@ -21,11 +21,10 @@ export const UPDATE_LINODE_DISKS = '@@linodes/UPDATE_LINODE_DISKS ';
 export const DELETE_LINODE_DISK = '@@linodes/DELETE_LINODE_DISK ';
 
 export const fetchLinodes = makeFetchPage(UPDATE_LINODES, 'linodes');
-export const updateLinode = makeUpdateItem(UPDATE_LINODE, 'linodes', 'linode');
+export const updateLinode = makeUpdateItem(UPDATE_LINODE, 'linode', 'linodes');
 export const updateLinodeUntil = makeUpdateUntil(UPDATE_LINODE, 'linodes', 'linode');
 export const deleteLinode = makeDeleteItem(DELETE_LINODE, 'linodes');
 export const putLinode = makePutItem(PUT_LINODE, 'linodes');
-
 
 function linodeAction(id, action, temp, expected, timeout = undefined) {
   return async (dispatch, getState) => {

--- a/src/actions/api/linodes.js
+++ b/src/actions/api/linodes.js
@@ -12,6 +12,14 @@ export const UPDATE_LINODE = '@@linodes/UPDATE_LINODE';
 export const DELETE_LINODE = '@@linodes/DELETE_LINODE';
 export const PUT_LINODE = '@@linodes/PUT_LINODE';
 
+export const UPDATE_LINODE_CONFIG = '@@linodes/UPDATE_LINODE_CONFIG ';
+export const UPDATE_LINODE_CONFIGS = '@@linodes/UPDATE_LINODE_CONFIGS ';
+export const DELETE_LINODE_CONFIG = '@@linodes/DELETE_LINODE_CONFIG ';
+
+export const UPDATE_LINODE_DISK = '@@linodes/UPDATE_LINODE_DISK ';
+export const UPDATE_LINODE_DISKS = '@@linodes/UPDATE_LINODE_DISKS ';
+export const DELETE_LINODE_DISK = '@@linodes/DELETE_LINODE_DISK ';
+
 export const fetchLinodes = makeFetchPage(UPDATE_LINODES, 'linodes');
 export const updateLinode = makeUpdateItem(UPDATE_LINODE, 'linodes', 'linode');
 export const updateLinodeUntil = makeUpdateUntil(UPDATE_LINODE, 'linodes', 'linode');

--- a/src/api-store.js
+++ b/src/api-store.js
@@ -122,7 +122,7 @@ export function makeFetchPage(action, ...plurals) {
   };
 }
 
-export function makeUpdateItem(action, singular, ...plurals) {
+export function makeFetchItem(action, singular, ...plurals) {
   return (...ids) => async (dispatch, getState) => {
     const pairs = _.zip(plurals, ids);
     const { token } = getState().authentication;
@@ -133,7 +133,7 @@ export function makeUpdateItem(action, singular, ...plurals) {
   };
 }
 
-export function makeUpdateUntil(action, plural, singular) {
+export function makeFetchUntil(action, plural, singular) {
   return (id, test, timeout = 3000) => async (dispatch, getState) => {
     const { token } = getState().authentication;
     const item = getState().api[plural][plural][id];

--- a/src/api-store.js
+++ b/src/api-store.js
@@ -111,19 +111,23 @@ export default function makeApiList(config, transform = d => d) {
 
 import { fetch } from './fetch';
 
-export function makeFetchPage(action, plural) {
-  return (page = 0) => async (dispatch, getState) => {
+export function makeFetchPage(action, ...plurals) {
+  return (page = 0, ...ids) => async (dispatch, getState) => {
+    const pairs = _.zip(plurals, ids);
     const { token } = getState().authentication;
-    const response = await fetch(token, `/${plural}?page=${page + 1}`);
+    const url = _.reduce(pairs, (u, [plural, id]) => `${u}/${plural}/${id || ''}`, '');
+    const response = await fetch(token, `${url}?page=${page + 1}`);
     const json = await response.json();
     dispatch({ type: action, response: json });
   };
 }
 
-export function makeUpdateItem(action, plural, singular) {
-  return id => async (dispatch, getState) => {
+export function makeUpdateItem(action, singular, ...plurals) {
+  return (...ids) => async (dispatch, getState) => {
+    const pairs = _.zip(plurals, ids);
     const { token } = getState().authentication;
-    const response = await fetch(token, `/${plural}/${id}`);
+    const url = _.reduce(pairs, (u, [plural, id]) => `${u}/${plural}/${id}`, '');
+    const response = await fetch(token, url);
     const json = await response.json();
     dispatch({ type: action, [singular]: json });
   };

--- a/src/reducers/api/datacenters.js
+++ b/src/reducers/api/datacenters.js
@@ -1,7 +1,11 @@
 import { UPDATE_DATACENTER, UPDATE_DATACENTERS } from '~/actions/api/datacenters';
 import makeApiList from '~/api-store';
 
-export default makeApiList('datacenters', 'datacenter', {
-  update_single: UPDATE_DATACENTER,
-  update_many: UPDATE_DATACENTERS,
+export default makeApiList({
+  singular: 'datacenter',
+  plural: 'datacenters',
+  actions: {
+    update_single: UPDATE_DATACENTER,
+    update_many: UPDATE_DATACENTERS,
+  },
 });

--- a/src/reducers/api/distros.js
+++ b/src/reducers/api/distros.js
@@ -1,6 +1,8 @@
 import { UPDATE_DISTROS } from '~/actions/api/distros';
 import makeApiList from '~/api-store';
 
-export default makeApiList('distributions', 'distribution', {
-  update_many: UPDATE_DISTROS,
+export default makeApiList({
+  singular: 'distribution',
+  plural: 'distributions',
+  actions: { update_many: UPDATE_DISTROS },
 });

--- a/src/reducers/api/linodes.js
+++ b/src/reducers/api/linodes.js
@@ -1,11 +1,36 @@
 import {
-    UPDATE_LINODES, UPDATE_LINODE,
-    DELETE_LINODE,
+    UPDATE_LINODES, UPDATE_LINODE, DELETE_LINODE,
+    UPDATE_LINODE_CONFIG, UPDATE_LINODE_CONFIGS, DELETE_LINODE_CONFIG,
+    UPDATE_LINODE_DISK, UPDATE_LINODE_DISKS, DELETE_LINODE_DISK,
 } from '~/actions/api/linodes';
 import makeApiList from '~/api-store';
 
-export default makeApiList('linodes', 'linode', {
-  update_singular: UPDATE_LINODE,
-  update_many: UPDATE_LINODES,
-  delete_one: DELETE_LINODE,
+export default makeApiList({
+  plural: 'linodes',
+  singular: 'linode',
+  actions: {
+    update_singular: UPDATE_LINODE,
+    update_many: UPDATE_LINODES,
+    delete_one: DELETE_LINODE,
+  },
+  subresources: {
+    _configs: {
+      plural: 'configs',
+      singular: 'config',
+      actions: {
+        update_singular: UPDATE_LINODE_CONFIG,
+        update_many: UPDATE_LINODE_CONFIGS,
+        delete_one: DELETE_LINODE_CONFIG,
+      },
+    },
+    _disks: {
+      plural: 'disks',
+      singular: 'disk',
+      actions: {
+        update_singular: UPDATE_LINODE_DISK,
+        update_many: UPDATE_LINODE_DISKS,
+        delete_one: DELETE_LINODE_DISK,
+      },
+    },
+  },
 });

--- a/src/reducers/api/services.js
+++ b/src/reducers/api/services.js
@@ -1,6 +1,8 @@
 import { UPDATE_SERVICES } from '~/actions/api/services';
 import makeApiList from '~/api-store';
 
-export default makeApiList('services', 'service', {
-  update_many: UPDATE_SERVICES,
+export default makeApiList({
+  singular: 'service',
+  plural: 'services',
+  actions: { update_many: UPDATE_SERVICES },
 });

--- a/test/actions/api/datacenters.spec.js
+++ b/test/actions/api/datacenters.spec.js
@@ -42,7 +42,7 @@ describe('actions/api/datacenters', async () => {
     await f(dispatch, getState);
 
     expect(fetchStub.calledWith(
-      auth.token, '/datacenters?page=1')).to.equal(true);
+      auth.token, '/datacenters/?page=1')).to.equal(true);
     expect(dispatch.calledWith({
       type: UPDATE_DATACENTERS,
       response: mockResponse,

--- a/test/actions/api/distros.spec.js
+++ b/test/actions/api/distros.spec.js
@@ -42,7 +42,7 @@ describe('actions/api/distros', async () => {
     await f(dispatch, getState);
 
     expect(fetchStub.calledWith(
-      auth.token, '/distributions?page=1')).to.equal(true);
+      auth.token, '/distributions/?page=1')).to.equal(true);
     expect(dispatch.calledWith({
       type: UPDATE_DISTROS,
       response: mockResponse,

--- a/test/actions/api/linodes.spec.js
+++ b/test/actions/api/linodes.spec.js
@@ -50,7 +50,7 @@ describe('actions/api/linodes', async () => {
     await f(dispatch, getState);
 
     expect(fetchStub.calledWith(
-      auth.token, '/linodes?page=1')).to.equal(true);
+      auth.token, '/linodes/?page=1')).to.equal(true);
     expect(dispatch.calledWith({
       type: UPDATE_LINODES,
       response: mockResponse,

--- a/test/actions/api/services.spec.js
+++ b/test/actions/api/services.spec.js
@@ -42,7 +42,7 @@ describe('actions/api/services', () => {
     await f(dispatch, getState);
 
     expect(fetchStub.calledWith(
-      auth.token, '/services?page=1')).to.equal(true);
+      auth.token, '/services/?page=1')).to.equal(true);
     expect(dispatch.calledWith({
       type: UPDATE_SERVICES,
       response: mockResponse,

--- a/test/api-store.spec.js
+++ b/test/api-store.spec.js
@@ -308,7 +308,7 @@ describe('api-store', () => {
       await p(dispatch, getState);
 
       expect(fetchStub.calledWith(
-        auth.token, '/foobars?page=1')).to.equal(true);
+        auth.token, '/foobars/?page=1')).to.equal(true);
       expect(dispatch.calledWith({
         type: 'FETCH_FOOBARS',
         response: mockFoobarsResponse,
@@ -325,7 +325,7 @@ describe('api-store', () => {
       await p(dispatch, getState);
 
       expect(fetchStub.calledWith(
-        auth.token, '/foobars?page=2')).to.equal(true);
+        auth.token, '/foobars/?page=2')).to.equal(true);
     });
   });
 
@@ -342,7 +342,7 @@ describe('api-store', () => {
     const getFetchStub = (rsp) => sandbox.stub(fetch, 'fetch').returns({ json() { return rsp; } });
 
     it('returns a function that itself returns a function', () => {
-      const f = makeUpdateItem('UPDATE_FOOBAR', 'foobars', 'foobar');
+      const f = makeUpdateItem('UPDATE_FOOBAR', 'foobar', 'foobars');
       expect(f).to.be.a('function');
       expect(f()).to.be.a('function');
     });
@@ -351,7 +351,7 @@ describe('api-store', () => {
       const dispatch = getDispatch();
       const fetchStub = getFetchStub(mockFoobarsResponse.foobars[0]);
       const getState = getGetState();
-      const f = makeUpdateItem('UPDATE_FOOBAR', 'foobars', 'foobar');
+      const f = makeUpdateItem('UPDATE_FOOBAR', 'foobar', 'foobars');
       const p = f('foobar_1');
 
       await p(dispatch, getState);

--- a/test/api-store.spec.js
+++ b/test/api-store.spec.js
@@ -31,23 +31,29 @@ describe('api-store', () => {
     });
 
     it('should handle initial state', () => {
-      const s = makeApiList('foobars', 'foobar', {
-        update_singular: 'UPDATE_ONE',
-        update_many: 'UPDATE_MANY',
-        delete_one: 'DELETE_ONE',
+      const s = makeApiList({
+        plural: 'foobars',
+        singular: 'foobar',
+        actions: {
+          update_singular: 'UPDATE_ONE',
+          update_many: 'UPDATE_MANY',
+          delete_one: 'DELETE_ONE',
+        },
       });
 
       expect(
         s(undefined, {})
       ).to.be.eql({
         pagesFetched: [], totalPages: -1, foobars: {},
-        _singular: 'foobar', _plural: 'foobars',
+        singular: 'foobar', plural: 'foobars',
       });
     });
 
     it('should not handle actions not specified', () => {
-      const s = makeApiList('foobars', 'foobar', {
-        update_singular: 'UPDATE_ONE',
+      const s = makeApiList({
+        plural: 'foobars',
+        singular: 'foobar',
+        actions: { update_singular: 'UPDATE_ONE' },
       });
       const state = s(undefined, {});
       deepFreeze(state);
@@ -58,8 +64,10 @@ describe('api-store', () => {
     });
 
     it('should handle updating many records', () => {
-      const s = makeApiList('foobars', 'foobar', {
-        update_many: 'UPDATE_MANY',
+      const s = makeApiList({
+        plural: 'foobars',
+        singular: 'foobar',
+        actions: { update_many: 'UPDATE_MANY' },
       });
 
       const state = s(undefined, {});
@@ -76,8 +84,10 @@ describe('api-store', () => {
     });
 
     it('should add internal properties to objects', () => {
-      const s = makeApiList('foobars', 'foobar', {
-        update_many: 'UPDATE_MANY',
+      const s = makeApiList({
+        plural: 'foobars',
+        singular: 'foobar',
+        actions: { update_many: 'UPDATE_MANY' },
       });
 
       const state = s(undefined, {});
@@ -103,8 +113,10 @@ describe('api-store', () => {
     });
 
     it('should invoke custom transforms', () => {
-      const s = makeApiList('foobars', 'foobar', {
-        update_many: 'UPDATE_MANY',
+      const s = makeApiList({
+        plural: 'foobars',
+        singular: 'foobar',
+        actions: { update_many: 'UPDATE_MANY' },
       }, o => ({ ...o, test: 1234 }));
 
       const state = s(undefined, {});
@@ -131,8 +143,10 @@ describe('api-store', () => {
     });
 
     it('should handle adding a single resource', () => {
-      const s = makeApiList('foobars', 'foobar', {
-        update_singular: 'UPDATE_SINGLE',
+      const s = makeApiList({
+        plural: 'foobars',
+        singular: 'foobar',
+        actions: { update_singular: 'UPDATE_SINGLE' },
       });
 
       const state = s(undefined, {});
@@ -149,8 +163,10 @@ describe('api-store', () => {
     });
 
     it('should handle updating a single resource', () => {
-      const s = makeApiList('foobars', 'foobar', {
-        update_singular: 'UPDATE_SINGLE',
+      const s = makeApiList({
+        plural: 'foobars',
+        singular: 'foobar',
+        actions: { update_singular: 'UPDATE_SINGLE' },
       });
 
       let state = s(undefined, {});
@@ -176,8 +192,10 @@ describe('api-store', () => {
     });
 
     it('should handle deleting a single resource', () => {
-      const s = makeApiList('foobars', 'foobar', {
-        delete_one: 'DELETE_ONE',
+      const s = makeApiList({
+        plural: 'foobars',
+        singular: 'foobar',
+        actions: { delete_one: 'DELETE_ONE' },
       });
 
       let state = s(undefined, {});
@@ -199,6 +217,67 @@ describe('api-store', () => {
         .to.have.property('foobars')
         .which/* .does*/.not.have.property('foobar_1');
     });
+  });
+
+  function makeApiListWithSub() {
+    return makeApiList({
+      plural: 'foobars',
+      singular: 'foobar',
+      actions: { update_many: 'UPDATE_MANY' },
+      subresources: {
+        foobazes: {
+          singular: 'foobaz',
+          plural: 'foobazes',
+          actions: { update_singular: 'UPDATE_ONE_FOOBAZ' },
+        },
+      },
+    });
+  }
+
+  it('should wire up subresources for items', () => {
+    const s = makeApiListWithSub();
+    const state = s(undefined, {});
+    deepFreeze(state);
+
+    const result = s(state, {
+      type: 'UPDATE_MANY',
+      response: mockFoobarsResponse,
+    });
+
+    expect(result)
+      .to.have.property('foobars')
+      .which.has.property('foobar_1')
+      .which.has.property('foobazes')
+      .which.has.keys(
+        'totalPages',
+        'foobazes',
+        'pagesFetched',
+        'singular',
+        'plural');
+  });
+
+  it('should handle subresource update singular', () => {
+    const s = makeApiListWithSub();
+
+    const state = s(undefined, {
+      type: 'UPDATE_MANY',
+      response: mockFoobarsResponse,
+    });
+    deepFreeze(state);
+
+    const result = s(state, {
+      type: 'UPDATE_ONE_FOOBAZ',
+      foobaz: { id: 'foobaz_123', test: 'hello world' },
+      foobar: 'foobar_1',
+    });
+
+    expect(result)
+      .to.have.property('foobars')
+      .which.has.property('foobar_1')
+      .which.has.property('foobazes')
+      .which.has.property('foobazes')
+      .which.has.property('foobaz_123')
+      .which.has.property('test').that.equals('hello world');
   });
 
   describe('api-store/makeFetchPage', () => {

--- a/test/data.js
+++ b/test/data.js
@@ -84,7 +84,7 @@ export const testLinode = {
   },
   state: 'running',
   datacenter: {
-    id: 'datacenter_6',
+    id: 'newark',
     label: 'Newark, NJ',
     datacenter: 'newark',
   },

--- a/test/linodes/create/layout/IndexPage.spec.js
+++ b/test/linodes/create/layout/IndexPage.spec.js
@@ -82,7 +82,7 @@ describe('linodes/create/layout/IndexPage', () => {
       authentication: { token: 'token' },
     }));
     expect(fetchStub.calledOnce).to.equal(true);
-    expect(fetchStub.firstCall.args[1]).to.equal('/distributions?page=1');
+    expect(fetchStub.firstCall.args[1]).to.equal('/distributions/?page=1');
     expect(dispatch.calledOnce).to.equal(true);
     expect(dispatch.firstCall.args[0].type).to.equal(UPDATE_DISTROS);
 
@@ -92,7 +92,7 @@ describe('linodes/create/layout/IndexPage', () => {
       authentication: { token: 'token' },
     }));
     expect(fetchStub.calledTwice).to.equal(true);
-    expect(fetchStub.secondCall.args[1]).to.equal('/datacenters?page=1');
+    expect(fetchStub.secondCall.args[1]).to.equal('/datacenters/?page=1');
     expect(dispatch.calledOnce).to.equal(true);
     expect(dispatch.firstCall.args[0].type).to.equal(UPDATE_DATACENTERS);
 
@@ -102,7 +102,7 @@ describe('linodes/create/layout/IndexPage', () => {
       authentication: { token: 'token' },
     }));
     expect(fetchStub.calledThrice).to.equal(true);
-    expect(fetchStub.thirdCall.args[1]).to.equal('/services?page=1');
+    expect(fetchStub.thirdCall.args[1]).to.equal('/services/?page=1');
     expect(dispatch.calledOnce).to.equal(true);
     expect(dispatch.firstCall.args[0].type).to.equal(UPDATE_SERVICES);
   });

--- a/test/linodes/layouts/IndexPage.spec.js
+++ b/test/linodes/layouts/IndexPage.spec.js
@@ -45,7 +45,7 @@ describe('linodes/layouts/IndexPage', () => {
       authentication: { token: 'token' },
     }));
     expect(fetchStub.calledOnce).to.equal(true);
-    expect(fetchStub.firstCall.args[1]).to.equal('/linodes?page=1');
+    expect(fetchStub.firstCall.args[1]).to.equal('/linodes/?page=1');
     expect(dispatch.calledOnce).to.equal(true);
     expect(dispatch.firstCall.args[0].type).to.equal(linodeActions.UPDATE_LINODES);
   });


### PR DESCRIPTION
This allows you to specify resource stores that are children of another.
For example:

    "linodes": {
        "linode_1234": {
            "configs": {
                ... this is another API store ...
            }
        }
    }

This also changes how makeApiList is invoked and some of its behavior.