### PR TITLE
Remove border from modal footer

### DIFF
--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -43,6 +43,7 @@
     padding-left: 0;
     padding-right: 0;
     padding-bottom: 0;
+    border-top: 0;
 
     .btn:not(:first-child) {
         margin-left: 0.5rem;


### PR DESCRIPTION
Closes #400

Not sure where the border was coming from in the first place. Inspect element said it came from modal-footer but there wasn't any mention of a border there.