### PR TITLE
Reset password modal

### DIFF
--- a/src/linodes/linode/backups/layouts/SettingsPage.js
+++ b/src/linodes/linode/backups/layouts/SettingsPage.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import { Link } from 'react-router';
 import { connect } from 'react-redux';
 
 import { ErrorSummary, FormGroup, reduceErrors } from '~/errors';
@@ -25,11 +24,11 @@ export class CancelBackupsModal extends Component {
           This cannot be undone.
         </p>
         <div className="modal-footer">
-          <Link
+          <button
             className="btn btn-cancel"
             disabled={loading}
             onClick={() => dispatch(hideModal())}
-          >Nevermind</Link>
+          >Nevermind</button>
           <button
             className="btn btn-danger"
             disabled={loading}

--- a/src/linodes/linode/backups/layouts/SettingsPage.js
+++ b/src/linodes/linode/backups/layouts/SettingsPage.js
@@ -46,7 +46,7 @@ export class CancelBackupsModal extends Component {
 }
 
 CancelBackupsModal.propTypes = {
-  linodeId: PropTypes.string.isRequired,
+  linodeId: PropTypes.number.isRequired,
   dispatch: PropTypes.func.isRequired,
 };
 

--- a/test/linodes/linode/layouts/RescuePage.spec.js
+++ b/test/linodes/linode/layouts/RescuePage.spec.js
@@ -223,39 +223,5 @@ describe('linodes/linode/layouts/RescuePage', () => {
       await expectRequest(fn, '/linode/instances/1237/disks/1234/password', dispatched,
                          { }, { method: 'POST' });
     });
-
-    it('power cycles running Linodes when resetting password', async () => {
-      const page = shallow(
-        <RescuePage
-          dispatch={dispatch}
-          linodes={linodes}
-          params={{ linodeId: '1234' }}
-        />);
-      page.setState({ loading: false, disk: 1234, password: 'new password' });
-      const { resetRootPassword } = page.instance();
-      await resetRootPassword();
-      let dispatched = dispatch.firstCall.args[0];
-      const fetchStub = sandbox.stub(fetch, 'fetch').returns({ json: () => {} });
-      const state = {
-        authentication: { token: 'hi' },
-        linodes: {
-          ...linodes,
-          linodes: {
-            ...linodes.linodes,
-            [testLinode.id]: { ...testLinode, status: 'offline' },
-          },
-        },
-      };
-      await dispatched(dispatch, () => state);
-      expect(fetchStub.calledOnce).to.equal(true);
-      expect(fetchStub.firstCall.args[1]).to.equal(
-        '/linode/instances/1234/shutdown');
-      fetchStub.reset();
-      dispatched = dispatch.thirdCall.args[0];
-      await dispatched(dispatch, () => state);
-      expect(fetchStub.calledOnce).to.equal(true);
-      expect(fetchStub.firstCall.args[1]).to.equal(
-        '/linode/instances/1234/boot');
-    });
   });
 });

--- a/test/linodes/linode/layouts/RescuePage.spec.js
+++ b/test/linodes/linode/layouts/RescuePage.spec.js
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 
 import * as fetch from '~/fetch';
 import { testLinode } from '@/data/linodes';
+import { SHOW_MODAL } from '~/actions/modal';
 import { RescuePage } from '~/linodes/linode/layouts/RescuePage';
 import { expectRequest } from '@/common';
 
@@ -222,6 +223,20 @@ describe('linodes/linode/layouts/RescuePage', () => {
       const dispatched = () => ({ authentication: { token: 'hi' } });
       await expectRequest(fn, '/linode/instances/1237/disks/1234/password', dispatched,
                          { }, { method: 'POST' });
+    });
+
+    it('shows a modal when reset root password button is pressed', async () => {
+      const page = shallow(
+        <RescuePage
+          dispatch={dispatch}
+          linodes={linodes}
+          params={{ linodeId: '1237' }}
+        />);
+      page.setState({ loading: false, disk: 1234, password: 'new password' });
+      page.find('button').simulate('click');
+      expect(dispatch.calledOnce).to.equal(true);
+      expect(dispatch.firstCall.args[0])
+        .to.have.property('type').which.equals(SHOW_MODAL);
     });
   });
 });


### PR DESCRIPTION
shows a modal before a password reset is issued on a Linode

changes the logic so that the button to raise the modal only works if the Linode is powered off.  Includes info text that says Linode must be powered off to reset the password.

![screen shot 2016-11-15 at 12 07 42 pm](https://cloud.githubusercontent.com/assets/1616275/20315514/2654819e-ab2c-11e6-84c2-74d966ea8c34.png)


Closes #513 
Closes #687 
