### PR TITLE
Support docs updates

### DIFF
--- a/docs/src/data/objects/supportticket.yaml
+++ b/docs/src/data/objects/supportticket.yaml
@@ -49,7 +49,7 @@ schema:
     description: The entity this ticket was opened regarding.
     id:
       type: Integer
-      value: 9302
+      value: 123
       description: The entity's ID that this event is for.  This is meaningless without a type.
     label:
       type: String
@@ -71,8 +71,8 @@ schema:
     value: ["screenshot.jpg", "stacktrace.txt"]
   gravatar_id:
     type: String
-    description: The gravatar id of the last user to update this ticket.
-    value: "c3933905f8e430d6a5872b9cf635cf35"
+    description: The gravatar id of the user who opened this ticket.
+    value: "aad889008f120255f1ac47fde3f5338b"
 enums:
   Status:
     new: The support ticket has just been opened.

--- a/docs/src/data/objects/supportticket.yaml
+++ b/docs/src/data/objects/supportticket.yaml
@@ -24,44 +24,55 @@ schema:
     filterable: true
   opened:
     type: Datetime
+    description: The time at which this ticket was opened.
     value: "2017-02-23T11:21:01"
     filterable: true
   closed:
     type: Datetime
+    description: The time at which this ticket was closed.
     value: "2017-02-25T03:20:00"
     filterable: true
   updated:
     type: Datetime
+    description: The time at which this ticket was last updated.
     value: "2017-02-23T11:21:01"
     filterable: true
+  opened_by:
+    type: String
+    value: some_user
+    description: The user who opened this ticket.
   updated_by:
     type: String
     value: some_other_user
     description: The user who last updated this ticket.
   entity:
-    description: The entity this ticket was opened regarding
-    type: Object
+    description: The entity this ticket was opened regarding.
     id:
       type: Integer
       value: 9302
-      description: >
-        The entity's ID that this event is for.  This is meaningless without a type.
+      description: The entity's ID that this event is for.  This is meaningless without a type.
     label:
       type: String
       value: linode123
-      description: >
-        The current label of this object.  This will reflect changes in label.
+      description: The current label of this object.  This will reflect changes in label.
     type:
       type: String
       value: linode
-      description: >
-        The type of entity this is related to.
+      description: The type of entity this is related to.
     url:
       type: String
       value: /v4/linode/instances/123
-      description: >
-        The URL where you can access the object this event is for.  If a relative URL, it is
-        relative to the domain you retrieved the event from.
+      description: The URL where you can access the object this event is for.
+        If a relative URL, it is relative to the domain you retrieved the event from.
+  attachments:
+    type: String
+    isArray: True
+    description: A list of files attached to this ticket.
+    value: ["screenshot.jpg", "stacktrace.txt"]
+  gravatar_id:
+    type: String
+    description: The gravatar id of the last user to update this ticket.
+    value: "c3933905f8e430d6a5872b9cf635cf35"
 enums:
   Status:
     new: The support ticket has just been opened.

--- a/docs/src/data/objects/supportticketreply.yaml
+++ b/docs/src/data/objects/supportticketreply.yaml
@@ -25,5 +25,5 @@ schema:
     value: True
   gravatar_id:
     type: String
-    description: The gravatar id of the last user to update this ticket.
-    value: "c3933905f8e430d6a5872b9cf635cf35"
+    description: The gravatar id of the user who posted this reply.
+    value: "aad889008f120255f1ac47fde3f5338b"

--- a/docs/src/data/objects/supportticketreply.yaml
+++ b/docs/src/data/objects/supportticketreply.yaml
@@ -19,3 +19,11 @@ schema:
     type: String
     value: some_other_user
     description: The user who submitted this reply.
+  from_linode:
+    type: Boolean
+    description: Whether or not this reply is from a linode employee.
+    value: True
+  gravatar_id:
+    type: String
+    description: The gravatar id of the last user to update this ticket.
+    value: "c3933905f8e430d6a5872b9cf635cf35"


### PR DESCRIPTION
#### What:
* Update supportticket:
  * Description for `opened` and `updated`
  * Add missing `opened_by` field
  * Add missing `attachment`s field
  * Add missing `gravatar_id` field
  * Fix issue rendering the `entity` Object by removing its `type` declaration, since it has a key named `type`. The renderer is to blame here.


* Update supportticketreply
  * Add missing `gravatar_id` field
  * Add missing`from_linode` field