### PR TITLE
Dynamically populate Linode dropdown actions based on status

### DIFF
--- a/src/linodes/components/StatusDropdown.js
+++ b/src/linodes/components/StatusDropdown.js
@@ -212,7 +212,7 @@ export default class StatusDropdown extends Component {
             { name: 'Power Off', action: this.powerOffLinode },
         ] });
       } else {
-        finalGroups.push = ({ elements: [
+        finalGroups.push({ elements: [
             { name: 'Power On', action: this.powerOnLinode },
         ] });
       }

--- a/src/linodes/components/StatusDropdown.js
+++ b/src/linodes/components/StatusDropdown.js
@@ -189,28 +189,49 @@ export default class StatusDropdown extends Component {
     setTimeout(() => dispatch(setProgress(linode, randomInitialProgress())), 10);
   }
 
+  linodeToGroups = linode => {
+    const status = linode.status;
+    // we always show the current status
+    const finalGroups = [{ elements: [
+      { name: LinodeStatesReadable[status] || _.capitalize(status) },
+    ] }];
+    const transitionStates = [
+      'shutting_down',
+      'booting',
+      'provisioning',
+      'rebooting',
+      'rebuilding',
+      'restoring',
+      'migrating',
+    ];
+    // don't allow power actions in a transition state
+    if (!(_.find(transitionStates, el => el === status))) {
+      if (status !== 'offline') {
+        finalGroups.push({ elements: [
+            { name: 'Reboot', action: this.rebootLinode },
+            { name: 'Power Off', action: this.powerOffLinode },
+        ] });
+      } else {
+        finalGroups.push = ({ elements: [
+            { name: 'Power On', action: this.powerOnLinode },
+        ] });
+      }
+    }
+    // we always allow Lish
+    finalGroups.push({ elements: [
+        { name: 'Launch Console', action: () => launchWeblishConsole(linode) },
+    ] });
+    // we always allow deletion
+    finalGroups.push({ elements: [
+        { name: 'Delete', action: this.deleteLinode },
+    ] });
+    return finalGroups;
+  }
+
   render() {
     const { linode } = this.props;
 
-    const status = LinodeStatesReadable[linode.status] || _.capitalize(linode.status);
-    const groups = [
-      { elements: [{ name: status }] },
-      {
-        elements: [
-          { name: 'Reboot', action: this.rebootLinode },
-          { name: 'Power Off', action: this.powerOffLinode },
-        ],
-      },
-      { elements: [{
-        name: 'Launch Console',
-        action: () => launchWeblishConsole(linode),
-      }] },
-      { elements: [{ name: 'Delete', action: this.deleteLinode }] },
-    ];
-
-    if (linode.status === 'offline') {
-      groups[1].elements = [{ name: 'Power On', action: this.powerOnLinode }];
-    }
+    const groups = this.linodeToGroups(linode);
 
     // The calc(x + 1px) is needed because we have left: -1px on this element.
     const progressWidth = `calc(${linode.__progress}%${linode.__progress === 0 ? '' : ' + 1px'})`;

--- a/test/data/linodes.js
+++ b/test/data/linodes.js
@@ -495,6 +495,11 @@ export const testLinode1247 = {
   },
 };
 
+export const testLinode1248 = {
+  ...createTestLinode(1248),
+  status: 'provisioning',
+};
+
 export const linodes = [
   testLinode,
   testLinode1233,
@@ -510,4 +515,5 @@ export const linodes = [
   testLinode1245,
   testLinode1246,
   testLinode1247,
+  testLinode1248,
 ].reduce((object, linode) => ({ ...object, [linode.id]: linode }), {});

--- a/test/linodes/components/StatusDropdown.spec.js
+++ b/test/linodes/components/StatusDropdown.spec.js
@@ -51,6 +51,20 @@ describe('linodes/components/StatusDropdown', () => {
     expect(dropdown.find('.Dropdown-item').at(3).text()).to.equal('Delete');
   });
 
+  it('renders correct options for provisioning Linodes', () => {
+    const dropdown = mount(
+      <StatusDropdown linode={linodes.linodes[1248]} dispatch={() => {}} />
+    );
+
+    expect(dropdown.find('.Dropdown-first').text().trim()).to.equal('Provisioning');
+
+    dropdown.find('.Dropdown-toggle').simulate('click');
+
+    expect(dropdown.find('.Dropdown-item').length).to.equal(2);
+    expect(dropdown.find('.Dropdown-item').at(0).text()).to.equal('Launch Console');
+    expect(dropdown.find('.Dropdown-item').at(1).text()).to.equal('Delete');
+  });
+
   it('dispatches on item click', async () => {
     const dispatch = sandbox.spy();
     const dropdown = mount(


### PR DESCRIPTION
Fixes #2319

When a Linode is in a transition state, which include the following

```
    const transitionStates = [
      'shutting_down',
      'booting',
      'provisioning',
      'rebooting',
      'rebuilding',
      'restoring',
      'migrating',
    ];
```

We should not allow any power actions, which include:

```
Reboot
Power Off
Power On
```

We should also maintain the fact that `Lish` and `Delete` are always an option, and that `Power On` is only an option when the Linode's status is `Offline`.