### PR TITLE
Make hr not transparent

### DIFF
--- a/components/scss/defaults.scss
+++ b/components/scss/defaults.scss
@@ -82,6 +82,7 @@ p {
 hr {
     width: 100%;
     margin: 0;
+    background: $dark-gray;
 }
 
 small {


### PR DESCRIPTION
Somehow Bootstrap is now setting the hr transparent which breaks dropdown menus with hr. (Like Linode mass action dropdown.)