### PR TITLE
Use separate `/account` and `account/settings` endpoints

### DIFF
--- a/src/api/generic/accountsettings.js
+++ b/src/api/generic/accountsettings.js
@@ -3,9 +3,9 @@ import {
 } from '~/api/internal';
 
 export const config = {
-  name: 'account',
+  name: 'accountsettings',
   primaryKey: 'id',
-  endpoint: () => '/account',
+  endpoint: () => '/account/settings',
   supports: [ONE, PUT],
 };
 

--- a/src/api/generic/index.js
+++ b/src/api/generic/index.js
@@ -1,8 +1,8 @@
 // Add file names to this list for their actions and reducers to be exported.
 const generics = [
   'images', 'regions', 'types', 'linodes', 'volumes', 'stackscripts', 'kernels', 'domains',
-  'nodebalancers', 'profile', 'account', 'events', 'tokens', 'clients', 'users', 'tickets', 'apps',
-  'invoices', 'payments', 'banners',
+  'nodebalancers', 'profile', 'account', 'accountsettings', 'events', 'tokens', 'clients',
+  'users', 'tickets', 'apps', 'invoices', 'payments', 'banners',
 ];
 
 // eslint-disable-next-line global-require

--- a/src/billing/layouts/ContactPage.spec.js
+++ b/src/billing/layouts/ContactPage.spec.js
@@ -50,7 +50,7 @@ describe('billing/layouts/ContactPage', () => {
     await page.find('Form').props().onSubmit();
     expect(dispatch.callCount).toEqual(2);
     await expectDispatchOrStoreErrors(dispatch.secondCall.args[0], [
-      ([fn]) => expectRequest(fn, '/account/settings', {
+      ([fn]) => expectRequest(fn, '/account', {
         method: 'PUT',
         body: {
           email: 'new@gmail.com',

--- a/src/profile/index.js
+++ b/src/profile/index.js
@@ -40,7 +40,7 @@ export class IndexPage extends Component {
         to: `${url}/authentication`,
         selected: matched(`${url}/authentication`),
       },
-      { name: 'API Tokens', to: `${url}/tokens`, selected: matched(`${url}/token`) },
+      { name: 'API Tokens', to: `${url}/tokens`, selected: matched(`${url}/tokens`) },
       { name: 'My API Clients', to: `${url}/clients`, selected: matched(`${url}/clients`) },
       {
         name: 'Notifications',
@@ -48,7 +48,7 @@ export class IndexPage extends Component {
         selected: matched(`${url}/notifications`),
       },
       { name: 'Referrals', to: `${url}/referrals`, selected: matched(`${url}/referrals`) },
-      { name: 'Lish', to: `${url}/lish`, selected: matched(`${url}/list`) },
+      { name: 'Lish', to: `${url}/lish`, selected: matched(`${url}/lish`) },
     ];
 
     return (

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -24,7 +24,7 @@ export class SettingsIndex extends Component {
     super(props);
 
     this.state = {
-      networkHelper: props.account.network_helper ? 'ON' : 'OFF',
+      networkHelper: props.accountsettings.network_helper ? 'ON' : 'OFF',
       errors: {},
     };
 
@@ -41,7 +41,7 @@ export class SettingsIndex extends Component {
     const { networkHelper } = this.state;
 
     return dispatch(dispatchOrStoreErrors.call(this, [
-      () => api.account.put({ network_helper: networkHelper === 'ON' }),
+      () => api.accountsettings.put({ network_helper: networkHelper === 'ON' }),
     ]));
   }
 
@@ -105,18 +105,18 @@ export class SettingsIndex extends Component {
 
 SettingsIndex.propTypes = {
   dispatch: PropTypes.func.isRequired,
-  account: PropTypes.object.isRequired,
+  accountsettings: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = (state) => {
   return {
-    account: state.api.account,
+    accountsettings: state.api.accountsettings,
   };
 };
 
 const preloadRequest = async (dispatch, props) => {
-  if (!Object.keys(props.account).length) {
-    await dispatch(api.account.one());
+  if (!Object.keys(props.accountsettings).length) {
+    await dispatch(api.accountsettings.one());
   }
 };
 


### PR DESCRIPTION
This fixes a breaking change in API v50.0

https://github.com/linode/linode-api-docs/pull/44