### PR TITLE
Fix Linode Table List Right Border

### DIFF
--- a/src/linodes/components/Linode.js
+++ b/src/linodes/components/Linode.js
@@ -183,7 +183,7 @@ function renderRow(props) {
   const checkbox = <input type="checkbox" checked={isSelected} onClick={select} />;
 
   return (
-    <tr className={`linode row ${linode.state} ${selectedClass}`}>
+    <tr className={`linode ${linode.state} ${selectedClass}`}>
       <td>{checkbox}</td>
       <td>
         <Link to={`/linodes/${linode.id}`} className="linode-label">{linode.label}</Link>

--- a/test/linodes/components/Linode.spec.js
+++ b/test/linodes/components/Linode.spec.js
@@ -75,8 +75,7 @@ describe('linodes/components/Linode', () => {
       />);
 
     expect(linode.find('tr').props().className)
-      .to.contain('linode')
-      .and.contain('row');
+      .to.contain('linode');
   });
 
   it('invokes the onSelect function when the checkbox is toggled', () => {


### PR DESCRIPTION
Closes #371 

This took some hunting to find a permanent fix.  Turns out it is caused by bootstrap, due to:
.row::after {
    content: '';
}

After playing around, the only solution was to remove .row, which turns out we don't need there anyways, since we aren't using col-[size]-# for sizing the cells.  This should be fixed once and for all though.