### PR TITLE
Allow docs nav to scroll vertically

### DIFF
--- a/docs/scss/components/Header.scss
+++ b/docs/scss/components/Header.scss
@@ -1,0 +1,8 @@
+.Header {
+    &-fixed {
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 10;
+    }
+}

--- a/docs/scss/components/VerticalNav.scss
+++ b/docs/scss/components/VerticalNav.scss
@@ -1,7 +1,7 @@
 .VerticalNav {
     height: 100%;
     padding: 25px;
-    overflow-y: auto;
+    overflow-y: scroll;
 
     &-section {
         &:not(:last-of-type) {

--- a/docs/scss/components/index.scss
+++ b/docs/scss/components/index.scss
@@ -7,3 +7,4 @@
 @import 'Tables/index';
 @import 'Title';
 @import 'VerticalNav';
+@import 'Header';

--- a/docs/scss/docs/Layout.scss
+++ b/docs/scss/docs/Layout.scss
@@ -1,4 +1,5 @@
 $sidebar-width: 250px;
+$header-height: 60px;
 
 .Layout {
     height: 100%;
@@ -9,18 +10,22 @@ $sidebar-width: 250px;
 
     &-navigationContainer {
         position: fixed;
+        top: $header-height;
+        bottom: 0;
         background-color: $light-gray;
         border: $border;
         width: $sidebar-width;
+        overflow-y: scroll;
     }
 
     &-content {
+        margin-top: 60px;
+        margin-left: calc(#{$sidebar-width} - 1px);
         background-color: $white;
-        margin-left: $sidebar-width - 1px;
         // Subtract the bootstrap margin too.
         width: calc(100% - #{$sidebar-width} - 30px);
         border: $border;
-        margin-bottom: 30px;
+        overflow-y: scroll;
     }
 
     @media screen and (max-width: #{$sidebar-breakpoint}) {
@@ -32,10 +37,11 @@ $sidebar-width: 250px;
 
         &-navigationContainer {
             display: none; 
-            overflow-y: visible;
             border: $border;
-            position: absolute;
-            top: 0;
+            position: fixed;
+            top: $header-height;
+            bottom: 0;
+            overflow-y: scroll;
             border-top: 0;
             border-right: 0;
 

--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -125,11 +125,12 @@ browserHistory.listen(function (location) {
     // the element is rendered on the page before trying to getElementById.
     setTimeout(() => {
       const id = hash.replace('#', '');
+      const headerHeight = 60;
       const element = document.getElementById(id);
       if (element) {
         element.classList.add('highlight');
-        document.documentElement.scrollTop =
-          element.getBoundingClientRect().top + window.pageYOffset;
+        document.scrollingElement.scrollTop =
+          element.getBoundingClientRect().top + window.pageYOffset - headerHeight;
       }
     }, 0);
     return;

--- a/docs/src/layouts/Layout.js
+++ b/docs/src/layouts/Layout.js
@@ -36,7 +36,7 @@ export default class Layout extends Component {
 
     return (
       <div className="Docs Layout">
-        <Header>
+        <Header className="Header-fixed">
           <div className="MainHeader-brand">
             <Link to="/">
               <span className="MainHeader-logo">
@@ -49,7 +49,7 @@ export default class Layout extends Component {
               </span>
             </Link>
           </div>
-          <span className="MainHeader-title">Developers</span>
+          <span className="MainHeader-title">Linode API v4</span>
           <button
             className="ToggleNav navbar-toggler navbar-toggler-right collapsed"
             type="button"


### PR DESCRIPTION
Fixes #2734 

Changes docs nav to float left instead of fixed, so that it can be scrolled on a window with a short height.