### PR TITLE
add an angle-down icon to the profile dropdown

### DIFF
--- a/components/scss/components/navigation/Header.scss
+++ b/components/scss/components/navigation/Header.scss
@@ -8,12 +8,7 @@
     height: $nav-height;
     background: $main-header-color;
     font-size: 0;
-
-    a:hover,
-    a:focus,
-    a:active {
-        text-decoration: none;
-    }
+    color: $main-header-color-text;
 
     &-link, &-brand {
         @extend .font-normal;
@@ -33,15 +28,16 @@
     }
     
     &-link {
-        color: $main-header-color-text;
         line-height: $nav-height;
         padding: 0 15px;
+        color: inherit;
 
         &--selected,
         &:hover,
         &:focus,
         &:active {
             color: $main-header-color-text-highlight;
+            text-decoration: none;
         }
 
         &--selected {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -139,6 +139,7 @@ export default class Header extends Component {
               height={35}
               width={35}
             />
+            <i className="fa fa-angle-down fa-fw" />
           </div>
         )}
         {!username ? null : (


### PR DESCRIPTION
In response to feedback, this PR adds a visual indicator that the username and profile image contain a menu.

> ![image](https://user-images.githubusercontent.com/317653/31681833-5b6f08e0-b346-11e7-9d66-5facbc307cc8.png)

I think this particular implementation creates UI conflict with the `Add a Linode` dropdown immediately below this dropdown.

Additionally, for consistency, the caret may need to be included with the notification menu.  This however, creates more visual noise.

> ![image](https://user-images.githubusercontent.com/317653/31682334-c2d1c404-b347-11e7-9994-733e41b8a36c.png)


--
https://github.com/linode/manager/issues/2683 is related
