### PR TITLE
Modifications to AddImage form

### DIFF
--- a/src/data/linodes.js
+++ b/src/data/linodes.js
@@ -504,6 +504,35 @@ export const testLinode1248 = {
   status: 'provisioning',
 };
 
+export const testLinodeWithRawDisk = {
+  ...createTestLinode(1249),
+  label: 'test-linode-raw',
+  _disks: {
+    totalResults: 1,
+    totalPages: 1,
+    disks: {
+      12345: {
+        id: 12345,
+        size: 6144,
+        created: '2016-08-09T19:47:11',
+        updated: '2016-08-09T19:47:11',
+        filesystem: 'raw',
+        label: 'Raw Disk',
+      },
+    },
+  },
+};
+
+export const testLinodeWithNoDisks = {
+  ...createTestLinode(1250),
+  label: 'test-linode-no-disks',
+  _disks: {
+    totalResults: 0,
+    totalPages: 1,
+    disks: {},
+  },
+};
+
 export const linodes = [
   testLinode,
   testLinode1233,
@@ -520,4 +549,6 @@ export const linodes = [
   testLinode1246,
   testLinode1247,
   testLinode1248,
+  testLinodeWithRawDisk,
+  testLinodeWithNoDisks,
 ].reduce((object, linode) => ({ ...object, [linode.id]: linode }), {});

--- a/src/linodes/images/components/AddImage.js
+++ b/src/linodes/images/components/AddImage.js
@@ -105,7 +105,8 @@ export default class AddImage extends Component {
     const { label, description, errors, linode, linodes, disk, allDisks, loading } = this.state;
     let disks = allDisks[linode] || [];
     // swap has already been filtered out
-    const isSimpleLinode = disks.length <= 1;
+    const hasRawDisks = disks.filter(disk => disk.filesystem === 'raw').length > 0;
+    const isSimpleLinode = !hasRawDisks && disks.length <= 1;
     // now that we know isSimpleLinode, filter out raw disks
     disks = disks.filter(disk => disk.filesystem !== 'raw');
 
@@ -128,7 +129,7 @@ export default class AddImage extends Component {
                 onChange={this.onLinodeChange}
               />
               <small className="text-muted">
-              Note: Disk usage may not exceed 2048 MB.
+                Disk usage may not exceed 2048 MB.
               </small>
             </ModalFormGroup>
             : null}
@@ -147,6 +148,11 @@ export default class AddImage extends Component {
                   value={loading ? '' : 'None'}
                   disabled
                 />
+              }
+              {(disks.length === 0 && hasRawDisks) &&
+                <small className="text-muted">
+                  Cannot create images from raw disks.
+                </small>
               }
             </ModalFormGroup>
             : null}

--- a/src/linodes/images/components/AddImage.js
+++ b/src/linodes/images/components/AddImage.js
@@ -103,8 +103,11 @@ export default class AddImage extends Component {
   render() {
     const { dispatch } = this.props;
     const { label, description, errors, linode, linodes, disk, allDisks, loading } = this.state;
-    const disks = allDisks[linode] || [];
-    const diskObj = linodes ? this.getDiskObject(disks, disk) : disk;
+    let disks = allDisks[linode] || [];
+    // swap has already been filtered out
+    const isSimpleLinode = disks.length <= 1;
+    // now that we know isSimpleLinode, filter out raw disks
+    disks = disks.filter(disk => disk.filesystem !== 'raw');
 
     return (
       <FormModalBody
@@ -124,9 +127,12 @@ export default class AddImage extends Component {
                 id="linode"
                 onChange={this.onLinodeChange}
               />
+              <small className="text-muted">
+              Note: Disk usage may not exceed 2048 MB.
+              </small>
             </ModalFormGroup>
             : null}
-          {linodes ?
+          {!isSimpleLinode ?
             <ModalFormGroup label="Disk" id="disk" apiKey="disk">
               {disks.length ?
                 <Select
@@ -142,25 +148,6 @@ export default class AddImage extends Component {
                   disabled
                 />
               }
-            </ModalFormGroup>
-            : null}
-          {disk && diskObj ?
-            <ModalFormGroup label="Type" id="type">
-              <Input
-                value={diskObj.filesystem}
-                disabled
-              />
-            </ModalFormGroup>
-            : null}
-          {disk && diskObj ?
-            <ModalFormGroup errors={errors} label="Size" id="size">
-              <Input
-                value={`${diskObj.size} MB`}
-                disabled
-              />
-              <small className="text-muted">
-                Disk usage may not exceed 2048 MB for this Image.
-              </small>
             </ModalFormGroup>
             : null}
           <ModalFormGroup errors={errors} id="label" label="Label" apiKey="label">

--- a/src/linodes/images/components/AddImage.js
+++ b/src/linodes/images/components/AddImage.js
@@ -132,9 +132,9 @@ export default class AddImage extends Component {
         input field. This indicates to the customer that they could choose
         disks if they modify their Linode's config.
       */
-      : <Input value="" disabled />;
+      : <Input name="disk" value="None" disabled />;
     const helpText = (diskOptions.length === 0 && (rawDisks.length > 0 || swapDisks.length > 0)) ?
-      <small className="text-muted">
+      <small id="help-raw" className="text-muted">
         Cannot create images from raw disks or swap volumes.
       </small>
       : null;

--- a/src/linodes/images/components/AddImage.spec.js
+++ b/src/linodes/images/components/AddImage.spec.js
@@ -5,7 +5,10 @@ import { AddImage } from '~/linodes/images/components';
 
 import { changeInput, expectDispatchOrStoreErrors, expectRequest } from '~/test.helpers';
 import { api } from '~/data';
-import { testLinode1238 } from '~/data/linodes';
+import {
+  testLinode1238,
+  testLinodeWithRawDisk,
+  testLinodeWithNoDisks } from '~/data/linodes';
 
 const { linodes } = api;
 
@@ -66,5 +69,65 @@ describe('linodes/images/components/AddImage', function () {
         },
       }),
     ], 2);
+  });
+
+  it('does not render a disk field for a simple linode', async function () {
+    AddImage.trigger(dispatch, linodes);
+    const modal = await mount(dispatch.firstCall.args[0].body);
+    const diskId = Object.keys(testLinode1238._disks.disks)[0].id;
+
+    await modal.setState({
+      linode: testLinode1238.id,
+      allDisks: { [testLinode1238.id]: Object.values(testLinode1238._disks.disks).map(
+        d => ({ value: d.id, label: d.label, size: d.size, filesystem: d.filesystem })) },
+      disk: diskId,
+      loading: false,
+    });
+
+    const linodeInput = modal.find('ModalFormGroup#linode');
+    expect(linodeInput.length).toBe(1);
+
+    const diskInput = modal.find('ModalFormGroup#disk');
+    expect(diskInput.length).toBe(0);
+  });
+
+  it('renders an input field and a message with only raw disks', async function () {
+    AddImage.trigger(dispatch, linodes);
+    const modal = await mount(dispatch.firstCall.args[0].body);
+    const diskId = Object.keys(testLinodeWithRawDisk._disks.disks)[0].id;
+
+    await modal.setState({
+      linode: testLinodeWithRawDisk.id,
+      allDisks: { [testLinodeWithRawDisk.id]:
+        Object.values(testLinodeWithRawDisk._disks.disks).map(
+          d => ({ value: d.id, label: d.label, size: d.size, filesystem: d.filesystem })) },
+      disk: diskId,
+      loading: false,
+    });
+
+    const diskInput = modal.find('Input[name="disk"]');
+    expect(diskInput.length).toBe(1);
+
+    const helpText = modal.find('#help-raw');
+    expect(helpText.length).toBe(1);
+  });
+
+  it('renders an input field and no message with no disks', async function () {
+    AddImage.trigger(dispatch, linodes);
+    const modal = await mount(dispatch.firstCall.args[0].body);
+
+    await modal.setState({
+      linode: testLinodeWithNoDisks.id,
+      allDisks: { [testLinodeWithNoDisks.id]:
+        Object.values(testLinodeWithNoDisks._disks.disks).map(
+          d => ({ value: d.id, label: d.label, size: d.size, filesystem: d.filesystem })) },
+      loading: false,
+    });
+
+    const diskInput = modal.find('Input[name="disk"]');
+    expect(diskInput.length).toBe(1);
+
+    const helpText = modal.find('#help-raw');
+    expect(helpText.length).toBe(0);
   });
 });

--- a/src/linodes/linode/backups/components/__snapshots__/BackupRestore.spec.js.snap
+++ b/src/linodes/linode/backups/components/__snapshots__/BackupRestore.spec.js.snap
@@ -373,6 +373,8 @@ ShallowWrapper {
           1246,
           1247,
           1248,
+          1249,
+          1250,
         ],
         "linodes": Object {
           "1233": Object {
@@ -5132,6 +5134,613 @@ ShallowWrapper {
             },
             "vcpus": 2,
           },
+          "1249": Object {
+            "_backups": Object {
+              "daily": Object {
+                "availability": "daily",
+                "configs": Array [
+                  "Ubuntu Disk",
+                ],
+                "created": "2017-01-31T07:28:52",
+                "disks": Array [
+                  Object {
+                    "filesystem": "ext4",
+                    "label": "Ubuntu 15.10 Disk",
+                    "size": 2330,
+                  },
+                  Object {
+                    "filesystem": "swap",
+                    "label": "512 MB Swap Image",
+                    "size": 0,
+                  },
+                ],
+                "finished": "2017-01-31T07:30:03",
+                "id": 54782214,
+                "label": null,
+                "region": "us-east-1a",
+                "status": "successful",
+                "type": "auto",
+                "updated": "2017-01-31T12:32:01",
+              },
+              "snapshot": Object {
+                "current": Object {
+                  "availability": "unavailable",
+                  "configs": Array [
+                    "Some config",
+                  ],
+                  "created": "2017-01-31T21:50:42",
+                  "disks": Array [
+                    Object {
+                      "filesystem": "ext4",
+                      "label": "Ubuntu 15.10 Disk",
+                      "size": 2330,
+                    },
+                    Object {
+                      "filesystem": "swap",
+                      "label": "512 MB Swap Image",
+                      "size": 0,
+                    },
+                  ],
+                  "finished": "2017-01-31T21:51:51",
+                  "id": 54782236,
+                  "label": "the label",
+                  "region": "us-east-1a",
+                  "status": "successful",
+                  "type": "snapshot",
+                  "updated": "2017-01-31T21:51:51",
+                },
+                "in_progress": null,
+              },
+              "weekly": Array [],
+            },
+            "_configs": Object {
+              "configs": Object {
+                "12345": Object {
+                  "comments": "Test comments",
+                  "created": "2015-09-29 11:21:38 +0000",
+                  "devices": Object {
+                    "sda": Object {
+                      "disk_id": 12345,
+                    },
+                    "sdb": Object {
+                      "disk_id": 12346,
+                    },
+                    "sdc": null,
+                    "sdd": null,
+                    "sde": null,
+                    "sdf": null,
+                    "sdg": null,
+                    "sdh": null,
+                  },
+                  "helpers": Object {
+                    "devtmpfs_automount": false,
+                    "distro": true,
+                    "modules_dep": true,
+                    "network": true,
+                    "updatedb_disabled": true,
+                  },
+                  "id": 12345,
+                  "initrd": "",
+                  "kernel": "linode/latest_64",
+                  "label": "Test config",
+                  "memory_limit": 1024,
+                  "root_device": "/dev/sda",
+                  "run_level": "default",
+                  "updated": "2015-09-29 11:21:38 +0000",
+                  "virt_mode": "paravirt",
+                },
+              },
+              "pagesFetched": Array [
+                0,
+              ],
+              "totalPages": 1,
+              "totalResults": 1,
+            },
+            "_disks": Object {
+              "disks": Object {
+                "12345": Object {
+                  "created": "2016-08-09T19:47:11",
+                  "filesystem": "raw",
+                  "id": 12345,
+                  "label": "Raw Disk",
+                  "size": 6144,
+                  "updated": "2016-08-09T19:47:11",
+                },
+              },
+              "totalPages": 1,
+              "totalResults": 1,
+            },
+            "_ips": Object {
+              "2600:3c03::f03c:91ff:fe0a:31": Object {
+                "address": "2600:3c03::f03c:91ff:fe0a:31",
+                "gateway": "fe80::1",
+                "key": "2600:3c03::f03c:91ff:fe0a:31",
+                "linode_id": 1249,
+                "prefix": "64",
+                "rdns": "li1-1.members.linode.com",
+                "type": "slaac",
+                "version": "ipv6",
+              },
+              "97.107.143.47": Object {
+                "address": "97.107.143.47",
+                "gateway": "97.107.143.0",
+                "key": "97.107.143.47",
+                "linode_id": 1249,
+                "prefix": 24,
+                "rdns": "li1-1.members.linode.com",
+                "type": "public",
+                "version": "ipv4",
+              },
+              "97.107.143.49": Object {
+                "address": "97.107.143.49",
+                "gateway": "97.107.143.0",
+                "key": "97.107.143.49",
+                "linode_id": 1249,
+                "prefix": 17,
+                "rdns": "li1-1.members.linode.com",
+                "type": "private",
+                "version": "ipv4",
+              },
+              "fe80::f03c:91ff:fe0a:181f": Object {
+                "address": "fe80::f03c:91ff:fe0a:181f",
+                "key": "fe80::f03c:91ff:fe0a:181f",
+                "linode_id": 1249,
+                "type": "link-local",
+                "version": "ipv6",
+              },
+            },
+            "_polling": false,
+            "_shared": Array [],
+            "_stats": Object {
+              "cpu": Array [
+                Array [
+                  1490378700000,
+                  1.67,
+                ],
+              ],
+              "io": Object {
+                "io": Array [
+                  Array [
+                    1490379000000,
+                    0.91,
+                  ],
+                ],
+                "swap": Array [
+                  Array [
+                    1490378100000,
+                    0,
+                  ],
+                ],
+              },
+              "netv4": Object {
+                "in": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "out": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "private_in": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "private_out": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+              },
+              "netv6": Object {
+                "in": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "out": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "private_in": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "private_out": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+              },
+            },
+            "_volumes": Object {
+              "pagesFetched": Array [
+                0,
+              ],
+              "totalPages": 1,
+              "totalResults": 1,
+              "volumes": Object {
+                "38": Object {
+                  "created": "2017-08-08T13:55:16",
+                  "id": 38,
+                  "label": "test",
+                  "linode_id": null,
+                  "region": "us-east-1a",
+                  "size": 20,
+                  "status": "active",
+                  "updated": "2017-08-08T04:00:00",
+                },
+              },
+            },
+            "alerts": Object {
+              "cpu": 90,
+              "io": 5000,
+              "network_in": 5,
+              "network_out": 5,
+              "tranfer_quota": 80,
+            },
+            "backups": Object {
+              "enabled": true,
+              "schedule": Object {
+                "day": "Monday",
+                "window": "W10",
+              },
+            },
+            "created": "2016-07-06T16:47:27",
+            "disk": 20480,
+            "group": "Test Group",
+            "hypervisor": "kvm",
+            "id": 1249,
+            "image": Object {
+              "id": "linode/ubuntu15.10",
+              "label": "Ubuntu 15.10",
+              "vendor": "Ubuntu",
+            },
+            "ipv4": Array [
+              "97.107.143.47",
+              "97.107.143.48",
+            ],
+            "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+            "label": "test-linode-raw",
+            "memory": 2048,
+            "region": "us-east-1a",
+            "status": "running",
+            "type": Object {
+              "_polling": false,
+              "addons": Object {
+                "backups": Object {
+                  "price": Object {
+                    "monthly": 2.5,
+                  },
+                },
+              },
+              "class": "standard",
+              "disk": 24576,
+              "id": "linode2048.5",
+              "label": "Linode 2048",
+              "memory": 2048,
+              "network_out": 125,
+              "price": Object {
+                "hourly": 0.015,
+                "monthly": 10,
+              },
+              "service_type": "linode",
+              "transfer": 2000,
+              "vcpus": 2,
+            },
+            "vcpus": 2,
+          },
+          "1250": Object {
+            "_backups": Object {
+              "daily": Object {
+                "availability": "daily",
+                "configs": Array [
+                  "Ubuntu Disk",
+                ],
+                "created": "2017-01-31T07:28:52",
+                "disks": Array [
+                  Object {
+                    "filesystem": "ext4",
+                    "label": "Ubuntu 15.10 Disk",
+                    "size": 2330,
+                  },
+                  Object {
+                    "filesystem": "swap",
+                    "label": "512 MB Swap Image",
+                    "size": 0,
+                  },
+                ],
+                "finished": "2017-01-31T07:30:03",
+                "id": 54782214,
+                "label": null,
+                "region": "us-east-1a",
+                "status": "successful",
+                "type": "auto",
+                "updated": "2017-01-31T12:32:01",
+              },
+              "snapshot": Object {
+                "current": Object {
+                  "availability": "unavailable",
+                  "configs": Array [
+                    "Some config",
+                  ],
+                  "created": "2017-01-31T21:50:42",
+                  "disks": Array [
+                    Object {
+                      "filesystem": "ext4",
+                      "label": "Ubuntu 15.10 Disk",
+                      "size": 2330,
+                    },
+                    Object {
+                      "filesystem": "swap",
+                      "label": "512 MB Swap Image",
+                      "size": 0,
+                    },
+                  ],
+                  "finished": "2017-01-31T21:51:51",
+                  "id": 54782236,
+                  "label": "the label",
+                  "region": "us-east-1a",
+                  "status": "successful",
+                  "type": "snapshot",
+                  "updated": "2017-01-31T21:51:51",
+                },
+                "in_progress": null,
+              },
+              "weekly": Array [],
+            },
+            "_configs": Object {
+              "configs": Object {
+                "12345": Object {
+                  "comments": "Test comments",
+                  "created": "2015-09-29 11:21:38 +0000",
+                  "devices": Object {
+                    "sda": Object {
+                      "disk_id": 12345,
+                    },
+                    "sdb": Object {
+                      "disk_id": 12346,
+                    },
+                    "sdc": null,
+                    "sdd": null,
+                    "sde": null,
+                    "sdf": null,
+                    "sdg": null,
+                    "sdh": null,
+                  },
+                  "helpers": Object {
+                    "devtmpfs_automount": false,
+                    "distro": true,
+                    "modules_dep": true,
+                    "network": true,
+                    "updatedb_disabled": true,
+                  },
+                  "id": 12345,
+                  "initrd": "",
+                  "kernel": "linode/latest_64",
+                  "label": "Test config",
+                  "memory_limit": 1024,
+                  "root_device": "/dev/sda",
+                  "run_level": "default",
+                  "updated": "2015-09-29 11:21:38 +0000",
+                  "virt_mode": "paravirt",
+                },
+              },
+              "pagesFetched": Array [
+                0,
+              ],
+              "totalPages": 1,
+              "totalResults": 1,
+            },
+            "_disks": Object {
+              "disks": Object {},
+              "totalPages": 1,
+              "totalResults": 0,
+            },
+            "_ips": Object {
+              "2600:3c03::f03c:91ff:fe0a:33": Object {
+                "address": "2600:3c03::f03c:91ff:fe0a:33",
+                "gateway": "fe80::1",
+                "key": "2600:3c03::f03c:91ff:fe0a:33",
+                "linode_id": 1250,
+                "prefix": "64",
+                "rdns": "li1-1.members.linode.com",
+                "type": "slaac",
+                "version": "ipv6",
+              },
+              "97.107.143.50": Object {
+                "address": "97.107.143.50",
+                "gateway": "97.107.143.0",
+                "key": "97.107.143.50",
+                "linode_id": 1250,
+                "prefix": 24,
+                "rdns": "li1-1.members.linode.com",
+                "type": "public",
+                "version": "ipv4",
+              },
+              "97.107.143.52": Object {
+                "address": "97.107.143.52",
+                "gateway": "97.107.143.0",
+                "key": "97.107.143.52",
+                "linode_id": 1250,
+                "prefix": 17,
+                "rdns": "li1-1.members.linode.com",
+                "type": "private",
+                "version": "ipv4",
+              },
+              "fe80::f03c:91ff:fe0a:181f": Object {
+                "address": "fe80::f03c:91ff:fe0a:181f",
+                "key": "fe80::f03c:91ff:fe0a:181f",
+                "linode_id": 1250,
+                "type": "link-local",
+                "version": "ipv6",
+              },
+            },
+            "_polling": false,
+            "_shared": Array [],
+            "_stats": Object {
+              "cpu": Array [
+                Array [
+                  1490378700000,
+                  1.67,
+                ],
+              ],
+              "io": Object {
+                "io": Array [
+                  Array [
+                    1490379000000,
+                    0.91,
+                  ],
+                ],
+                "swap": Array [
+                  Array [
+                    1490378100000,
+                    0,
+                  ],
+                ],
+              },
+              "netv4": Object {
+                "in": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "out": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "private_in": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "private_out": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+              },
+              "netv6": Object {
+                "in": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "out": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "private_in": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+                "private_out": Array [
+                  Array [
+                    1490377800000,
+                    0,
+                  ],
+                ],
+              },
+            },
+            "_volumes": Object {
+              "pagesFetched": Array [
+                0,
+              ],
+              "totalPages": 1,
+              "totalResults": 1,
+              "volumes": Object {
+                "38": Object {
+                  "created": "2017-08-08T13:55:16",
+                  "id": 38,
+                  "label": "test",
+                  "linode_id": null,
+                  "region": "us-east-1a",
+                  "size": 20,
+                  "status": "active",
+                  "updated": "2017-08-08T04:00:00",
+                },
+              },
+            },
+            "alerts": Object {
+              "cpu": 90,
+              "io": 5000,
+              "network_in": 5,
+              "network_out": 5,
+              "tranfer_quota": 80,
+            },
+            "backups": Object {
+              "enabled": true,
+              "schedule": Object {
+                "day": "Monday",
+                "window": "W10",
+              },
+            },
+            "created": "2016-07-06T16:47:27",
+            "disk": 20480,
+            "group": "Test Group",
+            "hypervisor": "kvm",
+            "id": 1250,
+            "image": Object {
+              "id": "linode/ubuntu15.10",
+              "label": "Ubuntu 15.10",
+              "vendor": "Ubuntu",
+            },
+            "ipv4": Array [
+              "97.107.143.50",
+              "97.107.143.51",
+            ],
+            "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+            "label": "test-linode-no-disks",
+            "memory": 2048,
+            "region": "us-east-1a",
+            "status": "running",
+            "type": Object {
+              "_polling": false,
+              "addons": Object {
+                "backups": Object {
+                  "price": Object {
+                    "monthly": 2.5,
+                  },
+                },
+              },
+              "class": "standard",
+              "disk": 24576,
+              "id": "linode2048.5",
+              "label": "Linode 2048",
+              "memory": 2048,
+              "network_out": 125,
+              "price": Object {
+                "hourly": 0.015,
+                "monthly": 10,
+              },
+              "service_type": "linode",
+              "transfer": 2000,
+              "vcpus": 2,
+            },
+            "vcpus": 2,
+          },
         },
         "pagesFetched": Array [
           1,
@@ -5139,7 +5748,7 @@ ShallowWrapper {
         "plural": "linodes",
         "singular": "linode",
         "totalPages": 1,
-        "totalResults": 15,
+        "totalResults": 17,
       }
     }
   />,
@@ -9595,6 +10204,613 @@ ShallowWrapper {
                     "memory": 2048,
                     "region": "us-east-1a",
                     "status": "provisioning",
+                    "type": Object {
+                      "_polling": false,
+                      "addons": Object {
+                        "backups": Object {
+                          "price": Object {
+                            "monthly": 2.5,
+                          },
+                        },
+                      },
+                      "class": "standard",
+                      "disk": 24576,
+                      "id": "linode2048.5",
+                      "label": "Linode 2048",
+                      "memory": 2048,
+                      "network_out": 125,
+                      "price": Object {
+                        "hourly": 0.015,
+                        "monthly": 10,
+                      },
+                      "service_type": "linode",
+                      "transfer": 2000,
+                      "vcpus": 2,
+                    },
+                    "vcpus": 2,
+                  },
+                  "1249": Object {
+                    "_backups": Object {
+                      "daily": Object {
+                        "availability": "daily",
+                        "configs": Array [
+                          "Ubuntu Disk",
+                        ],
+                        "created": "2017-01-31T07:28:52",
+                        "disks": Array [
+                          Object {
+                            "filesystem": "ext4",
+                            "label": "Ubuntu 15.10 Disk",
+                            "size": 2330,
+                          },
+                          Object {
+                            "filesystem": "swap",
+                            "label": "512 MB Swap Image",
+                            "size": 0,
+                          },
+                        ],
+                        "finished": "2017-01-31T07:30:03",
+                        "id": 54782214,
+                        "label": null,
+                        "region": "us-east-1a",
+                        "status": "successful",
+                        "type": "auto",
+                        "updated": "2017-01-31T12:32:01",
+                      },
+                      "snapshot": Object {
+                        "current": Object {
+                          "availability": "unavailable",
+                          "configs": Array [
+                            "Some config",
+                          ],
+                          "created": "2017-01-31T21:50:42",
+                          "disks": Array [
+                            Object {
+                              "filesystem": "ext4",
+                              "label": "Ubuntu 15.10 Disk",
+                              "size": 2330,
+                            },
+                            Object {
+                              "filesystem": "swap",
+                              "label": "512 MB Swap Image",
+                              "size": 0,
+                            },
+                          ],
+                          "finished": "2017-01-31T21:51:51",
+                          "id": 54782236,
+                          "label": "the label",
+                          "region": "us-east-1a",
+                          "status": "successful",
+                          "type": "snapshot",
+                          "updated": "2017-01-31T21:51:51",
+                        },
+                        "in_progress": null,
+                      },
+                      "weekly": Array [],
+                    },
+                    "_configs": Object {
+                      "configs": Object {
+                        "12345": Object {
+                          "comments": "Test comments",
+                          "created": "2015-09-29 11:21:38 +0000",
+                          "devices": Object {
+                            "sda": Object {
+                              "disk_id": 12345,
+                            },
+                            "sdb": Object {
+                              "disk_id": 12346,
+                            },
+                            "sdc": null,
+                            "sdd": null,
+                            "sde": null,
+                            "sdf": null,
+                            "sdg": null,
+                            "sdh": null,
+                          },
+                          "helpers": Object {
+                            "devtmpfs_automount": false,
+                            "distro": true,
+                            "modules_dep": true,
+                            "network": true,
+                            "updatedb_disabled": true,
+                          },
+                          "id": 12345,
+                          "initrd": "",
+                          "kernel": "linode/latest_64",
+                          "label": "Test config",
+                          "memory_limit": 1024,
+                          "root_device": "/dev/sda",
+                          "run_level": "default",
+                          "updated": "2015-09-29 11:21:38 +0000",
+                          "virt_mode": "paravirt",
+                        },
+                      },
+                      "pagesFetched": Array [
+                        0,
+                      ],
+                      "totalPages": 1,
+                      "totalResults": 1,
+                    },
+                    "_disks": Object {
+                      "disks": Object {
+                        "12345": Object {
+                          "created": "2016-08-09T19:47:11",
+                          "filesystem": "raw",
+                          "id": 12345,
+                          "label": "Raw Disk",
+                          "size": 6144,
+                          "updated": "2016-08-09T19:47:11",
+                        },
+                      },
+                      "totalPages": 1,
+                      "totalResults": 1,
+                    },
+                    "_ips": Object {
+                      "2600:3c03::f03c:91ff:fe0a:31": Object {
+                        "address": "2600:3c03::f03c:91ff:fe0a:31",
+                        "gateway": "fe80::1",
+                        "key": "2600:3c03::f03c:91ff:fe0a:31",
+                        "linode_id": 1249,
+                        "prefix": "64",
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "slaac",
+                        "version": "ipv6",
+                      },
+                      "97.107.143.47": Object {
+                        "address": "97.107.143.47",
+                        "gateway": "97.107.143.0",
+                        "key": "97.107.143.47",
+                        "linode_id": 1249,
+                        "prefix": 24,
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "public",
+                        "version": "ipv4",
+                      },
+                      "97.107.143.49": Object {
+                        "address": "97.107.143.49",
+                        "gateway": "97.107.143.0",
+                        "key": "97.107.143.49",
+                        "linode_id": 1249,
+                        "prefix": 17,
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "private",
+                        "version": "ipv4",
+                      },
+                      "fe80::f03c:91ff:fe0a:181f": Object {
+                        "address": "fe80::f03c:91ff:fe0a:181f",
+                        "key": "fe80::f03c:91ff:fe0a:181f",
+                        "linode_id": 1249,
+                        "type": "link-local",
+                        "version": "ipv6",
+                      },
+                    },
+                    "_polling": false,
+                    "_shared": Array [],
+                    "_stats": Object {
+                      "cpu": Array [
+                        Array [
+                          1490378700000,
+                          1.67,
+                        ],
+                      ],
+                      "io": Object {
+                        "io": Array [
+                          Array [
+                            1490379000000,
+                            0.91,
+                          ],
+                        ],
+                        "swap": Array [
+                          Array [
+                            1490378100000,
+                            0,
+                          ],
+                        ],
+                      },
+                      "netv4": Object {
+                        "in": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "out": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "private_in": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "private_out": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                      },
+                      "netv6": Object {
+                        "in": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "out": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "private_in": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "private_out": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                      },
+                    },
+                    "_volumes": Object {
+                      "pagesFetched": Array [
+                        0,
+                      ],
+                      "totalPages": 1,
+                      "totalResults": 1,
+                      "volumes": Object {
+                        "38": Object {
+                          "created": "2017-08-08T13:55:16",
+                          "id": 38,
+                          "label": "test",
+                          "linode_id": null,
+                          "region": "us-east-1a",
+                          "size": 20,
+                          "status": "active",
+                          "updated": "2017-08-08T04:00:00",
+                        },
+                      },
+                    },
+                    "alerts": Object {
+                      "cpu": 90,
+                      "io": 5000,
+                      "network_in": 5,
+                      "network_out": 5,
+                      "tranfer_quota": 80,
+                    },
+                    "backups": Object {
+                      "enabled": true,
+                      "schedule": Object {
+                        "day": "Monday",
+                        "window": "W10",
+                      },
+                    },
+                    "created": "2016-07-06T16:47:27",
+                    "disk": 20480,
+                    "group": "Test Group",
+                    "hypervisor": "kvm",
+                    "id": 1249,
+                    "image": Object {
+                      "id": "linode/ubuntu15.10",
+                      "label": "Ubuntu 15.10",
+                      "vendor": "Ubuntu",
+                    },
+                    "ipv4": Array [
+                      "97.107.143.47",
+                      "97.107.143.48",
+                    ],
+                    "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                    "label": "test-linode-raw",
+                    "memory": 2048,
+                    "region": "us-east-1a",
+                    "status": "running",
+                    "type": Object {
+                      "_polling": false,
+                      "addons": Object {
+                        "backups": Object {
+                          "price": Object {
+                            "monthly": 2.5,
+                          },
+                        },
+                      },
+                      "class": "standard",
+                      "disk": 24576,
+                      "id": "linode2048.5",
+                      "label": "Linode 2048",
+                      "memory": 2048,
+                      "network_out": 125,
+                      "price": Object {
+                        "hourly": 0.015,
+                        "monthly": 10,
+                      },
+                      "service_type": "linode",
+                      "transfer": 2000,
+                      "vcpus": 2,
+                    },
+                    "vcpus": 2,
+                  },
+                  "1250": Object {
+                    "_backups": Object {
+                      "daily": Object {
+                        "availability": "daily",
+                        "configs": Array [
+                          "Ubuntu Disk",
+                        ],
+                        "created": "2017-01-31T07:28:52",
+                        "disks": Array [
+                          Object {
+                            "filesystem": "ext4",
+                            "label": "Ubuntu 15.10 Disk",
+                            "size": 2330,
+                          },
+                          Object {
+                            "filesystem": "swap",
+                            "label": "512 MB Swap Image",
+                            "size": 0,
+                          },
+                        ],
+                        "finished": "2017-01-31T07:30:03",
+                        "id": 54782214,
+                        "label": null,
+                        "region": "us-east-1a",
+                        "status": "successful",
+                        "type": "auto",
+                        "updated": "2017-01-31T12:32:01",
+                      },
+                      "snapshot": Object {
+                        "current": Object {
+                          "availability": "unavailable",
+                          "configs": Array [
+                            "Some config",
+                          ],
+                          "created": "2017-01-31T21:50:42",
+                          "disks": Array [
+                            Object {
+                              "filesystem": "ext4",
+                              "label": "Ubuntu 15.10 Disk",
+                              "size": 2330,
+                            },
+                            Object {
+                              "filesystem": "swap",
+                              "label": "512 MB Swap Image",
+                              "size": 0,
+                            },
+                          ],
+                          "finished": "2017-01-31T21:51:51",
+                          "id": 54782236,
+                          "label": "the label",
+                          "region": "us-east-1a",
+                          "status": "successful",
+                          "type": "snapshot",
+                          "updated": "2017-01-31T21:51:51",
+                        },
+                        "in_progress": null,
+                      },
+                      "weekly": Array [],
+                    },
+                    "_configs": Object {
+                      "configs": Object {
+                        "12345": Object {
+                          "comments": "Test comments",
+                          "created": "2015-09-29 11:21:38 +0000",
+                          "devices": Object {
+                            "sda": Object {
+                              "disk_id": 12345,
+                            },
+                            "sdb": Object {
+                              "disk_id": 12346,
+                            },
+                            "sdc": null,
+                            "sdd": null,
+                            "sde": null,
+                            "sdf": null,
+                            "sdg": null,
+                            "sdh": null,
+                          },
+                          "helpers": Object {
+                            "devtmpfs_automount": false,
+                            "distro": true,
+                            "modules_dep": true,
+                            "network": true,
+                            "updatedb_disabled": true,
+                          },
+                          "id": 12345,
+                          "initrd": "",
+                          "kernel": "linode/latest_64",
+                          "label": "Test config",
+                          "memory_limit": 1024,
+                          "root_device": "/dev/sda",
+                          "run_level": "default",
+                          "updated": "2015-09-29 11:21:38 +0000",
+                          "virt_mode": "paravirt",
+                        },
+                      },
+                      "pagesFetched": Array [
+                        0,
+                      ],
+                      "totalPages": 1,
+                      "totalResults": 1,
+                    },
+                    "_disks": Object {
+                      "disks": Object {},
+                      "totalPages": 1,
+                      "totalResults": 0,
+                    },
+                    "_ips": Object {
+                      "2600:3c03::f03c:91ff:fe0a:33": Object {
+                        "address": "2600:3c03::f03c:91ff:fe0a:33",
+                        "gateway": "fe80::1",
+                        "key": "2600:3c03::f03c:91ff:fe0a:33",
+                        "linode_id": 1250,
+                        "prefix": "64",
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "slaac",
+                        "version": "ipv6",
+                      },
+                      "97.107.143.50": Object {
+                        "address": "97.107.143.50",
+                        "gateway": "97.107.143.0",
+                        "key": "97.107.143.50",
+                        "linode_id": 1250,
+                        "prefix": 24,
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "public",
+                        "version": "ipv4",
+                      },
+                      "97.107.143.52": Object {
+                        "address": "97.107.143.52",
+                        "gateway": "97.107.143.0",
+                        "key": "97.107.143.52",
+                        "linode_id": 1250,
+                        "prefix": 17,
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "private",
+                        "version": "ipv4",
+                      },
+                      "fe80::f03c:91ff:fe0a:181f": Object {
+                        "address": "fe80::f03c:91ff:fe0a:181f",
+                        "key": "fe80::f03c:91ff:fe0a:181f",
+                        "linode_id": 1250,
+                        "type": "link-local",
+                        "version": "ipv6",
+                      },
+                    },
+                    "_polling": false,
+                    "_shared": Array [],
+                    "_stats": Object {
+                      "cpu": Array [
+                        Array [
+                          1490378700000,
+                          1.67,
+                        ],
+                      ],
+                      "io": Object {
+                        "io": Array [
+                          Array [
+                            1490379000000,
+                            0.91,
+                          ],
+                        ],
+                        "swap": Array [
+                          Array [
+                            1490378100000,
+                            0,
+                          ],
+                        ],
+                      },
+                      "netv4": Object {
+                        "in": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "out": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "private_in": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "private_out": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                      },
+                      "netv6": Object {
+                        "in": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "out": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "private_in": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                        "private_out": Array [
+                          Array [
+                            1490377800000,
+                            0,
+                          ],
+                        ],
+                      },
+                    },
+                    "_volumes": Object {
+                      "pagesFetched": Array [
+                        0,
+                      ],
+                      "totalPages": 1,
+                      "totalResults": 1,
+                      "volumes": Object {
+                        "38": Object {
+                          "created": "2017-08-08T13:55:16",
+                          "id": 38,
+                          "label": "test",
+                          "linode_id": null,
+                          "region": "us-east-1a",
+                          "size": 20,
+                          "status": "active",
+                          "updated": "2017-08-08T04:00:00",
+                        },
+                      },
+                    },
+                    "alerts": Object {
+                      "cpu": 90,
+                      "io": 5000,
+                      "network_in": 5,
+                      "network_out": 5,
+                      "tranfer_quota": 80,
+                    },
+                    "backups": Object {
+                      "enabled": true,
+                      "schedule": Object {
+                        "day": "Monday",
+                        "window": "W10",
+                      },
+                    },
+                    "created": "2016-07-06T16:47:27",
+                    "disk": 20480,
+                    "group": "Test Group",
+                    "hypervisor": "kvm",
+                    "id": 1250,
+                    "image": Object {
+                      "id": "linode/ubuntu15.10",
+                      "label": "Ubuntu 15.10",
+                      "vendor": "Ubuntu",
+                    },
+                    "ipv4": Array [
+                      "97.107.143.50",
+                      "97.107.143.51",
+                    ],
+                    "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                    "label": "test-linode-no-disks",
+                    "memory": 2048,
+                    "region": "us-east-1a",
+                    "status": "running",
                     "type": Object {
                       "_polling": false,
                       "addons": Object {
@@ -14472,6 +15688,613 @@ ShallowWrapper {
                       },
                       "vcpus": 2,
                     },
+                    "1249": Object {
+                      "_backups": Object {
+                        "daily": Object {
+                          "availability": "daily",
+                          "configs": Array [
+                            "Ubuntu Disk",
+                          ],
+                          "created": "2017-01-31T07:28:52",
+                          "disks": Array [
+                            Object {
+                              "filesystem": "ext4",
+                              "label": "Ubuntu 15.10 Disk",
+                              "size": 2330,
+                            },
+                            Object {
+                              "filesystem": "swap",
+                              "label": "512 MB Swap Image",
+                              "size": 0,
+                            },
+                          ],
+                          "finished": "2017-01-31T07:30:03",
+                          "id": 54782214,
+                          "label": null,
+                          "region": "us-east-1a",
+                          "status": "successful",
+                          "type": "auto",
+                          "updated": "2017-01-31T12:32:01",
+                        },
+                        "snapshot": Object {
+                          "current": Object {
+                            "availability": "unavailable",
+                            "configs": Array [
+                              "Some config",
+                            ],
+                            "created": "2017-01-31T21:50:42",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T21:51:51",
+                            "id": 54782236,
+                            "label": "the label",
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "snapshot",
+                            "updated": "2017-01-31T21:51:51",
+                          },
+                          "in_progress": null,
+                        },
+                        "weekly": Array [],
+                      },
+                      "_configs": Object {
+                        "configs": Object {
+                          "12345": Object {
+                            "comments": "Test comments",
+                            "created": "2015-09-29 11:21:38 +0000",
+                            "devices": Object {
+                              "sda": Object {
+                                "disk_id": 12345,
+                              },
+                              "sdb": Object {
+                                "disk_id": 12346,
+                              },
+                              "sdc": null,
+                              "sdd": null,
+                              "sde": null,
+                              "sdf": null,
+                              "sdg": null,
+                              "sdh": null,
+                            },
+                            "helpers": Object {
+                              "devtmpfs_automount": false,
+                              "distro": true,
+                              "modules_dep": true,
+                              "network": true,
+                              "updatedb_disabled": true,
+                            },
+                            "id": 12345,
+                            "initrd": "",
+                            "kernel": "linode/latest_64",
+                            "label": "Test config",
+                            "memory_limit": 1024,
+                            "root_device": "/dev/sda",
+                            "run_level": "default",
+                            "updated": "2015-09-29 11:21:38 +0000",
+                            "virt_mode": "paravirt",
+                          },
+                        },
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                      },
+                      "_disks": Object {
+                        "disks": Object {
+                          "12345": Object {
+                            "created": "2016-08-09T19:47:11",
+                            "filesystem": "raw",
+                            "id": 12345,
+                            "label": "Raw Disk",
+                            "size": 6144,
+                            "updated": "2016-08-09T19:47:11",
+                          },
+                        },
+                        "totalPages": 1,
+                        "totalResults": 1,
+                      },
+                      "_ips": Object {
+                        "2600:3c03::f03c:91ff:fe0a:31": Object {
+                          "address": "2600:3c03::f03c:91ff:fe0a:31",
+                          "gateway": "fe80::1",
+                          "key": "2600:3c03::f03c:91ff:fe0a:31",
+                          "linode_id": 1249,
+                          "prefix": "64",
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "slaac",
+                          "version": "ipv6",
+                        },
+                        "97.107.143.47": Object {
+                          "address": "97.107.143.47",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.47",
+                          "linode_id": 1249,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "97.107.143.49": Object {
+                          "address": "97.107.143.49",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.49",
+                          "linode_id": 1249,
+                          "prefix": 17,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "private",
+                          "version": "ipv4",
+                        },
+                        "fe80::f03c:91ff:fe0a:181f": Object {
+                          "address": "fe80::f03c:91ff:fe0a:181f",
+                          "key": "fe80::f03c:91ff:fe0a:181f",
+                          "linode_id": 1249,
+                          "type": "link-local",
+                          "version": "ipv6",
+                        },
+                      },
+                      "_polling": false,
+                      "_shared": Array [],
+                      "_stats": Object {
+                        "cpu": Array [
+                          Array [
+                            1490378700000,
+                            1.67,
+                          ],
+                        ],
+                        "io": Object {
+                          "io": Array [
+                            Array [
+                              1490379000000,
+                              0.91,
+                            ],
+                          ],
+                          "swap": Array [
+                            Array [
+                              1490378100000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv4": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv6": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                      },
+                      "_volumes": Object {
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                        "volumes": Object {
+                          "38": Object {
+                            "created": "2017-08-08T13:55:16",
+                            "id": 38,
+                            "label": "test",
+                            "linode_id": null,
+                            "region": "us-east-1a",
+                            "size": 20,
+                            "status": "active",
+                            "updated": "2017-08-08T04:00:00",
+                          },
+                        },
+                      },
+                      "alerts": Object {
+                        "cpu": 90,
+                        "io": 5000,
+                        "network_in": 5,
+                        "network_out": 5,
+                        "tranfer_quota": 80,
+                      },
+                      "backups": Object {
+                        "enabled": true,
+                        "schedule": Object {
+                          "day": "Monday",
+                          "window": "W10",
+                        },
+                      },
+                      "created": "2016-07-06T16:47:27",
+                      "disk": 20480,
+                      "group": "Test Group",
+                      "hypervisor": "kvm",
+                      "id": 1249,
+                      "image": Object {
+                        "id": "linode/ubuntu15.10",
+                        "label": "Ubuntu 15.10",
+                        "vendor": "Ubuntu",
+                      },
+                      "ipv4": Array [
+                        "97.107.143.47",
+                        "97.107.143.48",
+                      ],
+                      "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                      "label": "test-linode-raw",
+                      "memory": 2048,
+                      "region": "us-east-1a",
+                      "status": "running",
+                      "type": Object {
+                        "_polling": false,
+                        "addons": Object {
+                          "backups": Object {
+                            "price": Object {
+                              "monthly": 2.5,
+                            },
+                          },
+                        },
+                        "class": "standard",
+                        "disk": 24576,
+                        "id": "linode2048.5",
+                        "label": "Linode 2048",
+                        "memory": 2048,
+                        "network_out": 125,
+                        "price": Object {
+                          "hourly": 0.015,
+                          "monthly": 10,
+                        },
+                        "service_type": "linode",
+                        "transfer": 2000,
+                        "vcpus": 2,
+                      },
+                      "vcpus": 2,
+                    },
+                    "1250": Object {
+                      "_backups": Object {
+                        "daily": Object {
+                          "availability": "daily",
+                          "configs": Array [
+                            "Ubuntu Disk",
+                          ],
+                          "created": "2017-01-31T07:28:52",
+                          "disks": Array [
+                            Object {
+                              "filesystem": "ext4",
+                              "label": "Ubuntu 15.10 Disk",
+                              "size": 2330,
+                            },
+                            Object {
+                              "filesystem": "swap",
+                              "label": "512 MB Swap Image",
+                              "size": 0,
+                            },
+                          ],
+                          "finished": "2017-01-31T07:30:03",
+                          "id": 54782214,
+                          "label": null,
+                          "region": "us-east-1a",
+                          "status": "successful",
+                          "type": "auto",
+                          "updated": "2017-01-31T12:32:01",
+                        },
+                        "snapshot": Object {
+                          "current": Object {
+                            "availability": "unavailable",
+                            "configs": Array [
+                              "Some config",
+                            ],
+                            "created": "2017-01-31T21:50:42",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T21:51:51",
+                            "id": 54782236,
+                            "label": "the label",
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "snapshot",
+                            "updated": "2017-01-31T21:51:51",
+                          },
+                          "in_progress": null,
+                        },
+                        "weekly": Array [],
+                      },
+                      "_configs": Object {
+                        "configs": Object {
+                          "12345": Object {
+                            "comments": "Test comments",
+                            "created": "2015-09-29 11:21:38 +0000",
+                            "devices": Object {
+                              "sda": Object {
+                                "disk_id": 12345,
+                              },
+                              "sdb": Object {
+                                "disk_id": 12346,
+                              },
+                              "sdc": null,
+                              "sdd": null,
+                              "sde": null,
+                              "sdf": null,
+                              "sdg": null,
+                              "sdh": null,
+                            },
+                            "helpers": Object {
+                              "devtmpfs_automount": false,
+                              "distro": true,
+                              "modules_dep": true,
+                              "network": true,
+                              "updatedb_disabled": true,
+                            },
+                            "id": 12345,
+                            "initrd": "",
+                            "kernel": "linode/latest_64",
+                            "label": "Test config",
+                            "memory_limit": 1024,
+                            "root_device": "/dev/sda",
+                            "run_level": "default",
+                            "updated": "2015-09-29 11:21:38 +0000",
+                            "virt_mode": "paravirt",
+                          },
+                        },
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                      },
+                      "_disks": Object {
+                        "disks": Object {},
+                        "totalPages": 1,
+                        "totalResults": 0,
+                      },
+                      "_ips": Object {
+                        "2600:3c03::f03c:91ff:fe0a:33": Object {
+                          "address": "2600:3c03::f03c:91ff:fe0a:33",
+                          "gateway": "fe80::1",
+                          "key": "2600:3c03::f03c:91ff:fe0a:33",
+                          "linode_id": 1250,
+                          "prefix": "64",
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "slaac",
+                          "version": "ipv6",
+                        },
+                        "97.107.143.50": Object {
+                          "address": "97.107.143.50",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.50",
+                          "linode_id": 1250,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "97.107.143.52": Object {
+                          "address": "97.107.143.52",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.52",
+                          "linode_id": 1250,
+                          "prefix": 17,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "private",
+                          "version": "ipv4",
+                        },
+                        "fe80::f03c:91ff:fe0a:181f": Object {
+                          "address": "fe80::f03c:91ff:fe0a:181f",
+                          "key": "fe80::f03c:91ff:fe0a:181f",
+                          "linode_id": 1250,
+                          "type": "link-local",
+                          "version": "ipv6",
+                        },
+                      },
+                      "_polling": false,
+                      "_shared": Array [],
+                      "_stats": Object {
+                        "cpu": Array [
+                          Array [
+                            1490378700000,
+                            1.67,
+                          ],
+                        ],
+                        "io": Object {
+                          "io": Array [
+                            Array [
+                              1490379000000,
+                              0.91,
+                            ],
+                          ],
+                          "swap": Array [
+                            Array [
+                              1490378100000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv4": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv6": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                      },
+                      "_volumes": Object {
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                        "volumes": Object {
+                          "38": Object {
+                            "created": "2017-08-08T13:55:16",
+                            "id": 38,
+                            "label": "test",
+                            "linode_id": null,
+                            "region": "us-east-1a",
+                            "size": 20,
+                            "status": "active",
+                            "updated": "2017-08-08T04:00:00",
+                          },
+                        },
+                      },
+                      "alerts": Object {
+                        "cpu": 90,
+                        "io": 5000,
+                        "network_in": 5,
+                        "network_out": 5,
+                        "tranfer_quota": 80,
+                      },
+                      "backups": Object {
+                        "enabled": true,
+                        "schedule": Object {
+                          "day": "Monday",
+                          "window": "W10",
+                        },
+                      },
+                      "created": "2016-07-06T16:47:27",
+                      "disk": 20480,
+                      "group": "Test Group",
+                      "hypervisor": "kvm",
+                      "id": 1250,
+                      "image": Object {
+                        "id": "linode/ubuntu15.10",
+                        "label": "Ubuntu 15.10",
+                        "vendor": "Ubuntu",
+                      },
+                      "ipv4": Array [
+                        "97.107.143.50",
+                        "97.107.143.51",
+                      ],
+                      "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                      "label": "test-linode-no-disks",
+                      "memory": 2048,
+                      "region": "us-east-1a",
+                      "status": "running",
+                      "type": Object {
+                        "_polling": false,
+                        "addons": Object {
+                          "backups": Object {
+                            "price": Object {
+                              "monthly": 2.5,
+                            },
+                          },
+                        },
+                        "class": "standard",
+                        "disk": 24576,
+                        "id": "linode2048.5",
+                        "label": "Linode 2048",
+                        "memory": 2048,
+                        "network_out": 125,
+                        "price": Object {
+                          "hourly": 0.015,
+                          "monthly": 10,
+                        },
+                        "service_type": "linode",
+                        "transfer": 2000,
+                        "vcpus": 2,
+                      },
+                      "vcpus": 2,
+                    },
                   }
                 }
                 name="target"
@@ -19316,6 +21139,613 @@ ShallowWrapper {
                         },
                         "vcpus": 2,
                       },
+                      "1249": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {
+                            "12345": Object {
+                              "created": "2016-08-09T19:47:11",
+                              "filesystem": "raw",
+                              "id": 12345,
+                              "label": "Raw Disk",
+                              "size": 6144,
+                              "updated": "2016-08-09T19:47:11",
+                            },
+                          },
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:31": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:31",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:31",
+                            "linode_id": 1249,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.47": Object {
+                            "address": "97.107.143.47",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.47",
+                            "linode_id": 1249,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.49": Object {
+                            "address": "97.107.143.49",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.49",
+                            "linode_id": 1249,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1249,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1249,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.47",
+                          "97.107.143.48",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                        "label": "test-linode-raw",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                      "1250": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {},
+                          "totalPages": 1,
+                          "totalResults": 0,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:33": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:33",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:33",
+                            "linode_id": 1250,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.50": Object {
+                            "address": "97.107.143.50",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.50",
+                            "linode_id": 1250,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.52": Object {
+                            "address": "97.107.143.52",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.52",
+                            "linode_id": 1250,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1250,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1250,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.50",
+                          "97.107.143.51",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                        "label": "test-linode-no-disks",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
                     }
                   }
                   name="target"
@@ -24117,6 +26547,613 @@ ShallowWrapper {
                           },
                           "vcpus": 2,
                         },
+                        "1249": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {
+                              "12345": Object {
+                                "created": "2016-08-09T19:47:11",
+                                "filesystem": "raw",
+                                "id": 12345,
+                                "label": "Raw Disk",
+                                "size": 6144,
+                                "updated": "2016-08-09T19:47:11",
+                              },
+                            },
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:31": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:31",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:31",
+                              "linode_id": 1249,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.47": Object {
+                              "address": "97.107.143.47",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.47",
+                              "linode_id": 1249,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.49": Object {
+                              "address": "97.107.143.49",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.49",
+                              "linode_id": 1249,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1249,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1249,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.47",
+                            "97.107.143.48",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                          "label": "test-linode-raw",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                        "1250": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {},
+                            "totalPages": 1,
+                            "totalResults": 0,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:33": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:33",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:33",
+                              "linode_id": 1250,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.50": Object {
+                              "address": "97.107.143.50",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.50",
+                              "linode_id": 1250,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.52": Object {
+                              "address": "97.107.143.52",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.52",
+                              "linode_id": 1250,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1250,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1250,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.50",
+                            "97.107.143.51",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                          "label": "test-linode-no-disks",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
                       }
                     }
                     name="target"
@@ -28876,6 +31913,613 @@ ShallowWrapper {
                         "memory": 2048,
                         "region": "us-east-1a",
                         "status": "provisioning",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                      "1249": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {
+                            "12345": Object {
+                              "created": "2016-08-09T19:47:11",
+                              "filesystem": "raw",
+                              "id": 12345,
+                              "label": "Raw Disk",
+                              "size": 6144,
+                              "updated": "2016-08-09T19:47:11",
+                            },
+                          },
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:31": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:31",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:31",
+                            "linode_id": 1249,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.47": Object {
+                            "address": "97.107.143.47",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.47",
+                            "linode_id": 1249,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.49": Object {
+                            "address": "97.107.143.49",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.49",
+                            "linode_id": 1249,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1249,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1249,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.47",
+                          "97.107.143.48",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                        "label": "test-linode-raw",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                      "1250": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {},
+                          "totalPages": 1,
+                          "totalResults": 0,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:33": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:33",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:33",
+                            "linode_id": 1250,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.50": Object {
+                            "address": "97.107.143.50",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.50",
+                            "linode_id": 1250,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.52": Object {
+                            "address": "97.107.143.52",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.52",
+                            "linode_id": 1250,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1250,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1250,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.50",
+                          "97.107.143.51",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                        "label": "test-linode-no-disks",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
                         "type": Object {
                           "_polling": false,
                           "addons": Object {
@@ -33893,6 +37537,613 @@ ShallowWrapper {
                       },
                       "vcpus": 2,
                     },
+                    "1249": Object {
+                      "_backups": Object {
+                        "daily": Object {
+                          "availability": "daily",
+                          "configs": Array [
+                            "Ubuntu Disk",
+                          ],
+                          "created": "2017-01-31T07:28:52",
+                          "disks": Array [
+                            Object {
+                              "filesystem": "ext4",
+                              "label": "Ubuntu 15.10 Disk",
+                              "size": 2330,
+                            },
+                            Object {
+                              "filesystem": "swap",
+                              "label": "512 MB Swap Image",
+                              "size": 0,
+                            },
+                          ],
+                          "finished": "2017-01-31T07:30:03",
+                          "id": 54782214,
+                          "label": null,
+                          "region": "us-east-1a",
+                          "status": "successful",
+                          "type": "auto",
+                          "updated": "2017-01-31T12:32:01",
+                        },
+                        "snapshot": Object {
+                          "current": Object {
+                            "availability": "unavailable",
+                            "configs": Array [
+                              "Some config",
+                            ],
+                            "created": "2017-01-31T21:50:42",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T21:51:51",
+                            "id": 54782236,
+                            "label": "the label",
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "snapshot",
+                            "updated": "2017-01-31T21:51:51",
+                          },
+                          "in_progress": null,
+                        },
+                        "weekly": Array [],
+                      },
+                      "_configs": Object {
+                        "configs": Object {
+                          "12345": Object {
+                            "comments": "Test comments",
+                            "created": "2015-09-29 11:21:38 +0000",
+                            "devices": Object {
+                              "sda": Object {
+                                "disk_id": 12345,
+                              },
+                              "sdb": Object {
+                                "disk_id": 12346,
+                              },
+                              "sdc": null,
+                              "sdd": null,
+                              "sde": null,
+                              "sdf": null,
+                              "sdg": null,
+                              "sdh": null,
+                            },
+                            "helpers": Object {
+                              "devtmpfs_automount": false,
+                              "distro": true,
+                              "modules_dep": true,
+                              "network": true,
+                              "updatedb_disabled": true,
+                            },
+                            "id": 12345,
+                            "initrd": "",
+                            "kernel": "linode/latest_64",
+                            "label": "Test config",
+                            "memory_limit": 1024,
+                            "root_device": "/dev/sda",
+                            "run_level": "default",
+                            "updated": "2015-09-29 11:21:38 +0000",
+                            "virt_mode": "paravirt",
+                          },
+                        },
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                      },
+                      "_disks": Object {
+                        "disks": Object {
+                          "12345": Object {
+                            "created": "2016-08-09T19:47:11",
+                            "filesystem": "raw",
+                            "id": 12345,
+                            "label": "Raw Disk",
+                            "size": 6144,
+                            "updated": "2016-08-09T19:47:11",
+                          },
+                        },
+                        "totalPages": 1,
+                        "totalResults": 1,
+                      },
+                      "_ips": Object {
+                        "2600:3c03::f03c:91ff:fe0a:31": Object {
+                          "address": "2600:3c03::f03c:91ff:fe0a:31",
+                          "gateway": "fe80::1",
+                          "key": "2600:3c03::f03c:91ff:fe0a:31",
+                          "linode_id": 1249,
+                          "prefix": "64",
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "slaac",
+                          "version": "ipv6",
+                        },
+                        "97.107.143.47": Object {
+                          "address": "97.107.143.47",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.47",
+                          "linode_id": 1249,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "97.107.143.49": Object {
+                          "address": "97.107.143.49",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.49",
+                          "linode_id": 1249,
+                          "prefix": 17,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "private",
+                          "version": "ipv4",
+                        },
+                        "fe80::f03c:91ff:fe0a:181f": Object {
+                          "address": "fe80::f03c:91ff:fe0a:181f",
+                          "key": "fe80::f03c:91ff:fe0a:181f",
+                          "linode_id": 1249,
+                          "type": "link-local",
+                          "version": "ipv6",
+                        },
+                      },
+                      "_polling": false,
+                      "_shared": Array [],
+                      "_stats": Object {
+                        "cpu": Array [
+                          Array [
+                            1490378700000,
+                            1.67,
+                          ],
+                        ],
+                        "io": Object {
+                          "io": Array [
+                            Array [
+                              1490379000000,
+                              0.91,
+                            ],
+                          ],
+                          "swap": Array [
+                            Array [
+                              1490378100000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv4": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv6": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                      },
+                      "_volumes": Object {
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                        "volumes": Object {
+                          "38": Object {
+                            "created": "2017-08-08T13:55:16",
+                            "id": 38,
+                            "label": "test",
+                            "linode_id": null,
+                            "region": "us-east-1a",
+                            "size": 20,
+                            "status": "active",
+                            "updated": "2017-08-08T04:00:00",
+                          },
+                        },
+                      },
+                      "alerts": Object {
+                        "cpu": 90,
+                        "io": 5000,
+                        "network_in": 5,
+                        "network_out": 5,
+                        "tranfer_quota": 80,
+                      },
+                      "backups": Object {
+                        "enabled": true,
+                        "schedule": Object {
+                          "day": "Monday",
+                          "window": "W10",
+                        },
+                      },
+                      "created": "2016-07-06T16:47:27",
+                      "disk": 20480,
+                      "group": "Test Group",
+                      "hypervisor": "kvm",
+                      "id": 1249,
+                      "image": Object {
+                        "id": "linode/ubuntu15.10",
+                        "label": "Ubuntu 15.10",
+                        "vendor": "Ubuntu",
+                      },
+                      "ipv4": Array [
+                        "97.107.143.47",
+                        "97.107.143.48",
+                      ],
+                      "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                      "label": "test-linode-raw",
+                      "memory": 2048,
+                      "region": "us-east-1a",
+                      "status": "running",
+                      "type": Object {
+                        "_polling": false,
+                        "addons": Object {
+                          "backups": Object {
+                            "price": Object {
+                              "monthly": 2.5,
+                            },
+                          },
+                        },
+                        "class": "standard",
+                        "disk": 24576,
+                        "id": "linode2048.5",
+                        "label": "Linode 2048",
+                        "memory": 2048,
+                        "network_out": 125,
+                        "price": Object {
+                          "hourly": 0.015,
+                          "monthly": 10,
+                        },
+                        "service_type": "linode",
+                        "transfer": 2000,
+                        "vcpus": 2,
+                      },
+                      "vcpus": 2,
+                    },
+                    "1250": Object {
+                      "_backups": Object {
+                        "daily": Object {
+                          "availability": "daily",
+                          "configs": Array [
+                            "Ubuntu Disk",
+                          ],
+                          "created": "2017-01-31T07:28:52",
+                          "disks": Array [
+                            Object {
+                              "filesystem": "ext4",
+                              "label": "Ubuntu 15.10 Disk",
+                              "size": 2330,
+                            },
+                            Object {
+                              "filesystem": "swap",
+                              "label": "512 MB Swap Image",
+                              "size": 0,
+                            },
+                          ],
+                          "finished": "2017-01-31T07:30:03",
+                          "id": 54782214,
+                          "label": null,
+                          "region": "us-east-1a",
+                          "status": "successful",
+                          "type": "auto",
+                          "updated": "2017-01-31T12:32:01",
+                        },
+                        "snapshot": Object {
+                          "current": Object {
+                            "availability": "unavailable",
+                            "configs": Array [
+                              "Some config",
+                            ],
+                            "created": "2017-01-31T21:50:42",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T21:51:51",
+                            "id": 54782236,
+                            "label": "the label",
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "snapshot",
+                            "updated": "2017-01-31T21:51:51",
+                          },
+                          "in_progress": null,
+                        },
+                        "weekly": Array [],
+                      },
+                      "_configs": Object {
+                        "configs": Object {
+                          "12345": Object {
+                            "comments": "Test comments",
+                            "created": "2015-09-29 11:21:38 +0000",
+                            "devices": Object {
+                              "sda": Object {
+                                "disk_id": 12345,
+                              },
+                              "sdb": Object {
+                                "disk_id": 12346,
+                              },
+                              "sdc": null,
+                              "sdd": null,
+                              "sde": null,
+                              "sdf": null,
+                              "sdg": null,
+                              "sdh": null,
+                            },
+                            "helpers": Object {
+                              "devtmpfs_automount": false,
+                              "distro": true,
+                              "modules_dep": true,
+                              "network": true,
+                              "updatedb_disabled": true,
+                            },
+                            "id": 12345,
+                            "initrd": "",
+                            "kernel": "linode/latest_64",
+                            "label": "Test config",
+                            "memory_limit": 1024,
+                            "root_device": "/dev/sda",
+                            "run_level": "default",
+                            "updated": "2015-09-29 11:21:38 +0000",
+                            "virt_mode": "paravirt",
+                          },
+                        },
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                      },
+                      "_disks": Object {
+                        "disks": Object {},
+                        "totalPages": 1,
+                        "totalResults": 0,
+                      },
+                      "_ips": Object {
+                        "2600:3c03::f03c:91ff:fe0a:33": Object {
+                          "address": "2600:3c03::f03c:91ff:fe0a:33",
+                          "gateway": "fe80::1",
+                          "key": "2600:3c03::f03c:91ff:fe0a:33",
+                          "linode_id": 1250,
+                          "prefix": "64",
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "slaac",
+                          "version": "ipv6",
+                        },
+                        "97.107.143.50": Object {
+                          "address": "97.107.143.50",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.50",
+                          "linode_id": 1250,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "97.107.143.52": Object {
+                          "address": "97.107.143.52",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.52",
+                          "linode_id": 1250,
+                          "prefix": 17,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "private",
+                          "version": "ipv4",
+                        },
+                        "fe80::f03c:91ff:fe0a:181f": Object {
+                          "address": "fe80::f03c:91ff:fe0a:181f",
+                          "key": "fe80::f03c:91ff:fe0a:181f",
+                          "linode_id": 1250,
+                          "type": "link-local",
+                          "version": "ipv6",
+                        },
+                      },
+                      "_polling": false,
+                      "_shared": Array [],
+                      "_stats": Object {
+                        "cpu": Array [
+                          Array [
+                            1490378700000,
+                            1.67,
+                          ],
+                        ],
+                        "io": Object {
+                          "io": Array [
+                            Array [
+                              1490379000000,
+                              0.91,
+                            ],
+                          ],
+                          "swap": Array [
+                            Array [
+                              1490378100000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv4": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv6": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                      },
+                      "_volumes": Object {
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                        "volumes": Object {
+                          "38": Object {
+                            "created": "2017-08-08T13:55:16",
+                            "id": 38,
+                            "label": "test",
+                            "linode_id": null,
+                            "region": "us-east-1a",
+                            "size": 20,
+                            "status": "active",
+                            "updated": "2017-08-08T04:00:00",
+                          },
+                        },
+                      },
+                      "alerts": Object {
+                        "cpu": 90,
+                        "io": 5000,
+                        "network_in": 5,
+                        "network_out": 5,
+                        "tranfer_quota": 80,
+                      },
+                      "backups": Object {
+                        "enabled": true,
+                        "schedule": Object {
+                          "day": "Monday",
+                          "window": "W10",
+                        },
+                      },
+                      "created": "2016-07-06T16:47:27",
+                      "disk": 20480,
+                      "group": "Test Group",
+                      "hypervisor": "kvm",
+                      "id": 1250,
+                      "image": Object {
+                        "id": "linode/ubuntu15.10",
+                        "label": "Ubuntu 15.10",
+                        "vendor": "Ubuntu",
+                      },
+                      "ipv4": Array [
+                        "97.107.143.50",
+                        "97.107.143.51",
+                      ],
+                      "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                      "label": "test-linode-no-disks",
+                      "memory": 2048,
+                      "region": "us-east-1a",
+                      "status": "running",
+                      "type": Object {
+                        "_polling": false,
+                        "addons": Object {
+                          "backups": Object {
+                            "price": Object {
+                              "monthly": 2.5,
+                            },
+                          },
+                        },
+                        "class": "standard",
+                        "disk": 24576,
+                        "id": "linode2048.5",
+                        "label": "Linode 2048",
+                        "memory": 2048,
+                        "network_out": 125,
+                        "price": Object {
+                          "hourly": 0.015,
+                          "monthly": 10,
+                        },
+                        "service_type": "linode",
+                        "transfer": 2000,
+                        "vcpus": 2,
+                      },
+                      "vcpus": 2,
+                    },
                   }
                 }
                 name="target"
@@ -38720,6 +42971,613 @@ ShallowWrapper {
                         "memory": 2048,
                         "region": "us-east-1a",
                         "status": "provisioning",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                      "1249": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {
+                            "12345": Object {
+                              "created": "2016-08-09T19:47:11",
+                              "filesystem": "raw",
+                              "id": 12345,
+                              "label": "Raw Disk",
+                              "size": 6144,
+                              "updated": "2016-08-09T19:47:11",
+                            },
+                          },
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:31": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:31",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:31",
+                            "linode_id": 1249,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.47": Object {
+                            "address": "97.107.143.47",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.47",
+                            "linode_id": 1249,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.49": Object {
+                            "address": "97.107.143.49",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.49",
+                            "linode_id": 1249,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1249,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1249,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.47",
+                          "97.107.143.48",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                        "label": "test-linode-raw",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                      "1250": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {},
+                          "totalPages": 1,
+                          "totalResults": 0,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:33": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:33",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:33",
+                            "linode_id": 1250,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.50": Object {
+                            "address": "97.107.143.50",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.50",
+                            "linode_id": 1250,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.52": Object {
+                            "address": "97.107.143.52",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.52",
+                            "linode_id": 1250,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1250,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1250,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.50",
+                          "97.107.143.51",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                        "label": "test-linode-no-disks",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
                         "type": Object {
                           "_polling": false,
                           "addons": Object {
@@ -43589,6 +48447,613 @@ ShallowWrapper {
                           },
                           "vcpus": 2,
                         },
+                        "1249": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {
+                              "12345": Object {
+                                "created": "2016-08-09T19:47:11",
+                                "filesystem": "raw",
+                                "id": 12345,
+                                "label": "Raw Disk",
+                                "size": 6144,
+                                "updated": "2016-08-09T19:47:11",
+                              },
+                            },
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:31": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:31",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:31",
+                              "linode_id": 1249,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.47": Object {
+                              "address": "97.107.143.47",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.47",
+                              "linode_id": 1249,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.49": Object {
+                              "address": "97.107.143.49",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.49",
+                              "linode_id": 1249,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1249,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1249,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.47",
+                            "97.107.143.48",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                          "label": "test-linode-raw",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                        "1250": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {},
+                            "totalPages": 1,
+                            "totalResults": 0,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:33": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:33",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:33",
+                              "linode_id": 1250,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.50": Object {
+                              "address": "97.107.143.50",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.50",
+                              "linode_id": 1250,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.52": Object {
+                              "address": "97.107.143.52",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.52",
+                              "linode_id": 1250,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1250,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1250,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.50",
+                            "97.107.143.51",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                          "label": "test-linode-no-disks",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
                       }
                     }
                     name="target"
@@ -48390,6 +53855,613 @@ ShallowWrapper {
                             },
                             "vcpus": 2,
                           },
+                          "1249": Object {
+                            "_backups": Object {
+                              "daily": Object {
+                                "availability": "daily",
+                                "configs": Array [
+                                  "Ubuntu Disk",
+                                ],
+                                "created": "2017-01-31T07:28:52",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T07:30:03",
+                                "id": 54782214,
+                                "label": null,
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "auto",
+                                "updated": "2017-01-31T12:32:01",
+                              },
+                              "snapshot": Object {
+                                "current": Object {
+                                  "availability": "unavailable",
+                                  "configs": Array [
+                                    "Some config",
+                                  ],
+                                  "created": "2017-01-31T21:50:42",
+                                  "disks": Array [
+                                    Object {
+                                      "filesystem": "ext4",
+                                      "label": "Ubuntu 15.10 Disk",
+                                      "size": 2330,
+                                    },
+                                    Object {
+                                      "filesystem": "swap",
+                                      "label": "512 MB Swap Image",
+                                      "size": 0,
+                                    },
+                                  ],
+                                  "finished": "2017-01-31T21:51:51",
+                                  "id": 54782236,
+                                  "label": "the label",
+                                  "region": "us-east-1a",
+                                  "status": "successful",
+                                  "type": "snapshot",
+                                  "updated": "2017-01-31T21:51:51",
+                                },
+                                "in_progress": null,
+                              },
+                              "weekly": Array [],
+                            },
+                            "_configs": Object {
+                              "configs": Object {
+                                "12345": Object {
+                                  "comments": "Test comments",
+                                  "created": "2015-09-29 11:21:38 +0000",
+                                  "devices": Object {
+                                    "sda": Object {
+                                      "disk_id": 12345,
+                                    },
+                                    "sdb": Object {
+                                      "disk_id": 12346,
+                                    },
+                                    "sdc": null,
+                                    "sdd": null,
+                                    "sde": null,
+                                    "sdf": null,
+                                    "sdg": null,
+                                    "sdh": null,
+                                  },
+                                  "helpers": Object {
+                                    "devtmpfs_automount": false,
+                                    "distro": true,
+                                    "modules_dep": true,
+                                    "network": true,
+                                    "updatedb_disabled": true,
+                                  },
+                                  "id": 12345,
+                                  "initrd": "",
+                                  "kernel": "linode/latest_64",
+                                  "label": "Test config",
+                                  "memory_limit": 1024,
+                                  "root_device": "/dev/sda",
+                                  "run_level": "default",
+                                  "updated": "2015-09-29 11:21:38 +0000",
+                                  "virt_mode": "paravirt",
+                                },
+                              },
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                            },
+                            "_disks": Object {
+                              "disks": Object {
+                                "12345": Object {
+                                  "created": "2016-08-09T19:47:11",
+                                  "filesystem": "raw",
+                                  "id": 12345,
+                                  "label": "Raw Disk",
+                                  "size": 6144,
+                                  "updated": "2016-08-09T19:47:11",
+                                },
+                              },
+                              "totalPages": 1,
+                              "totalResults": 1,
+                            },
+                            "_ips": Object {
+                              "2600:3c03::f03c:91ff:fe0a:31": Object {
+                                "address": "2600:3c03::f03c:91ff:fe0a:31",
+                                "gateway": "fe80::1",
+                                "key": "2600:3c03::f03c:91ff:fe0a:31",
+                                "linode_id": 1249,
+                                "prefix": "64",
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "slaac",
+                                "version": "ipv6",
+                              },
+                              "97.107.143.47": Object {
+                                "address": "97.107.143.47",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.47",
+                                "linode_id": 1249,
+                                "prefix": 24,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "public",
+                                "version": "ipv4",
+                              },
+                              "97.107.143.49": Object {
+                                "address": "97.107.143.49",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.49",
+                                "linode_id": 1249,
+                                "prefix": 17,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "private",
+                                "version": "ipv4",
+                              },
+                              "fe80::f03c:91ff:fe0a:181f": Object {
+                                "address": "fe80::f03c:91ff:fe0a:181f",
+                                "key": "fe80::f03c:91ff:fe0a:181f",
+                                "linode_id": 1249,
+                                "type": "link-local",
+                                "version": "ipv6",
+                              },
+                            },
+                            "_polling": false,
+                            "_shared": Array [],
+                            "_stats": Object {
+                              "cpu": Array [
+                                Array [
+                                  1490378700000,
+                                  1.67,
+                                ],
+                              ],
+                              "io": Object {
+                                "io": Array [
+                                  Array [
+                                    1490379000000,
+                                    0.91,
+                                  ],
+                                ],
+                                "swap": Array [
+                                  Array [
+                                    1490378100000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv4": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv6": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                            },
+                            "_volumes": Object {
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                              "volumes": Object {
+                                "38": Object {
+                                  "created": "2017-08-08T13:55:16",
+                                  "id": 38,
+                                  "label": "test",
+                                  "linode_id": null,
+                                  "region": "us-east-1a",
+                                  "size": 20,
+                                  "status": "active",
+                                  "updated": "2017-08-08T04:00:00",
+                                },
+                              },
+                            },
+                            "alerts": Object {
+                              "cpu": 90,
+                              "io": 5000,
+                              "network_in": 5,
+                              "network_out": 5,
+                              "tranfer_quota": 80,
+                            },
+                            "backups": Object {
+                              "enabled": true,
+                              "schedule": Object {
+                                "day": "Monday",
+                                "window": "W10",
+                              },
+                            },
+                            "created": "2016-07-06T16:47:27",
+                            "disk": 20480,
+                            "group": "Test Group",
+                            "hypervisor": "kvm",
+                            "id": 1249,
+                            "image": Object {
+                              "id": "linode/ubuntu15.10",
+                              "label": "Ubuntu 15.10",
+                              "vendor": "Ubuntu",
+                            },
+                            "ipv4": Array [
+                              "97.107.143.47",
+                              "97.107.143.48",
+                            ],
+                            "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                            "label": "test-linode-raw",
+                            "memory": 2048,
+                            "region": "us-east-1a",
+                            "status": "running",
+                            "type": Object {
+                              "_polling": false,
+                              "addons": Object {
+                                "backups": Object {
+                                  "price": Object {
+                                    "monthly": 2.5,
+                                  },
+                                },
+                              },
+                              "class": "standard",
+                              "disk": 24576,
+                              "id": "linode2048.5",
+                              "label": "Linode 2048",
+                              "memory": 2048,
+                              "network_out": 125,
+                              "price": Object {
+                                "hourly": 0.015,
+                                "monthly": 10,
+                              },
+                              "service_type": "linode",
+                              "transfer": 2000,
+                              "vcpus": 2,
+                            },
+                            "vcpus": 2,
+                          },
+                          "1250": Object {
+                            "_backups": Object {
+                              "daily": Object {
+                                "availability": "daily",
+                                "configs": Array [
+                                  "Ubuntu Disk",
+                                ],
+                                "created": "2017-01-31T07:28:52",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T07:30:03",
+                                "id": 54782214,
+                                "label": null,
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "auto",
+                                "updated": "2017-01-31T12:32:01",
+                              },
+                              "snapshot": Object {
+                                "current": Object {
+                                  "availability": "unavailable",
+                                  "configs": Array [
+                                    "Some config",
+                                  ],
+                                  "created": "2017-01-31T21:50:42",
+                                  "disks": Array [
+                                    Object {
+                                      "filesystem": "ext4",
+                                      "label": "Ubuntu 15.10 Disk",
+                                      "size": 2330,
+                                    },
+                                    Object {
+                                      "filesystem": "swap",
+                                      "label": "512 MB Swap Image",
+                                      "size": 0,
+                                    },
+                                  ],
+                                  "finished": "2017-01-31T21:51:51",
+                                  "id": 54782236,
+                                  "label": "the label",
+                                  "region": "us-east-1a",
+                                  "status": "successful",
+                                  "type": "snapshot",
+                                  "updated": "2017-01-31T21:51:51",
+                                },
+                                "in_progress": null,
+                              },
+                              "weekly": Array [],
+                            },
+                            "_configs": Object {
+                              "configs": Object {
+                                "12345": Object {
+                                  "comments": "Test comments",
+                                  "created": "2015-09-29 11:21:38 +0000",
+                                  "devices": Object {
+                                    "sda": Object {
+                                      "disk_id": 12345,
+                                    },
+                                    "sdb": Object {
+                                      "disk_id": 12346,
+                                    },
+                                    "sdc": null,
+                                    "sdd": null,
+                                    "sde": null,
+                                    "sdf": null,
+                                    "sdg": null,
+                                    "sdh": null,
+                                  },
+                                  "helpers": Object {
+                                    "devtmpfs_automount": false,
+                                    "distro": true,
+                                    "modules_dep": true,
+                                    "network": true,
+                                    "updatedb_disabled": true,
+                                  },
+                                  "id": 12345,
+                                  "initrd": "",
+                                  "kernel": "linode/latest_64",
+                                  "label": "Test config",
+                                  "memory_limit": 1024,
+                                  "root_device": "/dev/sda",
+                                  "run_level": "default",
+                                  "updated": "2015-09-29 11:21:38 +0000",
+                                  "virt_mode": "paravirt",
+                                },
+                              },
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                            },
+                            "_disks": Object {
+                              "disks": Object {},
+                              "totalPages": 1,
+                              "totalResults": 0,
+                            },
+                            "_ips": Object {
+                              "2600:3c03::f03c:91ff:fe0a:33": Object {
+                                "address": "2600:3c03::f03c:91ff:fe0a:33",
+                                "gateway": "fe80::1",
+                                "key": "2600:3c03::f03c:91ff:fe0a:33",
+                                "linode_id": 1250,
+                                "prefix": "64",
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "slaac",
+                                "version": "ipv6",
+                              },
+                              "97.107.143.50": Object {
+                                "address": "97.107.143.50",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.50",
+                                "linode_id": 1250,
+                                "prefix": 24,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "public",
+                                "version": "ipv4",
+                              },
+                              "97.107.143.52": Object {
+                                "address": "97.107.143.52",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.52",
+                                "linode_id": 1250,
+                                "prefix": 17,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "private",
+                                "version": "ipv4",
+                              },
+                              "fe80::f03c:91ff:fe0a:181f": Object {
+                                "address": "fe80::f03c:91ff:fe0a:181f",
+                                "key": "fe80::f03c:91ff:fe0a:181f",
+                                "linode_id": 1250,
+                                "type": "link-local",
+                                "version": "ipv6",
+                              },
+                            },
+                            "_polling": false,
+                            "_shared": Array [],
+                            "_stats": Object {
+                              "cpu": Array [
+                                Array [
+                                  1490378700000,
+                                  1.67,
+                                ],
+                              ],
+                              "io": Object {
+                                "io": Array [
+                                  Array [
+                                    1490379000000,
+                                    0.91,
+                                  ],
+                                ],
+                                "swap": Array [
+                                  Array [
+                                    1490378100000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv4": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv6": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                            },
+                            "_volumes": Object {
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                              "volumes": Object {
+                                "38": Object {
+                                  "created": "2017-08-08T13:55:16",
+                                  "id": 38,
+                                  "label": "test",
+                                  "linode_id": null,
+                                  "region": "us-east-1a",
+                                  "size": 20,
+                                  "status": "active",
+                                  "updated": "2017-08-08T04:00:00",
+                                },
+                              },
+                            },
+                            "alerts": Object {
+                              "cpu": 90,
+                              "io": 5000,
+                              "network_in": 5,
+                              "network_out": 5,
+                              "tranfer_quota": 80,
+                            },
+                            "backups": Object {
+                              "enabled": true,
+                              "schedule": Object {
+                                "day": "Monday",
+                                "window": "W10",
+                              },
+                            },
+                            "created": "2016-07-06T16:47:27",
+                            "disk": 20480,
+                            "group": "Test Group",
+                            "hypervisor": "kvm",
+                            "id": 1250,
+                            "image": Object {
+                              "id": "linode/ubuntu15.10",
+                              "label": "Ubuntu 15.10",
+                              "vendor": "Ubuntu",
+                            },
+                            "ipv4": Array [
+                              "97.107.143.50",
+                              "97.107.143.51",
+                            ],
+                            "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                            "label": "test-linode-no-disks",
+                            "memory": 2048,
+                            "region": "us-east-1a",
+                            "status": "running",
+                            "type": Object {
+                              "_polling": false,
+                              "addons": Object {
+                                "backups": Object {
+                                  "price": Object {
+                                    "monthly": 2.5,
+                                  },
+                                },
+                              },
+                              "class": "standard",
+                              "disk": 24576,
+                              "id": "linode2048.5",
+                              "label": "Linode 2048",
+                              "memory": 2048,
+                              "network_out": 125,
+                              "price": Object {
+                                "hourly": 0.015,
+                                "monthly": 10,
+                              },
+                              "service_type": "linode",
+                              "transfer": 2000,
+                              "vcpus": 2,
+                            },
+                            "vcpus": 2,
+                          },
                         }
                       }
                       name="target"
@@ -53149,6 +59221,613 @@ ShallowWrapper {
                           "memory": 2048,
                           "region": "us-east-1a",
                           "status": "provisioning",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                        "1249": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {
+                              "12345": Object {
+                                "created": "2016-08-09T19:47:11",
+                                "filesystem": "raw",
+                                "id": 12345,
+                                "label": "Raw Disk",
+                                "size": 6144,
+                                "updated": "2016-08-09T19:47:11",
+                              },
+                            },
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:31": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:31",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:31",
+                              "linode_id": 1249,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.47": Object {
+                              "address": "97.107.143.47",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.47",
+                              "linode_id": 1249,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.49": Object {
+                              "address": "97.107.143.49",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.49",
+                              "linode_id": 1249,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1249,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1249,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.47",
+                            "97.107.143.48",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                          "label": "test-linode-raw",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                        "1250": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {},
+                            "totalPages": 1,
+                            "totalResults": 0,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:33": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:33",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:33",
+                              "linode_id": 1250,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.50": Object {
+                              "address": "97.107.143.50",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.50",
+                              "linode_id": 1250,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.52": Object {
+                              "address": "97.107.143.52",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.52",
+                              "linode_id": 1250,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1250,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1250,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.50",
+                            "97.107.143.51",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                          "label": "test-linode-no-disks",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
                           "type": Object {
                             "_polling": false,
                             "addons": Object {

--- a/src/linodes/linode/networking/layouts/__snapshots__/IPSharingPage.spec.js.snap
+++ b/src/linodes/linode/networking/layouts/__snapshots__/IPSharingPage.spec.js.snap
@@ -5086,6 +5086,613 @@ ShallowWrapper {
           },
           "vcpus": 2,
         },
+        "1249": Object {
+          "_backups": Object {
+            "daily": Object {
+              "availability": "daily",
+              "configs": Array [
+                "Ubuntu Disk",
+              ],
+              "created": "2017-01-31T07:28:52",
+              "disks": Array [
+                Object {
+                  "filesystem": "ext4",
+                  "label": "Ubuntu 15.10 Disk",
+                  "size": 2330,
+                },
+                Object {
+                  "filesystem": "swap",
+                  "label": "512 MB Swap Image",
+                  "size": 0,
+                },
+              ],
+              "finished": "2017-01-31T07:30:03",
+              "id": 54782214,
+              "label": null,
+              "region": "us-east-1a",
+              "status": "successful",
+              "type": "auto",
+              "updated": "2017-01-31T12:32:01",
+            },
+            "snapshot": Object {
+              "current": Object {
+                "availability": "unavailable",
+                "configs": Array [
+                  "Some config",
+                ],
+                "created": "2017-01-31T21:50:42",
+                "disks": Array [
+                  Object {
+                    "filesystem": "ext4",
+                    "label": "Ubuntu 15.10 Disk",
+                    "size": 2330,
+                  },
+                  Object {
+                    "filesystem": "swap",
+                    "label": "512 MB Swap Image",
+                    "size": 0,
+                  },
+                ],
+                "finished": "2017-01-31T21:51:51",
+                "id": 54782236,
+                "label": "the label",
+                "region": "us-east-1a",
+                "status": "successful",
+                "type": "snapshot",
+                "updated": "2017-01-31T21:51:51",
+              },
+              "in_progress": null,
+            },
+            "weekly": Array [],
+          },
+          "_configs": Object {
+            "configs": Object {
+              "12345": Object {
+                "comments": "Test comments",
+                "created": "2015-09-29 11:21:38 +0000",
+                "devices": Object {
+                  "sda": Object {
+                    "disk_id": 12345,
+                  },
+                  "sdb": Object {
+                    "disk_id": 12346,
+                  },
+                  "sdc": null,
+                  "sdd": null,
+                  "sde": null,
+                  "sdf": null,
+                  "sdg": null,
+                  "sdh": null,
+                },
+                "helpers": Object {
+                  "devtmpfs_automount": false,
+                  "distro": true,
+                  "modules_dep": true,
+                  "network": true,
+                  "updatedb_disabled": true,
+                },
+                "id": 12345,
+                "initrd": "",
+                "kernel": "linode/latest_64",
+                "label": "Test config",
+                "memory_limit": 1024,
+                "root_device": "/dev/sda",
+                "run_level": "default",
+                "updated": "2015-09-29 11:21:38 +0000",
+                "virt_mode": "paravirt",
+              },
+            },
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+          },
+          "_disks": Object {
+            "disks": Object {
+              "12345": Object {
+                "created": "2016-08-09T19:47:11",
+                "filesystem": "raw",
+                "id": 12345,
+                "label": "Raw Disk",
+                "size": 6144,
+                "updated": "2016-08-09T19:47:11",
+              },
+            },
+            "totalPages": 1,
+            "totalResults": 1,
+          },
+          "_ips": Object {
+            "2600:3c03::f03c:91ff:fe0a:31": Object {
+              "address": "2600:3c03::f03c:91ff:fe0a:31",
+              "gateway": "fe80::1",
+              "key": "2600:3c03::f03c:91ff:fe0a:31",
+              "linode_id": 1249,
+              "prefix": "64",
+              "rdns": "li1-1.members.linode.com",
+              "type": "slaac",
+              "version": "ipv6",
+            },
+            "97.107.143.47": Object {
+              "address": "97.107.143.47",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.47",
+              "linode_id": 1249,
+              "prefix": 24,
+              "rdns": "li1-1.members.linode.com",
+              "type": "public",
+              "version": "ipv4",
+            },
+            "97.107.143.49": Object {
+              "address": "97.107.143.49",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.49",
+              "linode_id": 1249,
+              "prefix": 17,
+              "rdns": "li1-1.members.linode.com",
+              "type": "private",
+              "version": "ipv4",
+            },
+            "fe80::f03c:91ff:fe0a:181f": Object {
+              "address": "fe80::f03c:91ff:fe0a:181f",
+              "key": "fe80::f03c:91ff:fe0a:181f",
+              "linode_id": 1249,
+              "type": "link-local",
+              "version": "ipv6",
+            },
+          },
+          "_polling": false,
+          "_shared": Array [],
+          "_stats": Object {
+            "cpu": Array [
+              Array [
+                1490378700000,
+                1.67,
+              ],
+            ],
+            "io": Object {
+              "io": Array [
+                Array [
+                  1490379000000,
+                  0.91,
+                ],
+              ],
+              "swap": Array [
+                Array [
+                  1490378100000,
+                  0,
+                ],
+              ],
+            },
+            "netv4": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+            "netv6": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+          },
+          "_volumes": Object {
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+            "volumes": Object {
+              "38": Object {
+                "created": "2017-08-08T13:55:16",
+                "id": 38,
+                "label": "test",
+                "linode_id": null,
+                "region": "us-east-1a",
+                "size": 20,
+                "status": "active",
+                "updated": "2017-08-08T04:00:00",
+              },
+            },
+          },
+          "alerts": Object {
+            "cpu": 90,
+            "io": 5000,
+            "network_in": 5,
+            "network_out": 5,
+            "tranfer_quota": 80,
+          },
+          "backups": Object {
+            "enabled": true,
+            "schedule": Object {
+              "day": "Monday",
+              "window": "W10",
+            },
+          },
+          "created": "2016-07-06T16:47:27",
+          "disk": 20480,
+          "group": "Test Group",
+          "hypervisor": "kvm",
+          "id": 1249,
+          "image": Object {
+            "id": "linode/ubuntu15.10",
+            "label": "Ubuntu 15.10",
+            "vendor": "Ubuntu",
+          },
+          "ipv4": Array [
+            "97.107.143.47",
+            "97.107.143.48",
+          ],
+          "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+          "label": "test-linode-raw",
+          "memory": 2048,
+          "region": "us-east-1a",
+          "status": "running",
+          "type": Object {
+            "_polling": false,
+            "addons": Object {
+              "backups": Object {
+                "price": Object {
+                  "monthly": 2.5,
+                },
+              },
+            },
+            "class": "standard",
+            "disk": 24576,
+            "id": "linode2048.5",
+            "label": "Linode 2048",
+            "memory": 2048,
+            "network_out": 125,
+            "price": Object {
+              "hourly": 0.015,
+              "monthly": 10,
+            },
+            "service_type": "linode",
+            "transfer": 2000,
+            "vcpus": 2,
+          },
+          "vcpus": 2,
+        },
+        "1250": Object {
+          "_backups": Object {
+            "daily": Object {
+              "availability": "daily",
+              "configs": Array [
+                "Ubuntu Disk",
+              ],
+              "created": "2017-01-31T07:28:52",
+              "disks": Array [
+                Object {
+                  "filesystem": "ext4",
+                  "label": "Ubuntu 15.10 Disk",
+                  "size": 2330,
+                },
+                Object {
+                  "filesystem": "swap",
+                  "label": "512 MB Swap Image",
+                  "size": 0,
+                },
+              ],
+              "finished": "2017-01-31T07:30:03",
+              "id": 54782214,
+              "label": null,
+              "region": "us-east-1a",
+              "status": "successful",
+              "type": "auto",
+              "updated": "2017-01-31T12:32:01",
+            },
+            "snapshot": Object {
+              "current": Object {
+                "availability": "unavailable",
+                "configs": Array [
+                  "Some config",
+                ],
+                "created": "2017-01-31T21:50:42",
+                "disks": Array [
+                  Object {
+                    "filesystem": "ext4",
+                    "label": "Ubuntu 15.10 Disk",
+                    "size": 2330,
+                  },
+                  Object {
+                    "filesystem": "swap",
+                    "label": "512 MB Swap Image",
+                    "size": 0,
+                  },
+                ],
+                "finished": "2017-01-31T21:51:51",
+                "id": 54782236,
+                "label": "the label",
+                "region": "us-east-1a",
+                "status": "successful",
+                "type": "snapshot",
+                "updated": "2017-01-31T21:51:51",
+              },
+              "in_progress": null,
+            },
+            "weekly": Array [],
+          },
+          "_configs": Object {
+            "configs": Object {
+              "12345": Object {
+                "comments": "Test comments",
+                "created": "2015-09-29 11:21:38 +0000",
+                "devices": Object {
+                  "sda": Object {
+                    "disk_id": 12345,
+                  },
+                  "sdb": Object {
+                    "disk_id": 12346,
+                  },
+                  "sdc": null,
+                  "sdd": null,
+                  "sde": null,
+                  "sdf": null,
+                  "sdg": null,
+                  "sdh": null,
+                },
+                "helpers": Object {
+                  "devtmpfs_automount": false,
+                  "distro": true,
+                  "modules_dep": true,
+                  "network": true,
+                  "updatedb_disabled": true,
+                },
+                "id": 12345,
+                "initrd": "",
+                "kernel": "linode/latest_64",
+                "label": "Test config",
+                "memory_limit": 1024,
+                "root_device": "/dev/sda",
+                "run_level": "default",
+                "updated": "2015-09-29 11:21:38 +0000",
+                "virt_mode": "paravirt",
+              },
+            },
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+          },
+          "_disks": Object {
+            "disks": Object {},
+            "totalPages": 1,
+            "totalResults": 0,
+          },
+          "_ips": Object {
+            "2600:3c03::f03c:91ff:fe0a:33": Object {
+              "address": "2600:3c03::f03c:91ff:fe0a:33",
+              "gateway": "fe80::1",
+              "key": "2600:3c03::f03c:91ff:fe0a:33",
+              "linode_id": 1250,
+              "prefix": "64",
+              "rdns": "li1-1.members.linode.com",
+              "type": "slaac",
+              "version": "ipv6",
+            },
+            "97.107.143.50": Object {
+              "address": "97.107.143.50",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.50",
+              "linode_id": 1250,
+              "prefix": 24,
+              "rdns": "li1-1.members.linode.com",
+              "type": "public",
+              "version": "ipv4",
+            },
+            "97.107.143.52": Object {
+              "address": "97.107.143.52",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.52",
+              "linode_id": 1250,
+              "prefix": 17,
+              "rdns": "li1-1.members.linode.com",
+              "type": "private",
+              "version": "ipv4",
+            },
+            "fe80::f03c:91ff:fe0a:181f": Object {
+              "address": "fe80::f03c:91ff:fe0a:181f",
+              "key": "fe80::f03c:91ff:fe0a:181f",
+              "linode_id": 1250,
+              "type": "link-local",
+              "version": "ipv6",
+            },
+          },
+          "_polling": false,
+          "_shared": Array [],
+          "_stats": Object {
+            "cpu": Array [
+              Array [
+                1490378700000,
+                1.67,
+              ],
+            ],
+            "io": Object {
+              "io": Array [
+                Array [
+                  1490379000000,
+                  0.91,
+                ],
+              ],
+              "swap": Array [
+                Array [
+                  1490378100000,
+                  0,
+                ],
+              ],
+            },
+            "netv4": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+            "netv6": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+          },
+          "_volumes": Object {
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+            "volumes": Object {
+              "38": Object {
+                "created": "2017-08-08T13:55:16",
+                "id": 38,
+                "label": "test",
+                "linode_id": null,
+                "region": "us-east-1a",
+                "size": 20,
+                "status": "active",
+                "updated": "2017-08-08T04:00:00",
+              },
+            },
+          },
+          "alerts": Object {
+            "cpu": 90,
+            "io": 5000,
+            "network_in": 5,
+            "network_out": 5,
+            "tranfer_quota": 80,
+          },
+          "backups": Object {
+            "enabled": true,
+            "schedule": Object {
+              "day": "Monday",
+              "window": "W10",
+            },
+          },
+          "created": "2016-07-06T16:47:27",
+          "disk": 20480,
+          "group": "Test Group",
+          "hypervisor": "kvm",
+          "id": 1250,
+          "image": Object {
+            "id": "linode/ubuntu15.10",
+            "label": "Ubuntu 15.10",
+            "vendor": "Ubuntu",
+          },
+          "ipv4": Array [
+            "97.107.143.50",
+            "97.107.143.51",
+          ],
+          "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+          "label": "test-linode-no-disks",
+          "memory": 2048,
+          "region": "us-east-1a",
+          "status": "running",
+          "type": Object {
+            "_polling": false,
+            "addons": Object {
+              "backups": Object {
+                "price": Object {
+                  "monthly": 2.5,
+                },
+              },
+            },
+            "class": "standard",
+            "disk": 24576,
+            "id": "linode2048.5",
+            "label": "Linode 2048",
+            "memory": 2048,
+            "network_out": 125,
+            "price": Object {
+              "hourly": 0.015,
+              "monthly": 10,
+            },
+            "service_type": "linode",
+            "transfer": 2000,
+            "vcpus": 2,
+          },
+          "vcpus": 2,
+        },
       }
     }
   />,
@@ -9751,6 +10358,637 @@ ShallowWrapper {
                       "vcpus": 2,
                     },
                   },
+                  Object {
+                    "ip": Object {
+                      "address": "97.107.143.47",
+                      "gateway": "97.107.143.0",
+                      "key": "97.107.143.47",
+                      "linode_id": 1249,
+                      "prefix": 24,
+                      "rdns": "li1-1.members.linode.com",
+                      "type": "public",
+                      "version": "ipv4",
+                    },
+                    "linode": Object {
+                      "_backups": Object {
+                        "daily": Object {
+                          "availability": "daily",
+                          "configs": Array [
+                            "Ubuntu Disk",
+                          ],
+                          "created": "2017-01-31T07:28:52",
+                          "disks": Array [
+                            Object {
+                              "filesystem": "ext4",
+                              "label": "Ubuntu 15.10 Disk",
+                              "size": 2330,
+                            },
+                            Object {
+                              "filesystem": "swap",
+                              "label": "512 MB Swap Image",
+                              "size": 0,
+                            },
+                          ],
+                          "finished": "2017-01-31T07:30:03",
+                          "id": 54782214,
+                          "label": null,
+                          "region": "us-east-1a",
+                          "status": "successful",
+                          "type": "auto",
+                          "updated": "2017-01-31T12:32:01",
+                        },
+                        "snapshot": Object {
+                          "current": Object {
+                            "availability": "unavailable",
+                            "configs": Array [
+                              "Some config",
+                            ],
+                            "created": "2017-01-31T21:50:42",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T21:51:51",
+                            "id": 54782236,
+                            "label": "the label",
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "snapshot",
+                            "updated": "2017-01-31T21:51:51",
+                          },
+                          "in_progress": null,
+                        },
+                        "weekly": Array [],
+                      },
+                      "_configs": Object {
+                        "configs": Object {
+                          "12345": Object {
+                            "comments": "Test comments",
+                            "created": "2015-09-29 11:21:38 +0000",
+                            "devices": Object {
+                              "sda": Object {
+                                "disk_id": 12345,
+                              },
+                              "sdb": Object {
+                                "disk_id": 12346,
+                              },
+                              "sdc": null,
+                              "sdd": null,
+                              "sde": null,
+                              "sdf": null,
+                              "sdg": null,
+                              "sdh": null,
+                            },
+                            "helpers": Object {
+                              "devtmpfs_automount": false,
+                              "distro": true,
+                              "modules_dep": true,
+                              "network": true,
+                              "updatedb_disabled": true,
+                            },
+                            "id": 12345,
+                            "initrd": "",
+                            "kernel": "linode/latest_64",
+                            "label": "Test config",
+                            "memory_limit": 1024,
+                            "root_device": "/dev/sda",
+                            "run_level": "default",
+                            "updated": "2015-09-29 11:21:38 +0000",
+                            "virt_mode": "paravirt",
+                          },
+                        },
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                      },
+                      "_disks": Object {
+                        "disks": Object {
+                          "12345": Object {
+                            "created": "2016-08-09T19:47:11",
+                            "filesystem": "raw",
+                            "id": 12345,
+                            "label": "Raw Disk",
+                            "size": 6144,
+                            "updated": "2016-08-09T19:47:11",
+                          },
+                        },
+                        "totalPages": 1,
+                        "totalResults": 1,
+                      },
+                      "_ips": Object {
+                        "2600:3c03::f03c:91ff:fe0a:31": Object {
+                          "address": "2600:3c03::f03c:91ff:fe0a:31",
+                          "gateway": "fe80::1",
+                          "key": "2600:3c03::f03c:91ff:fe0a:31",
+                          "linode_id": 1249,
+                          "prefix": "64",
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "slaac",
+                          "version": "ipv6",
+                        },
+                        "97.107.143.47": Object {
+                          "address": "97.107.143.47",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.47",
+                          "linode_id": 1249,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "97.107.143.49": Object {
+                          "address": "97.107.143.49",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.49",
+                          "linode_id": 1249,
+                          "prefix": 17,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "private",
+                          "version": "ipv4",
+                        },
+                        "fe80::f03c:91ff:fe0a:181f": Object {
+                          "address": "fe80::f03c:91ff:fe0a:181f",
+                          "key": "fe80::f03c:91ff:fe0a:181f",
+                          "linode_id": 1249,
+                          "type": "link-local",
+                          "version": "ipv6",
+                        },
+                      },
+                      "_polling": false,
+                      "_shared": Array [],
+                      "_stats": Object {
+                        "cpu": Array [
+                          Array [
+                            1490378700000,
+                            1.67,
+                          ],
+                        ],
+                        "io": Object {
+                          "io": Array [
+                            Array [
+                              1490379000000,
+                              0.91,
+                            ],
+                          ],
+                          "swap": Array [
+                            Array [
+                              1490378100000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv4": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv6": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                      },
+                      "_volumes": Object {
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                        "volumes": Object {
+                          "38": Object {
+                            "created": "2017-08-08T13:55:16",
+                            "id": 38,
+                            "label": "test",
+                            "linode_id": null,
+                            "region": "us-east-1a",
+                            "size": 20,
+                            "status": "active",
+                            "updated": "2017-08-08T04:00:00",
+                          },
+                        },
+                      },
+                      "alerts": Object {
+                        "cpu": 90,
+                        "io": 5000,
+                        "network_in": 5,
+                        "network_out": 5,
+                        "tranfer_quota": 80,
+                      },
+                      "backups": Object {
+                        "enabled": true,
+                        "schedule": Object {
+                          "day": "Monday",
+                          "window": "W10",
+                        },
+                      },
+                      "created": "2016-07-06T16:47:27",
+                      "disk": 20480,
+                      "group": "Test Group",
+                      "hypervisor": "kvm",
+                      "id": 1249,
+                      "image": Object {
+                        "id": "linode/ubuntu15.10",
+                        "label": "Ubuntu 15.10",
+                        "vendor": "Ubuntu",
+                      },
+                      "ipv4": Array [
+                        "97.107.143.47",
+                        "97.107.143.48",
+                      ],
+                      "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                      "label": "test-linode-raw",
+                      "memory": 2048,
+                      "region": "us-east-1a",
+                      "status": "running",
+                      "type": Object {
+                        "_polling": false,
+                        "addons": Object {
+                          "backups": Object {
+                            "price": Object {
+                              "monthly": 2.5,
+                            },
+                          },
+                        },
+                        "class": "standard",
+                        "disk": 24576,
+                        "id": "linode2048.5",
+                        "label": "Linode 2048",
+                        "memory": 2048,
+                        "network_out": 125,
+                        "price": Object {
+                          "hourly": 0.015,
+                          "monthly": 10,
+                        },
+                        "service_type": "linode",
+                        "transfer": 2000,
+                        "vcpus": 2,
+                      },
+                      "vcpus": 2,
+                    },
+                  },
+                  Object {
+                    "ip": Object {
+                      "address": "97.107.143.50",
+                      "gateway": "97.107.143.0",
+                      "key": "97.107.143.50",
+                      "linode_id": 1250,
+                      "prefix": 24,
+                      "rdns": "li1-1.members.linode.com",
+                      "type": "public",
+                      "version": "ipv4",
+                    },
+                    "linode": Object {
+                      "_backups": Object {
+                        "daily": Object {
+                          "availability": "daily",
+                          "configs": Array [
+                            "Ubuntu Disk",
+                          ],
+                          "created": "2017-01-31T07:28:52",
+                          "disks": Array [
+                            Object {
+                              "filesystem": "ext4",
+                              "label": "Ubuntu 15.10 Disk",
+                              "size": 2330,
+                            },
+                            Object {
+                              "filesystem": "swap",
+                              "label": "512 MB Swap Image",
+                              "size": 0,
+                            },
+                          ],
+                          "finished": "2017-01-31T07:30:03",
+                          "id": 54782214,
+                          "label": null,
+                          "region": "us-east-1a",
+                          "status": "successful",
+                          "type": "auto",
+                          "updated": "2017-01-31T12:32:01",
+                        },
+                        "snapshot": Object {
+                          "current": Object {
+                            "availability": "unavailable",
+                            "configs": Array [
+                              "Some config",
+                            ],
+                            "created": "2017-01-31T21:50:42",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T21:51:51",
+                            "id": 54782236,
+                            "label": "the label",
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "snapshot",
+                            "updated": "2017-01-31T21:51:51",
+                          },
+                          "in_progress": null,
+                        },
+                        "weekly": Array [],
+                      },
+                      "_configs": Object {
+                        "configs": Object {
+                          "12345": Object {
+                            "comments": "Test comments",
+                            "created": "2015-09-29 11:21:38 +0000",
+                            "devices": Object {
+                              "sda": Object {
+                                "disk_id": 12345,
+                              },
+                              "sdb": Object {
+                                "disk_id": 12346,
+                              },
+                              "sdc": null,
+                              "sdd": null,
+                              "sde": null,
+                              "sdf": null,
+                              "sdg": null,
+                              "sdh": null,
+                            },
+                            "helpers": Object {
+                              "devtmpfs_automount": false,
+                              "distro": true,
+                              "modules_dep": true,
+                              "network": true,
+                              "updatedb_disabled": true,
+                            },
+                            "id": 12345,
+                            "initrd": "",
+                            "kernel": "linode/latest_64",
+                            "label": "Test config",
+                            "memory_limit": 1024,
+                            "root_device": "/dev/sda",
+                            "run_level": "default",
+                            "updated": "2015-09-29 11:21:38 +0000",
+                            "virt_mode": "paravirt",
+                          },
+                        },
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                      },
+                      "_disks": Object {
+                        "disks": Object {},
+                        "totalPages": 1,
+                        "totalResults": 0,
+                      },
+                      "_ips": Object {
+                        "2600:3c03::f03c:91ff:fe0a:33": Object {
+                          "address": "2600:3c03::f03c:91ff:fe0a:33",
+                          "gateway": "fe80::1",
+                          "key": "2600:3c03::f03c:91ff:fe0a:33",
+                          "linode_id": 1250,
+                          "prefix": "64",
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "slaac",
+                          "version": "ipv6",
+                        },
+                        "97.107.143.50": Object {
+                          "address": "97.107.143.50",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.50",
+                          "linode_id": 1250,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "97.107.143.52": Object {
+                          "address": "97.107.143.52",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.52",
+                          "linode_id": 1250,
+                          "prefix": 17,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "private",
+                          "version": "ipv4",
+                        },
+                        "fe80::f03c:91ff:fe0a:181f": Object {
+                          "address": "fe80::f03c:91ff:fe0a:181f",
+                          "key": "fe80::f03c:91ff:fe0a:181f",
+                          "linode_id": 1250,
+                          "type": "link-local",
+                          "version": "ipv6",
+                        },
+                      },
+                      "_polling": false,
+                      "_shared": Array [],
+                      "_stats": Object {
+                        "cpu": Array [
+                          Array [
+                            1490378700000,
+                            1.67,
+                          ],
+                        ],
+                        "io": Object {
+                          "io": Array [
+                            Array [
+                              1490379000000,
+                              0.91,
+                            ],
+                          ],
+                          "swap": Array [
+                            Array [
+                              1490378100000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv4": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                        "netv6": Object {
+                          "in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_in": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                          "private_out": Array [
+                            Array [
+                              1490377800000,
+                              0,
+                            ],
+                          ],
+                        },
+                      },
+                      "_volumes": Object {
+                        "pagesFetched": Array [
+                          0,
+                        ],
+                        "totalPages": 1,
+                        "totalResults": 1,
+                        "volumes": Object {
+                          "38": Object {
+                            "created": "2017-08-08T13:55:16",
+                            "id": 38,
+                            "label": "test",
+                            "linode_id": null,
+                            "region": "us-east-1a",
+                            "size": 20,
+                            "status": "active",
+                            "updated": "2017-08-08T04:00:00",
+                          },
+                        },
+                      },
+                      "alerts": Object {
+                        "cpu": 90,
+                        "io": 5000,
+                        "network_in": 5,
+                        "network_out": 5,
+                        "tranfer_quota": 80,
+                      },
+                      "backups": Object {
+                        "enabled": true,
+                        "schedule": Object {
+                          "day": "Monday",
+                          "window": "W10",
+                        },
+                      },
+                      "created": "2016-07-06T16:47:27",
+                      "disk": 20480,
+                      "group": "Test Group",
+                      "hypervisor": "kvm",
+                      "id": 1250,
+                      "image": Object {
+                        "id": "linode/ubuntu15.10",
+                        "label": "Ubuntu 15.10",
+                        "vendor": "Ubuntu",
+                      },
+                      "ipv4": Array [
+                        "97.107.143.50",
+                        "97.107.143.51",
+                      ],
+                      "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                      "label": "test-linode-no-disks",
+                      "memory": 2048,
+                      "region": "us-east-1a",
+                      "status": "running",
+                      "type": Object {
+                        "_polling": false,
+                        "addons": Object {
+                          "backups": Object {
+                            "price": Object {
+                              "monthly": 2.5,
+                            },
+                          },
+                        },
+                        "class": "standard",
+                        "disk": 24576,
+                        "id": "linode2048.5",
+                        "label": "Linode 2048",
+                        "memory": 2048,
+                        "network_out": 125,
+                        "price": Object {
+                          "hourly": 0.015,
+                          "monthly": 10,
+                        },
+                        "service_type": "linode",
+                        "transfer": 2000,
+                        "vcpus": 2,
+                      },
+                      "vcpus": 2,
+                    },
+                  },
                 ]
               }
               disableHeader={false}
@@ -9770,6 +11008,8 @@ ShallowWrapper {
                   "97.107.143.37": false,
                   "97.107.143.40": false,
                   "97.107.143.44": false,
+                  "97.107.143.47": false,
+                  "97.107.143.50": false,
                   "97.107.143.6": false,
                   "97.107.143.9": false,
                 }
@@ -14455,6 +15695,637 @@ ShallowWrapper {
                         "vcpus": 2,
                       },
                     },
+                    Object {
+                      "ip": Object {
+                        "address": "97.107.143.47",
+                        "gateway": "97.107.143.0",
+                        "key": "97.107.143.47",
+                        "linode_id": 1249,
+                        "prefix": 24,
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "public",
+                        "version": "ipv4",
+                      },
+                      "linode": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {
+                            "12345": Object {
+                              "created": "2016-08-09T19:47:11",
+                              "filesystem": "raw",
+                              "id": 12345,
+                              "label": "Raw Disk",
+                              "size": 6144,
+                              "updated": "2016-08-09T19:47:11",
+                            },
+                          },
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:31": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:31",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:31",
+                            "linode_id": 1249,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.47": Object {
+                            "address": "97.107.143.47",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.47",
+                            "linode_id": 1249,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.49": Object {
+                            "address": "97.107.143.49",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.49",
+                            "linode_id": 1249,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1249,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1249,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.47",
+                          "97.107.143.48",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                        "label": "test-linode-raw",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                    },
+                    Object {
+                      "ip": Object {
+                        "address": "97.107.143.50",
+                        "gateway": "97.107.143.0",
+                        "key": "97.107.143.50",
+                        "linode_id": 1250,
+                        "prefix": 24,
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "public",
+                        "version": "ipv4",
+                      },
+                      "linode": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {},
+                          "totalPages": 1,
+                          "totalResults": 0,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:33": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:33",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:33",
+                            "linode_id": 1250,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.50": Object {
+                            "address": "97.107.143.50",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.50",
+                            "linode_id": 1250,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.52": Object {
+                            "address": "97.107.143.52",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.52",
+                            "linode_id": 1250,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1250,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1250,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.50",
+                          "97.107.143.51",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                        "label": "test-linode-no-disks",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                    },
                   ]
                 }
                 disableHeader={false}
@@ -14474,6 +16345,8 @@ ShallowWrapper {
                     "97.107.143.37": false,
                     "97.107.143.40": false,
                     "97.107.143.44": false,
+                    "97.107.143.47": false,
+                    "97.107.143.50": false,
                     "97.107.143.6": false,
                     "97.107.143.9": false,
                   }
@@ -19167,6 +21040,637 @@ ShallowWrapper {
                           "vcpus": 2,
                         },
                       },
+                      Object {
+                        "ip": Object {
+                          "address": "97.107.143.47",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.47",
+                          "linode_id": 1249,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "linode": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {
+                              "12345": Object {
+                                "created": "2016-08-09T19:47:11",
+                                "filesystem": "raw",
+                                "id": 12345,
+                                "label": "Raw Disk",
+                                "size": 6144,
+                                "updated": "2016-08-09T19:47:11",
+                              },
+                            },
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:31": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:31",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:31",
+                              "linode_id": 1249,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.47": Object {
+                              "address": "97.107.143.47",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.47",
+                              "linode_id": 1249,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.49": Object {
+                              "address": "97.107.143.49",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.49",
+                              "linode_id": 1249,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1249,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1249,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.47",
+                            "97.107.143.48",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                          "label": "test-linode-raw",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                      },
+                      Object {
+                        "ip": Object {
+                          "address": "97.107.143.50",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.50",
+                          "linode_id": 1250,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "linode": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {},
+                            "totalPages": 1,
+                            "totalResults": 0,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:33": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:33",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:33",
+                              "linode_id": 1250,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.50": Object {
+                              "address": "97.107.143.50",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.50",
+                              "linode_id": 1250,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.52": Object {
+                              "address": "97.107.143.52",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.52",
+                              "linode_id": 1250,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1250,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1250,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.50",
+                            "97.107.143.51",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                          "label": "test-linode-no-disks",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                      },
                     ]
                   }
                   disableHeader={false}
@@ -19186,6 +21690,8 @@ ShallowWrapper {
                       "97.107.143.37": false,
                       "97.107.143.40": false,
                       "97.107.143.44": false,
+                      "97.107.143.47": false,
+                      "97.107.143.50": false,
                       "97.107.143.6": false,
                       "97.107.143.9": false,
                     }
@@ -23850,6 +26356,637 @@ ShallowWrapper {
                           "vcpus": 2,
                         },
                       },
+                      Object {
+                        "ip": Object {
+                          "address": "97.107.143.47",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.47",
+                          "linode_id": 1249,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "linode": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {
+                              "12345": Object {
+                                "created": "2016-08-09T19:47:11",
+                                "filesystem": "raw",
+                                "id": 12345,
+                                "label": "Raw Disk",
+                                "size": 6144,
+                                "updated": "2016-08-09T19:47:11",
+                              },
+                            },
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:31": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:31",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:31",
+                              "linode_id": 1249,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.47": Object {
+                              "address": "97.107.143.47",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.47",
+                              "linode_id": 1249,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.49": Object {
+                              "address": "97.107.143.49",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.49",
+                              "linode_id": 1249,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1249,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1249,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.47",
+                            "97.107.143.48",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                          "label": "test-linode-raw",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                      },
+                      Object {
+                        "ip": Object {
+                          "address": "97.107.143.50",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.50",
+                          "linode_id": 1250,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "linode": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {},
+                            "totalPages": 1,
+                            "totalResults": 0,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:33": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:33",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:33",
+                              "linode_id": 1250,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.50": Object {
+                              "address": "97.107.143.50",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.50",
+                              "linode_id": 1250,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.52": Object {
+                              "address": "97.107.143.52",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.52",
+                              "linode_id": 1250,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1250,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1250,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.50",
+                            "97.107.143.51",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                          "label": "test-linode-no-disks",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                      },
                     ]
                   }
                   disableHeader={false}
@@ -23869,6 +27006,8 @@ ShallowWrapper {
                       "97.107.143.37": false,
                       "97.107.143.40": false,
                       "97.107.143.44": false,
+                      "97.107.143.47": false,
+                      "97.107.143.50": false,
                       "97.107.143.6": false,
                       "97.107.143.9": false,
                     }
@@ -28509,6 +31648,637 @@ ShallowWrapper {
                         "vcpus": 2,
                       },
                     },
+                    Object {
+                      "ip": Object {
+                        "address": "97.107.143.47",
+                        "gateway": "97.107.143.0",
+                        "key": "97.107.143.47",
+                        "linode_id": 1249,
+                        "prefix": 24,
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "public",
+                        "version": "ipv4",
+                      },
+                      "linode": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {
+                            "12345": Object {
+                              "created": "2016-08-09T19:47:11",
+                              "filesystem": "raw",
+                              "id": 12345,
+                              "label": "Raw Disk",
+                              "size": 6144,
+                              "updated": "2016-08-09T19:47:11",
+                            },
+                          },
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:31": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:31",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:31",
+                            "linode_id": 1249,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.47": Object {
+                            "address": "97.107.143.47",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.47",
+                            "linode_id": 1249,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.49": Object {
+                            "address": "97.107.143.49",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.49",
+                            "linode_id": 1249,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1249,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1249,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.47",
+                          "97.107.143.48",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                        "label": "test-linode-raw",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                    },
+                    Object {
+                      "ip": Object {
+                        "address": "97.107.143.50",
+                        "gateway": "97.107.143.0",
+                        "key": "97.107.143.50",
+                        "linode_id": 1250,
+                        "prefix": 24,
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "public",
+                        "version": "ipv4",
+                      },
+                      "linode": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {},
+                          "totalPages": 1,
+                          "totalResults": 0,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:33": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:33",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:33",
+                            "linode_id": 1250,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.50": Object {
+                            "address": "97.107.143.50",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.50",
+                            "linode_id": 1250,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.52": Object {
+                            "address": "97.107.143.52",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.52",
+                            "linode_id": 1250,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1250,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1250,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.50",
+                          "97.107.143.51",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                        "label": "test-linode-no-disks",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                    },
                   ],
                   "disableHeader": false,
                   "noDataMessage": "No data found.",
@@ -28526,6 +32296,8 @@ ShallowWrapper {
                     "97.107.143.37": false,
                     "97.107.143.40": false,
                     "97.107.143.44": false,
+                    "97.107.143.47": false,
+                    "97.107.143.50": false,
                     "97.107.143.6": false,
                     "97.107.143.9": false,
                   },
@@ -33253,6 +37025,637 @@ ShallowWrapper {
                         "vcpus": 2,
                       },
                     },
+                    Object {
+                      "ip": Object {
+                        "address": "97.107.143.47",
+                        "gateway": "97.107.143.0",
+                        "key": "97.107.143.47",
+                        "linode_id": 1249,
+                        "prefix": 24,
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "public",
+                        "version": "ipv4",
+                      },
+                      "linode": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {
+                            "12345": Object {
+                              "created": "2016-08-09T19:47:11",
+                              "filesystem": "raw",
+                              "id": 12345,
+                              "label": "Raw Disk",
+                              "size": 6144,
+                              "updated": "2016-08-09T19:47:11",
+                            },
+                          },
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:31": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:31",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:31",
+                            "linode_id": 1249,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.47": Object {
+                            "address": "97.107.143.47",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.47",
+                            "linode_id": 1249,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.49": Object {
+                            "address": "97.107.143.49",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.49",
+                            "linode_id": 1249,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1249,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1249,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.47",
+                          "97.107.143.48",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                        "label": "test-linode-raw",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                    },
+                    Object {
+                      "ip": Object {
+                        "address": "97.107.143.50",
+                        "gateway": "97.107.143.0",
+                        "key": "97.107.143.50",
+                        "linode_id": 1250,
+                        "prefix": 24,
+                        "rdns": "li1-1.members.linode.com",
+                        "type": "public",
+                        "version": "ipv4",
+                      },
+                      "linode": Object {
+                        "_backups": Object {
+                          "daily": Object {
+                            "availability": "daily",
+                            "configs": Array [
+                              "Ubuntu Disk",
+                            ],
+                            "created": "2017-01-31T07:28:52",
+                            "disks": Array [
+                              Object {
+                                "filesystem": "ext4",
+                                "label": "Ubuntu 15.10 Disk",
+                                "size": 2330,
+                              },
+                              Object {
+                                "filesystem": "swap",
+                                "label": "512 MB Swap Image",
+                                "size": 0,
+                              },
+                            ],
+                            "finished": "2017-01-31T07:30:03",
+                            "id": 54782214,
+                            "label": null,
+                            "region": "us-east-1a",
+                            "status": "successful",
+                            "type": "auto",
+                            "updated": "2017-01-31T12:32:01",
+                          },
+                          "snapshot": Object {
+                            "current": Object {
+                              "availability": "unavailable",
+                              "configs": Array [
+                                "Some config",
+                              ],
+                              "created": "2017-01-31T21:50:42",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T21:51:51",
+                              "id": 54782236,
+                              "label": "the label",
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "snapshot",
+                              "updated": "2017-01-31T21:51:51",
+                            },
+                            "in_progress": null,
+                          },
+                          "weekly": Array [],
+                        },
+                        "_configs": Object {
+                          "configs": Object {
+                            "12345": Object {
+                              "comments": "Test comments",
+                              "created": "2015-09-29 11:21:38 +0000",
+                              "devices": Object {
+                                "sda": Object {
+                                  "disk_id": 12345,
+                                },
+                                "sdb": Object {
+                                  "disk_id": 12346,
+                                },
+                                "sdc": null,
+                                "sdd": null,
+                                "sde": null,
+                                "sdf": null,
+                                "sdg": null,
+                                "sdh": null,
+                              },
+                              "helpers": Object {
+                                "devtmpfs_automount": false,
+                                "distro": true,
+                                "modules_dep": true,
+                                "network": true,
+                                "updatedb_disabled": true,
+                              },
+                              "id": 12345,
+                              "initrd": "",
+                              "kernel": "linode/latest_64",
+                              "label": "Test config",
+                              "memory_limit": 1024,
+                              "root_device": "/dev/sda",
+                              "run_level": "default",
+                              "updated": "2015-09-29 11:21:38 +0000",
+                              "virt_mode": "paravirt",
+                            },
+                          },
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                        },
+                        "_disks": Object {
+                          "disks": Object {},
+                          "totalPages": 1,
+                          "totalResults": 0,
+                        },
+                        "_ips": Object {
+                          "2600:3c03::f03c:91ff:fe0a:33": Object {
+                            "address": "2600:3c03::f03c:91ff:fe0a:33",
+                            "gateway": "fe80::1",
+                            "key": "2600:3c03::f03c:91ff:fe0a:33",
+                            "linode_id": 1250,
+                            "prefix": "64",
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "slaac",
+                            "version": "ipv6",
+                          },
+                          "97.107.143.50": Object {
+                            "address": "97.107.143.50",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.50",
+                            "linode_id": 1250,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "97.107.143.52": Object {
+                            "address": "97.107.143.52",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.52",
+                            "linode_id": 1250,
+                            "prefix": 17,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "private",
+                            "version": "ipv4",
+                          },
+                          "fe80::f03c:91ff:fe0a:181f": Object {
+                            "address": "fe80::f03c:91ff:fe0a:181f",
+                            "key": "fe80::f03c:91ff:fe0a:181f",
+                            "linode_id": 1250,
+                            "type": "link-local",
+                            "version": "ipv6",
+                          },
+                        },
+                        "_polling": false,
+                        "_shared": Array [],
+                        "_stats": Object {
+                          "cpu": Array [
+                            Array [
+                              1490378700000,
+                              1.67,
+                            ],
+                          ],
+                          "io": Object {
+                            "io": Array [
+                              Array [
+                                1490379000000,
+                                0.91,
+                              ],
+                            ],
+                            "swap": Array [
+                              Array [
+                                1490378100000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv4": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                          "netv6": Object {
+                            "in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_in": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                            "private_out": Array [
+                              Array [
+                                1490377800000,
+                                0,
+                              ],
+                            ],
+                          },
+                        },
+                        "_volumes": Object {
+                          "pagesFetched": Array [
+                            0,
+                          ],
+                          "totalPages": 1,
+                          "totalResults": 1,
+                          "volumes": Object {
+                            "38": Object {
+                              "created": "2017-08-08T13:55:16",
+                              "id": 38,
+                              "label": "test",
+                              "linode_id": null,
+                              "region": "us-east-1a",
+                              "size": 20,
+                              "status": "active",
+                              "updated": "2017-08-08T04:00:00",
+                            },
+                          },
+                        },
+                        "alerts": Object {
+                          "cpu": 90,
+                          "io": 5000,
+                          "network_in": 5,
+                          "network_out": 5,
+                          "tranfer_quota": 80,
+                        },
+                        "backups": Object {
+                          "enabled": true,
+                          "schedule": Object {
+                            "day": "Monday",
+                            "window": "W10",
+                          },
+                        },
+                        "created": "2016-07-06T16:47:27",
+                        "disk": 20480,
+                        "group": "Test Group",
+                        "hypervisor": "kvm",
+                        "id": 1250,
+                        "image": Object {
+                          "id": "linode/ubuntu15.10",
+                          "label": "Ubuntu 15.10",
+                          "vendor": "Ubuntu",
+                        },
+                        "ipv4": Array [
+                          "97.107.143.50",
+                          "97.107.143.51",
+                        ],
+                        "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                        "label": "test-linode-no-disks",
+                        "memory": 2048,
+                        "region": "us-east-1a",
+                        "status": "running",
+                        "type": Object {
+                          "_polling": false,
+                          "addons": Object {
+                            "backups": Object {
+                              "price": Object {
+                                "monthly": 2.5,
+                              },
+                            },
+                          },
+                          "class": "standard",
+                          "disk": 24576,
+                          "id": "linode2048.5",
+                          "label": "Linode 2048",
+                          "memory": 2048,
+                          "network_out": 125,
+                          "price": Object {
+                            "hourly": 0.015,
+                            "monthly": 10,
+                          },
+                          "service_type": "linode",
+                          "transfer": 2000,
+                          "vcpus": 2,
+                        },
+                        "vcpus": 2,
+                      },
+                    },
                   ]
                 }
                 disableHeader={false}
@@ -33272,6 +37675,8 @@ ShallowWrapper {
                     "97.107.143.37": false,
                     "97.107.143.40": false,
                     "97.107.143.44": false,
+                    "97.107.143.47": false,
+                    "97.107.143.50": false,
                     "97.107.143.6": false,
                     "97.107.143.9": false,
                   }
@@ -37957,6 +42362,637 @@ ShallowWrapper {
                           "vcpus": 2,
                         },
                       },
+                      Object {
+                        "ip": Object {
+                          "address": "97.107.143.47",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.47",
+                          "linode_id": 1249,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "linode": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {
+                              "12345": Object {
+                                "created": "2016-08-09T19:47:11",
+                                "filesystem": "raw",
+                                "id": 12345,
+                                "label": "Raw Disk",
+                                "size": 6144,
+                                "updated": "2016-08-09T19:47:11",
+                              },
+                            },
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:31": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:31",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:31",
+                              "linode_id": 1249,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.47": Object {
+                              "address": "97.107.143.47",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.47",
+                              "linode_id": 1249,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.49": Object {
+                              "address": "97.107.143.49",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.49",
+                              "linode_id": 1249,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1249,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1249,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.47",
+                            "97.107.143.48",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                          "label": "test-linode-raw",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                      },
+                      Object {
+                        "ip": Object {
+                          "address": "97.107.143.50",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.50",
+                          "linode_id": 1250,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "linode": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {},
+                            "totalPages": 1,
+                            "totalResults": 0,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:33": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:33",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:33",
+                              "linode_id": 1250,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.50": Object {
+                              "address": "97.107.143.50",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.50",
+                              "linode_id": 1250,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.52": Object {
+                              "address": "97.107.143.52",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.52",
+                              "linode_id": 1250,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1250,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1250,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.50",
+                            "97.107.143.51",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                          "label": "test-linode-no-disks",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                      },
                     ]
                   }
                   disableHeader={false}
@@ -37976,6 +43012,8 @@ ShallowWrapper {
                       "97.107.143.37": false,
                       "97.107.143.40": false,
                       "97.107.143.44": false,
+                      "97.107.143.47": false,
+                      "97.107.143.50": false,
                       "97.107.143.6": false,
                       "97.107.143.9": false,
                     }
@@ -42669,6 +47707,637 @@ ShallowWrapper {
                             "vcpus": 2,
                           },
                         },
+                        Object {
+                          "ip": Object {
+                            "address": "97.107.143.47",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.47",
+                            "linode_id": 1249,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "linode": Object {
+                            "_backups": Object {
+                              "daily": Object {
+                                "availability": "daily",
+                                "configs": Array [
+                                  "Ubuntu Disk",
+                                ],
+                                "created": "2017-01-31T07:28:52",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T07:30:03",
+                                "id": 54782214,
+                                "label": null,
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "auto",
+                                "updated": "2017-01-31T12:32:01",
+                              },
+                              "snapshot": Object {
+                                "current": Object {
+                                  "availability": "unavailable",
+                                  "configs": Array [
+                                    "Some config",
+                                  ],
+                                  "created": "2017-01-31T21:50:42",
+                                  "disks": Array [
+                                    Object {
+                                      "filesystem": "ext4",
+                                      "label": "Ubuntu 15.10 Disk",
+                                      "size": 2330,
+                                    },
+                                    Object {
+                                      "filesystem": "swap",
+                                      "label": "512 MB Swap Image",
+                                      "size": 0,
+                                    },
+                                  ],
+                                  "finished": "2017-01-31T21:51:51",
+                                  "id": 54782236,
+                                  "label": "the label",
+                                  "region": "us-east-1a",
+                                  "status": "successful",
+                                  "type": "snapshot",
+                                  "updated": "2017-01-31T21:51:51",
+                                },
+                                "in_progress": null,
+                              },
+                              "weekly": Array [],
+                            },
+                            "_configs": Object {
+                              "configs": Object {
+                                "12345": Object {
+                                  "comments": "Test comments",
+                                  "created": "2015-09-29 11:21:38 +0000",
+                                  "devices": Object {
+                                    "sda": Object {
+                                      "disk_id": 12345,
+                                    },
+                                    "sdb": Object {
+                                      "disk_id": 12346,
+                                    },
+                                    "sdc": null,
+                                    "sdd": null,
+                                    "sde": null,
+                                    "sdf": null,
+                                    "sdg": null,
+                                    "sdh": null,
+                                  },
+                                  "helpers": Object {
+                                    "devtmpfs_automount": false,
+                                    "distro": true,
+                                    "modules_dep": true,
+                                    "network": true,
+                                    "updatedb_disabled": true,
+                                  },
+                                  "id": 12345,
+                                  "initrd": "",
+                                  "kernel": "linode/latest_64",
+                                  "label": "Test config",
+                                  "memory_limit": 1024,
+                                  "root_device": "/dev/sda",
+                                  "run_level": "default",
+                                  "updated": "2015-09-29 11:21:38 +0000",
+                                  "virt_mode": "paravirt",
+                                },
+                              },
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                            },
+                            "_disks": Object {
+                              "disks": Object {
+                                "12345": Object {
+                                  "created": "2016-08-09T19:47:11",
+                                  "filesystem": "raw",
+                                  "id": 12345,
+                                  "label": "Raw Disk",
+                                  "size": 6144,
+                                  "updated": "2016-08-09T19:47:11",
+                                },
+                              },
+                              "totalPages": 1,
+                              "totalResults": 1,
+                            },
+                            "_ips": Object {
+                              "2600:3c03::f03c:91ff:fe0a:31": Object {
+                                "address": "2600:3c03::f03c:91ff:fe0a:31",
+                                "gateway": "fe80::1",
+                                "key": "2600:3c03::f03c:91ff:fe0a:31",
+                                "linode_id": 1249,
+                                "prefix": "64",
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "slaac",
+                                "version": "ipv6",
+                              },
+                              "97.107.143.47": Object {
+                                "address": "97.107.143.47",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.47",
+                                "linode_id": 1249,
+                                "prefix": 24,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "public",
+                                "version": "ipv4",
+                              },
+                              "97.107.143.49": Object {
+                                "address": "97.107.143.49",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.49",
+                                "linode_id": 1249,
+                                "prefix": 17,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "private",
+                                "version": "ipv4",
+                              },
+                              "fe80::f03c:91ff:fe0a:181f": Object {
+                                "address": "fe80::f03c:91ff:fe0a:181f",
+                                "key": "fe80::f03c:91ff:fe0a:181f",
+                                "linode_id": 1249,
+                                "type": "link-local",
+                                "version": "ipv6",
+                              },
+                            },
+                            "_polling": false,
+                            "_shared": Array [],
+                            "_stats": Object {
+                              "cpu": Array [
+                                Array [
+                                  1490378700000,
+                                  1.67,
+                                ],
+                              ],
+                              "io": Object {
+                                "io": Array [
+                                  Array [
+                                    1490379000000,
+                                    0.91,
+                                  ],
+                                ],
+                                "swap": Array [
+                                  Array [
+                                    1490378100000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv4": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv6": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                            },
+                            "_volumes": Object {
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                              "volumes": Object {
+                                "38": Object {
+                                  "created": "2017-08-08T13:55:16",
+                                  "id": 38,
+                                  "label": "test",
+                                  "linode_id": null,
+                                  "region": "us-east-1a",
+                                  "size": 20,
+                                  "status": "active",
+                                  "updated": "2017-08-08T04:00:00",
+                                },
+                              },
+                            },
+                            "alerts": Object {
+                              "cpu": 90,
+                              "io": 5000,
+                              "network_in": 5,
+                              "network_out": 5,
+                              "tranfer_quota": 80,
+                            },
+                            "backups": Object {
+                              "enabled": true,
+                              "schedule": Object {
+                                "day": "Monday",
+                                "window": "W10",
+                              },
+                            },
+                            "created": "2016-07-06T16:47:27",
+                            "disk": 20480,
+                            "group": "Test Group",
+                            "hypervisor": "kvm",
+                            "id": 1249,
+                            "image": Object {
+                              "id": "linode/ubuntu15.10",
+                              "label": "Ubuntu 15.10",
+                              "vendor": "Ubuntu",
+                            },
+                            "ipv4": Array [
+                              "97.107.143.47",
+                              "97.107.143.48",
+                            ],
+                            "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                            "label": "test-linode-raw",
+                            "memory": 2048,
+                            "region": "us-east-1a",
+                            "status": "running",
+                            "type": Object {
+                              "_polling": false,
+                              "addons": Object {
+                                "backups": Object {
+                                  "price": Object {
+                                    "monthly": 2.5,
+                                  },
+                                },
+                              },
+                              "class": "standard",
+                              "disk": 24576,
+                              "id": "linode2048.5",
+                              "label": "Linode 2048",
+                              "memory": 2048,
+                              "network_out": 125,
+                              "price": Object {
+                                "hourly": 0.015,
+                                "monthly": 10,
+                              },
+                              "service_type": "linode",
+                              "transfer": 2000,
+                              "vcpus": 2,
+                            },
+                            "vcpus": 2,
+                          },
+                        },
+                        Object {
+                          "ip": Object {
+                            "address": "97.107.143.50",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.50",
+                            "linode_id": 1250,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "linode": Object {
+                            "_backups": Object {
+                              "daily": Object {
+                                "availability": "daily",
+                                "configs": Array [
+                                  "Ubuntu Disk",
+                                ],
+                                "created": "2017-01-31T07:28:52",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T07:30:03",
+                                "id": 54782214,
+                                "label": null,
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "auto",
+                                "updated": "2017-01-31T12:32:01",
+                              },
+                              "snapshot": Object {
+                                "current": Object {
+                                  "availability": "unavailable",
+                                  "configs": Array [
+                                    "Some config",
+                                  ],
+                                  "created": "2017-01-31T21:50:42",
+                                  "disks": Array [
+                                    Object {
+                                      "filesystem": "ext4",
+                                      "label": "Ubuntu 15.10 Disk",
+                                      "size": 2330,
+                                    },
+                                    Object {
+                                      "filesystem": "swap",
+                                      "label": "512 MB Swap Image",
+                                      "size": 0,
+                                    },
+                                  ],
+                                  "finished": "2017-01-31T21:51:51",
+                                  "id": 54782236,
+                                  "label": "the label",
+                                  "region": "us-east-1a",
+                                  "status": "successful",
+                                  "type": "snapshot",
+                                  "updated": "2017-01-31T21:51:51",
+                                },
+                                "in_progress": null,
+                              },
+                              "weekly": Array [],
+                            },
+                            "_configs": Object {
+                              "configs": Object {
+                                "12345": Object {
+                                  "comments": "Test comments",
+                                  "created": "2015-09-29 11:21:38 +0000",
+                                  "devices": Object {
+                                    "sda": Object {
+                                      "disk_id": 12345,
+                                    },
+                                    "sdb": Object {
+                                      "disk_id": 12346,
+                                    },
+                                    "sdc": null,
+                                    "sdd": null,
+                                    "sde": null,
+                                    "sdf": null,
+                                    "sdg": null,
+                                    "sdh": null,
+                                  },
+                                  "helpers": Object {
+                                    "devtmpfs_automount": false,
+                                    "distro": true,
+                                    "modules_dep": true,
+                                    "network": true,
+                                    "updatedb_disabled": true,
+                                  },
+                                  "id": 12345,
+                                  "initrd": "",
+                                  "kernel": "linode/latest_64",
+                                  "label": "Test config",
+                                  "memory_limit": 1024,
+                                  "root_device": "/dev/sda",
+                                  "run_level": "default",
+                                  "updated": "2015-09-29 11:21:38 +0000",
+                                  "virt_mode": "paravirt",
+                                },
+                              },
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                            },
+                            "_disks": Object {
+                              "disks": Object {},
+                              "totalPages": 1,
+                              "totalResults": 0,
+                            },
+                            "_ips": Object {
+                              "2600:3c03::f03c:91ff:fe0a:33": Object {
+                                "address": "2600:3c03::f03c:91ff:fe0a:33",
+                                "gateway": "fe80::1",
+                                "key": "2600:3c03::f03c:91ff:fe0a:33",
+                                "linode_id": 1250,
+                                "prefix": "64",
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "slaac",
+                                "version": "ipv6",
+                              },
+                              "97.107.143.50": Object {
+                                "address": "97.107.143.50",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.50",
+                                "linode_id": 1250,
+                                "prefix": 24,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "public",
+                                "version": "ipv4",
+                              },
+                              "97.107.143.52": Object {
+                                "address": "97.107.143.52",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.52",
+                                "linode_id": 1250,
+                                "prefix": 17,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "private",
+                                "version": "ipv4",
+                              },
+                              "fe80::f03c:91ff:fe0a:181f": Object {
+                                "address": "fe80::f03c:91ff:fe0a:181f",
+                                "key": "fe80::f03c:91ff:fe0a:181f",
+                                "linode_id": 1250,
+                                "type": "link-local",
+                                "version": "ipv6",
+                              },
+                            },
+                            "_polling": false,
+                            "_shared": Array [],
+                            "_stats": Object {
+                              "cpu": Array [
+                                Array [
+                                  1490378700000,
+                                  1.67,
+                                ],
+                              ],
+                              "io": Object {
+                                "io": Array [
+                                  Array [
+                                    1490379000000,
+                                    0.91,
+                                  ],
+                                ],
+                                "swap": Array [
+                                  Array [
+                                    1490378100000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv4": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv6": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                            },
+                            "_volumes": Object {
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                              "volumes": Object {
+                                "38": Object {
+                                  "created": "2017-08-08T13:55:16",
+                                  "id": 38,
+                                  "label": "test",
+                                  "linode_id": null,
+                                  "region": "us-east-1a",
+                                  "size": 20,
+                                  "status": "active",
+                                  "updated": "2017-08-08T04:00:00",
+                                },
+                              },
+                            },
+                            "alerts": Object {
+                              "cpu": 90,
+                              "io": 5000,
+                              "network_in": 5,
+                              "network_out": 5,
+                              "tranfer_quota": 80,
+                            },
+                            "backups": Object {
+                              "enabled": true,
+                              "schedule": Object {
+                                "day": "Monday",
+                                "window": "W10",
+                              },
+                            },
+                            "created": "2016-07-06T16:47:27",
+                            "disk": 20480,
+                            "group": "Test Group",
+                            "hypervisor": "kvm",
+                            "id": 1250,
+                            "image": Object {
+                              "id": "linode/ubuntu15.10",
+                              "label": "Ubuntu 15.10",
+                              "vendor": "Ubuntu",
+                            },
+                            "ipv4": Array [
+                              "97.107.143.50",
+                              "97.107.143.51",
+                            ],
+                            "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                            "label": "test-linode-no-disks",
+                            "memory": 2048,
+                            "region": "us-east-1a",
+                            "status": "running",
+                            "type": Object {
+                              "_polling": false,
+                              "addons": Object {
+                                "backups": Object {
+                                  "price": Object {
+                                    "monthly": 2.5,
+                                  },
+                                },
+                              },
+                              "class": "standard",
+                              "disk": 24576,
+                              "id": "linode2048.5",
+                              "label": "Linode 2048",
+                              "memory": 2048,
+                              "network_out": 125,
+                              "price": Object {
+                                "hourly": 0.015,
+                                "monthly": 10,
+                              },
+                              "service_type": "linode",
+                              "transfer": 2000,
+                              "vcpus": 2,
+                            },
+                            "vcpus": 2,
+                          },
+                        },
                       ]
                     }
                     disableHeader={false}
@@ -42688,6 +48357,8 @@ ShallowWrapper {
                         "97.107.143.37": false,
                         "97.107.143.40": false,
                         "97.107.143.44": false,
+                        "97.107.143.47": false,
+                        "97.107.143.50": false,
                         "97.107.143.6": false,
                         "97.107.143.9": false,
                       }
@@ -47352,6 +53023,637 @@ ShallowWrapper {
                             "vcpus": 2,
                           },
                         },
+                        Object {
+                          "ip": Object {
+                            "address": "97.107.143.47",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.47",
+                            "linode_id": 1249,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "linode": Object {
+                            "_backups": Object {
+                              "daily": Object {
+                                "availability": "daily",
+                                "configs": Array [
+                                  "Ubuntu Disk",
+                                ],
+                                "created": "2017-01-31T07:28:52",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T07:30:03",
+                                "id": 54782214,
+                                "label": null,
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "auto",
+                                "updated": "2017-01-31T12:32:01",
+                              },
+                              "snapshot": Object {
+                                "current": Object {
+                                  "availability": "unavailable",
+                                  "configs": Array [
+                                    "Some config",
+                                  ],
+                                  "created": "2017-01-31T21:50:42",
+                                  "disks": Array [
+                                    Object {
+                                      "filesystem": "ext4",
+                                      "label": "Ubuntu 15.10 Disk",
+                                      "size": 2330,
+                                    },
+                                    Object {
+                                      "filesystem": "swap",
+                                      "label": "512 MB Swap Image",
+                                      "size": 0,
+                                    },
+                                  ],
+                                  "finished": "2017-01-31T21:51:51",
+                                  "id": 54782236,
+                                  "label": "the label",
+                                  "region": "us-east-1a",
+                                  "status": "successful",
+                                  "type": "snapshot",
+                                  "updated": "2017-01-31T21:51:51",
+                                },
+                                "in_progress": null,
+                              },
+                              "weekly": Array [],
+                            },
+                            "_configs": Object {
+                              "configs": Object {
+                                "12345": Object {
+                                  "comments": "Test comments",
+                                  "created": "2015-09-29 11:21:38 +0000",
+                                  "devices": Object {
+                                    "sda": Object {
+                                      "disk_id": 12345,
+                                    },
+                                    "sdb": Object {
+                                      "disk_id": 12346,
+                                    },
+                                    "sdc": null,
+                                    "sdd": null,
+                                    "sde": null,
+                                    "sdf": null,
+                                    "sdg": null,
+                                    "sdh": null,
+                                  },
+                                  "helpers": Object {
+                                    "devtmpfs_automount": false,
+                                    "distro": true,
+                                    "modules_dep": true,
+                                    "network": true,
+                                    "updatedb_disabled": true,
+                                  },
+                                  "id": 12345,
+                                  "initrd": "",
+                                  "kernel": "linode/latest_64",
+                                  "label": "Test config",
+                                  "memory_limit": 1024,
+                                  "root_device": "/dev/sda",
+                                  "run_level": "default",
+                                  "updated": "2015-09-29 11:21:38 +0000",
+                                  "virt_mode": "paravirt",
+                                },
+                              },
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                            },
+                            "_disks": Object {
+                              "disks": Object {
+                                "12345": Object {
+                                  "created": "2016-08-09T19:47:11",
+                                  "filesystem": "raw",
+                                  "id": 12345,
+                                  "label": "Raw Disk",
+                                  "size": 6144,
+                                  "updated": "2016-08-09T19:47:11",
+                                },
+                              },
+                              "totalPages": 1,
+                              "totalResults": 1,
+                            },
+                            "_ips": Object {
+                              "2600:3c03::f03c:91ff:fe0a:31": Object {
+                                "address": "2600:3c03::f03c:91ff:fe0a:31",
+                                "gateway": "fe80::1",
+                                "key": "2600:3c03::f03c:91ff:fe0a:31",
+                                "linode_id": 1249,
+                                "prefix": "64",
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "slaac",
+                                "version": "ipv6",
+                              },
+                              "97.107.143.47": Object {
+                                "address": "97.107.143.47",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.47",
+                                "linode_id": 1249,
+                                "prefix": 24,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "public",
+                                "version": "ipv4",
+                              },
+                              "97.107.143.49": Object {
+                                "address": "97.107.143.49",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.49",
+                                "linode_id": 1249,
+                                "prefix": 17,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "private",
+                                "version": "ipv4",
+                              },
+                              "fe80::f03c:91ff:fe0a:181f": Object {
+                                "address": "fe80::f03c:91ff:fe0a:181f",
+                                "key": "fe80::f03c:91ff:fe0a:181f",
+                                "linode_id": 1249,
+                                "type": "link-local",
+                                "version": "ipv6",
+                              },
+                            },
+                            "_polling": false,
+                            "_shared": Array [],
+                            "_stats": Object {
+                              "cpu": Array [
+                                Array [
+                                  1490378700000,
+                                  1.67,
+                                ],
+                              ],
+                              "io": Object {
+                                "io": Array [
+                                  Array [
+                                    1490379000000,
+                                    0.91,
+                                  ],
+                                ],
+                                "swap": Array [
+                                  Array [
+                                    1490378100000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv4": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv6": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                            },
+                            "_volumes": Object {
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                              "volumes": Object {
+                                "38": Object {
+                                  "created": "2017-08-08T13:55:16",
+                                  "id": 38,
+                                  "label": "test",
+                                  "linode_id": null,
+                                  "region": "us-east-1a",
+                                  "size": 20,
+                                  "status": "active",
+                                  "updated": "2017-08-08T04:00:00",
+                                },
+                              },
+                            },
+                            "alerts": Object {
+                              "cpu": 90,
+                              "io": 5000,
+                              "network_in": 5,
+                              "network_out": 5,
+                              "tranfer_quota": 80,
+                            },
+                            "backups": Object {
+                              "enabled": true,
+                              "schedule": Object {
+                                "day": "Monday",
+                                "window": "W10",
+                              },
+                            },
+                            "created": "2016-07-06T16:47:27",
+                            "disk": 20480,
+                            "group": "Test Group",
+                            "hypervisor": "kvm",
+                            "id": 1249,
+                            "image": Object {
+                              "id": "linode/ubuntu15.10",
+                              "label": "Ubuntu 15.10",
+                              "vendor": "Ubuntu",
+                            },
+                            "ipv4": Array [
+                              "97.107.143.47",
+                              "97.107.143.48",
+                            ],
+                            "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                            "label": "test-linode-raw",
+                            "memory": 2048,
+                            "region": "us-east-1a",
+                            "status": "running",
+                            "type": Object {
+                              "_polling": false,
+                              "addons": Object {
+                                "backups": Object {
+                                  "price": Object {
+                                    "monthly": 2.5,
+                                  },
+                                },
+                              },
+                              "class": "standard",
+                              "disk": 24576,
+                              "id": "linode2048.5",
+                              "label": "Linode 2048",
+                              "memory": 2048,
+                              "network_out": 125,
+                              "price": Object {
+                                "hourly": 0.015,
+                                "monthly": 10,
+                              },
+                              "service_type": "linode",
+                              "transfer": 2000,
+                              "vcpus": 2,
+                            },
+                            "vcpus": 2,
+                          },
+                        },
+                        Object {
+                          "ip": Object {
+                            "address": "97.107.143.50",
+                            "gateway": "97.107.143.0",
+                            "key": "97.107.143.50",
+                            "linode_id": 1250,
+                            "prefix": 24,
+                            "rdns": "li1-1.members.linode.com",
+                            "type": "public",
+                            "version": "ipv4",
+                          },
+                          "linode": Object {
+                            "_backups": Object {
+                              "daily": Object {
+                                "availability": "daily",
+                                "configs": Array [
+                                  "Ubuntu Disk",
+                                ],
+                                "created": "2017-01-31T07:28:52",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T07:30:03",
+                                "id": 54782214,
+                                "label": null,
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "auto",
+                                "updated": "2017-01-31T12:32:01",
+                              },
+                              "snapshot": Object {
+                                "current": Object {
+                                  "availability": "unavailable",
+                                  "configs": Array [
+                                    "Some config",
+                                  ],
+                                  "created": "2017-01-31T21:50:42",
+                                  "disks": Array [
+                                    Object {
+                                      "filesystem": "ext4",
+                                      "label": "Ubuntu 15.10 Disk",
+                                      "size": 2330,
+                                    },
+                                    Object {
+                                      "filesystem": "swap",
+                                      "label": "512 MB Swap Image",
+                                      "size": 0,
+                                    },
+                                  ],
+                                  "finished": "2017-01-31T21:51:51",
+                                  "id": 54782236,
+                                  "label": "the label",
+                                  "region": "us-east-1a",
+                                  "status": "successful",
+                                  "type": "snapshot",
+                                  "updated": "2017-01-31T21:51:51",
+                                },
+                                "in_progress": null,
+                              },
+                              "weekly": Array [],
+                            },
+                            "_configs": Object {
+                              "configs": Object {
+                                "12345": Object {
+                                  "comments": "Test comments",
+                                  "created": "2015-09-29 11:21:38 +0000",
+                                  "devices": Object {
+                                    "sda": Object {
+                                      "disk_id": 12345,
+                                    },
+                                    "sdb": Object {
+                                      "disk_id": 12346,
+                                    },
+                                    "sdc": null,
+                                    "sdd": null,
+                                    "sde": null,
+                                    "sdf": null,
+                                    "sdg": null,
+                                    "sdh": null,
+                                  },
+                                  "helpers": Object {
+                                    "devtmpfs_automount": false,
+                                    "distro": true,
+                                    "modules_dep": true,
+                                    "network": true,
+                                    "updatedb_disabled": true,
+                                  },
+                                  "id": 12345,
+                                  "initrd": "",
+                                  "kernel": "linode/latest_64",
+                                  "label": "Test config",
+                                  "memory_limit": 1024,
+                                  "root_device": "/dev/sda",
+                                  "run_level": "default",
+                                  "updated": "2015-09-29 11:21:38 +0000",
+                                  "virt_mode": "paravirt",
+                                },
+                              },
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                            },
+                            "_disks": Object {
+                              "disks": Object {},
+                              "totalPages": 1,
+                              "totalResults": 0,
+                            },
+                            "_ips": Object {
+                              "2600:3c03::f03c:91ff:fe0a:33": Object {
+                                "address": "2600:3c03::f03c:91ff:fe0a:33",
+                                "gateway": "fe80::1",
+                                "key": "2600:3c03::f03c:91ff:fe0a:33",
+                                "linode_id": 1250,
+                                "prefix": "64",
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "slaac",
+                                "version": "ipv6",
+                              },
+                              "97.107.143.50": Object {
+                                "address": "97.107.143.50",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.50",
+                                "linode_id": 1250,
+                                "prefix": 24,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "public",
+                                "version": "ipv4",
+                              },
+                              "97.107.143.52": Object {
+                                "address": "97.107.143.52",
+                                "gateway": "97.107.143.0",
+                                "key": "97.107.143.52",
+                                "linode_id": 1250,
+                                "prefix": 17,
+                                "rdns": "li1-1.members.linode.com",
+                                "type": "private",
+                                "version": "ipv4",
+                              },
+                              "fe80::f03c:91ff:fe0a:181f": Object {
+                                "address": "fe80::f03c:91ff:fe0a:181f",
+                                "key": "fe80::f03c:91ff:fe0a:181f",
+                                "linode_id": 1250,
+                                "type": "link-local",
+                                "version": "ipv6",
+                              },
+                            },
+                            "_polling": false,
+                            "_shared": Array [],
+                            "_stats": Object {
+                              "cpu": Array [
+                                Array [
+                                  1490378700000,
+                                  1.67,
+                                ],
+                              ],
+                              "io": Object {
+                                "io": Array [
+                                  Array [
+                                    1490379000000,
+                                    0.91,
+                                  ],
+                                ],
+                                "swap": Array [
+                                  Array [
+                                    1490378100000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv4": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                              "netv6": Object {
+                                "in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_in": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                                "private_out": Array [
+                                  Array [
+                                    1490377800000,
+                                    0,
+                                  ],
+                                ],
+                              },
+                            },
+                            "_volumes": Object {
+                              "pagesFetched": Array [
+                                0,
+                              ],
+                              "totalPages": 1,
+                              "totalResults": 1,
+                              "volumes": Object {
+                                "38": Object {
+                                  "created": "2017-08-08T13:55:16",
+                                  "id": 38,
+                                  "label": "test",
+                                  "linode_id": null,
+                                  "region": "us-east-1a",
+                                  "size": 20,
+                                  "status": "active",
+                                  "updated": "2017-08-08T04:00:00",
+                                },
+                              },
+                            },
+                            "alerts": Object {
+                              "cpu": 90,
+                              "io": 5000,
+                              "network_in": 5,
+                              "network_out": 5,
+                              "tranfer_quota": 80,
+                            },
+                            "backups": Object {
+                              "enabled": true,
+                              "schedule": Object {
+                                "day": "Monday",
+                                "window": "W10",
+                              },
+                            },
+                            "created": "2016-07-06T16:47:27",
+                            "disk": 20480,
+                            "group": "Test Group",
+                            "hypervisor": "kvm",
+                            "id": 1250,
+                            "image": Object {
+                              "id": "linode/ubuntu15.10",
+                              "label": "Ubuntu 15.10",
+                              "vendor": "Ubuntu",
+                            },
+                            "ipv4": Array [
+                              "97.107.143.50",
+                              "97.107.143.51",
+                            ],
+                            "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                            "label": "test-linode-no-disks",
+                            "memory": 2048,
+                            "region": "us-east-1a",
+                            "status": "running",
+                            "type": Object {
+                              "_polling": false,
+                              "addons": Object {
+                                "backups": Object {
+                                  "price": Object {
+                                    "monthly": 2.5,
+                                  },
+                                },
+                              },
+                              "class": "standard",
+                              "disk": 24576,
+                              "id": "linode2048.5",
+                              "label": "Linode 2048",
+                              "memory": 2048,
+                              "network_out": 125,
+                              "price": Object {
+                                "hourly": 0.015,
+                                "monthly": 10,
+                              },
+                              "service_type": "linode",
+                              "transfer": 2000,
+                              "vcpus": 2,
+                            },
+                            "vcpus": 2,
+                          },
+                        },
                       ]
                     }
                     disableHeader={false}
@@ -47371,6 +53673,8 @@ ShallowWrapper {
                         "97.107.143.37": false,
                         "97.107.143.40": false,
                         "97.107.143.44": false,
+                        "97.107.143.47": false,
+                        "97.107.143.50": false,
                         "97.107.143.6": false,
                         "97.107.143.9": false,
                       }
@@ -52011,6 +58315,637 @@ ShallowWrapper {
                           "vcpus": 2,
                         },
                       },
+                      Object {
+                        "ip": Object {
+                          "address": "97.107.143.47",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.47",
+                          "linode_id": 1249,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "linode": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {
+                              "12345": Object {
+                                "created": "2016-08-09T19:47:11",
+                                "filesystem": "raw",
+                                "id": 12345,
+                                "label": "Raw Disk",
+                                "size": 6144,
+                                "updated": "2016-08-09T19:47:11",
+                              },
+                            },
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:31": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:31",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:31",
+                              "linode_id": 1249,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.47": Object {
+                              "address": "97.107.143.47",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.47",
+                              "linode_id": 1249,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.49": Object {
+                              "address": "97.107.143.49",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.49",
+                              "linode_id": 1249,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1249,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1249,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.47",
+                            "97.107.143.48",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+                          "label": "test-linode-raw",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                      },
+                      Object {
+                        "ip": Object {
+                          "address": "97.107.143.50",
+                          "gateway": "97.107.143.0",
+                          "key": "97.107.143.50",
+                          "linode_id": 1250,
+                          "prefix": 24,
+                          "rdns": "li1-1.members.linode.com",
+                          "type": "public",
+                          "version": "ipv4",
+                        },
+                        "linode": Object {
+                          "_backups": Object {
+                            "daily": Object {
+                              "availability": "daily",
+                              "configs": Array [
+                                "Ubuntu Disk",
+                              ],
+                              "created": "2017-01-31T07:28:52",
+                              "disks": Array [
+                                Object {
+                                  "filesystem": "ext4",
+                                  "label": "Ubuntu 15.10 Disk",
+                                  "size": 2330,
+                                },
+                                Object {
+                                  "filesystem": "swap",
+                                  "label": "512 MB Swap Image",
+                                  "size": 0,
+                                },
+                              ],
+                              "finished": "2017-01-31T07:30:03",
+                              "id": 54782214,
+                              "label": null,
+                              "region": "us-east-1a",
+                              "status": "successful",
+                              "type": "auto",
+                              "updated": "2017-01-31T12:32:01",
+                            },
+                            "snapshot": Object {
+                              "current": Object {
+                                "availability": "unavailable",
+                                "configs": Array [
+                                  "Some config",
+                                ],
+                                "created": "2017-01-31T21:50:42",
+                                "disks": Array [
+                                  Object {
+                                    "filesystem": "ext4",
+                                    "label": "Ubuntu 15.10 Disk",
+                                    "size": 2330,
+                                  },
+                                  Object {
+                                    "filesystem": "swap",
+                                    "label": "512 MB Swap Image",
+                                    "size": 0,
+                                  },
+                                ],
+                                "finished": "2017-01-31T21:51:51",
+                                "id": 54782236,
+                                "label": "the label",
+                                "region": "us-east-1a",
+                                "status": "successful",
+                                "type": "snapshot",
+                                "updated": "2017-01-31T21:51:51",
+                              },
+                              "in_progress": null,
+                            },
+                            "weekly": Array [],
+                          },
+                          "_configs": Object {
+                            "configs": Object {
+                              "12345": Object {
+                                "comments": "Test comments",
+                                "created": "2015-09-29 11:21:38 +0000",
+                                "devices": Object {
+                                  "sda": Object {
+                                    "disk_id": 12345,
+                                  },
+                                  "sdb": Object {
+                                    "disk_id": 12346,
+                                  },
+                                  "sdc": null,
+                                  "sdd": null,
+                                  "sde": null,
+                                  "sdf": null,
+                                  "sdg": null,
+                                  "sdh": null,
+                                },
+                                "helpers": Object {
+                                  "devtmpfs_automount": false,
+                                  "distro": true,
+                                  "modules_dep": true,
+                                  "network": true,
+                                  "updatedb_disabled": true,
+                                },
+                                "id": 12345,
+                                "initrd": "",
+                                "kernel": "linode/latest_64",
+                                "label": "Test config",
+                                "memory_limit": 1024,
+                                "root_device": "/dev/sda",
+                                "run_level": "default",
+                                "updated": "2015-09-29 11:21:38 +0000",
+                                "virt_mode": "paravirt",
+                              },
+                            },
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                          },
+                          "_disks": Object {
+                            "disks": Object {},
+                            "totalPages": 1,
+                            "totalResults": 0,
+                          },
+                          "_ips": Object {
+                            "2600:3c03::f03c:91ff:fe0a:33": Object {
+                              "address": "2600:3c03::f03c:91ff:fe0a:33",
+                              "gateway": "fe80::1",
+                              "key": "2600:3c03::f03c:91ff:fe0a:33",
+                              "linode_id": 1250,
+                              "prefix": "64",
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "slaac",
+                              "version": "ipv6",
+                            },
+                            "97.107.143.50": Object {
+                              "address": "97.107.143.50",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.50",
+                              "linode_id": 1250,
+                              "prefix": 24,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "public",
+                              "version": "ipv4",
+                            },
+                            "97.107.143.52": Object {
+                              "address": "97.107.143.52",
+                              "gateway": "97.107.143.0",
+                              "key": "97.107.143.52",
+                              "linode_id": 1250,
+                              "prefix": 17,
+                              "rdns": "li1-1.members.linode.com",
+                              "type": "private",
+                              "version": "ipv4",
+                            },
+                            "fe80::f03c:91ff:fe0a:181f": Object {
+                              "address": "fe80::f03c:91ff:fe0a:181f",
+                              "key": "fe80::f03c:91ff:fe0a:181f",
+                              "linode_id": 1250,
+                              "type": "link-local",
+                              "version": "ipv6",
+                            },
+                          },
+                          "_polling": false,
+                          "_shared": Array [],
+                          "_stats": Object {
+                            "cpu": Array [
+                              Array [
+                                1490378700000,
+                                1.67,
+                              ],
+                            ],
+                            "io": Object {
+                              "io": Array [
+                                Array [
+                                  1490379000000,
+                                  0.91,
+                                ],
+                              ],
+                              "swap": Array [
+                                Array [
+                                  1490378100000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv4": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                            "netv6": Object {
+                              "in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_in": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                              "private_out": Array [
+                                Array [
+                                  1490377800000,
+                                  0,
+                                ],
+                              ],
+                            },
+                          },
+                          "_volumes": Object {
+                            "pagesFetched": Array [
+                              0,
+                            ],
+                            "totalPages": 1,
+                            "totalResults": 1,
+                            "volumes": Object {
+                              "38": Object {
+                                "created": "2017-08-08T13:55:16",
+                                "id": 38,
+                                "label": "test",
+                                "linode_id": null,
+                                "region": "us-east-1a",
+                                "size": 20,
+                                "status": "active",
+                                "updated": "2017-08-08T04:00:00",
+                              },
+                            },
+                          },
+                          "alerts": Object {
+                            "cpu": 90,
+                            "io": 5000,
+                            "network_in": 5,
+                            "network_out": 5,
+                            "tranfer_quota": 80,
+                          },
+                          "backups": Object {
+                            "enabled": true,
+                            "schedule": Object {
+                              "day": "Monday",
+                              "window": "W10",
+                            },
+                          },
+                          "created": "2016-07-06T16:47:27",
+                          "disk": 20480,
+                          "group": "Test Group",
+                          "hypervisor": "kvm",
+                          "id": 1250,
+                          "image": Object {
+                            "id": "linode/ubuntu15.10",
+                            "label": "Ubuntu 15.10",
+                            "vendor": "Ubuntu",
+                          },
+                          "ipv4": Array [
+                            "97.107.143.50",
+                            "97.107.143.51",
+                          ],
+                          "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+                          "label": "test-linode-no-disks",
+                          "memory": 2048,
+                          "region": "us-east-1a",
+                          "status": "running",
+                          "type": Object {
+                            "_polling": false,
+                            "addons": Object {
+                              "backups": Object {
+                                "price": Object {
+                                  "monthly": 2.5,
+                                },
+                              },
+                            },
+                            "class": "standard",
+                            "disk": 24576,
+                            "id": "linode2048.5",
+                            "label": "Linode 2048",
+                            "memory": 2048,
+                            "network_out": 125,
+                            "price": Object {
+                              "hourly": 0.015,
+                              "monthly": 10,
+                            },
+                            "service_type": "linode",
+                            "transfer": 2000,
+                            "vcpus": 2,
+                          },
+                          "vcpus": 2,
+                        },
+                      },
                     ],
                     "disableHeader": false,
                     "noDataMessage": "No data found.",
@@ -52028,6 +58963,8 @@ ShallowWrapper {
                       "97.107.143.37": false,
                       "97.107.143.40": false,
                       "97.107.143.44": false,
+                      "97.107.143.47": false,
+                      "97.107.143.50": false,
                       "97.107.143.6": false,
                       "97.107.143.9": false,
                     },

--- a/src/linodes/linode/networking/layouts/__snapshots__/IPTransferPage.spec.js.snap
+++ b/src/linodes/linode/networking/layouts/__snapshots__/IPTransferPage.spec.js.snap
@@ -5086,6 +5086,613 @@ ShallowWrapper {
           },
           "vcpus": 2,
         },
+        "1249": Object {
+          "_backups": Object {
+            "daily": Object {
+              "availability": "daily",
+              "configs": Array [
+                "Ubuntu Disk",
+              ],
+              "created": "2017-01-31T07:28:52",
+              "disks": Array [
+                Object {
+                  "filesystem": "ext4",
+                  "label": "Ubuntu 15.10 Disk",
+                  "size": 2330,
+                },
+                Object {
+                  "filesystem": "swap",
+                  "label": "512 MB Swap Image",
+                  "size": 0,
+                },
+              ],
+              "finished": "2017-01-31T07:30:03",
+              "id": 54782214,
+              "label": null,
+              "region": "us-east-1a",
+              "status": "successful",
+              "type": "auto",
+              "updated": "2017-01-31T12:32:01",
+            },
+            "snapshot": Object {
+              "current": Object {
+                "availability": "unavailable",
+                "configs": Array [
+                  "Some config",
+                ],
+                "created": "2017-01-31T21:50:42",
+                "disks": Array [
+                  Object {
+                    "filesystem": "ext4",
+                    "label": "Ubuntu 15.10 Disk",
+                    "size": 2330,
+                  },
+                  Object {
+                    "filesystem": "swap",
+                    "label": "512 MB Swap Image",
+                    "size": 0,
+                  },
+                ],
+                "finished": "2017-01-31T21:51:51",
+                "id": 54782236,
+                "label": "the label",
+                "region": "us-east-1a",
+                "status": "successful",
+                "type": "snapshot",
+                "updated": "2017-01-31T21:51:51",
+              },
+              "in_progress": null,
+            },
+            "weekly": Array [],
+          },
+          "_configs": Object {
+            "configs": Object {
+              "12345": Object {
+                "comments": "Test comments",
+                "created": "2015-09-29 11:21:38 +0000",
+                "devices": Object {
+                  "sda": Object {
+                    "disk_id": 12345,
+                  },
+                  "sdb": Object {
+                    "disk_id": 12346,
+                  },
+                  "sdc": null,
+                  "sdd": null,
+                  "sde": null,
+                  "sdf": null,
+                  "sdg": null,
+                  "sdh": null,
+                },
+                "helpers": Object {
+                  "devtmpfs_automount": false,
+                  "distro": true,
+                  "modules_dep": true,
+                  "network": true,
+                  "updatedb_disabled": true,
+                },
+                "id": 12345,
+                "initrd": "",
+                "kernel": "linode/latest_64",
+                "label": "Test config",
+                "memory_limit": 1024,
+                "root_device": "/dev/sda",
+                "run_level": "default",
+                "updated": "2015-09-29 11:21:38 +0000",
+                "virt_mode": "paravirt",
+              },
+            },
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+          },
+          "_disks": Object {
+            "disks": Object {
+              "12345": Object {
+                "created": "2016-08-09T19:47:11",
+                "filesystem": "raw",
+                "id": 12345,
+                "label": "Raw Disk",
+                "size": 6144,
+                "updated": "2016-08-09T19:47:11",
+              },
+            },
+            "totalPages": 1,
+            "totalResults": 1,
+          },
+          "_ips": Object {
+            "2600:3c03::f03c:91ff:fe0a:31": Object {
+              "address": "2600:3c03::f03c:91ff:fe0a:31",
+              "gateway": "fe80::1",
+              "key": "2600:3c03::f03c:91ff:fe0a:31",
+              "linode_id": 1249,
+              "prefix": "64",
+              "rdns": "li1-1.members.linode.com",
+              "type": "slaac",
+              "version": "ipv6",
+            },
+            "97.107.143.47": Object {
+              "address": "97.107.143.47",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.47",
+              "linode_id": 1249,
+              "prefix": 24,
+              "rdns": "li1-1.members.linode.com",
+              "type": "public",
+              "version": "ipv4",
+            },
+            "97.107.143.49": Object {
+              "address": "97.107.143.49",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.49",
+              "linode_id": 1249,
+              "prefix": 17,
+              "rdns": "li1-1.members.linode.com",
+              "type": "private",
+              "version": "ipv4",
+            },
+            "fe80::f03c:91ff:fe0a:181f": Object {
+              "address": "fe80::f03c:91ff:fe0a:181f",
+              "key": "fe80::f03c:91ff:fe0a:181f",
+              "linode_id": 1249,
+              "type": "link-local",
+              "version": "ipv6",
+            },
+          },
+          "_polling": false,
+          "_shared": Array [],
+          "_stats": Object {
+            "cpu": Array [
+              Array [
+                1490378700000,
+                1.67,
+              ],
+            ],
+            "io": Object {
+              "io": Array [
+                Array [
+                  1490379000000,
+                  0.91,
+                ],
+              ],
+              "swap": Array [
+                Array [
+                  1490378100000,
+                  0,
+                ],
+              ],
+            },
+            "netv4": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+            "netv6": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+          },
+          "_volumes": Object {
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+            "volumes": Object {
+              "38": Object {
+                "created": "2017-08-08T13:55:16",
+                "id": 38,
+                "label": "test",
+                "linode_id": null,
+                "region": "us-east-1a",
+                "size": 20,
+                "status": "active",
+                "updated": "2017-08-08T04:00:00",
+              },
+            },
+          },
+          "alerts": Object {
+            "cpu": 90,
+            "io": 5000,
+            "network_in": 5,
+            "network_out": 5,
+            "tranfer_quota": 80,
+          },
+          "backups": Object {
+            "enabled": true,
+            "schedule": Object {
+              "day": "Monday",
+              "window": "W10",
+            },
+          },
+          "created": "2016-07-06T16:47:27",
+          "disk": 20480,
+          "group": "Test Group",
+          "hypervisor": "kvm",
+          "id": 1249,
+          "image": Object {
+            "id": "linode/ubuntu15.10",
+            "label": "Ubuntu 15.10",
+            "vendor": "Ubuntu",
+          },
+          "ipv4": Array [
+            "97.107.143.47",
+            "97.107.143.48",
+          ],
+          "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+          "label": "test-linode-raw",
+          "memory": 2048,
+          "region": "us-east-1a",
+          "status": "running",
+          "type": Object {
+            "_polling": false,
+            "addons": Object {
+              "backups": Object {
+                "price": Object {
+                  "monthly": 2.5,
+                },
+              },
+            },
+            "class": "standard",
+            "disk": 24576,
+            "id": "linode2048.5",
+            "label": "Linode 2048",
+            "memory": 2048,
+            "network_out": 125,
+            "price": Object {
+              "hourly": 0.015,
+              "monthly": 10,
+            },
+            "service_type": "linode",
+            "transfer": 2000,
+            "vcpus": 2,
+          },
+          "vcpus": 2,
+        },
+        "1250": Object {
+          "_backups": Object {
+            "daily": Object {
+              "availability": "daily",
+              "configs": Array [
+                "Ubuntu Disk",
+              ],
+              "created": "2017-01-31T07:28:52",
+              "disks": Array [
+                Object {
+                  "filesystem": "ext4",
+                  "label": "Ubuntu 15.10 Disk",
+                  "size": 2330,
+                },
+                Object {
+                  "filesystem": "swap",
+                  "label": "512 MB Swap Image",
+                  "size": 0,
+                },
+              ],
+              "finished": "2017-01-31T07:30:03",
+              "id": 54782214,
+              "label": null,
+              "region": "us-east-1a",
+              "status": "successful",
+              "type": "auto",
+              "updated": "2017-01-31T12:32:01",
+            },
+            "snapshot": Object {
+              "current": Object {
+                "availability": "unavailable",
+                "configs": Array [
+                  "Some config",
+                ],
+                "created": "2017-01-31T21:50:42",
+                "disks": Array [
+                  Object {
+                    "filesystem": "ext4",
+                    "label": "Ubuntu 15.10 Disk",
+                    "size": 2330,
+                  },
+                  Object {
+                    "filesystem": "swap",
+                    "label": "512 MB Swap Image",
+                    "size": 0,
+                  },
+                ],
+                "finished": "2017-01-31T21:51:51",
+                "id": 54782236,
+                "label": "the label",
+                "region": "us-east-1a",
+                "status": "successful",
+                "type": "snapshot",
+                "updated": "2017-01-31T21:51:51",
+              },
+              "in_progress": null,
+            },
+            "weekly": Array [],
+          },
+          "_configs": Object {
+            "configs": Object {
+              "12345": Object {
+                "comments": "Test comments",
+                "created": "2015-09-29 11:21:38 +0000",
+                "devices": Object {
+                  "sda": Object {
+                    "disk_id": 12345,
+                  },
+                  "sdb": Object {
+                    "disk_id": 12346,
+                  },
+                  "sdc": null,
+                  "sdd": null,
+                  "sde": null,
+                  "sdf": null,
+                  "sdg": null,
+                  "sdh": null,
+                },
+                "helpers": Object {
+                  "devtmpfs_automount": false,
+                  "distro": true,
+                  "modules_dep": true,
+                  "network": true,
+                  "updatedb_disabled": true,
+                },
+                "id": 12345,
+                "initrd": "",
+                "kernel": "linode/latest_64",
+                "label": "Test config",
+                "memory_limit": 1024,
+                "root_device": "/dev/sda",
+                "run_level": "default",
+                "updated": "2015-09-29 11:21:38 +0000",
+                "virt_mode": "paravirt",
+              },
+            },
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+          },
+          "_disks": Object {
+            "disks": Object {},
+            "totalPages": 1,
+            "totalResults": 0,
+          },
+          "_ips": Object {
+            "2600:3c03::f03c:91ff:fe0a:33": Object {
+              "address": "2600:3c03::f03c:91ff:fe0a:33",
+              "gateway": "fe80::1",
+              "key": "2600:3c03::f03c:91ff:fe0a:33",
+              "linode_id": 1250,
+              "prefix": "64",
+              "rdns": "li1-1.members.linode.com",
+              "type": "slaac",
+              "version": "ipv6",
+            },
+            "97.107.143.50": Object {
+              "address": "97.107.143.50",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.50",
+              "linode_id": 1250,
+              "prefix": 24,
+              "rdns": "li1-1.members.linode.com",
+              "type": "public",
+              "version": "ipv4",
+            },
+            "97.107.143.52": Object {
+              "address": "97.107.143.52",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.52",
+              "linode_id": 1250,
+              "prefix": 17,
+              "rdns": "li1-1.members.linode.com",
+              "type": "private",
+              "version": "ipv4",
+            },
+            "fe80::f03c:91ff:fe0a:181f": Object {
+              "address": "fe80::f03c:91ff:fe0a:181f",
+              "key": "fe80::f03c:91ff:fe0a:181f",
+              "linode_id": 1250,
+              "type": "link-local",
+              "version": "ipv6",
+            },
+          },
+          "_polling": false,
+          "_shared": Array [],
+          "_stats": Object {
+            "cpu": Array [
+              Array [
+                1490378700000,
+                1.67,
+              ],
+            ],
+            "io": Object {
+              "io": Array [
+                Array [
+                  1490379000000,
+                  0.91,
+                ],
+              ],
+              "swap": Array [
+                Array [
+                  1490378100000,
+                  0,
+                ],
+              ],
+            },
+            "netv4": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+            "netv6": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+          },
+          "_volumes": Object {
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+            "volumes": Object {
+              "38": Object {
+                "created": "2017-08-08T13:55:16",
+                "id": 38,
+                "label": "test",
+                "linode_id": null,
+                "region": "us-east-1a",
+                "size": 20,
+                "status": "active",
+                "updated": "2017-08-08T04:00:00",
+              },
+            },
+          },
+          "alerts": Object {
+            "cpu": 90,
+            "io": 5000,
+            "network_in": 5,
+            "network_out": 5,
+            "tranfer_quota": 80,
+          },
+          "backups": Object {
+            "enabled": true,
+            "schedule": Object {
+              "day": "Monday",
+              "window": "W10",
+            },
+          },
+          "created": "2016-07-06T16:47:27",
+          "disk": 20480,
+          "group": "Test Group",
+          "hypervisor": "kvm",
+          "id": 1250,
+          "image": Object {
+            "id": "linode/ubuntu15.10",
+            "label": "Ubuntu 15.10",
+            "vendor": "Ubuntu",
+          },
+          "ipv4": Array [
+            "97.107.143.50",
+            "97.107.143.51",
+          ],
+          "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+          "label": "test-linode-no-disks",
+          "memory": 2048,
+          "region": "us-east-1a",
+          "status": "running",
+          "type": Object {
+            "_polling": false,
+            "addons": Object {
+              "backups": Object {
+                "price": Object {
+                  "monthly": 2.5,
+                },
+              },
+            },
+            "class": "standard",
+            "disk": 24576,
+            "id": "linode2048.5",
+            "label": "Linode 2048",
+            "memory": 2048,
+            "network_out": 125,
+            "price": Object {
+              "hourly": 0.015,
+              "monthly": 10,
+            },
+            "service_type": "linode",
+            "transfer": 2000,
+            "vcpus": 2,
+          },
+          "vcpus": 2,
+        },
       }
     }
   />,
@@ -5207,6 +5814,14 @@ ShallowWrapper {
                     Object {
                       "label": "test-linode-1248",
                       "value": 1248,
+                    },
+                    Object {
+                      "label": "test-linode-raw",
+                      "value": 1249,
+                    },
+                    Object {
+                      "label": "test-linode-no-disks",
+                      "value": 1250,
                     },
                   ]
                 }
@@ -6042,6 +6657,14 @@ ShallowWrapper {
                       Object {
                         "label": "test-linode-1248",
                         "value": 1248,
+                      },
+                      Object {
+                        "label": "test-linode-raw",
+                        "value": 1249,
+                      },
+                      Object {
+                        "label": "test-linode-no-disks",
+                        "value": 1250,
                       },
                     ]
                   }
@@ -6886,6 +7509,14 @@ ShallowWrapper {
                           "label": "test-linode-1248",
                           "value": 1248,
                         },
+                        Object {
+                          "label": "test-linode-raw",
+                          "value": 1249,
+                        },
+                        Object {
+                          "label": "test-linode-no-disks",
+                          "value": 1250,
+                        },
                       ]
                     }
                     value={1233}
@@ -7701,6 +8332,14 @@ ShallowWrapper {
                             "label": "test-linode-1248",
                             "value": 1248,
                           },
+                          Object {
+                            "label": "test-linode-raw",
+                            "value": 1249,
+                          },
+                          Object {
+                            "label": "test-linode-no-disks",
+                            "value": 1250,
+                          },
                         ]
                       }
                       value={1233}
@@ -7835,6 +8474,14 @@ ShallowWrapper {
                               "label": "test-linode-1248",
                               "value": 1248,
                             },
+                            Object {
+                              "label": "test-linode-raw",
+                              "value": 1249,
+                            },
+                            Object {
+                              "label": "test-linode-no-disks",
+                              "value": 1250,
+                            },
                           ]
                         }
                         value={1233}
@@ -7923,6 +8570,14 @@ ShallowWrapper {
                           Object {
                             "label": "test-linode-1248",
                             "value": 1248,
+                          },
+                          Object {
+                            "label": "test-linode-raw",
+                            "value": 1249,
+                          },
+                          Object {
+                            "label": "test-linode-no-disks",
+                            "value": 1250,
                           },
                         ],
                         "value": 1233,
@@ -10190,6 +10845,14 @@ ShallowWrapper {
                         "label": "test-linode-1248",
                         "value": 1248,
                       },
+                      Object {
+                        "label": "test-linode-raw",
+                        "value": 1249,
+                      },
+                      Object {
+                        "label": "test-linode-no-disks",
+                        "value": 1250,
+                      },
                     ]
                   }
                   value={1233}
@@ -11024,6 +11687,14 @@ ShallowWrapper {
                         Object {
                           "label": "test-linode-1248",
                           "value": 1248,
+                        },
+                        Object {
+                          "label": "test-linode-raw",
+                          "value": 1249,
+                        },
+                        Object {
+                          "label": "test-linode-no-disks",
+                          "value": 1250,
                         },
                       ]
                     }
@@ -11868,6 +12539,14 @@ ShallowWrapper {
                             "label": "test-linode-1248",
                             "value": 1248,
                           },
+                          Object {
+                            "label": "test-linode-raw",
+                            "value": 1249,
+                          },
+                          Object {
+                            "label": "test-linode-no-disks",
+                            "value": 1250,
+                          },
                         ]
                       }
                       value={1233}
@@ -12683,6 +13362,14 @@ ShallowWrapper {
                               "label": "test-linode-1248",
                               "value": 1248,
                             },
+                            Object {
+                              "label": "test-linode-raw",
+                              "value": 1249,
+                            },
+                            Object {
+                              "label": "test-linode-no-disks",
+                              "value": 1250,
+                            },
                           ]
                         }
                         value={1233}
@@ -12817,6 +13504,14 @@ ShallowWrapper {
                                 "label": "test-linode-1248",
                                 "value": 1248,
                               },
+                              Object {
+                                "label": "test-linode-raw",
+                                "value": 1249,
+                              },
+                              Object {
+                                "label": "test-linode-no-disks",
+                                "value": 1250,
+                              },
                             ]
                           }
                           value={1233}
@@ -12905,6 +13600,14 @@ ShallowWrapper {
                             Object {
                               "label": "test-linode-1248",
                               "value": 1248,
+                            },
+                            Object {
+                              "label": "test-linode-raw",
+                              "value": 1249,
+                            },
+                            Object {
+                              "label": "test-linode-no-disks",
+                              "value": 1250,
                             },
                           ],
                           "value": 1233,

--- a/src/support/layouts/__snapshots__/CreatePage.spec.js.snap
+++ b/src/support/layouts/__snapshots__/CreatePage.spec.js.snap
@@ -5006,6 +5006,613 @@ ShallowWrapper {
           },
           "vcpus": 2,
         },
+        "1249": Object {
+          "_backups": Object {
+            "daily": Object {
+              "availability": "daily",
+              "configs": Array [
+                "Ubuntu Disk",
+              ],
+              "created": "2017-01-31T07:28:52",
+              "disks": Array [
+                Object {
+                  "filesystem": "ext4",
+                  "label": "Ubuntu 15.10 Disk",
+                  "size": 2330,
+                },
+                Object {
+                  "filesystem": "swap",
+                  "label": "512 MB Swap Image",
+                  "size": 0,
+                },
+              ],
+              "finished": "2017-01-31T07:30:03",
+              "id": 54782214,
+              "label": null,
+              "region": "us-east-1a",
+              "status": "successful",
+              "type": "auto",
+              "updated": "2017-01-31T12:32:01",
+            },
+            "snapshot": Object {
+              "current": Object {
+                "availability": "unavailable",
+                "configs": Array [
+                  "Some config",
+                ],
+                "created": "2017-01-31T21:50:42",
+                "disks": Array [
+                  Object {
+                    "filesystem": "ext4",
+                    "label": "Ubuntu 15.10 Disk",
+                    "size": 2330,
+                  },
+                  Object {
+                    "filesystem": "swap",
+                    "label": "512 MB Swap Image",
+                    "size": 0,
+                  },
+                ],
+                "finished": "2017-01-31T21:51:51",
+                "id": 54782236,
+                "label": "the label",
+                "region": "us-east-1a",
+                "status": "successful",
+                "type": "snapshot",
+                "updated": "2017-01-31T21:51:51",
+              },
+              "in_progress": null,
+            },
+            "weekly": Array [],
+          },
+          "_configs": Object {
+            "configs": Object {
+              "12345": Object {
+                "comments": "Test comments",
+                "created": "2015-09-29 11:21:38 +0000",
+                "devices": Object {
+                  "sda": Object {
+                    "disk_id": 12345,
+                  },
+                  "sdb": Object {
+                    "disk_id": 12346,
+                  },
+                  "sdc": null,
+                  "sdd": null,
+                  "sde": null,
+                  "sdf": null,
+                  "sdg": null,
+                  "sdh": null,
+                },
+                "helpers": Object {
+                  "devtmpfs_automount": false,
+                  "distro": true,
+                  "modules_dep": true,
+                  "network": true,
+                  "updatedb_disabled": true,
+                },
+                "id": 12345,
+                "initrd": "",
+                "kernel": "linode/latest_64",
+                "label": "Test config",
+                "memory_limit": 1024,
+                "root_device": "/dev/sda",
+                "run_level": "default",
+                "updated": "2015-09-29 11:21:38 +0000",
+                "virt_mode": "paravirt",
+              },
+            },
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+          },
+          "_disks": Object {
+            "disks": Object {
+              "12345": Object {
+                "created": "2016-08-09T19:47:11",
+                "filesystem": "raw",
+                "id": 12345,
+                "label": "Raw Disk",
+                "size": 6144,
+                "updated": "2016-08-09T19:47:11",
+              },
+            },
+            "totalPages": 1,
+            "totalResults": 1,
+          },
+          "_ips": Object {
+            "2600:3c03::f03c:91ff:fe0a:31": Object {
+              "address": "2600:3c03::f03c:91ff:fe0a:31",
+              "gateway": "fe80::1",
+              "key": "2600:3c03::f03c:91ff:fe0a:31",
+              "linode_id": 1249,
+              "prefix": "64",
+              "rdns": "li1-1.members.linode.com",
+              "type": "slaac",
+              "version": "ipv6",
+            },
+            "97.107.143.47": Object {
+              "address": "97.107.143.47",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.47",
+              "linode_id": 1249,
+              "prefix": 24,
+              "rdns": "li1-1.members.linode.com",
+              "type": "public",
+              "version": "ipv4",
+            },
+            "97.107.143.49": Object {
+              "address": "97.107.143.49",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.49",
+              "linode_id": 1249,
+              "prefix": 17,
+              "rdns": "li1-1.members.linode.com",
+              "type": "private",
+              "version": "ipv4",
+            },
+            "fe80::f03c:91ff:fe0a:181f": Object {
+              "address": "fe80::f03c:91ff:fe0a:181f",
+              "key": "fe80::f03c:91ff:fe0a:181f",
+              "linode_id": 1249,
+              "type": "link-local",
+              "version": "ipv6",
+            },
+          },
+          "_polling": false,
+          "_shared": Array [],
+          "_stats": Object {
+            "cpu": Array [
+              Array [
+                1490378700000,
+                1.67,
+              ],
+            ],
+            "io": Object {
+              "io": Array [
+                Array [
+                  1490379000000,
+                  0.91,
+                ],
+              ],
+              "swap": Array [
+                Array [
+                  1490378100000,
+                  0,
+                ],
+              ],
+            },
+            "netv4": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+            "netv6": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+          },
+          "_volumes": Object {
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+            "volumes": Object {
+              "38": Object {
+                "created": "2017-08-08T13:55:16",
+                "id": 38,
+                "label": "test",
+                "linode_id": null,
+                "region": "us-east-1a",
+                "size": 20,
+                "status": "active",
+                "updated": "2017-08-08T04:00:00",
+              },
+            },
+          },
+          "alerts": Object {
+            "cpu": 90,
+            "io": 5000,
+            "network_in": 5,
+            "network_out": 5,
+            "tranfer_quota": 80,
+          },
+          "backups": Object {
+            "enabled": true,
+            "schedule": Object {
+              "day": "Monday",
+              "window": "W10",
+            },
+          },
+          "created": "2016-07-06T16:47:27",
+          "disk": 20480,
+          "group": "Test Group",
+          "hypervisor": "kvm",
+          "id": 1249,
+          "image": Object {
+            "id": "linode/ubuntu15.10",
+            "label": "Ubuntu 15.10",
+            "vendor": "Ubuntu",
+          },
+          "ipv4": Array [
+            "97.107.143.47",
+            "97.107.143.48",
+          ],
+          "ipv6": "2600:3c03::f03c:91ff:fe0a:30",
+          "label": "test-linode-raw",
+          "memory": 2048,
+          "region": "us-east-1a",
+          "status": "running",
+          "type": Object {
+            "_polling": false,
+            "addons": Object {
+              "backups": Object {
+                "price": Object {
+                  "monthly": 2.5,
+                },
+              },
+            },
+            "class": "standard",
+            "disk": 24576,
+            "id": "linode2048.5",
+            "label": "Linode 2048",
+            "memory": 2048,
+            "network_out": 125,
+            "price": Object {
+              "hourly": 0.015,
+              "monthly": 10,
+            },
+            "service_type": "linode",
+            "transfer": 2000,
+            "vcpus": 2,
+          },
+          "vcpus": 2,
+        },
+        "1250": Object {
+          "_backups": Object {
+            "daily": Object {
+              "availability": "daily",
+              "configs": Array [
+                "Ubuntu Disk",
+              ],
+              "created": "2017-01-31T07:28:52",
+              "disks": Array [
+                Object {
+                  "filesystem": "ext4",
+                  "label": "Ubuntu 15.10 Disk",
+                  "size": 2330,
+                },
+                Object {
+                  "filesystem": "swap",
+                  "label": "512 MB Swap Image",
+                  "size": 0,
+                },
+              ],
+              "finished": "2017-01-31T07:30:03",
+              "id": 54782214,
+              "label": null,
+              "region": "us-east-1a",
+              "status": "successful",
+              "type": "auto",
+              "updated": "2017-01-31T12:32:01",
+            },
+            "snapshot": Object {
+              "current": Object {
+                "availability": "unavailable",
+                "configs": Array [
+                  "Some config",
+                ],
+                "created": "2017-01-31T21:50:42",
+                "disks": Array [
+                  Object {
+                    "filesystem": "ext4",
+                    "label": "Ubuntu 15.10 Disk",
+                    "size": 2330,
+                  },
+                  Object {
+                    "filesystem": "swap",
+                    "label": "512 MB Swap Image",
+                    "size": 0,
+                  },
+                ],
+                "finished": "2017-01-31T21:51:51",
+                "id": 54782236,
+                "label": "the label",
+                "region": "us-east-1a",
+                "status": "successful",
+                "type": "snapshot",
+                "updated": "2017-01-31T21:51:51",
+              },
+              "in_progress": null,
+            },
+            "weekly": Array [],
+          },
+          "_configs": Object {
+            "configs": Object {
+              "12345": Object {
+                "comments": "Test comments",
+                "created": "2015-09-29 11:21:38 +0000",
+                "devices": Object {
+                  "sda": Object {
+                    "disk_id": 12345,
+                  },
+                  "sdb": Object {
+                    "disk_id": 12346,
+                  },
+                  "sdc": null,
+                  "sdd": null,
+                  "sde": null,
+                  "sdf": null,
+                  "sdg": null,
+                  "sdh": null,
+                },
+                "helpers": Object {
+                  "devtmpfs_automount": false,
+                  "distro": true,
+                  "modules_dep": true,
+                  "network": true,
+                  "updatedb_disabled": true,
+                },
+                "id": 12345,
+                "initrd": "",
+                "kernel": "linode/latest_64",
+                "label": "Test config",
+                "memory_limit": 1024,
+                "root_device": "/dev/sda",
+                "run_level": "default",
+                "updated": "2015-09-29 11:21:38 +0000",
+                "virt_mode": "paravirt",
+              },
+            },
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+          },
+          "_disks": Object {
+            "disks": Object {},
+            "totalPages": 1,
+            "totalResults": 0,
+          },
+          "_ips": Object {
+            "2600:3c03::f03c:91ff:fe0a:33": Object {
+              "address": "2600:3c03::f03c:91ff:fe0a:33",
+              "gateway": "fe80::1",
+              "key": "2600:3c03::f03c:91ff:fe0a:33",
+              "linode_id": 1250,
+              "prefix": "64",
+              "rdns": "li1-1.members.linode.com",
+              "type": "slaac",
+              "version": "ipv6",
+            },
+            "97.107.143.50": Object {
+              "address": "97.107.143.50",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.50",
+              "linode_id": 1250,
+              "prefix": 24,
+              "rdns": "li1-1.members.linode.com",
+              "type": "public",
+              "version": "ipv4",
+            },
+            "97.107.143.52": Object {
+              "address": "97.107.143.52",
+              "gateway": "97.107.143.0",
+              "key": "97.107.143.52",
+              "linode_id": 1250,
+              "prefix": 17,
+              "rdns": "li1-1.members.linode.com",
+              "type": "private",
+              "version": "ipv4",
+            },
+            "fe80::f03c:91ff:fe0a:181f": Object {
+              "address": "fe80::f03c:91ff:fe0a:181f",
+              "key": "fe80::f03c:91ff:fe0a:181f",
+              "linode_id": 1250,
+              "type": "link-local",
+              "version": "ipv6",
+            },
+          },
+          "_polling": false,
+          "_shared": Array [],
+          "_stats": Object {
+            "cpu": Array [
+              Array [
+                1490378700000,
+                1.67,
+              ],
+            ],
+            "io": Object {
+              "io": Array [
+                Array [
+                  1490379000000,
+                  0.91,
+                ],
+              ],
+              "swap": Array [
+                Array [
+                  1490378100000,
+                  0,
+                ],
+              ],
+            },
+            "netv4": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+            "netv6": Object {
+              "in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_in": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+              "private_out": Array [
+                Array [
+                  1490377800000,
+                  0,
+                ],
+              ],
+            },
+          },
+          "_volumes": Object {
+            "pagesFetched": Array [
+              0,
+            ],
+            "totalPages": 1,
+            "totalResults": 1,
+            "volumes": Object {
+              "38": Object {
+                "created": "2017-08-08T13:55:16",
+                "id": 38,
+                "label": "test",
+                "linode_id": null,
+                "region": "us-east-1a",
+                "size": 20,
+                "status": "active",
+                "updated": "2017-08-08T04:00:00",
+              },
+            },
+          },
+          "alerts": Object {
+            "cpu": 90,
+            "io": 5000,
+            "network_in": 5,
+            "network_out": 5,
+            "tranfer_quota": 80,
+          },
+          "backups": Object {
+            "enabled": true,
+            "schedule": Object {
+              "day": "Monday",
+              "window": "W10",
+            },
+          },
+          "created": "2016-07-06T16:47:27",
+          "disk": 20480,
+          "group": "Test Group",
+          "hypervisor": "kvm",
+          "id": 1250,
+          "image": Object {
+            "id": "linode/ubuntu15.10",
+            "label": "Ubuntu 15.10",
+            "vendor": "Ubuntu",
+          },
+          "ipv4": Array [
+            "97.107.143.50",
+            "97.107.143.51",
+          ],
+          "ipv6": "2600:3c03::f03c:91ff:fe0a:32",
+          "label": "test-linode-no-disks",
+          "memory": 2048,
+          "region": "us-east-1a",
+          "status": "running",
+          "type": Object {
+            "_polling": false,
+            "addons": Object {
+              "backups": Object {
+                "price": Object {
+                  "monthly": 2.5,
+                },
+              },
+            },
+            "class": "standard",
+            "disk": 24576,
+            "id": "linode2048.5",
+            "label": "Linode 2048",
+            "memory": 2048,
+            "network_out": 125,
+            "price": Object {
+              "hourly": 0.015,
+              "monthly": 10,
+            },
+            "service_type": "linode",
+            "transfer": 2000,
+            "vcpus": 2,
+          },
+          "vcpus": 2,
+        },
       }
     }
     nodebalancers={
@@ -5264,6 +5871,14 @@ ShallowWrapper {
                           Object {
                             "label": "test-linode-1248",
                             "value": "linode_id:1248",
+                          },
+                          Object {
+                            "label": "test-linode-raw",
+                            "value": "linode_id:1249",
+                          },
+                          Object {
+                            "label": "test-linode-no-disks",
+                            "value": "linode_id:1250",
                           },
                         ],
                       },
@@ -5596,6 +6211,14 @@ ShallowWrapper {
                             "label": "test-linode-1248",
                             "value": "linode_id:1248",
                           },
+                          Object {
+                            "label": "test-linode-raw",
+                            "value": "linode_id:1249",
+                          },
+                          Object {
+                            "label": "test-linode-no-disks",
+                            "value": "linode_id:1250",
+                          },
                         ],
                       },
                       Object {
@@ -5834,6 +6457,14 @@ ShallowWrapper {
                             Object {
                               "label": "test-linode-1248",
                               "value": "linode_id:1248",
+                            },
+                            Object {
+                              "label": "test-linode-raw",
+                              "value": "linode_id:1249",
+                            },
+                            Object {
+                              "label": "test-linode-no-disks",
+                              "value": "linode_id:1250",
                             },
                           ],
                         },
@@ -6147,6 +6778,14 @@ ShallowWrapper {
                                 "label": "test-linode-1248",
                                 "value": "linode_id:1248",
                               },
+                              Object {
+                                "label": "test-linode-raw",
+                                "value": "linode_id:1249",
+                              },
+                              Object {
+                                "label": "test-linode-no-disks",
+                                "value": "linode_id:1250",
+                              },
                             ],
                           },
                           Object {
@@ -6305,6 +6944,14 @@ ShallowWrapper {
                                   "label": "test-linode-1248",
                                   "value": "linode_id:1248",
                                 },
+                                Object {
+                                  "label": "test-linode-raw",
+                                  "value": "linode_id:1249",
+                                },
+                                Object {
+                                  "label": "test-linode-no-disks",
+                                  "value": "linode_id:1250",
+                                },
                               ],
                             },
                             Object {
@@ -6441,6 +7088,14 @@ ShallowWrapper {
                               Object {
                                 "label": "test-linode-1248",
                                 "value": "linode_id:1248",
+                              },
+                              Object {
+                                "label": "test-linode-raw",
+                                "value": "linode_id:1249",
+                              },
+                              Object {
+                                "label": "test-linode-no-disks",
+                                "value": "linode_id:1250",
                               },
                             ],
                           },
@@ -6869,6 +7524,14 @@ ShallowWrapper {
                               "label": "test-linode-1248",
                               "value": "linode_id:1248",
                             },
+                            Object {
+                              "label": "test-linode-raw",
+                              "value": "linode_id:1249",
+                            },
+                            Object {
+                              "label": "test-linode-no-disks",
+                              "value": "linode_id:1250",
+                            },
                           ],
                         },
                         Object {
@@ -7200,6 +7863,14 @@ ShallowWrapper {
                               "label": "test-linode-1248",
                               "value": "linode_id:1248",
                             },
+                            Object {
+                              "label": "test-linode-raw",
+                              "value": "linode_id:1249",
+                            },
+                            Object {
+                              "label": "test-linode-no-disks",
+                              "value": "linode_id:1250",
+                            },
                           ],
                         },
                         Object {
@@ -7438,6 +8109,14 @@ ShallowWrapper {
                               Object {
                                 "label": "test-linode-1248",
                                 "value": "linode_id:1248",
+                              },
+                              Object {
+                                "label": "test-linode-raw",
+                                "value": "linode_id:1249",
+                              },
+                              Object {
+                                "label": "test-linode-no-disks",
+                                "value": "linode_id:1250",
                               },
                             ],
                           },
@@ -7751,6 +8430,14 @@ ShallowWrapper {
                                   "label": "test-linode-1248",
                                   "value": "linode_id:1248",
                                 },
+                                Object {
+                                  "label": "test-linode-raw",
+                                  "value": "linode_id:1249",
+                                },
+                                Object {
+                                  "label": "test-linode-no-disks",
+                                  "value": "linode_id:1250",
+                                },
                               ],
                             },
                             Object {
@@ -7909,6 +8596,14 @@ ShallowWrapper {
                                     "label": "test-linode-1248",
                                     "value": "linode_id:1248",
                                   },
+                                  Object {
+                                    "label": "test-linode-raw",
+                                    "value": "linode_id:1249",
+                                  },
+                                  Object {
+                                    "label": "test-linode-no-disks",
+                                    "value": "linode_id:1250",
+                                  },
                                 ],
                               },
                               Object {
@@ -8045,6 +8740,14 @@ ShallowWrapper {
                                 Object {
                                   "label": "test-linode-1248",
                                   "value": "linode_id:1248",
+                                },
+                                Object {
+                                  "label": "test-linode-raw",
+                                  "value": "linode_id:1249",
+                                },
+                                Object {
+                                  "label": "test-linode-no-disks",
+                                  "value": "linode_id:1250",
                                 },
                               ],
                             },


### PR DESCRIPTION
Addresses #2792 

The new behavior is as follows.

1. The "Type" and "Size" fields are removed entirely
2. The disks dropdown appears if the Linode is not a "simple Linode"
3. Raw images are now filtered out from disk options

A "simple Linode" is one that only has two disks, one of them being swap. A simple Linode also cannot have any raw disks.

Note that there is still a case where the dropdown appears with only one or zero disks: if the Linode has raw disks.