### PR TITLE
Remove Dependency CI badge for the time being

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 <p align="center">
   <a href="https://travis-ci.org/linode/manager"><img src="https://travis-ci.org/linode/manager.svg?branch=master" alt="Build status" /></a>
   <a href="https://coveralls.io/github/linode/manager?branch=master"><img src="https://coveralls.io/repos/github/linode/manager/badge.svg?branch=master" alt="Code coverage" /></a>
-  <a href='https://dependencyci.com/github/linode/manager'><img src='https://dependencyci.com/github/linode/manager/badge' alt='Dependency Status'/></a>
   <a href="https://waffle.io/linode/manager"><img src="https://badge.waffle.io/linode/manager.svg?label=ready&title=Agile%20board" alt="Sprint status" /></a>
   <img src="https://img.shields.io/badge/badges-many-brightgreen.svg" alt="much badges" />
 </p>


### PR DESCRIPTION
Due to badge displaying broken image. We are not failing the dependency check, the service seems to be failing.