### PR TITLE
change th to cubes for icon to more accurately reflect text

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -5,7 +5,7 @@ export default function Sidebar(props) {
   const { path } = props;
 
   const links = [
-    { icon: 'th', name: 'Linodes', link: '/linodes' },
+    { icon: 'cubes', name: 'Linodes', link: '/linodes' },
     { icon: 'code-fork', name: 'NodeBalancers', link: '/nodebalancers' },
     { icon: 'bar-chart-o', name: 'Longview', link: '/longview' },
     { icon: 'share-alt', name: 'DNS Manager', link: '/dnsmanager' },


### PR DESCRIPTION
Before:
<img width="162" alt="screen shot 2016-08-23 at 4 20 25 pm" src="https://cloud.githubusercontent.com/assets/1616275/17908225/905cc34c-694d-11e6-9154-db4f3de873d4.png">

After:
<img width="150" alt="screen shot 2016-08-23 at 4 20 32 pm" src="https://cloud.githubusercontent.com/assets/1616275/17908235/96845d3e-694d-11e6-91c5-ba2e5bab5772.png">
