### PR TITLE
when a restricted user fetches users, handle the 403 response

### DIFF
--- a/src/users/layouts/IndexPage.js
+++ b/src/users/layouts/IndexPage.js
@@ -39,7 +39,10 @@ function getGravatarURL(user) {
 
 export class IndexPage extends Component {
   static async preload({ dispatch }) {
-    await dispatch(api.users.all());
+    // Restricted users will get a 403 on /v4/profile/users
+    const onReject = reason => reason.status !== 403 ? Promise.reject(reason) : null;
+
+    await dispatch(api.users.all()).catch(onReject);
   }
 
   constructor(props) {


### PR DESCRIPTION
Closes #2762 by handling the 403 returned by the API when a restricted user requests the user list.

Since the user can not add Users, and can not see the Users on the account, a better UX may be to inform the user of these limitations instead of presenting an empty list.

Issue #2383 exists to better address navigation concerns for pages (lists) and functions that should not be presented to a user based on their grant restrictions.

(Replaces #2765)