### PR TITLE
Refactor banners to take a 'linode' prop, add remaining banners

### DIFF
--- a/scss/components/Banner.scss
+++ b/scss/components/Banner.scss
@@ -3,23 +3,21 @@
 
     .critical {
         padding: 5px;
-        margin-top: 1px;
-        background-color: rgb(248, 80, 80);
-        color: #f4f4f4;
+        background-color: $red;
+        color: $medium-gray;
         a {
-            color: rgb(197, 197, 240);
+            color: $dark-gray;
         }
     }
 
-    .notice {
+    .warning {
         padding: 5px;
-        margin-top: 1px;
-        background-color: #FFDE4C;
+        background-color: $dark-yellow;
     }
 
-    .outage {
-        color: #f4f4f4;
-        background-color: #555;
+    .info {
+        color: $medium-gray;
+        background-color: $light-black;
         padding: 5px;
     }
 }

--- a/scss/components/Banner.scss
+++ b/scss/components/Banner.scss
@@ -1,8 +1,11 @@
 .Banner {
     text-align: center;
 
+    div {
+        padding: 5px
+    }
+
     .critical {
-        padding: 5px;
         background-color: $red;
         color: $medium-gray;
         a {
@@ -11,14 +14,12 @@
     }
 
     .warning {
-        padding: 5px;
         background-color: $dark-yellow;
     }
 
     .info {
         color: $medium-gray;
         background-color: $light-black;
-        padding: 5px;
     }
 }
  

--- a/scss/components/Banner.scss
+++ b/scss/components/Banner.scss
@@ -14,7 +14,7 @@
     }
 
     .warning {
-        background-color: $dark-yellow;
+        background-color: $yellow;
     }
 
     .info {

--- a/scss/components/Banner.scss
+++ b/scss/components/Banner.scss
@@ -16,5 +16,11 @@
         margin-top: 1px;
         background-color: #FFDE4C;
     }
+
+    .outage {
+        color: #f4f4f4;
+        background-color: #555;
+        padding: 5px;
+    }
 }
  

--- a/scss/components/Banner.scss
+++ b/scss/components/Banner.scss
@@ -1,13 +1,20 @@
 .Banner {
     text-align: center;
 
-    .importantTicket, .migration {
-        background-color: #FFDE4C;
+    .critical {
         padding: 5px;
+        margin-top: 1px;
+        background-color: rgb(248, 80, 80);
+        color: #f4f4f4;
+        a {
+            color: rgb(197, 197, 240);
+        }
     }
 
-    .abuseTicket {
-        background-color: #FF3333;
+    .notice {
         padding: 5px;
+        margin-top: 1px;
+        background-color: #FFDE4C;
     }
 }
+ 

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -62,12 +62,9 @@ function abuseTicket(banners) {
       </div>
     );
   } else if (banners.length === 1) {
-    const ticket = banners[0].entity;
     return (
       <div className="critical">
-        You have an abuse ticket open!
-        &nbsp;<Link to={`/support/${ticket.id}`}>[Ticket #{ticket.id}]</Link>
-        &nbsp;{banners[0].entity.label}
+        You have an <Link to={`/support/${banners[0].entity.id}`}>abuse ticket</Link> open!
       </div>
     );
   }

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -118,43 +118,46 @@ function outage(banners) {
 
 function renderBanners(banners, linode = {}) {
   const abuseBanners = filterBy(
-    [(banner) => banner.type === 'abuse_ticket'],
+    [banner => banner.type === 'abuse_ticket'],
     banners
   );
 
   const importantTicketBanners = filterBy(
-    [(banner) => banner.type === 'important_ticket'],
+    [banner => banner.type === 'important_ticket'],
     banners
   );
 
   const outstandingBalanceBanners = filterBy(
-    [(banner) => banner.type === 'outstanding_balance'],
+    [banner => banner.type === 'outstanding_balance'],
     banners
   );
 
   const migrationBanners = filterBy(
-    [banner => ['pending_migration', 'scheduled_migration'].indexOf(banner.type) >= 0],
+    [
+      banner => ['pending_migration', 'scheduled_migration'].indexOf(banner.type) >= 0,
+      banner => banner.entity.id === linode.id,
+    ],
     banners
   );
 
   const scheduledRebootBanners = filterBy(
     [
-      (banner) => banner.type === 'scheduled_reboot',
-      (banner) => banner.entity.id === linode.id,
+      banner => banner.type === 'scheduled_reboot',
+      banner => banner.entity.id === linode.id,
     ],
     banners
   );
 
   const xenSecurityAdvisoryBanners = filterBy(
     [
-      (banner) => banner.type === 'xsa',
-      (banner) => banner.entity.id === linode.id,
+      banner => banner.type === 'xsa',
+      banner => banner.entity.id === linode.id,
     ],
     banners
   );
 
   const outageBanners = filterBy(
-    [(banner) => banner.type === 'outage'],
+    [banner => banner.type === 'outage'],
     banners
   );
 

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -56,14 +56,19 @@ function abuseTicket(banners) {
   }
 }
 
-function migrations(banners) {
-  banners.map((banner, key) => {
+function migrations(banners, linode) {
+  if (!linode) {
+    return null;
+  }
+
+  const banner = banners.find(banner => banner.entity.id === linode.id);
+  if (banner) {
     return (
       <div className="notice" key={key}>
         You have a host migration {banner.type.split('_')[0]} for this linode!
       </div>
     );
-  });
+  }
 }
 
 function scheduledReboot(banners) {

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -1,22 +1,36 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
+import isEmpty from 'lodash/isEmpty';
 
+/**
+ * @param {[function]} pred Array of functions whos only arguement is the
+ * data provided and must return a boolean.
+ * @param {[*]} data The data to be filtered.
+ */
+export function filterBy(pred, data) {
+  if (!Array.isArray(pred)) {
+    throw TypeError('\'pred\' must be an array of functions.');
+  }
+  if (!Array.isArray(data)) {
+    throw TypeError('\'data\' must be an array.');
+  }
 
-function filterBanners(banners, filter) {
-  return banners.filter(banner => filter.indexOf(banner.type) >= 0);
+  return data.filter((value) =>
+    pred.reduce((result, fn) =>
+      result ? fn(value) : result, true));
 }
 
 function importantTicket(banners) {
   if (banners.length > 1) {
     return (
-      <div className="importantTicket">
+      <div className="notice">
         You have <Link to="/support">important tickets</Link> open!
       </div>
     );
   } else if (banners.length === 1) {
     return (
-      <div className="importantTicket">
+      <div className="notice">
         You have an <Link to={`/support/${banners[0].entity.id}`}>important ticket</Link> open!
       </div>
     );
@@ -26,7 +40,7 @@ function importantTicket(banners) {
 function abuseTicket(banners) {
   if (banners.length > 1) {
     return (
-      <div className="abuseTicket">
+      <div className="critical">
         You have <Link to="/support">abuse tickets</Link> open!
       </div>
     );
@@ -42,28 +56,95 @@ function abuseTicket(banners) {
   }
 }
 
-function migrations(banners, linode) {
-  const banner = banners.find(banner => banner.entity.id === linode.id);
-
-  if (banner) {
+function migrations(banners) {
+  banners.map((banner, key) => {
     return (
-      <div className="migration">
+      <div className="notice" key={key}>
         You have a host migration {banner.type.split('_')[0]} for this linode!
       </div>
     );
-  }
+  });
 }
 
-function renderBanners(banners, linode) {
-  const abuseItems = filterBanners(banners, ['abuse_ticket']);
+function scheduledReboot(banners) {
+  return (
+    banners.map((banner, key) =>
+      <div className="notice" key={key}>
+        {banner.entity.label} is scheduled to reboot.
+      </div>
+    )
+  );
+}
+
+function xenSecurityAdvisory(banners) {
+  return (
+    banners.map((banner, key) =>
+      <div className="critical" key={key} >
+        {banner.entity.label} is scheduled for an XSA restart {banner.when}.
+      </div>
+    )
+  );
+}
+
+function outstandingBalance(banners) {
+  return (
+    /* eslint-disable max-len */
+    banners.map((banner, key) =>
+      <div className="critical" key={key}>
+        You have an outstanding balance. Please <Link to="/billing/payment">make a payment</Link> to avoid service interruption.
+      </div>
+      /* eslint-enable max-len */
+    )
+  );
+}
+
+function renderBanners(banners, linode = {}) {
+  const abuseBanners = filterBy(
+    [(banner) => banner.type === 'abuse_ticket'],
+    banners
+  );
+
+  const importantTicketBanners = filterBy(
+    [(banner) => banner.type === 'important_ticket'],
+    banners
+  );
+
+  const outstandingBalanceBanners = filterBy(
+    [(banner) => banner.type === 'outstanding_balance'],
+    banners
+  );
+
+  const migrationBanners = filterBy(
+    [banner => ['pending_migration', 'scheduled_migration'].indexOf(banner.type) >= 0],
+    banners
+  );
+
+  const scheduledRebootBanners = filterBy(
+    [
+      (banner) => banner.type === 'scheduled_reboot',
+      (banner) => banner.entity.id === linode.id,
+    ],
+    banners
+  );
+
+  const xenSecurityAdvisoryBanners = filterBy(
+    [
+      (banner) => banner.type === 'xsa',
+      (banner) => banner.entity.id === linode.id,
+    ],
+    banners
+  );
 
   return (
     <div className="Banner">
-      {abuseItems.length ?
-        abuseTicket(abuseItems) :
-        importantTicket(filterBanners(banners, ['important_ticket']))
+      {abuseBanners.length ?
+        abuseTicket(abuseBanners) :
+        importantTicket(importantTicketBanners)
       }
-      {migrations(filterBanners(banners, ['pending_migration', 'scheduled_migration']), linode)}
+      {outstandingBalance(outstandingBalanceBanners)}
+      {!isEmpty(migrationBanners) && migrations(migrationBanners)}
+      {!isEmpty(scheduledRebootBanners) && scheduledReboot(scheduledRebootBanners)}
+      {!isEmpty(xenSecurityAdvisoryBanners) && xenSecurityAdvisory(xenSecurityAdvisoryBanners)}
     </div>
   );
 }

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -64,10 +64,10 @@ function abuseTicket(banners) {
   } else if (banners.length === 1) {
     const ticket = banners[0].entity;
     return (
-      <div className="abuseTicket">
+      <div className="critical">
         You have an abuse ticket open!
         &nbsp;<Link to={`/support/${ticket.id}`}>[Ticket #{ticket.id}]</Link>
-        &nbsp;banners[0].entity.label
+        &nbsp;{banners[0].entity.label}
       </div>
     );
   }

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -7,25 +7,6 @@ function filterBanners(banners, filter) {
   return banners.filter(banner => filter.indexOf(banner.type) >= 0);
 }
 
-function getLinodeId(linodes, params) {
-  let linodeId = null;
-  if (params !== {} && linodes !== {}) {
-    let linodeObj = null;
-    if (linodes.linodes !== {}) {
-      linodeObj = Object.values(linodes.linodes).find(linode => {
-        if (linode.label === params.linodeLabel) {
-          return linode;
-        }
-      });
-    }
-    if (linodeObj) {
-      linodeId = linodeObj.id;
-    }
-  }
-
-  return linodeId;
-}
-
 function importantTicket(banners) {
   if (banners.length > 1) {
     return (
@@ -53,33 +34,27 @@ function abuseTicket(banners) {
     const ticket = banners[0].entity;
     return (
       <div className="abuseTicket">
-        You have an abuse ticket open! <Link
-          to={
-            `/support/${ticket.id}`
-          }
-        >[Ticket #{ticket.id}]</Link> {
-          banners[0].entity.label
-        }
+        You have an abuse ticket open!
+        &nbsp;<Link to={`/support/${ticket.id}`}>[Ticket #{ticket.id}]</Link>
+        &nbsp;banners[0].entity.label
       </div>
     );
   }
 }
 
-function migrations(banners, linodeId) {
-  const banner = banners.find(banner => {
-    return banner.entity.id === linodeId ? banner : null;
-  });
+function migrations(banners, linode) {
+  const banner = banners.find(banner => banner.entity.id === linode.id);
 
   if (banner) {
     return (
       <div className="migration">
-        You have a migration {banner.type.split('_')[0]}!
+        You have a host migration {banner.type.split('_')[0]} for this linode!
       </div>
     );
   }
 }
 
-function renderBanners(banners, linodeId) {
+function renderBanners(banners, linode) {
   const abuseItems = filterBanners(banners, ['abuse_ticket']);
 
   return (
@@ -88,23 +63,17 @@ function renderBanners(banners, linodeId) {
         abuseTicket(abuseItems) :
         importantTicket(filterBanners(banners, ['important_ticket']))
       }
-      {migrations(filterBanners(banners, ['pending_migration', 'scheduled_migration']), linodeId)}
+      {migrations(filterBanners(banners, ['pending_migration', 'scheduled_migration']), linode)}
     </div>
   );
 }
 
 export default function Banners(props) {
-  const { banners, params, linodes } = props;
-  if (!banners.length) {
-    return null;
-  }
-  const linodeId = getLinodeId(linodes, params);
-
-  return renderBanners(banners, linodeId);
+  const { banners, linode } = props;
+  return banners.length ? renderBanners(banners, linode) : null;
 }
 
 Banners.propTypes = {
-  params: PropTypes.object,
-  linodes: PropTypes.object,
+  linode: PropTypes.object,
   banners: PropTypes.array,
 };

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -24,13 +24,13 @@ export function filterBy(pred, data) {
 function importantTicket(banners) {
   if (banners.length > 1) {
     return (
-      <div className="notice">
+      <div className="warning">
         You have <Link to="/support">important tickets</Link> open!
       </div>
     );
   } else if (banners.length === 1) {
     return (
-      <div className="notice">
+      <div className="warning">
         You have an <Link to={`/support/${banners[0].entity.id}`}>important ticket</Link> open!
       </div>
     );
@@ -56,25 +56,20 @@ function abuseTicket(banners) {
   }
 }
 
-function migrations(banners, linode) {
-  if (!linode) {
-    return null;
-  }
-
-  const banner = banners.find(banner => banner.entity.id === linode.id);
-  if (banner) {
-    return (
-      <div className="notice" key={key}>
+function migrations(banners) {
+  return (
+    banners.map((banner, key) =>
+      <div className="warning" key={key}>
         You have a host migration {banner.type.split('_')[0]} for this linode!
       </div>
-    );
-  }
+    )
+  );
 }
 
 function scheduledReboot(banners) {
   return (
     banners.map((banner, key) =>
-      <div className="notice" key={key}>
+      <div className="warning" key={key}>
         {banner.entity.label} is scheduled to reboot.
       </div>
     )
@@ -108,7 +103,7 @@ function outage(banners) {
 
   if (datacenterNames.length) {
     return (
-      <div className="outage">
+      <div className="info">
         We are aware of issues affecting service in the following facilities:
         &nbsp;{datacenterNames.join(', ')}
       </div>

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -129,10 +129,10 @@ function outage(banners) {
 }
 
 function globalNotice(banner) {
-  if (banner) {
+  if (banner.length) {
     return (
       <div className="info">
-        {banner.type}
+        {banner[0].type}
       </div>
     );
   }
@@ -183,8 +183,8 @@ function renderBanners(banners, linode = {}) {
     banners
   );
 
-  const globalBanner = filterBy(
-    globalNoticeFilter,
+  const globalBanners = filterBy(
+    [globalNoticeFilter],
     banners
   );
 
@@ -199,7 +199,7 @@ function renderBanners(banners, linode = {}) {
       {!isEmpty(scheduledRebootBanners) && scheduledReboot(scheduledRebootBanners)}
       {!isEmpty(xenSecurityAdvisoryBanners) && xenSecurityAdvisory(xenSecurityAdvisoryBanners)}
       {!isEmpty(outageBanners) && outage(outageBanners)}
-      {!isEmpty(globalBanner) && globalNotice(globalBanner)}
+      {!isEmpty(globalBanners) && globalNotice(globalBanners)}
     </div>
   );
 }

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -93,14 +93,27 @@ function xenSecurityAdvisory(banners) {
 
 function outstandingBalance(banners) {
   return (
-    /* eslint-disable max-len */
     banners.map((banner, key) =>
       <div className="critical" key={key}>
-        You have an outstanding balance. Please <Link to="/billing/payment">make a payment</Link> to avoid service interruption.
+        You have an outstanding balance.
+        &nbsp;Please <Link to="/billing/payment">make a payment</Link>
+        &nbsp;to avoid service interruption.
       </div>
-      /* eslint-enable max-len */
     )
   );
+}
+
+function outage(banners) {
+  const datacenterNames = banners.map(banner => banner.entity.id);
+
+  if (datacenterNames.length) {
+    return (
+      <div className="outage">
+        We are aware of issues affecting service in the following facilities:
+        &nbsp;{datacenterNames.join(', ')}
+      </div>
+    );
+  }
 }
 
 function renderBanners(banners, linode = {}) {
@@ -140,9 +153,14 @@ function renderBanners(banners, linode = {}) {
     banners
   );
 
+  const outageBanners = filterBy(
+    [(banner) => banner.type === 'outage'],
+    banners
+  );
+
   return (
     <div className="Banner">
-      {abuseBanners.length ?
+      {!isEmpty(abuseBanners) ?
         abuseTicket(abuseBanners) :
         importantTicket(importantTicketBanners)
       }
@@ -150,6 +168,7 @@ function renderBanners(banners, linode = {}) {
       {!isEmpty(migrationBanners) && migrations(migrationBanners)}
       {!isEmpty(scheduledRebootBanners) && scheduledReboot(scheduledRebootBanners)}
       {!isEmpty(xenSecurityAdvisoryBanners) && xenSecurityAdvisory(xenSecurityAdvisoryBanners)}
+      {!isEmpty(outageBanners) && outage(outageBanners)}
     </div>
   );
 }

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -94,13 +94,14 @@ function scheduledReboot(banners) {
 }
 
 function xenSecurityAdvisory(banners) {
-  return (
-    banners.map((banner, key) =>
+  return banners.map((banner, key) => {
+    const timestamp = banner.when.replace('T', ' ');
+    return (
       <div className="critical" key={key} >
-        {banner.entity.label} is scheduled for an XSA restart {banner.when}.
+        {banner.entity.label} is scheduled for an XSA restart at {timestamp}.
       </div>
-    )
-  );
+    );
+  });
 }
 
 function outstandingBalance(banners) {

--- a/src/components/Banners.js
+++ b/src/components/Banners.js
@@ -21,6 +21,23 @@ export function filterBy(pred, data) {
       result ? fn(value) : result, true));
 }
 
+function globalNoticeFilter(banner) {
+  const standardBannerTypes = [
+    'outage',
+    'scheduled_migration',
+    'pending_migration',
+    'scheduled_reboot',
+    'xsa',
+    'outstanding_balance',
+    'important_ticket',
+    'abuse_ticket',
+  ];
+  /* A global banner has a dynamic type.
+     There is only ever one global banner. */
+  /* TODO: Request that the API return type "global" with an "entity" containing the message */
+  return standardBannerTypes.indexOf(banner.type) === -1;
+}
+
 function importantTicket(banners) {
   if (banners.length > 1) {
     return (
@@ -111,6 +128,16 @@ function outage(banners) {
   }
 }
 
+function globalNotice(banner) {
+  if (banner) {
+    return (
+      <div className="info">
+        {banner.type}
+      </div>
+    );
+  }
+}
+
 function renderBanners(banners, linode = {}) {
   const abuseBanners = filterBy(
     [banner => banner.type === 'abuse_ticket'],
@@ -156,6 +183,11 @@ function renderBanners(banners, linode = {}) {
     banners
   );
 
+  const globalBanner = filterBy(
+    globalNoticeFilter,
+    banners
+  );
+
   return (
     <div className="Banner">
       {!isEmpty(abuseBanners) ?
@@ -167,6 +199,7 @@ function renderBanners(banners, linode = {}) {
       {!isEmpty(scheduledRebootBanners) && scheduledReboot(scheduledRebootBanners)}
       {!isEmpty(xenSecurityAdvisoryBanners) && xenSecurityAdvisory(xenSecurityAdvisoryBanners)}
       {!isEmpty(outageBanners) && outage(outageBanners)}
+      {!isEmpty(globalBanner) && globalNotice(globalBanner)}
     </div>
   );
 }

--- a/src/components/Banners.spec.js
+++ b/src/components/Banners.spec.js
@@ -1,29 +1,70 @@
 import React from 'react';
-import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
-import Banners from '~/components/Banners';
+import Banners, { filterBy } from '~/components/Banners';
 import {
   importantBanner,
   importantBanners,
   abuseBanner,
   abuseBanners,
+  outstandingBalanceBanner,
+  scheduledRebootBanner,
+  xsaBanner,
 } from '~/data/banners';
 
-
-describe('components/Banners', () => {
-  const sandbox = sinon.sandbox.create();
-
-  beforeEach(() => {
-    sandbox.reset();
+describe('components/Banners filterBy', () => {
+  it('should throw if `pred` is not an array.', () => {
+    expect(() => filterBy([], undefined)).toThrow(TypeError);
   });
+
+  it('should throw if `data` is not an array.', () => {
+    expect(() => filterBy(undefined, [])).toThrow(TypeError);
+  });
+
+  it('should filter data by many pred', () => {
+    const marques = { role: 'senior developer', residentOf: 'new jersey' };
+    const andrew = { role: 'developer', residentOf: 'pennsylvania' };
+    const rob = { role: 'developer', residentOf: 'new jersey' };
+
+    const pred = [
+      (data) => data.role === 'developer',
+      (data) => data.residentOf === 'new jersey',
+    ];
+
+    const data = [marques, andrew, rob];
+
+    expect(
+      filterBy(pred, data)
+    ).toEqual([rob]);
+  });
+
+  it('should should filter by one pred', () => {
+    const marques = { role: 'senior developer', residentOf: 'new jersey' };
+    const andrew = { role: 'developer', residentOf: 'pennsylvania' };
+    const rob = { role: 'developer', residentOf: 'new jersey' };
+
+    const pred = [
+      (data) => data.role === 'developer',
+    ];
+
+    const data = [marques, andrew, rob];
+
+    expect(
+      filterBy(pred, data)
+    ).toEqual([andrew, rob]);
+  });
+});
+describe('components/Banners', () => {
+  const linode = {
+    id: 1234,
+    label: 'my-linode',
+  };
 
   it('renders an important ticket banner', () => {
     const banner = shallow(
       <Banners
         banners={importantBanner}
-        params={{}}
-        linodes={{ linodes: {} }}
+        linode={linode}
       />
     );
 
@@ -34,8 +75,7 @@ describe('components/Banners', () => {
     const banner = shallow(
       <Banners
         banners={importantBanners}
-        params={{}}
-        linodes={{ linodes: {} }}
+        linode={linode}
       />
     );
 
@@ -46,8 +86,7 @@ describe('components/Banners', () => {
     const banner = shallow(
       <Banners
         banners={abuseBanner}
-        params={{}}
-        linodes={{ linodes: {} }}
+        linode={linode}
       />
     );
 
@@ -58,11 +97,44 @@ describe('components/Banners', () => {
     const banner = shallow(
       <Banners
         banners={abuseBanners}
-        params={{}}
-        linodes={{ linodes: {} }}
+        linode={linode}
       />
     );
 
     expect(banner.find('.Banner Link').props().to).toBe('/support');
+  });
+
+  it('should render a notice for scheduled reboot banner', () => {
+    const wrapper = shallow(
+      <Banners
+        banners={[scheduledRebootBanner]}
+        linode={linode}
+      />
+    );
+
+    expect(wrapper.find('div.notice').length).toBe(1);
+  });
+
+  it('should render a critical for xsa banner', () => {
+    const wrapper = shallow(
+      <Banners
+        banners={[xsaBanner]}
+        linode={linode}
+      />
+    );
+
+    expect(wrapper.find('div.critical').length).toBe(1);
+  });
+
+  it('should render a critical for outstanding balance banner', () => {
+    const wrapper = shallow(
+      <Banners
+        banners={[outstandingBalanceBanner]}
+        linode={linode}
+      />
+    );
+    expect(wrapper.find('div.critical').length).toBe(1);
+    expect(wrapper.find('Link').length).toBe(1);
+    expect(wrapper.find('Link').prop('to')).toBe('/billing/payment');
   });
 });

--- a/src/components/Banners.spec.js
+++ b/src/components/Banners.spec.js
@@ -10,6 +10,7 @@ import {
   outstandingBalanceBanner,
   scheduledRebootBanner,
   xsaBanner,
+  outageBanners,
 } from '~/data/banners';
 
 describe('components/Banners filterBy', () => {
@@ -54,6 +55,7 @@ describe('components/Banners filterBy', () => {
     ).toEqual([andrew, rob]);
   });
 });
+
 describe('components/Banners', () => {
   const linode = {
     id: 1234,
@@ -136,5 +138,18 @@ describe('components/Banners', () => {
     expect(wrapper.find('div.critical').length).toBe(1);
     expect(wrapper.find('Link').length).toBe(1);
     expect(wrapper.find('Link').prop('to')).toBe('/billing/payment');
+  });
+
+  it('renders an outage banner for multiple datacenters', () => {
+    const banner = shallow(
+      <Banners
+        banners={outageBanners}
+        params={{}}
+        linodes={{ linodes: {} }}
+      />
+    );
+
+    expect(banner.find('.Banner > div').text().indexOf(
+      'us-east-1a, us-south-1a')).toBeGreaterThan(-1);
   });
 });

--- a/src/components/Banners.spec.js
+++ b/src/components/Banners.spec.js
@@ -62,6 +62,18 @@ describe('components/Banners', () => {
     label: 'my-linode',
   };
 
+  it('renders no banners when no notices are present', () => {
+    const banner = shallow(
+      <Banners
+        banners={[]}
+        params={{}}
+        linodes={{ linodes: {} }}
+      />
+    );
+
+    expect(banner.find('.Banner')).toHaveLength(0);
+  });
+
   it('renders an important ticket banner', () => {
     const banner = shallow(
       <Banners
@@ -149,7 +161,8 @@ describe('components/Banners', () => {
       />
     );
 
-    expect(banner.find('.Banner > div').text().indexOf(
-      'us-east-1a, us-south-1a')).toBeGreaterThan(-1);
+    expect(banner.find('.Banner')).toHaveLength(1);
+    const expected = expect.stringMatching('us-east-1a, us-south-1a');
+    expect(banner.find('.Banner > div').text()).toEqual(expected);
   });
 });

--- a/src/components/Banners.spec.js
+++ b/src/components/Banners.spec.js
@@ -11,6 +11,7 @@ import {
   scheduledRebootBanner,
   xsaBanner,
   outageBanners,
+  globalBanner,
 } from '~/data/banners';
 
 describe('components/Banners filterBy', () => {
@@ -164,5 +165,18 @@ describe('components/Banners', () => {
     expect(banner.find('.Banner')).toHaveLength(1);
     const expected = expect.stringMatching('us-east-1a, us-south-1a');
     expect(banner.find('.Banner > div').text()).toEqual(expected);
+  });
+
+  it('renders a global notice banner', () => {
+    const banner = shallow(
+      <Banners
+        banners={globalBanner}
+        params={{}}
+        linodes={{ linodes: {} }}
+      />
+    );
+
+    expect(banner.find('.Banner > div').text()).toBe(
+      'The new linode cloud manager is in the works!');
   });
 });

--- a/src/components/Banners.spec.js
+++ b/src/components/Banners.spec.js
@@ -118,7 +118,7 @@ describe('components/Banners', () => {
     expect(banner.find('.Banner Link').props().to).toBe('/support');
   });
 
-  it('should render a notice for scheduled reboot banner', () => {
+  it('should render a warning for scheduled reboot banner', () => {
     const wrapper = shallow(
       <Banners
         banners={[scheduledRebootBanner]}
@@ -126,7 +126,7 @@ describe('components/Banners', () => {
       />
     );
 
-    expect(wrapper.find('div.notice').length).toBe(1);
+    expect(wrapper.find('div.warning').length).toBe(1);
   });
 
   it('should render a critical for xsa banner', () => {

--- a/src/data/banners.js
+++ b/src/data/banners.js
@@ -85,6 +85,12 @@ const testOutageBanner2 = {
   },
 };
 
+export const testGlobalBanner = {
+  entity: null,
+  type: 'The new linode cloud manager is in the works!',
+  when: '2017-12-22T05:00:00',
+};
+
 export const importantBanner = [
   testApiBanner,
 ];
@@ -108,8 +114,13 @@ export const outageBanners = [
   testOutageBanner2,
 ];
 
+export const globalBanner = [
+  testGlobalBanner,
+];
+
 export const banners = [
   testApiBanner,
   testBillingBanner,
   testAbuseBanner,
+  testGlobalBanner,
 ];

--- a/src/data/banners.js
+++ b/src/data/banners.js
@@ -65,6 +65,26 @@ export const testAbuseBanner2 = {
   },
 };
 
+const testOutageBanner1 = {
+  when: null,
+  entity: {
+    label: null,
+    id: 'us-east-1a',
+    type: 'region',
+    url: '/regions/us-east-1a',
+  },
+  type: 'outage',
+};
+
+const testOutageBanner2 = {
+  ...testOutageBanner1,
+  entity: {
+    ...testOutageBanner1.entity,
+    id: 'us-south-1a',
+    url: '/regions/us-south-1a',
+  },
+};
+
 export const importantBanner = [
   testApiBanner,
 ];
@@ -81,6 +101,11 @@ export const abuseBanner = [
 export const abuseBanners = [
   testAbuseBanner,
   testAbuseBanner2,
+];
+
+export const outageBanners = [
+  testOutageBanner1,
+  testOutageBanner2,
 ];
 
 export const banners = [

--- a/src/data/banners.js
+++ b/src/data/banners.js
@@ -16,6 +16,39 @@ export const testBillingBanner = {
   },
 };
 
+export const xsaBanner = {
+  entity: {
+    id: 1234,
+    label: 'my-linode',
+    type: 'linode',
+    url: '/linode/instances/1234',
+  },
+  type: 'xsa',
+  when: '2017-01-01T00:00:01',
+};
+
+export const outstandingBalanceBanner = {
+  entity: {
+    id: null,
+    label: 'user@email.com',
+    type: 'account',
+    url: '/account/settings',
+  },
+  type: 'outstanding_balance',
+  when: null,
+};
+
+export const scheduledRebootBanner = {
+  entity: {
+    id: 1234,
+    label: 'my-linode',
+    type: 'linode',
+    url: '/linode/instances/1234',
+  },
+  type: 'scheduled_reboot',
+  when: '2017-12-31T23:59:59',
+};
+
 export const testAbuseBanner = {
   ...testApiBanner,
   entity: {

--- a/src/layouts/Layout.js
+++ b/src/layouts/Layout.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import isEmpty from 'lodash/isEmpty';
 
 import { ExternalLink } from 'linode-components';
 import { Error } from 'linode-components';
@@ -39,6 +40,13 @@ export class Layout extends Component {
     this.state = { title: '', link: '' };
   }
 
+  getPageLinode = (linodes, params) => {
+    if (isEmpty(params) || isEmpty(linodes) || isEmpty(linodes.linodes)) {
+      return;
+    }
+    return Object.values(linodes.linodes).find(linode => linode.label === params.linodeLabel);
+  }
+
   render() {
     const {
       username,
@@ -56,6 +64,7 @@ export class Layout extends Component {
     const githubRoot = `https://github.com/linode/manager/blob/${version}/`;
     const params = this.props.params;
     const linodes = this.props.linodes;
+    const pageLinode = this.getPageLinode(linodes, params);
 
     return (
       <div
@@ -95,8 +104,7 @@ export class Layout extends Component {
           />
           <div className="Main">
             <Banners
-              params={params}
-              linodes={linodes}
+              linode={pageLinode}
               banners={banners}
             />
             {errors.status ?

--- a/src/layouts/Layout.spec.js
+++ b/src/layouts/Layout.spec.js
@@ -35,6 +35,7 @@ describe('layouts/Layout', () => {
         linodes={linodes}
         events={events}
         modal={{ open: false }}
+        params={{ linodeLabel: 'test-linode' }}
       >{children}</Layout>
     );
   }
@@ -76,5 +77,11 @@ describe('layouts/Layout', () => {
     const component = shallow(makeLayout(
       dispatch, { ...errorsPopulated, status: 404 }));
     expect(component.find('Error').length).toBe(1);
+  });
+
+  it('passes the current linode to Banners', () => {
+    const component = shallow(makeLayout());
+    const banners = component.find('Banners');
+    expect(banners.props().linode.label).toBe('test-linode');
   });
 });


### PR DESCRIPTION
Refactor the way the current Linode is passed as a prop to the Banner component.
Also Refactor the way that banners are filtered for their rendering.

Add the following Banner types:

Scheduled Reboot
Xen Security Advisory
Outstanding Balance
Outage
Global Notice

Existing Banner types:

Pending Migration
Scheduled Migration
Abuse Ticket
Important Ticket