### PR TITLE
Adds Changelogs page

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+# [0.12.6] 2017-09-20
+### Added
+- Changelog page
+
 # [0.12.5] 2017-09-19
 ### Added
 - changes to document api release

--- a/docs/npm-shrinkwrap.json
+++ b/docs/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-api-docs",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "dependencies": {
     "asap": {
       "version": "2.0.5",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linode-api-docs",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Linode API Docs",
   "main": "src/index.js",
   "scripts": {

--- a/docs/src/getting_started/Routes.js
+++ b/docs/src/getting_started/Routes.js
@@ -13,6 +13,10 @@ import {
   Errors,
 } from './intros';
 
+import {
+  Changelogs,
+} from './changelogs';
+
 import { default as GuidesIndex } from './guides/GuidesIndex';
 
 
@@ -21,6 +25,7 @@ export default function GettingStartedRoutes(guides, crumbs) {
     <Route component={IndexLayout}>
       <IndexRedirect to="introduction" />
       <Redirect from="reference" to="introduction" />
+      <Route path="changelogs" components={Changelogs} />
       <Route path="introduction" component={Introduction} />
       <Route path="access" component={Access} />
       <Route path="pagination" component={Pagination} />

--- a/docs/src/getting_started/Routes.js
+++ b/docs/src/getting_started/Routes.js
@@ -25,13 +25,13 @@ export default function GettingStartedRoutes(guides, crumbs) {
     <Route component={IndexLayout}>
       <IndexRedirect to="introduction" />
       <Redirect from="reference" to="introduction" />
-      <Route path="changelogs" components={Changelogs} />
       <Route path="introduction" component={Introduction} />
       <Route path="access" component={Access} />
       <Route path="pagination" component={Pagination} />
       <Route path="filtering" component={Filtering} />
       <Route path="errors" component={Errors} />
       <Route path="guides" component={GuidesIndex} crumbs={crumbs} />
+      <Route path="changelogs" components={Changelogs} />
       {guides.map(function (guide) {
         return (<Route path={guide.routePath} component={guide.component} crumbs={guide.crumbs} />);
       })}

--- a/docs/src/getting_started/changelogs/Changelogs.js
+++ b/docs/src/getting_started/changelogs/Changelogs.js
@@ -1,0 +1,174 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+import { Table } from 'linode-components/tables';
+import { Code } from 'linode-components/formats';
+
+import { LOGIN_ROOT, API_VERSION } from '~/constants';
+
+
+export default function Authentication() {
+  return (
+    <section className="Article">
+      <h1>Changelogs</h1>
+      <section>
+        <p>
+        The API V4 is currently in beta, and there will be regular releases that
+        may introduce breaking changes.  This is where we will document changes
+        in each release.  If you are using the API V4, please check here regularly
+        for updates.
+        </p>
+      </section>
+      <section>
+        <h2>2017-09-18</h2>
+        <hr/><br/>
+        <b>Breaking Changes:</b><br/>
+        <ul>
+          <li>Pagination envelope has changed</li>
+            <ul>
+              <li> total_pages => pages</li>
+              <li> total_results => results</li>
+              <li> endpoint-specific key is now always "data"</li>
+            </ul>
+          <li>Region, Distribution, Type, and Kernel objects are now returned as slugs</li>
+            <ul>
+              <li> Previously, entire object was returned as part of other responses</li>
+            </ul>
+          <li>POST linode/instances and POST linode/rebuild automatically issue a boot job</li>
+            <ul>
+              <li> This behavior can be suppressed by sending "boot": false in the request</li>
+            </ul>
+          <li>Changed POST linode/instances</li>
+            <ul>
+              <li> with_backups => backups_enabled</li>
+              <li> Now accepts "booted" - defaults to true if distribution is provided</li>
+            </ul>
+          <li>Changed POST  linode/instances/:id/clone</li>
+            <ul>
+              <li> with_backups => backups_enabled</li>
+            </ul>
+          <li>Changed POST linode/instances/:id/rebuild</li>
+            <ul>
+              <li> Now accepts "booted" - defaults to true</li>
+            </ul>
+          <li>Changed LinodeNetworkingResponse</li>
+            <ul>
+              <li> region is now a slug instead of a nested object</li>
+            </ul>
+          <li>Changed IPv6 object</li>
+            <ul>
+              <li> region is now a slug instead of a nested object</li>
+            </ul>
+          <li>Changed Invoice object</li>
+            <ul>
+              <li> Removed "paid"</li>
+              <li> Removed "overdue"</li>
+            </ul>
+          <li>Changed Region object</li>
+            <ul>
+              <li> Removed "label"</li>
+            </ul>
+          <li>Changed Backup object</li>
+            <ul>
+              <li> regions is now a slug instead of a nested object</li>
+            </ul>
+          <li>Changed Distribution object</li>
+            <ul>
+              <li> Removed "created"</li>
+              <li> Added "updated"</li>
+              <li> minimum_storage_size => disk_minimum</li>
+              <li> x64 => architecture.  architecture is an enum returning either "x86_64" or "i386"</li>
+            </ul>
+          <li>Changed IPAddress object</li>
+            <ul>
+              <li> region is now a slug instead of a nested object</li>
+            </ul>
+          <li>Changed Kernel object</li>
+            <ul>
+              <li> x64 => architecture.  architecture is an enum returning either "x86_64" or "i386"</li>
+            </ul>
+          <li>Changed Linode object</li>
+            <ul>
+              <li> storage => disk</li>
+              <li> total_transfer => transfer_total</li>
+              <li> distribution is now a slug instead of a nested object</li>
+              <li> region is now a slug instead of a nested object</li>
+              <li> nested alert objects have been streamlined</li>
+              <li>"enabled" and "threshold" have been removed</li>
+              <li>a value of 0 now represents "disabled", any other value is "enabled" with
+                  that threshold</li>
+            </ul>
+          <li>Changed LinodeConfig object</li>
+            <ul>
+              <li> disable_updatedb => updatedb_disabled</li>
+              <li> enable_distro_helper => distro</li>
+              <li> enable_modules_dep_helper => modules_dep</li>
+              <li> enable_network_helper => network</li>
+              <li> ram_limit => memory_limit</li>
+              <li> devtmpfs_autocommit moved into "helpers" envelope</li>
+            </ul>
+          <li>Changed Nodebalancer object</li>
+            <ul>
+              <li> region is now a slug instead of a nested object</li>
+            </ul>
+          <li>Changed Type object</li>
+            <ul>
+              <li> hourly_price => price_hourly</li>
+              <li> monthly_price => price_monthly</li>
+              <li> ram => memory</li>
+              <li> storage => disk</li>
+              <li> mbits_out => network_out</li>
+              <li> backups_price is now a nested object containing "price_hourly" and
+                  "price_monthly"</li>
+            </ul>
+          <li>Changed StackScript object</li>
+            <ul>
+              <li> Removed "customer_id"</li>
+              <li> distributions is now a list of slugs instead of a list of nested objects</li>
+              <li> Removed "user_id"</li>
+              <li> Added "username"</li>
+              <li> Added "user_gravatar_id"</li>
+            </ul>
+          <li>Changed Volume object</li>
+            <ul>
+              <li> "status" can no longer contain "contact_support" - will return "offline"
+                  in that case</li>
+              <li> region is now a slug instead of a nested object</li>
+            </ul>
+          <li>Changes SupportTicket</li>
+            <ul>
+              <li> Removed "closed_by"</li>
+            </ul>
+          <li>IP Whitelist may not be enabled in PUT profile if it is already disabled</li>
+        </ul>
+        <b>Changes:</b><br/>
+        <ul>
+          <li>Default page size increased to 100</li>
+            <ul>
+              <li>Any page size between 25 and 100 may be requested in the url with ?page_size=</li>
+            </ul>
+          <li>Linode configs now accept deprecated kernels</li>
+          <li>Linode configs now default kernel to latest, no longer required on POST</li>
+          <li>Added /profile/whitelist</li>
+            <ul>
+              <li>GET - list all IPs on user's whitelist</li>
+              <li>POST - add IP to user's whitelist</li>
+              <li>Endpoint return a 400 if IP Whitelist is disabled</li>
+            </ul>
+          <li>Added /profile/whitelist/:id</li>
+            <ul>
+              <li>GET - return one entry on whitelist</li>
+              <li>DELETE - remove address from whitelist</li>
+              <li>Endpoints return a 400 if IP Whitelist if disabled</li>
+            </ul>
+          <li>Disk filesystems now default to ext4, no longer required on POST</li>
+        </ul>
+      </section>
+      <div className="text-sm-center">
+        <Link to={`/${API_VERSION}/introduction`}>
+          Go on to the Introduction
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/docs/src/getting_started/changelogs/Changelogs.js
+++ b/docs/src/getting_started/changelogs/Changelogs.js
@@ -1,11 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 
-import { Table } from 'linode-components/tables';
-import { Code } from 'linode-components/formats';
-
-import { LOGIN_ROOT, API_VERSION } from '~/constants';
-
+import { API_VERSION } from '~/constants';
 
 export default function Authentication() {
   return (
@@ -21,73 +17,89 @@ export default function Authentication() {
       </section>
       <section>
         <h2>2017-09-18</h2>
-        <hr/><br/>
-        <b>Breaking Changes:</b><br/>
+        <hr /><br />
+        <b>Breaking Changes:</b><br />
         <ul>
-          <li>Pagination envelope has changed</li>
+          <li>Pagination envelope has changed
             <ul>
               <li> total_pages => pages</li>
               <li> total_results => results</li>
               <li> endpoint-specific key is now always "data"</li>
             </ul>
-          <li>Region, Distribution, Type, and Kernel objects are now returned as slugs</li>
+          </li>
+          <li>Region, Distribution, Type, and Kernel objects are now returned as slugs
             <ul>
               <li> Previously, entire object was returned as part of other responses</li>
             </ul>
-          <li>POST linode/instances and POST linode/rebuild automatically issue a boot job</li>
+          </li>
+          <li>POST linode/instances and POST linode/rebuild automatically issue a boot job
             <ul>
               <li> This behavior can be suppressed by sending "boot": false in the request</li>
             </ul>
-          <li>Changed POST linode/instances</li>
+          </li>
+          <li>Changed POST linode/instances
             <ul>
               <li> with_backups => backups_enabled</li>
               <li> Now accepts "booted" - defaults to true if distribution is provided</li>
             </ul>
-          <li>Changed POST  linode/instances/:id/clone</li>
+          </li>
+          <li>Changed POST  linode/instances/:id/clone
             <ul>
               <li> with_backups => backups_enabled</li>
             </ul>
-          <li>Changed POST linode/instances/:id/rebuild</li>
+          </li>
+          <li>Changed POST linode/instances/:id/rebuild
             <ul>
               <li> Now accepts "booted" - defaults to true</li>
             </ul>
-          <li>Changed LinodeNetworkingResponse</li>
+          </li>
+          <li>Changed LinodeNetworkingResponse
             <ul>
               <li> region is now a slug instead of a nested object</li>
             </ul>
-          <li>Changed IPv6 object</li>
+          </li>
+          <li>Changed IPv6 object
             <ul>
               <li> region is now a slug instead of a nested object</li>
             </ul>
-          <li>Changed Invoice object</li>
+          </li>
+          <li>Changed Invoice object
             <ul>
               <li> Removed "paid"</li>
               <li> Removed "overdue"</li>
             </ul>
-          <li>Changed Region object</li>
+          </li>
+          <li>Changed Region object
             <ul>
               <li> Removed "label"</li>
             </ul>
-          <li>Changed Backup object</li>
+          </li>
+          <li>Changed Backup object
             <ul>
               <li> regions is now a slug instead of a nested object</li>
             </ul>
-          <li>Changed Distribution object</li>
+          </li>
+          <li>Changed Distribution object
             <ul>
               <li> Removed "created"</li>
               <li> Added "updated"</li>
               <li> minimum_storage_size => disk_minimum</li>
-              <li> x64 => architecture.  architecture is an enum returning either "x86_64" or "i386"</li>
+              <li> x64 => architecture.  architecture is an enum returning either
+              "x86_64" or "i386"</li>
             </ul>
-          <li>Changed IPAddress object</li>
+          </li>
+          <li>Changed IPAddress object
             <ul>
               <li> region is now a slug instead of a nested object</li>
             </ul>
-          <li>Changed Kernel object</li>
+          </li>
+          <li>Changed Kernel object
             <ul>
-              <li> x64 => architecture.  architecture is an enum returning either "x86_64" or "i386"</li>
+              <li> x64 => architecture.  architecture is an enum returning either
+              "x86_64" or "i386"</li>
             </ul>
-          <li>Changed Linode object</li>
+          </li>
+          <li>Changed Linode object
             <ul>
               <li> storage => disk</li>
               <li> total_transfer => transfer_total</li>
@@ -96,9 +108,10 @@ export default function Authentication() {
               <li> nested alert objects have been streamlined</li>
               <li>"enabled" and "threshold" have been removed</li>
               <li>a value of 0 now represents "disabled", any other value is "enabled" with
-                  that threshold</li>
+              that threshold</li>
             </ul>
-          <li>Changed LinodeConfig object</li>
+          </li>
+          <li>Changed LinodeConfig object
             <ul>
               <li> disable_updatedb => updatedb_disabled</li>
               <li> enable_distro_helper => distro</li>
@@ -107,11 +120,13 @@ export default function Authentication() {
               <li> ram_limit => memory_limit</li>
               <li> devtmpfs_autocommit moved into "helpers" envelope</li>
             </ul>
-          <li>Changed Nodebalancer object</li>
+          </li>
+          <li>Changed Nodebalancer object
             <ul>
               <li> region is now a slug instead of a nested object</li>
             </ul>
-          <li>Changed Type object</li>
+          </li>
+          <li>Changed Type object
             <ul>
               <li> hourly_price => price_hourly</li>
               <li> monthly_price => price_monthly</li>
@@ -119,9 +134,10 @@ export default function Authentication() {
               <li> storage => disk</li>
               <li> mbits_out => network_out</li>
               <li> backups_price is now a nested object containing "price_hourly" and
-                  "price_monthly"</li>
+              "price_monthly"</li>
             </ul>
-          <li>Changed StackScript object</li>
+          </li>
+          <li>Changed StackScript object
             <ul>
               <li> Removed "customer_id"</li>
               <li> distributions is now a list of slugs instead of a list of nested objects</li>
@@ -129,38 +145,44 @@ export default function Authentication() {
               <li> Added "username"</li>
               <li> Added "user_gravatar_id"</li>
             </ul>
-          <li>Changed Volume object</li>
+          </li>
+          <li>Changed Volume object
             <ul>
               <li> "status" can no longer contain "contact_support" - will return "offline"
-                  in that case</li>
+              in that case</li>
               <li> region is now a slug instead of a nested object</li>
             </ul>
-          <li>Changes SupportTicket</li>
+          </li>
+          <li>Changes SupportTicket
             <ul>
               <li> Removed "closed_by"</li>
             </ul>
+          </li>
           <li>IP Whitelist may not be enabled in PUT profile if it is already disabled</li>
         </ul>
-        <b>Changes:</b><br/>
+        <b>Changes:</b><br />
         <ul>
-          <li>Default page size increased to 100</li>
+          <li>Default page size increased to 100
             <ul>
               <li>Any page size between 25 and 100 may be requested in the url with ?page_size=</li>
             </ul>
+          </li>
           <li>Linode configs now accept deprecated kernels</li>
           <li>Linode configs now default kernel to latest, no longer required on POST</li>
-          <li>Added /profile/whitelist</li>
+          <li>Added /profile/whitelist
             <ul>
               <li>GET - list all IPs on user's whitelist</li>
               <li>POST - add IP to user's whitelist</li>
               <li>Endpoint return a 400 if IP Whitelist is disabled</li>
             </ul>
-          <li>Added /profile/whitelist/:id</li>
+          </li>
+          <li>Added /profile/whitelist/:id
             <ul>
               <li>GET - return one entry on whitelist</li>
               <li>DELETE - remove address from whitelist</li>
               <li>Endpoints return a 400 if IP Whitelist if disabled</li>
             </ul>
+          </li>
           <li>Disk filesystems now default to ext4, no longer required on POST</li>
         </ul>
       </section>

--- a/docs/src/getting_started/changelogs/Changelogs.js
+++ b/docs/src/getting_started/changelogs/Changelogs.js
@@ -9,10 +9,9 @@ export default function Authentication() {
       <h1>Changelogs</h1>
       <section>
         <p>
-        The API V4 is currently in beta, and there will be regular releases that
-        may introduce breaking changes.  This is where we will document changes
-        in each release.  If you are using the API V4, please check here regularly
-        for updates.
+        The API V4 is currently in beta.  There will be regular releases that may
+        introduce breaking changes.  The Developers site contains all changes to
+        API V4 since 2017-09-18.  Please check here regularly for updates.
         </p>
       </section>
       <section>

--- a/docs/src/getting_started/changelogs/index.js
+++ b/docs/src/getting_started/changelogs/index.js
@@ -1,0 +1,1 @@
+export { default as Changelogs } from './Changelogs';

--- a/docs/src/getting_started/intros/Introduction.js
+++ b/docs/src/getting_started/intros/Introduction.js
@@ -29,6 +29,12 @@ export default function Introduction() {
           All APIv4 endpoints are located at:
         </p>
         <Code example={`${API_ROOT}/${API_VERSION}/*`} name="bash" noclipboard />
+        <div className="alert alert-warning" role="alert">
+          We will regularly be making releases, some of which will contain breaking
+          changes. <Link to={`/${API_VERSION}/changelogs`}>
+            Please look at the changelogs
+          </Link> to keep up to date with recent changes.
+        </div>
         <p>
           Occasionally we will add features and improvements to our API -
           only certain changes will trigger a version bump, including:

--- a/docs/src/layouts/Layout.js
+++ b/docs/src/layouts/Layout.js
@@ -67,6 +67,7 @@ export default class Layout extends Component {
                 }}
                 path={path}
                 navItems={[
+                  { label: 'Changelogs', href: `/${API_VERSION}/changelogs` },
                   { label: 'Introduction', href: `/${API_VERSION}/introduction` },
                   { label: 'Access', href: `/${API_VERSION}/access` },
                   { label: 'Pagination', href: `/${API_VERSION}/pagination` },

--- a/docs/src/layouts/Layout.js
+++ b/docs/src/layouts/Layout.js
@@ -67,13 +67,13 @@ export default class Layout extends Component {
                 }}
                 path={path}
                 navItems={[
-                  { label: 'Changelogs', href: `/${API_VERSION}/changelogs` },
                   { label: 'Introduction', href: `/${API_VERSION}/introduction` },
                   { label: 'Access', href: `/${API_VERSION}/access` },
                   { label: 'Pagination', href: `/${API_VERSION}/pagination` },
                   { label: 'Filtering & Sorting', href: `/${API_VERSION}/filtering` },
                   { label: 'Errors', href: `/${API_VERSION}/errors` },
                   { label: 'Guides', href: `/${API_VERSION}/guides` },
+                  { label: 'Changelogs', href: `/${API_VERSION}/changelogs` },
                 ]}
               />
               <VerticalNavSection


### PR DESCRIPTION
With recent breaking changes there has been immense customer confusion.
This change introduces a Changelogs page on docs to be updated with
future changes as they are deployed so that users can see what has
changed without making requests and watching their clients break.