### PR TITLE
User menu too far right

### DIFF
--- a/scss/components/Header.scss
+++ b/scss/components/Header.scss
@@ -76,7 +76,7 @@
         height: $nav-height;
         float: right;
         padding: 0 15px;
-        margin-right: -15px;
+        margin-right: 0;
         position: relative; /* Give the badge something to relate to */
 
         /* Disable double click highlight */


### PR DESCRIPTION
This may have been correct at one point (that's debatable), but now this escapes the container and makes the header uneven.