### PR TITLE
Group distributions by lowercase vendor name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.11.4] 2017-07-14
+### Fixed
+- group by lowercase distribution vendor names
+
 ## [0.11.3] 2017-07-18
 ### Added
 - rebuild confirm check

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-manager",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-manager",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "The Linode Manager website",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/assets.js
+++ b/src/assets.js
@@ -1,14 +1,14 @@
-import Arch from 'file-loader!../assets/distros/Arch.png';
-import CentOS from 'file-loader!../assets/distros/CentOS.png';
-import Debian from 'file-loader!../assets/distros/Debian.png';
-import Fedora from 'file-loader!../assets/distros/Fedora.png';
-import Gentoo from 'file-loader!../assets/distros/Gentoo.png';
-import Slackware from 'file-loader!../assets/distros/Slackware.png';
-import Ubuntu from 'file-loader!../assets/distros/Ubuntu.png';
-import openSUSE from 'file-loader!../assets/distros/OpenSUSE.png';
+import arch from 'file-loader!../assets/distros/Arch.png';
+import centos from 'file-loader!../assets/distros/CentOS.png';
+import debian from 'file-loader!../assets/distros/Debian.png';
+import fedora from 'file-loader!../assets/distros/Fedora.png';
+import gentoo from 'file-loader!../assets/distros/Gentoo.png';
+import slackware from 'file-loader!../assets/distros/Slackware.png';
+import ubuntu from 'file-loader!../assets/distros/Ubuntu.png';
+import opensuse from 'file-loader!../assets/distros/OpenSUSE.png';
 
 export const distros = {
-  Arch, CentOS, Debian, Fedora, Gentoo, Slackware, Ubuntu, openSUSE,
+  arch, centos, debian, fedora, gentoo, slackware, ubuntu, opensuse,
 };
 
 import us from 'flag-icon-css/flags/4x3/us.svg';

--- a/src/linodes/components/Distributions.js
+++ b/src/linodes/components/Distributions.js
@@ -1,7 +1,8 @@
-import React, { PropTypes } from 'react';
 import _ from 'lodash';
+import React, { PropTypes } from 'react';
 
 import Distribution from './Distribution';
+
 
 export default function Distributions(props) {
   const { distributions, distribution, onSelected, noDistribution = true } = props;

--- a/src/linodes/components/Distributions.js
+++ b/src/linodes/components/Distributions.js
@@ -10,8 +10,13 @@ export default function Distributions(props) {
     return null;
   }
 
+  const withVendorLowerCased = _.map(distributions, d => ({
+    ...d,
+    vendor: d.vendor.toLowerCase(),
+  }));
+
   const vendorsUnsorted = _.map(
-    _.groupBy(distributions, 'vendor'),
+    _.groupBy(withVendorLowerCased, 'vendor'),
     (v, k) => ({
       name: k,
       versions: _.orderBy(v, ['recommended', 'created'], ['desc', 'desc']),

--- a/test/linodes/create/components/Source.spec.js
+++ b/test/linodes/create/components/Source.spec.js
@@ -16,7 +16,7 @@ describe('linodes/create/components/Source', () => {
     const onSourceSelected = sandbox.spy();
     const c = mount(
       <Source
-        distributions={api.distributions}
+        distributions={api.distributions.distributions}
         distribution={null}
         onDistroSelected={onSourceSelected}
       />


### PR DESCRIPTION
Ubuntu 17 isn't showing up in the list of distros because it's vendor is lowercase whereas the other versions vendor field is mixed case.