### PR TITLE
Simplify oauth and layout

### DIFF
--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -18,24 +18,32 @@ import { setStorage } from '~/storage';
 
 
 export class Layout extends Component {
+  // This is a special preload that is only called once on page load because
+  // all pages are rendered through here and preloads don't get called again
+  // if they were just called.
   static async preload({ dispatch, getState }) {
-    // Fetch not just timezone but also email and username.
-    if (!getState().api.profile.timezone) {
-      const { timezone } = await dispatch(api.profile.one());
-      // Needed for time display component that is not attached to Redux.
-      setStorage('profile/timezone', timezone);
-    }
-
-    if (!getState().api.account.network_helper) {
-      await dispatch(api.account.one());
-    }
-
     // Filter out objects we've already grabbed this page session.
-    const rest = ['kernels', 'types', 'regions', 'distributions'].filter(
-      type => Object.values(getState().api[type]).length);
+    // Note: this doesn't matter at this stage in the router implementation
+    // because this preload is only ever called once. However, future router
+    // implementations may decide to let a preload that has already been
+    // called before be called again if a certain amount of time has elapsed.
+    const requests = ['kernels', 'types', 'regions', 'distributions'].filter(
+      type => !Object.values(getState().api[type]).length).map(type => api[type].all());
+
+    if (!Object.keys(getState().api.profile).length) {
+      requests.push(api.profile.one());
+    }
+
+    if (!Object.keys(getState().api.account).length) {
+      requests.push(api.account.one());
+    }
 
     // Fetch all objects we haven't already grabbed this page session.
-    await Promise.all(rest.map(type => dispatch(api[type].all())));
+    await Promise.all(requests.map(request => dispatch(request)));
+
+    // Needed for time display component that is not attached to Redux.
+    const { timezone } = getState().api.profile;
+    setStorage('profile/timezone', timezone);
   }
 
   constructor() {

--- a/src/settings/layouts/IndexPage.js
+++ b/src/settings/layouts/IndexPage.js
@@ -14,16 +14,6 @@ import { dispatchOrStoreErrors, FormSummary } from '~/components/forms';
 
 
 export class IndexPage extends Component {
-  static async preload({ dispatch }) {
-    try {
-      await dispatch(account.one());
-    } catch (response) {
-      // eslint-disable-next-line no-console
-      console.error(response);
-      dispatch(setError(response));
-    }
-  }
-
   constructor(props) {
     super(props);
 

--- a/src/settings/layouts/IndexPage.js
+++ b/src/settings/layouts/IndexPage.js
@@ -6,7 +6,6 @@ import {
   Checkbox, Form, FormGroup, SubmitButton,
 } from 'linode-components/forms';
 
-import { setError } from '~/actions/errors';
 import { setSource } from '~/actions/source';
 import { setTitle } from '~/actions/title';
 import { account } from '~/api';

--- a/test/users/user/layouts/EditUserPage.spec.js
+++ b/test/users/user/layouts/EditUserPage.spec.js
@@ -34,6 +34,7 @@ describe('users/user/layouts/EditUserPage', () => {
 
     dispatch.reset();
     await page.find('Form').props().onSubmit({ preventDefault() {} });
+
     expect(dispatch.callCount).to.equal(1);
 
     await expectDispatchOrStoreErrors(dispatch.firstCall.args[0], [


### PR DESCRIPTION
* Drops email, hash, and username from localstorage
* Adds a cache file currently only for storing hashed emails
* Moves all API calls out of the router and into Layout
  * Calls to profile, kernels, distros, regions, and types
* Prevents a preload from being called after it just ran
  * Propagates previously run preloads through
* As few test and linter fixes as I could