### PR TITLE
Fix radio buttons site-wide

### DIFF
--- a/components/forms/utilities.js
+++ b/components/forms/utilities.js
@@ -2,7 +2,7 @@ export function onChange(event) {
   const { target: { name, value, type, checked } } = event;
 
   let realValue = value;
-  if (type === 'radio' || type === 'checkbox') {
+  if (type === 'checkbox') {
     realValue = checked;
   }
 

--- a/src/settings/layouts/IndexPage.js
+++ b/src/settings/layouts/IndexPage.js
@@ -30,7 +30,7 @@ export class IndexPage extends Component {
     super(props);
 
     this.state = {
-      networkHelper: !!props.account.network_helper,
+      networkHelper: props.account.network_helper ? 'ON' : 'OFF',
       errors: {},
     };
 
@@ -44,10 +44,10 @@ export class IndexPage extends Component {
 
   onSubmit = () => {
     const { dispatch } = this.props;
-    const { networkHelper: network_helper } = this.state;
+    const { networkHelper } = this.state;
 
     return dispatch(dispatchOrStoreErrors.call(this, [
-      () => api.account.put({ network_helper }),
+      () => api.account.put({ network_helper: networkHelper === 'ON' }),
     ]));
   }
 
@@ -74,15 +74,15 @@ export class IndexPage extends Component {
                   <Checkboxes>
                     <Radio
                       name="networkHelper"
-                      checked={!networkHelper}
-                      value="false"
+                      checked={networkHelper === 'OFF'}
+                      value="OFF"
                       label="OFF - This is the legacy / old account behavior"
                       onChange={this.onChange}
                     />
                     <Radio
                       name="networkHelper"
-                      checked={networkHelper}
-                      value="true"
+                      checked={networkHelper === 'ON'}
+                      value="ON"
                       onChange={this.onChange}
                       label="ON  - This is new account behavior. You probably want this."
                     />

--- a/src/users/components/AddUser.js
+++ b/src/users/components/AddUser.js
@@ -26,7 +26,13 @@ export default class AddUser extends Component {
   constructor(props) {
     super(props);
 
-    this.state = { errors: {}, username: '', email: '', password: '' };
+    this.state = {
+      errors: {},
+      username: '',
+      email: '',
+      password: '',
+      restricted: 'yes',
+    };
 
     this.onChange = onChange.bind(this);
   }
@@ -36,7 +42,7 @@ export default class AddUser extends Component {
     const data = {
       username: this.state.username,
       email: this.state.email,
-      restricted: this.state.restricted,
+      restricted: this.state.restricted === 'yes',
       password: this.state.password,
     };
 
@@ -89,16 +95,16 @@ export default class AddUser extends Component {
               <Radio
                 id="restricted"
                 name="restricted"
-                value
-                checked={restricted}
+                value="yes"
+                checked={restricted === 'yes'}
                 onChange={this.onChange}
                 label="Yes - this user can only do what I specify"
               />
               <Radio
                 id="unrestricted"
                 name="restricted"
-                value={false}
-                checked={!restricted}
+                value="no"
+                checked={restricted === 'no'}
                 onChange={this.onChange}
                 label="No - this user has no access restrictions"
               />

--- a/src/users/components/UserForm.js
+++ b/src/users/components/UserForm.js
@@ -20,7 +20,7 @@ export default class UserForm extends Component {
     this.state = {
       username: props.user.username,
       email: props.user.email,
-      restricted: props.user.restricted,
+      restricted: props.user.restricted ? 'yes' : 'no',
       password: '',
       loading: false,
       errors: {},
@@ -34,7 +34,7 @@ export default class UserForm extends Component {
     const data = {
       username: this.state.username,
       email: this.state.email,
-      restricted: this.state.restricted,
+      restricted: this.state.restricted === 'yes',
       password: this.state.password,
     };
 
@@ -112,16 +112,16 @@ export default class UserForm extends Component {
               <Radio
                 id="restricted"
                 name="restricted"
-                value
-                checked={restricted}
+                value="yes"
+                checked={restricted === 'yes'}
                 onChange={this.onChange}
                 label="Yes - this user can only do what I specify"
               />
               <Radio
                 id="unrestricted"
                 name="restricted"
-                value={false}
-                checked={!restricted}
+                value="no"
+                checked={restricted === 'no'}
                 onChange={this.onChange}
                 label="No - this user has no access restrictions"
               />

--- a/test/settings/layouts/IndexPage.spec.js
+++ b/test/settings/layouts/IndexPage.spec.js
@@ -26,8 +26,8 @@ describe('settings/layouts/IndexPage', () => {
       />
     );
 
-    const helper = page.find('input[name="networkHelper"]').at(0);
-    changeInput(helper, 'networkHelper', true);
+    const helper = page.find('input[name="networkHelper"]').at(1);
+    changeInput(helper, 'networkHelper', 'ON');
 
     dispatch.reset();
     await page.find('Form').props().onSubmit();

--- a/test/users/components/AddUser.spec.js
+++ b/test/users/components/AddUser.spec.js
@@ -24,7 +24,7 @@ describe('users/components/AddUser', () => {
     changeInput(modal, 'username', 'theUser');
     changeInput(modal, 'email', 'user@example.com');
     changeInput(modal, 'password', 'password');
-    changeInput(modal, 'restricted', true);
+    changeInput(modal, 'restricted', 'yes');
 
     await modal.find('Form').props().onSubmit();
     const fn = dispatch.firstCall.args[0];


### PR DESCRIPTION
This changes the shared `onChange` handler to properly use radio buttons values (which are strings).

This fixes both the "Virtualization Mode" and "Run Level" radio buttons on the Linode config form. 

Radio buttons side-wide were tested for functionality, and fixed where appropriate.

Fixes #2741