### PR TITLE
Update LinodeClient example docs in Python wrapper guide

### DIFF
--- a/docs/src/data/python/linode_client.yaml
+++ b/docs/src/data/python/linode_client.yaml
@@ -14,7 +14,7 @@ constructor:
             desc: Who this LinodeClient should talk to.
             _default: "'https://api.linode.com/v4'"
     example: >
-            client = linode.LinodeClient('my-token')
+            client = LinodeClient('my-token')
 methods:
     get_datacenters:
         desc: >


### PR DESCRIPTION
Since we are importing it as ```from linode import LinodeClient``` above, we don't want linode.LinodeClient, I think