### PR TITLE
Update api docs page titles

### DIFF
--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -147,7 +147,7 @@ browserHistory.listen(function (location) {
 
 window.setTitle = function (newTitle) {
   const title = document.querySelector('title');
-  title.textContent = 'Linode API Documentation';
+  title.textContent = 'Linode API v4 | Linode Developers';
 
   if (newTitle) {
     title.textContent = `${newTitle} | ${title.textContent}`;


### PR DESCRIPTION
Changes the title suffix from: `Linode API Documentation` to `Linode API v4 | Linode Developers`