### PR TITLE
Add disk no distro option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.12.3] 2017-08-04
+### Fixed
+- allow no distro option when creating disk #2375
+
 ## [0.12.2] 2017-08-04
 ### Fixed
 - reset disk slot to null correctly when deselecting a slot #2369

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-manager",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-manager",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "The Linode Manager website",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/linodes/components/DistributionSelect.js
+++ b/src/linodes/components/DistributionSelect.js
@@ -27,6 +27,10 @@ export default function DistributionSelect(props) {
 
   const options = [];
 
+  if (props.allowNone) {
+    options.push({ label: 'No distribution', value: 'none' });
+  }
+
   for (const vendorName of DISTRIBUTION_DISPLAY_ORDER) {
     const byName = vendorByName(vendorName);
 
@@ -46,4 +50,5 @@ export default function DistributionSelect(props) {
 DistributionSelect.propTypes = {
   ...Select.propTypes,
   distributions: PropTypes.object.isRequired,
+  allowNone: PropTypes.bool,
 };

--- a/src/linodes/linode/settings/advanced/components/AddDisk.js
+++ b/src/linodes/linode/settings/advanced/components/AddDisk.js
@@ -100,6 +100,7 @@ export default class AddDisk extends Component {
               value={distribution}
               distributions={distributions.distributions}
               onChange={this.onChange}
+              allowNone
             />
           </ModalFormGroup>
           {distribution ? (


### PR DESCRIPTION
This is a follow-up to v0.12.x noticed by @abemassry. Right now in v0.12.x the default option is a distribution but the password field is marked disabled because you hadn't actually picked default distro. This allows a no distro option -- which is both called for and fixes the problem of the password field being unnecessarily disabled.

I'll add the changelog and version bump after #2369 gets merged.