### PR TITLE
Fix getObjectByLabelLazily for support ticket page

### DIFF
--- a/src/api/util.js
+++ b/src/api/util.js
@@ -35,6 +35,11 @@ export function getObjectByLabelLazily(pluralName, label, labelName = 'label') {
       return oldResource;
     }
 
+    // API doesn't support X-Filter on 'id', so look it up directly.
+    if (labelName === 'id') {
+      return await dispatch(api[pluralName].one([label]));
+    }
+
     const response = await dispatch(api[pluralName].all([], undefined, {
       headers: {
         'X-Filter': { [labelName]: label },

--- a/src/support/layouts/TicketPage.js
+++ b/src/support/layouts/TicketPage.js
@@ -30,7 +30,6 @@ export class TicketPage extends Component {
   static async preload({ dispatch }, { ticketId }) {
     try {
       await dispatch(getObjectByLabelLazily('tickets', ticketId, 'id'));
-      await dispatch(tickets.one([ticketId]));
       await dispatch(tickets.replies.all([ticketId]));
     } catch (response) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
To test, load a support ticket page directly.