### PR TITLE
Apply Form component to linode/settings/alerts page

### DIFF
--- a/src/linodes/linode/settings/layouts/AlertsPage.js
+++ b/src/linodes/linode/settings/layouts/AlertsPage.js
@@ -12,7 +12,6 @@ export class AlertsPage extends Component {
     super(props);
     this.getLinode = getLinode.bind(this);
     this.renderAlertRow = this.renderAlertRow.bind(this);
-    this.saveChanges = this.saveChanges.bind(this);
     this.state = {
       loading: false,
       alerts: this.getLinode().alerts || {

--- a/src/linodes/linode/settings/layouts/AlertsPage.js
+++ b/src/linodes/linode/settings/layouts/AlertsPage.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 
 import HelpButton from '~/components/HelpButton';
 import { getLinode } from '~/linodes/linode/layouts/IndexPage';
+import { Form, SubmitButton } from '~/components/form';
 import { linodes } from '~/api';
 import { setSource } from '~/actions/source';
 
@@ -11,7 +12,7 @@ export class AlertsPage extends Component {
     super(props);
     this.getLinode = getLinode.bind(this);
     this.renderAlertRow = this.renderAlertRow.bind(this);
-    this.onSubmit = this.onSubmit.bind(this);
+    this.saveChanges = this.saveChanges.bind(this);
     this.state = {
       loading: false,
       alerts: this.getLinode().alerts || {
@@ -29,8 +30,7 @@ export class AlertsPage extends Component {
     dispatch(setSource(__filename));
   }
 
-  async onSubmit(e) {
-    e.preventDefault();
+  async saveChanges() {
     const { dispatch } = this.props;
     const { id } = this.getLinode();
     this.setState({ loading: true });
@@ -124,17 +124,14 @@ export class AlertsPage extends Component {
             <HelpButton to="https://google.com" />
           </h2>
         </header>
-        <form onSubmit={this.onSubmit}>
+        <Form onSubmit={() => this.saveChanges()}>
           {alerts.map(this.renderAlertRow)}
           <div className="row">
             <div className="offset-sm-2 col-sm-10">
-              <button
-                className="btn btn-default"
-                disabled={loading}
-              >Save</button>
+              <SubmitButton disabled={loading} />
             </div>
           </div>
-        </form>
+        </Form>
       </section>
     );
   }

--- a/test/linodes/linode/settings/components/DiskPanel.spec.js
+++ b/test/linodes/linode/settings/components/DiskPanel.spec.js
@@ -252,8 +252,8 @@ describe('linodes/linode/settings/components/DiskPanel', () => {
         json() {
           return {
             errors: [
-              { field: 'label', reason: 'You suck at naming things' },
-              { reason: 'You suck at things in general' },
+              { field: 'label', reason: 'Name error' },
+              { reason: 'General error' },
             ],
           };
         },
@@ -265,11 +265,11 @@ describe('linodes/linode/settings/components/DiskPanel', () => {
         .to.have.property('label')
         .which.deep.includes({
           field: 'label',
-          reason: 'You suck at naming things',
+          reason: 'Name error',
         });
       expect(errs)
         .to.have.property('_')
-        .which.deep.includes({ reason: 'You suck at things in general' });
+        .which.deep.includes({ reason: 'General error' });
     });
   });
 
@@ -459,9 +459,9 @@ describe('linodes/linode/settings/components/DiskPanel', () => {
         json() {
           return {
             errors: [
-              { field: 'label', reason: 'You suck at naming things' },
-              { field: 'size', reason: 'You suck at sizing things' },
-              { reason: 'You suck at things in general' },
+              { field: 'label', reason: 'Name error' },
+              { field: 'size', reason: 'Size error' },
+              { reason: 'General error' },
             ],
           };
         },
@@ -471,13 +471,13 @@ describe('linodes/linode/settings/components/DiskPanel', () => {
       const errs = modal.state('errors');
       expect(errs)
         .to.have.property('label')
-        .which.includes('You suck at naming things');
+        .which.includes('Name error');
       expect(errs)
         .to.have.property('size')
-        .which.includes('You suck at sizing things');
+        .which.includes('Size error');
       expect(errs)
         .to.have.property('_')
-        .which.includes('You suck at things in general');
+        .which.includes('General error');
     });
   });
 });

--- a/test/linodes/linode/settings/layouts/AlertsPage.spec.js
+++ b/test/linodes/linode/settings/layouts/AlertsPage.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 
 import { actions } from '~/api/configs/linodes';
@@ -40,7 +40,7 @@ describe('linodes/linode/settings/layouts/AlertsPage', async () => {
 
   it('maps form fields and dispatches a putLinode event', async () => {
     const dispatch = sandbox.spy();
-    const page = shallow(
+    const page = mount(
       <AlertsPage
         linodes={api.linodes}
         params={{ linodeLabel: testLinode.label }}
@@ -63,3 +63,4 @@ describe('linodes/linode/settings/layouts/AlertsPage', async () => {
       }, { }, { method: 'PUT' });
   });
 });
+


### PR DESCRIPTION
Apply the Form component to the linode/settings/alerts page.  We'd like to change all the forms to use this form component in order to try to maintain consistency. This is the next form I've attempted to change to using the Form component for.