### PR TITLE
Adjust max width

### DIFF
--- a/components/scss/linode-components.scss
+++ b/components/scss/linode-components.scss
@@ -106,4 +106,3 @@ header .sub-header {
 a:hover, a:focus, a:active {
     color: $blue;
 }
-

--- a/components/scss/variables.scss
+++ b/components/scss/variables.scss
@@ -56,7 +56,7 @@ $box-shadow: 0px 2px 4px 0px $transparent;
 $grid-gutter-width: 50px;
 $grid-gutter-width-base: 50px;
 
-$grid-max-width: 1440px;
+$grid-max-width: 1140px;
 
 // Basically just sets each max width to 100%
 $container-max-widths: (

--- a/src/linodes/layouts/IndexPage.js
+++ b/src/linodes/layouts/IndexPage.js
@@ -162,10 +162,13 @@ export class IndexPage extends Component {
                       hrefFn: (linode) => `/linodes/${linode.label}`,
                     },
                     { cellComponent: IPAddressCell },
-                    { cellComponent: RegionCell },
+                    {
+                      cellComponent: RegionCell,
+                      className: 'hidden-md-down',
+                    },
                     {
                       cellComponent: BackupsCell,
-                      className: 'hidden-md-down',
+                      className: 'hidden-lg-down',
                       hrefFn: (linode) => `/linodes/${linode.label}/backups`,
                     },
                     { cellComponent: StatusDropdownCell, dispatch: dispatch },


### PR DESCRIPTION
At first this PR was to drop the Bootstrap width overrides. However, the default Bootstrap widths are still terrible for our application. The best part about it was its max width of 1140px. At sm and md sizes though it has huge padding that takes up totally unnecessary amounts of space. This is a win all around and doesn't require crazy hackier to keep the user and notifications dropdown working.