### PR TITLE
reference item you are deleting in the modal

### DIFF
--- a/scss/components/ScrollingList.scss
+++ b/scss/components/ScrollingList.scss
@@ -1,0 +1,7 @@
+.ScrollingList {
+  margin: 10px 0;
+  max-height: 200px;
+  border: $border;
+  overflow-y: auto;
+  padding: 10px 30px;
+}

--- a/scss/components/index.scss
+++ b/scss/components/index.scss
@@ -12,6 +12,7 @@
 @import 'PrimaryPage';
 @import 'SessionMenu';
 @import 'LineGraph';
+@import 'ScrollingList';
 @import 'tables/index';
 @import 'cards/index';
 @import 'form/index';

--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -59,3 +59,8 @@
         }
     }
 }
+.DeleteModalBody {
+  li {
+    font-weight: bold;
+  }
+}

--- a/src/components/ScrollingList.js
+++ b/src/components/ScrollingList.js
@@ -1,0 +1,14 @@
+import React, { PropTypes } from 'react';
+
+export default function ScrollingList(props) {
+  const { items } = props;
+  return (
+    <ul className="ScrollingList">
+      {items.map(item => <li key={item}>{item}</li>)}
+    </ul>
+  );
+}
+
+ScrollingList.propTypes = {
+  items: PropTypes.array,
+};

--- a/src/components/modals/ConfirmModalBody.js
+++ b/src/components/modals/ConfirmModalBody.js
@@ -17,10 +17,15 @@ export default class ConfirmModalBody extends Component {
   }
 
   render() {
-    const { buttonText, onCancel, children } = this.props;
+    const {
+      className,
+      buttonText,
+      onCancel,
+      children,
+    } = this.props;
     const { loading } = this.state;
     return (
-      <div>
+      <div className={`ConfirmModalBody-body ${className}`}>
         {React.isValidElement(children) ? children : <p>{children}</p>}
         <div className="Modal-footer">
           <CancelButton disabled={loading} onClick={onCancel} />
@@ -33,7 +38,12 @@ export default class ConfirmModalBody extends Component {
   }
 }
 
+ConfirmModalBody.defaultProps = {
+  className: '',
+};
+
 ConfirmModalBody.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.any,
   buttonText: PropTypes.string,
   onOk: PropTypes.func.isRequired,

--- a/src/components/modals/DeleteModalBody.js
+++ b/src/components/modals/DeleteModalBody.js
@@ -1,0 +1,53 @@
+import React, { PropTypes } from 'react';
+import ConfirmModalBody from '~/components/modals/ConfirmModalBody';
+import ScrollingList from '~/components/ScrollingList';
+
+export default function DeleteModalBody(props) {
+  const {
+    onOk,
+    buttonText,
+    items,
+    selectedItems,
+    onCancel,
+    typeOfItem,
+    label,
+  } = props;
+  let sentence;
+  let newButtonText = buttonText;
+  if (selectedItems.length > 1) {
+    sentence = (<div>
+      <p>Are you sure you want to <strong>permanently</strong> delete these {typeOfItem}?</p>
+      <ScrollingList
+        items={selectedItems.map(selectedItem => items[selectedItem][label])}
+      />
+      <p>This operation cannot be undone.</p>
+    </div>);
+  } else {
+    sentence = (<p>
+      Are you sure you want
+      to <strong>permanently</strong> delete <strong>{items[selectedItems][label]}</strong>?
+    </p>);
+    newButtonText = buttonText.replace(/s$/, '');
+  }
+
+  return (
+    <ConfirmModalBody
+      className="DeleteModalBody"
+      buttonText={newButtonText}
+      onOk={onOk}
+      onCancel={onCancel}
+    >
+      {sentence}
+    </ConfirmModalBody>
+  );
+}
+
+DeleteModalBody.propTypes = {
+  onOk: PropTypes.func,
+  buttonText: PropTypes.string,
+  items: PropTypes.object,
+  selectedItems: PropTypes.array,
+  onCancel: PropTypes.func,
+  typeOfItem: PropTypes.string,
+  label: PropTypes.string,
+};

--- a/src/dnsmanager/layouts/IndexPage.js
+++ b/src/dnsmanager/layouts/IndexPage.js
@@ -6,11 +6,11 @@ import _ from 'lodash';
 
 import { setError } from '~/actions/errors';
 import { showModal, hideModal } from '~/actions/modal';
-import ConfirmModalBody from '~/components/modals/ConfirmModalBody';
 import { List, Table } from '~/components/tables';
 import { MassEditControl } from '~/components/tables/controls';
 import { ListHeader } from '~/components/tables/headers';
 import { ListBody, ListGroup } from '~/components/tables/bodies';
+import DeleteModalBody from '~/components/modals/DeleteModalBody';
 import {
   ButtonCell,
   CheckboxCell,
@@ -47,9 +47,9 @@ export class IndexPage extends Component {
   }
 
   remove(zones) {
-    const { dispatch } = this.props;
+    const { dispatch, selected, dnszones } = this.props;
     dispatch(showModal('Confirm deletion',
-      <ConfirmModalBody
+      <DeleteModalBody
         buttonText="Delete selected zones"
         onOk={() => {
           const zoneIds = zones.map((zone) => zone.id);
@@ -60,11 +60,12 @@ export class IndexPage extends Component {
           dispatch(toggleSelected(zoneIds));
           dispatch(hideModal());
         }}
+        items={dnszones.dnszones}
+        selectedItems={Object.keys(selected)}
+        typeOfItem="zones"
+        label="dnszone"
         onCancel={() => dispatch(hideModal())}
-      >
-        Are you sure you want to delete selected Zones?
-        This operation cannot be undone.
-      </ConfirmModalBody>
+      />
     ));
   }
 
@@ -74,20 +75,21 @@ export class IndexPage extends Component {
   }
 
   renderModal(zoneId) {
-    const { dispatch } = this.props;
+    const { dispatch, dnszones: theseZones } = this.props;
     return (
-      <ConfirmModalBody
-        buttonText="Delete"
+      <DeleteModalBody
+        buttonText="Delete selected zones"
         onOk={async () => {
           await dispatch(dnszones.delete(zoneId));
           dispatch(toggleSelectAll());
           dispatch(hideModal());
         }}
+        items={theseZones.dnszones}
+        selectedItems={zoneId}
+        typeOfItem="zones"
+        label="dnszone"
         onCancel={() => dispatch(hideModal())}
-      >
-        <span className="text-danger">WARNING!</span> This will permanently
-        delete this DNS Zone. Confirm below to proceed.
-      </ConfirmModalBody>
+      />
     );
   }
 

--- a/src/dnsmanager/layouts/IndexPage.js
+++ b/src/dnsmanager/layouts/IndexPage.js
@@ -16,7 +16,7 @@ import {
   CheckboxCell,
   LinkCell,
 } from '~/components/tables/cells';
-import { dnszones } from '~/api';
+import { dnszones as apiDnszones } from '~/api';
 import { setSource } from '~/actions/source';
 import { setTitle } from '~/actions/title';
 import { toggleSelected, toggleSelectAll } from '../actions';
@@ -25,7 +25,7 @@ import CreateHelper from '~/components/CreateHelper';
 export class IndexPage extends Component {
   static async preload({ dispatch }) {
     try {
-      await dispatch(dnszones.all());
+      await dispatch(apiDnszones.all());
     } catch (response) {
       // eslint-disable-next-line no-console
       console.error(response);
@@ -55,7 +55,7 @@ export class IndexPage extends Component {
           const zoneIds = zones.map((zone) => zone.id);
 
           zoneIds.forEach(function (id) {
-            dispatch(dnszones.delete(id));
+            dispatch(apiDnszones.delete(id));
           });
           dispatch(toggleSelected(zoneIds));
           dispatch(hideModal());
@@ -80,7 +80,7 @@ export class IndexPage extends Component {
       <DeleteModalBody
         buttonText="Delete selected zones"
         onOk={async () => {
-          await dispatch(dnszones.delete(zoneId));
+          await dispatch(apiDnszones.delete(zoneId));
           dispatch(toggleSelectAll());
           dispatch(hideModal());
         }}

--- a/src/linodes/layouts/IndexPage.js
+++ b/src/linodes/layouts/IndexPage.js
@@ -82,14 +82,13 @@ export class IndexPage extends Component {
     });
   }
 
-  remove(linodes) {
-    const { dispatch } = this.props;
-
+  remove(linodesToBeRemoved) {
+    const { dispatch, selected, linodes } = this.props;
     dispatch(showModal('Confirm deletion',
       <DeleteModalBody
         buttonText="Delete selected Linodes"
         onOk={() => {
-          linodes.forEach(function (linode) {
+          linodesToBeRemoved.forEach(function (linode) {
             dispatch(apiLinodes.delete(linode.id));
           });
           dispatch(hideModal());

--- a/src/linodes/layouts/IndexPage.js
+++ b/src/linodes/layouts/IndexPage.js
@@ -29,7 +29,7 @@ import {
 } from '~/api/linodes';
 import { setSource } from '~/actions/source';
 import { setTitle } from '~/actions/title';
-import ConfirmModalBody from '~/components/modals/ConfirmModalBody';
+import DeleteModalBody from '~/components/modals/DeleteModalBody';
 import { showModal, hideModal } from '~/actions/modal';
 
 
@@ -86,7 +86,7 @@ export class IndexPage extends Component {
     const { dispatch } = this.props;
 
     dispatch(showModal('Confirm deletion',
-      <ConfirmModalBody
+      <DeleteModalBody
         buttonText="Delete selected Linodes"
         onOk={() => {
           linodes.forEach(function (linode) {
@@ -94,11 +94,12 @@ export class IndexPage extends Component {
           });
           dispatch(hideModal());
         }}
+        items={linodes.linodes}
+        selectedItems={Object.keys(selected)}
+        typeOfItem="Linodes"
+        label="label"
         onCancel={() => dispatch(hideModal())}
-      >
-        Are you sure you want to delete selected Linodes?
-        This operation cannot be undone.
-      </ConfirmModalBody>
+      />
     ));
   }
 

--- a/src/linodes/linode/settings/components/ConfigPanel.js
+++ b/src/linodes/linode/settings/components/ConfigPanel.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 
 import { getLinode } from '~/linodes/linode/layouts/IndexPage';
-import { ConfirmModalBody } from '~/components/modals';
+import DeleteModalBody from '~/components/modals/DeleteModalBody';
 import { linodes } from '~/api';
 import { showModal, hideModal } from '~/actions/modal';
 import { Button } from '~/components/buttons';
@@ -23,17 +23,18 @@ export class ConfigPanel extends Component {
     const { dispatch } = this.props;
 
     dispatch(showModal('Confirm deletion',
-      <ConfirmModalBody
+      <DeleteModalBody
         buttonText="Delete config"
         onOk={async () => {
           await dispatch(linodes.configs.delete(linode.id, config.id));
           dispatch(hideModal());
         }}
+        items={{ config }}
+        selectedItems={['config']}
+        typeOfItem="Configs"
+        label="label"
         onCancel={() => dispatch(hideModal())}
-      >
-        Are you sure you want to delete this config?
-        This operation cannot be undone.
-      </ConfirmModalBody>
+      />
     ));
   }
 

--- a/src/linodes/linode/settings/components/DeleteModal.js
+++ b/src/linodes/linode/settings/components/DeleteModal.js
@@ -41,13 +41,14 @@ export class DeleteModal extends Component {
 
 
   render() {
-    const { dispatch } = this.props;
+    const { dispatch, disk } = this.props;
     const { loading, errors } = this.state;
     return (
       <Form
         onSubmit={() => this.deleteDisk()}
       >
-        <p>Are you sure you want to delete this disk? This cannot be undone.</p>
+        <p>Are you sure you want to <strong>permanently</strong> delete
+          the disk named: <strong>{disk.label}</strong>? This cannot be undone.</p>
         {errors._.length ?
           <div className="alert alert-danger">
             {errors._.map(error => <div key={error}>{error}</div>)}

--- a/src/profile/integrations/components/MyApplication.js
+++ b/src/profile/integrations/components/MyApplication.js
@@ -6,6 +6,7 @@ import Dropdown from '~/components/Dropdown';
 import { reduceErrors } from '~/errors';
 import EditApplication from './EditApplication';
 import { ConfirmModalBody } from '~/components/modals';
+import DeleteModalBody from '~/components/modals/DeleteModalBody';
 import { showModal, hideModal } from '~/actions/modal';
 import { renderSecret } from './CreatePersonalAccessToken';
 import { clients } from '~/api';
@@ -45,17 +46,19 @@ export default class MyApplication extends Component {
 
   deleteAction = () => {
     const { dispatch, client } = this.props;
-
     dispatch(showModal('Delete OAuth Client',
-      <ConfirmModalBody
-        onCancel={() => dispatch(hideModal())}
+      <DeleteModalBody
+        buttonText="Delete OAuth client"
         onOk={() => {
           dispatch(hideModal());
           this.deleteApp();
         }}
-      >
-        Are you sure you want to delete <strong>{client.label}</strong>?
-      </ConfirmModalBody>
+        onCancel={() => dispatch(hideModal())}
+        typeOfItem="Clients"
+        label="label"
+        items={{ client }}
+        selectedItems={['client']}
+      />
     ));
   }
 

--- a/src/profile/integrations/components/PersonalAccessToken.js
+++ b/src/profile/integrations/components/PersonalAccessToken.js
@@ -1,17 +1,18 @@
 import React, { PropTypes, Component } from 'react';
 import moment from 'moment';
+import { connect } from 'react-redux';
 
 import _ from 'lodash';
 import { API_ROOT } from '~/constants';
 import Dropdown from '~/components/Dropdown';
 import EditPersonalAccessToken from './EditPersonalAccessToken';
 import { Card, CardImageHeader } from '~/components/cards/';
-import { ConfirmModalBody } from '~/components/modals';
+import DeleteModalBody from '~/components/modals/DeleteModalBody';
 import { Table } from '~/components/tables';
 import { AuthScopeCell } from '~/components/tables/cells';
 import { OAUTH_SUBSCOPES, OAUTH_SCOPES } from '~/constants';
 import { showModal, hideModal } from '~/actions/modal';
-import { tokens } from '~/api';
+import { tokens as apiTokens } from '~/api';
 
 export default class PersonalAccessToken extends Component {
   constructor() {
@@ -33,18 +34,21 @@ export default class PersonalAccessToken extends Component {
   }
 
   deleteAction = () => {
-    const { dispatch, label, id } = this.props;
+    const { dispatch, id, client } = this.props;
 
     dispatch(showModal('Delete Personal Access Token',
-      <ConfirmModalBody
+      <DeleteModalBody
+        buttonText="Delete personal access token"
         onCancel={() => dispatch(hideModal())}
         onOk={() => {
-          dispatch(tokens.delete(id));
+          dispatch(apiTokens.delete(id));
           dispatch(hideModal());
         }}
-      >
-        Are you sure you want to delete <strong>{label}</strong>?
-      </ConfirmModalBody>
+        typeOfItem="Personal access tokens"
+        label="label"
+        items={{ client }}
+        selectedItems={['client']}
+      />
     ));
   }
 
@@ -109,4 +113,13 @@ PersonalAccessToken.propTypes = {
   id: PropTypes.any.isRequired,
   secret: PropTypes.string.isRequired,
   dispatch: PropTypes.func.isRequired,
+  client: PropTypes.object,
 };
+
+function select(state) {
+  return {
+    tokens: state.api.tokens,
+  };
+}
+
+connect(select)(PersonalAccessToken);

--- a/src/profile/integrations/layouts/PersonalAccessTokensPage.js
+++ b/src/profile/integrations/layouts/PersonalAccessTokensPage.js
@@ -55,6 +55,7 @@ export class PersonalAccessTokensPage extends Component {
                 expires={client.expiry}
                 secret={client.token}
                 dispatch={dispatch}
+                client={client}
               />
             </div>
            ) : (


### PR DESCRIPTION
closes #1407 

This change adds a DeleteModalBody component using composition.  It
composes the ConfirmModalBody instead of inheriting it and extending it
based on the React docs.  We can then use this DeleteModalBody component
in other places where we need to delete an item or group of items and
then ask for confirmation.

![image](https://cloud.githubusercontent.com/assets/1616275/24678475/aeb60a22-1958-11e7-91d2-ad2287d636f2.png)
