### PR TITLE
Add tests for the core Redux action creator generator

### DIFF
--- a/src/api/external.js
+++ b/src/api/external.js
@@ -1,6 +1,6 @@
 import { fetch } from './fetch';
 import {
-  ONE, MANY, DELETE, POST, PUT, generateDefaultStateFull,
+  ONE, MANY, DELETE, POST, PUT,
 } from './internal';
 
 

--- a/src/api/external.js
+++ b/src/api/external.js
@@ -1,6 +1,6 @@
 import { fetch } from './fetch';
 import {
-  ONE, MANY, DELETE, POST, PUT,
+  ONE, MANY, DELETE, POST, PUT, generateDefaultStateFull,
 } from './internal';
 
 

--- a/src/api/internal.js
+++ b/src/api/internal.js
@@ -46,23 +46,24 @@ function parseIntIfActualInt(string) {
   return isNaN(string) ? string : parseInt(string);
 }
 
-const actionGenerators = {
-  [ONE]: c => (resource, ...ids) => (dispatch) =>
+const actionCreatorGenerators = {
+  // These functions take a config and return Redux Action Creators
+  [ONE]: config => (resource, ...ids) => (dispatch) =>
     dispatch({
       resource,
       dispatch,
-      type: `GEN@${fullyQualified(c)}/ONE`,
+      type: `GEN@${fullyQualified(config)}/ONE`,
       ids: ids.map(parseIntIfActualInt),
     }),
-  [MANY]: c => (page, ...ids) => (dispatch) =>
+  [MANY]: config => (page, ...ids) => (dispatch) =>
     dispatch({
       page,
       dispatch,
-      type: `GEN@${fullyQualified(c)}/MANY`,
+      type: `GEN@${fullyQualified(config)}/MANY`,
       ids: ids.map(parseIntIfActualInt),
     }),
-  [DELETE]: c => (...ids) =>
-    ({ type: `GEN@${fullyQualified(c)}/DELETE`, ids: ids.map(parseIntIfActualInt) }),
+  [DELETE]: config => (...ids) =>
+    ({ type: `GEN@${fullyQualified(config)}/DELETE`, ids: ids.map(parseIntIfActualInt) }),
 };
 
 /**
@@ -76,8 +77,8 @@ export function genActions(config) {
     [DELETE]: 'delete',
   };
   config.supports.forEach((feature) => {
-    if (typeof actionGenerators[feature] !== 'undefined') {
-      actions[fns[feature]] = actionGenerators[feature](config);
+    if (typeof actionCreatorGenerators[feature] !== 'undefined') {
+      actions[fns[feature]] = actionCreatorGenerators[feature](config);
     }
   });
   if (config.subresources) {

--- a/src/api/internal.spec.js
+++ b/src/api/internal.spec.js
@@ -1,11 +1,51 @@
-import { genActions } from 'internal';
+import { genActions } from './internal';
+
+import sinon from 'sinon';
+
+import { testConfigOne, testConfigMany, testConfigDelete } from '~/data/reduxGen';
+import { resource, page } from '~/data/reduxGen';
 
 describe('internal', () => {
-  it('generates an action to update one resource');
-  const config = {
-    name: 'regions',
-    primaryKey: 'id',
-    endpoint: id => `/regions/${id}`,
-    supports: [ONE, MANY],
-  };
+  const sandbox = sinon.sandbox.create();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('generates an action to update one resource', function () {
+    const dispatch = sandbox.spy();
+
+    const config = testConfigOne;
+
+    const actions = genActions(config);
+    const oneThunk = actions.one(resource, '23');
+    oneThunk(dispatch);
+    expect(dispatch.firstCall.args[0].resource.label).toBe('nodebalancer-1');
+    expect(dispatch.firstCall.args[0].type).toBe('GEN@nodebalancers/ONE');
+    expect(dispatch.firstCall.args[0].ids[0]).toBe(23);
+  });
+
+  it('generates an action to update many resources', function () {
+    const dispatch = sandbox.spy();
+
+    const config = testConfigMany;
+
+    const actions = genActions(config);
+    const manyThunk = actions.many(page);
+    manyThunk(dispatch);
+    expect(dispatch.firstCall.args[0].page.nodebalancers[0].label)
+      .toBe('nodebalancer-1');
+    expect(dispatch.firstCall.args[0].page.nodebalancers[1].label)
+      .toBe('nodebalancer-2');
+    expect(dispatch.firstCall.args[0].type).toBe('GEN@nodebalancers/MANY');
+  });
+
+  it('generates an action to delete a resource', function () {
+    const config = testConfigDelete;
+
+    const actions = genActions(config);
+    const deleteAction = actions.delete('23');
+    expect(deleteAction.ids[0]).toBe(23);
+    expect(deleteAction.type).toBe('GEN@nodebalancers/DELETE');
+  });
 });

--- a/src/api/internal.spec.js
+++ b/src/api/internal.spec.js
@@ -1,0 +1,11 @@
+import { genActions } from 'internal';
+
+describe('internal', () => {
+  it('generates an action to update one resource');
+  const config = {
+    name: 'regions',
+    primaryKey: 'id',
+    endpoint: id => `/regions/${id}`,
+    supports: [ONE, MANY],
+  };
+});

--- a/src/api/internal.spec.js
+++ b/src/api/internal.spec.js
@@ -1,43 +1,36 @@
 import { genActions } from './internal';
 
-import sinon from 'sinon';
-
 import { testConfigOne, testConfigMany, testConfigDelete } from '~/data/reduxGen';
 import { resource, page } from '~/data/reduxGen';
 
 describe('internal', () => {
-  const sandbox = sinon.sandbox.create();
-
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   it('generates an action to update one resource', function () {
-    const dispatch = sandbox.spy();
+    const dispatch = jest.fn();
 
     const config = testConfigOne;
 
     const actions = genActions(config);
     const oneThunk = actions.one(resource, '23');
     oneThunk(dispatch);
-    expect(dispatch.firstCall.args[0].resource.label).toBe('nodebalancer-1');
-    expect(dispatch.firstCall.args[0].type).toBe('GEN@nodebalancers/ONE');
-    expect(dispatch.firstCall.args[0].ids[0]).toBe(23);
+
+    expect(dispatch.mock.calls[0][0].resource.label).toBe('nodebalancer-1');
+    expect(dispatch.mock.calls[0][0].type).toBe('GEN@nodebalancers/ONE');
+    expect(dispatch.mock.calls[0][0].ids[0]).toBe(23);
   });
 
   it('generates an action to update many resources', function () {
-    const dispatch = sandbox.spy();
+    const dispatch = jest.fn();
 
     const config = testConfigMany;
 
     const actions = genActions(config);
     const manyThunk = actions.many(page);
     manyThunk(dispatch);
-    expect(dispatch.firstCall.args[0].page.nodebalancers[0].label)
+    expect(dispatch.mock.calls[0][0].page.nodebalancers[0].label)
       .toBe('nodebalancer-1');
-    expect(dispatch.firstCall.args[0].page.nodebalancers[1].label)
+    expect(dispatch.mock.calls[0][0].page.nodebalancers[1].label)
       .toBe('nodebalancer-2');
-    expect(dispatch.firstCall.args[0].type).toBe('GEN@nodebalancers/MANY');
+    expect(dispatch.mock.calls[0][0].type).toBe('GEN@nodebalancers/MANY');
   });
 
   it('generates an action to delete a resource', function () {

--- a/src/data/reduxGen.js
+++ b/src/data/reduxGen.js
@@ -1,0 +1,33 @@
+import { ONE, MANY, DELETE } from '~/api/internal';
+
+import { configsNodeBalancer, noGroupNodeBalancer } from '~/data/nodebalancers';
+
+export const resource = { ...configsNodeBalancer };
+export const page = {
+  data: [configsNodeBalancer, noGroupNodeBalancer],
+  pages: 1,
+  results: 1,
+  page: 1,
+  nodebalancers: [configsNodeBalancer, noGroupNodeBalancer],
+};
+
+export const testConfigOne = {
+  name: 'nodebalancers',
+  primaryKey: 'id',
+  endpoint: id => `/nodebalancers/${id}`,
+  supports: [ONE],
+};
+
+export const testConfigMany = {
+  name: 'nodebalancers',
+  primaryKey: 'id',
+  endpoint: id => `/nodebalancers/${id}`,
+  supports: [MANY],
+};
+
+export const testConfigDelete = {
+  name: 'nodebalancers',
+  primaryKey: 'id',
+  endpoint: id => `/nodebalancers/${id}`,
+  supports: [DELETE],
+};

--- a/src/data/reduxGen.js
+++ b/src/data/reduxGen.js
@@ -12,21 +12,21 @@ export const page = {
 };
 
 export const testConfigOne = {
-  singular: 'nodebalancers',
+  name: 'nodebalancers',
   primaryKey: 'id',
   endpoint: id => `/nodebalancers/${id}`,
   supports: [ONE],
 };
 
 export const testConfigMany = {
-  plural: 'nodebalancers',
+  name: 'nodebalancers',
   primaryKey: 'id',
   endpoint: id => `/nodebalancers/${id}`,
   supports: [MANY],
 };
 
 export const testConfigDelete = {
-  singular: 'nodebalancers',
+  name: 'nodebalancers',
   primaryKey: 'id',
   endpoint: id => `/nodebalancers/${id}`,
   supports: [DELETE],

--- a/src/data/reduxGen.js
+++ b/src/data/reduxGen.js
@@ -12,21 +12,21 @@ export const page = {
 };
 
 export const testConfigOne = {
-  name: 'nodebalancers',
+  singular: 'nodebalancers',
   primaryKey: 'id',
   endpoint: id => `/nodebalancers/${id}`,
   supports: [ONE],
 };
 
 export const testConfigMany = {
-  name: 'nodebalancers',
+  plural: 'nodebalancers',
   primaryKey: 'id',
   endpoint: id => `/nodebalancers/${id}`,
   supports: [MANY],
 };
 
 export const testConfigDelete = {
-  name: 'nodebalancers',
+  singular: 'nodebalancers',
   primaryKey: 'id',
   endpoint: id => `/nodebalancers/${id}`,
   supports: [DELETE],


### PR DESCRIPTION
This PR adds tests for the core Redux `actionGenerators`, which are actually `actionCreatorGenerators`, and the name has been updated as such.

This object contains three functions, one which creates a thunk for updating a single resource in the store (ONE), one which creates a thunk for updating multiple resources in the store (MANY), and once which deletes resources in the store (DELETE). The ONE and MANY action creators are thunks, only so that they can pass the dispatch function to the reducer, this is in turn so that the reducer can add references to dispatch to _accessor_ functions on the objects in the store. **This is an anti-pattern and will be addressed in a future PR.**