### PR TITLE
Fix modal horizontal scroll

### DIFF
--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -14,7 +14,7 @@
 }
 
 .Modal {
-    width: 500px;
+    width: 600px;
     margin: $main-padding-tb auto;
     max-height: calc(100% - #{2 * $main-padding-tb});
     box-shadow: $box-shadow;
@@ -35,7 +35,8 @@
     }
 
     &-body {
-        padding: $main-padding-tb $main-padding-lr;
+        // TODO: address calculated gutter values where possible
+        padding: $main-padding-tb ($grid-gutter-width-base / 2);
         overflow-y: auto;
     }
 

--- a/scss/components/modal.scss
+++ b/scss/components/modal.scss
@@ -14,7 +14,7 @@
 }
 
 .Modal {
-    width: 600px;
+    width: 500px;
     margin: $main-padding-tb auto;
     max-height: calc(100% - #{2 * $main-padding-tb});
     box-shadow: $box-shadow;


### PR DESCRIPTION
Modal bodies horizontally scroll because of a mismatch in body padding and form group rows.

This is a temporary fix