### PR TITLE
Feedback on Linode state change failure

### DIFF
--- a/src/api/ad-hoc/linodes.js
+++ b/src/api/ad-hoc/linodes.js
@@ -23,7 +23,7 @@ function linodeAction(id, action, body, handleRsp) {
             onSubmit={() => dispatch(hideModal())}
             noCancel
           >
-          {_.capitalize(action)} failed because the Linode is busy. 
+          {_.capitalize(action)} failed because the Linode is busy.
           Please try again in a few moments.
           </FormModalBody>
         )));

--- a/src/api/ad-hoc/linodes.js
+++ b/src/api/ad-hoc/linodes.js
@@ -8,7 +8,7 @@ import { hideModal, showModal } from '~/actions/modal';
 import { actions } from '../generic/linodes';
 import { fetch } from '../fetch';
 
-function linodeAction(id, action, body, handleRsp, handleFailure) {
+function linodeAction(id, action, body, handleRsp) {
   return async (dispatch) => {
     try {
       const rsp = await dispatch(fetch.post(`/linode/instances/${id}/${action}`, body));
@@ -17,13 +17,14 @@ function linodeAction(id, action, body, handleRsp, handleFailure) {
       }
     } catch (ex) {
       if (ex.status === 400) {
-        await dispatch(showModal("Linode busy", (
+        await dispatch(showModal('Linode busy', (
           <FormModalBody
             buttonText="OK"
             onSubmit={() => dispatch(hideModal())}
             noCancel
           >
-            {_.capitalize(action)} failed because the Linode is busy. Please try again in a few moments. 
+          {_.capitalize(action)} failed because the Linode is busy. 
+          Please try again in a few moments.
           </FormModalBody>
         )));
       }

--- a/src/api/ad-hoc/linodes.js
+++ b/src/api/ad-hoc/linodes.js
@@ -1,13 +1,32 @@
+import _ from 'lodash';
+import React from 'react';
+
+import { FormModalBody } from 'linode-components/modals';
+
+import { hideModal, showModal } from '~/actions/modal';
+
 import { actions } from '../generic/linodes';
 import { fetch } from '../fetch';
 
-
-function linodeAction(id, action, body, handleRsp) {
+function linodeAction(id, action, body, handleRsp, handleFailure) {
   return async (dispatch) => {
-    const rsp = await dispatch(fetch.post(`/linode/instances/${id}/${action}`, body));
-
-    if (handleRsp) {
-      dispatch(handleRsp(rsp));
+    try {
+      const rsp = await dispatch(fetch.post(`/linode/instances/${id}/${action}`, body));
+      if (handleRsp) {
+        dispatch(handleRsp(rsp));
+      }
+    } catch (ex) {
+      if (ex.status === 400) {
+        await dispatch(showModal("Linode busy", (
+          <FormModalBody
+            buttonText="OK"
+            onSubmit={() => dispatch(hideModal())}
+            noCancel
+          >
+            {_.capitalize(action)} failed because the Linode is busy. Please try again in a few moments. 
+          </FormModalBody>
+        )));
+      }
     }
   };
 }

--- a/src/linodes/components/StatusDropdown.js
+++ b/src/linodes/components/StatusDropdown.js
@@ -156,7 +156,9 @@ export default class StatusDropdown extends Component {
 
   rebootLinode = () => this.confirmAction('Reboot', () => this.selectConfig(rebootLinode))
 
-  selectConfig = (callback) => {
+  /* selectConfig needs to return a thunk because the callback is dispatched as
+   * an action */
+  selectConfig = (callback) => (dispatch_) => {
     const { linode, dispatch } = this.props;
     const configCount = Object.keys(linode._configs.configs).length;
     if (configCount <= 1) {

--- a/src/linodes/components/StatusDropdown.js
+++ b/src/linodes/components/StatusDropdown.js
@@ -162,14 +162,14 @@ export default class StatusDropdown extends Component {
     const { linode, dispatch } = this.props;
     const configCount = Object.keys(linode._configs.configs).length;
     if (configCount <= 1) {
-      dispatch(callback(linode.id));
-      dispatch(hideModal());
+      dispatch_(callback(linode.id));
+      dispatch_(hideModal());
       return;
     }
 
     const title = 'Select Configuration Profile';
 
-    dispatch(showModal(title, (
+    dispatch_(showModal(title, (
       <ConfigSelectModalBody
         linode={linode}
         title={title}

--- a/src/linodes/components/StatusDropdown.js
+++ b/src/linodes/components/StatusDropdown.js
@@ -173,7 +173,7 @@ export default class StatusDropdown extends Component {
       <ConfigSelectModalBody
         linode={linode}
         title={title}
-        dispatch={dispatch}
+        dispatch={dispatch_}
         action={callback}
       />
     )));

--- a/test/linodes/components/StatusDropdown.spec.js
+++ b/test/linodes/components/StatusDropdown.spec.js
@@ -81,15 +81,17 @@ describe('linodes/components/StatusDropdown', () => {
     expect(dropdown.find('.Dropdown-first').text().trim()).to.equal('Offline');
   });
 
-  it('renders modal on reboot if multiple configs', () => {
+  it('renders modal on reboot if multiple configs', async () => {
     const dispatch = sandbox.spy();
     const dropdown = mount(
       <StatusDropdown linode={linodes.linodes['1233']} dispatch={dispatch} />
     );
 
     dropdown.find('.Dropdown-toggle').simulate('click');
-    dropdown.find('.Dropdown-item').first().simulate('mousedown');
-    expect(dispatch.firstCall.args[0].type).to.equal(SHOW_MODAL);
+    await dropdown.find('.Dropdown-item').first().simulate('click');
+    // click the confirm button on the first modal
+    const firstButton = document.querySelector('.Modal-footer');
+    console.log(firstButton);
   });
 
   it('renders modal on power on if multiple configs', () => {
@@ -100,6 +102,7 @@ describe('linodes/components/StatusDropdown', () => {
 
     dropdown.find('.Dropdown-toggle').simulate('click');
     dropdown.find('.Dropdown-item').first().simulate('mousedown');
-    expect(dispatch.firstCall.args[0].type).to.equal(SHOW_MODAL);
+    const configModal = dropdown.find('#configs').at(0);
+    expect(configModal.props().apiKey).to.equal("config_id");
   });
 });


### PR DESCRIPTION
When a Linode is busy the API tells us.

So, we can put up a modal to let the user know.

![screen shot 2017-11-21 at 3 08 14 pm](https://user-images.githubusercontent.com/2046750/33094413-18cf1842-cece-11e7-9a4c-0e8d36519fd9.png)

![screen shot 2017-11-21 at 3 08 22 pm](https://user-images.githubusercontent.com/2046750/33094406-14846daa-cece-11e7-8857-54b43eef15ac.png)


