### PR TITLE
progress bar functional when provisioning

### DIFF
--- a/test/linodes/create/layout/IndexPage.spec.js
+++ b/test/linodes/create/layout/IndexPage.spec.js
@@ -165,7 +165,7 @@ describe('linodes/create/layout/IndexPage', () => {
       backups: false,
       group: null,
     });
-    expect(dispatch.calledTwice).to.equal(true);
+    expect(dispatch.calledThrice).to.equal(true);
     expect(dispatch.firstCall.args[0]).to.deep.equal({
       root_pass: 'password',
       type: 'type',
@@ -176,118 +176,7 @@ describe('linodes/create/layout/IndexPage', () => {
       with_backups: false,
       group: null,
     });
-
-    expect(dispatch.secondCall.args[0]).to.deep.equal(push(`/linodes/${createdLinodeId}`));
-  });
-
-  it('creates multiple linodes when the form is submitted', async () => {
-    const env = { dispatch() {} };
-    const dispatch = sandbox.stub(env, 'dispatch');
-    const createdLinodeId = 1;
-    sandbox.stub(thunks, 'post', d => d);
-    const page = shallow(
-      <IndexPage
-        dispatch={dispatch}
-        distributions={api.distributions}
-        datacenters={api.datacenters}
-        types={api.types}
-        linodes={api.linodes}
-      />
-    );
-    dispatch.reset();
-    dispatch.onCall(0).returns({ id: createdLinodeId });
-    dispatch.onCall(1).returns({ id: createdLinodeId + 1 });
-
-    page.find('Plan').props().onServiceSelected('type');
-    page.find('Datacenter').props().onDatacenterSelected('datacenter');
-    page.find('Source').props().onSourceSelected('distribution', 'source');
-    await page.instance().onSubmit({
-      labels: ['label', 'label-2'],
-      password: 'password',
-      backups: false,
-      group: 'group',
-    });
-    expect(dispatch.callCount).to.equal(3);
-    expect(dispatch.firstCall.args[0]).to.deep.equal({
-      root_pass: 'password',
-      type: 'type',
-      distribution: 'source',
-      backup: null,
-      datacenter: 'datacenter',
-      label: 'label',
-      with_backups: false,
-      group: 'group',
-    });
-    expect(dispatch.secondCall.args[0]).to.deep.equal({
-      root_pass: 'password',
-      type: 'type',
-      distribution: 'source',
-      backup: null,
-      datacenter: 'datacenter',
-      label: 'label-2',
-      with_backups: false,
-      group: 'group',
-    });
-    expect(dispatch.thirdCall.args[0]).to.deep.equal(push('/linodes'));
-  });
-
-  it('generates labels when submitting multiple linodes', async () => {
-    const env = { dispatch() {} };
-    const dispatch = sandbox.stub(env, 'dispatch');
-    const createdLinodeId = 1;
-    sandbox.stub(thunks, 'post', d => d);
-    const page = shallow(
-      <IndexPage
-        dispatch={dispatch}
-        distributions={api.distributions}
-        datacenters={api.datacenters}
-        types={api.types}
-        linodes={api.linodes}
-      />
-    );
-    dispatch.reset();
-    dispatch.onCall(0).returns({ id: createdLinodeId });
-    dispatch.onCall(1).returns({ id: createdLinodeId + 1 });
-
-    page.find('Plan').props().onServiceSelected('type');
-    page.find('Datacenter').props().onDatacenterSelected('datacenter');
-    page.find('Source').props().onSourceSelected('distribution', 'source');
-    await page.instance().onSubmit({
-      labels: ['label', null, null],
-      password: 'password',
-      backups: false,
-      group: 'group',
-    });
-    expect(dispatch.firstCall.args[0]).to.deep.equal({
-      root_pass: 'password',
-      type: 'type',
-      distribution: 'source',
-      backup: null,
-      datacenter: 'datacenter',
-      label: 'label',
-      with_backups: false,
-      group: 'group',
-    });
-    expect(dispatch.secondCall.args[0]).to.deep.equal({
-      root_pass: 'password',
-      type: 'type',
-      distribution: 'source',
-      backup: null,
-      datacenter: 'datacenter',
-      label: 'label-1',
-      with_backups: false,
-      group: 'group',
-    });
-    expect(dispatch.thirdCall.args[0]).to.deep.equal({
-      root_pass: 'password',
-      type: 'type',
-      distribution: 'source',
-      backup: null,
-      datacenter: 'datacenter',
-      label: 'label-2',
-      with_backups: false,
-      group: 'group',
-    });
+    expect(dispatch.thirdCall.args[0]).to.deep.equal(push(`/linodes/${createdLinodeId}`));
   });
 
   it('sets errors on create a linode failure', async () => {
@@ -315,7 +204,6 @@ describe('linodes/create/layout/IndexPage', () => {
       password: 'password',
       backups: false,
     });
-
     expect(page.state('errors')).to.deep.equal({ label: [error] });
   });
 });


### PR DESCRIPTION
This was actually always a problem, it was just found when we
went to a progress bar, now it works as expected.  Tests had to be
changed for an additional call to dispatch.  In addition the code we
were editing was right next to code that controlled creating multiple
linodes at the same time.  The multiple linodes at the same time code
was removed from the view so this commit also removes that section of
code as well.  This can be added back in at a later time by referencing
a commit earlier than this one; if a decision is made to add that
functionality back in.

closes #686