### PR TITLE
Fix IPv4 rendering on dashboard

### DIFF
--- a/src/linodes/linode/layouts/DashboardPage.js
+++ b/src/linodes/linode/layouts/DashboardPage.js
@@ -194,11 +194,11 @@ export class DashboardPage extends Component {
                 <div className="input-group">
                   <Input
                     id="ssh-input"
-                    value={`ssh root@${linode.ipv4}`}
+                    value={`ssh root@${linode.ipv4[0]}`}
                     readOnly
                   />
                   <span className="input-group-btn">
-                    <Button href={`ssh://root@${linode.ipv4}`}>SSH</Button>
+                    <Button href={`ssh://root@${linode.ipv4[0]}`}>SSH</Button>
                   </span>
                 </div>
               </div>

--- a/src/linodes/linode/layouts/DashboardPage.js
+++ b/src/linodes/linode/layouts/DashboardPage.js
@@ -156,7 +156,7 @@ export class DashboardPage extends Component {
               </div>
               <div className="col-sm-8">
                 <ul className="list-unstyled" id="ips">
-                  <li>{linode.ipv4}</li>
+                  <li>{linode.ipv4[0]}</li>
                   <li className="text-muted">{linode.ipv6.split('/')[0]}</li>
                   <li><Link to={`/linodes/${linode.label}/networking`}>(...)</Link></li>
                 </ul>

--- a/test/data/linodes.js
+++ b/test/data/linodes.js
@@ -52,7 +52,7 @@ function createTestLinode(id) {
     id,
     group: 'Test Group',
     label: `test-linode-${id}`,
-    ipv4: [ipv4.address],
+    ipv4: [ipv4.address, createTestIpv4(id)],
     ipv6: ipv6.address,
     created: '2016-07-06T16:47:27',
     type: testType,

--- a/test/data/linodes.js
+++ b/test/data/linodes.js
@@ -47,12 +47,13 @@ function createTestIpv6(linodeId) {
 
 function createTestLinode(id) {
   const ipv4 = createTestIpv4(id);
+  const secondIpv4 = createTestIpv4(id);
   const ipv6 = createTestIpv6(id);
   return {
     id,
     group: 'Test Group',
     label: `test-linode-${id}`,
-    ipv4: [ipv4.address, createTestIpv4(id)],
+    ipv4: [ipv4.address, secondIpv4.address],
     ipv6: ipv6.address,
     created: '2016-07-06T16:47:27',
     type: testType,

--- a/test/linodes/linode/layouts/DashboardPage.spec.js
+++ b/test/linodes/linode/layouts/DashboardPage.spec.js
@@ -105,15 +105,13 @@ describe('linodes/linode/layouts/DashboardPage', async () => {
 
   it('renders ssh path', () => {
     const ipv4 = testLinode.ipv4;
-    const sshPath = `ssh root@${ipv4}`;
+    const sshPath = `ssh root@${ipv4[0]}`;
     const page = shallow(
       <DashboardPage
         linode={testLinode}
       />);
 
-    expect(page.find('#ssh-input').props())
-      .to.have.property('value')
-      .to.equal(sshPath);
+    expect(page.find('#ssh-input').props().value).to.equal(sshPath);
   });
 
   it('renders lish input elements', () => {


### PR DESCRIPTION
To test: go to the dashboard page of a Linode with two IPv4 addresses. Only one IPv4 address should be shown in the summary section.