### PR TITLE
Cleanup styleguide modals sections

### DIFF
--- a/scss/styleguide/components/sections/StyleguideModals.scss
+++ b/scss/styleguide/components/sections/StyleguideModals.scss
@@ -1,0 +1,20 @@
+.StyleguideModals {
+  &-examples {
+    ul {
+      padding: 0;
+    }
+
+    ul > li {
+      display: inline;
+      margin-left: 15px;
+    }
+
+    ul > li:first-child {
+      margin-left: 0;
+    }
+  }
+
+  .modal-overlay {
+    top: 0;
+  }
+}

--- a/scss/styleguide/components/sections/index.scss
+++ b/scss/styleguide/components/sections/index.scss
@@ -1,5 +1,6 @@
 @import 'StyleguideColor';
+@import 'StyleguideForm';
+@import 'StyleguideModals';
 @import 'StyleguideNavigation';
 @import 'StyleguideTabs';
 @import 'StyleguideTypography';
-@import 'StyleguideForm';

--- a/src/styleguide/components/sections/Modals.js
+++ b/src/styleguide/components/sections/Modals.js
@@ -1,117 +1,149 @@
 import React, { Component } from 'react';
 
-import { StyleguideSection } from '~/styleguide/components';
+import { Button } from '~/components/buttons';
+import { CancelButton } from '~/components/form';
 import { ModalShell } from '~/components/modals';
-import CancelButton from '~/components/form/CancelButton';
+import { StyleguideSection } from '~/styleguide/components';
 
 export default class Modals extends Component {
   constructor() {
     super();
     this.state = {
+      basicOpen: false,
       confirmOpen: false,
-      generalOpen: false,
+      formOpen: false,
     };
   }
 
   render() {
     return (
       <StyleguideSection name="modals" title="Modals">
-        This is an example of a
-        <br />
-        <a onClick={() => this.setState({ confirmOpen: true })} className="btn btn-default">
-          Confirm modal
-        </a>
-        <ModalShell
-          title="Modal example"
-          open={this.state.confirmOpen}
-          close={() => { this.setState({ confirmOpen: false }); }}
-        >
-          <div>
-            <p>
-              Content goes here
-            </p>
-            <div className="modal-footer">
-              <CancelButton onClick={() => { this.setState({ confirmOpen: false }); }} />
-              <button
-                className="btn btn-default"
-                onClick={() => { this.setState({ confirmOpen: false }); }}
-              >
-                OK
-              </button>
+        <div className="StyleguideModals col-sm-12">
+          <div className="StyleguideSubSection row">
+            <div className="col-sm-12">
+              <div className="StyleguideSubSection-header">
+                <p>
+                  Modals are used to display an important message
+                  or obtain a response from the user.
+                </p>
+              </div>
+              <div className="StyleguideModals-examples">
+                <p>Examples:</p>
+                <ul>
+                  <li>
+                    <Button onClick={() => this.setState({ basicOpen: true })}>
+                      Basic Modal
+                    </Button>
+                    <ModalShell
+                      title="Basic Modal Example"
+                      open={this.state.basicOpen}
+                      close={() => { this.setState({ basicOpen: false }); }}
+                    >
+                      <div>
+                        <p>
+                          A very important message.
+                        </p>
+                        <div className="modal-footer">
+                          <Button onClick={() => { this.setState({ basicOpen: false }); }}>
+                            Ok
+                          </Button>
+                        </div>
+                      </div>
+                    </ModalShell>
+                  </li>
+                  <li>
+                    <Button onClick={() => this.setState({ confirmOpen: true })}>
+                      Confirm modal
+                    </Button>
+                    <ModalShell
+                      title="Confirm Modal Example"
+                      open={this.state.confirmOpen}
+                      close={() => { this.setState({ confirmOpen: false }); }}
+                    >
+                      <div>
+                        <p>
+                          Please confirm your choice.
+                        </p>
+                        <div className="modal-footer">
+                          <CancelButton
+                            onClick={() => { this.setState({ confirmOpen: false }); }}
+                          />
+                          <Button onClick={() => { this.setState({ confirmOpen: false }); }}>
+                            Confirm
+                          </Button>
+                        </div>
+                      </div>
+                    </ModalShell>
+                  </li>
+                  <li>
+                    <Button onClick={() => this.setState({ formOpen: true })}>
+                      Form Modal
+                    </Button>
+                    <ModalShell
+                      title="Form Modal Example"
+                      open={this.state.formOpen}
+                      close={() => { this.setState({ formOpen: false }); }}
+                    >
+                      <div>
+                        <p>
+                          A short description about this form.
+                        </p>
+                        <div className="ConfigSelectModalBody-configs">
+                          <div key="1" className="radio">
+                            <label>
+                              <input
+                                type="checkbox"
+                                name="config1"
+                                value="Item 1"
+                              />
+                              <span>Item 1</span>
+                            </label>
+                          </div>
+                          <div key="2" className="radio">
+                            <label>
+                              <input
+                                type="checkbox"
+                                name="config2"
+                                value="Item 2"
+                              />
+                              <span>Item 2</span>
+                            </label>
+                          </div>
+                          <div key="3" className="radio">
+                            <label>
+                              <input
+                                type="checkbox"
+                                name="config3"
+                                value="Item 3"
+                              />
+                              <span>Item 3</span>
+                            </label>
+                          </div>
+                          <div key="4" className="radio">
+                            <label>
+                              <input
+                                type="checkbox"
+                                name="config4"
+                                value="Item 4"
+                              />
+                              <span>Item 4</span>
+                            </label>
+                          </div>
+                        </div>
+                        <div className="modal-footer">
+                          <CancelButton onClick={() => { this.setState({ formOpen: false }); }} />
+                          <Button onClick={() => { this.setState({ formOpen: false }); }}>
+                            Save
+                          </Button>
+                        </div>
+                      </div>
+                    </ModalShell>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
-        </ModalShell>
-        <br />
-        <br />
-        This is an example of a
-        <br />
-        <a onClick={() => this.setState({ generalOpen: true })} className="btn btn-default">
-          General modal
-        </a>
-        <ModalShell
-          title="Modal example"
-          open={this.state.generalOpen}
-          close={() => { this.setState({ generalOpen: false }); }}
-        >
-          <div>
-            <p>
-              Content goes here
-            </p>
-            <div className="ConfigSelectModalBody-configs">
-              <div key="1" className="radio">
-                <label>
-                  <input
-                    type="checkbox"
-                    name="config1"
-                    value="Item 1"
-                  />
-                  <span>Item 1</span>
-                </label>
-              </div>
-              <div key="2" className="radio">
-                <label>
-                  <input
-                    type="checkbox"
-                    name="config2"
-                    value="Item 2"
-                  />
-                  <span>Item 2</span>
-                </label>
-              </div>
-              <div key="3" className="radio">
-                <label>
-                  <input
-                    type="checkbox"
-                    name="config3"
-                    value="Item 3"
-                  />
-                  <span>Item 3</span>
-                </label>
-              </div>
-              <div key="4" className="radio">
-                <label>
-                  <input
-                    type="checkbox"
-                    name="config4"
-                    value="Item 4"
-                  />
-                  <span>Item 4</span>
-                </label>
-              </div>
-            </div>
-            <div className="modal-footer">
-              <CancelButton onClick={() => { this.setState({ generalOpen: false }); }} />
-              <button
-                className="btn btn-default"
-                onClick={() => { this.setState({ generalOpen: false }); }}
-              >
-                Change
-              </button>
-            </div>
-          </div>
-        </ModalShell>
-        <br />
-        You can have form elements or other elements inside a general modal.
+        </div>
       </StyleguideSection>
     );
   }


### PR DESCRIPTION
Adds a modal example, short description, cleans up markup and css.

Fixes an issue where the overlay did not cover the whole page.

![screen shot 2017-01-17 at 3 04 36 pm](https://cloud.githubusercontent.com/assets/709951/22037764/8991b706-dcc6-11e6-88cf-07d3220ef80e.png)
![screen shot 2017-01-17 at 3 04 40 pm](https://cloud.githubusercontent.com/assets/709951/22037766/8ee51982-dcc6-11e6-9dbb-ced3e8b78ac0.png)
![screen shot 2017-01-17 at 3 04 46 pm](https://cloud.githubusercontent.com/assets/709951/22037769/92e89d1a-dcc6-11e6-9eaf-d19a9e5d2489.png)
![screen shot 2017-01-17 at 3 04 51 pm](https://cloud.githubusercontent.com/assets/709951/22037775/9f2d5d22-dcc6-11e6-83bd-25518ef5f3d5.png)

