### PR TITLE
[ Proposal ] Don't Die on Unrecognized Events

### DIFF
--- a/src/components/notifications/NotificationListItem.js
+++ b/src/components/notifications/NotificationListItem.js
@@ -27,7 +27,24 @@ export default function NotificationListItem(props) {
     className += ` ${baseCls}--read`;
   }
 
-  if (timeRemaining !== null && timeRemaining > 0) {
+  if (eventOptions == null) {
+    message = (
+        <div>
+          <div>
+            {`${event.action} `}
+            {entity}
+          </div>
+          <div>
+            <small>
+              <span className="text-muted">
+                <TimeDisplay time={event.created} /> by&nbsp;
+                <strong>{event.username}</strong>
+              </span>
+            </small>
+          </div>
+        </div>
+    );
+  } else if (timeRemaining !== null && timeRemaining > 0) {
     message = (
       <div>
         <div>
@@ -87,9 +104,12 @@ export default function NotificationListItem(props) {
     }
   }
 
+  const eventLink = eventOptions != null ? eventOptions.redirectUrl(event.entity)
+      : '#';
+
   return (
     <Link
-      to={eventOptions.redirectUrl(event.entity)}
+      to={eventLink}
       className={className}
       onClick={() => props.onClick(event)}
     >


### PR DESCRIPTION
This relates to https://github.com/linode/manager/issues/2621

The api adds event actions with most new features, and unless they are
met immediately with a change here, they cause a "This page is broken"
message.  This is a proposal to display a generic event notification for
unrecognized events.  Ideally this would never happen, but realistically
this could provide a stop-gap solution while proper handling for new
events can be implemented, and should reduce downtime.

I will include tests for this if the proposal is approved - I don't want to spend
extra time writing tests if it's going to get shot down.