### PR TITLE
No soa_email is sent in slave domain edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.4] 2017-06-16
+### Fixed
+- allow saving soa records on slave domains
+
 ## [0.9.3] 2017-06-16
 ### Fixed
 - dont crash on no nodebalancer ipv6

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-manager",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "dependencies": {
     "asap": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-manager",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "The Linode Manager website",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/domains/components/EditSOARecord.js
+++ b/src/domains/components/EditSOARecord.js
@@ -69,6 +69,10 @@ export default class EditSOARecord extends Component {
       delete data.group;
     }
 
+    if (!data.soa_email) {
+      delete data.soa_email;
+    }
+
     return dispatch(dispatchOrStoreErrors.call(this, [
       () => domains.put(data, this.props.domains.id),
       () => setTitle(data.domain),


### PR DESCRIPTION
Closes #2096 which was reported by a customer. The real issue is that you can't save any changes to the SOA record because it tried to submit an empty soa_email.