### PR TITLE
Add support for implict OAuth flow, remove support for code grant

### DIFF
--- a/src/components/AuthenticationWrapper.js
+++ b/src/components/AuthenticationWrapper.js
@@ -89,7 +89,7 @@ const mapDispatchToProps = (state, ownProps) => ({
       `${LOGIN_ROOT}/oauth/authorize`,
       clientId,
       '*',
-      'code',
+      'token',
       `${APP_ROOT}/oauth/callback?returnTo=${returnURL}`,
       nonce
     );

--- a/src/layouts/OAuth.js
+++ b/src/layouts/OAuth.js
@@ -87,10 +87,9 @@ const mapDispatchToProps = (dispatch) => ({
     // nonce should be set and equal to ours otherwise retry auth
     const storedNonce = getStorage('authentication/nonce');
     if (!(nonce && storedNonce === nonce)) {
+      setStorage('authentication/nonce', '');
       dispatch(push('/'));
-      return;
     }
-    setStorage('authentication/nonce', '');
   },
   redirect(path) {
     dispatch(push(path));

--- a/src/layouts/OAuth.js
+++ b/src/layouts/OAuth.js
@@ -4,115 +4,106 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { push } from 'react-router-redux';
+import isEmpty from 'lodash/isEmpty';
 
 import parseQuery from '~/decorators/parseQuery';
-import { LOGIN_ROOT, ENVIRONMENT } from '~/constants';
-import { rawFetch } from '~/fetch';
-import { clientId, clientSecret } from '~/secrets';
 import * as session from '~/session';
 import { getStorage, setStorage } from '~/storage';
 
-function getImplicitParams() {
-  const hashParams = window.location.hash.substr(1).split('&');
-  const params = {};
-  hashParams.forEach(function (hashParam) {
-    const hashParamParts = hashParam.split('=');
-    if (hashParamParts[0] === 'return') {
-      // In src/session.js we send /oauth/callback?{returnTo} as the redirect URI. The oauth
-      // server, login, will return to this URI verbatim. The part we need (for internal use)
-      // is the {returnTo} bit that tells us where in the app to go once we've been authenticated.
-      params.returnTo = hashParam.split('?')[1];
-    } else {
-      params[hashParamParts[0]] = hashParamParts[1];
-    }
-  });
-  return params;
+/**
+ * Splits a string into at most two parts using a separator character.
+ *
+ * @param {string} str The string to split
+ * @param {string} sep The separator character to use
+ * @returns {Array<string>} An array of length 2, which are the two separated parts of str
+ */
+export function splitIntoTwo(str, sep) {
+  const idx = str.indexOf(sep);
+  if (idx === -1 || idx === (str.length - 1)) {
+    throw new Error(`"${str}" cannot be split into two parts by ${sep}`);
+  }
+  return [str.substr(0, idx), str.substr(idx + 1)];
+}
+
+/**
+ * Parses a string of key/value paris separated by '&', with the key and value separated by '='
+ *
+ * @param {string} str The string to parse
+ * @returns {Object} An object of the parsed key/value pairs
+ */
+export function parseQueryParams(str) {
+  return str
+    .split('&')
+    .reduce((acc, keyVal) => {
+      if (isEmpty(keyVal)) { return { ...acc }; }
+      const [key, value] = splitIntoTwo(keyVal, '=');
+      return { ...acc, [key]: value };
+    }, {});
 }
 
 export class OAuthCallbackPage extends Component {
   async componentDidMount() {
-    const { dispatch, location } = this.props;
-    const { error, code } = location.query;
-    if (error) {
-      // These errors only happen while developing or setting up the app.
-      /* eslint-disable no-console */
-      console.log('Error during OAuth callback:');
-      console.error(error);
-      /* eslint-enable no-console */
-      return;
+    const { location, redirect, checkNonce, startSession } = this.props;
+    if (!location.hash || location.hash.length < 2) {
+      return redirect('/');
     }
 
-    let accessToken;
-    let scopes;
-    let expiresIn;
-    let returnTo;
-    const implicitParams = getImplicitParams();
-
-    if (code) {
-      const data = new FormData();
-      data.append('client_id', clientId);
-      data.append('client_secret', clientSecret);
-      data.append('code', code);
-      returnTo = location.query.returnTo;
-
-      // Exchange temporary code for access token.
-      let resp;
-      try {
-        resp = await rawFetch(`${LOGIN_ROOT}/oauth/token`, {
-          method: 'POST',
-          body: data,
-          mode: 'cors',
-        });
-      } catch (e) {
-        const message = `Failed to exchange temporary code for access token: ${e}`;
-        if (ENVIRONMENT === 'development') {
-          /* eslint-disable no-alert */
-          alert(message);
-          /* eslint-enable no-alert */
-        } else {
-          /* eslint-disable no-console */
-          console.log(message);
-          /* eslint-enable no-console */
-        }
-      }
-
-      ({ access_token: accessToken, scope: scopes, expires_in: expiresIn } = await resp.json());
-    } else if (implicitParams.access_token) {
-      ({
-        access_token: accessToken,
-        scope: scopes,
-        expires_in: expiresIn,
-        returnTo,
-      } = implicitParams);
-      const { state: nonce } = implicitParams;
-      const storedNonce = getStorage('authentication/nonce');
-      // nonce should be set and equal otherwise redirect
-      if (!(nonce && storedNonce === nonce)) {
-        // Retry auth flow
-        dispatch(push('/'));
-        return;
-      }
-      setStorage('authentication/nonce', '');
-    } else {
-      dispatch(push('/'));
-      return;
+    const hashParams = parseQueryParams(location.hash.substr(1));
+    const {
+      access_token: accessToken,
+      scope: scopes,
+      expires_in: expiresIn,
+      state: nonce,
+    } = hashParams;
+    if (!accessToken) {
+      return redirect('/');
     }
+
+    let returnTo = '/';
+    if (hashParams['return']
+        && hashParams['return'].indexOf('?') > -1) {
+      returnTo = parseQueryParams(hashParams['return'].split('?')[1]).returnTo;
+    }
+
+    checkNonce(nonce);
 
     const expireDate = new Date();
-    expireDate.setSeconds(expireDate.getSeconds() + expiresIn);
-    // Token needs to be in redux state for all API calls
-    dispatch(session.start(accessToken, scopes, expireDate));
+    expireDate.setTime(expireDate.getTime() + ((+expiresIn) * 1000));
 
-    // Done OAuth flow. Let the app begin.
-    dispatch(push(returnTo || '/'));
+    // begin our authenticated session
+    startSession(accessToken, scopes, expireDate);
+
+    // redirect to prior page
+    redirect(returnTo);
   }
+
   render() {
     return null;
   }
 }
 
+const mapDispatchToProps = (dispatch) => ({
+  checkNonce(nonce) {
+    // nonce should be set and equal to ours otherwise retry auth
+    const storedNonce = getStorage('authentication/nonce');
+    if (!(nonce && storedNonce === nonce)) {
+      dispatch(push('/'));
+      return;
+    }
+    setStorage('authentication/nonce', '');
+  },
+  redirect(path) {
+    dispatch(push(path));
+  },
+  startSession(accessToken, scopes, expireDate) {
+    dispatch(session.start(accessToken, scopes, expireDate));
+  },
+});
+
 OAuthCallbackPage.propTypes = {
-  dispatch: PropTypes.func.isRequired,
+  redirect: PropTypes.func.isRequired,
+  checkNonce: PropTypes.func.isRequired,
+  startSession: PropTypes.func.isRequired,
   location: PropTypes.shape({
     hash: PropTypes.any,
     query: PropTypes.object,
@@ -120,7 +111,7 @@ OAuthCallbackPage.propTypes = {
 };
 
 export default compose(
-  connect(),
+  connect(undefined, mapDispatchToProps),
   withRouter,
   parseQuery,
 )(OAuthCallbackPage);

--- a/src/layouts/OAuth.spec.js
+++ b/src/layouts/OAuth.spec.js
@@ -1,11 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { push } from 'react-router-redux';
+import isEmpty from 'lodash/isEmpty';
 
-import { LOGIN_ROOT } from '~/constants';
-import { OAuthCallbackPage } from '~/layouts/OAuth';
-import { rawFetch } from '~/fetch';
-import { start } from '~/session';
+import { splitIntoTwo, parseQueryParams, OAuthCallbackPage } from '~/layouts/OAuth';
 
 jest.mock('../fetch');
 
@@ -31,58 +28,87 @@ describe('layouts/OAuth', () => {
   });
 
   it('redirects to / when no code is provided', async () => {
-    const component = shallow(
-      <OAuthCallbackPage dispatch={dispatch} location={{ query: {} }} />
-    );
+    const redirectMock = jest.fn();
 
-    await component.instance().componentDidMount();
-    expect(dispatch).toBeCalledWith(push('/'));
-  });
-
-  it('exchanges the code for an OAuth token', async () => {
     const component = shallow(
       <OAuthCallbackPage
-        dispatch={() => ({ timezone: '' })}
-        location={{ query: { code: 'code' } }}
+        redirect={redirectMock}
+        location={{ hash: '#' }}
       />
     );
-    await component.instance().componentDidMount();
 
-    expect(rawFetch.mock.calls[0][0]).toBe(`${LOGIN_ROOT}/oauth/token`);
+    await component.instance().componentDidMount();
+    expect(redirectMock).toBeCalledWith('/');
   });
 
   it('dispatches a setToken action', async () => {
-    const dispatch = jest.fn(() => ({ timezone: '' }));
+    const startMock = jest.fn();
 
     const component = shallow(
       <OAuthCallbackPage
         dispatch={dispatch}
         location={{
-          query: {
-            code: 'code',
-          },
+          hash: '#access_token=123456',
         }}
+        startSession={startMock}
+        checkNonce={() => null}
+        redirect={() => null}
       />);
 
-
     await component.instance().componentDidMount();
-    expect(start).toBeCalled();
+    expect(startMock).toBeCalled();
   });
 
   it('supports the return query string option', async () => {
-    const dispatch = jest.fn(() => ({ timezone: '' }));
+    const redirectMock = jest.fn();
 
     const component = shallow(
       <OAuthCallbackPage
         dispatch={dispatch}
         location={{
-          query: {
-            code: 'code',
-            returnTo: '/asdf',
-          },
+          hash: '#access_token=123456&return=https://localhost:3000/oauth/callback?returnTo=/asdf',
         }}
+        startSession={() => null}
+        checkNonce={() => null}
+        redirect={redirectMock}
       />);
+
     await component.instance().componentDidMount();
-    expect(push).toBeCalledWith('/asdf');
+    expect(redirectMock).toBeCalledWith('/asdf');
+  });
+
+  describe('splitIntoTwo', () => {
+    it('splits a string into two parts', () => {
+      const res = splitIntoTwo('split&this', '&');
+      expect(res[0]).toBe('split');
+      expect(res[1]).toBe('this');
+    });
+
+    it('raises an error if the string can\'t be split', () => {
+      expect(() => {
+        splitIntoTwo('split&this', '%');
+      }).toThrow();
+    });
+  });
+
+  describe('parseQueryParams', () => {
+    it('parses query params of the expected format', () => {
+      const res = parseQueryParams('entity=key&color=bronze&weight=20%20grams');
+      expect(res.entity).toBe('key');
+      expect(res.color).toBe('bronze');
+      expect(res.weight).toBe('20%20grams');
+    });
+
+    it('returns an empty object for an empty string', () => {
+      const res = parseQueryParams('');
+      expect(isEmpty(res)).toBe(true);
+    });
+
+    it('doesn\'t truncate values that include =', () => {
+      const res = parseQueryParams(
+        'access_token=123456&return=https://localhost:3000/oauth/callback?returnTo=/asdf');
+      expect(res.access_token).toBe('123456');
+      expect(res.return).toBe('https://localhost:3000/oauth/callback?returnTo=/asdf');
+    });
   });
 });


### PR DESCRIPTION
## Purpose

-  This implements support for the implicit OAuth flow, with a nearly complete rewrite of OAuth.js

## How to test

- Set a breakpoint in OAuth.js
- Log out
- Log back in
- Note that the OAuth parameters are coming back in the URL hash, and that no token is requested using a the code grant flow