### PR TITLE
Add _id for fields that expect an integer id

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.3] 2017-08-08
+### Changed
+- switch to _id for fields that expect an integer id #2385
+
 ## [0.11.2] 2017-08-08
 ### Added
 - docs for linode clone endpoint #2399

--- a/docs/npm-shrinkwrap.json
+++ b/docs/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-api-docs",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-api-docs",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Linode API Docs",
   "main": "src/index.js",
   "scripts": {

--- a/docs/src/data/endpoints/linodes.yaml
+++ b/docs/src/data/endpoints/linodes.yaml
@@ -552,11 +552,11 @@ endpoints:
         oauth: linodes:modify
         dangerous: true
         params:
-          config:
+          config_id:
             optional: true
             description: >
               Optional config ID to boot the linode with.
-            type: Linode_config
+            type: Integer
         examples:
           curl: |
             curl -H "Content-Type: application/json" \

--- a/docs/src/data/endpoints/linodes.yaml
+++ b/docs/src/data/endpoints/linodes.yaml
@@ -64,8 +64,8 @@ endpoints:
             optional: true
             description: >
               A public SSH key file to install at `/root/.ssh/authorized_keys` when creating this Linode.
-            type: String
-          stackscript:
+            type: string
+          stackscript_id:
             optional: true
             description: >
               The stackscript ID to deploy with this disk.
@@ -77,8 +77,8 @@ endpoints:
             description: >
               UDF (user-defined fields) for this stackscript. Defaults to "{}".
               <ul><li>Must match UDFs required by stackscript.</li></ul>
-            type: String
-          backup:
+            type: string
+          backup_id:
             optional: true
             description: >
               The <a href="#object-backup">Backup</a> to restore to the newly created
@@ -210,8 +210,8 @@ endpoints:
             optional: true
             description: >
               If true, this disk is read-only.
-            type: Boolean
-          stackscript:
+            type: boolean
+          stackscript_id:
             optional: true
             description: >
               The stackscript ID to deploy with this disk.
@@ -510,7 +510,7 @@ endpoints:
         oauth: linodes:modify
         dangerous: false
         params:
-          config:
+          config_id:
             optional: true
             description: >
               Optional config ID to boot the linode with.
@@ -794,7 +794,7 @@ endpoints:
         oauth: linodes:create
         dangerous: true
         params:
-          linode:
+          linode_id:
             description: >
               The ID of the Linode to restore a backup to.
             type: Linode
@@ -928,8 +928,8 @@ endpoints:
             optional: true
             description: >
                 The key to authorize for root access to the new deployment.
-            type: String
-          stackscript:
+            type: string
+          stackscript_id:
             optional: true
             description: >
               The stackscript ID to deploy with this disk.

--- a/docs/src/data/endpoints/linodes.yaml
+++ b/docs/src/data/endpoints/linodes.yaml
@@ -210,7 +210,7 @@ endpoints:
             optional: true
             description: >
               If true, this disk is read-only.
-            type: boolean
+            type: Boolean
           stackscript_id:
             optional: true
             description: >

--- a/docs/src/data/endpoints/linodes.yaml
+++ b/docs/src/data/endpoints/linodes.yaml
@@ -64,26 +64,26 @@ endpoints:
             optional: true
             description: >
               A public SSH key file to install at `/root/.ssh/authorized_keys` when creating this Linode.
-            type: string
+            type: String
           stackscript_id:
             optional: true
             description: >
               The stackscript ID to deploy with this disk.
               <ul><li>Must provide a distribution. Distribution must be
               one that the stackscript can be deployed to.</li></ul>
-            type: Stackscript
+            type: Integer
           stackscript_data:
             optional: true
             description: >
               UDF (user-defined fields) for this stackscript. Defaults to "{}".
               <ul><li>Must match UDFs required by stackscript.</li></ul>
-            type: string
+            type: String
           backup_id:
             optional: true
             description: >
               The <a href="#object-backup">Backup</a> to restore to the newly created
               Linode.  May not be included if 'distribution' is sent.
-            type: Backup
+            type: Integer
           with_backup:
             optional: true
             description: >
@@ -217,7 +217,7 @@ endpoints:
               The stackscript ID to deploy with this disk.
               <ul><li>Must provide a distribution. Distribution must be
               one that the stackscript can be deployed to.</li></ul>
-            type: Stackscript
+            type: Integer
           stackscript_data:
             optional: true
             description: >
@@ -514,7 +514,7 @@ endpoints:
             optional: true
             description: >
               Optional config ID to boot the linode with.
-            type: Linode_config
+            type: Integer
         examples:
           curl: |
             curl -H "Content-Type: application/json" \
@@ -797,7 +797,7 @@ endpoints:
           linode_id:
             description: >
               The ID of the Linode to restore a backup to.
-            type: Linode
+            type: Integer
           overwrite:
             description: >
                 If true, deletes all disks and configs on the target linode before restoring.
@@ -928,14 +928,14 @@ endpoints:
             optional: true
             description: >
                 The key to authorize for root access to the new deployment.
-            type: string
+            type: String
           stackscript_id:
             optional: true
             description: >
               The stackscript ID to deploy with this disk.
               <ul><li>Must provide a distribution. Distribution must be
               one that the stackscript can be deployed to.</li></ul>
-            type: Stackscript
+            type: Integer
           stackscript_data:
             optional: true
             description: >
@@ -978,12 +978,12 @@ endpoints:
             description: >
               Label of StackScript.
             limit: 3-128 characters
-            type: string
+            type: String
           description:
             optional: true
             description: >
               Description of the StackScript.
-            type: string
+            type: String
           distributions:
             description: >
               A list of <a href="#object-distribution">distributions</a>
@@ -994,17 +994,17 @@ endpoints:
             description: >
               If true, this StackScript will be publicly visible in the Linode
               StackScript library. Defaults to False.
-            type: boolean
+            type: Boolean
           rev_note:
             optional: true
             description: >
               Release notes for this revision.
             limit: 0-512 characters
-            type: string
+            type: String
           script:
             description: >
               The shell script to run on boot.
-            type: string
+            type: String
         examples:
           curl: |
             curl -H "Content-Type: application/json" \

--- a/docs/src/data/endpoints/networking.yaml
+++ b/docs/src/data/endpoints/networking.yaml
@@ -29,7 +29,7 @@ endpoints:
         description: >
           Create a new Public <a href="#object-ipaddress">IPv4 Address</a>
         params:
-          linode:
+          linode_id:
             description: >
               The Linode ID to assign this IP to.
             type: Integer

--- a/docs/src/data/objects/volume.yaml
+++ b/docs/src/data/objects/volume.yaml
@@ -42,7 +42,7 @@ schema:
     _type: datetime
     _value: "2017-06-20T11:21:01"
   linode_id:
-    _type: integer
+    _type: Integer
     _description: The ID of the linode this volume is attached to.
     _value: 456
 enums:


### PR DESCRIPTION
To be consistent, anywhere input is expected to be an integer based id
the field has been appended with `_id`.