### PR TITLE
Add charset to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.2/css/font-awesome.min.css">
     <title>Linode Manager</title>
   </head>


### PR DESCRIPTION
`&nbsp;` is being replaced by `Â &nbsp;` in production builds for some reason. Some cursory [searching](http://stackoverflow.com/questions/1461907/html-encoding-issues-%C3%82-character-showing-up-instead-of-nbsp) suggests adding the charset specifier.
![screen shot 2016-07-12 at 12 50 04 pm](https://cloud.githubusercontent.com/assets/3925912/16775608/6ac80676-482f-11e6-9ad7-f089e9bca355.png)
