### PR TITLE
Don't wrap linode title in notifications

### DIFF
--- a/scss/components/Notifications.scss
+++ b/scss/components/Notifications.scss
@@ -32,6 +32,7 @@
     &-subject {
         font-size: $font-normal;
         padding-right: 5px;
+        white-space: nowrap;
     }
 }
 


### PR DESCRIPTION
Is currently:

![screen shot 2017-01-06 at 5 01 22 pm](https://cloud.githubusercontent.com/assets/3925912/21734518/ca45b9f2-d431-11e6-9fdd-62b890e942ad.png)

Is after this commit:

![screen shot 2017-01-06 at 5 01 59 pm](https://cloud.githubusercontent.com/assets/3925912/21734543/dded0212-d431-11e6-831f-3e0a6230f696.png)

There's still a lot of cleanup to do for the notifications UI but this particularly bothered me.
