### PR TITLE
don't allow click on overlay to close modals

### DIFF
--- a/components/modals/ModalShell.js
+++ b/components/modals/ModalShell.js
@@ -1,17 +1,11 @@
 import React, { PropTypes } from 'react';
-import { EmitEvent } from '../utils';
+
 
 export default function ModalShell(props) {
   const { title, open } = props;
 
   return (
-    <div
-      className={`ModalOverlay ${open ? 'ModalOverlay--visible' : ''}`}
-      onClick={() => {
-        props.close();
-        EmitEvent('modal:close', 'Modal', 'close-overlay', title);
-      }}
-    >
+    <div className={`ModalOverlay ${open ? 'ModalOverlay--visible' : ''}`}>
       <div className="Modal" onClick={(e) => e.stopPropagation()}>
         <header className="Modal-header">
           <h3>{title}</h3>
@@ -26,7 +20,6 @@ ModalShell.propTypes = {
   title: PropTypes.string,
   children: PropTypes.any,
   open: PropTypes.bool.isRequired,
-  close: PropTypes.func.isRequired,
 };
 
 ModalShell.defaultProps = {

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -5,7 +5,6 @@ import { Link } from 'react-router';
 import { Error } from 'linode-components/errors';
 import { ModalShell } from 'linode-components/modals';
 
-import { hideModal } from '~/actions/modal';
 import { hideNotifications } from '~/actions/notifications';
 import { hideSession } from '~/actions/session';
 import { profile } from '~/api';

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -72,7 +72,6 @@ export class Layout extends Component {
         <ModalShell
           open={this.props.modal.open}
           title={this.props.modal.title}
-          close={() => dispatch(hideModal())}
         >
           {this.props.modal.body}
         </ModalShell>

--- a/src/linodes/components/StatusDropdown.js
+++ b/src/linodes/components/StatusDropdown.js
@@ -184,7 +184,7 @@ export default class StatusDropdown extends Component {
         }}
         items={[linode.label]}
         onCancel={() => {
-          Event('modal:cancel', 'Modal', 'cancel', 'Delete Linode');
+          EmitEvent('modal:cancel', 'Modal', 'cancel', 'Delete Linode');
           dispatch(hideModal());
         }}
       />


### PR DESCRIPTION
this prevents loss of form information before submit

cancel (which all modals have) can be used explicitly to close a modal