### PR TITLE
prevent jumping to top of page when modal opens

### DIFF
--- a/components/scss/components/modals/Modal.scss
+++ b/components/scss/components/modals/Modal.scss
@@ -69,3 +69,7 @@
         font-weight: bold;
     }
 }
+
+.layout--modal {
+    overflow: visible;
+}


### PR DESCRIPTION
Fixes a problem where if a modal is opened at the bottom of the page, it cause a scroll to the top of the page.