### PR TITLE
#2706 Correct CC number input alignment.

### DIFF
--- a/src/billing/layouts/CreditCardPage.js
+++ b/src/billing/layouts/CreditCardPage.js
@@ -9,7 +9,6 @@ import {
   FormGroupError,
   FormSummary,
   Select,
-  Input,
   SubmitButton,
 } from 'linode-components/forms';
 import { onChange } from 'linode-components/forms/utilities';
@@ -74,17 +73,20 @@ export class CreditCardPage extends Component {
             >
               <FormGroup className="row" errors={errors} name="card_number">
                 <label className="col-sm-3 col-form-label">Credit Card</label>
-                <div className="col-sm-9">
-                  <Input
-                    name="card"
-                    id="card"
-                    type="text"
-                    value={card}
-                    maxLength={19}
-                    pattern="[0-9]{13,19}"
-                    onChange={this.onChange}
-                  />
-                  <FormGroupError errors={errors} name="card_number" />
+                <div className="col-sm-3">
+                  <div className="input-group">
+                    <input
+                      name="card"
+                      id="card"
+                      type="text"
+                      value={card}
+                      maxLength={19}
+                      pattern="[0-9]{13,19}"
+                      onChange={this.onChange}
+                      className="form-control"
+                    />
+                    <FormGroupError errors={errors} name="card_number" />
+                  </div>
                 </div>
               </FormGroup>
               <FormGroup errors={errors} name={['expiry_month', 'expiry_year']} className="row">


### PR DESCRIPTION
- Matched the columns in the credit card number row to the columns in the credit card expiration row.
- Since this was a specific case I felt using the existing ID selector to override the width definition was safe.

Closes #2706 


### Old
> 
![image](https://user-images.githubusercontent.com/317653/33081871-5401ef4a-cea9-11e7-9ab5-a42316e7c4d1.png)
### New
> 
![image](https://user-images.githubusercontent.com/317653/33081888-602caa62-cea9-11e7-8d26-2fca186944d5.png)

