### PR TITLE
Fix notifications hover and dropdown onblur

### DIFF
--- a/components/dropdowns/Dropdown.js
+++ b/components/dropdowns/Dropdown.js
@@ -48,6 +48,16 @@ export default class Dropdown extends Component {
     };
   }
 
+  closeWithFirefoxFix = (e) => {
+    console.log('HERE');
+    if (e.nativeEvent.explicitOriginalTarget &&
+        e.nativeEvent.explicitOriginalTarget == e.nativeEvent.originalTarget) {
+      return;
+    }
+
+    this.close();
+  }
+
   render() {
     const [{ elements: [first] }, ...groups] = this.props.groups;
     const { disabled, dropdownIcon } = this.props;
@@ -77,7 +87,8 @@ export default class Dropdown extends Component {
     return (
       <div
         className={`Dropdown btn-group ${this.state.open ? 'Dropdown--open' : ''}`}
-        onBlur={this.close}
+        onBlur={this.closeWithFirefoxFix}
+        tabIndex="-1"
       >
         <Button
           type="button"

--- a/components/dropdowns/Dropdown.js
+++ b/components/dropdowns/Dropdown.js
@@ -48,16 +48,6 @@ export default class Dropdown extends Component {
     };
   }
 
-  closeWithFirefoxFix = (e) => {
-    console.log('HERE');
-    if (e.nativeEvent.explicitOriginalTarget &&
-        e.nativeEvent.explicitOriginalTarget == e.nativeEvent.originalTarget) {
-      return;
-    }
-
-    this.close();
-  }
-
   render() {
     const [{ elements: [first] }, ...groups] = this.props.groups;
     const { disabled, dropdownIcon } = this.props;
@@ -87,8 +77,8 @@ export default class Dropdown extends Component {
     return (
       <div
         className={`Dropdown btn-group ${this.state.open ? 'Dropdown--open' : ''}`}
-        onBlur={this.closeWithFirefoxFix}
-        tabIndex="-1"
+        onBlur={this.close}
+        tabIndex="-1" // This allows firefox to treat this as a blurrable element.
       >
         <Button
           type="button"

--- a/scss/components/Header.scss
+++ b/scss/components/Header.scss
@@ -24,9 +24,9 @@
 
         float: right;
         height: 100%;
-        padding: 19px 14px;
+        line-height: $nav-height;
+        padding: 0 14px;
         position: relative;
-        width: 48px;
 
         &:hover {
             background: $main-header-highlight-color;


### PR DESCRIPTION
@jfrederickson feel free to test this out if you'd like. This allows the onBlur callback to actually work with the dropdown and avoids the problem in #2150 (closes #2150). This also fixes the size of the notifications menu item in the header that is noticeably wrong on hover.