### PR TITLE
Fix ip sharing link

### DIFF
--- a/docs/src/data/endpoints/account.yaml
+++ b/docs/src/data/endpoints/account.yaml
@@ -61,7 +61,7 @@ endpoints:
           python: |
             from linode import OAuthScopes
             new_token = client.account.create_personal_access_token(scopes=[OAuthScopes.Linodes.view, OAuthScopes.Domains.view])
-  /account/tokens/::id:
+  /account/tokens/$id:
     _group: Tokens
     type: resource
     description: >
@@ -193,7 +193,7 @@ endpoints:
                 https://$api_root/$version/account/clients
           python: |
             new_client = client.account.create_oauth_client('Example app', 'https://oauthreturn.example.org/')
-  /account/clients/::id:
+  /account/clients/$id:
     _group: Clients
     type: resource
     authenticated: true
@@ -240,7 +240,7 @@ endpoints:
           python: |
             my_client = linode.OAuthClient(client, 123)
             my_client.delete()
-  /account/clients/::id/reset_secret:
+  /account/clients/$id/reset_secret:
     _group: Clients
     type: Action
     authenticated: true
@@ -259,7 +259,7 @@ endpoints:
           python: |
             my_client = linode.OAuthClient(client, 123)
             new_secret = my_client.reset_secret()
-  /account/clients/::id/thumbnail:
+  /account/clients/$id/thumbnail:
     _group: Clients
     type: Action
     authenticated: true
@@ -341,7 +341,7 @@ endpoints:
                 https://$api_root/$version/account/users
           python: |
             # currently unimplemented
-  /account/users/::username:
+  /account/users/$username:
     _group: Users
     type: resource
     description: >
@@ -381,7 +381,7 @@ endpoints:
           python: |
             my_user = linode.User(client, 'username')
             my_user.delete()
-  /account/users/::username/password:
+  /account/users/$username/password:
     _group: Users
     type: Action
     description: >
@@ -403,7 +403,7 @@ endpoints:
           python: |
             my_user = linode.User(client, 'username')
             my_user.change_password('hunter7')
-  /account/users/::username/grants:
+  /account/users/$username/grants:
     _group: Users
     type: resource
     description: >
@@ -479,7 +479,7 @@ endpoints:
                     "redirect_uri": "https://oauthreturn.example.org/",
                 }' \
                 https://$api_root/$version/account/clients
-  /account/clients/::id:
+  /account/clients/$id:
     _group: Clients
     type: resource
     authenticated: true
@@ -534,7 +534,7 @@ endpoints:
             curl https://$api_root/$version/account/events
           python: |
             my_events = client.account.get_events()
-  /account/events/::id:
+  /account/events/$id:
     _group: Events
     type: resource
     authenticated: true
@@ -550,7 +550,7 @@ endpoints:
             curl https://$api_root/$version/account/event/123
           python: |
             event = linode.Event(client, 123)
-  /account/events/::id/seen:
+  /account/events/$id/seen:
     _group: Events
     type: resource
     authenticated: true
@@ -563,7 +563,7 @@ endpoints:
             curl https://$api_root/$version/account/event/123/seen
           python: |
             client.mark_lask_seen_event(event)
-  /account/events/::id/read:
+  /account/events/$id/read:
     _group: Events
     type: resource
     authenticated: true

--- a/docs/src/data/endpoints/account.yaml
+++ b/docs/src/data/endpoints/account.yaml
@@ -61,7 +61,7 @@ endpoints:
           python: |
             from linode import OAuthScopes
             new_token = client.account.create_personal_access_token(scopes=[OAuthScopes.Linodes.view, OAuthScopes.Domains.view])
-  /account/tokens/:id:
+  /account/tokens/::id:
     _group: Tokens
     type: resource
     description: >
@@ -193,7 +193,7 @@ endpoints:
                 https://$api_root/$version/account/clients
           python: |
             new_client = client.account.create_oauth_client('Example app', 'https://oauthreturn.example.org/')
-  /account/clients/:id:
+  /account/clients/::id:
     _group: Clients
     type: resource
     authenticated: true
@@ -240,7 +240,7 @@ endpoints:
           python: |
             my_client = linode.OAuthClient(client, 123)
             my_client.delete()
-  /account/clients/:id/reset_secret:
+  /account/clients/::id/reset_secret:
     _group: Clients
     type: Action
     authenticated: true
@@ -259,7 +259,7 @@ endpoints:
           python: |
             my_client = linode.OAuthClient(client, 123)
             new_secret = my_client.reset_secret()
-  /account/clients/:id/thumbnail:
+  /account/clients/::id/thumbnail:
     _group: Clients
     type: Action
     authenticated: true
@@ -341,7 +341,7 @@ endpoints:
                 https://$api_root/$version/account/users
           python: |
             # currently unimplemented
-  /account/users/:username:
+  /account/users/::username:
     _group: Users
     type: resource
     description: >
@@ -381,7 +381,7 @@ endpoints:
           python: |
             my_user = linode.User(client, 'username')
             my_user.delete()
-  /account/users/:username/password:
+  /account/users/::username/password:
     _group: Users
     type: Action
     description: >
@@ -403,7 +403,7 @@ endpoints:
           python: |
             my_user = linode.User(client, 'username')
             my_user.change_password('hunter7')
-  /account/users/:username/grants:
+  /account/users/::username/grants:
     _group: Users
     type: resource
     description: >
@@ -479,7 +479,7 @@ endpoints:
                     "redirect_uri": "https://oauthreturn.example.org/",
                 }' \
                 https://$api_root/$version/account/clients
-  /account/clients/:id:
+  /account/clients/::id:
     _group: Clients
     type: resource
     authenticated: true
@@ -534,7 +534,7 @@ endpoints:
             curl https://$api_root/$version/account/events
           python: |
             my_events = client.account.get_events()
-  /account/events/:id:
+  /account/events/::id:
     _group: Events
     type: resource
     authenticated: true
@@ -550,7 +550,7 @@ endpoints:
             curl https://$api_root/$version/account/event/123
           python: |
             event = linode.Event(client, 123)
-  /account/events/:id/seen:
+  /account/events/::id/seen:
     _group: Events
     type: resource
     authenticated: true
@@ -563,7 +563,7 @@ endpoints:
             curl https://$api_root/$version/account/event/123/seen
           python: |
             client.mark_lask_seen_event(event)
-  /account/events/:id/read:
+  /account/events/::id/read:
     _group: Events
     type: resource
     authenticated: true

--- a/docs/src/data/endpoints/domains.yaml
+++ b/docs/src/data/endpoints/domains.yaml
@@ -113,7 +113,7 @@ endpoints:
           python: |
             import linode
             TODO
-  /domains/:id:
+  /domains/::id:
     authenticated: true
     methods:
       GET:
@@ -166,7 +166,7 @@ endpoints:
           python: |
             import linode
             TODO
-  /domains/:id/records:
+  /domains/::id/records:
     authenticated: true
     description: >
       Manage the collection of Domain Records your account may access.
@@ -254,7 +254,7 @@ endpoints:
           python: |
             import linode
             TODO
-  /domains/:id/records/:id:
+  /domains/::id/records/::id:
     authenticated: true
     methods:
       GET:

--- a/docs/src/data/endpoints/domains.yaml
+++ b/docs/src/data/endpoints/domains.yaml
@@ -113,7 +113,7 @@ endpoints:
           python: |
             import linode
             TODO
-  /domains/::id:
+  /domains/$id:
     authenticated: true
     methods:
       GET:
@@ -166,7 +166,7 @@ endpoints:
           python: |
             import linode
             TODO
-  /domains/::id/records:
+  /domains/$id/records:
     authenticated: true
     description: >
       Manage the collection of Domain Records your account may access.
@@ -254,7 +254,7 @@ endpoints:
           python: |
             import linode
             TODO
-  /domains/::id/records/::id:
+  /domains/$id/records/$id:
     authenticated: true
     methods:
       GET:

--- a/docs/src/data/endpoints/linodes.yaml
+++ b/docs/src/data/endpoints/linodes.yaml
@@ -101,7 +101,7 @@ endpoints:
 
             distro = client.linode.get_distributons(linode.Distribution.vendor == 'debian').first()
             ( my_linode_2, password ) = client.linode.create_instance('us-east-1a', 'g5-standard-1', distribution=distro)
-  /linode/instances/::id:
+  /linode/instances/$id:
     type: resource
     authenticated: true
     description: >
@@ -149,7 +149,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id
           python: |
             my_linode.delete()
-  /linode/instances/::id/disks:
+  /linode/instances/$id/disks:
     _group: Disks
     authenticated: true
     description: >
@@ -234,7 +234,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/disks
           python: |
             new_disk = my_linode.create_disk(4096, filesystem='ext4', label='Example Disk')
-  /linode/instances/::id/disks/::id:
+  /linode/instances/$id/disks/$id:
     _group: Disks
     type: resource
     authenticated: true
@@ -291,7 +291,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/disks/$disk_id
           python: |
             disk.delete()
-  /linode/instances/::id/disks/::id/resize:
+  /linode/instances/$id/disks/$id/resize:
     _group: Disks
     type: Strange
     authenticated: true
@@ -312,7 +312,7 @@ endpoints:
                     "size": 1024
                 }' \
                 https://$api_root/$version/linode/instances/$linode_id/disks/$disk_id/resize
-  /linode/instances/::id/disks/::id/password:
+  /linode/instances/$id/disks/$id/password:
     _group: Disks
     type: Strange
     authenticated: true
@@ -337,7 +337,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/disks/$disk_id/password
           python: |
             disk.reset_root_password('hunter2')
-  /linode/instances/::id/configs:
+  /linode/instances/$id/configs:
     _group: Configs
     authenticated: true
     description: >
@@ -424,7 +424,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/configs
           python: |
             config = my_linode.create_config('linode/latest_64', disks=linode.disks, label='Arch Linux Config')
-  /linode/instances/::id/configs/::id:
+  /linode/instances/$id/configs/$id:
     _group: Configs
     type: resource
     authenticated: true
@@ -478,7 +478,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/configs/$config_id
           python: |
             config.delete()
-  /linode/instances/::id/volumes:
+  /linode/instances/$id/volumes:
     authenticated: true
     description: >
         View Block Storage Volumes attached to this Linode.
@@ -496,7 +496,7 @@ endpoints:
           python: |
             l = linode.Linode(client, 123)
             volumes_for_linode = l.volumes
-  /linode/instances/::id/boot:
+  /linode/instances/$id/boot:
     type: Action
     authenticated: true
     description: >
@@ -521,7 +521,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/boot
           python: |
             my_linode.boot()
-  /linode/instances/::id/shutdown:
+  /linode/instances/$id/shutdown:
     type: Action
     authenticated: true
     description: >
@@ -538,7 +538,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/shutdown
           python: |
             my_linode.shutdown()
-  /linode/instances/::id/reboot:
+  /linode/instances/$id/reboot:
     type: Action
     authenticated: true
     description: >
@@ -564,7 +564,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/reboot
           python: |
             my_linode.reboot()
-  /linode/instances/::id/kvmify:
+  /linode/instances/$id/kvmify:
     type: Action
     authenticated: true
     description: >
@@ -581,7 +581,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/kvmify
           python: |
             my_linode.kvmify()
-  /linode/instances/::id/rescue:
+  /linode/instances/$id/rescue:
     type: Action
     authenticated: true
     description: >
@@ -610,7 +610,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/rescue
           python: |
             my_linode.rescue()
-  /linode/instances/::id/clone:
+  /linode/instances/$id/clone:
     type: Action
     authenticated: true
     description: >
@@ -676,7 +676,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/clone
           python: |
             my_linode.clone(region="us-east-1a", type="g5-standard-1", disks=[2450])
-  /linode/instances/::id/mutate:
+  /linode/instances/$id/mutate:
     type: Action
     authenticated: true
     description: >
@@ -693,7 +693,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/mutate
           python: |
             my_linode.mutate()
-  /linode/instances/::id/resize:
+  /linode/instances/$id/resize:
     type: Action
     authenticated: true
     description: >
@@ -717,7 +717,7 @@ endpoints:
                     }
                 }' \
                 https://$api_root/$version/linode/instances/$linode_id/resize
-  /linode/instances/::id/backups:
+  /linode/instances/$id/backups:
     _group: Backups
     authenticated: true
     description: >
@@ -758,7 +758,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/backups
           python: |
             my_linode.snapshot()
-  /linode/instances/::id/backups/enable:
+  /linode/instances/$id/backups/enable:
     _group: Backups
     type: Action
     authenticated: true
@@ -777,7 +777,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/backups/enable
           python: |
             my_linode.enable_backups()
-  /linode/instances/::id/backups/cancel:
+  /linode/instances/$id/backups/cancel:
     _group: Backups
     type: Action
     authenticated: true
@@ -795,7 +795,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/backups/cancel
           python: |
             my_linode.cancel_backups()
-  /linode/instances/::id/backups/::id/restore:
+  /linode/instances/$id/backups/$id/restore:
     _group: Backups
     type: Action
     authenticated: true
@@ -826,7 +826,7 @@ endpoints:
           python: |
             backup = my_linode.available_backups.daily
             backup.restore()
-  /linode/instances/::id/ips:
+  /linode/instances/$id/ips:
     _group: IPs
     type: Strange
     authenticated: true
@@ -860,7 +860,7 @@ endpoints:
                     "type": "private"
                 }' \
                 https://$api_root/$version/linode/instances/$linode_id/ips
-  /linode/instances/::id/ips/sharing:
+  /linode/instances/$id/ips/sharing:
     _group: IPs
     methods:
       POST:
@@ -879,7 +879,7 @@ endpoints:
                   "ips": [ "97.107.143.29", "97.107.143.112" ]
                 }' \
                 https://$api_root/$version/linode/instances/$linode_id/ips/sharing
-  /linode/instances/::id/ips/::ip_address:
+  /linode/instances/$id/ips/$ip_address:
     _group: IPs
     type: Action
     authenticated: true
@@ -916,7 +916,7 @@ endpoints:
             curl -H "Authorization: Bearer $TOKEN" \
                 -X DELETE \
                 https://$api_root/$version/linode/instances/$linode_id/ips/97.107.143.37
-  /linode/instances/::id/rebuild:
+  /linode/instances/$id/rebuild:
     type: Action
     authenticated: true
     description: >
@@ -1028,7 +1028,7 @@ endpoints:
           python: |
             import stackscript
             TODO
-  /linode/stackscripts/::id:
+  /linode/stackscripts/$id:
     _group: StackScripts
     authenticated: true
     description: >
@@ -1090,7 +1090,7 @@ endpoints:
             curl https://$api_root/$version/linode/distributions
           python: |
             client.linode.get_distributions()
-  /linode/distributions/::id:
+  /linode/distributions/$id:
     _group: Distributions
     type: resource
     description: >
@@ -1120,7 +1120,7 @@ endpoints:
             curl https://$api_root/$version/linode/kernels
           python: |
             client.linode.get_kernels()
-  /linode/kernels/::id:
+  /linode/kernels/$id:
     _group: Kernels
     type: resource
     description: >
@@ -1150,7 +1150,7 @@ endpoints:
             curl https://$api_root/$version/linode/types
           python: |
             client.linode.get_types()
-  /linode/types/::id:
+  /linode/types/$id:
     _group: Types
     type: resource
     description: >
@@ -1228,7 +1228,7 @@ endpoints:
           python: |
             import linode
             TODO
-  /linode/volumes/::id:
+  /linode/volumes/$id:
     _group: Volumes
     type: resource
     authenticated: true
@@ -1303,7 +1303,7 @@ endpoints:
           python: |
             import linode
             TODO 
-  /linode/volumes/::id/attach:
+  /linode/volumes/$id/attach:
     _group: Volumes
     authenticated: true
     methods:
@@ -1335,7 +1335,7 @@ endpoints:
           python: |
             import linode
             TODO
-  /linode/volumes/::id/detach:
+  /linode/volumes/$id/detach:
     _group: Volumes
     type: resource
     authenticated: true
@@ -1352,7 +1352,7 @@ endpoints:
           python: |
             v = linode.Volume(client, 123)
             v.detach()
-  /linode/instances/::id/stats:
+  /linode/instances/$id/stats:
     _group: Stats
     type: Action
     authenticated: true
@@ -1368,7 +1368,7 @@ endpoints:
           curl: |
             curl -H "Authorization: token $TOKEN" \
                 https://$api_root/$version/linode/instances/$linode_id/stats
-  /linode/instances/::id/stats/::year/::month:
+  /linode/instances/$id/stats/$year/$month:
     _group: Stats
     type: Action
     authenticated: true

--- a/docs/src/data/endpoints/linodes.yaml
+++ b/docs/src/data/endpoints/linodes.yaml
@@ -101,7 +101,7 @@ endpoints:
 
             distro = client.linode.get_distributons(linode.Distribution.vendor == 'debian').first()
             ( my_linode_2, password ) = client.linode.create_instance('us-east-1a', 'g5-standard-1', distribution=distro)
-  /linode/instances/:id:
+  /linode/instances/::id:
     type: resource
     authenticated: true
     description: >
@@ -149,7 +149,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id
           python: |
             my_linode.delete()
-  /linode/instances/:id/disks:
+  /linode/instances/::id/disks:
     _group: Disks
     authenticated: true
     description: >
@@ -234,7 +234,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/disks
           python: |
             new_disk = my_linode.create_disk(4096, filesystem='ext4', label='Example Disk')
-  /linode/instances/:id/disks/:id:
+  /linode/instances/::id/disks/::id:
     _group: Disks
     type: resource
     authenticated: true
@@ -291,7 +291,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/disks/$disk_id
           python: |
             disk.delete()
-  /linode/instances/:id/disks/:id/resize:
+  /linode/instances/::id/disks/::id/resize:
     _group: Disks
     type: Strange
     authenticated: true
@@ -312,7 +312,7 @@ endpoints:
                     "size": 1024
                 }' \
                 https://$api_root/$version/linode/instances/$linode_id/disks/$disk_id/resize
-  /linode/instances/:id/disks/:id/password:
+  /linode/instances/::id/disks/::id/password:
     _group: Disks
     type: Strange
     authenticated: true
@@ -337,7 +337,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/disks/$disk_id/password
           python: |
             disk.reset_root_password('hunter2')
-  /linode/instances/:id/configs:
+  /linode/instances/::id/configs:
     _group: Configs
     authenticated: true
     description: >
@@ -424,7 +424,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/configs
           python: |
             config = my_linode.create_config('linode/latest_64', disks=linode.disks, label='Arch Linux Config')
-  /linode/instances/:id/configs/:id:
+  /linode/instances/::id/configs/::id:
     _group: Configs
     type: resource
     authenticated: true
@@ -478,7 +478,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/configs/$config_id
           python: |
             config.delete()
-  /linode/instances/:id/volumes:
+  /linode/instances/::id/volumes:
     authenticated: true
     description: >
         View Block Storage Volumes attached to this Linode.
@@ -496,7 +496,7 @@ endpoints:
           python: |
             l = linode.Linode(client, 123)
             volumes_for_linode = l.volumes
-  /linode/instances/:id/boot:
+  /linode/instances/::id/boot:
     type: Action
     authenticated: true
     description: >
@@ -521,7 +521,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/boot
           python: |
             my_linode.boot()
-  /linode/instances/:id/shutdown:
+  /linode/instances/::id/shutdown:
     type: Action
     authenticated: true
     description: >
@@ -538,7 +538,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/shutdown
           python: |
             my_linode.shutdown()
-  /linode/instances/:id/reboot:
+  /linode/instances/::id/reboot:
     type: Action
     authenticated: true
     description: >
@@ -564,7 +564,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/reboot
           python: |
             my_linode.reboot()
-  /linode/instances/:id/kvmify:
+  /linode/instances/::id/kvmify:
     type: Action
     authenticated: true
     description: >
@@ -581,7 +581,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/kvmify
           python: |
             my_linode.kvmify()
-  /linode/instances/:id/rescue:
+  /linode/instances/::id/rescue:
     type: Action
     authenticated: true
     description: >
@@ -610,7 +610,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/rescue
           python: |
             my_linode.rescue()
-  /linode/instances/:id/clone:
+  /linode/instances/::id/clone:
     type: Action
     authenticated: true
     description: >
@@ -676,7 +676,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/clone
           python: |
             my_linode.clone(region="us-east-1a", type="g5-standard-1", disks=[2450])
-  /linode/instances/:id/mutate:
+  /linode/instances/::id/mutate:
     type: Action
     authenticated: true
     description: >
@@ -693,7 +693,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/mutate
           python: |
             my_linode.mutate()
-  /linode/instances/:id/resize:
+  /linode/instances/::id/resize:
     type: Action
     authenticated: true
     description: >
@@ -717,7 +717,7 @@ endpoints:
                     }
                 }' \
                 https://$api_root/$version/linode/instances/$linode_id/resize
-  /linode/instances/:id/backups:
+  /linode/instances/::id/backups:
     _group: Backups
     authenticated: true
     description: >
@@ -758,7 +758,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/backups
           python: |
             my_linode.snapshot()
-  /linode/instances/:id/backups/enable:
+  /linode/instances/::id/backups/enable:
     _group: Backups
     type: Action
     authenticated: true
@@ -777,7 +777,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/backups/enable
           python: |
             my_linode.enable_backups()
-  /linode/instances/:id/backups/cancel:
+  /linode/instances/::id/backups/cancel:
     _group: Backups
     type: Action
     authenticated: true
@@ -795,7 +795,7 @@ endpoints:
                 https://$api_root/$version/linode/instances/$linode_id/backups/cancel
           python: |
             my_linode.cancel_backups()
-  /linode/instances/:id/backups/:id/restore:
+  /linode/instances/::id/backups/::id/restore:
     _group: Backups
     type: Action
     authenticated: true
@@ -826,7 +826,7 @@ endpoints:
           python: |
             backup = my_linode.available_backups.daily
             backup.restore()
-  /linode/instances/:id/ips:
+  /linode/instances/::id/ips:
     _group: IPs
     type: Strange
     authenticated: true
@@ -860,7 +860,7 @@ endpoints:
                     "type": "private"
                 }' \
                 https://$api_root/$version/linode/instances/$linode_id/ips
-  /linode/instances/:id/ips/sharing:
+  /linode/instances/::id/ips/sharing:
     _group: IPs
     methods:
       POST:
@@ -879,7 +879,7 @@ endpoints:
                   "ips": [ "97.107.143.29", "97.107.143.112" ]
                 }' \
                 https://$api_root/$version/linode/instances/$linode_id/ips/sharing
-  /linode/instances/:id/ips/:ip_address:
+  /linode/instances/::id/ips/::ip_address:
     _group: IPs
     type: Action
     authenticated: true
@@ -916,7 +916,7 @@ endpoints:
             curl -H "Authorization: Bearer $TOKEN" \
                 -X DELETE \
                 https://$api_root/$version/linode/instances/$linode_id/ips/97.107.143.37
-  /linode/instances/:id/rebuild:
+  /linode/instances/::id/rebuild:
     type: Action
     authenticated: true
     description: >
@@ -1028,7 +1028,7 @@ endpoints:
           python: |
             import stackscript
             TODO
-  /linode/stackscripts/:id:
+  /linode/stackscripts/::id:
     _group: StackScripts
     authenticated: true
     description: >
@@ -1090,7 +1090,7 @@ endpoints:
             curl https://$api_root/$version/linode/distributions
           python: |
             client.linode.get_distributions()
-  /linode/distributions/:id:
+  /linode/distributions/::id:
     _group: Distributions
     type: resource
     description: >
@@ -1120,7 +1120,7 @@ endpoints:
             curl https://$api_root/$version/linode/kernels
           python: |
             client.linode.get_kernels()
-  /linode/kernels/:id:
+  /linode/kernels/::id:
     _group: Kernels
     type: resource
     description: >
@@ -1150,7 +1150,7 @@ endpoints:
             curl https://$api_root/$version/linode/types
           python: |
             client.linode.get_types()
-  /linode/types/:id:
+  /linode/types/::id:
     _group: Types
     type: resource
     description: >
@@ -1228,7 +1228,7 @@ endpoints:
           python: |
             import linode
             TODO
-  /linode/volumes/:id:
+  /linode/volumes/::id:
     _group: Volumes
     type: resource
     authenticated: true
@@ -1303,7 +1303,7 @@ endpoints:
           python: |
             import linode
             TODO 
-  /linode/volumes/:id/attach:
+  /linode/volumes/::id/attach:
     _group: Volumes
     authenticated: true
     methods:
@@ -1335,7 +1335,7 @@ endpoints:
           python: |
             import linode
             TODO
-  /linode/volumes/:id/detach:
+  /linode/volumes/::id/detach:
     _group: Volumes
     type: resource
     authenticated: true
@@ -1352,7 +1352,7 @@ endpoints:
           python: |
             v = linode.Volume(client, 123)
             v.detach()
-  /linode/instances/:id/stats:
+  /linode/instances/::id/stats:
     _group: Stats
     type: Action
     authenticated: true
@@ -1368,7 +1368,7 @@ endpoints:
           curl: |
             curl -H "Authorization: token $TOKEN" \
                 https://$api_root/$version/linode/instances/$linode_id/stats
-  /linode/instances/:id/stats/:year/:month:
+  /linode/instances/::id/stats/::year/::month:
     _group: Stats
     type: Action
     authenticated: true

--- a/docs/src/data/endpoints/networking.yaml
+++ b/docs/src/data/endpoints/networking.yaml
@@ -40,7 +40,7 @@ endpoints:
                 https://$api_root/$version/networking/ipv4
           python: |
             # presently unsupported
-  /networking/ipv4/::address:
+  /networking/ipv4/$address:
     _group: IPv4
     type: resource
     authenticated: true
@@ -98,7 +98,7 @@ endpoints:
                 https://$api_root/$version/networking/ipv6
           python: |
             my_ipv6s = client.networking.get_ipv6()
-  /networking/ipv6/::address:
+  /networking/ipv6/$address:
     _group: IPv6
     type: resource
     authenticated: true

--- a/docs/src/data/endpoints/networking.yaml
+++ b/docs/src/data/endpoints/networking.yaml
@@ -40,7 +40,7 @@ endpoints:
                 https://$api_root/$version/networking/ipv4
           python: |
             # presently unsupported
-  /networking/ipv4/:address:
+  /networking/ipv4/::address:
     _group: IPv4
     type: resource
     authenticated: true
@@ -98,7 +98,7 @@ endpoints:
                 https://$api_root/$version/networking/ipv6
           python: |
             my_ipv6s = client.networking.get_ipv6()
-  /networking/ipv6/:address:
+  /networking/ipv6/::address:
     _group: IPv6
     type: resource
     authenticated: true

--- a/docs/src/data/endpoints/nodebalancers.yaml
+++ b/docs/src/data/endpoints/nodebalancers.yaml
@@ -52,7 +52,7 @@ endpoints:
                 https://$api_root/$version/nodebalancers
           python: |
             new_nodebalancer = client.create_nodebalancer('us-east-1a', label='my_cool_balancer', client_conn_throttle=10)
-  /nodebalancers/:id:
+  /nodebalancers/::id:
     type: resource
     authenticated: true
     description: >
@@ -101,7 +101,7 @@ endpoints:
          python: |
            my_nodebalancer = linode.NodeBalancer(client, 123)
            my_nodebalancer.delete()
-  /nodebalancers/:id/configs:
+  /nodebalancers/::id/configs:
     _group: Configs
     authenticated: true
     description: >
@@ -196,7 +196,7 @@ endpoints:
                     algorithm='roundrobin', stickiness='none', check='http_body', check_interval=5, check_timeout=3,
                     check_attempts=10, check_path='/path/to/check', check_body='we got some stuff back',
                     cipher_suite='legacy')
-  /nodebalancers/:id/configs/:id:
+  /nodebalancers/::id/configs/::id:
     _group: Configs
     type: resource
     authenticated: true
@@ -227,7 +227,7 @@ endpoints:
           python: |
             nb_config = linode.NodeBalancerConfig(client, 456, 123) # linode_client, nodebalancer_config_id, nodebalancer_id
             nb_config.delete()
-  /nodebalancers/:id/configs/:id/ssl:
+  /nodebalancers/::id/configs/::id/ssl:
     _group: Configs
     type: resource
     authenticated: true
@@ -248,7 +248,7 @@ endpoints:
                 https://$api_root/$version/nodebalancers/$nodebalancer_id/configs/$config_id/ssl
           python: |
             # currently unimplemented
-  /nodebalancers/:id/configs/:id/nodes:
+  /nodebalancers/::id/configs/::id/nodes:
     _group: Configs
     authenticated: true
     description: >
@@ -295,7 +295,7 @@ endpoints:
                   "mode": "accept"
               }' \
               https://$api_root/$version/nodebalancers/$nodebalancer_id/configs/$config_id/nodes
-  /nodebalancers/:id/configs/:id/nodes/:id:
+  /nodebalancers/::id/configs/::id/nodes/::id:
     _group: Configs
     type: resource
     authenticated: true

--- a/docs/src/data/endpoints/nodebalancers.yaml
+++ b/docs/src/data/endpoints/nodebalancers.yaml
@@ -52,7 +52,7 @@ endpoints:
                 https://$api_root/$version/nodebalancers
           python: |
             new_nodebalancer = client.create_nodebalancer('us-east-1a', label='my_cool_balancer', client_conn_throttle=10)
-  /nodebalancers/::id:
+  /nodebalancers/$id:
     type: resource
     authenticated: true
     description: >
@@ -101,7 +101,7 @@ endpoints:
          python: |
            my_nodebalancer = linode.NodeBalancer(client, 123)
            my_nodebalancer.delete()
-  /nodebalancers/::id/configs:
+  /nodebalancers/$id/configs:
     _group: Configs
     authenticated: true
     description: >
@@ -196,7 +196,7 @@ endpoints:
                     algorithm='roundrobin', stickiness='none', check='http_body', check_interval=5, check_timeout=3,
                     check_attempts=10, check_path='/path/to/check', check_body='we got some stuff back',
                     cipher_suite='legacy')
-  /nodebalancers/::id/configs/::id:
+  /nodebalancers/$id/configs/$id:
     _group: Configs
     type: resource
     authenticated: true
@@ -227,7 +227,7 @@ endpoints:
           python: |
             nb_config = linode.NodeBalancerConfig(client, 456, 123) # linode_client, nodebalancer_config_id, nodebalancer_id
             nb_config.delete()
-  /nodebalancers/::id/configs/::id/ssl:
+  /nodebalancers/$id/configs/$id/ssl:
     _group: Configs
     type: resource
     authenticated: true
@@ -248,7 +248,7 @@ endpoints:
                 https://$api_root/$version/nodebalancers/$nodebalancer_id/configs/$config_id/ssl
           python: |
             # currently unimplemented
-  /nodebalancers/::id/configs/::id/nodes:
+  /nodebalancers/$id/configs/$id/nodes:
     _group: Configs
     authenticated: true
     description: >
@@ -295,7 +295,7 @@ endpoints:
                   "mode": "accept"
               }' \
               https://$api_root/$version/nodebalancers/$nodebalancer_id/configs/$config_id/nodes
-  /nodebalancers/::id/configs/::id/nodes/::id:
+  /nodebalancers/$id/configs/$id/nodes/$id:
     _group: Configs
     type: resource
     authenticated: true

--- a/docs/src/data/endpoints/regions.yaml
+++ b/docs/src/data/endpoints/regions.yaml
@@ -17,7 +17,7 @@ endpoints:
             curl https://$api_root/$version/regions
           python: |
             all_regions = client.get_regions()
-  /regions/::id:
+  /regions/$id:
     type: resource
     description: >
       Return a particular region.

--- a/docs/src/data/endpoints/regions.yaml
+++ b/docs/src/data/endpoints/regions.yaml
@@ -17,7 +17,7 @@ endpoints:
             curl https://$api_root/$version/regions
           python: |
             all_regions = client.get_regions()
-  /regions/:id:
+  /regions/::id:
     type: resource
     description: >
       Return a particular region.

--- a/docs/src/data/endpoints/support.yaml
+++ b/docs/src/data/endpoints/support.yaml
@@ -59,7 +59,7 @@ endpoints:
                     "linode_id": 123,
                 }' \
                 https://$api_root/$version/support/tickets
-  /support/tickets/::id:
+  /support/tickets/$id:
     type: resource
     authenticated: true
     description: >
@@ -74,7 +74,7 @@ endpoints:
           curl: |
             curl -H "Authorization: Bearer $TOKEN" \
                 https://$api_root/$version/support/ticket/$ticket_id
-  /support/tickets/::id/replies:
+  /support/tickets/$id/replies:
     paginationKey: replies
     authenticated: true
     description: >
@@ -106,7 +106,7 @@ endpoints:
                     "description": "More details about the ticket",
                 }' \
                 https://$api_root/$version/support/tickets/$ticket_id/replies
-  /support/tickets/::id/attachments:
+  /support/tickets/$id/attachments:
     authenticated: true
     methods:
       POST:

--- a/docs/src/data/endpoints/support.yaml
+++ b/docs/src/data/endpoints/support.yaml
@@ -59,7 +59,7 @@ endpoints:
                     "linode_id": 123,
                 }' \
                 https://$api_root/$version/support/tickets
-  /support/tickets/:id:
+  /support/tickets/::id:
     type: resource
     authenticated: true
     description: >
@@ -74,7 +74,7 @@ endpoints:
           curl: |
             curl -H "Authorization: Bearer $TOKEN" \
                 https://$api_root/$version/support/ticket/$ticket_id
-  /support/tickets/:id/replies:
+  /support/tickets/::id/replies:
     paginationKey: replies
     authenticated: true
     description: >
@@ -106,7 +106,7 @@ endpoints:
                     "description": "More details about the ticket",
                 }' \
                 https://$api_root/$version/support/tickets/$ticket_id/replies
-  /support/tickets/:id/attachments:
+  /support/tickets/::id/attachments:
     authenticated: true
     methods:
       POST:

--- a/docs/src/data/objects/linode.yaml
+++ b/docs/src/data/objects/linode.yaml
@@ -65,7 +65,7 @@ schema:
         _description: Transfer Quota % (Range 0-400, default 80).
   backups:
     _type: Object
-    _seeAlso: "/reference/endpoints/linode/instances/::id/backups"
+    _seeAlso: "/reference/endpoints/linode/instances/$id/backups"
     _description: >
       Displays if backups are enabled, last backup datetime if applicable, and
       the day/window your backups will occur. Window is prefixed by a "W" and an
@@ -190,13 +190,13 @@ schema:
     _type: string
     _isArray: true
     _description: This Linode's IPv4 addresses.
-    _seeAlso: ["/reference/endpoints/linode/instances/::id/ips", "/reference/endpoints/networking/ipv4"]
+    _seeAlso: ["/reference/endpoints/linode/instances/$id/ips", "/reference/endpoints/networking/ipv4"]
     _value: ["97.107.143.8", "192.168.149.108"]
   ipv6:
     _editable: false
     _type: String
     _description: This Linode's IPv6 slaac address.
-    _seeAlso: ["/reference/endpoints/linode/instances/::id/ips", "/reference/endpoints/networking/ipv6"]
+    _seeAlso: ["/reference/endpoints/linode/instances/$id/ips", "/reference/endpoints/networking/ipv6"]
     _value: "2a01:7e00::f03c:91ff:fe96:46f5/64"
   label:
     _editable: true

--- a/docs/src/data/objects/linode.yaml
+++ b/docs/src/data/objects/linode.yaml
@@ -65,7 +65,7 @@ schema:
         _description: Transfer Quota % (Range 0-400, default 80).
   backups:
     _type: Object
-    _seeAlso: "/reference/endpoints/linode/instances/:id/backups"
+    _seeAlso: "/reference/endpoints/linode/instances/::id/backups"
     _description: >
       Displays if backups are enabled, last backup datetime if applicable, and
       the day/window your backups will occur. Window is prefixed by a "W" and an
@@ -190,13 +190,13 @@ schema:
     _type: string
     _isArray: true
     _description: This Linode's IPv4 addresses.
-    _seeAlso: ["/reference/endpoints/linode/instances/:id/ips", "/reference/endpoints/networking/ipv4"]
+    _seeAlso: ["/reference/endpoints/linode/instances/::id/ips", "/reference/endpoints/networking/ipv4"]
     _value: ["97.107.143.8", "192.168.149.108"]
   ipv6:
     _editable: false
     _type: String
     _description: This Linode's IPv6 slaac address.
-    _seeAlso: ["/reference/endpoints/linode/instances/:id/ips", "/reference/endpoints/networking/ipv6"]
+    _seeAlso: ["/reference/endpoints/linode/instances/::id/ips", "/reference/endpoints/networking/ipv6"]
     _value: "2a01:7e00::f03c:91ff:fe96:46f5/64"
   label:
     _editable: true

--- a/docs/src/data/objects/linode_config.yaml
+++ b/docs/src/data/objects/linode_config.yaml
@@ -26,7 +26,7 @@ schema:
   disks:
     _type: object
     _description: Disks attached to this Linode config.
-    _seeAlso: "/reference/endpoints/linode/instances/:id/disks"
+    _seeAlso: "/reference/endpoints/linode/instances/::id/disks"
     _editable: true
     sda:
       _type: Disk

--- a/docs/src/data/objects/linode_config.yaml
+++ b/docs/src/data/objects/linode_config.yaml
@@ -26,7 +26,7 @@ schema:
   disks:
     _type: object
     _description: Disks attached to this Linode config.
-    _seeAlso: "/reference/endpoints/linode/instances/::id/disks"
+    _seeAlso: "/reference/endpoints/linode/instances/$id/disks"
     _editable: true
     sda:
       _type: Disk

--- a/docs/src/getting_started/intros/Pagination.js
+++ b/docs/src/getting_started/intros/Pagination.js
@@ -43,7 +43,8 @@ export default function Pagination() {
         <p>
           Some objects contain lists of other objects, which you can get at
           <code>/::type/::subtype/::id/::subtype</code>.
-          You can get an individual sub-object at <code>/::type/::subtype/::id/::subtype/::id</code>.
+          You can get an individual sub-object
+          at <code>/::type/::subtype/::id/::subtype/::id</code>.
         </p>
         <p>
           For example, you can list your Linodes at <code>/linode/instances</code>, and get

--- a/docs/src/getting_started/intros/Pagination.js
+++ b/docs/src/getting_started/intros/Pagination.js
@@ -37,14 +37,14 @@ export default function Pagination() {
           There are generally two kinds of resources you can retrieve with a GET
           request: objects and lists. An object is a representation of an individual resource.
           It has an ID that can be used to retrieve it directly. A list is a collection of objects.
-          You'll generally find lists of objects at <code>/::type/::subtype</code>,
-          and an individual object at <code>/::type/::subtype/::id</code>.
+          You'll generally find lists of objects at <code>/$type/$subtype</code>,
+          and an individual object at <code>/$type/$subtype/$id</code>.
         </p>
         <p>
           Some objects contain lists of other objects, which you can get at
-          <code>/::type/::subtype/::id/::subtype</code>.
+          <code>/$type/$subtype/$id/$subtype</code>.
           You can get an individual sub-object
-          at <code>/::type/::subtype/::id/::subtype/::id</code>.
+          at <code>/$type/$subtype/$id/$subtype/$id</code>.
         </p>
         <p>
           For example, you can list your Linodes at <code>/linode/instances</code>, and get

--- a/docs/src/getting_started/intros/Pagination.js
+++ b/docs/src/getting_started/intros/Pagination.js
@@ -37,13 +37,13 @@ export default function Pagination() {
           There are generally two kinds of resources you can retrieve with a GET
           request: objects and lists. An object is a representation of an individual resource.
           It has an ID that can be used to retrieve it directly. A list is a collection of objects.
-          You'll generally find lists of objects at <code>/:type/:subtype</code>,
-          and an individual object at <code>/:type/:subtype/:id</code>.
+          You'll generally find lists of objects at <code>/::type/::subtype</code>,
+          and an individual object at <code>/::type/::subtype/::id</code>.
         </p>
         <p>
           Some objects contain lists of other objects, which you can get at
-          <code>/:type/:subtype/:id/:subtype</code>.
-          You can get an individual sub-object at <code>/:type/:subtype/:id/:subtype/:id</code>.
+          <code>/::type/::subtype/::id/::subtype</code>.
+          You can get an individual sub-object at <code>/::type/::subtype/::id/::subtype/::id</code>.
         </p>
         <p>
           For example, you can list your Linodes at <code>/linode/instances</code>, and get


### PR DESCRIPTION
Closes #2454

We use the same variable scheme in our route demonstrations as react-router does... So it saw /:ip/sharing as a variable that matched /:ip/:ip_address... I changed the prefix from : to :: to avoid this.