### PR TITLE
Add view link to notifications

### DIFF
--- a/scss/components/Notifications.scss
+++ b/scss/components/Notifications.scss
@@ -31,10 +31,10 @@
 
     &-subject {
         display: block;
-        color: black;
+        color: $black;
 
         &:hover {
-            color: black;
+            color: $black;
         }
     }
 }

--- a/scss/components/Notifications.scss
+++ b/scss/components/Notifications.scss
@@ -30,14 +30,12 @@
     }
 
     &-subject {
-        font-size: $font-normal;
-        padding-right: 5px;
-        white-space: nowrap;
-    }
+        display: block;
+        color: black;
 
-    &-view {
-        float: right;
-        margin-top: 5px;
+        &:hover {
+            color: black;
+        }
     }
 }
 

--- a/scss/components/Notifications.scss
+++ b/scss/components/Notifications.scss
@@ -34,6 +34,11 @@
         padding-right: 5px;
         white-space: nowrap;
     }
+
+    &-view {
+        float: right;
+        margin-top: 5px;
+    }
 }
 
 .Notifications {
@@ -64,11 +69,11 @@
         background: $white;
         border-bottom: $border;
         padding: 10px 15px;
-        
+
         a {
             line-height: $input-height;
         }
-        
+
         .fa {
             padding-left: 5px;
             color: $blue;

--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -69,47 +69,56 @@ export function Notification(props) {
   const event = new Event(props);
 
   function handleNotificationClick() {
-    if (props.read) {
-      let page = `/linodes/${props.linode_id}`;
+    return props.readNotification(props.id);
+  }
 
-      switch (event.getType()) {
-        case Event.LINODE_DELETE:
-          // No page to change to.
-          return;
-
-        case Event.LINODE_REBOOT:
-        case Event.LINODE_BOOT:
-        case Event.LINODE_POWER_OFF:
-        case Event.LINODE_CREATE:
-          break; // Default is good
-
-        case Event.LINODE_DISK_DELETE:
-        case Event.LINODE_DISK_CREATE:
-        case Event.LINODE_DISK_RESIZE:
-          page = `${page}/settings/advanced`;
-          break;
-
-        case Event.LINODE_BACKUPS_ENABLE:
-        case Event.LINODE_BACKUPS_DISABLE:
-          page = `${page}/backups`;
-          break;
-
-        default:
-          break;
-      }
-
-      return props.gotoPage(page);
+  function handleNotificationView(e) {
+    if (!props.read) {
+      props.readNotification(props.id);
     }
 
-    return props.readNotification(props.id);
+    let page = `/linodes/${getLinodeName(event, props.linodes)}`;
+
+    switch (event.getType()) {
+      case Event.LINODE_DELETE:
+        // No page to change to.
+        return;
+
+      case Event.LINODE_REBOOT:
+      case Event.LINODE_BOOT:
+      case Event.LINODE_POWER_OFF:
+      case Event.LINODE_CREATE:
+        break; // Default is good
+
+      case Event.LINODE_DISK_DELETE:
+      case Event.LINODE_DISK_CREATE:
+      case Event.LINODE_DISK_RESIZE:
+        page = `${page}/settings/advanced`;
+        break;
+
+      case Event.LINODE_BACKUPS_ENABLE:
+      case Event.LINODE_BACKUPS_DISABLE:
+        page = `${page}/backups`;
+        break;
+
+      default:
+        break;
+    }
+
+    props.gotoPage(page);
+    return props.hideShowNotifications(e);
   }
 
   return (
     <div
-      className={`Notification ${props.read ? '' : 'Notification--unread'}`}
+      className={`clearfix Notification ${props.read ? '' : 'Notification--unread'}`}
       onClick={handleNotificationClick}
     >
       <header className="Notification-header">
+        <button
+          className="btn btn-cancel Notification-view"
+          onClick={handleNotificationView}
+        >View</button>
         <div className="Notification-text">{notificationMessage(event, props.linodes)}</div>
         <div className="Notification-time">
           {moment.utc(props.updated, moment.ISO_8601).fromNow()}
@@ -131,6 +140,7 @@ Notification.propTypes = {
   nodebalancer_id: PropTypes.number,
   stackscript_id: PropTypes.number,
   linodes: PropTypes.object.isRequired,
+  hideShowNotifications: PropTypes.func.isRequired,
 };
 
 export function sortNotifications(eventsDict) {
@@ -180,6 +190,7 @@ export default class Notifications extends Component {
                 readNotification={readNotification}
                 gotoPage={gotoPage}
                 linodes={linodes}
+                hideShowNotifications={hideShowNotifications}
                 {...e}
               />)}
             <div className="Notifications-end text-xs-center">

--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -19,15 +19,18 @@ function getLinodeName(event, linodes) {
   }
 }
 
-function linodeNotificationMessage(event, linodes, objectType, tempText, doneText) {
+function linodeNotificationMessage(event, linodes, objectType, tempText,
+    doneText, view) {
   const linodeName = getLinodeName(event, linodes);
   const eventFinished = event.getProgress() === 100;
 
   return (
     <span>
-      <span className="Notification-subject">
-        {linodeName}
-      </span>
+      <Link
+        to="#"
+        onClick={view}
+        className="Notification-subject"
+      >{linodeName}</Link>
       {objectType}&nbsp;
       {eventFinished ? doneText : tempText}&nbsp;
       {event._event.status === 'failed' ? 'failed' : ''}
@@ -35,30 +38,31 @@ function linodeNotificationMessage(event, linodes, objectType, tempText, doneTex
   );
 }
 
-function notificationMessage(event, linodes) {
+function notificationMessage(event, linodes, view) {
   switch (event.getType()) {
     case Event.LINODE_REBOOT:
-      return linodeNotificationMessage(event, linodes, 'Linode', 'rebooting', 'rebooted');
+      return linodeNotificationMessage(event, linodes, 'Linode', 'rebooting', 'rebooted', view);
     case Event.LINODE_BOOT:
-      return linodeNotificationMessage(event, linodes, 'Linode', 'booting', 'booted');
+      return linodeNotificationMessage(event, linodes, 'Linode', 'booting', 'booted', view);
     case Event.LINODE_POWER_OFF:
-      return linodeNotificationMessage(event, linodes, 'Linode', 'being shut down', 'shut down');
+      return linodeNotificationMessage(event, linodes, 'Linode', 'being shut down', 'shut down',
+        view);
     case Event.LINODE_CREATE:
-      return linodeNotificationMessage(event, linodes, 'Linode', 'provisioning', 'created');
+      return linodeNotificationMessage(event, linodes, 'Linode', 'provisioning', 'created', view);
     case Event.LINODE_DELETE:
-      return linodeNotificationMessage(event, linodes, 'Linode', 'being deleted', 'deleted');
+      return linodeNotificationMessage(event, linodes, 'Linode', 'being deleted', 'deleted', view);
 
     case Event.LINODE_BACKUPS_ENABLE:
-      return linodeNotificationMessage(event, linodes, 'Backups', 'enabled', 'enabled');
+      return linodeNotificationMessage(event, linodes, 'Backups', 'enabled', 'enabled', view);
     case Event.LINODE_BACKUPS_DISABLE:
-      return linodeNotificationMessage(event, linodes, 'Backups', 'disabled', 'disabled');
+      return linodeNotificationMessage(event, linodes, 'Backups', 'disabled', 'disabled', view);
 
     case Event.LINODE_DISK_DELETE:
-      return linodeNotificationMessage(event, linodes, 'Disk', 'being deleted', 'deleted');
+      return linodeNotificationMessage(event, linodes, 'Disk', 'being deleted', 'deleted', view);
     case Event.LINODE_DISK_CREATE:
-      return linodeNotificationMessage(event, linodes, 'Disk', 'being created', 'created');
+      return linodeNotificationMessage(event, linodes, 'Disk', 'being created', 'created', view);
     case Event.LINODE_DISK_RESIZE:
-      return linodeNotificationMessage(event, linodes, 'Disk', 'being resized', 'resized');
+      return linodeNotificationMessage(event, linodes, 'Disk', 'being resized', 'resized', view);
 
     default:
       return '';
@@ -111,15 +115,13 @@ export function Notification(props) {
 
   return (
     <div
-      className={`clearfix Notification ${props.read ? '' : 'Notification--unread'}`}
+      className={`Notification ${props.read ? '' : 'Notification--unread'}`}
       onClick={handleNotificationClick}
     >
       <header className="Notification-header">
-        <button
-          className="btn btn-cancel Notification-view"
-          onClick={handleNotificationView}
-        >View</button>
-        <div className="Notification-text">{notificationMessage(event, props.linodes)}</div>
+        <div className="Notification-text">
+          {notificationMessage(event, props.linodes, handleNotificationView)}
+        </div>
         <div className="Notification-time">
           {moment.utc(props.updated, moment.ISO_8601).fromNow()}
         </div>

--- a/test/components/Notifications.spec.js
+++ b/test/components/Notifications.spec.js
@@ -45,7 +45,7 @@ describe('components/Notification', () => {
     const notification = shallow(makeNotification(
       api.events.events[385], undefined, undefined, readNotification));
     notification.find('.Notification').simulate('click');
-    expect(readNotification.calledOnce).to.equal(true);
+    expect(readNotification.callCount).to.equal(1);
     expect(readNotification.args[0][0]).to.equal(385);
   });
 
@@ -57,13 +57,13 @@ describe('components/Notification', () => {
       undefined, gotoPage, readNotification, hideShowNotifications));
     notification.find('.Notification-subject').simulate('click');
 
-    expect(readNotification.calledOnce).to.equal(true);
+    expect(readNotification.callCount).to.equal(1);
     expect(readNotification.args[0][0]).to.equal(385);
 
-    expect(gotoPage.calledOnce).to.equal(true);
+    expect(gotoPage.callCount).to.equal(1);
     expect(gotoPage.args[0][0]).to.equal('/linodes/test-linode-3');
 
-    expect(hideShowNotifications.calledOnce).to.equal(true);
+    expect(hideShowNotifications.callCount).to.equal(1);
   });
 
   function testNotificationText(eventType, expectedText) {

--- a/test/components/Notifications.spec.js
+++ b/test/components/Notifications.spec.js
@@ -13,13 +13,15 @@ describe('components/Notification', () => {
   function makeNotification(event = api.events.events[386],
                             linodes = api.linodes,
                             gotoPage = sandbox.spy(),
-                            readNotification = sandbox.spy()) {
+                            readNotification = sandbox.spy(),
+                            hideShowNotifications = sandbox.spy()) {
     return (
       <Notification
         {...event}
         linodes={linodes}
         readNotification={readNotification}
         gotoPage={gotoPage}
+        hideShowNotifications={hideShowNotifications}
       />
     );
   }
@@ -47,13 +49,21 @@ describe('components/Notification', () => {
     expect(readNotification.args[0][0]).to.equal(385);
   });
 
-  it('calls gotoPage on read notification onclick', () => {
+  it('marks unread, redirects, and closes pane on view click', () => {
+    const readNotification = sandbox.spy();
     const gotoPage = sandbox.spy();
-    const notification = shallow(makeNotification(
-      undefined, undefined, gotoPage));
-    notification.find('.Notification').simulate('click');
+    const hideShowNotifications = sandbox.spy();
+    const notification = shallow(makeNotification(api.events.events[385],
+      undefined, gotoPage, readNotification, hideShowNotifications));
+    notification.find('.Notification-view').simulate('click');
+
+    expect(readNotification.calledOnce).to.equal(true);
+    expect(readNotification.args[0][0]).to.equal(385);
+
     expect(gotoPage.calledOnce).to.equal(true);
-    expect(gotoPage.args[0][0]).to.equal(`/linodes/${api.events.events[386].linode_id}`);
+    expect(gotoPage.args[0][0]).to.equal('/linodes/test-linode-3');
+
+    expect(hideShowNotifications.calledOnce).to.equal(true);
   });
 
   function testNotificationText(eventType, expectedText) {

--- a/test/components/Notifications.spec.js
+++ b/test/components/Notifications.spec.js
@@ -55,7 +55,7 @@ describe('components/Notification', () => {
     const hideShowNotifications = sandbox.spy();
     const notification = shallow(makeNotification(api.events.events[385],
       undefined, gotoPage, readNotification, hideShowNotifications));
-    notification.find('.Notification-view').simulate('click');
+    notification.find('.Notification-subject').simulate('click');
 
     expect(readNotification.calledOnce).to.equal(true);
     expect(readNotification.args[0][0]).to.equal(385);


### PR DESCRIPTION
Closes #857 

1. When you click a notification it marks it read.

2. When you click the 'View' link, the notification is marked read, the
notifications pane is closed, and the page redirects to the mentioned
Linode.

![screen shot 2017-01-10 at 11 27 14 am](https://cloud.githubusercontent.com/assets/4149249/21814798/7eca1366-d728-11e6-8bb2-5c5282bf6430.png)
