### PR TITLE
new: Add documentation for POST domain//clone

### DIFF
--- a/docs/src/data/endpoints/domains.yaml
+++ b/docs/src/data/endpoints/domains.yaml
@@ -171,7 +171,7 @@ endpoints:
     authenticated: true
     description: >
       Clones the provided Domain into a new Domain. You must provide a new
-      domain name (url) for the cloned domain as Domains must be unique.
+      domain for the cloned domain as Domains must be unique.
     methods:
       POST:
         response: domain
@@ -181,7 +181,7 @@ endpoints:
             description: >
               The Domain name for the new Domain.
             type: String
-            value: www.mynewdomain.com
+            value: mynewdomain.com
         examples:
           curl: |
             curl -H "Authorization: Bearer $TOKEN" \

--- a/docs/src/data/endpoints/domains.yaml
+++ b/docs/src/data/endpoints/domains.yaml
@@ -167,6 +167,25 @@ endpoints:
           python: |
             import linode
             TODO
+  /domains/$id/clone:
+    authenticated: true
+    description: >
+      Clones the provided Domain into a new Domain. You must provide a new
+      domain name (url) for the cloned domain as Domains must be unique.
+    methods:
+      POST:
+        response: domain
+        oauth: domains:modify
+        params:
+          domain:
+            description: >
+              The Domain name for the new Domain.
+            type: String
+            value: www.mynewdomain.com
+        examples:
+          curl: |
+            curl -H "Authorization: Bearer $TOKEN" \
+                https://$api_root/$version/domains/$domain_id/records
   /domains/$id/records:
     authenticated: true
     description: >


### PR DESCRIPTION
Add documentation for cloning a dns zone

Domain endpoint reference:
<img width="807" alt="screen shot 2017-11-22 at 2 41 31 pm" src="https://user-images.githubusercontent.com/4519791/33146719-59981fa2-cf93-11e7-8669-35a63ebb59b5.png">

Detailed endpoint reference
<img width="802" alt="screen shot 2017-11-22 at 2 41 14 pm" src="https://user-images.githubusercontent.com/4519791/33146723-5d26e2ac-cf93-11e7-99e1-0857cdea7532.png">
