### PR TITLE
Don't crash within Notifications if there are no previous Events

### DIFF
--- a/components/dropdowns/Dropdown.js
+++ b/components/dropdowns/Dropdown.js
@@ -52,7 +52,12 @@ export default class Dropdown extends Component {
     const [{ elements: [first] }, ...groups] = this.props.groups;
     const { disabled, dropdownIcon } = this.props;
 
-    const dropdownMenu = groups.map((group, i) => (
+    let allGroups = this.props.groups;
+    if (!this.props.duplicateFirst) {
+      allGroups = groups;
+    }
+
+    const dropdownMenu = allGroups.map((group, i) => (
       <div className="Dropdown-group" key={group.name || i}>
         {!group.name ? null : (
           <div className="Dropdown-groupLabel">{group.name}</div>
@@ -123,6 +128,7 @@ Dropdown.propTypes = {
   leftOriented: PropTypes.bool,
   disabled: PropTypes.bool,
   dropdownIcon: PropTypes.string,
+  duplicateFirst: PropTypes.bool,
   onOpen: PropTypes.func,
   onClose: PropTypes.func,
   analytics: PropTypes.shape({
@@ -133,4 +139,5 @@ Dropdown.propTypes = {
 Dropdown.defaultProps = {
   dropdownIcon: 'fa-caret-down',
   analytics: {},
+  duplicateFirst: true,
 };

--- a/components/scss/components/forms/Select.scss
+++ b/components/scss/components/forms/Select.scss
@@ -1,8 +1,12 @@
 .Select {
     display: inline-block;
 
-    &-control, &-value, &-input {
+    &-mult-value-wrapper {
         height: $form-field-height;
+
+        &-control, &-value, &-input {
+            height: $form-field-height;
+        }
     }
 
     &-label {

--- a/components/scss/components/forms/form.scss
+++ b/components/scss/components/forms/form.scss
@@ -41,9 +41,12 @@ form {
     }
 }
 
+input.form-control {
+    height: $form-field-height;
+}
+
 input.form-control,
 .Select {
-    height: $form-field-height;
     width: 225px;
     max-width: 100%;
 }

--- a/docs/src/getting_started/intros/Introduction.js
+++ b/docs/src/getting_started/intros/Introduction.js
@@ -28,7 +28,9 @@ export default function Introduction() {
         <p>
           All APIv4 endpoints are located at:
         </p>
-        <Code example={`${API_ROOT}/${API_VERSION}/*`} name="bash" noclipboard />
+        <section>
+          <Code example={`${API_ROOT}/${API_VERSION}/*`} name="bash" noclipboard />
+        </section>
         <div className="alert alert-warning" role="alert">
           We will regularly be making releases, some of which will contain breaking
           changes. <Link to={`/${API_VERSION}/changelogs`}>

--- a/src/components/notifications/Notifications.js
+++ b/src/components/notifications/Notifications.js
@@ -68,11 +68,13 @@ export class Notifications extends Component {
     // total results is relative to the last filtered request
     // TODO: review api structure to account for totalResults seen all time vs in last request
     if (events.totalResults > 0 || actionExpectingEvent) {
-      const latest = events.events[events.ids[0]];
-      filterOptions = {
-        ...filterOptions,
-        ...greaterThanDatetimeFilter('created', latest.created),
-      };
+      if (events.ids[0]) {
+        const latest = events.events[events.ids[0]];
+        filterOptions = {
+          ...filterOptions,
+          ...greaterThanDatetimeFilter('created', latest.created),
+        };
+      }
       POLLING.reset();
     }
 

--- a/src/linodes/components/StatusDropdown.js
+++ b/src/linodes/components/StatusDropdown.js
@@ -216,7 +216,7 @@ export default class StatusDropdown extends Component {
 
     return (
       <div className="StatusDropdown StatusDropdown--dropdown">
-        <Dropdown groups={groups} analytics={{ title: 'Linode actions' }} />
+        <Dropdown groups={groups} duplicateFirst={false} analytics={{ title: 'Linode actions' }} />
         <div className="StatusDropdown-container">
           <div
             style={{ width: progressWidth }}

--- a/src/linodes/volumes/components/VolumesList.js
+++ b/src/linodes/volumes/components/VolumesList.js
@@ -82,10 +82,12 @@ export default class VolumesList extends Component {
 
     const groups = [
       { elements: [{ name: 'More Info', action: () => MoreInfo.trigger(dispatch, record) }] },
-      { elements: [{ name: 'Edit', action: () =>
-        AddEditVolume.trigger(dispatch, linodes, record) }] },
-      { elements: [{ name: 'Resize', action: () => ResizeVolume.trigger(dispatch, record) }] },
-      { elements: [record.linode_id === null ?
+      { elements: [
+        { name: 'Edit', action: () =>
+          AddEditVolume.trigger(dispatch, linodes, record) },
+        { name: 'Resize',
+          action: () => ResizeVolume.trigger(dispatch, record) },
+        record.linode_id === null ?
         { name: 'Attach', action: () =>
           AttachVolume.trigger(dispatch, linodes, record) } :
         { name: 'Detach', action: () => this.detachVolumes(record) },

--- a/test/components/Dropdown.spec.js
+++ b/test/components/Dropdown.spec.js
@@ -26,9 +26,9 @@ describe('components/Dropdown', () => {
 
     expect(dropdown.find('.Dropdown-first').text()).to.equal('Drew');
 
-    expect(dropdown.find('.Dropdown-item').length).to.equal(2);
-    expect(dropdown.find('.Dropdown-item').at(0).text()).to.equal('Phil');
-    expect(dropdown.find('.Dropdown-item').at(1).text()).to.equal('Will');
+    expect(dropdown.find('.Dropdown-item').length).to.equal(3);
+    expect(dropdown.find('.Dropdown-item').at(1).text()).to.equal('Phil');
+    expect(dropdown.find('.Dropdown-item').at(2).text()).to.equal('Will');
   });
 
   it('clickable dropdown', () => {
@@ -52,7 +52,7 @@ describe('components/Dropdown', () => {
     // Click toggle should open body
     dropdown.find('.Dropdown-toggle').simulate('click');
     // Click first menu item should trigger clickBodyItem
-    dropdown.find('.Dropdown-item').first().simulate('mousedown');
+    dropdown.find('.Dropdown-item').at(1).simulate('mousedown');
     // Last menu item goes unclicked
 
     expect(clickFirst.callCount).to.equal(1);


### PR DESCRIPTION
The Notifications component updates a module-level api filter using the `latest` event when it's props change. If the user is is new user, then they have no previous Events, and `latest` is set to `undefined` and the app crashes.

For a new user, this can happen in many places, anywhere that a PUT, POST, or DELETE request is made. See:

https://github.com/linode/manager/blob/develop/src/fetch.js#L52 and
https://github.com/linode/manager/blob/develop/src/reducers/events.js#L9
