### PR TITLE
better padding for anchor text highlight

### DIFF
--- a/docs/scss/docs/Docs.scss
+++ b/docs/scss/docs/Docs.scss
@@ -9,6 +9,15 @@
         padding: 0;
     }
 
+    h3 {
+        padding: 5px 0;
+    }
+
+    .highlight h3 {
+        padding: 5px 0 5px 5px;
+        margin: 0 0 0 -5px;
+    }
+
     table {
         margin-bottom: 15px;
     }

--- a/docs/scss/layout.scss
+++ b/docs/scss/layout.scss
@@ -12,9 +12,5 @@ body {
     transition: background .5s;
 }
 
-.highlight h3 {
-    padding: 5px;
-}
-
 $sidebar-breakpoint: 1000px;
 $table-breakpoint: 768px;

--- a/docs/scss/layout.scss
+++ b/docs/scss/layout.scss
@@ -12,5 +12,9 @@ body {
     transition: background .5s;
 }
 
+.highlight h3 {
+    padding: 5px;
+}
+
 $sidebar-breakpoint: 1000px;
 $table-breakpoint: 768px;


### PR DESCRIPTION
<img width="735" alt="screen shot 2017-11-08 at 1 27 28 pm" src="https://user-images.githubusercontent.com/2124557/32567240-b178e7e4-c488-11e7-89a6-d73d5cdcea74.png">
<img width="817" alt="screen shot 2017-11-08 at 1 27 22 pm" src="https://user-images.githubusercontent.com/2124557/32567241-b18486ee-c488-11e7-9087-fd54974c3df9.png">
