### PR TITLE
Fix linodes groups

### DIFF
--- a/scss/manager.scss
+++ b/scss/manager.scss
@@ -518,17 +518,6 @@ footer {
         color: $light-black;
         margin-bottom: 5px;
     }
-
-    tr.display-group {
-        border-left: 0;
-        font-size: $font-small;
-
-        td {
-            background: $light-gray;
-            padding-bottom: 0;
-            padding-left: 0;
-        }
-    }
 }
 
 .sub-header {

--- a/scss/manager.scss
+++ b/scss/manager.scss
@@ -458,6 +458,12 @@ footer {
     }
 }
 
+.Linodes {
+    &-group-container {
+        margin-bottom: 20px;
+    }
+}
+
 .linodes {
     .linode-label {
         color: $black !important;
@@ -510,7 +516,7 @@ footer {
 
     .display-group {
         color: $light-black;
-        margin-bottom: $main-padding-tb/3;
+        margin-bottom: 5px;
     }
 
     tr.display-group {

--- a/src/linodes/layouts/IndexPage.js
+++ b/src/linodes/layouts/IndexPage.js
@@ -149,17 +149,16 @@ export class IndexPage extends Component {
       );
     }
 
-    const ret = sortedLinodes.map(l => renderLinode(l, true));
-
-    if (group) {
-      ret.splice(0, 0, (
-        <tr className="display-group">
-          <td>{group}</td>
-        </tr>
-      ));
-    }
-
-    return ret;
+    return (
+      <div className="Linodes-group-container">
+        {group ? <div className="display-group">{group}</div> : null}
+        <table>
+          <tbody>
+            {sortedLinodes.map(l => renderLinode(l, true))}
+          </tbody>
+        </table>
+      </div>
+    );
   }
 
   renderLinodes(linodes) {
@@ -178,11 +177,9 @@ export class IndexPage extends Component {
     }
 
     return (
-      <table className="linodes">
-        <tbody>
-          {groups}
-        </tbody>
-      </table>
+      <div className="linodes">
+        {groups}
+      </div>
     );
   }
 

--- a/test/linodes/layouts/IndexPage.spec.js
+++ b/test/linodes/layouts/IndexPage.spec.js
@@ -85,15 +85,10 @@ describe('linodes/layouts/IndexPage', () => {
       />
     );
 
-    const table = page.find('table.linodes');
-    expect(table.length).to.equal(1);
-
-    // There should be as many rows as there are Linodes and display groups,
-    // minus 1 for the default empty group.
-    const groups = Object.values(linodes.linodes).map(l => l.group);
-    const groupCount = [...new Set(groups)].length;
-    expect(table.find('tbody tr').length).to.equal(
-      Object.keys(linodes.linodes).length + groupCount - 1);
+    const linodesContainer = page.find('.linodes');
+    expect(linodesContainer.length).to.equal(1);
+    expect(linodesContainer.find('tr').length).to.equal(
+      Object.keys(linodes.linodes).length);
   });
 
   it('renders a power management dropdown', () => {


### PR DESCRIPTION
Closes #1009

When part of a group, linode label alignment was off, because it is defined in a `td` as part of the linodes table.

This separates group names from lists (table) of linodes, allowing us to style group headers independently.

Example from @na3d of group labels effecting cell widths:

![group_widths](https://cloud.githubusercontent.com/assets/709951/22084854/abf30d66-dd9f-11e6-9ee4-7bd0271c5de8.png)

Example Screenshot with change:

![screen shot 2017-01-18 at 5 03 50 pm](https://cloud.githubusercontent.com/assets/709951/22084971/287150fa-dda0-11e6-9d06-21c2f6a858df.png)

