### PR TITLE
Render only first ipv4 address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.5.4] 2017-05-18
+### Fixed
+- fixed ipv4 rendering #1816
+
 ## [0.5.3] 2017-05-18
 ### Fixed
 - fixed miscalculated plan values #1811

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-manager",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "dependencies": {
     "asap": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-manager",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "The Linode Manager website",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/components/tables/cells/IPAddressCell.js
+++ b/src/components/tables/cells/IPAddressCell.js
@@ -14,7 +14,7 @@ export default function IPAddressCell(props) {
 
   return (
     <TableCell column={column} record={record}>
-      {record.ipv4}
+      {record.ipv4[0]}
       {ipv6}
     </TableCell>
   );

--- a/test/data/linodes.js
+++ b/test/data/linodes.js
@@ -52,7 +52,7 @@ function createTestLinode(id) {
     id,
     group: 'Test Group',
     label: `test-linode-${id}`,
-    ipv4: ipv4.address,
+    ipv4: [ipv4.address],
     ipv6: ipv6.address,
     created: '2016-07-06T16:47:27',
     type: testType,

--- a/test/linodes/linode/layouts/DashboardPage.spec.js
+++ b/test/linodes/linode/layouts/DashboardPage.spec.js
@@ -24,7 +24,8 @@ describe('linodes/linode/layouts/DashboardPage', async () => {
       />);
 
     const ipSection = page.find('#ips');
-    expect(ipSection.find('li').at(0).text()).to.equal(ipv4);
+    console.log('THIS REALLY SHOULDNT PASS');
+    expect(ipSection.find('li').at(0).text()).to.equal(ipv4[0]);
     expect(ipSection.find('li').at(1).text()).to.equal(ipv6.split('/')[0]);
   });
 

--- a/test/linodes/linode/layouts/DashboardPage.spec.js
+++ b/test/linodes/linode/layouts/DashboardPage.spec.js
@@ -24,7 +24,6 @@ describe('linodes/linode/layouts/DashboardPage', async () => {
       />);
 
     const ipSection = page.find('#ips');
-    console.log('THIS REALLY SHOULDNT PASS');
     expect(ipSection.find('li').at(0).text()).to.equal(ipv4[0]);
     expect(ipSection.find('li').at(1).text()).to.equal(ipv6.split('/')[0]);
   });


### PR DESCRIPTION
To test, go to the Linode list page and make sure Linodes with one IPv4 address don't break rendering. Add an IPv4 address to a Linode and make sure only one IPv4 address is rendered for the Linode on the Linode list page.