### PR TITLE
Set half of a HD display as the .Layout min-width

### DIFF
--- a/scss/layout/Layout.scss
+++ b/scss/layout/Layout.scss
@@ -7,7 +7,7 @@ body,
 }
 
 .Layout {
-    min-width: 1024px;
+    min-width: 960px;
     display: flex;
     flex-direction: column;
     min-height: 100%;


### PR DESCRIPTION
Please set the minimum .Layout width to half of 1920x1080 display. Meaning the manager can be used without horizontal scrolling on a standard full-HD display with two windows side-by-side (e.g. browser and terminal). This use pattern is encouraged by window snapping in Windows and in other window managers.

For what it’s worth: I’ve created new instances and poked a bit around in the interface. It seems to work.