### PR TITLE
Fix linode creation bugs

### DIFF
--- a/src/api/gen.js
+++ b/src/api/gen.js
@@ -32,11 +32,11 @@ function fullyQualified(resource) {
 
 const actionGenerators = {
   [ONE]: c => (resource, ...ids) =>
-    ({ type: `GEN@${fullyQualified(c)}/ONE`, resource, ids: ids.map(n => parseInt(n)) }),
+    ({ type: `GEN@${fullyQualified(c)}/ONE`, resource, ids: ids.map(n => parseInt(n) || n) }),
   [MANY]: c => (page, ...ids) =>
-    ({ type: `GEN@${fullyQualified(c)}/MANY`, page, ids: ids.map(n => parseInt(n)) }),
+    ({ type: `GEN@${fullyQualified(c)}/MANY`, page, ids: ids.map(n => parseInt(n) || n) }),
   [DELETE]: c => (...ids) =>
-    ({ type: `GEN@${fullyQualified(c)}/DELETE`, ids: ids.map(n => parseInt(n)) }),
+    ({ type: `GEN@${fullyQualified(c)}/DELETE`, ids: ids.map(n => parseInt(n) || n) }),
 };
 
 /**
@@ -84,9 +84,8 @@ export function generateDefaultStateOne(config, one) {
 }
 
 export class ReducerGenerator {
-
   static one(config, oldStateMany, action) {
-    const id = action.ids.length ? action.ids.pop() : action.resource.id;
+    const id = action.ids.length ? action.ids[action.ids.length - 1] : action.resource.id;
     const oldStateOne = oldStateMany[config.plural][id];
     const newStateOne = oldStateOne ? action.resource :
                         generateDefaultStateOne(config, action.resource);

--- a/src/api/linodes.js
+++ b/src/api/linodes.js
@@ -5,19 +5,23 @@ export const LINODE_STATUS_TRANSITION_RESULT = {
   booting: 'running',
   shutting_down: 'offline',
   rebooting: 'running',
+  creating: 'offline', // Technically this is "finished", but offline is more useful to us.
 };
 
 export const RANDOM_PROGRESS_MAX = 75;
+export const RANDOM_PROGRESS_MIN = 40;
+
+export function randomInitialProgress() {
+  return Math.random() * (RANDOM_PROGRESS_MAX - RANDOM_PROGRESS_MIN) + RANDOM_PROGRESS_MIN;
+}
 
 function linodeAction(id, action, temp, body, handleRsp) {
   return async (dispatch, getState) => {
     const state = getState();
     const { token } = state.authentication;
-    dispatch(actions.one({ ...state, status: temp, __progress: 1 }, id));
+    dispatch(actions.one({ status: temp, __progress: 1 }, id));
     await new Promise(resolve => setTimeout(resolve, 0));
-    const randomProgress = ((min, max) =>
-      Math.random() * (max - min) + min)(RANDOM_PROGRESS_MAX, 40);
-    dispatch(actions.one({ ...state, __progress: randomProgress }, id));
+    dispatch(actions.one({ __progress: randomInitialProgress() }, id));
 
     const rsp = await fetch(token, `/linode/instances/${id}/${action}`, { method: 'POST', body });
     dispatch(actions.one({ ...body }, id));

--- a/src/api/objects/Event.js
+++ b/src/api/objects/Event.js
@@ -45,6 +45,9 @@ export class Event {
       case Event.LINODE_BOOT:
         status = 'booting';
         break;
+      case Event.LINODE_CREATE:
+        status = 'creating';
+        break;
       default:
         status = null;
     }

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -64,6 +64,7 @@ export class Layout extends Component {
     const event = new Event(_event);
 
     switch (event.getType()) {
+      case Event.LINODE_CREATE:
       case Event.LINODE_REBOOT:
       case Event.LINODE_BOOT:
       case Event.LINODE_POWER_OFF: {
@@ -78,12 +79,10 @@ export class Layout extends Component {
 
           if (newEvent && (statusChanged || changeInProgress && progressMade)) {
             dispatch(linodeActions.one({
-              ...linode,
               __progress: event.getProgress(),
             }, linode.id));
 
             setTimeout(() => dispatch(linodeActions.one({
-              ...linode,
               status: event.getStatus(),
               // For best UX, keep the below timeout length the same as the width transition for
               // this component.

--- a/src/linodes/components/Distributions.js
+++ b/src/linodes/components/Distributions.js
@@ -11,7 +11,7 @@ export default function Distributions(props) {
   }
 
   const vendorsUnsorted = _.map(
-    _.groupBy(Object.values(distributions), d => d.vendor),
+    _.groupBy(distributions, 'vendor'),
     (v, k) => ({
       name: k,
       versions: _.orderBy(v, ['recommended', 'created'], ['desc', 'desc']),

--- a/src/linodes/create/components/Datacenter.js
+++ b/src/linodes/create/components/Datacenter.js
@@ -5,12 +5,6 @@ import { flags } from '~/assets';
 import { regionMap } from '~/constants';
 
 export default class Datacenter extends Component {
-  constructor() {
-    super();
-    this.renderRegion = this.renderRegion.bind(this);
-    this.renderDisabled = this.renderDisabled.bind(this);
-  }
-
   renderHeader() {
     return (
       <header>
@@ -19,9 +13,10 @@ export default class Datacenter extends Component {
     );
   }
 
-  renderDatacenter(datacenter) {
+  renderDatacenter = (datacenter) => {
     const { selected, onDatacenterSelected } = this.props;
     const dcClass = datacenter.id === selected ? 'selected' : '';
+
     return (
       <div
         className={`datacenter ${dcClass}`}
@@ -43,7 +38,7 @@ export default class Datacenter extends Component {
     );
   }
 
-  renderRegion(datacentersInRegion, region) {
+  renderRegion = (datacentersInRegion, region) => {
     const allRealDatacenters = this.props.datacenters;
     const datacenters = Object.values(allRealDatacenters).filter(({ id }) =>
       datacentersInRegion.indexOf(id) !== -1);
@@ -52,7 +47,7 @@ export default class Datacenter extends Component {
       <div key={region}>
         <h3>{region}</h3>
         <div className="datacenter-group">
-          {datacenters.map(this.renderDatacenter.bind(this))}
+          {datacenters.map(this.renderDatacenter)}
         </div>
       </div>
     ) : null;
@@ -69,7 +64,7 @@ export default class Datacenter extends Component {
             The source you selected limits the datacenters you may deploy
             your new Linode to.
           </p>
-          {this.renderDatacenter.bind(this)(dc)}
+          {this.renderDatacenter(dc)}
         </div>
       </div>
     );

--- a/src/linodes/create/components/Plan.js
+++ b/src/linodes/create/components/Plan.js
@@ -25,7 +25,7 @@ export default class Plan extends Component {
     return (
       <div
         className={`plan ${planClass}`}
-        key={plan.label}
+        key={plan.id}
         onClick={() => onServiceSelected(plan.id)}
       >
         <header>

--- a/src/linodes/create/layouts/IndexPage.js
+++ b/src/linodes/create/layouts/IndexPage.js
@@ -6,8 +6,9 @@ import Source from '../components/Source';
 import Plan from '../components/Plan';
 import Datacenter from '../components/Datacenter';
 import Details from '../components/Details';
-import { parallel } from '~/api/util';
-import { linodes, distributions, datacenters, types } from '~/api';
+import { linodes } from '~/api';
+import { actions as linodeActions } from '~/api/configs/linodes';
+import { randomInitialProgress } from '~/api/linodes';
 import { setError } from '~/actions/errors';
 import { setSource } from '~/actions/source';
 
@@ -15,12 +16,7 @@ export class IndexPage extends Component {
   static async preload(store) {
     const { dispatch } = store;
     try {
-      await dispatch(parallel(
-        distributions.all(),
-        datacenters.all(),
-        types.all(),
-        linodes.all(),
-      ));
+      await dispatch(linodes.all());
     } catch (response) {
       dispatch(setError(response));
     }
@@ -69,7 +65,8 @@ export class IndexPage extends Component {
     const { dispatch } = this.props;
     try {
       this.setState({ loading: true });
-      await this.createLinode({ group, label, password, backups });
+      const { id } = await this.createLinode({ group, label, password, backups });
+      dispatch(linodeActions.one({ __progress: randomInitialProgress() }, id));
 
       this.setState({ loading: false });
       dispatch(push(`/linodes/${label}`));

--- a/test/layouts/Layout.spec.js
+++ b/test/layouts/Layout.spec.js
@@ -158,15 +158,13 @@ describe('layouts/Layout', () => {
 
     dispatch.firstCall.args[0].resource.__updatedAt = undefined;
     expectObjectDeepEquals(dispatch.firstCall.args[0], linodeActions.one({
-      ...api.linodes.linodes['1237'],
       __progress: 100,
-    }, [1237]));
+    }, 1237));
 
     dispatch.secondCall.args[0].resource.__updatedAt = undefined;
     expectObjectDeepEquals(dispatch.secondCall.args[0], linodeActions.one({
-      ...api.linodes.linodes['1237'],
       status: 'running',
-    }, [1237]));
+    }, 1237));
   });
 
   it('fetches only one page when some results are read', async () => {

--- a/test/linodes/create/layout/IndexPage.spec.js
+++ b/test/linodes/create/layout/IndexPage.spec.js
@@ -156,7 +156,7 @@ describe('linodes/create/layout/IndexPage', () => {
       backups: false,
       group: null,
     });
-    expect(dispatch.callCount).to.equal(2);
+    expect(dispatch.callCount).to.equal(3);
     expectObjectDeepEquals(dispatch.firstCall.args[0], {
       root_pass: 'password',
       type: 'type',

--- a/test/linodes/create/layout/IndexPage.spec.js
+++ b/test/linodes/create/layout/IndexPage.spec.js
@@ -167,7 +167,7 @@ describe('linodes/create/layout/IndexPage', () => {
       with_backups: false,
       group: null,
     });
-    expectObjectDeepEquals(dispatch.secondCall.args[0], push('/linodes/label'));
+    expectObjectDeepEquals(dispatch.thirdCall.args[0], push('/linodes/label'));
   });
 
   it('sets errors on create a linode failure', async () => {


### PR DESCRIPTION
Closes #905 

Few things were going wrong here aside from what was actually mentioned in 905 (could not reproduce anything that had to do with labels [undefined keys, etc]):

* All ids were being converted into integers. That does not work for datacenters / distros / plans.
* The event handlers were not handling the beginning and done states of the creation / provisioning
* Datacenters / distros / plans were being rendered with bad keys in some places which caused React warnings