### PR TITLE
disable some more linting options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,6 @@
     "babel/no-await-in-loop": 0,
     "babel/arrow-parens": 0,
     "arrow-body-style": 0,
-    "comma-dangle": 0,
     "func-names": 0,
     "import/no-unresolved": 0,
     "no-underscore-dangle": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,10 +12,13 @@
     "babel/generator-star-spacing": 2,
     "babel/new-cap": 2,
     "babel/array-bracket-spacing": 2,
-    "babel/object-shorthand": 2,
+    "babel/object-shorthand": 0,
     "babel/flow-object-type": 2,
     "babel/no-await-in-loop": 0,
     "babel/arrow-parens": 0,
+    "arrow-body-style": 0,
+    "comma-dangle": 0,
+    "func-names": 0,
     "import/no-unresolved": 0,
     "no-underscore-dangle": 0,
     "no-unused-expressions": 0,
@@ -28,6 +31,7 @@
     "import/no-duplicates": 0,
     "no-duplicate-imports": 0,
     "no-shadow": 0,
+    "object-shorthand": 0,
     "radix": 0,
     "dot-notation": [
       "error", {


### PR DESCRIPTION
things I want to be able to do:

- anon fat arrow functions with `{ }` body
- anon `function() {}` without a name
- objects with `key: val`, instead of just `key` shorthand
