### PR TITLE
Vendor bundle removal

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": ["stage-0", "react", "es2015"],
-  "compact": true,
+  "compact": "true",
   "plugins": [
     ["transform-runtime",
     {
@@ -20,7 +20,9 @@
       "presets": ["react-hmre"]
     }
   },
-  "ignore": [
-    "**/node_modules/**"
+  "only": [
+    "src/*.+(js|jsx)",
+    "src/**/*.+(js|jsx)",
+    "node_modules/react-vnc-display/lib/VncDisplay.js"
   ]
 }

--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
     </noscript>
     <div id="root" class="full-height"></div>
     <div id="emergency-modal"></div>
-    <script src="/static/vendor.js"></script>
     <script async src="/assets/zxcvbn.js"></script>
     <script async src="/static/main.js"></script>
   </body>

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -22,10 +22,6 @@ module.exports = {
     publicPath: '/static/',
   },
   plugins: [
-    new webpack.optimize.CommonsChunkPlugin({
-      name: 'vendor',
-      minChunks: ({ resource }) => /node_modules/.test(resource),
-    }),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
     new webpack.DefinePlugin({

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -65,9 +65,10 @@ module.exports = {
       },
       {
         test: /\.jsx?/,
-        use: ['babel-loader'],
+        loader: require.resolve('babel-loader'),
         include: [
-          path.join(__dirname, 'src'),
+          path.resolve(__dirname, 'src'),
+          path.resolve(__dirname, 'node_modules/react-vnc-display'),
         ],
       },
       {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -5,10 +5,6 @@ const _package = require('./package.json');
 
 _.entry = './src/index';
 _.plugins = [
-  new webpack.optimize.CommonsChunkPlugin({
-    name: 'vendor',
-    minChunks: ({ resource }) => /node_modules/.test(resource),
-  }),
   new webpack.DefinePlugin({
     'process.env': {
       NODE_ENV: JSON.stringify('production'),


### PR DESCRIPTION
## Purpose
While calculating bundle sizes for review it was found that vendor bundle was duplicating and subsequently bloating the bundle sizes (significantly).

Loading `/linodes`
- 0.js - 176kb (gz)
- main.js - 286kb (gz)

![image](https://user-images.githubusercontent.com/12218651/35239197-ceb1f7b2-ff7d-11e7-9486-26a6018c1a0a.png)
