### PR TITLE
Render correct tooltip when unit changes

### DIFF
--- a/src/components/graphs/LineGraph.js
+++ b/src/components/graphs/LineGraph.js
@@ -55,7 +55,7 @@ export default class LineGraph extends Component {
     return undefined;
   }
 
-  renderChart({ timezone, data, title, yAxis, unit }) {
+  renderChart({ timezone, data, title, yAxis, tooltipFormat }) {
     const thisDOMNode = ReactDOM.findDOMNode(this);
     const ctx = thisDOMNode.getContext('2d');
     const config = {
@@ -102,7 +102,7 @@ export default class LineGraph extends Component {
               if (label) {
                 label += ': ';
               }
-              label += tooltipItem.yLabel + unit;
+              label += tooltipFormat(tooltipItem.yLabel);
               return label;
             },
           },

--- a/src/linodes/components/DistroStyle.js
+++ b/src/linodes/components/DistroStyle.js
@@ -10,11 +10,12 @@ export default function DistroStyle(props) {
     return (<span>Unknown</span>);
   }
 
+  const src = distroAssets[linode.distribution.vendor.toLowerCase()];
+
   return (
     <span className="distro-style">
       <img
-        src={distroAssets[linode.distribution.vendor]
-          ? distroAssets[linode.distribution.vendor] : '//placehold.it/50x50'}
+        src={src}
         alt={linode.distribution.vendor}
         width="15" height="15"
       />

--- a/src/linodes/components/Region.js
+++ b/src/linodes/components/Region.js
@@ -9,8 +9,7 @@ export default function Region(props) {
   return (
     <span className="region-style">
       <img
-        src={flags[obj.region.country]
-          ? flags[obj.region.country] : '//placehold.it/50x50'}
+        src={flags[obj.region.country]}
         height="15" width="20" alt={obj.region.label}
       />
       <span>{obj.region.label}</span>

--- a/src/linodes/linode/layouts/DashboardPage.js
+++ b/src/linodes/linode/layouts/DashboardPage.js
@@ -16,6 +16,7 @@ import Region from '~/linodes/components/Region';
 import DistroStyle from '~/linodes/components/DistroStyle';
 import PlanStyle from '~/linodes/components/PlanStyle';
 import WeblishLaunch from '~/linodes/components/WeblishLaunch';
+import { convertUnits } from '~/utilities';
 
 import { selectLinode } from '../utilities';
 
@@ -98,44 +99,44 @@ export class DashboardPage extends Component {
             format: p => `${p.toFixed(1)}%`,
           },
           data: formatData(['0033CC'], [stats.cpu]),
-          unit: '%',
+          tooltipFormat: v => `${v}%`,
         },
         io: {
           title: 'IO',
           yAxis: {
             label: `${IO_UNITS[units]} per second`,
-            format: r => `${r.toFixed(1) / Math.pow(1000, units)}${IO_UNITS[units]}/s`,
+            format: v => convertUnits(v, units, IO_UNITS, 1),
           },
           data: formatData(['FFD04B', 'FA373E'],
                            [stats.io.io, stats.io.swap],
                            ['Disk', 'Swap']),
-          unit: `${IO_UNITS[units]}/s`,
+          tooltipFormat: v => convertUnits(v, units, IO_UNITS, 1),
         },
         netv4: {
           title: 'IPv4 Network',
           yAxis: {
             label: `${NETWORK_UNITS[units]} per second`,
-            format: r => `${r.toFixed() / Math.pow(1000, units)}${NETWORK_UNITS[units]}/s`,
+            format: v => convertUnits(v, units, NETWORK_UNITS),
           },
           data: formatData(['0033CC', 'CC0099', '32CD32', 'FFFF99'],
                            [stats.netv4.in, stats.netv4.private_in,
                             stats.netv4.out, stats.netv4.private_out],
                            ['Public IPv4 Inbound', 'Private IPv4 Inbound',
                             'Public IPv4 Outbound', 'Private IPv4 Outbound']),
-          unit: `${NETWORK_UNITS[units]}/s`,
+          tooltipFormat: v => convertUnits(v, units, NETWORK_UNITS),
         },
         netv6: {
           title: 'IPv6 Network',
           yAxis: {
             label: `${NETWORK_UNITS[units]} per second`,
-            format: r => `${r.toFixed() / Math.pow(1000, units)}${NETWORK_UNITS[units]}/s`,
+            format: v => convertUnits(v, units, NETWORK_UNITS),
           },
           data: formatData(['0033CC', 'CC0099', '32CD32', 'FFFF99'],
                            [stats.netv6.in, stats.netv6.private_in,
                             stats.netv6.out, stats.netv6.private_out],
                            ['Public IPv6 Inbound', 'Private IPv6 Inbound',
                             'Public IPv6 Outbound', 'Private IPv6 Outbound']),
-          unit: `${NETWORK_UNITS[units]}/s`,
+          tooltipFormat: v => convertUnits(v, units, NETWORK_UNITS),
         },
       };
     }

--- a/src/nodebalancers/nodebalancer/layouts/DashboardPage.js
+++ b/src/nodebalancers/nodebalancer/layouts/DashboardPage.js
@@ -22,6 +22,7 @@ import LineGraph from '~/components/graphs/LineGraph';
 import {
   NODEBALANCER_CONFIG_ALGORITHMS, NODEBALANCER_CONFIG_STICKINESS,
 } from '~/constants';
+import { convertUnits } from '~/utilities';
 
 
 const CONNECTION_UNITS = [' connections', 'K connections', 'M connections'];
@@ -120,21 +121,21 @@ export class DashboardPage extends Component {
           title: 'Connections',
           yAxis: {
             label: `${CONNECTION_UNITS[units]} per second`,
-            format: r => `${r.toFixed(1) / Math.pow(1000, units)}${CONNECTION_UNITS[units]}/s`,
+            format: v => convertUnits(v, units, CONNECTION_UNITS, 1),
           },
           data: formatData(['990066'], [stats.connections]),
-          unit: `${CONNECTION_UNITS[units]}/s`,
+          tooltipFormat: v => convertUnits(v, units, CONNECTION_UNITS, 1),
         },
         traffic: {
           title: 'Traffic',
           yAxis: {
             label: `${NETWORK_UNITS[units]} per second`,
-            format: r => `${r.toFixed(1) / Math.pow(1000, units)}${NETWORK_UNITS[units]}/s`,
+            format: v => convertUnits(v, units, NETWORK_UNITS, 1),
           },
           data: formatData(['0033CC', '32CD32'],
                            [stats.traffic.in, stats.traffic.out],
                            ['In', 'Out']),
-          unit: `${NETWORK_UNITS[units]}/s`,
+          tooltipFormat: v => convertUnits(v, units, NETWORK_UNITS, 1),
         },
       };
     }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,0 +1,3 @@
+export function convertUnits(value, units, unitType, fixedNumber = 0) {
+  return `${value.toFixed(fixedNumber) / Math.pow(1000, units)}${unitType[units]}/s`;
+}


### PR DESCRIPTION
Closes #2287

To test:
* Change the units of the IO or Network graphs on the Linode and NodeBalancer pages, the tooltip data for a datapoint should now be accurate / take into account the units you picked.
* Make sure that the distro icon shows up on the Linode dashboard page