### PR TITLE
Remove the requirement for fetches to be dispatched to Redux

### DIFF
--- a/src/api/ad-hoc/linodes.js
+++ b/src/api/ad-hoc/linodes.js
@@ -59,7 +59,7 @@ export function rebuildLinode(id, config = null) {
 }
 
 export function lishToken(linodeId) {
-  return (dispatch) => dispatch(fetch.post(`/linode/instances/${linodeId}/lish_token`));
+  return fetch.post(`/linode/instances/${linodeId}/lish_token`);
 }
 
 export function resetPassword(linodeId, diskId, password) {

--- a/src/api/external.js
+++ b/src/api/external.js
@@ -97,7 +97,7 @@ export function filterResources(config, resources, resourceFilter) {
 function genThunkOne(config, actions) {
   return (ids = [], headers = {}) => async (dispatch) => {
     const endpoint = config.endpoint(...ids);
-    const resource = await dispatch(fetch.get(endpoint, undefined, headers));
+    const resource = await fetch.get(endpoint, undefined, headers);
     dispatch(actions.one(resource, ...ids));
     return resource;
   };
@@ -114,7 +114,7 @@ function genThunkPage(config, actions) {
     return async (dispatch, getState) => {
       const endpoint = `${config.endpoint(...ids, '')}?page=${page + 1}`;
 
-      const resources = await dispatch(fetch.get(endpoint, undefined, headers));
+      const resources = await fetch.get(endpoint, undefined, headers);
       resources[config.plural] = resources.data || [];
 
       const now = fetchBeganAt || new Date();
@@ -232,7 +232,7 @@ function genThunkAll(config, actions, fetchPage) {
 function genThunkDelete(config, actions) {
   return (...ids) => async (dispatch) => {
     const endpoint = config.endpoint(...ids);
-    const json = await dispatch(fetch.delete(endpoint));
+    const json = await fetch.delete(endpoint);
     dispatch(actions.delete(...ids));
     return json;
   };
@@ -241,7 +241,7 @@ function genThunkDelete(config, actions) {
 function genThunkPut(config, actions) {
   return (resource, ...ids) => async (dispatch) => {
     const endpoint = config.endpoint(...ids);
-    const json = await dispatch(fetch.put(endpoint, resource));
+    const json = await fetch.put(endpoint, resource);
     dispatch(actions.one(json, ...ids));
     return json;
   };
@@ -251,7 +251,7 @@ function genThunkPost(config, actions) {
   return (resource, ...ids) => {
     return async (dispatch) => {
       const endpoint = config.endpoint(...ids, '');
-      const json = await dispatch(fetch.post(endpoint, resource));
+      const json = await fetch.post(endpoint, resource);
       dispatch(actions.one(json, ...ids));
       return json;
     };

--- a/src/linodes/linode/layouts/Weblish.js
+++ b/src/linodes/linode/layouts/Weblish.js
@@ -47,9 +47,8 @@ export class Weblish extends Component {
   }
 
   async connect() {
-    const { dispatch } = this.props;
     const { linode } = this.state;
-    const { lish_token: token } = await dispatch(lishToken(linode.id));
+    const { lish_token: token } = await lishToken(linode.id);
     const socket = new WebSocket(
       `wss://${ZONES[linode.region]}.webconsole.linode.com:8181/${token}/weblish`);
     socket.addEventListener('open', () =>


### PR DESCRIPTION
Api endpoints that use the fetch api are unnecessarily dispatched through the Redux store because the curried `fetch` functions are thunks. In addition, some of the api endpoint functions are thunks, resulting in two unnecessary `dispatch` calls. This PR begins the process of removing those calls to `dispatch`.