### PR TITLE
fix ip address column size

### DIFF
--- a/scss/components/Tables/Cells/Columns.scss
+++ b/scss/components/Tables/Cells/Columns.scss
@@ -6,6 +6,10 @@
     width: 400px;
 }
 
+.LinodeIPAddressColumn {
+    width: 275px;
+}
+
 .RegionColumn {
     width: 175px;
 }

--- a/src/linodes/layouts/IndexPage.js
+++ b/src/linodes/layouts/IndexPage.js
@@ -158,7 +158,7 @@ export class IndexPage extends Component {
                       cellComponent: LinkCell,
                       hrefFn: (linode) => `/linodes/${linode.label}`,
                     },
-                    { cellComponent: IPAddressCell, headerClassName: 'IPAddressColumn' },
+                    { cellComponent: IPAddressCell, headerClassName: 'LinodeIPAddressColumn' },
                     {
                       cellComponent: RegionCell,
                       headerClassName: 'RegionColumn hidden-md-down',


### PR DESCRIPTION
An attempt to address breaks in domains for ipv6 display negatively impacted this list ( the linode label gets cut off too soon ). This adjusts the size here, fixing the label

w/ this fix:
![image](https://user-images.githubusercontent.com/709951/27104114-172b7614-5059-11e7-9f1e-e1f75a377ce4.png)
