### PR TITLE
Preloading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,9 +59,9 @@ class LoadingRouterContext extends RouterContext {
     }, async (error, redirectLocation, redirectParams) => {
       // Call any route preload functions
       for (let i = 0; i < redirectParams.routes.length; i++) {
-        if (redirectParams.routes[i].hasOwnProperty('preload')) {
-          await redirectParams.routes[i].preload(store.dispatch,
-                                                 newProps.params);
+        let component = redirectParams.routes[i].component;
+        if (component !== undefined && component.hasOwnProperty('preload')) {
+          await component.preload(store.dispatch, newProps.params);
         }
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -60,9 +60,11 @@ class LoadingRouterContext extends RouterContext {
       this.fetching = false;
 
       // Set anything at all to force an update
-      this.setState({
-        updateNow: 'please',
-      });
+      if (!this.initialLoad) {
+        this.setState({
+          updateNow: 'please',
+        });
+      }
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,8 @@ class LoadingRouterContext extends RouterContext {
       routes: newProps.routes,
       location: newProps.location.pathname,
     }, async (error, redirectLocation, redirectParams) => {
-      // Call any route preload functions
+      // Call preload (if present) on any components rendered by the route,
+      // down to the page level (Layout -> IndexPage -> EditConfigPage)
       for (let i = 0; i < redirectParams.routes.length; i++) {
         const component = redirectParams.routes[i].component;
         if (component !== undefined && component.hasOwnProperty('preload')) {

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ class LoadingRouterContext extends RouterContext {
     });
   }
 
-  shouldComponentUpdate(newProps, newState) {
+  shouldComponentUpdate() {
     return !this.fetching;
   }
 }
@@ -84,8 +84,11 @@ const init = () => {
   render(
     <Provider store={store}>
       <div>
-        <Router history={history} onUpdate={logPageView}
-          render={props => <LoadingRouterContext {...props} />}>
+        <Router
+          history={history}
+          onUpdate={logPageView}
+          render={props => <LoadingRouterContext {...props} />}
+        >
           <Route
             path="/logout"
             component={Logout}

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ class LoadingRouterContext extends RouterContext {
       for (let i = 0; i < redirectParams.routes.length; i++) {
         const component = redirectParams.routes[i].component;
         if (component !== undefined && component.hasOwnProperty('preload')) {
-          await component.preload(store.dispatch, newProps.params);
+          await component.preload(store, newProps.params);
         }
       }
 

--- a/src/linodes/create/layouts/IndexPage.js
+++ b/src/linodes/create/layouts/IndexPage.js
@@ -12,6 +12,20 @@ import { setError } from '~/actions/errors';
 import { setSource } from '~/actions/source';
 
 export class IndexPage extends Component {
+  static async preload(store, newParams) {
+    const { dispatch } = store;
+    try {
+      await dispatch(parallel(
+        distributions.all(),
+        datacenters.all(),
+        types.all(),
+        linodes.all(),
+      ));
+    } catch (response) {
+      dispatch(setError(response));
+    }
+  }
+
   constructor() {
     super();
     this.onSubmit = this.onSubmit.bind(this);
@@ -30,16 +44,6 @@ export class IndexPage extends Component {
   async componentDidMount() {
     const { dispatch } = this.props;
     dispatch(setSource(__filename));
-    try {
-      await dispatch(parallel(
-        distributions.all(),
-        datacenters.all(),
-        types.all(),
-        linodes.all(),
-      ));
-    } catch (response) {
-      dispatch(setError(response));
-    }
     const { location } = this.props;
     if (location.query && location.query.linode && location.query.backup) {
       let _linodes = this.props.linodes;

--- a/src/linodes/create/layouts/IndexPage.js
+++ b/src/linodes/create/layouts/IndexPage.js
@@ -12,7 +12,7 @@ import { setError } from '~/actions/errors';
 import { setSource } from '~/actions/source';
 
 export class IndexPage extends Component {
-  static async preload(store, newParams) {
+  static async preload(store) {
     const { dispatch } = store;
     try {
       await dispatch(parallel(

--- a/src/linodes/layouts/IndexPage.js
+++ b/src/linodes/layouts/IndexPage.js
@@ -17,6 +17,15 @@ import {
 import { setSource } from '~/actions/source';
 
 export class IndexPage extends Component {
+  static async preload(dispatch) {
+    try {
+      await dispatch(linodes.all());
+      // TODO: Start until on transient linodes
+    } catch (response) {
+      dispatch(setError(response));
+    }
+  }
+
   constructor() {
     super();
     this.renderGroup = this.renderGroup.bind(this);
@@ -32,12 +41,6 @@ export class IndexPage extends Component {
     const { dispatch } = this.props;
 
     dispatch(setSource(__filename));
-    try {
-      await dispatch(linodes.all());
-      // TODO: Start until on transient linodes
-    } catch (response) {
-      dispatch(setError(response));
-    }
   }
 
   componentWillUnmount() {

--- a/src/linodes/layouts/IndexPage.js
+++ b/src/linodes/layouts/IndexPage.js
@@ -17,12 +17,12 @@ import {
 import { setSource } from '~/actions/source';
 
 export class IndexPage extends Component {
-  static async preload(dispatch) {
+  static async preload(store) {
     try {
-      await dispatch(linodes.all());
+      await store.dispatch(linodes.all());
       // TODO: Start until on transient linodes
     } catch (response) {
-      dispatch(setError(response));
+      store.dispatch(setError(response));
     }
   }
 

--- a/src/linodes/linode/backups/layouts/IndexPage.js
+++ b/src/linodes/linode/backups/layouts/IndexPage.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import { getLinode, loadLinode, renderTabs } from '~/linodes/linode/layouts/IndexPage';
+import { getLinode, renderTabs } from '~/linodes/linode/layouts/IndexPage';
 import { parallel } from '~/api/util';
 import { linodes } from '~/api';
 import { enableBackup } from '~/api/backups';
@@ -15,7 +15,6 @@ export class IndexPage extends Component {
     this.enableBackups = this.enableBackups.bind(this);
     this.componentDidMount = this.componentDidMount.bind(this);
     this.renderTabs = renderTabs.bind(this);
-    this.loadLinode = loadLinode.bind(this);
     this.state = { errors: {} };
   }
 

--- a/src/linodes/linode/layouts/DashboardPage.js
+++ b/src/linodes/linode/layouts/DashboardPage.js
@@ -10,19 +10,17 @@ import {
   renderPlanStyle,
 } from '~/linodes/components/Linode';
 import { launchWeblishConsole } from '~/linodes/components/StatusDropdown';
-import { getLinode, loadLinode } from './IndexPage';
+import { getLinode } from './IndexPage';
 import { setSource } from '~/actions/source';
 
 export class DashboardPage extends Component {
   constructor() {
     super();
     this.getLinode = getLinode.bind(this);
-    this.loadLinode = loadLinode.bind(this);
     this.renderBackupStatus = renderBackupStatus.bind(this);
     this.renderDistroStyle = renderDistroStyle.bind(this);
     this.renderDatacenterStyle = renderDatacenterStyle.bind(this);
     this.renderPlanStyle = renderPlanStyle.bind(this);
-    this.componentDidMount = loadLinode.bind(this);
     this.renderDetails = this.renderDetails.bind(this);
     this.renderGraphs = this.renderGraphs.bind(this);
     this.graphSelection = this.graphSelection.bind(this);
@@ -38,7 +36,6 @@ export class DashboardPage extends Component {
   componentDidMount() {
     const { dispatch } = this.props;
     dispatch(setSource(__filename));
-    this.loadLinode();
   }
 
   graphRangeUpdate(value) {

--- a/src/linodes/linode/layouts/RebuildPage.js
+++ b/src/linodes/linode/layouts/RebuildPage.js
@@ -11,6 +11,16 @@ import { distributions } from '~/api';
 import { rebuildLinode } from '~/api/linodes';
 
 export class RebuildPage extends Component {
+  static async preload(store) {
+    const { dispatch } = store;
+
+    try {
+      await dispatch(distributions.all());
+    } catch (response) {
+      dispatch(setError(response));
+    }
+  }
+
   constructor() {
     super();
     this.onSubmit = this.onSubmit.bind(this);
@@ -20,12 +30,6 @@ export class RebuildPage extends Component {
   async componentDidMount() {
     const { dispatch } = this.props;
     dispatch(setSource(__filename));
-
-    try {
-      await dispatch(distributions.all());
-    } catch (response) {
-      dispatch(setError(response));
-    }
   }
 
   async onSubmit() {

--- a/src/linodes/linode/layouts/RescuePage.js
+++ b/src/linodes/linode/layouts/RescuePage.js
@@ -54,10 +54,10 @@ ResetRootPwModal.propTypes = {
 };
 
 export class RescuePage extends Component {
-  static async preload(dispatch, params) {
+  static async preload(store, params) {
     const { linodeId } = params;
-    await dispatch(linodes.one(linodeId));
-    await dispatch(linodes.disks.all(linodeId));
+    await store.dispatch(linodes.one(linodeId));
+    await store.dispatch(linodes.disks.all(linodeId));
   }
 
   constructor() {

--- a/src/linodes/linode/layouts/RescuePage.js
+++ b/src/linodes/linode/layouts/RescuePage.js
@@ -54,6 +54,12 @@ ResetRootPwModal.propTypes = {
 };
 
 export class RescuePage extends Component {
+  static async preload(dispatch, params) {
+    const { linodeId } = params;
+    await dispatch(linodes.one(linodeId));
+    await dispatch(linodes.disks.all(linodeId));
+  }
+
   constructor() {
     super();
     this.getLinode = getLinode.bind(this);
@@ -72,9 +78,6 @@ export class RescuePage extends Component {
   async componentDidMount() {
     const { dispatch } = this.props;
     dispatch(setSource(__filename));
-    const { linodeId } = this.props.params;
-    await dispatch(linodes.one(linodeId));
-    await dispatch(linodes.disks.all(linodeId));
     const linode = this.getLinode();
     const disk = Object.values(linode._disks.disks)
                        .filter(d => d.filesystem !== 'swap')[0];

--- a/src/linodes/linode/layouts/RescuePage.js
+++ b/src/linodes/linode/layouts/RescuePage.js
@@ -54,8 +54,8 @@ ResetRootPwModal.propTypes = {
 };
 
 export class RescuePage extends Component {
-  static async preload(store, params) {
-    const { linodeId } = params;
+  static async preload(store, newParams) {
+    const { linodeId } = newParams;
     await store.dispatch(linodes.one(linodeId));
     await store.dispatch(linodes.disks.all(linodeId));
   }

--- a/src/linodes/linode/settings/components/ConfigPanel.js
+++ b/src/linodes/linode/settings/components/ConfigPanel.js
@@ -55,13 +55,14 @@ export class ConfigPanel extends Component {
     super();
     this.getLinode = getLinode.bind(this);
   }
-
+/*
   async componentDidMount() {
     const { dispatch } = this.props;
     const { linodeId } = this.props.params;
     await dispatch(linodes.one(linodeId));
     await dispatch(linodes.configs.all(linodeId));
   }
+*/
 
   render() {
     const linode = this.getLinode();

--- a/src/linodes/linode/settings/components/ConfigPanel.js
+++ b/src/linodes/linode/settings/components/ConfigPanel.js
@@ -51,8 +51,8 @@ function configContent(linode, configs, dispatch) {
 }
 
 export class ConfigPanel extends Component {
-  static async preload(store, params) {
-    const { linodeId } = params;
+  static async preload(store, newParams) {
+    const { linodeId } = newParams;
     await store.dispatch(linodes.one(linodeId));
     await store.dispatch(linodes.configs.all(linodeId));
   }

--- a/src/linodes/linode/settings/components/ConfigPanel.js
+++ b/src/linodes/linode/settings/components/ConfigPanel.js
@@ -51,15 +51,15 @@ function configContent(linode, configs, dispatch) {
 }
 
 export class ConfigPanel extends Component {
-  constructor() {
-    super();
-    this.getLinode = getLinode.bind(this);
-  }
-
   static async preload(dispatch, params) {
     const { linodeId } = params;
     await dispatch(linodes.one(linodeId));
     await dispatch(linodes.configs.all(linodeId));
+  }
+
+  constructor() {
+    super();
+    this.getLinode = getLinode.bind(this);
   }
 
   render() {

--- a/src/linodes/linode/settings/components/ConfigPanel.js
+++ b/src/linodes/linode/settings/components/ConfigPanel.js
@@ -51,10 +51,10 @@ function configContent(linode, configs, dispatch) {
 }
 
 export class ConfigPanel extends Component {
-  static async preload(dispatch, params) {
+  static async preload(store, params) {
     const { linodeId } = params;
-    await dispatch(linodes.one(linodeId));
-    await dispatch(linodes.configs.all(linodeId));
+    await store.dispatch(linodes.one(linodeId));
+    await store.dispatch(linodes.configs.all(linodeId));
   }
 
   constructor() {

--- a/src/linodes/linode/settings/components/ConfigPanel.js
+++ b/src/linodes/linode/settings/components/ConfigPanel.js
@@ -55,14 +55,12 @@ export class ConfigPanel extends Component {
     super();
     this.getLinode = getLinode.bind(this);
   }
-/*
-  async componentDidMount() {
-    const { dispatch } = this.props;
-    const { linodeId } = this.props.params;
+
+  static async preload(dispatch, params) {
+    const { linodeId } = params;
     await dispatch(linodes.one(linodeId));
     await dispatch(linodes.configs.all(linodeId));
   }
-*/
 
   render() {
     const linode = this.getLinode();

--- a/src/linodes/linode/settings/components/DiskPanel.js
+++ b/src/linodes/linode/settings/components/DiskPanel.js
@@ -349,8 +349,8 @@ function select(state) {
 const AddModalRedux = connect(select)(AddModal);
 
 export class DiskPanel extends Component {
-  static async preload(store, params) {
-    const { linodeId } = params;
+  static async preload(store, newParams) {
+    const { linodeId } = newParams;
     await store.dispatch(linodes.one(linodeId));
     await store.dispatch(linodes.disks.all(linodeId));
   }

--- a/src/linodes/linode/settings/components/DiskPanel.js
+++ b/src/linodes/linode/settings/components/DiskPanel.js
@@ -353,14 +353,12 @@ export class DiskPanel extends Component {
     super();
     this.getLinode = getLinode.bind(this);
   }
-/*
-  async componentDidMount() {
-    const { dispatch } = this.props;
-    const { linodeId } = this.props.params;
+
+  static async preload(dispatch, params) {
+    const { linodeId } = params;
     await dispatch(linodes.one(linodeId));
     await dispatch(linodes.disks.all(linodeId));
   }
-*/
 
   render() {
     const { dispatch } = this.props;

--- a/src/linodes/linode/settings/components/DiskPanel.js
+++ b/src/linodes/linode/settings/components/DiskPanel.js
@@ -349,15 +349,15 @@ function select(state) {
 const AddModalRedux = connect(select)(AddModal);
 
 export class DiskPanel extends Component {
-  constructor() {
-    super();
-    this.getLinode = getLinode.bind(this);
-  }
-
   static async preload(dispatch, params) {
     const { linodeId } = params;
     await dispatch(linodes.one(linodeId));
     await dispatch(linodes.disks.all(linodeId));
+  }
+
+  constructor() {
+    super();
+    this.getLinode = getLinode.bind(this);
   }
 
   render() {

--- a/src/linodes/linode/settings/components/DiskPanel.js
+++ b/src/linodes/linode/settings/components/DiskPanel.js
@@ -353,13 +353,14 @@ export class DiskPanel extends Component {
     super();
     this.getLinode = getLinode.bind(this);
   }
-
+/*
   async componentDidMount() {
     const { dispatch } = this.props;
     const { linodeId } = this.props.params;
     await dispatch(linodes.one(linodeId));
     await dispatch(linodes.disks.all(linodeId));
   }
+*/
 
   render() {
     const { dispatch } = this.props;

--- a/src/linodes/linode/settings/components/DiskPanel.js
+++ b/src/linodes/linode/settings/components/DiskPanel.js
@@ -349,10 +349,10 @@ function select(state) {
 const AddModalRedux = connect(select)(AddModal);
 
 export class DiskPanel extends Component {
-  static async preload(dispatch, params) {
+  static async preload(store, params) {
     const { linodeId } = params;
-    await dispatch(linodes.one(linodeId));
-    await dispatch(linodes.disks.all(linodeId));
+    await store.dispatch(linodes.one(linodeId));
+    await store.dispatch(linodes.disks.all(linodeId));
   }
 
   constructor() {

--- a/src/linodes/linode/settings/index.js
+++ b/src/linodes/linode/settings/index.js
@@ -6,12 +6,20 @@ import AdvancedPage from './layouts/AdvancedPage';
 import EditConfigPage from './layouts/EditConfigPage';
 import AddConfigPage from './layouts/AddConfigPage';
 
+import { linodes } from '~/api';
+
+async function advanced_preload(dispatch, params) {
+  const { linodeId } = params;
+  await dispatch(linodes.one(linodeId));
+  await dispatch(linodes.configs.all(linodeId));
+}
+
 export default (
   <Route path="settings" component={IndexPage}>
     <IndexRoute component={DisplayPage} />
     <Route path="alerts" component={AlertsPage} />
     <Route path="advanced">
-      <IndexRoute component={AdvancedPage} />
+      <IndexRoute component={AdvancedPage} preload={advanced_preload} />
       <Route path="configs">
         <IndexRedirect to=".." />
         <Route path="create" component={AddConfigPage} />

--- a/src/linodes/linode/settings/index.js
+++ b/src/linodes/linode/settings/index.js
@@ -6,21 +6,12 @@ import AdvancedPage from './layouts/AdvancedPage';
 import EditConfigPage from './layouts/EditConfigPage';
 import AddConfigPage from './layouts/AddConfigPage';
 
-import { linodes } from '~/api';
-
-async function advancedPreload(dispatch, params) {
-  const { linodeId } = params;
-  await dispatch(linodes.one(linodeId));
-  await dispatch(linodes.configs.all(linodeId));
-  await dispatch(linodes.disks.all(linodeId));
-}
-
 export default (
   <Route path="settings" component={IndexPage}>
     <IndexRoute component={DisplayPage} />
     <Route path="alerts" component={AlertsPage} />
     <Route path="advanced">
-      <IndexRoute component={AdvancedPage} preload={advancedPreload} />
+      <IndexRoute component={AdvancedPage} />
       <Route path="configs">
         <IndexRedirect to=".." />
         <Route path="create" component={AddConfigPage} />

--- a/src/linodes/linode/settings/index.js
+++ b/src/linodes/linode/settings/index.js
@@ -8,10 +8,11 @@ import AddConfigPage from './layouts/AddConfigPage';
 
 import { linodes } from '~/api';
 
-async function advanced_preload(dispatch, params) {
+async function advancedPreload(dispatch, params) {
   const { linodeId } = params;
   await dispatch(linodes.one(linodeId));
   await dispatch(linodes.configs.all(linodeId));
+  await dispatch(linodes.disks.all(linodeId));
 }
 
 export default (
@@ -19,7 +20,7 @@ export default (
     <IndexRoute component={DisplayPage} />
     <Route path="alerts" component={AlertsPage} />
     <Route path="advanced">
-      <IndexRoute component={AdvancedPage} preload={advanced_preload} />
+      <IndexRoute component={AdvancedPage} preload={advancedPreload} />
       <Route path="configs">
         <IndexRedirect to=".." />
         <Route path="create" component={AddConfigPage} />

--- a/src/linodes/linode/settings/layouts/AddConfigPage.js
+++ b/src/linodes/linode/settings/layouts/AddConfigPage.js
@@ -7,6 +7,8 @@ export function AddConfigPage(props) {
   return <EditConfigPage create {...props} />;
 }
 
+AddConfigPage.preload = EditConfigPage.preload;
+
 AddConfigPage.propTypes = {
   ...EditConfigPage.propTypes,
 };

--- a/src/linodes/linode/settings/layouts/AdvancedPage.js
+++ b/src/linodes/linode/settings/layouts/AdvancedPage.js
@@ -5,9 +5,9 @@ import { DiskPanel } from '~/linodes/linode/settings/components/DiskPanel';
 import { setSource } from '~/actions/source';
 
 export class AdvancedPage extends Component {
-  static async preload(dispatch, params) {
-    await ConfigPanel.preload(dispatch, params);
-    await DiskPanel.preload(dispatch, params);
+  static async preload(store, params) {
+    await ConfigPanel.preload(store, params);
+    await DiskPanel.preload(store, params);
   }
 
   componentDidMount() {

--- a/src/linodes/linode/settings/layouts/AdvancedPage.js
+++ b/src/linodes/linode/settings/layouts/AdvancedPage.js
@@ -3,8 +3,16 @@ import { connect } from 'react-redux';
 import { ConfigPanel } from '~/linodes/linode/settings/components/ConfigPanel';
 import { DiskPanel } from '~/linodes/linode/settings/components/DiskPanel';
 import { setSource } from '~/actions/source';
+import { linodes } from '~/api';
 
 export class AdvancedPage extends Component {
+  static async preload(dispatch, params) {
+    const { linodeId } = params;
+    await dispatch(linodes.one(linodeId));
+    await dispatch(linodes.configs.all(linodeId));
+    await dispatch(linodes.disks.all(linodeId));
+  }
+
   componentDidMount() {
     const { dispatch } = this.props;
     dispatch(setSource(__filename));

--- a/src/linodes/linode/settings/layouts/AdvancedPage.js
+++ b/src/linodes/linode/settings/layouts/AdvancedPage.js
@@ -3,14 +3,11 @@ import { connect } from 'react-redux';
 import { ConfigPanel } from '~/linodes/linode/settings/components/ConfigPanel';
 import { DiskPanel } from '~/linodes/linode/settings/components/DiskPanel';
 import { setSource } from '~/actions/source';
-import { linodes } from '~/api';
 
 export class AdvancedPage extends Component {
   static async preload(dispatch, params) {
-    const { linodeId } = params;
-    await dispatch(linodes.one(linodeId));
-    await dispatch(linodes.configs.all(linodeId));
-    await dispatch(linodes.disks.all(linodeId));
+    await ConfigPanel.preload(dispatch, params);
+    await DiskPanel.preload(dispatch, params);
   }
 
   componentDidMount() {

--- a/src/linodes/linode/settings/layouts/EditConfigPage.js
+++ b/src/linodes/linode/settings/layouts/EditConfigPage.js
@@ -13,16 +13,16 @@ export const AVAILABLE_DISK_SLOTS =
   ['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg', 'sdh'];
 
 export class EditConfigPage extends Component {
-  static async preload(dispatch, params) {
+  static async preload(store, params) {
     const { linodeId } = params;
 
     try {
-      await dispatch(linodes.one(linodeId));
+      await store.dispatch(linodes.one(linodeId));
 
       const promises = [
-        dispatch(kernels.all()),
-        dispatch(linodes.configs.all(linodeId)),
-        dispatch(linodes.disks.all(linodeId)),
+        store.dispatch(kernels.all()),
+        store.dispatch(linodes.configs.all(linodeId)),
+        store.dispatch(linodes.disks.all(linodeId)),
       ];
 
       for (const promise of promises) {

--- a/src/linodes/linode/settings/layouts/EditConfigPage.js
+++ b/src/linodes/linode/settings/layouts/EditConfigPage.js
@@ -8,30 +8,25 @@ import HelpButton from '~/components/HelpButton';
 import { ErrorSummary, FormGroup, reduceErrors } from '~/errors';
 import { Link } from '~/components/Link';
 import { setSource } from '~/actions/source';
+import { setError } from '~/actions/errors';
 
 export const AVAILABLE_DISK_SLOTS =
   ['sda', 'sdb', 'sdc', 'sdd', 'sde', 'sdf', 'sdg', 'sdh'];
 
 export class EditConfigPage extends Component {
-  static async preload(store, params) {
-    const { linodeId } = params;
+  static async preload(store, newParams) {
+    const { linodeId } = newParams;
 
     try {
       await store.dispatch(linodes.one(linodeId));
 
-      const promises = [
+      await Promise.all([
         store.dispatch(kernels.all()),
         store.dispatch(linodes.configs.all(linodeId)),
         store.dispatch(linodes.disks.all(linodeId)),
-      ];
-
-      for (const promise of promises) {
-        await promise;
-      }
+      ]);
     } catch (e) {
-      // TODO: handle errors
-      // eslint-disable-next-line no-console
-      console.error(e);
+      store.dispatch(setError(e));
     }
   }
 

--- a/test/data/linodes.js
+++ b/test/data/linodes.js
@@ -254,4 +254,16 @@ export const linodes = {
       },
     },
   },
+  1241: {
+    ...testLinode,
+    id: 1241,
+    label: 'Test Linode 7',
+    status: 'running',
+    backups: { ...testLinode.backups, enabled: false },
+    _configs: {
+      totalResults: 0,
+      totalPages: -1,
+      configs: {},
+    },
+  },
 };

--- a/test/linodes/create/layout/IndexPage.spec.js
+++ b/test/linodes/create/layout/IndexPage.spec.js
@@ -79,22 +79,12 @@ describe('linodes/create/layout/IndexPage', () => {
     const env = { dispatch() {} };
     const error = 'this is my error string';
     const dispatch = sandbox.stub(env, 'dispatch');
-    dispatch.onCall(1).throws(new Error(error));
+    dispatch.onCall(0).throws(new Error(error));
 
-    const page = shallow(
-      <IndexPage
-        dispatch={dispatch}
-        distributions={api.distributions}
-        datacenters={api.datacenters}
-        types={api.types}
-        linodes={api.linodes}
-        location={{ query: {} }}
-      />);
+    await IndexPage.preload({ dispatch }, { });
 
-    await page.instance().componentDidMount();
-
-    expect(dispatch.callCount).to.equal(3);
-    expect(dispatch.args[2][0].message).to.equal(error);
+    expect(dispatch.callCount).to.equal(2);
+    expect(dispatch.args[1][0].message).to.equal(error);
   });
 
   it('selects a source when appropriate', () => {

--- a/test/linodes/linode/layouts/DashboardPage.spec.js
+++ b/test/linodes/linode/layouts/DashboardPage.spec.js
@@ -4,7 +4,6 @@ import { mount, shallow } from 'enzyme';
 import { expect } from 'chai';
 import { testLinode } from '@/data/linodes';
 import { DashboardPage } from '~/linodes/linode/layouts/DashboardPage';
-import * as IndexPage from '~/linodes/linode/layouts/IndexPage';
 import moment from 'moment';
 
 describe('linodes/linode/layouts/DashboardPage', async () => {
@@ -50,23 +49,11 @@ describe('linodes/linode/layouts/DashboardPage', async () => {
     linodeId: `${testLinode.id}`,
   };
 
-  it('calls loadLinode on mount', async () => {
-    const loadLinode = sinon.stub(IndexPage, 'loadLinode');
-    const page = shallow(
-      <DashboardPage
-        linodes={linodes}
-        params={params}
-      />
-    );
-    await page.instance().componentDidMount();
-    expect(loadLinode.calledOnce).to.equal(true);
-    loadLinode.restore();
-  });
-
   it('renders public ipv4 and ipv6', () => {
     const { ipv4, ipv6 } = testLinode;
     const page = mount(
       <DashboardPage
+        dispatch={dispatch}
         linodes={linodes}
         params={params}
       />);

--- a/test/linodes/linode/layouts/RescuePage.spec.js
+++ b/test/linodes/linode/layouts/RescuePage.spec.js
@@ -64,39 +64,9 @@ describe('linodes/linode/layouts/RescuePage', () => {
     _plural: 'linodes',
   };
 
-  it('fetches a linode when mounted with an unknown linode', async () => {
-    const page = shallow(
-      <RescuePage
-        dispatch={dispatch}
-        linodes={{ linodes: { } }}
-        params={{ linodeId: '1234' }}
-      />);
-    const get = sandbox.stub(page.instance(), 'getLinode');
-    get.onFirstCall().returns(testLinode);
-    await page.instance().componentDidMount();
-    const dispatched = dispatch.secondCall.args[0];
-    // Assert that dispatched is a function that fetches a linode
-    const fetchStub = sandbox.stub(fetch, 'fetch').returns({
-      json: () => {},
-    });
-    dispatch.reset();
-    await dispatched(dispatch, () => ({
-      authentication: { token: 'token' },
-      api: { linodes: { totalPages: -1, linodes: { } } },
-    }));
-    expect(fetchStub.calledOnce).to.equal(true);
-    expect(fetchStub.firstCall.args[1]).to.equal('/linode/instances/1234');
-  });
-
   it('fetches linode disks', async () => {
-    const page = shallow(
-      <RescuePage
-        dispatch={dispatch}
-        linodes={linodes}
-        params={{ linodeId: '1234' }}
-      />);
-    await page.instance().componentDidMount();
-    let dispatched = dispatch.thirdCall.args[0];
+    await RescuePage.preload({ dispatch }, { linodeId: '1234' });
+    let dispatched = dispatch.secondCall.args[0];
     // Assert that dispatched is a function that fetches disks
     const fetchStub = sandbox.stub(fetch, 'fetch').returns({
       json: () => {},
@@ -127,17 +97,6 @@ describe('linodes/linode/layouts/RescuePage', () => {
     await dispatched(dispatch, () => state);
     expect(fetchStub.calledOnce).to.equal(true);
     expect(fetchStub.firstCall.args[1]).to.equal('/linode/instances/1234/disks/?page=1');
-  });
-
-  it('does not fetch when mounted with a known linode', async () => {
-    const page = shallow(
-      <RescuePage
-        dispatch={dispatch}
-        linodes={linodes}
-        params={{ linodeId: `${testLinode.id}` }}
-      />);
-    await page.instance().componentDidMount();
-    expect(dispatch.callCount).to.equal(3);
   });
 
   describe('reset root password', () => {


### PR DESCRIPTION
Closes #694 

To test it out, refresh the page on Linode/Settings/Alerts, then click the Advanced tab. The page should not switch immediately, and when it does, the configs and disks should appear immediately without the flash of "You have no configs" etc.

Not sure about where to put the preload code. Ideally each component/page could provide some preload function that could be called unlike the current setup where preload has to be registered in the route. Open to suggestions on how to do that cleanly.