### PR TITLE
update guides url for obtaining token

### DIFF
--- a/docs/src/getting_started/guides/curl/TestingWithCurl.js
+++ b/docs/src/getting_started/guides/curl/TestingWithCurl.js
@@ -85,7 +85,7 @@ export default function Introduction(props) {
         </p>
         <p>
           To generate a personal access token,&nbsp;
-          <ExternalLink to={`${MANAGER_ROOT}/profile/integrations/tokens`}>
+          <ExternalLink to={`${MANAGER_ROOT}/profile/tokens`}>
             visit the new manager
           </ExternalLink>
           . These tokens can be used to make authenticated API requests with your Linode

--- a/docs/src/getting_started/guides/python/Introduction.js
+++ b/docs/src/getting_started/guides/python/Introduction.js
@@ -6,7 +6,7 @@ import { ExternalLink } from 'linode-components/buttons';
 import { Code } from 'linode-components/formats';
 
 import { API_VERSION,
-  MANAGER_ROOT
+  MANAGER_ROOT,
 } from '~/constants';
 
 

--- a/docs/src/getting_started/guides/python/Introduction.js
+++ b/docs/src/getting_started/guides/python/Introduction.js
@@ -5,7 +5,9 @@ import { Breadcrumbs } from 'linode-components/breadcrumbs';
 import { ExternalLink } from 'linode-components/buttons';
 import { Code } from 'linode-components/formats';
 
-import { API_VERSION } from '~/constants';
+import { API_VERSION,
+  MANAGER_ROOT
+} from '~/constants';
 
 
 export default function Introduction(props) {
@@ -35,9 +37,9 @@ export default function Introduction(props) {
         <p>
           In order to make requests to the API, you're going to need an OAuth Token.
           You can make a personal access token at&nbsp;
-          <ExternalLink
-            to="https://cloud.linode.com/profile/integrations/tokens"
-          >cloud.linode.com</ExternalLink>.
+          <ExternalLink to={`${MANAGER_ROOT}/profile/tokens`}>
+            cloud.linode.com
+          </ExternalLink>.
         </p>
       </section>
       <section>

--- a/docs/src/getting_started/guides/python/Introduction.js
+++ b/docs/src/getting_started/guides/python/Introduction.js
@@ -5,9 +5,7 @@ import { Breadcrumbs } from 'linode-components/breadcrumbs';
 import { ExternalLink } from 'linode-components/buttons';
 import { Code } from 'linode-components/formats';
 
-import { API_VERSION,
-  MANAGER_ROOT,
-} from '~/constants';
+import { API_VERSION, MANAGER_ROOT } from '~/constants';
 
 
 export default function Introduction(props) {


### PR DESCRIPTION
I updated the token URL to point to its new location.  While I was there, I also updated the Python guide to use the `MANAGER_REPO` for the `ExternalLink`, matching what is in the curl guide.