### PR TITLE
Fix margin for mobile docs

### DIFF
--- a/docs/scss/docs/Layout.scss
+++ b/docs/scss/docs/Layout.scss
@@ -65,6 +65,12 @@ $header-height: 60px;
             }
         }
 
+        &-contentBox {
+            margin-left: 0;
+            width: 100%;
+            border: 0;
+        }
+
         &-content {
             margin-left: 0;
             width: 100%;


### PR DESCRIPTION
The new container that makes the white background go to the bottom of the screen doesn't have mobile styles.

We want the docs to look like this:
![screen shot 2017-11-30 at 10 03 11 am](https://user-images.githubusercontent.com/2046750/33437404-d115dfec-d5b5-11e7-8ffc-b533e6f6d1d0.png)

But they look like this:
![screen shot 2017-11-30 at 10 03 04 am](https://user-images.githubusercontent.com/2046750/33437416-d9cdc708-d5b5-11e7-8a75-68dabb01b80c.png)

