### PR TITLE
Switches polling to setTimeout

### DIFF
--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -28,7 +28,7 @@ export class Layout extends Component {
       'notifications', hideNotifications, showNotifications).bind(this);
     this.hideShowFeedback = this.hideShow(
       'feedback', hideFeedback, showFeedback).bind(this);
-    this._pollingIntervalId = null;
+    this._pollingTimeoutId = null;
     this.state = { title: '', link: '' };
   }
 
@@ -121,16 +121,16 @@ export class Layout extends Component {
     const { dispatch } = this.props;
 
     this._pollingTimeoutId = setTimeout(async () => {
-      const processedEvents = await this.fetchEventsPage(0);
+      //const processedEvents = await this.fetchEventsPage(0);
 
       try {
-        dispatch(eventsActions.many(processedEvents));
+        //dispatch(eventsActions.many(processedEvents));
         this.pollForEvents();
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error(e);
       }
-    }, EVENT_POLLING_DELAY);
+    }, 10);
   }
 
   stopPollingForEvents() {

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -121,16 +121,16 @@ export class Layout extends Component {
     const { dispatch } = this.props;
 
     this._pollingTimeoutId = setTimeout(async () => {
-      //const processedEvents = await this.fetchEventsPage(0);
+      const processedEvents = await this.fetchEventsPage(0);
 
       try {
-        //dispatch(eventsActions.many(processedEvents));
+        dispatch(eventsActions.many(processedEvents));
         this.pollForEvents();
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error(e);
       }
-    }, 10);
+    }, EVENT_POLLING_DELAY);
   }
 
   stopPollingForEvents() {

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -117,14 +117,15 @@ export class Layout extends Component {
     return allProcessedEvents;
   }
 
-  startPollingForEvents() {
+  pollForEvents() {
     const { dispatch } = this.props;
 
-    this._pollingIntervalId = setInterval(async () => {
+    this._pollingTimeoutId = setTimeout(async () => {
       const processedEvents = await this.fetchEventsPage(0);
 
       try {
         dispatch(eventsActions.many(processedEvents));
+        this.pollForEvents();
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error(e);
@@ -133,8 +134,8 @@ export class Layout extends Component {
   }
 
   stopPollingForEvents() {
-    clearInterval(this._pollingIntervalId);
-    this._pollingIntervalId = null;
+    clearTimeout(this._pollingTimeoutId);
+    this._pollingTimeoutId = null;
   }
 
   async attachEventTimeout() {
@@ -148,7 +149,7 @@ export class Layout extends Component {
     // Grab events first time right away
     dispatch(events.all([], this.eventHandler));
 
-    this.startPollingForEvents();
+    this.pollForEvents();
   }
 
   hideShow(type, hide, show) {

--- a/test/layouts/Layout.spec.js
+++ b/test/layouts/Layout.spec.js
@@ -135,7 +135,7 @@ describe('layouts/Layout', () => {
 
     page.instance().componentWillUnmount();
 
-    expect(page.instance()._pollingIntervalId).to.equal(null);
+    expect(page.instance()._pollingTimeoutId).to.equal(null);
   });
 
   it('deals with individual events', () => {


### PR DESCRIPTION
Switches polling to `setTimeout` so that the next api fetch is not until `EVENT_POLLING_DELAY` ms after the previous response has returned

@eatonphil re: your concern about using recursive calls and the stack with `setTimeout`, JavaScript does not save the context of calls to `setTimeout`, so recursively calling within the function delayed by `setTimeout` like this does not infinitely increase the stack size.

I checked this by looking at the timeline in chrome, (disabled the actual api fetch), and just recursively called the poll function from within setTimeout at `10ms` intervals (to stress test), the result of which looks like this:

![screen shot 2017-01-06 at 11 04 22 am](https://cloud.githubusercontent.com/assets/709951/21723896/30b406e4-d400-11e6-9370-1a7a361989d0.png)

largest stack traces are from GCs, and no signs of infinite up trends.