### PR TITLE
Don't double display sdh and set rescue disks correctly

### DIFF
--- a/src/linodes/linode/components/RescueMode.js
+++ b/src/linodes/linode/components/RescueMode.js
@@ -29,7 +29,7 @@ export default class RescueMode extends Component {
     const { disks } = this.state;
 
     return dispatch(dispatchOrStoreErrors.apply(this, [
-      [() => rescueLinode(linode.id, { disks })],
+      [() => rescueLinode(linode.id, disks)],
     ]));
   }
 
@@ -40,7 +40,7 @@ export default class RescueMode extends Component {
     return (
       <Card header={<CardHeader title="Rescue mode" />}>
         <Form className="RescueMode-form" onSubmit={this.onSubmit}>
-          {AVAILABLE_DISK_SLOTS.map((slot, i) => (
+          {AVAILABLE_DISK_SLOTS.map((slot, i) => slot === 'sdh' ? null : (
             <DiskSelect
               key={i}
               disks={disks}

--- a/test/linodes/linode/components/RescueMode.spec.js
+++ b/test/linodes/linode/components/RescueMode.spec.js
@@ -38,12 +38,17 @@ describe('linodes/linode/components/RescueMode', () => {
         linode={testLinode}
       />);
 
-    page.setState({ diskSlots: [12345, 12346] });
+    page.setState({ disks: { sda: 12345, sdb: 12346 } });
     await page.find('Form').props().onSubmit();
 
     expect(dispatch.callCount).to.equal(1);
     await expectDispatchOrStoreErrors(dispatch.firstCall.args[0], [
-      ([fn]) => expectRequest(fn, '/linode/instances/1234/rescue', { method: 'POST' }),
+      ([fn]) => expectRequest(fn, '/linode/instances/1234/rescue', {
+        method: 'POST',
+        body: {
+          disks: { sda: 12345, sdb: 12346 },
+        },
+      }),
     ]);
   });
 });


### PR DESCRIPTION
To test: set disk mappings and boot into rescue mode. Enter weblish and type lsblk. The devices you set should be available.

Closes #1903 
