### PR TITLE
Enable external source map

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -4,7 +4,7 @@ var webpack = require('webpack');
 var _ = require('./webpack.config.dev.js');
 var _package = require('./package.json');
 
-_.devtool = 'cheap-module-source-map';
+_.devtool = 'source-map';
 _.entry = './src/index';
 _.plugins = [
   new webpack.optimize.CommonsChunkPlugin({
@@ -24,8 +24,9 @@ _.plugins = [
     'ENV_VERSION': JSON.stringify(_package.version)
   }),
   new webpack.optimize.UglifyJsPlugin({
+    sourceMap: true,
     compressor: {
-      warnings: false
+      warnings: false,
     }
   }),
   new webpack.optimize.AggressiveMergingPlugin()

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -25,7 +25,7 @@ _.plugins = [
   new webpack.optimize.UglifyJsPlugin({
     sourceMap: true,
     compressor: {
-      warnings: false,
+      warnings: false
     }
   }),
   new webpack.optimize.AggressiveMergingPlugin()

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -4,7 +4,6 @@ var webpack = require('webpack');
 var _ = require('./webpack.config.dev.js');
 var _package = require('./package.json');
 
-_.devtool = 'source-map';
 _.entry = './src/index';
 _.plugins = [
   new webpack.optimize.CommonsChunkPlugin({


### PR DESCRIPTION
Closes #2210 

Without the `sourceMap: true` flag to Uglify, it squashes the source map into the bundle. This keeps them separate. This should Just Work.