### PR TITLE
Allow anonymous functions in linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
     "no-underscore-dangle": 0,
     "no-unused-expressions": 0,
     "no-confusing-arrow": 0,
+    "prefer-arrow-callback": 0,
     "array-callback-return": 0,
     "consistent-return": 0,
     "react/no-multi-comp": 0,


### PR DESCRIPTION
I'd like to be able to use anonymous functions when binding `this` is not needed:

`arr.map(function() { return ...; });`

instead of needing to use fat arrow:

`arr.map(() => { return ...; });`

Both still acceptable, this just disabled the rule in the linter.
