### PR TITLE
Fix circular dependencies

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,11 +1,11 @@
 var webpack = require("webpack");
-var webpackKarma = require("karma-webpack");
 var path = require("path");
+var CircularDependencyPlugin = require('circular-dependency-plugin');
 
 module.exports = function(config) {
   config.set({
     frameworks: ['mocha'],
-    browsers: ['PhantomJS'],
+    browsers: ['PhantomJS', 'Chrome'],
     files: [
       './node_modules/phantomjs-polyfill/bind-polyfill.js',
       'test/index.js',
@@ -59,6 +59,10 @@ module.exports = function(config) {
           ENV_API_ROOT: null,
           ENV_LOGIN_ROOT: null,
           ENV_APP_ROOT: null
+        }),
+        new CircularDependencyPlugin({
+          failOnError: true,
+          exclude: /node_modules/,
         })
       ]
     },
@@ -75,10 +79,11 @@ module.exports = function(config) {
       subdir: '.'
     },
     plugins: [
-      webpackKarma,
+      require("karma-webpack"),
       require("karma-mocha"),
       require("karma-spec-reporter"),
       require("karma-phantomjs-launcher"),
+      require("karma-chrome-launcher"),
       require("karma-sourcemap-loader"),
       require("karma-coverage")
     ],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,7 +5,7 @@ var CircularDependencyPlugin = require('circular-dependency-plugin');
 module.exports = function(config) {
   config.set({
     frameworks: ['mocha'],
-    browsers: ['PhantomJS', 'Chrome'],
+    browsers: ['PhantomJS'],
     files: [
       './node_modules/phantomjs-polyfill/bind-polyfill.js',
       'test/index.js',

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-react-hmre": "^1.0.0",
     "babel-root-import": "^4.1.0",
     "chai": "^3.5.0",
+    "circular-dependency-plugin": "^2.0.0",
     "coveralls": "^2.11.9",
     "cross-env": "^1.0.6",
     "enzyme": "^2.3.0",

--- a/src/api/configs/datacenters.js
+++ b/src/api/configs/datacenters.js
@@ -1,5 +1,7 @@
-import { genConfig, genThunks, genReducer, genActions } from '~/api/gen';
-import { ONE, MANY } from '~/api/gen';
+import {
+  genConfig, genReducer, genActions,
+  ONE, MANY,
+} from '~/api/gen';
 
 export const config = genConfig({
   plural: 'datacenters',
@@ -9,5 +11,4 @@ export const config = genConfig({
 });
 
 export const actions = genActions(config);
-export const thunks = genThunks(config, actions);
 export const reducer = genReducer(config);

--- a/src/api/configs/distributions.js
+++ b/src/api/configs/distributions.js
@@ -1,5 +1,7 @@
-import { genConfig, genThunks, genReducer, genActions } from '~/api/gen';
-import { ONE, MANY } from '~/api/gen';
+import {
+  genConfig, genReducer, genActions,
+  ONE, MANY,
+} from '~/api/gen';
 
 export const config = genConfig({
   plural: 'distributions',
@@ -9,5 +11,4 @@ export const config = genConfig({
 });
 
 export const actions = genActions(config);
-export const thunks = genThunks(config, actions);
 export const reducer = genReducer(config);

--- a/src/api/configs/kernels.js
+++ b/src/api/configs/kernels.js
@@ -1,5 +1,7 @@
-import { genConfig, genThunks, genReducer, genActions } from '~/api/gen';
-import { ONE, MANY } from '~/api/gen';
+import {
+  genConfig, genReducer, genActions,
+  ONE, MANY,
+} from '~/api/gen';
 
 export const config = genConfig({
   plural: 'kernels',
@@ -9,5 +11,4 @@ export const config = genConfig({
 });
 
 export const actions = genActions(config);
-export const thunks = genThunks(config, actions);
 export const reducer = genReducer(config);

--- a/src/api/configs/linodes.js
+++ b/src/api/configs/linodes.js
@@ -1,5 +1,7 @@
-import { genConfig, genThunks, genReducer, genActions } from '~/api/gen';
-import { ONE, MANY, PUT, DELETE, POST } from '~/api/gen';
+import {
+  genConfig, genReducer, genActions,
+  ONE, MANY, PUT, DELETE, POST,
+} from '~/api/gen';
 
 export const config = genConfig({
   plural: 'linodes',
@@ -29,5 +31,4 @@ export const config = genConfig({
 });
 
 export const actions = genActions(config);
-export const thunks = genThunks(config, actions);
 export const reducer = genReducer(config);

--- a/src/api/configs/types.js
+++ b/src/api/configs/types.js
@@ -1,5 +1,7 @@
-import { genConfig, genThunks, genReducer, genActions } from '~/api/gen';
-import { ONE, MANY } from '~/api/gen';
+import {
+  genConfig, genReducer, genActions,
+  ONE, MANY,
+} from '~/api/gen';
 
 export const config = genConfig({
   plural: 'types',
@@ -9,5 +11,4 @@ export const config = genConfig({
 });
 
 export const actions = genActions(config);
-export const thunks = genThunks(config, actions);
 export const reducer = genReducer(config);

--- a/src/api/genThunks.js
+++ b/src/api/genThunks.js
@@ -1,0 +1,193 @@
+import _ from 'lodash';
+
+import { ONE, MANY, DELETE, POST, PUT } from './gen';
+import { fetch } from '../fetch';
+
+function refineState(config, state, ids) {
+  const path = [];
+  let root = config;
+  const match = (sub, parent) => {
+    if (parent.subresources[sub] === root) {
+      path.push(sub);
+    }
+  };
+  while (root.parent) {
+    const parent = root.parent;
+    Object.keys(parent.subresources).forEach(s => match(s, parent));
+    root = parent;
+  }
+  let refined = state.api[root.plural];
+  const _ids = [...ids];
+  let current = root;
+  let name = null;
+  while (current !== config) {
+    name = path.pop();
+    refined = refined[current.plural][_ids.shift()][name];
+    current = current.subresources[name];
+  }
+  return refined;
+}
+
+function genThunkOne(config, actions) {
+  return (...ids) => async (dispatch, getState) => {
+    let overwrite = false;
+    if (typeof ids[ids.length - 1] === 'boolean') {
+      overwrite = ids.pop();
+    }
+    const state = refineState(config, getState(), ids);
+    const id = ids[ids.length - 1];
+    const prev = state[config.plural][id];
+    if (!overwrite && !_.isUndefined(prev)) {
+      return prev;
+    }
+    const { token } = getState().authentication;
+    const response = await fetch(token, config.endpoint(...ids));
+    const resource = await response.json();
+    dispatch(actions.one(resource, ...ids));
+    return resource;
+  };
+}
+
+function genThunkPage(config, actions) {
+  function fetchPage(page = 0, ...ids) {
+    return async (dispatch, getState) => {
+      const { token } = getState().authentication;
+      const state = refineState(config, getState(), ids);
+      if (state.totalPages !== -1 &&
+          state.pagesFetched.indexOf(page) !== -1) {
+        // cache hit
+        return;
+      }
+      // Update the pages fetched first so we don't double-fetch this resource
+      dispatch(actions.many({
+        page: page + 1,
+        totalPages: -2,
+        totalResults: -2,
+        [config.plural]: [],
+      }, ...ids));
+      const endpoint = `${config.endpoint(...ids, '')}?page=${page + 1}`;
+      const response = await fetch(token, endpoint);
+      const resources = await response.json();
+      actions.many();
+      if (state.totalPages !== -1 &&
+          state.totalResults !== resources.totalResults) {
+        dispatch(actions.invalidate());
+        for (let i = 0; i < state.pagesFetched.length; i += 1) {
+          if (state.pagesFetched[i] - 1 !== page) {
+            await dispatch(fetchPage(state.pagesFetched[i] - 1, ...ids));
+          }
+        }
+      }
+      dispatch(actions.many(resources, ...ids));
+      return resources;
+    };
+  }
+  return fetchPage;
+}
+
+function genThunkAll(config, page) {
+  return (...ids) => async (dispatch, getState) => {
+    let state = refineState(config, getState(), ids);
+    if (state.totalPages === -1) {
+      await dispatch(page(0, ...ids));
+      state = refineState(config, getState(), ids);
+    }
+
+    for (let i = 1; i < state.totalPages; i += 1) {
+      if (state.pagesFetched.indexOf(i + 1) === -1) {
+        await dispatch(page(i, ...ids));
+      }
+    }
+  };
+}
+
+function genThunkUntil(config, actions, one) {
+  return (test, ...ids) => async (dispatch) => {
+    dispatch(actions.one({ _polling: true }, ...ids));
+    for (;;) {
+      try {
+        const resource = await dispatch(one(...ids, true));
+        if (test(resource)) break;
+      } catch (ex) {
+        if (ex.statusCode === 404) {
+          dispatch(actions.delete(...ids));
+          return;
+        }
+        throw ex;
+      }
+      await new Promise(r => setTimeout(r, 3000));
+    }
+    dispatch(actions.one({ _polling: false }, ...ids));
+  };
+}
+
+function genThunkDelete(config, actions) {
+  return (...ids) => async (dispatch, getState) => {
+    const { token } = getState().authentication;
+    const response = await fetch(token, config.endpoint(...ids),
+      { method: 'DELETE' });
+    const json = await response.json();
+    dispatch(actions.delete(...ids));
+    return json;
+  };
+}
+
+function genThunkPut(config, actions) {
+  return (resource, ...ids) => async (dispatch, getState) => {
+    const { token } = getState().authentication;
+    const response = await fetch(token, config.endpoint(...ids), {
+      method: 'PUT',
+      body: JSON.stringify(resource),
+    });
+    const json = await response.json();
+    dispatch(actions.one(json, ...ids));
+    return json;
+  };
+}
+
+function genThunkPost(config, actions) {
+  return (resource, ...ids) => async (dispatch, getState) => {
+    const { token } = getState().authentication;
+    const response = await fetch(token, config.endpoint(...ids, ''), {
+      method: 'POST',
+      body: JSON.stringify(resource),
+    });
+    const json = await response.json();
+    dispatch(actions.one(json, ...ids));
+    return json;
+  };
+}
+
+/**
+ * Generates thunks for the provided config.
+ */
+export default function genThunks(config, actions) {
+  const thunks = { };
+  const supports = a => config.supports.indexOf(a) !== -1;
+  if (supports(ONE)) {
+    thunks.one = genThunkOne(config, actions);
+    thunks.until = genThunkUntil(config, actions, thunks.one);
+  }
+  if (supports(MANY)) {
+    thunks.page = genThunkPage(config, actions);
+    thunks.all = genThunkAll(config, thunks.page);
+  }
+  if (supports(DELETE)) {
+    thunks.delete = genThunkDelete(config, actions);
+  }
+  if (supports(PUT)) {
+    thunks.put = genThunkPut(config, actions);
+  }
+  if (supports(POST)) {
+    thunks.post = genThunkPost(config, actions);
+  }
+  if (config.subresources) {
+    Object.keys(config.subresources).forEach((key) => {
+      const subr = config.subresources[key];
+      const plural = subr.plural;
+      thunks[plural] = genThunks(subr, actions[plural]);
+    });
+  }
+  thunks.type = config.plural;
+  return thunks;
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,5 +1,13 @@
-export { thunks as distros } from './configs/distributions';
-export { thunks as datacenters } from './configs/datacenters';
-export { thunks as types } from './configs/types';
-export { thunks as linodes } from './configs/linodes';
-export { thunks as kernels } from './configs/kernels';
+import * as distributionsModule from './configs/distributions';
+import * as datacentersModule from './configs/datacenters';
+import * as typesModule from './configs/types';
+import * as linodesModule from './configs/linodes';
+import * as kernelsModule from './configs/kernels';
+
+import genThunks from './genThunks';
+
+export const distributions = genThunks(distributionsModule.config, distributionsModule.actions);
+export const datacenters = genThunks(datacentersModule.config, datacentersModule.actions);
+export const types = genThunks(typesModule.config, typesModule.actions);
+export const linodes = genThunks(linodesModule.config, linodesModule.actions);
+export const kernels = genThunks(kernelsModule.config, kernelsModule.actions);

--- a/src/api/linodes.js
+++ b/src/api/linodes.js
@@ -1,5 +1,6 @@
 import { fetch } from '~/fetch';
-import { actions, thunks } from './configs/linodes';
+import { linodes as thunks } from '~/api';
+import { actions } from './configs/linodes';
 
 function linodeAction(id, action, temp, expected, body = undefined) {
   return async (dispatch, getState) => {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,8 +1,9 @@
-import { API_ROOT } from './constants';
 import * as isomorphicFetch from 'isomorphic-fetch';
+
 import store from '~/store';
 import checkLogin from '~/session';
 import { setToken } from '~/actions/authentication';
+import { API_ROOT } from './constants';
 
 /*
  * Sinon cannot stub out a function in a function-only module.
@@ -38,7 +39,7 @@ export function fetch(token, _path, _options) {
   const path = API_ROOT + _path;
   const promise = fetchRef(path, options);
   return new Promise((accept, reject) => {
-    promise.then(response => {
+    promise.then((response) => {
       const _status = response.headers.get('X-Status');
       const status = _status ? parseInt(_status, 10) : response.status;
       // eslint-disable-next-line no-param-reassign

--- a/src/linodes/create/components/Source.js
+++ b/src/linodes/create/components/Source.js
@@ -12,22 +12,22 @@ export default class Source extends Component {
     this.render = this.render.bind(this);
     this.renderSourceTabs = this.renderSourceTabs.bind(this);
     this.renderHeader = this.renderHeader.bind(this);
-    this.renderDistros = this.renderDistros.bind(this);
+    this.renderDistributions = this.renderDistributions.bind(this);
     this.state = { backupsPage: 0, backupsFilter: '', selectedLinode: -1 };
   }
 
-  renderDistros() {
-    const { distros, distribution, onSourceSelected } = this.props;
+  renderDistributions() {
+    const { distributions, distribution, onSourceSelected } = this.props;
     const vendors = _.sortBy(
       _.map(
-        _.groupBy(Object.values(distros), d => d.vendor),
+        _.groupBy(Object.values(distributions), d => d.vendor),
         (v, k) => ({
           name: k,
           versions: _.orderBy(v, ['recommended', 'created'], ['desc', 'desc']),
         })
       ), vendor => vendor.name);
     return (
-      <div className="distros">
+      <div className="distributions">
         {vendors.map(v =>
           <Distributions
             selected={distribution}
@@ -176,7 +176,7 @@ export default class Source extends Component {
             <Tab>Backups</Tab>
           </TabList>
           <TabPanel>
-            {this.renderDistros()}
+            {this.renderDistributions()}
           </TabPanel>
           <TabPanel>
             {this.renderBackups()}
@@ -205,7 +205,7 @@ export default class Source extends Component {
 }
 
 Source.propTypes = {
-  distros: PropTypes.object.isRequired,
+  distributions: PropTypes.object.isRequired,
   linodes: PropTypes.object.isRequired,
   selectedTab: PropTypes.number.isRequired,
   onTabChange: PropTypes.func,

--- a/src/linodes/create/layouts/IndexPage.js
+++ b/src/linodes/create/layouts/IndexPage.js
@@ -7,7 +7,7 @@ import Plan from '../components/Plan';
 import Datacenter from '../components/Datacenter';
 import Details from '../components/Details';
 import { parallel } from '~/api/util';
-import { linodes, distros, datacenters, types } from '~/api';
+import { linodes, distributions, datacenters, types } from '~/api';
 import { setError } from '~/actions/errors';
 
 export class IndexPage extends Component {
@@ -32,7 +32,7 @@ export class IndexPage extends Component {
     const { dispatch } = this.props;
     try {
       await dispatch(parallel(
-        distros.all(),
+        distributions.all(),
         datacenters.all(),
         types.all(),
         linodes.all(),
@@ -130,7 +130,7 @@ export class IndexPage extends Component {
 
   render() {
     const {
-      distros,
+      distributions,
       linodes,
       datacenters,
       types,
@@ -159,7 +159,7 @@ export class IndexPage extends Component {
             distribution={distribution}
             backup={backup}
             selectedTab={sourceTab}
-            distros={distros.distributions}
+            distributions={distributions.distributions}
             onTabChange={ix => this.setState({ sourceTab: ix })}
             onSourceSelected={(type, id, linodeId) => {
               if (type === 'backup' && linodeId && id) {
@@ -207,7 +207,7 @@ export class IndexPage extends Component {
 
 IndexPage.propTypes = {
   dispatch: PropTypes.func.isRequired,
-  distros: PropTypes.object,
+  distributions: PropTypes.object,
   linodes: PropTypes.object,
   types: PropTypes.object,
   datacenters: PropTypes.object,
@@ -216,7 +216,7 @@ IndexPage.propTypes = {
 
 function select(state) {
   return {
-    distros: state.api.distributions,
+    distributions: state.api.distributions,
     linodes: state.api.linodes,
     datacenters: state.api.datacenters,
     types: state.api.types,

--- a/src/linodes/linode/settings/components/DiskPanel.js
+++ b/src/linodes/linode/settings/components/DiskPanel.js
@@ -1,13 +1,14 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 import { connect } from 'react-redux';
-import { linodes, distros } from '~/api';
+import _ from 'lodash';
+
+import { linodes, distributions } from '~/api';
 import { resizeLinodeDisk } from '~/api/linodes';
 import HelpButton from '~/components/HelpButton';
 import PasswordInput from '~/components/PasswordInput';
 import { getLinode, loadLinode } from '~/linodes/linode/layouts/IndexPage';
 import { showModal, hideModal } from '~/actions/modal';
-import _ from 'lodash';
 import { ErrorSummary, FormGroup, reduceErrors } from '~/errors';
 
 const borderColors = [
@@ -175,7 +176,7 @@ export class AddModal extends Component {
   async componentDidMount() {
     const { dispatch, free } = this.props;
     this.setState({ size: free });
-    await dispatch(distros.all());
+    await dispatch(distributions.all());
     this.setState({ loading: false });
   }
 

--- a/test/data/distributions.js
+++ b/test/data/distributions.js
@@ -13,7 +13,7 @@ export const testDistro = {
   _polling: false,
 };
 
-export const distros = {
+export const distributions = {
   'linode/arch2016.05': testDistro,
   'linode/debian7': {
     ...testDistro,

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -3,7 +3,7 @@ import reducer from '~/reducers';
 import deepFreeze from 'deep-freeze';
 
 import { linodes } from './linodes';
-import { distros } from './distros';
+import { distributions } from './distributions';
 import { datacenters } from './datacenters';
 import { types } from './types';
 import { kernels } from './kernels';
@@ -27,8 +27,8 @@ export const api = {
     linodes,
   },
   distributions: {
-    ...fakeAPIStore(distros, 'distribution', 'distributions'),
-    distributions: distros,
+    ...fakeAPIStore(distributions, 'distribution', 'distributions'),
+    distributions: distributions,
   },
   datacenters: {
     ...fakeAPIStore(datacenters, 'datacenter', 'datacenters'),

--- a/test/data/index.js
+++ b/test/data/index.js
@@ -28,7 +28,7 @@ export const api = {
   },
   distributions: {
     ...fakeAPIStore(distributions, 'distribution', 'distributions'),
-    distributions: distributions,
+    distributions,
   },
   datacenters: {
     ...fakeAPIStore(datacenters, 'datacenter', 'datacenters'),

--- a/test/linodes/create/components/Distributions.spec.js
+++ b/test/linodes/create/components/Distributions.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { distros } from '~/assets';
-import { distros as testDistros } from '@/data/distros';
+import { distributions as testDistros } from '@/data/distributions';
 import Distributions from '~/linodes/create/components/Distributions';
 
 describe('linodes/create/components/Distributions', () => {

--- a/test/linodes/create/components/Source.spec.js
+++ b/test/linodes/create/components/Source.spec.js
@@ -18,7 +18,7 @@ describe('linodes/create/components/Source', () => {
   it('renders the card header', () => {
     const c = shallow(
       <Source
-        distros={api.distributions}
+        distributions={api.distributions}
         linodes={api.linodes}
         distribution={null}
         backup={null}
@@ -31,7 +31,7 @@ describe('linodes/create/components/Source', () => {
   it('renders the source tabs', () => {
     const c = shallow(
       <Source
-        distros={api.distributions}
+        distributions={api.distributions}
         linodes={api.linodes}
         distribution={null}
         backup={null}
@@ -46,7 +46,7 @@ describe('linodes/create/components/Source', () => {
     const onTabChange = sandbox.spy();
     const c = shallow(
       <Source
-        distros={api.distributions}
+        distributions={api.distributions}
         linodes={api.linodes}
         distribution={null}
         backup={null}
@@ -61,7 +61,7 @@ describe('linodes/create/components/Source', () => {
   it('renders Distributions', () => {
     const c = shallow(
       <Source
-        distros={api.distributions.distributions}
+        distributions={api.distributions.distributions}
         linodes={api.linodes}
         distribution={null}
         backup={null}
@@ -78,7 +78,7 @@ describe('linodes/create/components/Source', () => {
     const onSourceSelected = sandbox.spy();
     const c = shallow(
       <Source
-        distros={api.distributions}
+        distributions={api.distributions}
         linodes={api.linodes}
         distribution={null}
         backup={null}
@@ -109,7 +109,7 @@ describe('linodes/create/components/Source', () => {
   it('renders Linodes', () => {
     const c = shallow(
       <Source
-        distros={api.distributions}
+        distributions={api.distributions}
         linodes={moreBackupsLinodes}
         distribution={null}
         backup={null}
@@ -125,7 +125,7 @@ describe('linodes/create/components/Source', () => {
   it('only shows shows n linodes per page of Backups', () => {
     const c = shallow(
       <Source
-        distros={api.distributions}
+        distributions={api.distributions}
         linodes={moreBackupsLinodes}
         distribution={null}
         backup={null}
@@ -148,7 +148,7 @@ describe('linodes/create/components/Source', () => {
   it('changes pages when requested', () => {
     const c = shallow(
       <Source
-        distros={api.distributions}
+        distributions={api.distributions}
         linodes={moreBackupsLinodes}
         distribution={null}
         backup={null}
@@ -191,7 +191,7 @@ describe('linodes/create/components/Source', () => {
   it('filters backups when updating filter', () => {
     const c = shallow(
       <Source
-        distros={api.distributions}
+        distributions={api.distributions}
         linodes={moreBackupsLinodes}
         distribution={null}
         backup={null}

--- a/test/linodes/create/layout/IndexPage.spec.js
+++ b/test/linodes/create/layout/IndexPage.spec.js
@@ -6,7 +6,7 @@ import { push } from 'react-router-redux';
 
 import { IndexPage } from '~/linodes/create/layouts/IndexPage';
 import * as errors from '~/actions/errors';
-import { thunks } from '~/api/configs/linodes';
+import { linodes as thunks } from '~/api';
 import { api } from '@/data';
 
 describe('linodes/create/layout/IndexPage', () => {
@@ -20,7 +20,7 @@ describe('linodes/create/layout/IndexPage', () => {
       const page = shallow(
         <IndexPage
           dispatch={() => {}}
-          distros={api.distributions}
+          distributions={api.distributions}
           datacenters={api.datacenters}
           types={api.types}
           linodes={api.linodes}
@@ -40,7 +40,7 @@ describe('linodes/create/layout/IndexPage', () => {
     const page = shallow(
       <IndexPage
         dispatch={() => {}}
-        distros={api.distributions}
+        distributions={api.distributions}
         datacenters={api.datacenters}
         types={api.types}
         linodes={api.linodes}
@@ -55,7 +55,7 @@ describe('linodes/create/layout/IndexPage', () => {
     const page = shallow(
       <IndexPage
         dispatch={dispatch}
-        distros={api.distributions}
+        distributions={api.distributions}
         datacenters={api.datacenters}
         types={api.types}
         linodes={api.linodes}
@@ -84,7 +84,7 @@ describe('linodes/create/layout/IndexPage', () => {
     const page = shallow(
       <IndexPage
         dispatch={dispatch}
-        distros={api.distributions}
+        distributions={api.distributions}
         datacenters={api.datacenters}
         types={api.types}
         linodes={api.linodes}
@@ -101,7 +101,7 @@ describe('linodes/create/layout/IndexPage', () => {
     const page = shallow(
       <IndexPage
         dispatch={() => {}}
-        distros={api.distributions}
+        distributions={api.distributions}
         datacenters={api.datacenters}
         types={api.types}
         linodes={api.linodes}
@@ -115,7 +115,7 @@ describe('linodes/create/layout/IndexPage', () => {
     const page = shallow(
       <IndexPage
         dispatch={() => {}}
-        distros={api.distributions}
+        distributions={api.distributions}
         datacenters={api.datacenters}
         types={api.types}
         linodes={api.linodes}
@@ -129,7 +129,7 @@ describe('linodes/create/layout/IndexPage', () => {
     const page = shallow(
       <IndexPage
         dispatch={() => {}}
-        distros={api.distributions}
+        distributions={api.distributions}
         datacenters={api.datacenters}
         types={api.types}
         linodes={api.linodes}
@@ -147,7 +147,7 @@ describe('linodes/create/layout/IndexPage', () => {
     const page = shallow(
       <IndexPage
         dispatch={dispatch}
-        distros={api.distributions}
+        distributions={api.distributions}
         datacenters={api.datacenters}
         types={api.types}
         linodes={api.linodes}
@@ -188,7 +188,7 @@ describe('linodes/create/layout/IndexPage', () => {
     const page = shallow(
       <IndexPage
         dispatch={dispatch}
-        distros={api.distributions}
+        distributions={api.distributions}
         datacenters={api.datacenters}
         types={api.types}
         linodes={api.linodes}
@@ -239,7 +239,7 @@ describe('linodes/create/layout/IndexPage', () => {
     const page = shallow(
       <IndexPage
         dispatch={dispatch}
-        distros={api.distributions}
+        distributions={api.distributions}
         datacenters={api.datacenters}
         types={api.types}
         linodes={api.linodes}
@@ -297,7 +297,7 @@ describe('linodes/create/layout/IndexPage', () => {
     const page = shallow(
       <IndexPage
         dispatch={dispatch}
-        distros={api.distributions}
+        distributions={api.distributions}
         datacenters={api.datacenters}
         types={api.types}
         linodes={api.linodes}

--- a/test/linodes/layouts/IndexPage.spec.js
+++ b/test/linodes/layouts/IndexPage.spec.js
@@ -11,7 +11,7 @@ import { testLinode } from '@/data/linodes';
 import Dropdown from '~/components/Dropdown';
 import { SET_ERROR } from '~/actions/errors';
 import { expectRequest } from '@/common.js';
-import { thunks } from '~/api/configs/linodes';
+import { linodes as thunks } from '~/api';
 
 const { linodes } = api;
 

--- a/test/linodes/linode/layouts/IndexPage.spec.js
+++ b/test/linodes/linode/layouts/IndexPage.spec.js
@@ -8,7 +8,8 @@ import { api, freshState } from '@/data';
 import { testLinode } from '@/data/linodes';
 import { expectRequest } from '@/common';
 import * as IndexPageWrapper from '~/linodes/linode/layouts/IndexPage';
-import { actions, thunks } from '~/api/configs/linodes';
+import { actions } from '~/api/configs/linodes';
+import { linodes as thunks } from '~/api';
 import Dropdown from '~/components/Dropdown';
 import { SET_ERROR } from '~/actions/errors';
 

--- a/test/linodes/linode/settings/components/DiskPanel.spec.js
+++ b/test/linodes/linode/settings/components/DiskPanel.spec.js
@@ -323,7 +323,7 @@ describe('linodes/linode/settings/components/DiskPanel', () => {
       free: 4096,
     };
 
-    it('should fetch distros on mount', async () => {
+    it('should fetch distributions on mount', async () => {
       const dispatch = sandbox.spy();
       const modal = shallow(
         <AddModal


### PR DESCRIPTION
Circular dependencies left me with a nasty bug I discovered in #536 (why it's taken me so long to get tests passing in that PR). It took forever to figure out that this actually was a circular dependency issue. Modules were seemingly imported multiple times and certain exported values within the module were undefined. I refactored the api code a bit to not need circular dependencies any more.

While I was trying to figure out what was going on, I also upgraded all packages in case there was an issue in babel or sth. I upgraded the linter during that time and started fixing linter issues - so that's why there are a few random changes. I'll be submitting another PR soon with all packages upgraded and the full linter changes (some 300+ changes or sth).

This PR is a WIP because I haven't yet tested out how the code works for real - I just finally got tests passing. However, I recommend this PR get merged as soon as possible because the bugs I saw in #536 could show up for anyone at any time because there are circular dependencies in our code _right now_.

Also, there's some weird stuff going on locally where this test keeps failing:

```
) renders the projected time of the first backup when its window is < $NOW
     linodes/components/Linode renderBackupStatus
12 10 2016 22:31:00.533:WARN [reporter]: SourceMap position not found for trace: undefined
     expected 'In ~an hour' to equal 'In ~a day'
AssertionError@webpack:///~/assertion-error/index.js:74:0 <- test/index.js:303:25
assert@webpack:///~/chai/lib/chai/assertion.js:107:0 <- test/index.js:4635:32
assertEqual@webpack:///~/chai/lib/chai/core/assertions.js:487:0 <- test/index.js:5152:19
webpack:///~/chai/lib/chai/utils/addMethod.js:41:0 <- test/index.js:4222:31
test/index.js:104379:9517
```

I do not understand - it even fails on master (with no changes) locally here. @na3d @abemassry @briansteffens Can anyone corroborate?