### PR TITLE
Independent method response fields

### DIFF
--- a/docs/prebuild.js
+++ b/docs/prebuild.js
@@ -278,34 +278,35 @@ function createEnumMap(enums) {
 
 function formatMethodResponse(methodObj) {
   let response = methodObj.response;
+
+  let resourceObject;
   if (typeof response === 'string') {
     let resourceName = response;
 
-    // IF this is a GET endpoint and has an associated resource object, combine them
-    let resourceObject;
-
     // Paginated endpoints will modify the schema, so we need to be using a copy of the data.
     resourceObject = _.cloneDeep(getResourceObjByName(resourceName));
+  } else {
+    resourceObject = { schema: response };
+  }
 
-    let enums;
-    let schema;
-    if (resourceObject) {
-      enums = resourceObject.enums;
+  let enums;
+  let schema;
+  if (resourceObject) {
+    enums = resourceObject.enums;
 
-      let enumMap;
-      if (enums) {
-        enumMap = createEnumMap(enums);
-      }
-
-      schema = resourceObject.schema;
-      if (schema) {
-        resourceObject.schema = formatSchema(schema, enumMap, methodObj.paginationKey, methodObj.response);
-        resourceObject.example = formatSchemaExample(resourceObject.schema, methodObj.paginationKey);
-      }
+    let enumMap;
+    if (enums) {
+      enumMap = createEnumMap(enums);
     }
 
-    return resourceObject;
+    schema = resourceObject.schema;
+    if (schema) {
+      resourceObject.schema = formatSchema(schema, enumMap, methodObj.paginationKey, methodObj.response);
+      resourceObject.example = formatSchemaExample(resourceObject.schema, methodObj.paginationKey);
+    }
   }
+
+  return resourceObject;
 }
 
 function formatMethod(endpoint, method) {

--- a/docs/prebuild.js
+++ b/docs/prebuild.js
@@ -88,10 +88,12 @@ function getResourceObjByName(name) {
 }
 
 function formatMethodParams(methodObj) {
-  let params;
-  if (methodObj.params) {
-    params = Object.keys(methodObj.params).map(function(paramName) {
-      const param = methodObj.params[paramName];
+  let params = methodObj.params;
+
+  let formattedParams;
+  if (params) {
+    formattedParams = Object.keys(params).map(function(paramName) {
+      const param = params[paramName];
 
       param.description = convertUlToArray(stripATags(param.description));
 
@@ -115,7 +117,8 @@ function formatMethodParams(methodObj) {
       });
     });
   }
-  return params;
+
+  return formattedParams;
 }
 
 function formatMethodExamples(methodObj) {
@@ -273,14 +276,16 @@ function createEnumMap(enums) {
   return enumMap;
 }
 
-function formatMethodResource(endpoint, method) {
-  // IF this is a GET endpoint and has an associated resource object, combine them
-  let resourceObject;
-  if (method === 'GET' && endpoint.resource) {
-    let resource = endpoint.resource;
+function formatMethodResponse(methodObj) {
+  let response = methodObj.response;
+  if (typeof response === 'string') {
+    let resourceName = response;
+
+    // IF this is a GET endpoint and has an associated resource object, combine them
+    let resourceObject;
 
     // Paginated endpoints will modify the schema, so we need to be using a copy of the data.
-    resourceObject = _.cloneDeep(getResourceObjByName(resource));
+    resourceObject = _.cloneDeep(getResourceObjByName(resourceName));
 
     let enums;
     let schema;
@@ -294,27 +299,29 @@ function formatMethodResource(endpoint, method) {
 
       schema = resourceObject.schema;
       if (schema) {
-        resourceObject.schema = formatSchema(schema, enumMap, endpoint.paginationKey, endpoint.resource);
-        resourceObject.example = formatSchemaExample(resourceObject.schema, endpoint.paginationKey);
+        resourceObject.schema = formatSchema(schema, enumMap, methodObj.paginationKey, methodObj.response);
+        resourceObject.example = formatSchemaExample(resourceObject.schema, methodObj.paginationKey);
       }
     }
-  }
 
-  return resourceObject;
+    return resourceObject;
+  }
 }
 
 function formatMethod(endpoint, method) {
   const methodObj = endpoint.methods[method];
   methodObj.description = stripATags(methodObj.description);
-  const resourceObj = formatMethodResource(endpoint, method);
-  const examples = formatMethodExamples(methodObj);
+
   const params = formatMethodParams(methodObj);
+  const response = formatMethodResponse(methodObj);
+
+  const examples = formatMethodExamples(methodObj);
 
   return _.merge({}, methodObj, {
     name: method,
     examples: examples,
     params: params,
-    resource: resourceObj
+    response: response
   });
 }
 

--- a/docs/src/components/Method.js
+++ b/docs/src/components/Method.js
@@ -15,10 +15,8 @@ export default function Method(props) {
     money,
     oauth,
     params,
-    resource = {},
+    response,
   } = method;
-
-  const { schema = [] } = resource;
 
   // TODO: Break these out if needed
   let methodParams = null;
@@ -34,11 +32,12 @@ export default function Method(props) {
 
   let methodResponse = null;
   let methodResponseExample = null;
-  if (name === 'GET') {
+  if (response) {
+    const { schema = [] } = response;
     methodResponse = (<MethodResponse schema={schema} />);
 
-    if (resource.example) {
-      methodResponseExample = (<MethodResponseExample resource={resource} />);
+    if (response.example) {
+      methodResponseExample = (<MethodResponseExample response={response} />);
     }
   }
 

--- a/docs/src/components/Method.js
+++ b/docs/src/components/Method.js
@@ -32,9 +32,10 @@ export default function Method(props) {
 
   let methodResponse = null;
   let methodResponseExample = null;
-  if (response) {
-    const { schema = [] } = response;
-    methodResponse = (<MethodResponse schema={schema} />);
+
+  const responseSchema = response.schema;
+  if (responseSchema) {
+    methodResponse = (<MethodResponse schema={responseSchema} />);
 
     if (response.example) {
       methodResponseExample = (<MethodResponseExample response={response} />);

--- a/docs/src/components/MethodResponseExample.js
+++ b/docs/src/components/MethodResponseExample.js
@@ -18,7 +18,7 @@ export default class MethodResponseExample extends Component {
   }
 
   render() {
-    const { resource } = this.props;
+    const { response } = this.props;
     const { collapsed } = this.state;
 
     const caretClass = collapsed ? 'fa-caret-right' : 'fa-caret-down';
@@ -33,7 +33,7 @@ export default class MethodResponseExample extends Component {
           </span>
         </div>
         <Example
-          example={JSON.stringify(resource.example, null, 2)}
+          example={JSON.stringify(response.example, null, 2)}
           name="json"
           noclipboard
           collapsed={collapsed}
@@ -44,7 +44,7 @@ export default class MethodResponseExample extends Component {
 }
 
 MethodResponseExample.propTypes = {
-  resource: PropTypes.shape({
+  response: PropTypes.shape({
     example: PropTypes.string,
   }),
 };

--- a/docs/src/data/endpoints/account.yaml
+++ b/docs/src/data/endpoints/account.yaml
@@ -13,6 +13,7 @@ endpoints:
       Manage your user information.
     methods:
       GET:
+        response: account
         description: >
           Returns your user information.
         examples:
@@ -119,9 +120,9 @@ endpoints:
   /account/profile/grants:
     _group: Profile
     type: strange
-    resource: usergrants
     methods:
       GET:
+        response: usergrants
         description: >
           Get grants for the current user.
         examples:
@@ -133,12 +134,12 @@ endpoints:
             my_grants = my_profile.grants
   /account/tokens:
     _group: Tokens
-    resource: oauthtoken
-    paginationKey: tokens
     description: >
       Manage OAuth Tokens created for your user.
     methods:
       GET:
+        response: oauthtoken
+        paginationKey: tokens
         oauth: tokens:view
         description: >
           Get a list of all OAuth Tokens active for your user.  This includes first-party (manager) tokens,
@@ -190,11 +191,11 @@ endpoints:
   /account/tokens/:id:
     _group: Tokens
     type: resource
-    resource: oauthtoken
     description: >
       Manage individual OAuth Tokens for your user.
     methods:
       GET:
+        response: oauthtoken
         oauth: tokens:view
         description: >
           Get a single token.
@@ -233,11 +234,11 @@ endpoints:
   /account/settings:
     _group: Settings
     type: resource
-    resource: account
     description: >
       Manage your account settings.
     methods:
       GET:
+        response: account
         description: >
           Returns your account settings.
         examples:
@@ -279,13 +280,13 @@ endpoints:
             my_settings.save()
   /account/clients:
     _group: Clients
-    resource: client
-    paginationKey: clients
     authenticated: true
     description: >
       Manage the collection of OAuth client applications your account may access.
     methods:
       GET:
+        response: client
+        paginationKey: clients
         oauth: clients:view
         description: >
           Returns a list of <a href="#object-client">clients</a>.
@@ -322,12 +323,12 @@ endpoints:
   /account/clients/:id:
     _group: Clients
     type: resource
-    resource: client
     authenticated: true
     description: >
       Manage a particular OAuth client application your account may access.
     methods:
       GET:
+        response: client
         oauth: clients:view
         description: >
           Returns information about this <a href="#object-client">OAuth client</a>.
@@ -427,12 +428,12 @@ endpoints:
             my_client.set_thumbnail(img)
   /account/users:
     _group: Users
-    resource: user
-    paginationKey: users
     description: >
       Returns a list of <a href="#object-user">User objects</a> associated with your account.
     methods:
       GET:
+        response: user
+        paginationKey: users
         examples:
           curl: |
             curl https://$api_root/$version/account/users
@@ -470,11 +471,11 @@ endpoints:
   /account/users/:username:
     _group: Users
     type: resource
-    resource: user
     description: >
       Returns information about a specific user associated with your account.
     methods:
       GET:
+        response: user
         examples:
           curl: |
             curl https://$api_root/$version/account/users/$username
@@ -532,12 +533,12 @@ endpoints:
   /account/users/:username/grants:
     _group: Users
     type: resource
-    resource: usergrants
     description: >
       Manage grants for restricted users.  It is an error to call this endpoint for unrestrcited users.  Only unrestricted
       users may access this endpoint.
     methods:
       GET:
+        response: usergrants
         description: Get grants for a restricted user.
         examples:
           curl: |
@@ -569,13 +570,13 @@ endpoints:
             my_user.grants.save()
   /account/clients:
     _group: Clients
-    resource: client
-    paginationKey: clients
     authenticated: true
     description: >
       Manage the collection of OAuth client applications your account may access.
     methods:
       GET:
+        response: client
+        paginationKey: clients
         oauth: clients:view
         description: >
           Returns a list of <a href="#object-client">clients</a>.
@@ -608,12 +609,12 @@ endpoints:
   /account/clients/:id:
     _group: Clients
     type: resource
-    resource: client
     authenticated: true
     description: >
       Manage a particular OAuth client application your account may access.
     methods:
       GET:
+        response: client
         oauth: clients:view
         description: >
           Returns information about this <a href="#object-client">OAuth client</a>.
@@ -646,13 +647,13 @@ endpoints:
                 https://$api_root/$version/account/clients/$client_id
   /account/events:
     _group: Events
-    resource: event
-    paginationKey: events
     authenticated: true
     description: >
       View the collection of events.
     methods:
       GET:
+        response: event
+        paginationKey: events
         description: >
           Returns a list of <a href="#object-event">events</a>.
         examples:
@@ -663,12 +664,12 @@ endpoints:
   /account/events/:id:
     _group: Events
     type: resource
-    resource: events
     authenticated: true
     description: >
       Returns information about a specific event.
     methods:
       GET:
+        response: events
         description: >
           Returns information about this <a href="#object-event">
           event</a>.

--- a/docs/src/data/endpoints/domains.yaml
+++ b/docs/src/data/endpoints/domains.yaml
@@ -8,13 +8,13 @@ description: >
   here. We'll just direct you to [RFC 1035](https://www.ietf.org/rfc/rfc1035.txt).
 endpoints:
   /domains:
-    resource: domain
     authenticated: true
-    paginationKey: domains
     description: >
       Manage the collection of Domains your account may access.
     methods:
       GET:
+        response: domain
+        paginationKey: domains
         oauth: domains:view
         description: >
           Returns a list of <a href="#object-domain">Domains</a>.
@@ -116,9 +116,9 @@ endpoints:
             TODO
   /domains/:id:
     authenticated: true
-    resource: domain
     methods:
       GET:
+        response: domain
         oauth: domains:view
         description: >
           Returns information for the <a href="#object-domain">Domain</a>
@@ -169,13 +169,13 @@ endpoints:
             import linode
             TODO
   /domains/:id/records:
-    resource: domainrecords
-    paginationKey: records
     authenticated: true
     description: >
       Manage the collection of Domain Records your account may access.
     methods:
       GET:
+        response: domainrecords
+        paginationKey: records
         oauth: domains:view
         description: >
           Returns a list of <a href="#object-domainrecord">Domain Records</a>.
@@ -258,9 +258,9 @@ endpoints:
             TODO
   /domains/:id/records/:id:
     authenticated: true
-    resource: domainrecord
     methods:
       GET:
+        response: domainrecord
         oauth: domains:view
         description: >
           Returns information for the <a href="#object-domainrecord">Domain

--- a/docs/src/data/endpoints/linodes.yaml
+++ b/docs/src/data/endpoints/linodes.yaml
@@ -6,13 +6,13 @@ description: >
   Linode objects</a> on your account.
 endpoints:
   /linode/instances:
-    resource: linode
-    paginationKey: linodes
     authenticated: true
     description: >
       Manage the collection of Linodes your account may access.
     methods:
       GET:
+        response: linode
+        paginationKey: linodes
         oauth: linodes:view
         description: >
           Returns a list of <a href="#object-linode">Linodes</a>.
@@ -105,12 +105,12 @@ endpoints:
             ( my_linode_2, password ) = client.linode.create_instance('us-east-1a', 'g5-standard-1', distribution=distro)
   /linode/instances/:id:
     type: resource
-    resource: linode
     authenticated: true
     description: >
       Manage a particular Linode your account may access.
     methods:
       GET:
+        response: linode
         oauth: linodes:view
         description: >
           Returns information about this <a href="#object-linode">Linode</a>.
@@ -153,13 +153,13 @@ endpoints:
             my_linode.delete()
   /linode/instances/:id/disks:
     _group: Disks
-    resource: disk
-    paginationKey: disks
     authenticated: true
     description: >
       Manage the disks associated with this Linode.
     methods:
       GET:
+        response: disk
+        paginationKey: disks
         oauth: linodes:view
         description: >
           Returns a list of <a href="#object-disk">disks</a>.
@@ -239,12 +239,12 @@ endpoints:
   /linode/instances/:id/disks/:id:
     _group: Disks
     type: resource
-    resource: disk
     authenticated: true
     description: >
       Manage a particular disk associated with this Linode.
     methods:
       GET:
+        response: disk
         oauth: linodes:view
         description: >
           Returns information about this <a href="#object-disk">disk</a>.
@@ -341,13 +341,13 @@ endpoints:
             disk.reset_root_password('hunter2')
   /linode/instances/:id/configs:
     _group: Configs
-    resource: linode_config
-    paginationKey: configs
     authenticated: true
     description: >
       Manage the boot configs on this Linode.
     methods:
       GET:
+        response: linode_config
+        paginationKey: configs
         oauth: linodes:view
         description: >
           Returns a list of <a href="#object-linode_config">configs</a> for a
@@ -430,12 +430,12 @@ endpoints:
   /linode/instances/:id/configs/:id:
     _group: Configs
     type: resource
-    resource: linode_config
     authenticated: true
     description: >
       Manage a particular config for a given Linode.
     methods:
       GET:
+        response: linode_config
         oauth: linodes:view
         description: >
           Returns information about this <a href="#object-linode_config">
@@ -483,13 +483,13 @@ endpoints:
           python: |
             config.delete()
   /linode/instances/:id/volumes:
-    resource: volume
-    paginationKey: volumes
     authenticated: true
     description: >
         View Block Storage Volumes attached to this Linode.
     methods:
       GET:
+        response: volume
+        paginationKey: volumes
         oauth: linodes:view
         description: >
           Returns a list of <a href="#object-volume">volumes</a>.
@@ -639,13 +639,13 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/resize
   /linode/instances/:id/backups:
     _group: Backups
-    resource: backupsresponse
-    paginationKey: backups
     authenticated: true
     description: >
       Returns information about this Linode's available <a href="#object-backup">backups</a>.
     methods:
       GET:
+        response: backupsresponse
+        paginationKey: backups
         description: >
           Returns a <a href="#object-backupsresponse">Backups Response</a> with information on this Linode's
           available backups.
@@ -750,12 +750,12 @@ endpoints:
   /linode/instances/:id/ips:
     _group: IPs
     type: Strange
-    resource: linodenetworking
     authenticated: true
     description: >
       View networking information for this Linode.
     methods:
       GET:
+        response: linodenetworking
         oauth: linodes:view
         description: >
           Returns a <a href="#object-linodenetworking">Linode Networking Object</a>.
@@ -803,12 +803,12 @@ endpoints:
   /linode/instances/:id/ips/:ip_address:
     _group: IPs
     type: Action
-    resource: ipaddress
     authenticated: true
     description: >
       Manage a particular IP Address associated with this Linode.
     methods:
       GET:
+        response: ipaddress
         oauth: linodes:view
         description: >
           Returns information about this <a href="#object-ipaddress">IPv4</a> or
@@ -886,12 +886,12 @@ endpoints:
             my_linode.rebuild('linode/ubuntu16.04LTS', root_pass='hunter7')
   /linode/stackscripts:
     _group: StackScripts
-    resource: stackscript
-    paginationKey: stackscripts
     description: >
       View public StackScripts.
     methods:
       GET:
+        response: stackscript
+        paginationKey: stackscripts
         description: >
           Returns a list of public <a href="#object-stackscript">StackScripts</a>.
           Results can be <a href="#filtering">filtered</a>.  Include '"mine": true'
@@ -953,12 +953,12 @@ endpoints:
             TODO
   /linode/stackscripts/:id:
     _group: StackScripts
-    resource: stackscript
     authenticated: true
     description: >
       Manage a particular StackScript.
     methods:
       GET:
+        response: stackscript
         oauth: stackscripts:view
         description: >
           Returns information about this <a href="#object-stackscript">
@@ -1001,12 +1001,12 @@ endpoints:
             TODO
   /linode/distributions:
     _group: Distributions
-    resource: distributions
-    paginationKey: distributions
     description: >
       View the collection of distributions.
     methods:
       GET:
+        response: distributions
+        paginationKey: distributions
         description: >
           Returns a list of <a href="#object-distribution">distributions</a>.
         examples:
@@ -1017,11 +1017,11 @@ endpoints:
   /linode/distributions/:id:
     _group: Distributions
     type: resource
-    resource: distributions
     description: >
       Returns information about a specific distribution.
     methods:
       GET:
+        response: distributions
         description: >
           Returns information about this <a href="#object-distribution">
           distribution</a>.
@@ -1032,12 +1032,12 @@ endpoints:
             distro = linode.Distribution(client, 'linode/debian8')
   /linode/kernels:
     _group: Kernels
-    resource: kernels
-    paginationKey: kernels
     description: >
       Returns collection of kernels.
     methods:
       GET:
+        response: kernels
+        paginationKey: kernels
         description: >
           Returns list of <a href="#object-kernel">kernels</a>.
         examples:
@@ -1048,11 +1048,11 @@ endpoints:
   /linode/kernels/:id:
     _group: Kernels
     type: resource
-    resource: kernels
     description: >
       Returns information about a specific kernel.
     methods:
       GET:
+        response: kernels
         description: >
           Returns information about this <a href="#object-kernel">kernel</a>.
         examples:
@@ -1062,12 +1062,12 @@ endpoints:
             kernel = linode.Kernel(client, 'linode/latest')
   /linode/types:
     _group: Types
-    resource: types
-    paginationKey: types
     description: >
       Returns collection of types.
     methods:
       GET:
+        response: types
+        paginationKey: types
         description: >
           Returns list of types.
         examples:
@@ -1078,11 +1078,11 @@ endpoints:
   /linode/types/:id:
     _group: Types
     type: resource
-    resource: types
     description: >
       Returns information about a specific Linode type offered by Linode.
     methods:
       GET:
+        response: types
         description: >
           Returns information about this type.
         examples:
@@ -1092,13 +1092,13 @@ endpoints:
             type = linode.Type(client, 'g5-standard=1')
   /linode/volumes:
     _group: Volumes
-    resource: volume
-    paginationKey: volumes
     authenticated: true
     description: >
         Manage your Block Storage Volumes.
     methods:
       GET:
+        response: volume
+        paginationKey: volumes
         oauth: volumes:view
         description: >
           Returns a list of volumes.
@@ -1111,12 +1111,12 @@ endpoints:
   /linode/volumes/:id:
     _group: Volumes
     type: resource
-    resource: volume
     authenticated: true
     description: >
       Manage an individual Block Storage Volume.
     methods:
       GET:
+        response: volume
         oauth: volumes:view
         description: >
           Returns information about this Volume.

--- a/docs/src/data/endpoints/networking.yaml
+++ b/docs/src/data/endpoints/networking.yaml
@@ -8,12 +8,12 @@ endpoints:
   /networking/ipv4:
     _group: IPv4
     authenticated: true
-    resource: ipaddress
-    paginationKey: ipv4s
     description: >
       View and manage IPv4 Addresses you own.
     methods:
       GET:
+        response: ipaddress
+        paginationKey: ipv4s
         oauth: ips:view
         description: >
           Returns a list of <a href="#object-ipaddress">IPv4 Addresses</a>
@@ -44,12 +44,12 @@ endpoints:
   /networking/ipv4/:address:
     _group: IPv4
     type: resource
-    resource: ipaddress
     authenticated: true
     description: >
       Manage a single <a href="#object-ipaddress">IPv4 Address</a>
     methods:
       GET:
+        response: ipaddress
         oauth: ips:get
         description: >
             Returns a single <a href="#object-ipaddress">IPv4 Address</a>
@@ -83,13 +83,13 @@ endpoints:
                 https://$api_root/$version/networking/ipv4/97.107.143.37
   /networking/ipv6:
     _group: IPv6
-    resource: ipv6pool
-    paginationKey: ipv6s
     authenticated: true
     description: >
       Manage <a href="#object-ipv6pool">IPv6 Global Pools</a>.
     methods:
       GET:
+        response: ipv6pool
+        paginationKey: ipv6s
         oauth: ips:view
         description: >
           Returns a list of <a href="#object-ipv6pool">IPv6 Pools</a>.
@@ -102,13 +102,13 @@ endpoints:
   /networking/ipv6/:address:
     _group: IPv6
     type: resource
-    resource: ipv6pool
     authenticated: true
     description: >
       Manage a single <a href="#object-ipv6-address">IPv6 Address</a>.  Address in URL
       can be as compressed as you want.
     methods:
       GET:
+        response: ipv6pool
         oauth: ips:view
         description: >
           Return a single <a href="#object-ipv6-address">IPv6 Address</a>.

--- a/docs/src/data/endpoints/nodebalancers.yaml
+++ b/docs/src/data/endpoints/nodebalancers.yaml
@@ -5,13 +5,13 @@ description: >
   NodeBalancer objects</a> on your account.
 endpoints:
   /nodebalancers:
-    resource: nodebalancer
-    paginationKey: nodebalancers
     authenticated: true
     description: >
       Manage the collection of NodeBalancers your account may access.
     methods:
       GET:
+        response: nodebalancer
+        paginationKey: nodebalancers
         oauth: nodebalancers:view
         description: >
           Returns a list of <a href="#object-nodebalancer">NodeBalancers</a>.
@@ -56,12 +56,12 @@ endpoints:
             new_nodebalancer = client.create_nodebalancer('us-east-1a', label='my_cool_balancer', client_conn_throttle=10)
   /nodebalancers/:id:
     type: resource
-    resource: nodebalancer
     authenticated: true
     description: >
       Manage a particular NodeBalancer your account may access.
     methods:
       GET:
+        response: nodebalancer
         oauth: nodebalancers:view
         description: >
           Returns information about this <a href="#object-nodebalancer">NodeBalancer</a>.
@@ -105,13 +105,13 @@ endpoints:
            my_nodebalancer.delete()
   /nodebalancers/:id/configs:
     _group: Configs
-    resource: nodebalancer_config
-    paginationKey: configs
     authenticated: true
     description: >
       Manage the configs on this NodeBalancer.
     methods:
       GET:
+        response: nodebalancer_config
+        paginationKey: configs
         oauth: nodebalancers:view
         description: >
           Returns a list of <a href="#object-nodebalancer_config">configs</a> for a
@@ -202,12 +202,12 @@ endpoints:
   /nodebalancers/:id/configs/:id:
     _group: Configs
     type: resource
-    resource: nodebalancer_config
     authenticated: true
     description: >
       Manage a particular NodeBalancer config.
     methods:
       GET:
+        response: nodebalancer_config
         oauth: nodebalancers:view
         description: >
           Returns information about this NodeBalancer config.
@@ -253,13 +253,13 @@ endpoints:
             # currently unimplemented
   /nodebalancers/:id/configs/:id/nodes:
     _group: Configs
-    resource: nodebalancer_config_nodes
-    paginationKey: nodes
     authenticated: true
     description: >
       Manage the nodes for a specified NodeBalancer config.
     methods:
       GET:
+        response: nodebalancer_config_nodes
+        paginationKey: nodes
         oauth: nodebalancers:view
         description: >
           Returns a list of <a href="#object-nodebalancer_config_node">config nodes</a> for a
@@ -302,12 +302,12 @@ endpoints:
   /nodebalancers/:id/configs/:id/nodes/:id:
     _group: Configs
     type: resource
-    resource: nodebalancer_config_nodes
     authenticated: true
     description: >
       Manage a particular NodeBalancer config node.
     methods:
       GET:
+        response: nodebalancer_config_nodes
         oauth: nodebalancers:view
         description: >
           Returns information about this node..

--- a/docs/src/data/endpoints/regions.yaml
+++ b/docs/src/data/endpoints/regions.yaml
@@ -5,12 +5,12 @@ description: >
   region objects</a>.
 endpoints:
   /regions:
-    resource: region
-    paginationKey: regions
     description: >
       Returns collection of regions.
     methods:
       GET:
+        response: region
+        paginationKey: regions
         description: >
           Returns list of <a href="#object-region">regions</a>.
         examples:
@@ -20,11 +20,11 @@ endpoints:
             all_regions = client.get_regions()
   /regions/:id:
     type: resource
-    resource: region
     description: >
       Return a particular region.
     methods:
       GET:
+        response: region
         description: >
           Returns information about this <a href="#object-region">
           region</a>.

--- a/docs/src/data/endpoints/support.yaml
+++ b/docs/src/data/endpoints/support.yaml
@@ -5,13 +5,13 @@ description: >
   the Linode support team.
 endpoints:
   /support/tickets:
-    resource: supportticket
-    paginationKey: tickets
     authenticated: true
     description: >
       Manage the support tickets your account can access.
     methods:
       GET:
+        response: supportticket
+        paginationKey: tickets
         oauth: tickets:view
         description: >
           Returns a list of <a href="#object-supportticket">Support Tickets</a>.


### PR DESCRIPTION
closes #2196 

This updates support for defining method params + response fields in yaml by placing definitions within methods ( right now associated response resources are only defined at the endpoint level ).

For example (yaml):

```
endpoints:
  /linode/instances:
    authenticated: true
    description: >
      Manage the collection of Linodes your account may access.
    methods:
      GET:
        response: linode // reference to /objects/linode.yaml
        paginationKey: linodes
```

Ideally, this supports method keys with no restrictions on method verb:
`response` ( renamed from `resource` at the endpoint level )
`params`

where the value could be a string ( referencing something defined in `/objects` ) or a nested dict, as most `params` definitions exist currently. 

most formatting stays the same, primary adjustments made to how definitions are referenced.