### PR TITLE
Implement redirect after login and refactor session.js

### DIFF
--- a/src/components/AuthenticationWrapper.js
+++ b/src/components/AuthenticationWrapper.js
@@ -6,21 +6,22 @@ import { compose } from 'redux';
 import { v4 } from 'uuid';
 import { stringify } from 'querystring';
 import { APP_ROOT, LOGIN_ROOT } from '~/constants';
+import { setStorage } from '~/storage';
 import { clientId } from '~/secrets';
 
-const createOAuth = (path, clientId, scope = '*', responseType, redirectUri) => {
+const createOAuth = (path, clientId, scope = '*', responseType, redirectUri, nonce) => {
   const query = {
     client_id: clientId,
     scope,
     response_type: responseType,
     redirect_uri: redirectUri,
-    ...(responseType === 'token') && { state: v4() },
+    ...(responseType === 'token') && { state: nonce },
   };
 
   return `${path}?${stringify(query)}`;
 };
 
-class AuthenticationWrapper extends Component {
+export class AuthenticationWrapper extends Component {
   constructor(props) {
     super(props);
 
@@ -38,6 +39,13 @@ class AuthenticationWrapper extends Component {
     }
 
     if (!isAuthenticated) {
+      return redirectToLogin();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { isAuthenticated, location: { pathname }, redirectToLogin } = nextProps;
+    if (!isAuthenticated && !this.isExcludedRoute(pathname)) {
       return redirectToLogin();
     }
   }
@@ -74,13 +82,16 @@ const mapDispatchToProps = (state, ownProps) => ({
   redirectToLogin() {
     const { location: { pathname, search } } = ownProps;
     const returnURL = `${pathname}${search && `%3F${search}`}`;
+    const nonce = v4();
+    setStorage('authentication/nonce', nonce);
 
     window.location = createOAuth(
       `${LOGIN_ROOT}/oauth/authorize`,
       clientId,
       '*',
       'code',
-      `${APP_ROOT}/oauth/callback?${returnURL}`
+      `${APP_ROOT}/oauth/callback?returnTo=${returnURL}`,
+      nonce
     );
   },
 });

--- a/src/components/AuthenticationWrapper.spec.js
+++ b/src/components/AuthenticationWrapper.spec.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { StaticRouter } from 'react-router-dom';
+
+import { AuthenticationWrapper } from '~/components/AuthenticationWrapper';
+
+describe('AuthenticationWrapper', () => {
+  it('redirects when logged out and hitting /linodes', () => {
+    const mockRedirect = jest.fn();
+    const location = {
+      pathname: '/linodes',
+    };
+    const mockHistory = {
+      push: jest.fn(),
+    };
+
+    mount(
+      <StaticRouter>
+        <AuthenticationWrapper
+          isAuthenticated={false}
+          redirectToLogin={mockRedirect}
+          location={location}
+          history={mockHistory}
+        />
+      </StaticRouter>
+    );
+
+    expect(expect(mockRedirect.mock.calls.length).toBe(1));
+  });
+
+  it('doesn\'t redirect when logged out and hitting /oauth/callback', () => {
+    const mockRedirect = jest.fn();
+    const location = {
+      pathname: '/oauth/callback?returnTo=/linodes?code=123456',
+    };
+    const mockHistory = {
+      push: jest.fn(),
+    };
+
+    mount(
+      <StaticRouter>
+        <AuthenticationWrapper
+          isAuthenticated={false}
+          redirectToLogin={mockRedirect}
+          location={location}
+          history={mockHistory}
+        >
+          Hello
+        </AuthenticationWrapper>
+      </StaticRouter>
+    );
+
+    expect(expect(mockRedirect.mock.calls.length).toBe(0));
+  });
+});

--- a/src/components/AuthenticationWrapper.spec.js
+++ b/src/components/AuthenticationWrapper.spec.js
@@ -52,4 +52,29 @@ describe('AuthenticationWrapper', () => {
 
     expect(expect(mockRedirect.mock.calls.length).toBe(0));
   });
+
+  it('doesn\'t redirect when authenticated', () => {
+    const mockRedirect = jest.fn();
+    const location = {
+      pathname: '/linodes',
+    };
+    const mockHistory = {
+      push: jest.fn(),
+    };
+
+    mount(
+      <StaticRouter>
+        <AuthenticationWrapper
+          isAuthenticated
+          redirectToLogin={mockRedirect}
+          location={location}
+          history={mockHistory}
+        >
+          Hello
+        </AuthenticationWrapper>
+      </StaticRouter>
+    );
+
+    expect(expect(mockRedirect.mock.calls.length).toBe(0));
+  });
 });

--- a/src/components/AuthenticationWrapper.spec.js
+++ b/src/components/AuthenticationWrapper.spec.js
@@ -5,14 +5,15 @@ import { StaticRouter } from 'react-router-dom';
 import { AuthenticationWrapper } from '~/components/AuthenticationWrapper';
 
 describe('AuthenticationWrapper', () => {
+  const mockRedirect = jest.fn();
+  const mockHistory = { push: jest.fn() };
+
+  beforeEach(() => {
+    mockRedirect.mockClear();
+  });
+
   it('redirects when logged out and hitting /linodes', () => {
-    const mockRedirect = jest.fn();
-    const location = {
-      pathname: '/linodes',
-    };
-    const mockHistory = {
-      push: jest.fn(),
-    };
+    const location = { pathname: '/linodes' };
 
     mount(
       <StaticRouter>
@@ -29,13 +30,7 @@ describe('AuthenticationWrapper', () => {
   });
 
   it('doesn\'t redirect when logged out and hitting /oauth/callback', () => {
-    const mockRedirect = jest.fn();
-    const location = {
-      pathname: '/oauth/callback?returnTo=/linodes?code=123456',
-    };
-    const mockHistory = {
-      push: jest.fn(),
-    };
+    const location = { pathname: '/oauth/callback?returnTo=/linodes?code=123456' };
 
     mount(
       <StaticRouter>
@@ -54,13 +49,7 @@ describe('AuthenticationWrapper', () => {
   });
 
   it('doesn\'t redirect when authenticated', () => {
-    const mockRedirect = jest.fn();
-    const location = {
-      pathname: '/linodes',
-    };
-    const mockHistory = {
-      push: jest.fn(),
-    };
+    const location = { pathname: '/linodes' };
 
     mount(
       <StaticRouter>

--- a/src/components/Logout.js
+++ b/src/components/Logout.js
@@ -17,8 +17,7 @@ export class Logout extends Component {
     // Reset state
     dispatch(logout());
 
-    // Called this way allows us to stub it out.
-    session.redirect(`${LOGIN_ROOT}/logout`);
+    window.location = `${LOGIN_ROOT}/logout`;
   }
 
   render() {

--- a/src/components/Logout.spec.js
+++ b/src/components/Logout.spec.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { LOGIN_ROOT } from '~/constants';
 import { Logout } from './Logout';
 import { logout } from '~/actions/authentication';
-import { expire, redirect } from '~/session';
+import { expire } from '~/session';
 
 jest.mock('../session.js');
 jest.mock('../actions/authentication');
@@ -21,13 +20,5 @@ describe('layouts/Logout', () => {
     await component.instance().componentDidMount();
     expect(dispatch).toBeCalledWith(expire);
     expect(dispatch).toBeCalledWith(logout());
-  });
-
-  /**
-   * @todo This seems like a waste of a test.
-   */
-  it('redirects to login\'s logout', async () => {
-    await component.instance().componentDidMount();
-    expect(redirect).toBeCalledWith(`${LOGIN_ROOT}/logout`);
   });
 });

--- a/src/handleError.js
+++ b/src/handleError.js
@@ -5,7 +5,6 @@ import InternalError from 'linode-components/dist/errors/InternalError';
 import ModalShell from 'linode-components/dist/modals/ModalShell';
 import { store } from './store';
 import { setError } from '~/actions/errors';
-import * as session from '~/session';
 
 export default (history) => (e) => {
   Raven.captureException(e);
@@ -20,7 +19,7 @@ export default (history) => (e) => {
     const errorPagePathname = window.location.pathname;
     history.listen(function (location) {
       if (location.pathname !== errorPagePathname) {
-        session.redirect(location.pathname);
+        window.location = location.pathname;
       }
     });
 
@@ -34,7 +33,7 @@ export default (history) => (e) => {
           {/* Yes, we could use window.reload() but we've already got this utility function that
           * can be stubbed out. */}
           <InternalError
-            returnHome={() => session.redirect(window.location.pathname)}
+            returnHome={() => { window.location = window.location.pathname; }}
           />
         </ModalShell>,
         document.getElementById('emergency-modal')

--- a/src/layouts/OAuth.js
+++ b/src/layouts/OAuth.js
@@ -53,7 +53,7 @@ export class OAuthCallbackPage extends Component {
       data.append('client_id', clientId);
       data.append('client_secret', clientSecret);
       data.append('code', code);
-      returnTo = location.query['return'];
+      returnTo = location.query.returnTo;
 
       // Exchange temporary code for access token.
       let resp;

--- a/src/layouts/OAuth.spec.js
+++ b/src/layouts/OAuth.spec.js
@@ -78,7 +78,7 @@ describe('layouts/OAuth', () => {
         location={{
           query: {
             code: 'code',
-            return: '/asdf',
+            returnTo: '/asdf',
           },
         }}
       />);

--- a/src/request.js
+++ b/src/request.js
@@ -1,7 +1,7 @@
 import { resetEventsPoll } from '~/actions/events';
 import { API_ROOT } from '~/constants';
 import LinodeAPI from '~/LinodeAPI';
-import * as session from '~/session';
+import { expire } from '~/session';
 import { store } from '~/store';
 
 const request = new LinodeAPI(API_ROOT);
@@ -26,7 +26,7 @@ Also rejects non-error responses if the API is in Maintainence mode
 request.interceptors.response.use(
   (response) => {
     if (!!response.headers['x-maintenance-mode']) {
-      store.dispatch(session.expireAndReAuth);
+      store.dispatch(expire);
       Promise.reject(response);
     }
 
@@ -35,7 +35,7 @@ request.interceptors.response.use(
   (error) => {
     if (!!error.config.headers['x-maintenance-mode']
         || error.response.status === 401) {
-      store.dispatch(session.expireAndReAuth);
+      store.dispatch(expire);
     }
     return Promise.reject(error);
   }

--- a/src/session.js
+++ b/src/session.js
@@ -1,60 +1,9 @@
 import { setToken } from '~/actions/authentication';
-import { APP_ROOT, LOGIN_ROOT } from '~/constants';
-import { clientId } from '~/secrets';
 import { getStorage, setStorage } from '~/storage';
-import { store } from '~/store';
 const AUTH_TOKEN = 'authentication/oauth-token';
 const AUTH_SCOPES = 'authentication/scopes';
 const AUTH_EXPIRES = 'authentication/expires';
 
-export function redirect(location) {
-  window.location = location;
-}
-
-// Source: https://gist.github.com/jed/982883
-function uuid4(a) {
-  return a ? (
-    a ^ Math.random() * 16 >> a / 4
-  ).toString(16) : (
-    [1e7] + -1e3 + -4e3 + -8e3 + -1e11
-  ).replace(/[018]/g, uuid4);
-}
-
-export function loginAuthorizePath(returnTo) {
-  const nonce = uuid4();
-  const responseType = 'code'; // TODO: response_type should be 'token' for implicit grant flow
-  setStorage('authentication/nonce', nonce);
-  /* eslint-disable prefer-template */
-  return `${LOGIN_ROOT}/oauth/authorize?` +
-         `client_id=${clientId}` +
-         '&scope=*' +
-         `&response_type=${responseType}` +
-         (responseType === 'token' ? `&state=${nonce}` : '') +
-         `&redirect_uri=${encodeURIComponent(APP_ROOT)}/oauth/callback?${returnTo}`;
-  /* eslint-enable prefer-template */
-}
-
-export function checkLogin(next) {
-  const state = store.getState();
-  if (next.location.pathname !== '/oauth/callback'
-      && next.location.pathname !== '/logout'
-      && state.authentication.token === null) {
-    const query = Object.keys(next.location.query || {})
-      .reduce((a, k) => [
-        ...a,
-        `${k}=${encodeURIComponent(next.location.query[k])}`,
-      ], []).join('%26');
-
-    // During testing we'll need to be able to replace this.
-    const { redirect } = module.exports;
-    const redirectTo = loginAuthorizePath(
-      encodeURIComponent(`${next.location.pathname}${query ? `%3F${query}` : ''}`));
-    redirect(redirectTo);
-    return redirectTo;
-  }
-
-  return null;
-}
 
 export function expire(dispatch) {
   // Remove these from local storage so if login fails, next time we jump to login sooner.
@@ -62,11 +11,6 @@ export function expire(dispatch) {
   setStorage(AUTH_SCOPES, '');
   setStorage(AUTH_EXPIRES, '');
   dispatch(setToken(null, null));
-}
-
-export function expireAndReAuth(dispatch) {
-  dispatch(expire);
-  checkLogin(window);
 }
 
 export function start(oauthToken = '', scopes = '', expires) {

--- a/src/session.spec.js
+++ b/src/session.spec.js
@@ -1,6 +1,5 @@
 import sinon from 'sinon';
 
-import { store } from '~/store';
 import * as session from '~/session';
 import * as storage from '~/storage';
 
@@ -12,39 +11,8 @@ describe('session', () => {
     sandbox.restore();
   });
 
-  it('allows the request when logged out and hitting /oauth/callback', () => {
-    const redirectStub = sandbox.stub(session, 'redirect');
-    sandbox.stub(store, 'getState').callsFake(() =>
-      ({ authentication: { token: null } }));
-
-    session.checkLogin({ location: { pathname: '/oauth/callback' } });
-
-    expect(redirectStub.callCount).toBe(0);
-  });
-
-  it('allows the request when the oauth token is not null', () => {
-    const redirectStub = sandbox.stub(session, 'redirect');
-    sandbox.stub(store, 'getState').callsFake(() => ({ authentication: { token: 'not null' } }));
-
-    session.checkLogin({ location: { pathname: '/' } });
-
-    expect(redirectStub.callCount).toBe(0);
-  });
-
-  it('redirects to login when the oauth token is null', () => {
-    const redirectStub = sandbox.stub(session, 'redirect');
-    sandbox.stub(store, 'getState').callsFake(() => ({ authentication: { token: null } }));
-
-    session.checkLogin({ location: { pathname: '/linodes', query: { foo: 'bar' } } });
-
-    expect(redirectStub.callCount).toBe(1);
-    expect(redirectStub.args[0][0]).toBe(
-      session.loginAuthorizePath('%2Flinodes%253Ffoo%3Dbar'));
-  });
-
   it('removes localstorage endpoint on expire', () => {
     const setStorage = sandbox.stub(storage, 'setStorage');
-    sandbox.stub(session, 'redirect');
     const dispatch = sandbox.stub();
 
     session.expire(dispatch);
@@ -61,6 +29,7 @@ describe('session', () => {
       expect(setStorage.args[i][1]).toBe('');
     });
   });
+
   /**
    * @todo skipped
    * Not providing value.


### PR DESCRIPTION
## Purpose

- Implement redirect to prior page after login

## How to test

1. Log out
1. Hit localhost:3000/domains manually
1. After logging-in note that your are redirected to `/domains`

## Boy Scouting

- Removed duplicate `/authorize` logic in session.js and AuthenticationWrapper.js
- Implemented test logic previously for session.js as tests for AuthenticationWrapper.js 