### PR TITLE
dont display backup ids in select

### DIFF
--- a/src/linodes/components/BackupSelect.js
+++ b/src/linodes/components/BackupSelect.js
@@ -1,27 +1,33 @@
 import React, { PropTypes } from 'react';
 
+import moment from 'moment-timezone';
 import { Select } from 'linode-components/forms';
+import { getStorage } from '~/storage';
 
 
 export default function BackupSelect(props) {
   const { daily, weekly, snapshot } = props.backups;
+  const timezone = getStorage('profile/timezone') || 'UTC';
+  console.log('d', daily);
+  console.log('w', weekly);
+  console.log('s', snapshot);
 
   const initialLabel = props.disabled ? 'Fetching backups' : 'Pick a Linode';
   const options = [{ label: initialLabel, value: 0 }];
 
   if (daily) {
-    options[0] = { label: 'Daily', options: [{ label: daily.id, value: daily.id }] };
+    options[0] = { label: 'Daily', options: [{ label: moment.utc(daily.created).fromNow(), value: daily.id }] };
   }
 
   if (weekly) {
-    options.push({ label: 'Weekly', options: weekly.map(w => ({ label: w.id, value: w.id })) });
+    options.push({ label: 'Weekly', options: weekly.map(w => ({ label: moment.utc(w.created).fromNow(), value: w.id })) });
   }
 
   if (snapshot && snapshot.current) {
     const { current } = snapshot;
     const option = {
       label: 'Snapshot',
-      options: [{ label: current.label || current.id, value: current.id }],
+      options: [{ label: current.label || moment.utc(current.created).fromNow(), value: current.id }],
     };
 
     if (!daily) {

--- a/src/linodes/components/BackupSelect.js
+++ b/src/linodes/components/BackupSelect.js
@@ -2,32 +2,36 @@ import React, { PropTypes } from 'react';
 
 import moment from 'moment-timezone';
 import { Select } from 'linode-components/forms';
-import { getStorage } from '~/storage';
 
 
 export default function BackupSelect(props) {
   const { daily, weekly, snapshot } = props.backups;
-  const timezone = getStorage('profile/timezone') || 'UTC';
-  console.log('d', daily);
-  console.log('w', weekly);
-  console.log('s', snapshot);
 
   const initialLabel = props.disabled ? 'Fetching backups' : 'Pick a Linode';
   const options = [{ label: initialLabel, value: 0 }];
 
   if (daily) {
-    options[0] = { label: 'Daily', options: [{ label: moment.utc(daily.created).fromNow(), value: daily.id }] };
+    options[0] = { label: 'Daily', options: [{
+      label: moment.utc(daily.created).fromNow(),
+      value: daily.id,
+    }] };
   }
 
   if (weekly) {
-    options.push({ label: 'Weekly', options: weekly.map(w => ({ label: moment.utc(w.created).fromNow(), value: w.id })) });
+    options.push({ label: 'Weekly', options: weekly.map(w => ({
+      label: moment.utc(w.created).fromNow(),
+      value: w.id,
+    })) });
   }
 
   if (snapshot && snapshot.current) {
     const { current } = snapshot;
     const option = {
       label: 'Snapshot',
-      options: [{ label: current.label || moment.utc(current.created).fromNow(), value: current.id }],
+      options: [{
+        label: current.label || moment.utc(current.created).fromNow(),
+        value: current.id,
+      }],
     };
 
     if (!daily) {


### PR DESCRIPTION
Closes #2450 

![screen shot 2017-09-22 at 3 11 44 pm](https://user-images.githubusercontent.com/6047142/30760512-7616d8c8-9fa8-11e7-93e7-8ec78967a0d5.png)
The reason the weeklies are saying a month ago is because the backups aren't running on that Linode.