### PR TITLE
Preload Indicator stays at top of page

### DIFF
--- a/scss/components/PreloadIndicator.scss
+++ b/scss/components/PreloadIndicator.scss
@@ -1,5 +1,5 @@
 .PreloadIndicator {
-    position: absolute;
+    position: fixed;
     left: 0px;
     top: 0px;
     width: 0px;


### PR DESCRIPTION
The preload bar stays at the top of the page even when scrolling down.