### PR TITLE
MAN2-2959 Fix authentication error/refresh.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -130,6 +130,7 @@ try {
             <Switch>
               <Route exact path="/linodes/:linodeLabel/glish" component={Glish} />
               <Route exact path="/linodes/:linodeLabel/weblish" component={Weblish} />
+              <Route exact path="/oauth/callback" component={OAuthComponent} />
               <Route
                 render={() => (
                   <Fragment>
@@ -158,7 +159,6 @@ try {
                           <Route path="/users" component={Users} />
                           <Route exact path="/" render={() => (<Redirect to="/linodes" />)} />
                           <Route exact path="/logout" component={Logout} />
-                          <Route exact path="/oauth/callback" component={OAuthComponent} />
                           <Route component={NotFound} />
                         </Switch>
                       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,7 @@ try {
               <Route exact path="/linodes/:linodeLabel/glish" component={Glish} />
               <Route exact path="/linodes/:linodeLabel/weblish" component={Weblish} />
               <Route exact path="/oauth/callback" component={OAuthComponent} />
+              <Route exact path="/logout" component={Logout} />
               <Route
                 render={() => (
                   <Fragment>
@@ -158,7 +159,6 @@ try {
                           <Route path="/settings" component={Settings} />
                           <Route path="/users" component={Users} />
                           <Route exact path="/" render={() => (<Redirect to="/linodes" />)} />
-                          <Route exact path="/logout" component={Logout} />
                           <Route component={NotFound} />
                         </Switch>
                       </div>


### PR DESCRIPTION
## Upon authentication the manager would show errors in the console (401 requests) and reload, eventually successfully authenticating.

This was a result of the profile and events getting 401 requests due to a race condition with the token authentication. Moving the oauth route outside of the rendered layout prevents events and profile from being called before the oauth route was mounted.