### PR TITLE
Add react-vnc to inclusion list.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": ["stage-0", "react", "es2015"],
-  "compact": true,
+  "compact": "true",
   "plugins": [
     ["transform-runtime",
     {
@@ -20,7 +20,9 @@
       "presets": ["react-hmre"]
     }
   },
-  "ignore": [
-    "**/node_modules/**"
+  "only": [
+    "src/*.+(js|jsx)",
+    "src/**/*.+(js|jsx)",
+    "node_modules/react-vnc-display/lib/VncDisplay.js"
   ]
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -65,9 +65,10 @@ module.exports = {
       },
       {
         test: /\.jsx?/,
-        use: ['babel-loader'],
+        loader: require.resolve('babel-loader'),
         include: [
-          path.join(__dirname, 'src'),
+          path.resolve(__dirname, 'src'),
+          path.resolve(__dirname, 'node_modules/react-vnc-display'),
         ],
       },
       {


### PR DESCRIPTION
## Purpose
Upon testing production building it was found that `react-vnc-display` exports ES6, which conflicts with the Uglifier. I've added the vnc display library to the inclusion list in both babel and Webpack.