### PR TITLE
#2704 Add current balance to MakeAPayment.

### DIFF
--- a/scss/components/forms/FormText.scss
+++ b/scss/components/forms/FormText.scss
@@ -1,0 +1,3 @@
+.col-form-text {
+    padding: 6px 15px;
+}

--- a/scss/components/forms/index.scss
+++ b/scss/components/forms/index.scss
@@ -1,1 +1,2 @@
 @import "FormSummary";
+@import "FormText";

--- a/src/billing/layouts/MakeAPaymentPage.js
+++ b/src/billing/layouts/MakeAPaymentPage.js
@@ -18,6 +18,7 @@ import { dispatchOrStoreErrors } from '~/api/util';
 import { setSource } from '~/actions/source';
 import { ChainedDocumentTitle } from '~/components';
 
+import DisplayCurrency from '~/components/DisplayCurrency';
 
 export class MakeAPaymentPage extends Component {
   constructor(props) {
@@ -47,6 +48,7 @@ export class MakeAPaymentPage extends Component {
 
   render() {
     const { errors, loading, usd, cvv } = this.state;
+    const { balance } = this.props;
 
     return (
       <div>
@@ -57,6 +59,13 @@ export class MakeAPaymentPage extends Component {
               onSubmit={this.onSubmit}
               analytics={{ title: 'Make Payment' }}
             >
+              <FormGroup errors={errors} className="row" name="balance">
+                <label className="col-sm-3 col-form-label">Balance</label>
+                <div className="col-sm-5 col-form-text">
+                  <DisplayCurrency value={balance} />
+                  <FormGroupError errors={errors} name="balance" />
+                </div>
+              </FormGroup>
               <FormGroup errors={errors} className="row" name="usd">
                 <label className="col-sm-3 col-form-label">Amount to Charge</label>
                 <div className="col-sm-5">
@@ -68,7 +77,7 @@ export class MakeAPaymentPage extends Component {
                     onChange={this.onChange}
                     pattern="[0-9]{0,7}(.[0-9]{0,2})?"
                     maxLength={7}
-                    // max="2500"
+                  // max="2500"
                   />
                   <small className="text-muted col-sm-1">(USD)</small>
                   <FormGroupError errors={errors} name="usd" />
@@ -85,8 +94,8 @@ export class MakeAPaymentPage extends Component {
                     onChange={this.onChange}
                     maxLength={4}
                     pattern="[0-9]{3,4}"
-                    // min="0000"
-                    // max="9999"
+                  // min="0000"
+                  // max="9999"
                   />
                   <small className="text-muted col-sm-1">(Optional)</small>
                 </div>
@@ -110,6 +119,11 @@ export class MakeAPaymentPage extends Component {
 
 MakeAPaymentPage.propTypes = {
   dispatch: PropTypes.func.isRequired,
+  balance: PropTypes.number,
 };
 
-export default connect()(MakeAPaymentPage);
+const mapStateToProps = (state) => ({
+  balance: state.api.account.balance,
+});
+
+export default connect(mapStateToProps)(MakeAPaymentPage);


### PR DESCRIPTION
- Maps api.account.balance to props of the MakeAPayment component.
- Added CSS to line up with existing form.

Closes #2704