### PR TITLE
Document all APIv4 enums

### DIFF
--- a/docs/src/data/endpoints/domains.yaml
+++ b/docs/src/data/endpoints/domains.yaml
@@ -35,7 +35,7 @@ endpoints:
             type: String
           type:
             description: >
-              Domain type as master or slave.
+              Domain type. Can be "master" or "slave".
             type: Enum
           soa_email:
             description: >
@@ -74,7 +74,7 @@ endpoints:
           status:
             optional: true
             description: >
-              The status of the Domain; it can be disabled, active, or edit_mode.
+              The status of the Domain. Can be "disabled", "active", or "edit_mode".
             type: Enum
           master_ips:
             optional: true
@@ -195,7 +195,8 @@ endpoints:
         params:
           type:
             description: >
-              Type of record.
+              Type of record. Can be one of "A", "AAAA", "NS", "MX",
+              "CNAME", "TXT", "SRV", "PTR", or "CAA".
             type: Enum
           name:
             optional: true
@@ -241,8 +242,8 @@ endpoints:
           tag:
             optional: true
             description: >
-              The tag attribute for a CAA record. One of issue, issuewild,
-              iodef. Ignored on other record types.
+              The tag attribute for a CAA record. One of "issue", "issuewild",
+              or "iodef". Ignored on other record types.
             type: Enum
           ttl:
             optional: true

--- a/docs/src/data/endpoints/linodes.yaml
+++ b/docs/src/data/endpoints/linodes.yaml
@@ -454,12 +454,14 @@ endpoints:
           run_level:
             optional: true
             description: >
-              Sets the run level for Linode boot. Defaults to "default".
+              Sets the run level for Linode boot. One of "default",
+              "single" (for single user mode), or "binbash".
             type: Enum
           virt_mode:
             optional: true
             description: >
-              Controls the virtualization mode. Defaults to "paravirt".
+              Controls the virtualization mode. One of "paravirt" (default)
+              or "fullvirt".
             type: Enum
           helpers:
             type: Object

--- a/docs/src/data/endpoints/nodebalancers.yaml
+++ b/docs/src/data/endpoints/nodebalancers.yaml
@@ -130,38 +130,88 @@ endpoints:
             limit: 1-65534
             type: Integer
             optional: true
+            value: 80
           protocol:
             description: The protocol used for the config.
             type: String
+            optional: true
+            value: https
           algorithm:
             description: Balancing algorithm.
             type: Enum
+            optional: true
+            roundrobin:
+              type: String
+              description: Round robin
+            leastconn:
+              type: String
+              description: Assigns connections to the backend with the least connections.
+            source:
+              type: String
+              description: Uses the client's IPv4 address.
+            value: roundrobin
           stickiness:
             description: Session persistence. Route subsequent requests from a client to the same backend.
             type: Enum
+            none:
+              type: String
+              description: no stickiness
+            table:
+              type: String
+              description: Keep track of clients with a table
+            http_cookie:
+              type: String
+              description: Use an HTTP Cookie to keep track of clients
+            value: none
           check:
             description: Perform active health checks on the backend nodes.
             type: Enum
+            optional: true
+            none:
+              type: String
+              description: None
+            connection:
+              type: String
+              description: Requires a successful TCP handshake.
+            http:
+              type: String
+              description: Requires a 2xx or 3xx response from the backend node.
+            http_body:
+              type: String
+              description: Uses a regex to match against an expected result body.
+            value: http_body
           check_interval:
             description: Seconds between health check probes.
             type: Integer
+            optional: true
+            value: 5
           check_timeout:
             description: Seconds to wait before considering the probe a failure.
             limit: 1-30. Must be less than check_interval # leave the final period off!
             type: Integer
+            optional: true
+            value: 3
           check_attempts:
             description: Number of failed probes before taking a node out of rotation.
             limit: 1-30
             type: Integer
+            optional: true
+            value: 10
           check_path:
             description: When check is "http", the path to request.
             type: String
+            optional: true
+            value: "/path/to/check"
           check_body:
             description: When check is "http", a regex to match within the first 16,384 bytes of the response body.
             type: String
+            optional: true
+            value: we got some stuff back
           check_passive:
             description: Enable passive checks based on observing communication with back-end nodes.
             type: Boolean
+            optional: true
+            value: true
           # ssl_cert:
           #  description: SSL certificate served by the NodeBalancer when the protocol is "https".
           # ssl_key:
@@ -169,6 +219,13 @@ endpoints:
           cipher_suite:
             description: SSL cipher suite to enforce.
             type: Enum
+            recommended:
+              type: String
+              description: Recommended
+            legacy:
+              type: String
+              description: Legacy
+            value: legacy
         examples:
           curl: |
             curl -H "Content-Type: application/json" \
@@ -280,7 +337,7 @@ endpoints:
             description: Load balancing weight, 1-255. Higher means more connections.
             type: Integer
           mode:
-            description: The connections mode for this node. One of 'accept', 'reject', or 'drain'.
+            description: The connections mode for this node. One of "accept", "reject", or "drain".
             type: Enum
         examples:
           curl: |

--- a/docs/src/data/objects/image.yaml
+++ b/docs/src/data/objects/image.yaml
@@ -53,3 +53,11 @@ schema:
     type: String
     value: "2017-10-19T11:21:01"
     description: The last time this image was used.
+enums:
+  Status:
+    creating: creating
+    available: available
+    deleted: deleted
+  Type:
+    0: Image was created manually
+    1: Image was created automatically from a deleted Linode

--- a/docs/src/data/objects/nodebalancer_config.yaml
+++ b/docs/src/data/objects/nodebalancer_config.yaml
@@ -60,7 +60,7 @@ schema:
   check_body:
     editable: true
     type: String
-    value: 
+    value:  "we got some stuff back"
     description: When check is "http", a regex to match within the first 16,384 bytes of the response body.
   check_passive:
     editable: true


### PR DESCRIPTION
Fixes #2464 

Documents all enums in the APIv4 docs.

For Nodebalancer config, use inline sub-tables to describe the enums.

For Images, use auto-generated subtables.

For everything else, use a list of strings in the description.

Values cross checked.