### PR TITLE
fix default root device in new linode configs

### DIFF
--- a/src/linodes/linode/components/RescueMode.js
+++ b/src/linodes/linode/components/RescueMode.js
@@ -74,7 +74,7 @@ export default class RescueMode extends Component {
             />
           ))}
           <FormGroup className="row">
-            <label className="col-sm-3 row-label">/dev/sdh</label>
+            <label className="col-sm-3 row-label">/dev/{slots[slots.length - 1]}</label>
             <div className="col-sm-9">Finnix Media</div>
           </FormGroup>
           <FormGroup className="row">

--- a/src/linodes/linode/settings/advanced/components/CreateOrEditConfig.js
+++ b/src/linodes/linode/settings/advanced/components/CreateOrEditConfig.js
@@ -37,19 +37,20 @@ export default class CreateOrEditConfig extends Component {
 
   componentWillMount(nextProps) {
     const { config, account, linode } = nextProps || this.props;
+    const slots = AVAILABLE_DISK_SLOTS[linode.hypervisor];
+    const rootSansDev = config.root_device.substring('/dev/'.length);
 
     this.setState({
       label: config.label,
       comments: config.comments,
       kernel: config.kernel,
       initrd: config.initrd || '',
-      rootDevice: config.root_device,
+      rootDevice: config.root_device || `/dev/${slots[0]}`,
       devices: _.mapValues(config.devices, d => JSON.stringify(_.pickBy(d, Boolean))),
       virtMode: config.virt_mode,
       runLevel: config.run_level,
       ramLimit: config.ram_limit,
-      isCustomRoot: AVAILABLE_DISK_SLOTS[linode.hypervisor].indexOf(
-        config.root_device.replace('/dev/', '')) === -1,
+      isCustomRoot: !!config.root_device.length && (slots.indexOf(rootSansDev) === -1),
       isMaxRam: config.ram_limit === 0,
       enableDistroHelper: config.helpers.enable_distro_helper,
       enableNetworkHelper: config.helpers.enable_network_helper,
@@ -406,6 +407,7 @@ CreateOrEditConfig.propTypes = {
 CreateOrEditConfig.defaultProps = {
   config: {
     devices: {},
+    isCustomRoot: false,
     root_device: '',
     helpers: {
       enable_distro_helper: true,


### PR DESCRIPTION
Configs are currently coming up with Custom as the default disk with a value of ''.

This PR addreses that:
> ![image](https://user-images.githubusercontent.com/317653/30276741-c6ea76ca-96d3-11e7-8bf0-5364985f90cb.png)
> ![image](https://user-images.githubusercontent.com/317653/30276756-d6dbc62e-96d3-11e7-8221-c2205be3d02f.png)

This PR also corrects an improper label for the Finnix Media on Xen Linodes.