### PR TITLE
Mark seen notifications immediately

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,7 +3,16 @@ import { logoOnly } from '~/assets';
 import { Link } from '~/components/Link';
 
 export default function Header(props) {
-  const { username, emailHash, title, link, showInfobar, hideShowNotifications, events } = props;
+  const {
+    username,
+    emailHash,
+    title,
+    link,
+    showInfobar,
+    hideShowNotifications,
+    events,
+    notificationsOpen
+  } = props;
   const gravatarLink = `https://gravatar.com/avatar/${emailHash}`;
 
   const infobar = (
@@ -24,8 +33,10 @@ export default function Header(props) {
     </div>
   );
 
-  const unseenNotifications = Object.values(events.events).reduce((unseen, e) =>
-    e.seen ? unseen : unseen + 1, 0);
+  const unseenNotifications = notificationsOpen ? 0 :
+    Object.values(events.events).reduce((unseen, e) =>
+      e.seen ? unseen : unseen + 1, 0);
+
   const main = (
     <div className="MainHeader clearfix">
       <div className="MainHeader-brand">
@@ -82,6 +93,7 @@ Header.propTypes = {
   showInfobar: PropTypes.bool.isRequired,
   hideShowNotifications: PropTypes.func,
   events: PropTypes.object,
+  notificationsOpen: PropTypes.bool.isRequired,
 };
 
 Header.defaultProps = {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -11,7 +11,7 @@ export default function Header(props) {
     showInfobar,
     hideShowNotifications,
     events,
-    notificationsOpen
+    notificationsOpen,
   } = props;
   const gravatarLink = `https://gravatar.com/avatar/${emailHash}`;
 

--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react';
+import React, { PropTypes, Component } from 'react';
 import { Link } from 'react-router';
 import moment from 'moment';
 
@@ -146,35 +146,54 @@ export function sortNotifications(eventsDict) {
   return events;
 }
 
-export default function Notifications(props) {
-  const {
-    open, hideShowNotifications, readNotification, events, linodes, gotoPage,
-  } = props;
+export default class Notifications extends Component {
+  constructor() {
+    super();
+  }
 
-  return (
-    <div className={`Notifications ${open ? 'Notifications--open' : ''}`}>
-      <div
-        className="Notifications-overlay"
-        onClick={hideShowNotifications}
-      />
-      <div className="Notifications-body">
-        <header className="Notifications-header text-xs-right">
-          <Link to="/logout">Logout</Link>
-        </header>
-        <div>
-          {sortNotifications(events).map((e, index) =>
-            <Notification
-              key={index}
-              readNotification={readNotification}
-              gotoPage={gotoPage}
-              linodes={linodes}
-              {...e}
-            />)}
-          <div className="Notifications-end text-xs-center">No more notifications.</div>
+  componentWillUpdate(nextProps, nextState) {
+    const { open, events, eventSeen } = nextProps;
+    const sortedEvents = sortNotifications(events);
+
+    if (open && sortedEvents[0] && !sortedEvents[0].seen) {
+      eventSeen(sortedEvents[0].id);
+    }
+  }
+
+  render() {
+    const {
+      open, hideShowNotifications, readNotification, events, linodes, gotoPage,
+    } = this.props;
+
+    const sortedEvents = sortNotifications(events);
+
+    return (
+      <div className={`Notifications ${open ? 'Notifications--open' : ''}`}>
+        <div
+          className="Notifications-overlay"
+          onClick={hideShowNotifications}
+        />
+        <div className="Notifications-body">
+          <header className="Notifications-header text-xs-right">
+            <Link to="/logout">Logout</Link>
+          </header>
+          <div>
+            {sortedEvents.map((e, index) =>
+              <Notification
+                key={index}
+                readNotification={readNotification}
+                gotoPage={gotoPage}
+                linodes={linodes}
+                {...e}
+              />)}
+            <div className="Notifications-end text-xs-center">
+              No more notifications.
+            </div>
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  }
 }
 
 Notifications.propTypes = {
@@ -184,6 +203,7 @@ Notifications.propTypes = {
   gotoPage: PropTypes.func.isRequired,
   events: PropTypes.object,
   linodes: PropTypes.object,
+  eventSeen: PropTypes.func.isRequired,
 };
 
 Notifications.defaultProps = {

--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -147,11 +147,7 @@ export function sortNotifications(eventsDict) {
 }
 
 export default class Notifications extends Component {
-  constructor() {
-    super();
-  }
-
-  componentWillUpdate(nextProps, nextState) {
+  componentWillUpdate(nextProps) {
     const { open, events, eventSeen } = nextProps;
     const sortedEvents = sortNotifications(events);
 

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -160,10 +160,6 @@ export class Layout extends Component {
       if (open) {
         dispatch(hide());
       } else {
-        const sortedEvents = sortNotifications(events);
-        if (type === 'notifications' && sortedEvents[0] && !sortedEvents[0].seen) {
-          dispatch(eventSeen(sortedEvents[0].id));
-        }
         dispatch(hideModal());
         dispatch(show());
       }
@@ -196,6 +192,7 @@ export class Layout extends Component {
           title={title}
           hideShowNotifications={this.hideShowNotifications}
           events={this.props.events}
+          notificationsOpen={this.props.notifications.open}
         />
         <Sidebar path={currentPath} />
         <Notifications
@@ -205,6 +202,7 @@ export class Layout extends Component {
           readNotification={async (id) => await dispatch(eventRead(id))}
           events={this.props.events}
           linodes={this.props.linodes}
+          eventSeen={(id) => dispatch(eventSeen(id))}
         />
         <Feedback
           email={email}

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -9,7 +9,7 @@ import { actions as eventsActions } from '~/api/configs/events';
 import { eventRead, eventSeen } from '~/api/events';
 import Header from '~/components/Header';
 import Sidebar from '~/components/Sidebar';
-import Notifications, { sortNotifications } from '~/components/Notifications';
+import Notifications from '~/components/Notifications';
 import Modal from './Modal';
 import Error from '~/components/Error';
 import Feedback from '~/components/Feedback';
@@ -156,7 +156,7 @@ export class Layout extends Component {
     return async (e) => {
       e.preventDefault();
       e.stopPropagation();
-      const { dispatch, [type]: { open }, events } = this.props;
+      const { dispatch, [type]: { open } } = this.props;
       if (open) {
         dispatch(hide());
       } else {

--- a/test/components/Notifications.spec.js
+++ b/test/components/Notifications.spec.js
@@ -118,12 +118,14 @@ describe('components/Notifications', () => {
   function makeNotifications(_dispatch = sandbox.spy(),
                              events = api.events,
                              linodes = api.linodes,
-                             hideShowNotifications = sandbox.spy()) {
+                             hideShowNotifications = sandbox.spy(),
+                             eventSeen = sandbox.spy()) {
     return (
       <Notifications
         hideShowNotifications={hideShowNotifications}
         events={events}
         linodes={linodes}
+        eventSeen={eventSeen}
       />
     );
   }
@@ -149,5 +151,13 @@ describe('components/Notifications', () => {
 
     // This event was updated last.
     expect(notifications.find('Notification').at(0).props().id).to.equal(386);
+  });
+
+  it('calls eventSeen when opened', () => {
+    const notifications = shallow(makeNotifications());
+    const eventSeen = sandbox.spy();
+    notifications.instance().componentWillUpdate(
+      { open: true, events: api.events, eventSeen }, {});
+    expect(eventSeen.callCount).to.equal(1);
   });
 });

--- a/test/layouts/Layout.spec.js
+++ b/test/layouts/Layout.spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { expectRequest } from '@/common';
 
 import { expectObjectDeepEquals } from '@/common';
 import { Layout } from '~/layouts/Layout';
@@ -11,7 +10,6 @@ import { api } from '@/data';
 import { testEvent } from '@/data/events';
 import { actions as linodeActions } from '~/api/configs/linodes';
 import { hideModal } from '~/actions/modal';
-import { sortNotifications } from '~/components/Notifications';
 import { showNotifications } from '~/actions/notifications';
 
 describe('layouts/Layout', () => {
@@ -219,7 +217,7 @@ describe('layouts/Layout', () => {
     });
   });
 
-  it('marks all events as seen when the notifications is opened', async () => {
+  it('marks all events as seen when the notifications is opened', () => {
     const page = shallow(
       <Layout
         dispatch={dispatch}
@@ -234,13 +232,9 @@ describe('layouts/Layout', () => {
 
     page.instance().hideShowNotifications({ stopPropagation() {}, preventDefault() {} });
 
-    const sortedEvents = sortNotifications(api.events);
-    expect(dispatch.callCount).to.equal(3);
+    expect(dispatch.callCount).to.equal(2);
 
-    const fn = dispatch.firstCall.args[0];
-    await expectRequest(fn, `/account/events/${sortedEvents[0].id}/seen`);
-
-    expectObjectDeepEquals(dispatch.secondCall.args[0], hideModal());
-    expectObjectDeepEquals(dispatch.thirdCall.args[0], showNotifications());
+    expectObjectDeepEquals(dispatch.firstCall.args[0], hideModal());
+    expectObjectDeepEquals(dispatch.secondCall.args[0], showNotifications());
   });
 });


### PR DESCRIPTION
Closes #865 
Closes #941

This does a couple of things to help with notifications bouncing back
and forth between seen and unseen in local state, mostly related to a
new invariant that all notifications are counted as seen as long as the
notification view is open:

1. When the notifications pane is open, the header never shows an unseen
number over the gravatar, even if it briefly thinks there are unseen
notifications.

2. The code that marks notifications as seen has been moved into the
notifications view itself, during componentWillUpdate. This way, events
are marked seen a) when the notification pane is opened and b) whenever
new events arrive while the pane is still open.