### PR TITLE
Fix plans layout

### DIFF
--- a/scss/components/region.scss
+++ b/scss/components/region.scss
@@ -5,7 +5,7 @@
 }
 
 .region, .plan, .backup {
-    $width: 250px;
+    $width: 225px;
     border: $border;
     cursor: pointer;
     height: 150px;

--- a/scss/linodes/components/Distribution.scss
+++ b/scss/linodes/components/Distribution.scss
@@ -4,6 +4,7 @@
     border: $border;
     margin-top: 0;
     cursor: pointer;
+    width: 225px;
 
     &:not(&--isSelected) &-body:hover {
         background-color: $gray;

--- a/scss/linodes/components/Distributions.scss
+++ b/scss/linodes/components/Distributions.scss
@@ -1,9 +1,0 @@
-.LinodesDistributions {
-    @extend .row;
-    margin-bottom: -15px;
-
-    &-wrapper {
-        @extend .col-sm-3;
-        margin-bottom: 15px;
-    }
-}

--- a/scss/linodes/components/index.scss
+++ b/scss/linodes/components/index.scss
@@ -1,4 +1,3 @@
 @import 'ConfigSelectModalBody';
 @import 'Distribution';
-@import 'Distributions';
 @import 'StatusDropdown';

--- a/src/linodes/components/Distributions.js
+++ b/src/linodes/components/Distributions.js
@@ -36,24 +36,37 @@ export default function Distributions(props) {
     }
   }
 
+  const chunkedDistros = _.chunk(vendors, 4);
+
   return (
-    <div className="LinodesDistributions">
-      {vendors.map(v =>
-        <div className="LinodesDistributions-wrapper" key={v.name}>
-          <Distribution
-            selected={distribution}
-            vendor={v}
-            onClick={onSelected}
-          />
-        </div>)}
-        {!noDistribution ? null : (
-          <div className="LinodesDistributions-wrapper">
+    <div>
+      {chunkedDistros.map((arr, index) => {
+        return (
+          <div key={index} className="row">
+            {arr.map((distro, index) => {
+              return (
+                <div key={index} className="col-sm-3">
+                  <Distribution
+                    selected={distribution}
+                    vendor={distro}
+                    onClick={onSelected}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+      {!noDistribution ? null : (
+        <div className="row">
+          <div className="col-sm-3">
             <Distribution
               noDistribution
               selected={distribution}
               onClick={onSelected}
             />
-          </div>)}
+          </div>
+        </div>)}
     </div>
   );
 }

--- a/src/linodes/components/Plan.js
+++ b/src/linodes/components/Plan.js
@@ -40,9 +40,24 @@ export default class Plan extends Component {
     const { types } = this.props;
     const sortedPlans = Object.values(types).sort(
       (a, b) => a.ram > b.ram);
+
+    const chunkedPlans = _.chunk(sortedPlans, 4);
+
     return (
       <div>
-        {sortedPlans.map(this.renderPlan)}
+        {chunkedPlans.map((arr, index) => {
+          return (
+            <div key={index} className="row">
+              {arr.map((plan, index) => {
+                return (
+                  <div key={index} className="col-sm-3">
+                    {this.renderPlan(plan)}
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
       </div>
     );
   }


### PR DESCRIPTION
Updates plans layout and makes distros the same for now.

Order has not changed, plans are just chunked into 4s

![screen shot 2017-05-11 at 12 05 28 pm](https://cloud.githubusercontent.com/assets/709951/25959627/35ddd77c-3642-11e7-8ee4-1f42972e235d.png)
![screen shot 2017-05-11 at 12 05 32 pm](https://cloud.githubusercontent.com/assets/709951/25959628/35de1444-3642-11e7-9a57-c63872fc69e2.png)

