### PR TITLE
Make links in footer underlined and footer smaller

### DIFF
--- a/scss/manager.scss
+++ b/scss/manager.scss
@@ -138,11 +138,17 @@
 }
 
 footer {
+    @extend .font-small;
+
     padding-bottom: 15px;
 
     span, a {
         color: $lightest-black;
         padding: 0 10px;
+    }
+
+    a {
+        text-decoration: underline;
     }
 }
 


### PR DESCRIPTION
Adds underline to links to distinguish them from the version which is not a link. Also makes the whole thing smaller. I think they used to be smaller. Either way, this helps distinguish it from the actual content on the page.

<img width="1440" alt="screen shot 2017-03-27 at 1 01 36 am" src="https://cloud.githubusercontent.com/assets/3925912/24341655/307cbf28-1289-11e7-9917-d490b3792ce5.png">
