### PR TITLE
Styleguide textareas

### DIFF
--- a/scss/components/form/form.scss
+++ b/scss/components/form/form.scss
@@ -30,20 +30,38 @@ select.form-control:not([size]):not([multiple]) {
   height: $form-field-height;
 }
 
-.form-control {
+input.form-control,
+select.form-control {
   width: 225px;
 }
 
-.form-control.input-md {
+input.form-control.input-md,
+select.form-control.input-md {
   width: 275px;
 }
 
-.form-control.input-lg {
+input.form-control.input-lg,
+select.form-control.input-lg {
   width: 325px;
 }
 
 input[type="number"].form-control {
   width: 125px;
+}
+
+textarea {
+    border: 1px solid $dark-gray;
+    max-width: 100%;
+    min-height: 100px;
+    min-width: 400px;
+    outline: none;
+    padding: 6px 8px;
+    resize: both;
+}
+
+textarea.textarea-md {
+    min-width: 600px;
+    min-height: 200px;
 }
 
 .form-control-feedback {

--- a/scss/components/form/form.scss
+++ b/scss/components/form/form.scss
@@ -50,7 +50,7 @@ input[type="number"].form-control {
 }
 
 textarea {
-    border: 1px solid $border-gray;
+    border: $border;
     max-width: 100%;
     min-height: 100px;
     min-width: 400px;

--- a/scss/components/form/form.scss
+++ b/scss/components/form/form.scss
@@ -50,7 +50,7 @@ input[type="number"].form-control {
 }
 
 textarea {
-    border: 1px solid $dark-gray;
+    border: 1px solid $border-gray;
     max-width: 100%;
     min-height: 100px;
     min-width: 400px;

--- a/scss/manager.scss
+++ b/scss/manager.scss
@@ -245,7 +245,7 @@ header .sub-header {
 
 .feedback {
     position: fixed;
-    right: -400px;
+    right: -430px;
     top: 300px;
     z-index: 999;
     -webkit-transition: all .3s ease-out;
@@ -270,7 +270,7 @@ header .sub-header {
     }
 
     .card {
-        width: 400px;
+        width: 430px;
     }
 }
 

--- a/src/dnsmanager/components/NewSlaveZone.js
+++ b/src/dnsmanager/components/NewSlaveZone.js
@@ -24,14 +24,14 @@ export default function NewSlaveZone(props) {
         <div className="col-sm-6">
           <textarea
             value={props.master_ips.length ? props.master_ips.join(';') : ''}
-            className="form-control"
             placeholder="127.0.0.1;255.255.255.1"
             onChange={props.onChange('master_ips')}
           />
-          <small className="text-muted">
-            The IP addresses of the master DNS servers for this<br />
-            zone must be semicolon or new line delimited.
-          </small>
+          <div>
+            <small className="text-muted">
+              The IP addresses of the master DNS servers for this zone must be semicolon or new line delimited.
+            </small>
+          </div>
         </div>
         <FormGroupError errors={props.errors} name="master_ips" />
       </FormGroup>

--- a/src/dnsmanager/components/NewSlaveZone.js
+++ b/src/dnsmanager/components/NewSlaveZone.js
@@ -29,7 +29,8 @@ export default function NewSlaveZone(props) {
           />
           <div>
             <small className="text-muted">
-              The IP addresses of the master DNS servers for this zone must be semicolon or new line delimited.
+              The IP addresses of the master DNS servers for
+              this zone must be semicolon or new line delimited.
             </small>
           </div>
         </div>

--- a/src/linodes/linode/settings/layouts/EditConfigPage.js
+++ b/src/linodes/linode/settings/layouts/EditConfigPage.js
@@ -349,7 +349,6 @@ export class EditConfigPage extends Component {
               <div className="col-sm-6">
                 <textarea
                   id="config-comments"
-                  className="form-control col-sm-3"
                   placeholder="Notes"
                   value={comments}
                   disabled={loading}

--- a/src/profile/layouts/LishPage.js
+++ b/src/profile/layouts/LishPage.js
@@ -47,9 +47,11 @@ export default class NotificationsPage extends Component {
             <FormGroup className="row" errors={errors} name="keys">
               <label htmlFor="keys" className="col-sm-2 col-form-label">Lish keys:</label>
               <div className="col-sm-10">
-                <textarea id="keys" name="keys" className="form-control" value={keys}></textarea>
+                <textarea id="keys" className="textarea-md" name="keys" value={keys}></textarea>
                 <div>
-                  <small>Place your SSH public keys here for use with Lish console access.</small>
+                  <small className="text-muted">
+                    Place your SSH public keys here for use with Lish console access.
+                  </small>
                 </div>
                 <FormGroupError errors={errors} name="keys" />
               </div>

--- a/src/styleguide/components/sections/Forms.js
+++ b/src/styleguide/components/sections/Forms.js
@@ -381,6 +381,12 @@ export default function Forms() {
                       </Select>
                     </div>
                   </FormGroup>
+                  <FormGroup className="row">
+                    <label className="col-sm-3 col-form-label">Textarea</label>
+                    <div className="col-sm-9">
+                      <textarea placeholder="Notes"></textarea>
+                    </div>
+                  </FormGroup>
                 </Form>
               </div>
             </div>


### PR DESCRIPTION
closes https://github.com/linode/manager/issues/1179

Adds default sized textarea to styleguide forms section:

![screen shot 2017-02-16 at 4 53 17 pm](https://cloud.githubusercontent.com/assets/709951/23043094/2983abca-f469-11e6-828d-650d50b9ba9d.png)

Updates edit config:
![screen shot 2017-02-16 at 5 06 19 pm](https://cloud.githubusercontent.com/assets/709951/23043454/497a82c2-f46a-11e6-9967-b15bc6d3a679.png)

Updates current add slave zone:
![screen shot 2017-02-16 at 4 53 03 pm](https://cloud.githubusercontent.com/assets/709951/23043115/3ac053ca-f469-11e6-9277-a5f66b080110.png)

see related issue created for wording: https://github.com/linode/manager/issues/1248

Updates lish key (using a slightly larger default):
![screen shot 2017-02-16 at 4 45 30 pm](https://cloud.githubusercontent.com/assets/709951/23043242/a7d5569a-f469-11e6-87cb-4f7baae6f029.png)

see related issue created for wording: https://github.com/linode/manager/issues/1249

updates feedback sizing:
![screen shot 2017-02-16 at 4 57 20 pm](https://cloud.githubusercontent.com/assets/709951/23043336/e86b1852-f469-11e6-8ae3-3c29c79cc28c.png)
