### PR TITLE
Keep modals where they are on the page

### DIFF
--- a/components/scss/components/modals/Modal.scss
+++ b/components/scss/components/modals/Modal.scss
@@ -69,3 +69,7 @@
         font-weight: bold;
     }
 }
+
+.layout--modal {
+    overflow: visible;
+}


### PR DESCRIPTION
Prevents modals from jumping to the top of the page