### PR TITLE
Document changes to UserGrant structure

### DIFF
--- a/docs/src/data/endpoints/account.yaml
+++ b/docs/src/data/endpoints/account.yaml
@@ -348,7 +348,13 @@ endpoints:
                 -X PUT -d '{
                     "global": {
                         "add_linodes": true
-                    }
+                    },
+                    "linodes": {[
+                        {
+                            "id": 123,
+                            "permissions": "read_only"
+                        }
+                    ]}
                 }' \
                 https://$api_root/$version/account/users/testguy/grants
           python: |

--- a/docs/src/data/objects/usergrants.yaml
+++ b/docs/src/data/objects/usergrants.yaml
@@ -29,96 +29,175 @@ schema:
       type: Boolean
       value: true
       description: If this user may manage longview subscription.
-  customer:
-    type: Object
-    description: Grants related to modifying the account.
-    access:
+    add_images:
+      type: Boolean
+      value: true
+      description: If this user may create images.
+    add_volumes:
+      type: Boolean
+      value: true
+      description: If this user may create volumes.
+    account_access:
+      type: Enum
+      subtype: GrantLevel
+      value: read_write
+      description: >
+        The level of access this user has to account information.  read_only gives
+        access to view billing and payment history, read_write gives access to
+        make payments, and null is no access.
+    cancel_account:
       type: Boolean
       value: false
-      description: If this user may modify the account.
-    cancel:
-      type: Boolean
-      value: false
-      description: If this user may cancel the account.
+      description: If this user may cancel the entire account.
   stackscript:
     type: Object
     isArray: true
-    description: Individual grants to StackScripts you own.  Grants include all, use, edit and delete
-    all:
-      type: Boolean
-      value: false
-    edit:
-      type: Boolean
-      value: true
-    delete:
-      type: Boolean
-      value: false
+    description: Individual grants this user has to StackScripts you own.
     id:
       type: Boolean
-      value: 123
+      value: 456
     label:
       type: string
       value: Wordpress
-    use:
-      type: Boolean
-      value: false
+    permissions:
+      type: Enum
+      subtype: GrantLevel
+      value: read_only
+      description: >
+        The level of access this user has to this StackScript.  null
+        is no access, read_only allows viewing and deploying from the stackscript,
+        and read_write allows making revisions.
   nodebalancer:
     type: object
     isArray: true
-    description: Individual grants to NodeBalancers you own.  Grants inlcude all, access, and delete
-    all:
-      type: Boolean
-      value: false
-    access:
-      type: Boolean
-      value: true
-    delete:
-      type: Boolean
-      value: false
+    description: Individual grants this user has to NodeBalancers you own.
     id:
       type: Integer
-      value: 123
+      value: 567
     label:
       type: String
       value: linode123
+    permissions:
+      type: Enum
+      subtype: GrantLevel
+      value: read_only
+      description: >
+        The level of access this user has to this NodeBalancer.  null is no access,
+        read_only allows viewing it and its configs and nodes, and read_write
+        allows changing the NodeBalancer and its configs and nodes, including
+        adding/removing configs and nodes.
   linode:
     type: object
     isArray: true
-    description: Individual grants to a Linode you own.  Grants include all, access, resize, and delete
-    all:
-      type: Boolean
-      value: false
-    access:
-      type: Boolean
-      value: true
-    resize:
-      type: Boolean
-      value: true
-    delete:
-      type: Boolean
-      value: false
+    description: Individual grants this user has to a Linode you own.
     id:
       type: Integer
       value: 123
+      description: The ID of the Linode this grant applies to.
     label:
       type: String
       value: linode123
+      description: The label of the Linode this grant applies to.
+    permissions:
+      type: Enum
+      subtype: GrantLevel
+      value: read_write
+      description: >
+        The level of access this user has to this Linode.  null is no access,
+        read_only gives the ability to view this Linode and its disks, and
+        read_write allows complete control over this Linode, including its
+        configs, disks, attached volumes, and power state.
   domain:
     type: object
     isArray: true
-    description: Individual grants to a Domain you own.  Grants include all, access and delete
-    all:
-      type: Boolean
-      value: false
-    access:
-      type: Boolean
-      value: true
-    delete:
-      type: Boolean
-      value: false
+    description: Individual grants a user has to a Domain you own.
     id:
       type: Boolean
-      value: 123
+      value: 432
+      description: The ID of the domain this grant applies to.
     label:
       type: Boolean
       value: example.com
+      description: The domain name this grant applies to.
+    permissions:
+      type: Enum
+      subtype: GrantLevel
+      value: read_write
+      description: >
+        The level of access this user has to this Domain.  null is no access,
+        read_only gives access to view this domain and its records, and read_write
+        gives complete control over the domain, including adding and removing
+        records.
+  volume:
+    type: object
+    isArray: true
+    description: Individual grants a user has to a Volume you own.
+    id:
+      type: Boolean
+      value: 987
+      description: The ID of the volume this grant applies to.
+    label:
+      type: Boolean
+      value: example.com
+      description: The label of the volume this grant applies to.
+    permissions:
+      type: Enum
+      subtype: GrantLevel
+      value: null
+      description: >
+        The level of access this user has to this Volume.  null is no access,
+        read_only gives access to view this volume, and read_write
+        gives full control over the volume, including allow it to be attached
+        and detached.
+  image:
+    type: object
+    isArray: true
+    description: Individual grants a user has to a Image you own.
+    id:
+      type: Boolean
+      value: 903
+      description: The ID of the image this grant applies to.
+    label:
+      type: Boolean
+      value: example.com
+      description: The label of the image this grant applies to.
+    permissions:
+      type: Enum
+      subtype: GrantLevel
+      value: read_write
+      description: >
+        The level of access this user has to this Image.  null is no access,
+        read_only gives access to view this image, and read_write allows full
+        control over this image, including deploying linodes from it and
+        removing it from the account.
+  longview:
+    type: object
+    isArray: true
+    description: Individual grants a user has to a Longview Client you own.
+    id:
+      type: Boolean
+      value: 231
+      description: The ID of the longview client this grant applies to.
+    label:
+      type: Boolean
+      value: example.com
+      description: The label of the longview client this grant applies to.
+    permissions:
+      type: Enum
+      subtype: GrantLevel
+      value: read_write
+      description: >
+        The level of access this user has to this Longview Client.  null is no access,
+        read_only gives access to view this client, including viewing its api key
+        that can be used to retrieve the stats it is tracking, and read_write
+        grants full access to the client, including the ability to remove it from
+        the account.
+enums:
+  GrantLevel:
+    null: no access
+    read_only: >
+       access to GET endpoints related to this entity and its subobjects, events
+       related to it, and this entities appearance in listing endpoints.
+    read_write: >
+       access to all endpoints related to this entity, including POST, PUT, and
+       DELETE endpoints for this entity and its subobjects


### PR DESCRIPTION
Documents the new UserGrant scheme that uses null/read_only/read_write
permission levels for all entity classes.