### PR TITLE
Doc update: distribution slugs rather than objects

### DIFF
--- a/docs/src/data/endpoints/linodes.yaml
+++ b/docs/src/data/endpoints/linodes.yaml
@@ -50,7 +50,7 @@ endpoints:
           distribution:
             optional: true
             description: >
-              The Distribution to deploy this Linode with.  May not be included
+              The ID of a Distribution to deploy this Linode with.  May not be included
               if 'backup_id' or 'image' is sent.
             type: String
           root_pass:
@@ -192,10 +192,10 @@ endpoints:
           distribution:
             optional: true
             description: >
-              Optional distribution to deploy with this disk.
+              Optional ID of a distribution to deploy with this disk.
               <ul><li>If no distribution is provided, a blank disk
               is created.</li></ul> You may not provide distribution if image is provided.
-            type: Distribution
+            type: String
           image:
             optional: true
             description: >
@@ -1010,8 +1010,8 @@ endpoints:
         params:
           distribution:
             description: >
-                An Distribution to deploy to this Linode.
-            type: Distribution
+                An ID of a Distribution to deploy to this Linode.
+            type: String
           image:
             optional: true
             description: >

--- a/docs/src/data/objects/linode.yaml
+++ b/docs/src/data/objects/linode.yaml
@@ -74,7 +74,7 @@ schema:
     value: us-east-1a
   distribution:
     description: The distribution that this Linode booted to last.
-    type: Distribution
+    type: String
     seeAlso: "/reference/endpoints/linode/distributions"
     filterable: true
   group:


### PR DESCRIPTION
properly document distribution parameters as slugs rather than as objects