### PR TITLE
jscodeshift cleanup in preparation for React 16

### DIFF
--- a/components/breadcrumbs/Breadcrumbs.js
+++ b/components/breadcrumbs/Breadcrumbs.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 export default function Breadcrumbs(props) {

--- a/components/buttons/Button.js
+++ b/components/buttons/Button.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 export default function Button(props) {

--- a/components/buttons/CancelButton.js
+++ b/components/buttons/CancelButton.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import Button from './Button';
 

--- a/components/buttons/ExternalLink.js
+++ b/components/buttons/ExternalLink.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 
 export default function ExternalLink(props) {

--- a/components/buttons/LinkButton.js
+++ b/components/buttons/LinkButton.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import Button from './Button';
 

--- a/components/buttons/PrimaryButton.js
+++ b/components/buttons/PrimaryButton.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Dropdown } from '../dropdowns';
 

--- a/components/cards/Card.js
+++ b/components/cards/Card.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 
 export default function Card(props) {

--- a/components/cards/CardHeader.js
+++ b/components/cards/CardHeader.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function CardHeader(props) {
   return (

--- a/components/cards/CardImageHeader.js
+++ b/components/cards/CardImageHeader.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 
 export default function CardImageHeader(props) {

--- a/components/dropdowns/Dropdown.js
+++ b/components/dropdowns/Dropdown.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 import React, { Component } from 'react';
 
 // Avoid a circular import by importing ../buttons by itself.

--- a/components/editors/CodeEditor.js
+++ b/components/editors/CodeEditor.js
@@ -1,7 +1,8 @@
 import 'brace';
 import 'brace/mode/javascript';
 import 'brace/theme/tomorrow';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import AceEditor from 'react-ace';
 
 

--- a/components/errors/ComingSoon.js
+++ b/components/errors/ComingSoon.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 
 export default function ComingSoon(props) {

--- a/components/errors/Error.js
+++ b/components/errors/Error.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 
 export default function Error(props) {

--- a/components/errors/InternalError.js
+++ b/components/errors/InternalError.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { ExternalLink } from '../buttons';
 import { FormModalBody } from '../modals';

--- a/components/formats/Code.js
+++ b/components/formats/Code.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Highlight from 'react-highlight';
 import ClipboardButton from 'react-clipboard.js';
 

--- a/components/forms/Checkbox.js
+++ b/components/forms/Checkbox.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function Checkbox(props) {
   return (

--- a/components/forms/CheckboxInputCombo.js
+++ b/components/forms/CheckboxInputCombo.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import Checkbox from './Checkbox';
 import Input from './Input';

--- a/components/forms/Checkboxes.js
+++ b/components/forms/Checkboxes.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function Checkboxes(props) {
   return <fieldset className="Checkboxes">{props.children}</fieldset>;

--- a/components/forms/Form.js
+++ b/components/forms/Form.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { EmitEvent, FORM_SUBMIT } from '../utils';
 

--- a/components/forms/FormGroup.js
+++ b/components/forms/FormGroup.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function FormGroup(props) {
   const { errors, name, crumbs } = props;

--- a/components/forms/FormGroupError.js
+++ b/components/forms/FormGroupError.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function FormGroupError(props) {
   const { errors, name, crumbs, inline, className } = props;

--- a/components/forms/FormSummary.js
+++ b/components/forms/FormSummary.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 
 export default class FormSummary extends Component {

--- a/components/forms/Input.js
+++ b/components/forms/Input.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function Input(props) {
   return (

--- a/components/forms/ModalFormGroup.js
+++ b/components/forms/ModalFormGroup.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import FormGroup from './FormGroup';
 import FormGroupError from './FormGroupError';

--- a/components/forms/PasswordInput.js
+++ b/components/forms/PasswordInput.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import Input from './Input';
 

--- a/components/forms/Radio.js
+++ b/components/forms/Radio.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function Radio(props) {
   return (

--- a/components/forms/RadioInputCombo.js
+++ b/components/forms/RadioInputCombo.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import Radio from './Radio';
 import Input from './Input';

--- a/components/forms/RadioSelectCombo.js
+++ b/components/forms/RadioSelectCombo.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import Radio from './Radio';
 import Select from './Select';

--- a/components/forms/Select.js
+++ b/components/forms/Select.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import VendorSelect from 'react-select-plus';
 
 import { EmitEvent, SELECT_CHANGE } from '../utils';

--- a/components/forms/SubmitButton.js
+++ b/components/forms/SubmitButton.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Button } from 'linode-components/buttons';
 

--- a/components/forms/Textarea.js
+++ b/components/forms/Textarea.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 
 export default function Textarea(props) {

--- a/components/lists/List.js
+++ b/components/lists/List.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 export default function List(props) {

--- a/components/lists/ScrollingList.js
+++ b/components/lists/ScrollingList.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function ScrollingList(props) {
   const { items } = props;

--- a/components/lists/bodies/ListBody.js
+++ b/components/lists/bodies/ListBody.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 export default function ListBody(props) {

--- a/components/lists/bodies/ListGroup.js
+++ b/components/lists/bodies/ListGroup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 export default function ListGroup(props) {

--- a/components/lists/controls/MassEditControl.js
+++ b/components/lists/controls/MassEditControl.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import MassEditDropdown from './MassEditDropdown';
 

--- a/components/lists/controls/MassEditDropdown.js
+++ b/components/lists/controls/MassEditDropdown.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import { Dropdown } from '../../dropdowns';
 

--- a/components/lists/headers/ListHeader.js
+++ b/components/lists/headers/ListHeader.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 export default function ListHeader(props) {

--- a/components/modals/DeleteModalBody.js
+++ b/components/modals/DeleteModalBody.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import FormModalBody from './FormModalBody';
 import { ScrollingList } from '../lists';

--- a/components/modals/FormModalBody.js
+++ b/components/modals/FormModalBody.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { CancelButton } from '../buttons';
 import { Form, FormSummary, SubmitButton } from '../forms';

--- a/components/modals/ModalShell.js
+++ b/components/modals/ModalShell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { EmitEvent, MODAL_CLOSE } from '../utils';
 

--- a/components/navigation/Header.js
+++ b/components/navigation/Header.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 
 export default function Header(props) {

--- a/components/tables/Table.js
+++ b/components/tables/Table.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import TableHeaderRow from './TableHeaderRow';
 import TableRow from './TableRow';

--- a/components/tables/TableHeaderCell.js
+++ b/components/tables/TableHeaderCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 export default function TableHeaderCell(props) {

--- a/components/tables/TableHeaderRow.js
+++ b/components/tables/TableHeaderRow.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import TableHeaderCell from './TableHeaderCell';
 

--- a/components/tables/TableRow.js
+++ b/components/tables/TableRow.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import { TableCell, CheckboxCell } from 'linode-components/tables/cells';
 

--- a/components/tables/cells/AnchorCell.js
+++ b/components/tables/cells/AnchorCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import TableCell from './TableCell';
 

--- a/components/tables/cells/ButtonCell.js
+++ b/components/tables/cells/ButtonCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import { Button } from 'linode-components/buttons';
 import TableCell from './TableCell';

--- a/components/tables/cells/CheckboxCell.js
+++ b/components/tables/cells/CheckboxCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import { Checkbox } from 'linode-components/forms';
 import TableCell from './TableCell';

--- a/components/tables/cells/DropdownCell.js
+++ b/components/tables/cells/DropdownCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import { Dropdown } from 'linode-components/dropdowns';
 

--- a/components/tables/cells/InputCell.js
+++ b/components/tables/cells/InputCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import { Input } from 'linode-components/forms';
 import TableCell from './TableCell';
@@ -25,7 +25,7 @@ InputCell.propTypes = {
   placeholder: PropTypes.string,
   record: PropTypes.object.isRequired,
   value: PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.number,
+    PropTypes.string,
+    PropTypes.number,
   ]),
 };

--- a/components/tables/cells/LabelCell.js
+++ b/components/tables/cells/LabelCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 import { Tooltip } from '../../tooltips';

--- a/components/tables/cells/LinkCell.js
+++ b/components/tables/cells/LinkCell.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import { Tooltip } from '../../tooltips';
 import TableCell from './TableCell';

--- a/components/tables/cells/TableCell.js
+++ b/components/tables/cells/TableCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 export default function TableCell(props) {

--- a/components/tables/cells/ThumbnailCell.js
+++ b/components/tables/cells/ThumbnailCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import TableCell from './TableCell';
 

--- a/components/tabs/Tabs.js
+++ b/components/tabs/Tabs.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import { Tab, Tabs as ReactTabs, TabList, TabPanel } from 'react-tabs';
 import { Link } from 'react-router';

--- a/components/tooltips/Tooltip.js
+++ b/components/tooltips/Tooltip.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import ReactTooltip from 'react-tooltip';
 
 

--- a/docs/src/RoutesGenerator.js
+++ b/docs/src/RoutesGenerator.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Route } from 'react-router';
 
 import {

--- a/docs/src/components/Endpoint.js
+++ b/docs/src/components/Endpoint.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 import { Breadcrumbs } from 'linode-components/breadcrumbs';

--- a/docs/src/components/EndpointIndex.js
+++ b/docs/src/components/EndpointIndex.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Breadcrumbs } from 'linode-components/breadcrumbs';
 import { Table } from 'linode-components/tables';

--- a/docs/src/components/Library.js
+++ b/docs/src/components/Library.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Breadcrumbs } from 'linode-components/breadcrumbs';
 import { Table } from 'linode-components/tables';

--- a/docs/src/components/Method.js
+++ b/docs/src/components/Method.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { default as UseExample } from './UseExample';
 import { default as SpecExample } from './SpecExample';

--- a/docs/src/components/Spec.js
+++ b/docs/src/components/Spec.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Table, TableRow } from 'linode-components/tables';
 import { Code } from 'linode-components/formats';

--- a/docs/src/components/SpecExample.js
+++ b/docs/src/components/SpecExample.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Code } from 'linode-components/formats';
 

--- a/docs/src/components/UseExample.js
+++ b/docs/src/components/UseExample.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Tabs } from 'linode-components/tabs';
 import { Code } from 'linode-components/formats';

--- a/docs/src/components/VerticalNav.js
+++ b/docs/src/components/VerticalNav.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 
 export default function VerticalNav(props) {

--- a/docs/src/components/VerticalNavSection.js
+++ b/docs/src/components/VerticalNavSection.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Link } from 'react-router';
 
 

--- a/docs/src/components/tables/cells/DescriptionCell.js
+++ b/docs/src/components/tables/cells/DescriptionCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 import { Link } from 'react-router';
 import { API_VERSION } from '~/constants';
 

--- a/docs/src/components/tables/cells/ExampleCell.js
+++ b/docs/src/components/tables/cells/ExampleCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 import { Code } from 'linode-components/formats';
 

--- a/docs/src/components/tables/cells/FieldCell.js
+++ b/docs/src/components/tables/cells/FieldCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 export default function FieldCell(props) {

--- a/docs/src/components/tables/cells/NestedParentCell.js
+++ b/docs/src/components/tables/cells/NestedParentCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 export default function NestedParentCell(props) {

--- a/docs/src/components/tables/cells/ParamFieldCell.js
+++ b/docs/src/components/tables/cells/ParamFieldCell.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 export default function ParamFieldCell(props) {

--- a/docs/src/getting_started/guides/GuidesIndex.js
+++ b/docs/src/getting_started/guides/GuidesIndex.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Breadcrumbs } from 'linode-components/breadcrumbs';
 import { Table } from 'linode-components/tables';

--- a/docs/src/getting_started/guides/curl/CreateLinode.js
+++ b/docs/src/getting_started/guides/curl/CreateLinode.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 import { Breadcrumbs } from 'linode-components/breadcrumbs';

--- a/docs/src/getting_started/guides/curl/TestingWithCurl.js
+++ b/docs/src/getting_started/guides/curl/TestingWithCurl.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 import { ExternalLink } from 'linode-components/buttons';

--- a/docs/src/getting_started/guides/python/CoreConcepts.js
+++ b/docs/src/getting_started/guides/python/CoreConcepts.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 import { Breadcrumbs } from 'linode-components/breadcrumbs';

--- a/docs/src/getting_started/guides/python/Introduction.js
+++ b/docs/src/getting_started/guides/python/Introduction.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 import { Breadcrumbs } from 'linode-components/breadcrumbs';

--- a/docs/src/getting_started/guides/python/OAuthWorkflow.js
+++ b/docs/src/getting_started/guides/python/OAuthWorkflow.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 import { Breadcrumbs } from 'linode-components/breadcrumbs';

--- a/docs/src/layouts/IndexLayout.js
+++ b/docs/src/layouts/IndexLayout.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 
 export default function IndexLayout(props) {

--- a/docs/src/layouts/Layout.js
+++ b/docs/src/layouts/Layout.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Link } from 'react-router';
 
 import { Header } from 'linode-components/navigation';

--- a/docs/src/libraries/python/Python.js
+++ b/docs/src/libraries/python/Python.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { ExternalLink } from 'linode-components/buttons';
 import { Table } from 'linode-components/tables';

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 export default function Breadcrumbs(props) {

--- a/src/components/CreateHelper.js
+++ b/src/components/CreateHelper.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 export default function CreateHelper({ label, href, linkText, onClick }) {

--- a/src/components/GroupLabel.js
+++ b/src/components/GroupLabel.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function GroupLabel(props) {
   if (props.object.group) {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Link } from 'react-router';
 
 import { Header as HeaderWrapper } from 'linode-components/navigation';

--- a/src/components/PreloadIndicator.js
+++ b/src/components/PreloadIndicator.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 
 export function PreloadIndicator(props) {

--- a/src/components/RegionSelect.js
+++ b/src/components/RegionSelect.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { ExternalLink } from 'linode-components/buttons';
 import { Select } from 'linode-components/forms';

--- a/src/components/SessionMenu.js
+++ b/src/components/SessionMenu.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 import { ExternalLink } from 'linode-components/buttons';

--- a/src/components/TimeDisplay.js
+++ b/src/components/TimeDisplay.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import moment from 'moment-timezone';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { getStorage } from '~/storage';
 

--- a/src/components/TransferPool.js
+++ b/src/components/TransferPool.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Card, CardHeader } from 'linode-components/cards';
 

--- a/src/components/graphs/GraphGroup.js
+++ b/src/components/graphs/GraphGroup.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Select } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/components/graphs/LineGraph.js
+++ b/src/components/graphs/LineGraph.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import Chart from 'chart.js';
 import _ from 'lodash';

--- a/src/components/notifications/NotificationList.js
+++ b/src/components/notifications/NotificationList.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import NotificationListItem from './NotificationListItem';
 

--- a/src/components/notifications/NotificationListItem.js
+++ b/src/components/notifications/NotificationListItem.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Link } from 'react-router';
 import TimeDisplay from '~/components/TimeDisplay';

--- a/src/components/notifications/Notifications.js
+++ b/src/components/notifications/Notifications.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import api from '~/api';

--- a/src/components/tables/cells/AuthScopeCell.js
+++ b/src/components/tables/cells/AuthScopeCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import _ from 'lodash';
 import { OAUTH_SUBSCOPES } from '~/constants';

--- a/src/components/tables/cells/BackupsCell.js
+++ b/src/components/tables/cells/BackupsCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { LinkCell } from 'linode-components/tables/cells';
 

--- a/src/components/tables/cells/IPAddressCell.js
+++ b/src/components/tables/cells/IPAddressCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 
 import { TableCell } from 'linode-components/tables/cells';

--- a/src/components/tables/cells/IPRdnsCell.js
+++ b/src/components/tables/cells/IPRdnsCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { TableCell } from 'linode-components/tables/cells';
 

--- a/src/components/tables/cells/LastBackupCell.js
+++ b/src/components/tables/cells/LastBackupCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { TableCell } from 'linode-components/tables/cells';
 import TimeDisplay from '~/components/TimeDisplay';

--- a/src/components/tables/cells/NameserversCell.js
+++ b/src/components/tables/cells/NameserversCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Dropdown } from 'linode-components/dropdowns';
 import { TableCell } from 'linode-components/tables/cells';

--- a/src/components/tables/cells/RegionCell.js
+++ b/src/components/tables/cells/RegionCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { TableCell } from 'linode-components/tables/cells';
 import Region from '~/linodes/components/Region';

--- a/src/components/tables/cells/TimeCell.js
+++ b/src/components/tables/cells/TimeCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { TableCell } from 'linode-components/tables/cells';
 

--- a/src/domains/components/AddMaster.js
+++ b/src/domains/components/AddMaster.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';

--- a/src/domains/components/AddSlave.js
+++ b/src/domains/components/AddSlave.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { Input, ModalFormGroup, Textarea } from 'linode-components/forms';

--- a/src/domains/components/EditARecord.js
+++ b/src/domains/components/EditARecord.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/domains/components/EditCNAMERecord.js
+++ b/src/domains/components/EditCNAMERecord.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/domains/components/EditMXRecord.js
+++ b/src/domains/components/EditMXRecord.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { ModalFormGroup, Input } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/domains/components/EditNSRecord.js
+++ b/src/domains/components/EditNSRecord.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/domains/components/EditSOARecord.js
+++ b/src/domains/components/EditSOARecord.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { replace } from 'react-router-redux';
 
 import { Input, ModalFormGroup, Select, Textarea } from 'linode-components/forms';

--- a/src/domains/components/EditSRVRecord.js
+++ b/src/domains/components/EditSRVRecord.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup, Select } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/domains/components/EditTXTRecord.js
+++ b/src/domains/components/EditTXTRecord.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/domains/components/MasterZone.js
+++ b/src/domains/components/MasterZone.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 

--- a/src/domains/components/SelectDNSSeconds.js
+++ b/src/domains/components/SelectDNSSeconds.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Select } from 'linode-components/forms';
 

--- a/src/domains/components/SlaveZone.js
+++ b/src/domains/components/SlaveZone.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 

--- a/src/domains/layouts/IndexPage.js
+++ b/src/domains/layouts/IndexPage.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { PrimaryButton } from 'linode-components/buttons';

--- a/src/domains/layouts/ZonePage.js
+++ b/src/domains/layouts/ZonePage.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { setAnalytics, setSource, setTitle } from '~/actions';

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { ExternalLink } from 'linode-components/buttons';

--- a/src/layouts/Logout.js
+++ b/src/layouts/Logout.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { logout } from '~/actions/authentication';

--- a/src/layouts/OAuth.js
+++ b/src/layouts/OAuth.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 

--- a/src/linodes/components/AddLinode.js
+++ b/src/linodes/components/AddLinode.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { Input, ModalFormGroup, PasswordInput } from 'linode-components/forms';

--- a/src/linodes/components/Backup.js
+++ b/src/linodes/components/Backup.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import TimeDisplay from '~/components/TimeDisplay';
 
 export default function Backup(props) {

--- a/src/linodes/components/BackupSelect.js
+++ b/src/linodes/components/BackupSelect.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import moment from 'moment-timezone';
 import { Select } from 'linode-components/forms';

--- a/src/linodes/components/BackupsCheckbox.js
+++ b/src/linodes/components/BackupsCheckbox.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { ExternalLink } from 'linode-components/buttons';
 import { Checkbox } from 'linode-components/forms';

--- a/src/linodes/components/CloneLinode.js
+++ b/src/linodes/components/CloneLinode.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';

--- a/src/linodes/components/ConfigSelectModalBody.js
+++ b/src/linodes/components/ConfigSelectModalBody.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { ModalFormGroup, Radio } from 'linode-components/forms';
 import { FormModalBody } from 'linode-components/modals';

--- a/src/linodes/components/DistributionSelect.js
+++ b/src/linodes/components/DistributionSelect.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { ExternalLink } from 'linode-components/buttons';
 import { Select } from 'linode-components/forms';

--- a/src/linodes/components/DistroStyle.js
+++ b/src/linodes/components/DistroStyle.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { distros as distroAssets } from '~/assets';
 

--- a/src/linodes/components/LinodeSelect.js
+++ b/src/linodes/components/LinodeSelect.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Select } from 'linode-components/forms';
 

--- a/src/linodes/components/PlanSelect.js
+++ b/src/linodes/components/PlanSelect.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { ExternalLink } from 'linode-components/buttons';
 import { Select } from 'linode-components/forms';

--- a/src/linodes/components/PlanStyle.js
+++ b/src/linodes/components/PlanStyle.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 
 export function planStyle(plan, withPrice = false) {

--- a/src/linodes/components/Region.js
+++ b/src/linodes/components/Region.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { flags } from '~/assets';
 

--- a/src/linodes/components/RestoreLinode.js
+++ b/src/linodes/components/RestoreLinode.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';

--- a/src/linodes/components/StatusDropdown.js
+++ b/src/linodes/components/StatusDropdown.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { Dropdown } from 'linode-components/dropdowns';

--- a/src/linodes/components/StatusDropdownCell.js
+++ b/src/linodes/components/StatusDropdownCell.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { TableCell } from 'linode-components/tables/cells';
 import StatusDropdown from './StatusDropdown';

--- a/src/linodes/components/WeblishLaunch.js
+++ b/src/linodes/components/WeblishLaunch.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Button } from 'linode-components/buttons';
 

--- a/src/linodes/layouts/IndexPage.js
+++ b/src/linodes/layouts/IndexPage.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { PrimaryButton } from 'linode-components/buttons';

--- a/src/linodes/linode/backups/components/BackupDetails.js
+++ b/src/linodes/linode/backups/components/BackupDetails.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Card, CardHeader } from 'linode-components/cards';
 import { Form, FormGroup, SubmitButton } from 'linode-components/forms';

--- a/src/linodes/linode/backups/components/BackupRestore.js
+++ b/src/linodes/linode/backups/components/BackupRestore.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/backups/components/CancelForm.js
+++ b/src/linodes/linode/backups/components/CancelForm.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Form, FormSummary, SubmitButton } from 'linode-components/forms';
 import { FormModalBody } from 'linode-components/modals';

--- a/src/linodes/linode/backups/components/ScheduleForm.js
+++ b/src/linodes/linode/backups/components/ScheduleForm.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import {
   Form,

--- a/src/linodes/linode/backups/components/TakeSnapshot.js
+++ b/src/linodes/linode/backups/components/TakeSnapshot.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { ModalFormGroup, Input } from 'linode-components/forms';

--- a/src/linodes/linode/backups/layouts/BackupPage.js
+++ b/src/linodes/linode/backups/layouts/BackupPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import api from '~/api';

--- a/src/linodes/linode/backups/layouts/IndexPage.js
+++ b/src/linodes/linode/backups/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { push } from 'react-router-redux';

--- a/src/linodes/linode/backups/layouts/SettingsPage.js
+++ b/src/linodes/linode/backups/layouts/SettingsPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/backups/layouts/SummaryPage.js
+++ b/src/linodes/linode/backups/layouts/SummaryPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 

--- a/src/linodes/linode/components/DeviceSelect.js
+++ b/src/linodes/linode/components/DeviceSelect.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { FormGroup, FormGroupError, Select } from 'linode-components/forms';
 

--- a/src/linodes/linode/components/RescueMode.js
+++ b/src/linodes/linode/components/RescueMode.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Card, CardHeader } from 'linode-components/cards';
 import {

--- a/src/linodes/linode/components/ResetRootPassword.js
+++ b/src/linodes/linode/components/ResetRootPassword.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Card, CardHeader } from 'linode-components/cards';
 import {

--- a/src/linodes/linode/components/UpgradeToKVM.js
+++ b/src/linodes/linode/components/UpgradeToKVM.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { ExternalLink } from 'linode-components/buttons';
 import { ConfirmModalBody } from 'linode-components/modals';

--- a/src/linodes/linode/layouts/DashboardPage.js
+++ b/src/linodes/linode/layouts/DashboardPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 

--- a/src/linodes/linode/layouts/IndexPage.js
+++ b/src/linodes/linode/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { Link } from 'react-router';

--- a/src/linodes/linode/layouts/RebuildPage.js
+++ b/src/linodes/linode/layouts/RebuildPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/layouts/RescuePage.js
+++ b/src/linodes/linode/layouts/RescuePage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { setSource } from '~/actions/source';

--- a/src/linodes/linode/layouts/ResizePage.js
+++ b/src/linodes/linode/layouts/ResizePage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/layouts/Weblish.js
+++ b/src/linodes/linode/layouts/Weblish.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 

--- a/src/linodes/linode/networking/components/AddIP.js
+++ b/src/linodes/linode/networking/components/AddIP.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Link } from 'react-router';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';

--- a/src/linodes/linode/networking/components/EditRDNS.js
+++ b/src/linodes/linode/networking/components/EditRDNS.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/linodes/linode/networking/components/IPList.js
+++ b/src/linodes/linode/networking/components/IPList.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Table } from 'linode-components/tables';
 import { CheckboxCell } from 'linode-components/tables/cells';

--- a/src/linodes/linode/networking/components/MoreInfo.js
+++ b/src/linodes/linode/networking/components/MoreInfo.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { ExternalLink } from 'linode-components/buttons';
 import { ModalFormGroup, Input, Textarea } from 'linode-components/forms';

--- a/src/linodes/linode/networking/layouts/DNSResolversPage.js
+++ b/src/linodes/linode/networking/layouts/DNSResolversPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/networking/layouts/IPSharingPage.js
+++ b/src/linodes/linode/networking/layouts/IPSharingPage.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/networking/layouts/IPTransferPage.js
+++ b/src/linodes/linode/networking/layouts/IPTransferPage.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/networking/layouts/IndexPage.js
+++ b/src/linodes/linode/networking/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { push } from 'react-router-redux';

--- a/src/linodes/linode/networking/layouts/SummaryPage.js
+++ b/src/linodes/linode/networking/layouts/SummaryPage.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { PrimaryButton } from 'linode-components/buttons';

--- a/src/linodes/linode/settings/advanced/components/AddDisk.js
+++ b/src/linodes/linode/settings/advanced/components/AddDisk.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup, PasswordInput, Select } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/linodes/linode/settings/advanced/components/Configs.js
+++ b/src/linodes/linode/settings/advanced/components/Configs.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { PrimaryButton } from 'linode-components/buttons';
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/settings/advanced/components/CreateOrEditConfig.js
+++ b/src/linodes/linode/settings/advanced/components/CreateOrEditConfig.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { CancelButton, ExternalLink } from 'linode-components/buttons';

--- a/src/linodes/linode/settings/advanced/components/Disks.js
+++ b/src/linodes/linode/settings/advanced/components/Disks.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { PrimaryButton } from 'linode-components/buttons';
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/settings/advanced/components/EditDisk.js
+++ b/src/linodes/linode/settings/advanced/components/EditDisk.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { ModalFormGroup, Input } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/linodes/linode/settings/advanced/components/Volumes.js
+++ b/src/linodes/linode/settings/advanced/components/Volumes.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { PrimaryButton } from 'linode-components/buttons';
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/settings/advanced/layouts/AddConfigPage.js
+++ b/src/linodes/linode/settings/advanced/layouts/AddConfigPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/settings/advanced/layouts/AdvancedPage.js
+++ b/src/linodes/linode/settings/advanced/layouts/AdvancedPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { setSource } from '~/actions/source';

--- a/src/linodes/linode/settings/advanced/layouts/EditConfigPage.js
+++ b/src/linodes/linode/settings/advanced/layouts/EditConfigPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 

--- a/src/linodes/linode/settings/advanced/layouts/IndexPage.js
+++ b/src/linodes/linode/settings/advanced/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 
 import api from '~/api';

--- a/src/linodes/linode/settings/layouts/AlertsPage.js
+++ b/src/linodes/linode/settings/layouts/AlertsPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/linodes/linode/settings/layouts/DisplayPage.js
+++ b/src/linodes/linode/settings/layouts/DisplayPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 

--- a/src/linodes/linode/settings/layouts/IndexPage.js
+++ b/src/linodes/linode/settings/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { push } from 'react-router-redux';

--- a/src/linodes/stackscripts/components/AddStackScript.js
+++ b/src/linodes/stackscripts/components/AddStackScript.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';

--- a/src/linodes/stackscripts/components/Editor.js
+++ b/src/linodes/stackscripts/components/Editor.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { CodeEditor } from 'linode-components/editors';
 import {

--- a/src/linodes/stackscripts/components/Settings.js
+++ b/src/linodes/stackscripts/components/Settings.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import {
   Checkbox,

--- a/src/linodes/stackscripts/layouts/IndexPage.js
+++ b/src/linodes/stackscripts/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { PrimaryButton } from 'linode-components/buttons';

--- a/src/linodes/stackscripts/layouts/StackScriptPage.js
+++ b/src/linodes/stackscripts/layouts/StackScriptPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 

--- a/src/linodes/volumes/components/AddEditVolume.js
+++ b/src/linodes/volumes/components/AddEditVolume.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Link } from 'react-router';
 
 import { Input, ModalFormGroup, Select } from 'linode-components/forms';

--- a/src/linodes/volumes/components/AttachVolume.js
+++ b/src/linodes/volumes/components/AttachVolume.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { ModalFormGroup, Select } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';
@@ -87,7 +88,7 @@ export default class AttachVolume extends Component {
     ) : null;
 
     const linodeConfigs = [
-      ...allConfigs[linode] || configs || {},
+      ...(allConfigs[linode] || configs || {}),
     ];
 
     if (config === undefined && linodeConfigs[0]) {

--- a/src/linodes/volumes/components/MoreInfo.js
+++ b/src/linodes/volumes/components/MoreInfo.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { ExternalLink } from 'linode-components/buttons';
 import { Code } from 'linode-components/formats';

--- a/src/linodes/volumes/components/ResizeVolume.js
+++ b/src/linodes/volumes/components/ResizeVolume.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/linodes/volumes/components/VolumesList.js
+++ b/src/linodes/volumes/components/VolumesList.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { LinkButton } from 'linode-components/buttons';
 import { Dropdown } from 'linode-components/dropdowns';

--- a/src/linodes/volumes/layouts/IndexPage.js
+++ b/src/linodes/volumes/layouts/IndexPage.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { PrimaryButton } from 'linode-components/buttons';

--- a/src/nodebalancers/components/AddNodeBalancer.js
+++ b/src/nodebalancers/components/AddNodeBalancer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';

--- a/src/nodebalancers/layouts/IndexPage.js
+++ b/src/nodebalancers/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { PrimaryButton } from 'linode-components/buttons';

--- a/src/nodebalancers/nodebalancer/components/ConfigForm.js
+++ b/src/nodebalancers/nodebalancer/components/ConfigForm.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import {

--- a/src/nodebalancers/nodebalancer/configs/components/NodeModal.js
+++ b/src/nodebalancers/nodebalancer/configs/components/NodeModal.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { ModalFormGroup, Input, Select } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/nodebalancers/nodebalancer/configs/layouts/DashboardPage.js
+++ b/src/nodebalancers/nodebalancer/configs/layouts/DashboardPage.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { ListBody } from 'linode-components/lists/bodies';

--- a/src/nodebalancers/nodebalancer/configs/layouts/EditConfigPage.js
+++ b/src/nodebalancers/nodebalancer/configs/layouts/EditConfigPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 

--- a/src/nodebalancers/nodebalancer/configs/layouts/IndexPage.js
+++ b/src/nodebalancers/nodebalancer/configs/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import { push } from 'react-router-redux';

--- a/src/nodebalancers/nodebalancer/layouts/AddConfigPage.js
+++ b/src/nodebalancers/nodebalancer/layouts/AddConfigPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { ExternalLink } from 'linode-components/buttons';

--- a/src/nodebalancers/nodebalancer/layouts/DashboardPage.js
+++ b/src/nodebalancers/nodebalancer/layouts/DashboardPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { PrimaryButton } from 'linode-components/buttons';

--- a/src/nodebalancers/nodebalancer/layouts/IndexPage.js
+++ b/src/nodebalancers/nodebalancer/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import { push } from 'react-router-redux';

--- a/src/nodebalancers/nodebalancer/layouts/SettingsPage.js
+++ b/src/nodebalancers/nodebalancer/layouts/SettingsPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 

--- a/src/profile/components/ChangeEmail.js
+++ b/src/profile/components/ChangeEmail.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Card, CardHeader } from 'linode-components/cards';
 import {

--- a/src/profile/components/ChangePassword.js
+++ b/src/profile/components/ChangePassword.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Card, CardHeader } from 'linode-components/cards';
 import {

--- a/src/profile/components/ChangeTimezone.js
+++ b/src/profile/components/ChangeTimezone.js
@@ -1,5 +1,6 @@
 import moment from 'moment-timezone';
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Card, CardHeader } from 'linode-components/cards';
 import {

--- a/src/profile/components/CreateOrEditApplication.js
+++ b/src/profile/components/CreateOrEditApplication.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/profile/components/CreatePersonalAccessToken.js
+++ b/src/profile/components/CreatePersonalAccessToken.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup, Select } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/profile/components/EditPersonalAccessToken.js
+++ b/src/profile/components/EditPersonalAccessToken.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Input, ModalFormGroup } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/profile/components/SelectExpiration.js
+++ b/src/profile/components/SelectExpiration.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import moment from 'moment';
 
 import { Select } from 'linode-components/forms';

--- a/src/profile/components/TokenMoreInfo.js
+++ b/src/profile/components/TokenMoreInfo.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { ConfirmModalBody } from 'linode-components/modals';
 import { Table } from 'linode-components/tables';

--- a/src/profile/components/TwoFactor.js
+++ b/src/profile/components/TwoFactor.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Card, CardHeader } from 'linode-components/cards';
 import { Form, FormSummary, SubmitButton } from 'linode-components/forms';

--- a/src/profile/components/TwoFactorModal.js
+++ b/src/profile/components/TwoFactorModal.js
@@ -1,5 +1,6 @@
+import PropTypes from 'prop-types';
 import QRious from 'qrious';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 
 import { ModalFormGroup, Input } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';

--- a/src/profile/layouts/APITokensPage.js
+++ b/src/profile/layouts/APITokensPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { PrimaryButton } from 'linode-components/buttons';

--- a/src/profile/layouts/AuthenticationPage.js
+++ b/src/profile/layouts/AuthenticationPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import { ChangePassword, TwoFactor } from '../components';

--- a/src/profile/layouts/DisplayPage.js
+++ b/src/profile/layouts/DisplayPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import { ChangeTimezone, ChangeEmail } from '../components';

--- a/src/profile/layouts/IndexPage.js
+++ b/src/profile/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 

--- a/src/profile/layouts/LishPage.js
+++ b/src/profile/layouts/LishPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/profile/layouts/MyAPIClientsPage.js
+++ b/src/profile/layouts/MyAPIClientsPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { PrimaryButton } from 'linode-components/buttons';

--- a/src/profile/layouts/NotificationsPage.js
+++ b/src/profile/layouts/NotificationsPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/profile/layouts/ReferralsPage.js
+++ b/src/profile/layouts/ReferralsPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/settings/layouts/IndexPage.js
+++ b/src/settings/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card, CardHeader } from 'linode-components/cards';

--- a/src/support/components/TicketHelper.js
+++ b/src/support/components/TicketHelper.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import { Card, CardHeader } from 'linode-components/cards';
 import { ExternalLink, LinkButton } from 'linode-components/buttons';

--- a/src/support/components/TicketReply.js
+++ b/src/support/components/TicketReply.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Card, CardImageHeader } from 'linode-components/cards';
 import TimeDisplay from '~/components/TimeDisplay';

--- a/src/support/layouts/CreatePage.js
+++ b/src/support/layouts/CreatePage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import { push } from 'react-router-redux';

--- a/src/support/layouts/IndexPage.js
+++ b/src/support/layouts/IndexPage.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 

--- a/src/support/layouts/TicketPage.js
+++ b/src/support/layouts/TicketPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 

--- a/src/users/components/AddUser.js
+++ b/src/users/components/AddUser.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import { Checkboxes, Input, ModalFormGroup, PasswordInput, Radio } from 'linode-components/forms';

--- a/src/users/components/UserForm.js
+++ b/src/users/components/UserForm.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { push } from 'react-router-redux';
 
 import {

--- a/src/users/layouts/IndexPage.js
+++ b/src/users/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { PrimaryButton } from 'linode-components/buttons';

--- a/src/users/user/components/PermissionsTable.js
+++ b/src/users/user/components/PermissionsTable.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { Table } from 'linode-components/tables';
 import { CheckboxCell, LabelCell } from 'linode-components/tables/cells';

--- a/src/users/user/layouts/EditUserPage.js
+++ b/src/users/user/layouts/EditUserPage.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import { Card } from 'linode-components/cards';

--- a/src/users/user/layouts/IndexPage.js
+++ b/src/users/user/layouts/IndexPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import { push } from 'react-router-redux';

--- a/src/users/user/layouts/PermissionsPage.js
+++ b/src/users/user/layouts/PermissionsPage.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { Card } from 'linode-components/cards';

--- a/styleguide/src/StyleguideNav.js
+++ b/styleguide/src/StyleguideNav.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 import { Link } from 'react-router';
 
 import { VerticalNav, VerticalNavSection } from 'linode-components/navigation';

--- a/styleguide/src/components/StyleguideSection.js
+++ b/styleguide/src/components/StyleguideSection.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropTypes } from 'prop-types';
+import 'prop-types';
 
 
 export default function StyleguideSection(props) {


### PR DESCRIPTION
This PR intends to apply the follow jscodeshift transforms:
- [] `jscodeshift -t react-codemod/transforms/React-PropTypes-to-prop-types.js`
- [] `jscodeshift -t react-codemod/transforms/manual-bind-to-arrow.js`
- [] `jscodeshift -t react-codemod/transforms/pure-component.js`
- [] `jscodeshift -t react-codemod/transforms/sort-comp.js`

I'm doing this in a checklist to ensure a clean build at each step.