### PR TITLE
use relative links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Currently this software is *early-access* and is available at [cloud.linode.com]
 
 ## Contributing
 
-Read the [contributing guidelines](https://github.com/linode/manager/blob/master/CONTRIBUTING.md) to get started.
+Read the [contributing guidelines](CONTRIBUTING.md) to get started.
 
 Come chat with us in [#linode-next on
 irc.oftc.net](https://webchat.oftc.net/?channels=linode-next&uio=d4) if you're
@@ -29,6 +29,6 @@ the right patterns - some large scale refactorings may be in order.
 ## License
 
 The Linode Manager's code is distributed under the terms of the [BSD 3-clause
-license](https://github.com/linode/manager/blob/master/LICENSE). The assets are
+license](LICENSE). The assets are
 not licensed for any purpose without prior written approval from Linode, unless
 otherwise noted.


### PR DESCRIPTION
The reasoning here is that if you are on the develop branch, you will be linked to the CONTRIBUTING guide for the develop branch.  If you are on master, you will get the version that is on master, and so forth.