### PR TITLE
Preload 404 navs

### DIFF
--- a/src/linodes/linode/layouts/IndexPage.js
+++ b/src/linodes/linode/layouts/IndexPage.js
@@ -27,6 +27,7 @@ export class IndexPage extends Component {
       // eslint-disable-next-line no-console
       console.error(e);
       dispatch(setError(e));
+      await dispatch(push('/404'));
     }
   }
 

--- a/src/nodebalancers/nodebalancer/layouts/IndexPage.js
+++ b/src/nodebalancers/nodebalancer/layouts/IndexPage.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
 import _ from 'lodash';
 
 import { nodebalancers } from '~/api';
@@ -26,6 +27,7 @@ export class IndexPage extends Component {
       // eslint-disable-next-line no-console
       console.error(response);
       dispatch(setError(response));
+      await dispatch(push('/404'));
     }
   }
 
@@ -171,7 +173,7 @@ export class IndexPage extends Component {
 IndexPage.propTypes = {
   dispatch: PropTypes.func,
   nbLabel: PropTypes.string,
-  nodebalancer: PropTypes.object,
+  nodebalancer: PropTypes.any,
 };
 
 function select(state, ownProps) {
@@ -187,4 +189,3 @@ function select(state, ownProps) {
 }
 
 export default connect(select)(IndexPage);
-

--- a/src/support/layouts/TicketPage.js
+++ b/src/support/layouts/TicketPage.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
+import { push } from 'react-router-redux';
 
 import { MAX_UPLOAD_SIZE_MB } from '~/constants';
 import { tickets } from '~/api';
@@ -22,6 +23,7 @@ export class TicketPage extends Component {
       // eslint-disable-next-line no-console
       console.error(response);
       dispatch(setError(response));
+      await dispatch(push('/404'));
     }
   }
 

--- a/src/users/user/layouts/IndexPage.js
+++ b/src/users/user/layouts/IndexPage.js
@@ -18,6 +18,7 @@ export class IndexPage extends Component {
       // eslint-disable-next-line no-console
       console.error(response);
       dispatch(setError(response));
+      await dispatch(push('/404'));
     }
   }
 


### PR DESCRIPTION
fixing two issues where a preload not found was not redirecting to the 404 page.
Also have to fix two more issues I found with nav
/support/asdfasdfa gives a `Cannot read property '_replies' of
undefined`
error message
and clicking on NodeBalancers from the 404 page gives
 `Cannot read property 'configs' of undefined`
 `Cannot read property '_configs' of undefined`
sometimes

I'll submit commits with fixes for these two in the same PR. Hopefully.
