### PR TITLE
show and hide new images appropriately

### DIFF
--- a/src/api/ad-hoc/linodes.js
+++ b/src/api/ad-hoc/linodes.js
@@ -1,4 +1,5 @@
 import { actions } from '../generic/linodes';
+import { actions as imageActions } from '../generic/images';
 import { fetch } from '../fetch';
 
 
@@ -77,8 +78,10 @@ export function resizeLinodeDisk(linodeId, diskId, size) {
 
 export function imagizeLinodeDisk(linodeId, diskId, data) {
   return async (dispatch) => {
-    await dispatch(fetch.post(`/linode/instances/${linodeId}/disks/${diskId}/imagize`, data));
-    // TODO: fetch until complete
+    const imagizeUrl = `/linode/instances/${linodeId}/disks/${diskId}/imagize`;
+    const image = await dispatch(fetch.post(imagizeUrl, data));
+    dispatch(imageActions.one(image));
+    return image;
   };
 }
 

--- a/src/linodes/components/DistributionSelect.js
+++ b/src/linodes/components/DistributionSelect.js
@@ -11,8 +11,9 @@ import { DISTRIBUTION_DISPLAY_ORDER } from '~/constants';
 export default function DistributionSelect(props) {
   const vendorsOrdered = [...DISTRIBUTION_DISPLAY_ORDER];
 
+  const imageFilter = im => im.status === 'available';
   const imageOptions = props.images !== undefined ?
-    _.map(Object.values(props.images), im => {
+    _.map(Object.values(props.images).filter(imageFilter), im => {
       const image = { ...im };
       // ensure that each image has a vendor
       if (!image.vendor) {

--- a/src/linodes/images/components/AddImage.js
+++ b/src/linodes/images/components/AddImage.js
@@ -83,11 +83,14 @@ export default class AddImage extends Component {
     const { description, label, linode, disk } = this.state;
     const { dispatch } = this.props;
 
-    const requests = [hideModal];
-    requests.unshift(() => imagizeLinodeDisk(linode.id || linode, disk.id || disk, {
-      label,
-      description,
-    }));
+    const requests = [
+      () => imagizeLinodeDisk(
+        linode.id || linode,
+        disk.id || disk,
+        { label, description },
+      ),
+      hideModal,
+    ];
 
     return dispatch(dispatchOrStoreErrors.call(this, requests));
   }

--- a/src/linodes/images/layouts/IndexPage.js
+++ b/src/linodes/images/layouts/IndexPage.js
@@ -146,11 +146,10 @@ export class IndexPage extends Component {
                 label: 'Created',
               },
               {
-                cellComponent: LabelCell,
-                dataKey: 'status',
                 headerClassName: 'StatusColumn',
                 titleKey: 'status',
                 label: 'Status',
+                dataFn: (image) => _.capitalize(image.status),
               },
               { cellComponent: this.renderImageActions },
             ]}


### PR DESCRIPTION
- Adds newly created images to the image list.
- Hides images that are not ready to be deployed (recently created images) from the list of deployable images/distros.
- Capitalizes the status of images on the image list

Closes #2759 
Closes #2711 
