### PR TITLE
revert the truthiness of the emailHash

### DIFF
--- a/src/reducers/authentication.js
+++ b/src/reducers/authentication.js
@@ -14,7 +14,7 @@ export default function authentication(_state = null, action) {
   switch (action.type) {
     case SET_TOKEN:
       emailHash = action.emailHash;
-      if (action.email && !!emailHash) {
+      if (action.email && !emailHash) {
         emailHash = md5(action.email.trim().toLowerCase());
       }
       setStorage('authentication/oauth-token', action.token);


### PR DESCRIPTION
the code started out as:
```
emailHash = !!action.emailHash ? action.emailHash : md5(action.email.trim().toLowerCase());
```

then it was changed to: `if (action.email && !!emailHash) {`

the intent is if the email hash does not exist in localStorage
generate a new one, if it exists in localStorage pull it out of
there and don't generate a new one.