### PR TITLE
Remove extra 'Power On' action from StatusDropdown

### DIFF
--- a/src/linodes/components/StatusDropdown.js
+++ b/src/linodes/components/StatusDropdown.js
@@ -241,9 +241,6 @@ export default class StatusDropdown extends Component {
         ] });
       }
     }
-    finalGroups.push({ elements: [
-      { name: 'Power On', action: this.powerOnLinode },
-    ] });
     // we always allow Lish
     finalGroups.push({ elements: [
       { name: 'Launch Console', action: () => launchWeblishConsole(linode) },

--- a/src/linodes/components/StatusDropdown.spec.js
+++ b/src/linodes/components/StatusDropdown.spec.js
@@ -26,19 +26,19 @@ describe('linodes/components/StatusDropdown', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it.skip('renders correct options for offline Linodes', () => {
+  it('renders correct options for offline Linodes', () => {
     const dropdown = mount(
       <StatusDropdown linode={linodes.linodes[1236]} dispatch={() => {}} />
     );
 
-    expect(dropdown.find('.Dropdown-first').text().trim()).toBe('Offline');
+    expect(dropdown.find('button.Dropdown-first').text().trim()).toBe('Offline');
 
-    dropdown.find('.Dropdown-toggle').simulate('click');
+    dropdown.find('button.Dropdown-toggle').simulate('click');
 
-    expect(dropdown.find('.Dropdown-item').length).toBe(3);
-    expect(dropdown.find('.Dropdown-item').at(0).text()).toBe('Power On');
-    expect(dropdown.find('.Dropdown-item').at(1).text()).toBe('Launch Console');
-    expect(dropdown.find('.Dropdown-item').at(2).text()).toBe('Delete');
+    expect(dropdown.find('button.Dropdown-item').length).toBe(3);
+    expect(dropdown.find('button.Dropdown-item').at(0).text()).toBe('Power On');
+    expect(dropdown.find('button.Dropdown-item').at(1).text()).toBe('Launch Console');
+    expect(dropdown.find('button.Dropdown-item').at(2).text()).toBe('Delete');
   });
 
   it.skip('renders correct options for online Linodes', () => {

--- a/src/linodes/components/__snapshots__/StatusDropdown.spec.js.snap
+++ b/src/linodes/components/__snapshots__/StatusDropdown.spec.js.snap
@@ -323,14 +323,6 @@ ShallowWrapper {
                   "elements": Array [
                     Object {
                       "action": [Function],
-                      "name": "Power On",
-                    },
-                  ],
-                },
-                Object {
-                  "elements": Array [
-                    Object {
-                      "action": [Function],
                       "name": "Launch Console",
                     },
                   ],
@@ -399,14 +391,6 @@ ShallowWrapper {
                     "elements": Array [
                       Object {
                         "action": [Function],
-                        "name": "Power On",
-                      },
-                    ],
-                  },
-                  Object {
-                    "elements": Array [
-                      Object {
-                        "action": [Function],
                         "name": "Launch Console",
                       },
                     ],
@@ -454,14 +438,6 @@ ShallowWrapper {
                   "elements": Array [
                     Object {
                       "name": "Offline",
-                    },
-                  ],
-                },
-                Object {
-                  "elements": Array [
-                    Object {
-                      "action": [Function],
-                      "name": "Power On",
                     },
                   ],
                 },
@@ -573,14 +549,6 @@ ShallowWrapper {
                     "elements": Array [
                       Object {
                         "action": [Function],
-                        "name": "Power On",
-                      },
-                    ],
-                  },
-                  Object {
-                    "elements": Array [
-                      Object {
-                        "action": [Function],
                         "name": "Launch Console",
                       },
                     ],
@@ -649,14 +617,6 @@ ShallowWrapper {
                       "elements": Array [
                         Object {
                           "action": [Function],
-                          "name": "Power On",
-                        },
-                      ],
-                    },
-                    Object {
-                      "elements": Array [
-                        Object {
-                          "action": [Function],
                           "name": "Launch Console",
                         },
                       ],
@@ -704,14 +664,6 @@ ShallowWrapper {
                     "elements": Array [
                       Object {
                         "name": "Offline",
-                      },
-                    ],
-                  },
-                  Object {
-                    "elements": Array [
-                      Object {
-                        "action": [Function],
-                        "name": "Power On",
                       },
                     ],
                   },


### PR DESCRIPTION
Fixes a bug in which the "Power On" action would be repeated in the Linode StatusDropdown