### PR TITLE
Switch console.trace to console.error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ function fillInMissingProps(props) {
 window.handleError = function (e) {
   try {
     // eslint-disable-next-line no-console
-    console.trace(e);
+    console.error(e);
 
     store.dispatch(setError(e));
 
@@ -99,7 +99,7 @@ window.handleError = function (e) {
     }
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.trace(e);
+    console.error(e);
   }
 
   // TraceKit.report throws an error.


### PR DESCRIPTION
`console.trace` can be helpful from time to time. But having it here as the default is just a pain in the butt... Switching to console.error for a fun time.