### PR TITLE
reduce primary list item height to 50px

### DIFF
--- a/scss/components/tables/Table.scss
+++ b/scss/components/tables/Table.scss
@@ -26,7 +26,7 @@
 }
 
 .TableRow {
-    height: 65px;
+    height: 50px;
     border: $border;
     margin: 0 15px;
     background: $white;


### PR DESCRIPTION
somewhat aesthetically subjective, but removes excess whitespace, and is a closer ratio to relative UI elements.
