### PR TITLE
Proposing UI Tweaks

### DIFF
--- a/scss/components/card.scss
+++ b/scss/components/card.scss
@@ -105,7 +105,7 @@
         [role=tab] {
             color: $light-black;
             border-radius: 0;
-            padding: 3px 12px;
+            padding: 3px 12px 5px 12px;
 
             &:not(:last-of-type) {
                 margin-right: $main-padding-tb;

--- a/scss/manager.scss
+++ b/scss/manager.scss
@@ -356,7 +356,7 @@ hr {
         $size: 24px;
         .fa {
             color: $lightest-black;
-            line-height: $size;
+            line-height: $size - 2px;
         }
         background-color: $gray;
         font-size: $size / 2;
@@ -368,7 +368,7 @@ hr {
         height: $size;
         border-radius: $size / 2;
         font-weight: bold;
-        text-indent: -0.5px;
+        text-indent: -1px;
 
         &:hover {
             background-color: $blue;
@@ -391,6 +391,7 @@ hr {
         }
         background-color: $red;
         border-color: $red;
+        text-indent: -0.5px;
 
         &:hover {
             background-color: $white;


### PR DESCRIPTION
The main thing is getting the symbols in Help and Warning buttons to be centered, but also want to propose the idea of a little more white space below the tab text, because it seemed a little cramped.
<img width="1162" alt="screen shot 2016-07-20 at 11 03 58 am" src="https://cloud.githubusercontent.com/assets/6047142/16991572/f9c6ee2e-4e69-11e6-92a3-cd758a377a13.png">