### PR TITLE
Small fixes to dns zone display and subtabs in cards

### DIFF
--- a/scss/components/cards/Card.scss
+++ b/scss/components/cards/Card.scss
@@ -19,4 +19,9 @@
     .row:not(:first-child) {
         margin-top: 10px;
     }
+
+    .SubTabs-container {
+        // Deals with default padding bottom of SubTabs-container
+        padding-bottom: 0;
+    }
 }

--- a/scss/linodes/components/Distributions.scss
+++ b/scss/linodes/components/Distributions.scss
@@ -1,5 +1,6 @@
 .LinodesDistributions {
     @extend .row;
+    margin-bottom: -15px;
 
     &-wrapper {
         @extend .col-sm-3;

--- a/scss/linodes/create/create.scss
+++ b/scss/linodes/create/create.scss
@@ -5,16 +5,6 @@
         display: inline-block;
         margin: $main-padding-tb/2 0 0 0;
     }
-
-    .SubTabs-container {
-        // Deals with default padding bottom of SubTabs-container
-        padding-bottom: 0;
-
-        &:first-of-type {
-            // Deals with extra padding bottom of the Distribution wrappers
-            margin-bottom: -15px;
-        }
-    }
 }
 
 .LinodeSelection {

--- a/src/dnsmanager/components/NewMasterZone.js
+++ b/src/dnsmanager/components/NewMasterZone.js
@@ -8,8 +8,8 @@ export default function NewMasterZone(props) {
   return (
     <Form onSubmit={props.onSubmit}>
       <FormGroup errors={props.errors} name="dnszone" className="row">
-        <label className="col-sm-2 col-form-label">Domain:</label>
-        <div className="col-sm-6">
+        <label className="col-sm-2 col-form-label">Domain</label>
+        <div className="col-sm-10">
           <Input
             placeholder="mydomain.net"
             value={props.dnszone}
@@ -19,8 +19,8 @@ export default function NewMasterZone(props) {
         <FormGroupError errors={props.errors} name="dnszone" />
       </FormGroup>
       <FormGroup errors={props.errors} name="soa_email" className="row">
-        <label className="col-sm-2 col-form-label">SOA email:</label>
-        <div className="col-sm-6">
+        <label className="col-sm-2 col-form-label">SOA email</label>
+        <div className="col-sm-10">
           <Input
             type="email"
             value={props.soa_email}
@@ -30,8 +30,7 @@ export default function NewMasterZone(props) {
         <FormGroupError errors={props.errors} name="soa_email" />
       </FormGroup>
       <div className="row">
-        <div className="col-sm-2"></div>
-        <div className="col-sm-6">
+        <div className="offset-sm-2 col-sm-10">
           <SubmitButton
             disabled={props.loading}
           >Create</SubmitButton>

--- a/src/dnsmanager/components/NewSlaveZone.js
+++ b/src/dnsmanager/components/NewSlaveZone.js
@@ -8,7 +8,7 @@ export default function NewSlaveZone(props) {
   return (
     <Form onSubmit={props.onSubmit}>
       <FormGroup errors={props.errors} name="dnszone" className="row">
-        <label className="col-sm-2 col-form-label">Domain:</label>
+        <label className="col-sm-2 col-form-label">Domain</label>
         <div className="col-sm-6">
           <Input
             className="form-control"
@@ -20,11 +20,11 @@ export default function NewSlaveZone(props) {
         <FormGroupError errors={props.errors} name="dnszone" />
       </FormGroup>
       <FormGroup errors={props.errors} name="master_ips" className="row">
-        <label className="col-sm-2 col-form-label">Masters:</label>
-        <div className="col-sm-6">
+        <label className="col-sm-2 col-form-label">Masters</label>
+        <div className="col-sm-10">
           <textarea
             value={props.master_ips.length ? props.master_ips.join(';') : ''}
-            placeholder="127.0.0.1;255.255.255.1"
+            placeholder="172.92.1.4;209.124.103.15"
             onChange={props.onChange('master_ips')}
           />
           <div>
@@ -37,8 +37,7 @@ export default function NewSlaveZone(props) {
         <FormGroupError errors={props.errors} name="master_ips" />
       </FormGroup>
       <div className="row">
-        <div className="col-sm-2"></div>
-        <div className="col-sm-6">
+        <div className="offset-sm-2 col-sm-10">
           <SubmitButton
             disabled={props.loading}
           >Create</SubmitButton>

--- a/src/dnsmanager/layouts/CreatePage.js
+++ b/src/dnsmanager/layouts/CreatePage.js
@@ -39,6 +39,7 @@ export class CreatePage extends Component {
   componentDidMount() {
     const { dispatch } = this.props;
     dispatch(setSource(__filename));
+
     dispatch(setTitle('Add a zone'));
   }
 


### PR DESCRIPTION
How dns zones looks on master:

<img width="1294" alt="screen shot 2017-03-15 at 5 42 26 pm" src="https://cloud.githubusercontent.com/assets/3925912/23972061/cc7847e4-09a6-11e7-9d9c-a78bb1b6cb6f.png">

And now:

<img width="1281" alt="screen shot 2017-03-15 at 5 41 28 pm" src="https://cloud.githubusercontent.com/assets/3925912/23972072/d3b9e74c-09a6-11e7-9e01-caea177fad9b.png">

And:

<img width="1371" alt="screen shot 2017-03-15 at 5 41 22 pm" src="https://cloud.githubusercontent.com/assets/3925912/23972073/d3bb48bc-09a6-11e7-96ff-18a307e16895.png">