### PR TITLE
Changed root_ssh_key to authorized_keys

### DIFF
--- a/docs/src/data/endpoints/linodes.yaml
+++ b/docs/src/data/endpoints/linodes.yaml
@@ -57,11 +57,12 @@ endpoints:
               The root password to use when sourcing this Linode from a distribution.
               <ul><li>root_pass is required if the source provided is a distribution.</li></ul>
             type: String
-          root_ssh_key:
+          authorized_keys:
             optional: true
             description: >
-              A public SSH key file to install at `/root/.ssh/authorized_keys` when creating this Linode.
-            type: String
+              An array of public SSH keys to be installed into the distribution's
+              default user's `authorized_keys` file when creating a Linode.
+            type: Array
           stackscript_id:
             optional: true
             description: >
@@ -186,11 +187,13 @@ endpoints:
               Root password to deploy distribution with.
               <ul><li>root_pass is required if a distribution is provided.</li></ul>
             type: String
-          root_ssh_key:
+          authorized_keys:
             optional: unless distribution is not specified
             description: >
-              SSH key to add to root's authorized_keys.
-            type: String
+              An array of public SSH keys to be installed into the distribution's
+              default user's `authorized_keys` file when creating a new disk from
+              a Linode provided distribution.
+            type: Array
           label:
             description: >
               User-friendly string to name this disk.
@@ -956,11 +959,12 @@ endpoints:
             description: >
                 The root password for the new deployment.
             type: String
-          root_ssh_key:
+          authorized_keys:
             optional: true
             description: >
-                The key to authorize for root access to the new deployment.
-            type: String
+              An array of public SSH keys to be installed into the distribution's
+              default user's `authorized_keys` file when rebuilding a Linode.
+            type: Array
           stackscript_id:
             optional: true
             description: >
@@ -1432,7 +1436,7 @@ endpoints:
         response: stats
         oauth: linodes:view
         description: >
-          Returns statistics for the requested month. The last 30 days of 
+          Returns statistics for the requested month. The last 30 days of
           available data will be returned if the current month is requested.
         examples:
           curl: |


### PR DESCRIPTION
You can now deploy as many SSH public key files as you'd like when creating or
rebuilding a Linode or when creating a new Linode Disk image that is based on a
Linode provided Distribution.