### PR TITLE
Hide volume linodes and configs when appropriate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ When creating a new feature:
 1. `git checkout develop`
 2. `git checkout -b my-feature-name`
 3. stage and commit changes to your feature branch
-4. `yarn run lint` # to lint your code
+4. `yarn lint` # to lint your code
 5. `yarn test` # to test your code, see 
 6. `git push -u your-remote my-feature-name` # push to your remote and --set-upstream-to
 7. `git checkout develop` and `git pull origin develop` # make sure you're up to date
@@ -139,7 +139,7 @@ Copy relative changes from the [CHANGELOG.md](https://github.com/linode/manager/
 **Tip**: set up your local git repository to lint before every commit.
 ```sh
 echo '#!/usr/bin/env bash' > .git/hooks/pre-commit
-echo 'yarn run lint' >> .git/hooks/pre-commit
+echo 'yarn lint' >> .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
 
@@ -151,11 +151,11 @@ To run tests:
 
 To automatically re-run tests when you make changes:
 
-    yarn run test:watch
+    yarn test:watch
     
 To automatically re-run tests on a single test file:
 
-    yarn run test:watch --single_file=**/name.spec.js
+    yarn test:watch --single_file=**/name.spec.js
 
 Our tests live in test/**.spec.js. They're based on
 [Mocha](https://mochajs.org/) and do assertions with

--- a/src/linodes/volumes/components/AddEditVolume.js
+++ b/src/linodes/volumes/components/AddEditVolume.js
@@ -34,7 +34,7 @@ export default class AddEditVolume extends Component {
     const { volume = {}, linode } = props;
 
     this.state = {
-      linode,
+      linode: linode ? linode.id : null,
       config: null,
       errors: {},
       label: volume.label || '',
@@ -135,6 +135,7 @@ export default class AddEditVolume extends Component {
     const linodeConfigs = [
       ...allConfigs[linode] || configs || {},
     ];
+    const showLinodeConfigs = (existingVolume && (linodeConfigs.length > 1));
 
     if (config === undefined && linodeConfigs[0]) {
       config = linodeConfigs[0].value;
@@ -207,7 +208,7 @@ export default class AddEditVolume extends Component {
               </ModalFormGroup>
             </div>
           )}
-          {linodeConfigs.length === 1 ? null :
+          {!showLinodeConfigs ? null :
             <ModalFormGroup label="Config" id="config" apiKey="config" errors={errors}>
               <Select
                 options={linodeConfigs}

--- a/src/linodes/volumes/components/AddEditVolume.js
+++ b/src/linodes/volumes/components/AddEditVolume.js
@@ -31,10 +31,11 @@ export default class AddEditVolume extends Component {
 
   constructor(props) {
     super(props);
-    const { volume = {}, linode } = props;
+    const { volume = {}, linode, linodes } = props;
 
     this.state = {
-      linode: linode ? linode.id : null,
+      linode,
+      filteredLinodes: linodes,
       config: null,
       errors: {},
       label: volume.label || '',
@@ -79,6 +80,19 @@ export default class AddEditVolume extends Component {
     return dispatch(dispatchOrStoreErrors.call(this, actions));
   }
 
+  onRegionChange = async (e) => {
+    let linodes = { ...this.props.linodes };
+    this.onChange(e);
+
+    linodes = Object.keys(linodes)
+      .filter(id => linodes[id].region === this.state.region)
+      .reduce((obj, key) => {
+        return { ...obj, key: linodes[key] };
+      }, {});
+
+    this.setState({ filteredLinodes: linodes });
+  }
+
   onLinodeChange = async (e) => {
     const { allConfigs } = this.state;
     const linodeId = e.target.value;
@@ -106,8 +120,17 @@ export default class AddEditVolume extends Component {
   }
 
   render() {
-    const { close, title, volume, linode: original, linodes } = this.props;
-    const { errors, region, label, size, linode, allConfigs, config } = this.state;
+    const { close, title, volume, linode: original } = this.props;
+    const {
+      errors,
+      region,
+      label,
+      size,
+      linode,
+      filteredLinodes: linodes,
+      allConfigs,
+      config,
+    } = this.state;
 
     const configs = allConfigs[linode] || [];
 
@@ -149,7 +172,7 @@ export default class AddEditVolume extends Component {
                 value={region}
                 name="region"
                 id="region"
-                onChange={this.onChange}
+                onChange={this.onRegionChange}
               />
             </ModalFormGroup>
           )}

--- a/test/linodes/volumes/components/AddEditVolume.spec.js
+++ b/test/linodes/volumes/components/AddEditVolume.spec.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 import { expect } from 'chai';
@@ -75,16 +74,18 @@ describe('linodes/volumes/components/AddEditVolume', function () {
   });
 
   it('creates a volume and attaches it to selected config', async function () {
-    AddEditVolume.trigger(dispatch, linodes, undefined, testLinode1238);
+    AddEditVolume.trigger(dispatch, linodes);
     const modal = mount(dispatch.firstCall.args[0].body);
     const configId = Object.keys(testLinode1238._configs.configs)[0];
-
-    expect(modal.find('config').length).to.equal(1);
 
     changeInput(modal, 'label', 'my-volume');
     changeInput(modal, 'region', REGION_MAP.Asia[0]);
     changeInput(modal, 'size', 20);
     changeInput(modal, 'linode', testLinode1238.id);
+    modal.instance().setState({
+      allConfigs: { [testLinode1238.id]: Object.values(testLinode1238._configs.configs).map(
+        c => ({ value: c.id, label: c.label })) },
+    });
     changeInput(modal, 'config', configId);
 
     dispatch.reset();

--- a/test/linodes/volumes/components/AddEditVolume.spec.js
+++ b/test/linodes/volumes/components/AddEditVolume.spec.js
@@ -2,7 +2,7 @@ import { mount } from 'enzyme';
 import sinon from 'sinon';
 import { expect } from 'chai';
 
-import { REGION_MAP } from '~/constants';
+import { AVAILABLE_VOLUME_REGIONS } from '~/constants';
 import { AddEditVolume } from '~/linodes/volumes/components';
 
 import { changeInput, expectDispatchOrStoreErrors, expectRequest } from '@/common';
@@ -28,7 +28,7 @@ describe('linodes/volumes/components/AddEditVolume', function () {
     expect(modal.find('config').length).to.equal(0);
 
     changeInput(modal, 'label', 'my-volume');
-    changeInput(modal, 'region', REGION_MAP.Asia[0]);
+    changeInput(modal, 'region', AVAILABLE_VOLUME_REGIONS[0]);
     changeInput(modal, 'size', 20);
 
     dispatch.reset();
@@ -39,7 +39,7 @@ describe('linodes/volumes/components/AddEditVolume', function () {
         method: 'POST',
         body: {
           label: 'my-volume',
-          region: REGION_MAP.Asia[0],
+          region: AVAILABLE_VOLUME_REGIONS[0],
           size: 20,
         },
       }),
@@ -53,7 +53,7 @@ describe('linodes/volumes/components/AddEditVolume', function () {
     expect(modal.find('config').length).to.equal(0);
 
     changeInput(modal, 'label', 'my-volume');
-    changeInput(modal, 'region', REGION_MAP.Asia[0]);
+    changeInput(modal, 'region', AVAILABLE_VOLUME_REGIONS[0]);
     changeInput(modal, 'size', 20);
     changeInput(modal, 'linode', 12345);
 
@@ -65,7 +65,7 @@ describe('linodes/volumes/components/AddEditVolume', function () {
         method: 'POST',
         body: {
           label: 'my-volume',
-          region: REGION_MAP.Asia[0],
+          region: AVAILABLE_VOLUME_REGIONS[0],
           size: 20,
           linode_id: 12345,
         },
@@ -79,7 +79,7 @@ describe('linodes/volumes/components/AddEditVolume', function () {
     const configId = Object.keys(testLinode1238._configs.configs)[0];
 
     changeInput(modal, 'label', 'my-volume');
-    changeInput(modal, 'region', REGION_MAP.Asia[0]);
+    changeInput(modal, 'region', AVAILABLE_VOLUME_REGIONS[0]);
     changeInput(modal, 'size', 20);
     changeInput(modal, 'linode', testLinode1238.id);
     modal.instance().setState({
@@ -96,7 +96,7 @@ describe('linodes/volumes/components/AddEditVolume', function () {
         method: 'POST',
         body: {
           label: 'my-volume',
-          region: REGION_MAP.Asia[0],
+          region: AVAILABLE_VOLUME_REGIONS[0],
           size: 20,
           linode_id: testLinode1238.id,
           config_id: configId,


### PR DESCRIPTION
In the AddEditVolumes modal:
- Hides Linode Config lists when there is only one Linode Config or the volume is already attached
- Filters Linodes to the datacenter of the volume to be created