### PR TITLE
Fix long labels in notifications

### DIFF
--- a/scss/components/Notifications.scss
+++ b/scss/components/Notifications.scss
@@ -40,8 +40,10 @@
         color: $black;
         cursor: pointer;
         cursor: hand;
-        display: block;
         padding: 10px 15px;
+        text-overflow: ellipsis;
+        display: block;
+        overflow-x: hidden;
 
         &:hover,
         &:active,


### PR DESCRIPTION
Before:

![screen shot 2017-08-07 at 9 25 43 am](https://user-images.githubusercontent.com/3925912/29028480-77b75af6-7b52-11e7-85e8-68bab1057724.png)

After:

![screen shot 2017-08-07 at 9 25 28 am](https://user-images.githubusercontent.com/3925912/29028481-77b74c64-7b52-11e7-9663-c58a83832d35.png)
