### PR TITLE
Docs - extend the white background for short content blocks

### DIFF
--- a/docs/scss/docs/Layout.scss
+++ b/docs/scss/docs/Layout.scss
@@ -5,7 +5,9 @@ $header-height: 60px;
     height: 100%;
 
     &-container {
+        height: 100%;
         margin: 0 auto;
+        position: relative;
     }
 
     &-navigationContainer {
@@ -18,14 +20,21 @@ $header-height: 60px;
         overflow-y: scroll;
     }
 
-    &-content {
+    &-contentBox {
+        position: absolute;
+        top: 0;
+        bottom: 0;
         margin-top: 60px;
         margin-left: calc(#{$sidebar-width} - 1px);
-        background-color: $white;
+        height: calc(100% - 60px);
         // Subtract the bootstrap margin too.
         width: calc(100% - #{$sidebar-width} - 30px);
+        background-color: $white;
         border: $border;
-        overflow-y: scroll;
+    }
+
+    &-content {
+        background-color: $white;
     }
 
     @media screen and (max-width: #{$sidebar-breakpoint}) {

--- a/docs/scss/layout.scss
+++ b/docs/scss/layout.scss
@@ -1,3 +1,7 @@
+html, body, #root {
+  height: 100%;
+}
+
 body {
     background-color: $gray;
 }

--- a/docs/src/layouts/Layout.js
+++ b/docs/src/layouts/Layout.js
@@ -103,8 +103,10 @@ export default class Layout extends Component {
               />
             </VerticalNav>
           </div>
-          <div className="Layout-content">
-            {this.props.children}
+          <div className="Layout-contentBox">
+            <div className="Layout-content">
+              {this.props.children}
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Make short pages look like this, while allowing the nav to scroll

![screen shot 2017-11-29 at 12 22 13 pm](https://user-images.githubusercontent.com/2046750/33389230-288e55f8-d500-11e7-81d5-2d00268ae6e8.png)
