### PR TITLE
Scroll to top of page on page change if not jumping to id

### DIFF
--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -56,6 +56,9 @@ function hashLinkScroll() {
         element.scrollTop = element.offsetHeight;
       }
     }, 0);
+  } else {
+    // If we're not jumping to a specific place, scroll to top.
+    window.scroll(0, 0);
   }
 }
 


### PR DESCRIPTION
To test: go to a scrollable page (Linodes) and scroll down to bottom. Then go to another scrollable page (Filtering & Sorting). You should be at the top of the page. Without this change you'd be in the same position on the second scrollable page as you were in the first scrollable page.