### PR TITLE
add description for field type --> id

### DIFF
--- a/docs/src/data/objects/type.yaml
+++ b/docs/src/data/objects/type.yaml
@@ -8,6 +8,7 @@ schema:
   id:
     _type: String
     _value: linode2048.5
+    _description: The service plan type.
   storage:
     _type: Integer
     _value: 24576


### PR DESCRIPTION
Adds a description to the id field [on this page](https://developers.linode.com/v4/reference/endpoints/linode/types) under the types heading.
![image](https://user-images.githubusercontent.com/5460225/30242527-0448f5ce-9566-11e7-9568-f69b250301d1.png)

