### PR TITLE
Replaced contact_support with offline for volumes

### DIFF
--- a/docs/src/data/objects/volume.yaml
+++ b/docs/src/data/objects/volume.yaml
@@ -50,4 +50,4 @@ enums:
     creating: creating
     active: active
     resizing: resizing
-    contact_support: contact_support
+    offline: offline


### PR DESCRIPTION
Caker wanted something other than contact_support, so I created offline
to replace