### PR TITLE
Fix modal styles and standardize buttons

### DIFF
--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -21,6 +21,11 @@
     margin-top: $main-padding-tb;
     box-shadow: $box-shadow;
     background: $white;
+
+    .open & {
+        display: block;
+        bottom: auto;
+    }
 }
 
 .modal-header {
@@ -34,8 +39,10 @@
 }
 
 .modal-footer {
-    @extend .pull-right;
     text-align: right;
+    padding-left: 0;
+    padding-right: 0;
+    padding-bottom: 0;
 
     .btn:not(:first-child) {
         margin-left: 0.5rem;

--- a/src/linodes/layouts/BackupsPage.js
+++ b/src/linodes/layouts/BackupsPage.js
@@ -111,16 +111,16 @@ export class BackupsPage extends Component {
         </p>
         <div className="modal-footer">
           <button
+            className="btn btn-default"
+            onClick={() => dispatch(hideModal())}
+          >Nevermind</button>
+          <button
             className="btn btn-primary"
             onClick={() => {
               this.cancelLinodeBackup(linode);
               dispatch(hideModal());
             }}
           >Cancel backups</button>
-          <button
-            className="btn btn-default"
-            onClick={() => dispatch(hideModal())}
-          >Abort</button>
         </div>
       </div>);
   }
@@ -137,16 +137,16 @@ export class BackupsPage extends Component {
         </p>
         <div className="modal-footer">
           <button
+            className="btn btn-default"
+            onClick={() => dispatch(hideModal())}
+          >Nevermind</button>
+          <button
             className="btn btn-primary"
             onClick={() => {
               this.restore(target, backup, true);
               dispatch(hideModal());
             }}
           >Erase and restore</button>
-          <button
-            className="btn btn-default"
-            onClick={() => dispatch(hideModal())}
-          >Cancel</button>
         </div>
       </div>);
   }


### PR DESCRIPTION
![2016-08-17_13 36 13](https://cloud.githubusercontent.com/assets/1310872/17746752/9428cde0-647f-11e6-957a-982aab7439d8.png)

This PR

* Fixes the CSS, the modals probably broke with a recent bootstrap change
* Standardizes the "proceed" action on the right and the "cancel" action on the left
* Uses "Nevermind" to dismiss modals everywhere