### PR TITLE
Fix docs long endpoints breaking page layout

### DIFF
--- a/docs/scss/components/Title.scss
+++ b/docs/scss/components/Title.scss
@@ -2,6 +2,8 @@
     padding: 10px 0;
 
     &-heading {
+        overflow-x: scroll;
+
         h1, h2 {
             display: inline;
         }


### PR DESCRIPTION
Now a long endpoint will scroll instead of forcing the page to be wider than it is supposed to be.