### PR TITLE
update docs method param calculations to include object id types for post/put

### DIFF
--- a/docs/prebuild.js
+++ b/docs/prebuild.js
@@ -89,7 +89,18 @@ function formatMethodParams(methodObj) {
 
       param.description = convertUlToArray(stripATags(param.description));
 
-      const type = apiObjectMap[param.type] ? 'integer' : param.type;
+      let type = param.type;
+      if (type) {
+        const resourceObj = getResourceObjByName(param.type);
+        if (resourceObj) {
+          if (Array.isArray(resourceObj.schema)) {
+            type = resourceObj.schema.filter(function(schemaObj) { return schemaObj.name === 'id'; })[0]._type;
+          } else {
+            type = resourceObj.schema.id._type;
+          }
+        }
+      }
+
       const required = !param.optional;
       return _.merge({}, param, {
         name: paramName,


### PR DESCRIPTION
this fixes cases where POST param types say object/integer instead of "String" or what is defined in the corresponding resource object.

for example, /linodes/instances now correctly shows the corresponding region id type:

![screen shot 2017-07-12 at 11 39 18 am](https://user-images.githubusercontent.com/709951/28126195-c84152b2-66f6-11e7-805a-65db364589a5.png)
