### PR TITLE
Fix notification swap problem

### DIFF
--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -139,8 +139,10 @@ export function sortNotifications(eventsDict) {
     return [];
   }
 
-  events.sort((e1, e2) =>
-    new Date(e2.updated) - new Date(e1.updated));
+  events.sort((e1, e2) => {
+    const timeDelta = new Date(e2.updated) - new Date(e1.updated);
+    return timeDelta !== 0 ? timeDelta : e2.id - e1.id;
+  });
   return events;
 }
 


### PR DESCRIPTION
I don't see any swapping with this change applied, but it may behave differently against different sets of events. Might be good to pull the change down and test it against your event list @peaton