### PR TITLE
Other linode in IP Transfer must be in same datacenter

### DIFF
--- a/src/linodes/linode/networking/layouts/IPTransferPage.js
+++ b/src/linodes/linode/networking/layouts/IPTransferPage.js
@@ -90,7 +90,8 @@ export class IPTransferPage extends Component {
 
   otherLinodes() {
     const { linodes, linode } = this.props;
-    return Object.values(linodes).filter(l => l.id !== linode.id);
+    return Object.values(_.pickBy(linodes, l => l.region.id === linode.region.id))
+      .filter(l => l.id !== linode.id);
   }
 
   render() {
@@ -99,8 +100,7 @@ export class IPTransferPage extends Component {
 
     // Although we only explicitly looked up all linodes in the current dc,
     // other linodes may already exist in the state.
-    const linodesInRegion = _.pickBy(linodes, l =>
-      l.region.id === linode.region.id);
+    const linodesInRegion = this.otherLinodes();
 
     let body = (
       <p>
@@ -131,7 +131,7 @@ export class IPTransferPage extends Component {
                   name="selectedOtherLinode"
                   onChange={({ target: { name, value } }) =>
                     this.setState({ [name]: value, checkedB: {} })}
-                  options={this.otherLinodes().map(linode => ({ ...linode, value: linode.id }))}
+                  options={linodesInRegion.map(linode => ({ ...linode, value: linode.id }))}
                 />
               </div>
             </FormGroup>
@@ -151,7 +151,7 @@ export class IPTransferPage extends Component {
               </div>
               <div className="col-lg-6 col-md-12 col-sm-12" id="sectionB">
                 <IPList
-                  linode={linodesInRegion[selectedOtherLinode]}
+                  linode={linodes[selectedOtherLinode]}
                   checked={checkedB}
                   onChange={(record, checked) => {
                     this.setState({


### PR DESCRIPTION
Right now it was picking any other Linode of yours as the initial Linode for the Select. It was also allowing all Linodes to show up in the Select. Both must be restricted to the current DC. Closes #2108. @stvnjacobs if you have a second, could you pull this down and confirm the fix?
