### PR TITLE
revert the truthiness of action.emailHash

### DIFF
--- a/src/reducers/authentication.js
+++ b/src/reducers/authentication.js
@@ -13,8 +13,7 @@ export default function authentication(_state = null, action) {
   let emailHash = null;
   switch (action.type) {
     case SET_TOKEN:
-      emailHash = action.emailHash;
-      if (action.email && !emailHash) {
+      if (action.email && !action.emailHash) {
         emailHash = md5(action.email.trim().toLowerCase());
       }
       setStorage('authentication/oauth-token', action.token);

--- a/src/reducers/authentication.js
+++ b/src/reducers/authentication.js
@@ -15,6 +15,8 @@ export default function authentication(_state = null, action) {
     case SET_TOKEN:
       if (action.email && !action.emailHash) {
         emailHash = md5(action.email.trim().toLowerCase());
+      } else {
+        emailHash = state.emailHash;
       }
       setStorage('authentication/oauth-token', action.token);
       setStorage('authentication/username', action.username);

--- a/src/reducers/authentication.js
+++ b/src/reducers/authentication.js
@@ -16,7 +16,7 @@ export default function authentication(_state = null, action) {
       if (action.email && !action.emailHash) {
         emailHash = md5(action.email.trim().toLowerCase());
       } else {
-        emailHash = state.emailHash;
+        emailHash = action.emailHash;
       }
       setStorage('authentication/oauth-token', action.token);
       setStorage('authentication/username', action.username);

--- a/test/reducers/authentication.spec.js
+++ b/test/reducers/authentication.spec.js
@@ -3,6 +3,7 @@ import deepFreeze from 'deep-freeze';
 import authentication from '../../src/reducers/authentication';
 import * as actions from '../../src/actions/authentication';
 import { getStorage } from '~/storage';
+import md5 from 'md5';
 
 describe('authentication reducer', () => {
   it('should handle initial state', () => {
@@ -24,6 +25,7 @@ describe('authentication reducer', () => {
         scopes: [],
         username: 'me',
         email: 'me@example.org',
+        emailHash: md5('me@example.org'.trim().toLowerCase()),
         token: 'token',
       })
     ).to.be.eql({
@@ -51,6 +53,32 @@ describe('authentication reducer', () => {
   });
 
   it('should not reproduce #12', () => {
+    window.localStorage.clear();
+    const state = authentication(undefined, {});
+    deepFreeze(state);
+
+    expect(
+      authentication(state, {
+        type: actions.SET_TOKEN,
+        scopes: [],
+        username: 'me',
+        email: 'me@example.org',
+        emailHash: 'cd11923284fc0f904c4732bb8f7d7e3c',
+        token: 'token',
+      })
+    ).to.be.eql({
+      scopes: [],
+      username: 'me',
+      email: 'me@example.org',
+      emailHash: 'cd11923284fc0f904c4732bb8f7d7e3c',
+      token: 'token',
+    });
+    expect(getStorage('authentication/email')).to.equal('me@example.org');
+    expect(getStorage('authentication/email-hash')).to.equal('cd11923284fc0f904c4732bb8f7d7e3c');
+    expect(getStorage('authentication/username')).to.equal('me');
+  });
+
+  it('should work without providing an emailHash', () => {
     window.localStorage.clear();
     const state = authentication(undefined, {});
     deepFreeze(state);

--- a/test/reducers/authentication.spec.js
+++ b/test/reducers/authentication.spec.js
@@ -3,7 +3,6 @@ import deepFreeze from 'deep-freeze';
 import authentication from '../../src/reducers/authentication';
 import * as actions from '../../src/actions/authentication';
 import { getStorage } from '~/storage';
-import md5 from 'md5';
 
 describe('authentication reducer', () => {
   it('should handle initial state', () => {
@@ -25,7 +24,6 @@ describe('authentication reducer', () => {
         scopes: [],
         username: 'me',
         email: 'me@example.org',
-        emailHash: md5('me@example.org'.trim().toLowerCase()),
         token: 'token',
       })
     ).to.be.eql({
@@ -63,7 +61,6 @@ describe('authentication reducer', () => {
         scopes: [],
         username: 'me',
         email: 'me@example.org',
-        emailHash: 'cd11923284fc0f904c4732bb8f7d7e3c',
         token: 'token',
       })
     ).to.be.eql({


### PR DESCRIPTION
the code started out as:
```
emailHash = !!action.emailHash ? action.emailHash :
                                 md5(action.email.trim().toLowerCase());
```

then it was changed to: `if (action.email && !!emailHash) {`

the intent is if the email hash does not exist in localStorage
generate a new one, if it exists in localStorage pull it out of
there and don't generate a new one.

after we ran it we found another problem where the localStorage item
would be set to undefined instead of null.  So we changed it so that
if the action.email was undefined it would set the localStorage to null.
All of the other localStorage items are set to null incase they don't
have a value.

closes #315 