### PR TITLE
Header on Linode page is link

### DIFF
--- a/scss/layout/Layout.scss
+++ b/scss/layout/Layout.scss
@@ -52,7 +52,15 @@ body,
   }
 
   h1 {
-    margin-bottom: 0;
+      margin-bottom: 0;
+
+      a,
+      a:focus,
+      a:active,
+      a:hover {
+          color: inherit;
+          text-decoration: none;
+      }
   }
 }
 

--- a/src/linodes/linode/layouts/IndexPage.js
+++ b/src/linodes/linode/layouts/IndexPage.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 
+import { Link } from '~/components/Link';
 import Tabs from '~/components/Tabs';
 import StatusDropdown from '~/linodes/components/StatusDropdown';
 import { setError } from '~/actions/errors';
@@ -50,38 +51,6 @@ export class IndexPage extends Component {
     });
   }
 
-  renderLabel(linode) {
-    const label = linode.group ?
-      <span>{linode.group} / {linode.label}</span> :
-      <span>{linode.label}</span>;
-
-    return (
-      <div className="float-xs-left">
-        <h1 title={linode.id}>{label}</h1>
-      </div>
-    );
-  }
-
-  renderHeader() {
-    const linode = this.getLinode();
-
-    return (
-      <header className="main-header">
-        <div className="container">
-          {this.renderLabel(linode)}
-          <span className="float-xs-right">
-            <StatusDropdown
-              shortcuts={false}
-              linode={linode}
-              short
-              dispatch={this.props.dispatch}
-            />
-          </span>
-        </div>
-      </header>
-    );
-  }
-
   render() {
     const linode = this.getLinode();
     if (!linode) return <span></span>;
@@ -102,7 +71,25 @@ export class IndexPage extends Component {
 
     return (
       <div className="details-page">
-        {this.renderHeader(linode)}
+        <header className="main-header">
+          <div className="container">
+            <div className="float-xs-left">
+              <h1 title={linode.id}>
+                <Link to={`/linodes/${linode.label}`}>
+                  {linode.group ? `${linode.group} / ${linode.label}` : linode.label}
+                </Link>
+              </h1>
+            </div>
+            <span className="float-xs-right">
+              <StatusDropdown
+                shortcuts={false}
+                linode={linode}
+                short
+                dispatch={this.props.dispatch}
+              />
+            </span>
+          </div>
+        </header>
         <div className="main-header-fix"></div>
         <Tabs
           tabs={tabs}

--- a/test/linodes/linode/layouts/IndexPage.spec.js
+++ b/test/linodes/linode/layouts/IndexPage.spec.js
@@ -56,7 +56,7 @@ describe('linodes/linode/layouts/IndexPage', () => {
   });
 
   it('renders the linode label and group', () => {
-    const page = mount(
+    const page = shallow(
       <IndexPage
         dispatch={dispatch}
         linodes={linodes}
@@ -64,8 +64,10 @@ describe('linodes/linode/layouts/IndexPage', () => {
         detail={detail}
         router={router}
       />);
-    expect(page.contains(<span>{testLinode.group} / {testLinode.label}</span>))
-      .to.equal(true);
+
+    const h1Link = page.find('h1 Link');
+    expect(h1Link.props().to).to.equal(`/linodes/${testLinode.label}`);
+    expect(h1Link.props().children).to.equal(`${testLinode.group} / ${testLinode.label}`);
   });
 
   it('renders the linode label alone when ungrouped', () => {
@@ -77,8 +79,10 @@ describe('linodes/linode/layouts/IndexPage', () => {
         detail={detail}
         router={router}
       />);
-    expect(page.contains(<span>{linodes.linodes[1235].label}</span>))
-      .to.equal(true);
+
+    const h1Link = page.find('h1 Link');
+    expect(h1Link.props().to).to.equal('/linodes/test-linode-1');
+    expect(h1Link.text()).to.equal('test-linode-1');
   });
 
   it('renders a power management dropdown', () => {


### PR DESCRIPTION
Open for discussion, but I keep expecting to be able to hit the header on the multi-tab page and return to the dashboard / home page. I'd expect this to follow if other pages for objects were multi-tabbed (nodebalancers, perhaps; not dns right now because it doesn't have tabs).