### PR TITLE
Impose session expiration

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -240,3 +240,5 @@ export const IPV6_DNS_RESOLVERS = [
 ];
 
 export const MONTHLY_IP_COST = 1;
+
+export const SESSION_DURATION = 120;

--- a/src/constants.js
+++ b/src/constants.js
@@ -241,4 +241,4 @@ export const IPV6_DNS_RESOLVERS = [
 
 export const MONTHLY_IP_COST = 1;
 
-export const SESSION_DURATION = 120;
+export const SESSION_DURATION = 119; // minutes

--- a/src/constants.js
+++ b/src/constants.js
@@ -240,5 +240,3 @@ export const IPV6_DNS_RESOLVERS = [
 ];
 
 export const MONTHLY_IP_COST = 1;
-
-export const SESSION_DURATION = 119; // minutes

--- a/src/layouts/OAuth.js
+++ b/src/layouts/OAuth.js
@@ -35,10 +35,12 @@ export class OAuthCallbackPage extends Component {
         body: data,
         mode: 'cors',
       });
-      const { access_token, scopes } = await resp.json();
+      const { access_token, scopes, expires_in } = await resp.json();
 
+      const expires = new Date();
+      expires.setSeconds(expires.getSeconds() + expires_in);
       // Token needs to be in redux state for all API calls
-      dispatch(session.start(access_token, scopes));
+      dispatch(session.start(access_token, scopes, expires));
 
       // Done OAuth flow. Let the app begin.
       dispatch(push(returnTo || '/'));

--- a/src/layouts/OAuth.js
+++ b/src/layouts/OAuth.js
@@ -35,10 +35,10 @@ export class OAuthCallbackPage extends Component {
         body: data,
         mode: 'cors',
       });
-      const { access_token, scopes, expires_in } = await resp.json();
+      const { access_token, scopes, expires_in: expiresIn } = await resp.json();
 
       const expires = new Date();
-      expires.setSeconds(expires.getSeconds() + expires_in);
+      expires.setSeconds(expires.getSeconds() + expiresIn);
       // Token needs to be in redux state for all API calls
       dispatch(session.start(access_token, scopes, expires));
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,6 @@
 import { combineReducers } from 'redux';
 import { routerReducer } from 'react-router-redux';
 
-import { LOGOUT } from '~/actions/authentication';
 import authentication from './authentication';
 import modal from './modal';
 import notifications from './notifications';

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -28,9 +28,5 @@ const appReducer = combineReducers({
 });
 
 export default function rootReducer(state, action) {
-  if (action.type === LOGOUT) {
-    return appReducer(undefined, action);
-  }
-
   return appReducer(state, action);
 }

--- a/src/session.js
+++ b/src/session.js
@@ -44,19 +44,6 @@ export function checkLogin(next) {
   return null;
 }
 
-export function initialize(dispatch) {
-  const expires = getStorage(AUTH_EXPIRES) || null;
-  if (expires && new Date(expires) < new Date()) {
-    // Calling expire makes sure the full expire steps are taken.
-    return dispatch(expire);
-  }
-
-  const token = getStorage(AUTH_TOKEN) || null;
-  const scopes = getStorage(AUTH_SCOPES) || null;
-  // Calling this makes sure AUTH_EXPIRES is always set.
-  dispatch(start(token, scopes, expires));
-}
-
 export function expire(dispatch) {
   // Remove these from local storage so if login fails, next time we jump to login sooner.
   setStorage(AUTH_TOKEN, '');
@@ -80,4 +67,17 @@ export function start(oauthToken = '', scopes = '', expires) {
     // Add all to state for this (page load) session
     dispatch(setToken(oauthToken, scopes));
   };
+}
+
+export function initialize(dispatch) {
+  const expires = getStorage(AUTH_EXPIRES) || null;
+  if (expires && new Date(expires) < new Date()) {
+    // Calling expire makes sure the full expire steps are taken.
+    return dispatch(expire);
+  }
+
+  const token = getStorage(AUTH_TOKEN) || null;
+  const scopes = getStorage(AUTH_SCOPES) || null;
+  // Calling this makes sure AUTH_EXPIRES is always set.
+  dispatch(start(token, scopes, expires));
 }

--- a/test/session.spec.js
+++ b/test/session.spec.js
@@ -55,7 +55,7 @@ describe('session', () => {
     const sessionValues = [
       'authentication/oauth-token',
       'authentication/scopes',
-      'authentication/expiration',
+      'authentication/expires',
     ];
 
     expect(setStorage.callCount).to.equal(sessionValues.length);

--- a/test/session.spec.js
+++ b/test/session.spec.js
@@ -6,7 +6,7 @@ import * as session from '~/session';
 import * as storage from '~/storage';
 
 
-describe('session/checkLogin', () => {
+describe('session', () => {
   const sandbox = sinon.sandbox.create();
 
   afterEach(() => {
@@ -55,6 +55,7 @@ describe('session/checkLogin', () => {
     const sessionValues = [
       'authentication/oauth-token',
       'authentication/scopes',
+      'authentication/expiration',
     ];
 
     expect(setStorage.callCount).to.equal(sessionValues.length);


### PR DESCRIPTION
This automatically redirects you to grab a new token once you've reached the SESSION_DURATION. This way there is less wait while you (currently) wait for your first request to fail because of an invalid token.