### PR TITLE
Fix stats 400

### DIFF
--- a/src/linodes/linode/layouts/DashboardPage.js
+++ b/src/linodes/linode/layouts/DashboardPage.js
@@ -24,13 +24,19 @@ function formatData(datasets, legends) {
 
 export class DashboardPage extends Component {
   static async preload({ dispatch, getState }, { linodeLabel }) {
+    let id;
     try {
-      const { id } = await dispatch(getObjectByLabelLazily('linodes', linodeLabel));
-      await dispatch(linodeStats([id]));
+      ({ id } = await dispatch(getObjectByLabelLazily('linodes', linodeLabel)));
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(e);
       await dispatch(setError(e));
+    }
+
+    try {
+      await dispatch(linodeStats([id]));
+    } catch (e) {
+      // Stats aren't available.
     }
   }
 


### PR DESCRIPTION
Was on the fence over whether this should be considered an error on our side or on the API's. Seems reasonable for us to catch it.

This prevents the 400 page from being shown when no graphs are available.