### PR TITLE
set compilerOptions basePath for vscode (and others) hinting

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,5 +8,11 @@
         "coverage",
         "node_modules",
         "exclude"
-    ]
+    ],
+    "compilerOptions": {
+        "baseUrl": "./src",
+        "paths": {
+            "~/*": ["*"]
+        }
+    }
 }


### PR DESCRIPTION
This allows ctrl+click'ing of import paths in VSCode.

https://code.visualstudio.com/docs/languages/jsconfig#_using-webpack-aliases 