### PR TITLE
fix css warnings about 100% width container breakpoints

### DIFF
--- a/components/scss/variables.scss
+++ b/components/scss/variables.scss
@@ -71,11 +71,16 @@ $grid-max-width: 1140px;
 
 // Basically just sets each max width to 100%
 $container-max-widths: (
-  sm: 100%,
-  md: 100%,
-  lg: 100%,
   xl: $grid-max-width
 );
+
+@each $breakpoint, $container-max-width in $container-max-widths {
+  @if $breakpoint != 'xl' {
+    $container-max-widths: (
+      $breakpoint: 100%
+    );
+  }
+}
 
 /* END bootstrap overrides */
 


### PR DESCRIPTION
This PR prevents the following warning from being generated on build:
```
WARNING: Invalid value for $container-max-widths: This map must be in ascending order, but key 'md' has value 100% which isn't greater than 100%, the value of the previous key 'sm' !
Backtrace:
        node_modules/bootstrap/scss/_variables.scss:53, in mixin `-assert-ascending`
        node_modules/bootstrap/scss/_variables.scss:226
```

This particular warning appears 6 times when restarting the manager and docs apps, so it is particularly offensive.

( Derived from https://github.com/twbs/bootstrap/issues/22439 )