### PR TITLE
Fix infinite loop

### DIFF
--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -128,13 +128,10 @@ export class Layout extends Component {
     this._shouldPoll = true;
     dispatch(events.all([], this.eventHandler));
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
+    setInterval(async () => {
       if (this._shouldPoll) {
-        // And every N seconds
-        await new Promise(resolve => setTimeout(resolve, EVENT_POLLING_DELAY));
-
         const processedEvents = await this.fetchEventsPage(0);
+
         try {
           dispatch(eventsActions.many(processedEvents));
         } catch (e) {
@@ -142,7 +139,7 @@ export class Layout extends Component {
           console.error(e);
         }
       }
-    }
+    }, EVENT_POLLING_DELAY);
   }
 
   hideShow(type, hide, show) {

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -28,6 +28,7 @@ export class Layout extends Component {
       'notifications', hideNotifications, showNotifications).bind(this);
     this.hideShowFeedback = this.hideShow(
       'feedback', hideFeedback, showFeedback).bind(this);
+    this._pollingIntervalId = null;
     this.state = { title: '', link: '' };
   }
 
@@ -37,7 +38,7 @@ export class Layout extends Component {
   }
 
   componentWillUnmount() {
-    this._shouldPoll = false;
+    this.stopPollingForEvents();
   }
 
   async fetchBlog() {
@@ -116,6 +117,26 @@ export class Layout extends Component {
     return allProcessedEvents;
   }
 
+  startPollingForEvents() {
+    const { dispatch } = this.props;
+
+    this._pollingIntervalId = setInterval(async () => {
+      const processedEvents = await this.fetchEventsPage(0);
+
+      try {
+        dispatch(eventsActions.many(processedEvents));
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
+    }, EVENT_POLLING_DELAY);
+  }
+
+  stopPollingForEvents() {
+    clearInterval(this._pollingIntervalId);
+    this._pollingIntervalId = null;
+  }
+
   async attachEventTimeout() {
     const { dispatch } = this.props;
 
@@ -125,21 +146,9 @@ export class Layout extends Component {
     }
 
     // Grab events first time right away
-    this._shouldPoll = true;
     dispatch(events.all([], this.eventHandler));
 
-    setInterval(async () => {
-      if (this._shouldPoll) {
-        const processedEvents = await this.fetchEventsPage(0);
-
-        try {
-          dispatch(eventsActions.many(processedEvents));
-        } catch (e) {
-          // eslint-disable-next-line no-console
-          console.error(e);
-        }
-      }
-    }, EVENT_POLLING_DELAY);
+    this.startPollingForEvents();
   }
 
   hideShow(type, hide, show) {

--- a/test/layouts/Layout.spec.js
+++ b/test/layouts/Layout.spec.js
@@ -135,7 +135,7 @@ describe('layouts/Layout', () => {
 
     page.instance().componentWillUnmount();
 
-    expect(page.instance()._pollingIntervalId).to.be.null;
+    expect(page.instance()._pollingIntervalId).to.equal(null);
   });
 
   it('deals with individual events', () => {

--- a/test/layouts/Layout.spec.js
+++ b/test/layouts/Layout.spec.js
@@ -135,7 +135,7 @@ describe('layouts/Layout', () => {
 
     page.instance().componentWillUnmount();
 
-    expect(page.instance()._shouldPoll).to.equal(false);
+    expect(page.instance()._pollingIntervalId).to.be.null;
   });
 
   it('deals with individual events', () => {


### PR DESCRIPTION
When navigating to a new route at the same level as `/`, unmount is triggered, causing the infinite `while(true)` to break the page (trying to poll for events).

- Changes `while(true)` to use `setInterval` for polling
