### PR TITLE
Removes jump to

### DIFF
--- a/docs/scss/components/Endpoint.scss
+++ b/docs/scss/components/Endpoint.scss
@@ -8,7 +8,7 @@
     }
 
     &-title {
-        padding: 10px 0;
+        padding: 10px 0 0 0;
 
         h1 {
             margin: 0;

--- a/docs/src/components/Endpoint.js
+++ b/docs/src/components/Endpoint.js
@@ -23,18 +23,6 @@ export default function Endpoint(props) {
           <h1>{path}</h1>
           <p>{description}</p>
         </div>
-        <div className="Endpoint-methods">
-          <span className="Endpoint-methodsLabel">JUMP TO:</span>
-          <ul className="Endpoint-methodsList">
-            {methods.map(function(method, index) {
-              return (
-                <li key={index}>
-                  <Link to={`#${method.name}`}>{method.name}</Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
       </div>
       <div className="divider"></div>
       <div className="Endpoint-body">


### PR DESCRIPTION
closes #1670 

Instead of fixing the jump links, which you can see a version of here:  https://github.com/linode/manager/compare/master...mparke:fix-docs-jump-links

this pull opts to remove them, because for the majority of endpoint pages with multiple methods, GET, POST, etc, each method is already visible on the page or is visible by scrolling slightly. The jump doesn't have much effect in most cases. 

