### PR TITLE
Path fixes for the Router 4 upgrade

### DIFF
--- a/src/linodes/linode/backups/layouts/BackupPage.js
+++ b/src/linodes/linode/backups/layouts/BackupPage.js
@@ -36,7 +36,7 @@ BackupPage.propTypes = {
 function mapStateToProps(state, props) {
   const { linode } = selectLinode(state, props);
   const { linodes } = state.api;
-  const backupId = parseInt(props.params.backupId);
+  const backupId = parseInt(props.match.params.backupId);
 
   const backups = linode._backups;
   let backup;

--- a/src/nodebalancers/index.js
+++ b/src/nodebalancers/index.js
@@ -10,8 +10,8 @@ const NodeBalancersIndex = (props) => {
   const { match: { path } } = props;
   return (
     <Switch>
+      <Route component={NodeBalancerConfigAdd} path={`${path}/:nbLabel/configs/create`} />
       <Route component={Configs} path={`${path}/:nbLabel/configs/:configId`} />
-      <Route exact component={NodeBalancerConfigAdd} path={`${path}/:nbLabel/configs/create`} />
       <Route component={NodeBalancerIndex} path={`${path}/:nbLabel`} />
       <Route component={NodeBalancersList} exact path={`${path}/`} />
       <Redirect to="/not-found" />

--- a/src/nodebalancers/nodebalancer/layouts/NodeBalancerConfigAdd.js
+++ b/src/nodebalancers/nodebalancer/layouts/NodeBalancerConfigAdd.js
@@ -46,7 +46,7 @@ NodeBalancerConfigAdd.propTypes = {
 };
 
 function mapStateToProps(state, ownProps) {
-  const params = ownProps.params;
+  const params = ownProps.match.params;
   const nbLabel = params.nbLabel;
 
   const nodebalancer = objectFromMapByLabel(state.api.nodebalancers.nodebalancers, nbLabel);


### PR DESCRIPTION
This fixes two instances in which components attempts to read path data using `.params` instead of `.match.params`, and a Route for nodebalancer configs.