### PR TITLE
Add public option for oauth clients

### DIFF
--- a/src/profile/components/CreateOrEditApplication.js
+++ b/src/profile/components/CreateOrEditApplication.js
@@ -35,6 +35,7 @@ export default class CreateOrEditApplication extends Component {
       label: props.label || '',
       redirect: props.redirect_uri || '',
       thumbnail: props.thumbnail || '',
+      public_: props.public || false,
       errors: {},
     };
 
@@ -43,9 +44,9 @@ export default class CreateOrEditApplication extends Component {
 
   onSubmit = () => {
     const { dispatch, id, close } = this.props;
-    const { label, redirect, thumbnail } = this.state;
+    const { label, redirect, thumbnail, public_ } = this.state;
 
-    const data = { label, redirect_uri: redirect };
+    const data = { label, redirect_uri: redirect, public: public_ };
     const idsPath = [id].filter(Boolean);
 
     return dispatch(dispatchOrStoreErrors.call(this, [
@@ -71,8 +72,8 @@ export default class CreateOrEditApplication extends Component {
   }
 
   render() {
-    const { close, title, id } = this.props;
-    const { errors, label, redirect } = this.state;
+    const { close, title, id, forEdit } = this.props;
+    const { errors, label, redirect, public_ } = this.state;
 
     return (
       <FormModalBody
@@ -108,6 +109,16 @@ export default class CreateOrEditApplication extends Component {
               onChange={(e) => this.setState({ thumbnail: e.target.files[0] })}
             />
           </ModalFormGroup>
+          <ModalFormGroup id="public" label="Public" apiKey="public" errors={errors}>
+            <Input
+              name="public_"
+              id="public_"
+              type="checkbox"
+              checked={public_}
+              disabled={forEdit}
+              onChange={this.onChange}
+            />
+          </ModalFormGroup>
         </div>
       </FormModalBody>
     );
@@ -122,4 +133,6 @@ CreateOrEditApplication.propTypes = {
   id: PropTypes.string,
   redirect_uri: PropTypes.string,
   thumbnail: PropTypes.string,
+  public: PropTypes.boolean,
+  forEdit: PropTypes.boolean,
 };

--- a/src/profile/layouts/MyAPIClientsPage.js
+++ b/src/profile/layouts/MyAPIClientsPage.js
@@ -45,11 +45,12 @@ export class MyAPIClientsPage extends Component {
 
   createDropdownGroups = (client) => {
     const { dispatch } = this.props;
+    const editClient = { ...client, forEdit: true };
     const groups = [
       { elements: [{ name: 'Edit', action: () =>
-        CreateOrEditApplication.trigger(dispatch, client) }] },
-      { elements: [{ name: 'Reset Secret', action: () => this.resetAction(client) }] },
-      { elements: [{ name: 'Delete', action: () => this.deleteClients(client) }] },
+        CreateOrEditApplication.trigger(dispatch, editClient) }] },
+      { elements: [{ name: 'Reset Secret', action: () => this.resetAction(editClient) }] },
+      { elements: [{ name: 'Delete', action: () => this.deleteClients(editClient) }] },
     ];
     return groups;
   }

--- a/test/profile/components/CreateOrEditApplication.spec.js
+++ b/test/profile/components/CreateOrEditApplication.spec.js
@@ -32,6 +32,7 @@ describe('profile/components/CreateOrEditApplication', () => {
 
     changeInput(page, 'label', 'My new client');
     changeInput(page, 'redirect', 'http://example.com');
+    changeInput(page, 'public_', true);
     const thumbnail = { size: (MAX_UPLOAD_SIZE_MB - 0.5) * 1024 * 1024 };
     page.instance().setState({ thumbnail });
 
@@ -44,6 +45,7 @@ describe('profile/components/CreateOrEditApplication', () => {
         body: {
           label: 'My new client',
           redirect_uri: 'http://example.com',
+          public: true,
         },
       }),
       async ([fn]) => expectRequest(fn, '/account/oauth-clients/1/thumbnail', {
@@ -51,7 +53,7 @@ describe('profile/components/CreateOrEditApplication', () => {
         body: thumbnail,
         headers: { 'Content-Type': 'image/png' },
       }),
-    ], 3, [{ id: 1, secret: '' }]);
+    ], 3, [{ id: 1, secret: '', public: true }]);
     // One call to save the data, one call to save the thumbnail, one call to show the secret.
   });
 
@@ -65,6 +67,7 @@ describe('profile/components/CreateOrEditApplication', () => {
 
     changeInput(page, 'label', 'My new client');
     changeInput(page, 'redirect', 'http://example.com');
+    changeInput(page, 'public_', true);
     const thumbnail = { size: (MAX_UPLOAD_SIZE_MB + 1) * 1024 * 1024 };
     page.instance().setState({ thumbnail });
 
@@ -89,6 +92,7 @@ describe('profile/components/CreateOrEditApplication', () => {
 
     changeInput(page, 'label', 'My new client');
     changeInput(page, 'redirect', 'http://google.com');
+    changeInput(page, 'public_', false);
 
     dispatch.reset();
     await page.props().onSubmit();
@@ -100,10 +104,27 @@ describe('profile/components/CreateOrEditApplication', () => {
         body: {
           label: 'My new client',
           redirect_uri: 'http://google.com',
+          public: false,
         },
       }),
     ], 1, [{ id: 1 }]);
 
     expect(close.callCount).to.equal(1);
+  });
+
+  it('has the public field disabled upon edit', async () => {
+    const page = shallow(
+      <CreateOrEditApplication
+        dispatch={dispatch}
+        close={close}
+        label="My awesome client"
+        redirect_uri="http://example.com"
+        id="1"
+        public
+        forEdit
+      />
+    );
+
+    expect(page.find('#public_').at(0).props().disabled).to.equal(true);
   });
 });


### PR DESCRIPTION
This adds a checkbox for the "public" option when creating an OAuth client.

![screen shot 2017-11-21 at 9 02 24 am](https://user-images.githubusercontent.com/2046750/33076474-d4271de4-ce9a-11e7-9fe7-ae151ec30325.png)

When editing an OAuth client the field is disabled because it is not editable on the backend.

![screen shot 2017-11-21 at 9 03 10 am](https://user-images.githubusercontent.com/2046750/33076483-da5095e2-ce9a-11e7-8608-ea26b1877ddb.png)


