### PR TITLE
update good node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following buzzwords are involved in this project:
 
     git clone https://github.com/Linode/manager.git
     cd manager
-    node --version # should be 6.x or better
+    node --version # should be 6.x - 7.2.1
     npm install
 
 Currently the codebase is hardcoded to point to our [alpha


### PR DESCRIPTION
I don't know if that's an exhaustive range, but v8.0.0 (default installed by brew) definitely doesn't work and gives import errors like:

    Module not found: Error: Cannot resolve module 'linode-components/forms' in
    .../manager/src/linodes/linode/settings/advanced/components
    @ ./src/linodes/linode/settings/advanced/components/CreateOrEditConfig.js 1:1833-1867

The exceptions appear to only happen for imports that look like:

    linode-components/*

Switched with `n 7.2.1` then removed `node_modules` followed by `npm install` and all working now