### PR TITLE
Add support for specifying a single test file to be run

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,19 +3,11 @@ var path = require("path");
 var CircularDependencyPlugin = require('circular-dependency-plugin');
 
 module.exports = function(config) {
-  config.set({
+  var files = process.env.npm_config_single_file ? process.env.npm_config_single_file : 'test/index.js';
+  var option = {
+    basePath: __dirname,
     frameworks: ['mocha'],
     browsers: ['PhantomJS'],
-    files: [
-      './node_modules/phantomjs-polyfill/bind-polyfill.js',
-      'test/index.js',
-      'test/setup.js'
-    ],
-    preprocessors: {
-      'test/index.js': ['webpack', 'sourcemap'],
-      'src/**/*.js': ['webpack', 'sourcemap'],
-      'test/setup.js': ['webpack', 'sourcemap']
-    },
     webpack: {
       devtool: 'inline-source-map',
       module: {
@@ -93,5 +85,18 @@ module.exports = function(config) {
       require("karma-coverage")
     ],
     browserNoActivityTimeout: 100000
-  });
+  };
+
+  option.files = [
+    './node_modules/phantomjs-polyfill/bind-polyfill.js',
+    'test/setup.js',
+    { pattern: files, watch: false }
+  ];
+  option.preprocessors = {
+    'src/**/*.js': ['webpack', 'sourcemap'],
+    'test/setup.js': ['webpack', 'sourcemap']
+  };
+  option.preprocessors[files] = ['webpack', 'sourcemap'];
+
+  config.set(option);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,2 @@
-import zxcvbn from 'zxcvbn';
-window.zxcvbn = zxcvbn;
-
 const testsContext = require.context('.', true, /spec.js$/);
 testsContext.keys().forEach(testsContext);

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,5 @@
+import zxcvbn from 'zxcvbn';
+window.zxcvbn = zxcvbn;
 window.localStorage.clear();
 
 import '../src/index';


### PR DESCRIPTION
This still requires the entire source be loaded, but is great in watch mode.

Run example:

`npm run test:watch --single_file=**/Details.spec.js`