### PR TITLE
Pass enable backups to API on create

### DIFF
--- a/src/linodes/create/components/Details.js
+++ b/src/linodes/create/components/Details.js
@@ -23,7 +23,7 @@ export default class Details extends Component {
     this.props.onSubmit({
       password: this.state.password,
       label: this.state.label,
-      enableBackups: this.state.enableBackups,
+      backups: this.state.enableBackups,
     });
   }
 

--- a/src/linodes/create/layouts/IndexPage.js
+++ b/src/linodes/create/layouts/IndexPage.js
@@ -43,17 +43,16 @@ export class IndexPage extends Component {
     }
   }
 
-  async onSubmit({ label, password }) {
+  async onSubmit({ label, password, backups }) {
     const { dispatch } = this.props;
     const { service, source, datacenter } = this.state;
     try {
       this.setState({ loading: true });
       const linode = await dispatch(createLinode({
-        root_pass: password, service, source, datacenter, label,
+        root_pass: password, service, source, datacenter, label, backups,
       }));
       this.setState({ loading: false });
       // TODO: show user introductory stuff
-      // TODO: enable backups
       dispatch(push(`/linodes/${linode.id}`));
     } catch (response) {
       const { errors } = await response.json();

--- a/test/linodes/create/components/Details.spec.js
+++ b/test/linodes/create/components/Details.spec.js
@@ -45,7 +45,7 @@ describe('linodes/create/components/Details', () => {
     expect(onSubmit.firstCall.args[0]).to.deep.equal({
       password: 'my-password',
       label: 'my-label',
-      enableBackups: true,
+      backups: true,
     });
   });
 });

--- a/test/linodes/create/layout/IndexPage.spec.js
+++ b/test/linodes/create/layout/IndexPage.spec.js
@@ -194,7 +194,11 @@ describe('linodes/create/layout/IndexPage', () => {
     expectIsDisabled();
     page.find('SourceSelection').props().onSourceSelected('source');
     expectIsDisabled();
-    await page.find('Details').props().onSubmit({ label: 'label', password: 'password' });
+    await page.find('Details').props().onSubmit({
+      label: 'label',
+      password: 'password',
+      backups: false,
+    });
     expect(dispatch.calledTwice).to.equal(true);
     expect(dispatch.firstCall.args[0]).to.deep.equal({
       root_pass: 'password',
@@ -202,6 +206,7 @@ describe('linodes/create/layout/IndexPage', () => {
       source: 'source',
       datacenter: 'datacenter',
       label: 'label',
+      backups: false,
     });
 
     expect(dispatch.secondCall.args[0]).to.deep.equal(push(`/linodes/${createdLinodeId}`));


### PR DESCRIPTION
Closes #251

cc @Dorthu, this depends on a future feature of the API (passing `backups: true` to POST /linodes)