### PR TITLE
Add take first snapshot link

### DIFF
--- a/scss/components/backup.scss
+++ b/scss/components/backup.scss
@@ -35,6 +35,7 @@
   margin: 13px;
   border: $border;
   color: $black;
+  height: 120px;
 
   &.clickable:hover {
     background-color: $light-gray;
@@ -47,6 +48,10 @@
   }
 
   .description {
-    margin: 19px 0px 25px 0px;
+    margin: 29px 0px 15px 0px;
+  }
+
+  .no-snapshot {
+    margin-top: 18px;
   }
 }

--- a/src/api/backups.js
+++ b/src/api/backups.js
@@ -24,6 +24,7 @@ export function takeBackup(id) {
       { method: 'POST' });
     const json = await response.json();
     dispatch(actions.backups.one(json, id, json.id));
+    return json;
   };
 }
 


### PR DESCRIPTION
Closes #660

Currently it tries to redirect to the new snapshot which doesn't exist yet in the data from the API so that part is fairly broken right now. This is as good as I can do on this task until the API changes how snapshots are returned (in progress).

![screen shot 2017-01-06 at 10 09 01 am](https://cloud.githubusercontent.com/assets/4149249/21721907/4d1af67e-d3f8-11e6-8b91-9df35fdb913d.png)
