### PR TITLE
Decouple plural/singular from endpoint name

### DIFF
--- a/src/api/generic/account.js
+++ b/src/api/generic/account.js
@@ -1,12 +1,13 @@
 import {
-  genConfig, ReducerGenerator, genActions, ONE, PUT,
+  ReducerGenerator, genActions, ONE, PUT,
 } from '~/api/internal';
 
-export const config = genConfig({
-  singular: 'account',
+export const config = {
+  name: 'account',
+  primaryKey: 'id',
   endpoint: () => '/account/settings',
   supports: [ONE, PUT],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/apps.js
+++ b/src/api/generic/apps.js
@@ -1,13 +1,14 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  ReducerGenerator, genActions,
   ONE, MANY, DELETE, POST, PUT,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'apps',
+export const config = {
+  name: 'apps',
+  primaryKey: 'id',
   endpoint: id => `/profile/apps/${id}`,
   supports: [ONE, MANY, DELETE, POST, PUT],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/banners.js
+++ b/src/api/generic/banners.js
@@ -1,12 +1,13 @@
 import {
-  genConfig, ReducerGenerator, genActions, ONE,
+  ReducerGenerator, genActions, ONE,
 } from '~/api/internal';
 
-export const config = genConfig({
-  singular: 'banners',
+export const config = {
+  name: 'banners',
+  primaryKey: 'id',
   endpoint: () => '/account/notifications',
   supports: [ONE],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/clients.js
+++ b/src/api/generic/clients.js
@@ -1,13 +1,14 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  ReducerGenerator, genActions,
   ONE, MANY, POST, PUT, DELETE,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'clients',
+export const config = {
+  name: 'clients',
+  primaryKey: 'id',
   endpoint: id => `/account/oauth-clients/${id}`,
   supports: [ONE, MANY, POST, PUT, DELETE],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/domains.js
+++ b/src/api/generic/domains.js
@@ -1,15 +1,17 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  addParentRefs, ReducerGenerator, genActions,
   ONE, MANY, PUT, DELETE, POST,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'domains',
+export const config = addParentRefs({
+  name: 'domains',
+  primaryKey: 'id',
   endpoint: id => `/domains/${id}`,
   supports: [ONE, MANY, POST, PUT, DELETE],
   subresources: {
     _records: {
-      plural: 'records',
+      name: 'records',
+      primaryKey: 'id',
       endpoint: (domain, record) => `/domains/${domain}/records/${record}`,
       supports: [ONE, MANY, PUT, POST, DELETE],
     },

--- a/src/api/generic/events.js
+++ b/src/api/generic/events.js
@@ -1,9 +1,10 @@
 import {
-  genConfig, ReducerGenerator, genActions, ONE, MANY,
+  ReducerGenerator, genActions, ONE, MANY,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'events',
+export const config = {
+  name: 'events',
+  primaryKey: 'id',
   endpoint: id => `/account/events/${id}`,
   supports: [ONE, MANY],
 
@@ -24,7 +25,7 @@ export const config = genConfig({
       return 0;
     });
   },
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/images.js
+++ b/src/api/generic/images.js
@@ -1,13 +1,14 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  ReducerGenerator, genActions,
   ONE, MANY, POST, PUT, DELETE,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'images',
+export const config = {
+  name: 'images',
+  primaryKey: 'id',
   endpoint: id => `/images/${id}`,
   supports: [ONE, MANY, POST, PUT, DELETE],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/invoices.js
+++ b/src/api/generic/invoices.js
@@ -1,14 +1,15 @@
 import {
-  genConfig, ReducerGenerator, genActions, ONE, MANY,
+  addParentRefs, ReducerGenerator, genActions, ONE, MANY,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'invoices',
+export const config = addParentRefs({
+  name: 'invoices',
+  primaryKey: 'id',
   endpoint: id => `/account/invoices/${id}`,
   supports: [ONE, MANY],
   subresources: {
     _items: {
-      plural: 'items',
+      name: 'items',
       primaryKey: 'label',
       endpoint: id => `/account/invoices/${id}/items`,
       supports: [MANY],

--- a/src/api/generic/kernels.js
+++ b/src/api/generic/kernels.js
@@ -1,13 +1,14 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  ReducerGenerator, genActions,
   ONE, MANY,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'kernels',
+export const config = {
+  name: 'kernels',
+  primaryKey: 'id',
   endpoint: id => `/linode/kernels/${id}`,
   supports: [ONE, MANY],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/linodes.js
+++ b/src/api/generic/linodes.js
@@ -1,10 +1,11 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  addParentRefs, ReducerGenerator, genActions,
   ONE, MANY, PUT, DELETE, POST,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'linodes',
+export const config = addParentRefs({
+  name: 'linodes',
+  primaryKey: 'id',
   endpoint: id => `/linode/instances/${id}`,
   supports: [ONE, MANY, PUT, DELETE, POST],
   properties: {
@@ -31,17 +32,20 @@ export const config = genConfig({
   },
   subresources: {
     _configs: {
-      plural: 'configs',
+      name: 'configs',
+      primaryKey: 'id',
       endpoint: (linode, conf) => `/linode/instances/${linode}/configs/${conf}`,
       supports: [ONE, MANY, PUT, DELETE, POST],
     },
     _disks: {
-      plural: 'disks',
+      name: 'disks',
+      primaryKey: 'id',
       endpoint: (linode, disk) => `/linode/instances/${linode}/disks/${disk}`,
       supports: [ONE, MANY, PUT, DELETE, POST],
     },
     _volumes: {
-      plural: 'volumes',
+      name: 'volumes',
+      primaryKey: 'id',
       endpoint: (linode, volume) => `/linode/instances/${linode}/volumes/${volume}`,
       supports: [ONE, MANY, PUT, DELETE, POST],
     },

--- a/src/api/generic/nodebalancers.js
+++ b/src/api/generic/nodebalancers.js
@@ -1,20 +1,23 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  addParentRefs, ReducerGenerator, genActions,
   ONE, MANY, PUT, DELETE, POST,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'nodebalancers',
+export const config = addParentRefs({
+  name: 'nodebalancers',
+  primaryKey: 'id',
   endpoint: id => `/nodebalancers/${id}`,
   supports: [ONE, MANY, PUT, DELETE, POST],
   subresources: {
     _configs: {
-      plural: 'configs',
+      name: 'configs',
+      primaryKey: 'id',
       endpoint: (id, nbConfigId) => `/nodebalancers/${id}/configs/${nbConfigId}`,
       supports: [ONE, MANY, PUT, POST, DELETE],
       subresources: {
         _nodes: {
-          plural: 'nodes',
+          name: 'nodes',
+          primaryKey: 'id',
           endpoint: (id, nbConfigId, nodeId) => {
             return `/nodebalancers/${id}/configs/${nbConfigId}/nodes/${nodeId}`;
           },

--- a/src/api/generic/payments.js
+++ b/src/api/generic/payments.js
@@ -1,9 +1,10 @@
 import {
-  genConfig, ReducerGenerator, genActions, ONE, MANY,
+  ReducerGenerator, genActions, ONE, MANY,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'payments',
+export const config = {
+  name: 'payments',
+  primaryKey: 'id',
   endpoint: id => `/account/payments/${id}`,
   supports: [ONE, MANY],
 
@@ -24,7 +25,7 @@ export const config = genConfig({
       return 0;
     });
   },
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/profile.js
+++ b/src/api/generic/profile.js
@@ -1,12 +1,13 @@
 import {
-  genConfig, ReducerGenerator, genActions, ONE, PUT,
+  ReducerGenerator, genActions, ONE, PUT,
 } from '~/api/internal';
 
-export const config = genConfig({
-  singular: 'profile',
+export const config = {
+  name: 'profile',
+  primaryKey: 'id',
   endpoint: () => '/profile',
   supports: [ONE, PUT],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/regions.js
+++ b/src/api/generic/regions.js
@@ -1,13 +1,14 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  ReducerGenerator, genActions,
   ONE, MANY,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'regions',
+export const config = {
+  name: 'regions',
+  primaryKey: 'id',
   endpoint: id => `/regions/${id}`,
   supports: [ONE, MANY],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/stackscripts.js
+++ b/src/api/generic/stackscripts.js
@@ -1,13 +1,14 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  ReducerGenerator, genActions,
   ONE, MANY, POST, PUT, DELETE,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'stackscripts',
+export const config = {
+  name: 'stackscripts',
+  primaryKey: 'id',
   endpoint: id => `/linode/stackscripts/${id}`,
   supports: [ONE, MANY, POST, PUT, DELETE],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/tickets.js
+++ b/src/api/generic/tickets.js
@@ -1,14 +1,16 @@
 import {
-  genConfig, ReducerGenerator, genActions, ONE, MANY, POST,
+  addParentRefs, ReducerGenerator, genActions, ONE, MANY, POST,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'tickets',
+export const config = addParentRefs({
+  name: 'tickets',
+  primaryKey: 'id',
   endpoint: id => `/support/tickets/${id}`,
   supports: [ONE, MANY, POST],
   subresources: {
     _replies: {
-      plural: 'replies',
+      name: 'replies',
+      primaryKey: 'id',
       endpoint: (ticket, reply) => `/support/tickets/${ticket}/replies/${reply}`,
       supports: [ONE, MANY, POST],
     },

--- a/src/api/generic/tokens.js
+++ b/src/api/generic/tokens.js
@@ -1,13 +1,14 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  ReducerGenerator, genActions,
   ONE, MANY, DELETE, POST, PUT,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'tokens',
+export const config = {
+  name: 'tokens',
+  primaryKey: 'id',
   endpoint: id => `/profile/tokens/${id}`,
   supports: [ONE, MANY, DELETE, POST, PUT],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/types.js
+++ b/src/api/generic/types.js
@@ -1,13 +1,14 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  ReducerGenerator, genActions,
   ONE, MANY,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'types',
+export const config = {
+  name: 'types',
+  primaryKey: 'id',
   endpoint: id => `/linode/types/${id}`,
   supports: [ONE, MANY],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);

--- a/src/api/generic/users.js
+++ b/src/api/generic/users.js
@@ -1,21 +1,23 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  addParentRefs, ReducerGenerator, genActions,
   ONE, MANY, DELETE, PUT, POST,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'users',
+export const config = addParentRefs({
+  name: 'users',
   primaryKey: 'username',
   endpoint: user => `/account/users/${user}`,
   supports: [ONE, MANY, DELETE, PUT, POST],
   subresources: {
     _permissions: {
-      singular: 'permissions',
+      name: 'permissions',
+      primaryKey: 'id',
       endpoint: user => `/account/users/${user}/grants`,
       supports: [ONE, PUT],
     },
     _password: {
-      singular: 'password',
+      name: 'password',
+      primaryKey: 'id',
       endpoint: user => `/account/users/${user}/password`,
       supports: [POST],
     },

--- a/src/api/generic/volumes.js
+++ b/src/api/generic/volumes.js
@@ -1,13 +1,14 @@
 import {
-  genConfig, ReducerGenerator, genActions,
+  ReducerGenerator, genActions,
   ONE, MANY, POST, PUT, DELETE,
 } from '~/api/internal';
 
-export const config = genConfig({
-  plural: 'volumes',
+export const config = {
+  name: 'volumes',
+  primaryKey: 'id',
   endpoint: id => `/volumes/${id}`,
   supports: [ONE, MANY, POST, PUT, DELETE],
-});
+};
 
 export const actions = genActions(config);
 export const { reducer } = new ReducerGenerator(config);


### PR DESCRIPTION
Currently, the configs for the Redux generators must contain either a property "plural", **or** a property "singular", the value of which is the intended name of the endpoint. This causes two issues in the code that uses these configs.

1. Everywhere that the **name** of the endpoint is needed, we first check the "plural" property and then the "singular" property. Take for example was was previously at line 286 of `external.js`:

```
     if (subresource.plural) {
        thunks[subresource.plural] = apiActionReducerGenerator(subresource,
          actions[subresource.plural]);
      } else if (subresource.singular) {
        thunks[subresource.singular] = apiActionReducerGenerator(subresource,
          actions[subresource.singular]);
     }
```

By introducing a "name" property, we can simplify these instances, for example:

```
      thunks[subresource.name] = apiActionReducerGenerator(subresource,
        actions[subresource.name]);
```

2. The existence of the "plural" property was used as an indicator of whether the endpoint supported multiple pages. For example, what was previously at line 46 of `external.js`

`if (current.singular) {`

The actual intent is to know whether or not the endpoint supports the `MANY` action type, so we now determine that implicitly and use it place of these checks.

```
export function isPlural(config) {
  return config.supports.indexOf(MANY) > -1;
}
```