### PR TITLE
Tabbed pages use same container padding / margin as non tabbed pages

### DIFF
--- a/scss/components/tabs/Tabs.scss
+++ b/scss/components/tabs/Tabs.scss
@@ -4,7 +4,6 @@
         background: $white;
         border-bottom: $border;
         margin: 0 auto;
-        padding: 0 15px;
     }
 
     [role="tablist"].form-tab-list [role="tab"] {
@@ -50,8 +49,6 @@
     
     &-container {
         @extend .container;
-
-        padding: 0 15px 15px 15px;
         margin-top: 15px;
     }
 }

--- a/scss/layout/Layout.scss
+++ b/scss/layout/Layout.scss
@@ -54,11 +54,6 @@ body,
         margin-bottom: 15px;
     }
 
-    // TODO: look at grid defaults. this fixes tab alignment
-    .container {
-        padding: 0 15px;
-    }
-
     h1 {
         margin-bottom: 0;
 


### PR DESCRIPTION
<img width="1411" alt="screen shot 2017-03-29 at 5 38 19 pm" src="https://cloud.githubusercontent.com/assets/3925912/24477860/acd7cc7e-14a6-11e7-82c4-d2c1bfa372bb.png">
<img width="1410" alt="screen shot 2017-03-29 at 5 38 28 pm" src="https://cloud.githubusercontent.com/assets/3925912/24477859/acd75d84-14a6-11e7-8c40-6cfe485b652f.png">
