### PR TITLE
Docs params

### DIFF
--- a/docs/scss/components/Method.scss
+++ b/docs/scss/components/Method.scss
@@ -67,7 +67,7 @@
     }
 
     .TypeColumn {
-        width: 75px;
+        width: 100px;
     }
 
     .DescriptionColumn {

--- a/docs/scss/components/Tables/cells/Columns.scss
+++ b/docs/scss/components/Tables/cells/Columns.scss
@@ -1,7 +1,3 @@
-.FieldColumn {
-    width: 75px;
-}
-
 .EndpointColumn {
     width: 300px;
 }

--- a/docs/src/components/Method.js
+++ b/docs/src/components/Method.js
@@ -21,7 +21,6 @@ export default function Method(props) {
   // TODO: Break these out if needed
   let methodParams = null;
   if (params) {
-    // { label: 'Type', dataKey: 'type' }
     methodParams = (
       <div className="Method-section Method-params">
         <h4><b>Params</b></h4>
@@ -29,6 +28,7 @@ export default function Method(props) {
           className="Table--secondary"
           columns={[
             { label: 'Field', dataKey: 'name', headerClassName: 'FieldColumn' },
+            { label: 'Type', dataKey: 'type', headerClassName: 'TypeColumn' },
             { label: 'Description', dataKey: 'description', headerClassName: 'DescriptionColumn' }
           ]}
           data={params}
@@ -62,6 +62,7 @@ export default function Method(props) {
           className="Table--secondary"
           columns={[
             { cellComponent: FieldCell, label: 'Field', headerClassName: 'FieldColumn' },
+            { label: 'Type', dataKey: 'type', headerClassName: 'TypeColumn' },
             { cellComponent: DescriptionCell, label: 'Description', headerClassName: 'DescriptionColumn' }
           ]}
           data={schema}

--- a/docs/src/components/Method.js
+++ b/docs/src/components/Method.js
@@ -12,7 +12,7 @@ export default function Method(props) {
     name,
     description,
     examples,
-    params = [],
+    params,
     resource = {},
   } = method;
 
@@ -23,7 +23,7 @@ export default function Method(props) {
   if (params) {
     methodParams = (
       <div className="Method-section Method-params">
-        <h4><b>Params</b></h4>
+        <h4><b>Parameters</b></h4>
         <Table
           className="Table--secondary"
           columns={[


### PR DESCRIPTION
closes #1628 

Adjusts the display of params ( already being rendered ). Is the same style as the response tables.

![screen shot 2017-05-08 at 10 54 45 am](https://cloud.githubusercontent.com/assets/709951/25810138/30ad3f20-33dd-11e7-874d-55356f20a1c5.png)

Also adds `type` to both parameters and response:

![screen shot 2017-05-08 at 10 51 31 am](https://cloud.githubusercontent.com/assets/709951/25810155/3dffe79a-33dd-11e7-95d7-801860c243ae.png)


