### PR TITLE
Build updates

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -1,0 +1,9 @@
+const path = require('path');
+const fs = require('fs');
+
+const appDirectory = fs.realpathSync(process.cwd());
+const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
+
+module.exports = {
+  appHtml: resolveApp('src/index.html'),
+};

--- a/config/webpack.parts.js
+++ b/config/webpack.parts.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const p = require('../package');
 
 const asyncChunkByModuleName = (moduleName) => new webpack.optimize.CommonsChunkPlugin({
   async: true,
@@ -9,7 +10,22 @@ const asyncChunkByModuleName = (moduleName) => new webpack.optimize.CommonsChunk
 
 const ignoreMomentLocales = new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/);
 
+const envVariables = (environment) => new webpack.DefinePlugin({
+  'process.env': {
+    NODE_ENV: JSON.stringify(environment),
+  },
+  ENV_DEVTOOLS_DISABLED: JSON.stringify(process.env.DEVTOOLS_DISBLED),
+  ENV_APP_ROOT: JSON.stringify(process.env.APP_ROOT),
+  ENV_API_ROOT: JSON.stringify(process.env.API_ROOT),
+  ENV_LOGIN_ROOT: JSON.stringify(process.env.LOGIN_ROOT),
+  ENV_LISH_ROOT: JSON.stringify(process.env.LISH_ROOT),
+  ENV_GA_ID: JSON.stringify(process.env.GA_ID),
+  ENV_SENTRY_URL: JSON.stringify(process.env.SENTRY_URL),
+  ENV_VERSION: JSON.stringify(p.version),
+});
+
 module.exports = {
   asyncChunkByModuleName,
   ignoreMomentLocales,
+  envVariables,
 };

--- a/config/webpack.parts.js
+++ b/config/webpack.parts.js
@@ -24,8 +24,13 @@ const envVariables = (environment) => new webpack.DefinePlugin({
   ENV_VERSION: JSON.stringify(p.version),
 });
 
+const manifest = new webpack.optimize.CommonsChunkPlugin({
+  name: 'manifest',
+});
+
 module.exports = {
   asyncChunkByModuleName,
   ignoreMomentLocales,
   envVariables,
+  manifest,
 };

--- a/config/webpack.parts.js
+++ b/config/webpack.parts.js
@@ -14,7 +14,10 @@ const asyncChunkByModuleName = (moduleName) => new webpack.optimize.CommonsChunk
   },
 });
 
+const ignoreMomentLocales = new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/);
+
 module.exports = {
   asyncChunks,
   asyncChunkByModuleName,
+  ignoreMomentLocales,
 };

--- a/config/webpack.parts.js
+++ b/config/webpack.parts.js
@@ -1,0 +1,20 @@
+const webpack = require('webpack');
+
+const asyncChunks = new webpack.optimize.CommonsChunkPlugin({
+  async: true,
+  minChunks: ({ resource }, count) => {
+    return resource && /node_modules/.test(resource) && count > 1;
+  },
+});
+
+const asyncChunkByModuleName = (moduleName) => new webpack.optimize.CommonsChunkPlugin({
+  async: true,
+  minChunks: ({ resource }, count) => {
+    return resource && resource.indexOf(moduleName) > -1 && count > 1;
+  },
+});
+
+module.exports = {
+  asyncChunks,
+  asyncChunkByModuleName,
+};

--- a/config/webpack.parts.js
+++ b/config/webpack.parts.js
@@ -1,12 +1,5 @@
 const webpack = require('webpack');
 
-const asyncChunks = new webpack.optimize.CommonsChunkPlugin({
-  async: true,
-  minChunks: ({ resource }, count) => {
-    return resource && /node_modules/.test(resource) && count > 1;
-  },
-});
-
 const asyncChunkByModuleName = (moduleName) => new webpack.optimize.CommonsChunkPlugin({
   async: true,
   minChunks: ({ resource }, count) => {
@@ -17,7 +10,6 @@ const asyncChunkByModuleName = (moduleName) => new webpack.optimize.CommonsChunk
 const ignoreMomentLocales = new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/);
 
 module.exports = {
-  asyncChunks,
   asyncChunkByModuleName,
   ignoreMomentLocales,
 };

--- a/src/components/graphs/GraphGroup.js
+++ b/src/components/graphs/GraphGroup.js
@@ -1,11 +1,15 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import Loadable from 'react-loadable';
 
 import Select from 'linode-components/dist/forms/Select';
 import { onChange } from 'linode-components/dist/forms/utilities';
 
-import LineGraph from './LineGraph';
 
+const LineGraph = Loadable({
+  loader: () => import('./LineGraph'),
+  loading: () => null,
+});
 
 const CONNECTION_UNITS = [' connections', 'K connections', 'M connections'];
 const IO_UNITS = [' blocks', 'K blocks', 'M blocks'];
@@ -15,10 +19,34 @@ export function convertUnits(value, currentUnit, unitType, fixedNumber = 0) {
   return `${value.toFixed(fixedNumber) / Math.pow(1000, currentUnit)}${unitType[currentUnit]}/s`;
 }
 
+function rgbaFromHex(hex, alpha) {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  const r = parseInt(result[1], 16);
+  const g = parseInt(result[2], 16);
+  const b = parseInt(result[3], 16);
+
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+
+function fformatData(x, ys, colors, legends = []) {
+  return {
+    labels: x,
+    datasets: ys.map((y, i) => ({
+      label: legends[i],
+      data: y,
+      pointRadius: 0,
+      fill: false,
+      borderColor: rgbaFromHex(colors[i], 1),
+      backgroundColor: rgbaFromHex(colors[i], 0.3),
+    })),
+  };
+}
+
 function formatData(colors, datasets, legends) {
   const x = datasets[0].map(([x]) => x);
   const ys = datasets.map(dataset => dataset.map(([, y]) => y));
-  return LineGraph.formatData(x, ys, colors, legends);
+  return fformatData(x, ys, colors, legends);
 }
 
 export function makeCPUGraphMetadata(graphData) {
@@ -60,10 +88,14 @@ export function makeNetv4GraphMetadata(graphData) {
       format: (v, currentUnit) => convertUnits(v, currentUnit, UNITS),
     },
     data: formatData(['0033CC', 'CC0099', '32CD32', 'FFFF99'],
-      [graphData.in, graphData.private_in,
-        graphData.out, graphData.private_out],
-      ['Public IPv4 Inbound', 'Private IPv4 Inbound',
-        'Public IPv4 Outbound', 'Private IPv4 Outbound']),
+      [graphData.in, graphData.private_in, graphData.out, graphData.private_out],
+      [
+        'Public IPv4 Inbound',
+        'Private IPv4 Inbound',
+        'Public IPv4 Outbound',
+        'Private IPv4 Outbound',
+      ]
+    ),
     tooltipFormat: (v, currentUnit) => convertUnits(v, currentUnit, UNITS),
     units: UNITS,
   };
@@ -79,10 +111,14 @@ export function makeNetv6GraphMetadata(graphData) {
       format: (v, currentUnit) => convertUnits(v, currentUnit, UNITS),
     },
     data: formatData(['0033CC', 'CC0099', '32CD32', 'FFFF99'],
-      [graphData.in, graphData.private_in,
-        graphData.out, graphData.private_out],
-      ['Public IPv6 Inbound', 'Private IPv6 Inbound',
-        'Public IPv6 Outbound', 'Private IPv6 Outbound']),
+      [graphData.in, graphData.private_in, graphData.out, graphData.private_out],
+      [
+        'Public IPv6 Inbound',
+        'Private IPv6 Inbound',
+        'Public IPv6 Outbound',
+        'Private IPv6 Outbound',
+      ]
+    ),
     tooltipFormat: (v, currentUnit) => convertUnits(v, currentUnit, UNITS),
     units: UNITS,
   };

--- a/src/components/graphs/LineGraph.js
+++ b/src/components/graphs/LineGraph.js
@@ -12,31 +12,7 @@ export function formatGraphTime(time, timezone, format) {
   return moment.utc(time).tz(timezone).format(format);
 }
 
-// Source: http://stackoverflow.com/a/5624139/1507139
-function rgbaFromHex(hex, alpha) {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  const r = parseInt(result[1], 16);
-  const g = parseInt(result[2], 16);
-  const b = parseInt(result[3], 16);
-
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
 export default class LineGraph extends Component {
-  static formatData(x, ys, colors, legends = []) {
-    return {
-      labels: x,
-      datasets: ys.map((y, i) => ({
-        label: legends[i],
-        data: y,
-        pointRadius: 0,
-        fill: false,
-        borderColor: rgbaFromHex(colors[i], 1),
-        backgroundColor: rgbaFromHex(colors[i], 0.3),
-      })),
-    };
-  }
-
   componentDidMount() {
     this.renderChart(this.props);
   }

--- a/src/components/modal/PortalModal.js
+++ b/src/components/modal/PortalModal.js
@@ -2,8 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component, isValidElement } from 'react';
 import ReactDOM from 'react-dom';
 
-import { ModalShell } from 'linode-components';
-
+import ModalShell from 'linode-components/dist/modals/ModalShell.js';
 
 class PortalModal extends Component {
   constructor(props) {

--- a/src/stackscripts/components/Editor.js
+++ b/src/stackscripts/components/Editor.js
@@ -1,16 +1,19 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import CodeEditor from 'linode-components/dist/editors/CodeEditor';
+import Loadable from 'react-loadable';
 import Form from 'linode-components/dist/forms/Form';
 import FormGroup from 'linode-components/dist/forms/FormGroup';
 import FormSummary from 'linode-components/dist/forms/FormSummary';
 import SubmitButton from 'linode-components/dist/forms/SubmitButton';
 import Input from 'linode-components/dist/forms/Input';
 import { onChange } from 'linode-components/dist/forms/utilities';
-
 import api from '~/api';
 import { dispatchOrStoreErrors } from '~/api/util';
 
+const CodeEditor = Loadable({
+  loader: () => import('linode-components/dist/editors/CodeEditor'),
+  loading: () => null,
+});
 
 export default class Editor extends Component {
   constructor() {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -33,9 +33,7 @@ module.exports = {
 
     parts.asyncChunkByModuleName('chart.js'),
 
-    new webpack.optimize.CommonsChunkPlugin({
-      name: 'manifest',
-    }),
+    parts.manifest,
 
     parts.ignoreMomentLocales,
 

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -4,7 +4,6 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const autoprefixer = require('autoprefixer');
-const _package = require('./package.json');
 const parts = require('./config/webpack.parts');
 
 module.exports = {
@@ -43,19 +42,8 @@ module.exports = {
 
     new webpack.NoEmitOnErrorsPlugin(),
 
-    new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify(process.env.NODE_ENV),
-      },
-      ENV_DEVTOOLS_DISABLED: JSON.stringify(process.env.DEVTOOLS_DISBLED),
-      ENV_APP_ROOT: JSON.stringify(process.env.APP_ROOT),
-      ENV_API_ROOT: JSON.stringify(process.env.API_ROOT),
-      ENV_LOGIN_ROOT: JSON.stringify(process.env.LOGIN_ROOT),
-      ENV_LISH_ROOT: JSON.stringify(process.env.LISH_ROOT),
-      ENV_GA_ID: JSON.stringify(process.env.GA_ID),
-      ENV_SENTRY_URL: JSON.stringify(process.env.SENTRY_URL),
-      ENV_VERSION: JSON.stringify(_package.version),
-    }),
+    parts.envVariables(process.env.NODE_ENV),
+
   ],
   module: {
     rules: [

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -121,5 +121,6 @@ module.exports = {
     port: 3000,
     hot: true,
     historyApiFallback: true,
+    compress: true
   },
 };

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -31,8 +31,6 @@ module.exports = {
       template: paths.appHtml,
     }),
 
-    parts.asyncChunkByModuleName('chart.js'),
-
     parts.manifest,
 
     parts.ignoreMomentLocales,

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -60,29 +60,42 @@ module.exports = {
           },
           {
             test: /\.s?css$/,
-            use: ExtractTextPlugin.extract({
-              fallback: 'style-loader',
-              use: [
-                'css-loader',
-                {
-                  loader: 'postcss-loader', // Run post css actions
-                  options: {
-                    plugins: () => [
-                      require('precss'),
-                      autoprefixer(),
-                    ],
-                  },
+            use: [
+              require.resolve('style-loader'),
+              {
+                loader: require.resolve('css-loader'),
+                options: {
+                  importLoaders: 1,
                 },
-                {
-                  loader: 'sass-loader',
-                  options: {
-                    includePaths: [
-                      path.resolve(__dirname, './node_modules/bootstrap/scss/'),
-                    ],
-                  },
+              },
+              {
+                loader: require.resolve('postcss-loader'),
+                options: {
+                  // Necessary for external CSS imports to work
+                  // https://github.com/facebookincubator/create-react-app/issues/2677
+                  ident: 'postcss',
+                  plugins: () => [
+                    autoprefixer({
+                      browsers: [
+                        '>1%',
+                        'last 4 versions',
+                        'Firefox ESR',
+                        'not ie < 9', // React doesn't support IE8 anyway
+                      ],
+                      flexbox: 'no-2009',
+                    }),
+                  ],
                 },
-              ],
-            }),
+              },
+              {
+                loader: 'sass-loader',
+                options: {
+                  includePaths: [
+                    path.resolve(__dirname, './node_modules/bootstrap/scss/'),
+                  ],
+                },
+              },
+            ],
           },
           {
             test: /\.jsx?/,
@@ -101,9 +114,11 @@ module.exports = {
       },
     ],
   },
+
   resolve: {
     extensions: ['.js', '.jsx'],
   },
+
   devServer: {
     port: 3000,
     hot: true,

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -35,6 +35,8 @@ module.exports = {
       name: 'manifest',
     }),
 
+    parts.ignoreMomentLocales,
+
     new webpack.NamedModulesPlugin(),
 
     new webpack.HotModuleReplacementPlugin(),

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -5,6 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const parts = require('./config/webpack.parts');
+const paths = require('./config/paths');
 
 module.exports = {
   context: __dirname,
@@ -24,8 +25,10 @@ module.exports = {
   },
   plugins: [
     new ExtractTextPlugin('[name]-[hash].css'),
+
     new HtmlWebpackPlugin({
-      template: 'src/index.html',
+      inject: true,
+      template: paths.appHtml,
     }),
 
     parts.asyncChunkByModuleName('chart.js'),

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -5,6 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const _package = require('./package.json');
+const parts = require('./config/webpack.parts');
 
 module.exports = {
   context: __dirname,
@@ -28,6 +29,8 @@ module.exports = {
       template: 'src/index.html',
     }),
 
+    parts.asyncChunkByModuleName('chart.js'),
+
     new webpack.optimize.CommonsChunkPlugin({
       name: 'manifest',
     }),
@@ -42,11 +45,11 @@ module.exports = {
       'process.env': {
         NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       },
-      ENV_DEVTOOLS_DISABLED: JSON.stringify(process.env.DEVTOOLS_DISABLED),
+      ENV_DEVTOOLS_DISABLED: JSON.stringify(process.env.DEVTOOLS_DISBLED),
+      ENV_APP_ROOT: JSON.stringify(process.env.APP_ROOT),
       ENV_API_ROOT: JSON.stringify(process.env.API_ROOT),
       ENV_LOGIN_ROOT: JSON.stringify(process.env.LOGIN_ROOT),
       ENV_LISH_ROOT: JSON.stringify(process.env.LISH_ROOT),
-      ENV_APP_ROOT: JSON.stringify(process.env.APP_ROOT),
       ENV_GA_ID: JSON.stringify(process.env.GA_ID),
       ENV_SENTRY_URL: JSON.stringify(process.env.SENTRY_URL),
       ENV_VERSION: JSON.stringify(_package.version),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -3,13 +3,28 @@ const _ = require('./webpack.config.dev.js');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const parts = require('./config/webpack.parts');
+const paths = require('./config/paths');
 
 _.entry = './src/index';
 _.plugins = [
   /** Will not work if ExtractTextPlugin is removed from module.ruls */
   new ExtractTextPlugin('[name]-[hash].css'),
+
   new HtmlWebpackPlugin({
-    template: 'src/index.html',
+    inject: true,
+    template: paths.appHtml,
+    minify: {
+      removeComments: true,
+      collapseWhitespace: true,
+      removeRedundantAttributes: true,
+      useShortDoctype: true,
+      removeEmptyAttributes: true,
+      removeStyleLinkTypeAttributes: true,
+      keepClosingSlash: true,
+      minifyJS: true,
+      minifyCSS: true,
+      minifyURLs: true,
+    },
   }),
 
   parts.asyncChunkByModuleName('chart.js'),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -20,6 +20,8 @@ _.plugins = [
     name: 'manifest',
   }),
 
+  parts.ignoreMomentLocales,
+
   new webpack.HashedModuleIdsPlugin(),
 
   new webpack.DefinePlugin({

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -33,8 +33,6 @@ _.plugins = [
     },
   }),
 
-  parts.asyncChunkByModuleName('chart.js'),
-
   parts.manifest,
 
   parts.ignoreMomentLocales,

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -4,6 +4,7 @@ const _ = require('./webpack.config.dev.js');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const _package = require('./package.json');
+const parts = require('./config/webpack.parts');
 
 _.entry = './src/index';
 _.plugins = [
@@ -12,6 +13,8 @@ _.plugins = [
   new HtmlWebpackPlugin({
     template: 'src/index.html',
   }),
+
+  parts.asyncChunkByModuleName('chart.js'),
 
   new webpack.optimize.CommonsChunkPlugin({
     name: 'manifest',

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -29,9 +29,7 @@ _.plugins = [
 
   parts.asyncChunkByModuleName('chart.js'),
 
-  new webpack.optimize.CommonsChunkPlugin({
-    name: 'manifest',
-  }),
+  parts.manifest,
 
   parts.ignoreMomentLocales,
 

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,9 +1,7 @@
-const process = require('process');
 const webpack = require('webpack');
 const _ = require('./webpack.config.dev.js');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
-const _package = require('./package.json');
 const parts = require('./config/webpack.parts');
 
 _.entry = './src/index';
@@ -24,19 +22,8 @@ _.plugins = [
 
   new webpack.HashedModuleIdsPlugin(),
 
-  new webpack.DefinePlugin({
-    'process.env': {
-      NODE_ENV: JSON.stringify('production'),
-    },
-    ENV_DEVTOOLS_DISABLED: JSON.stringify(process.env.DEVTOOLS_DISBLED),
-    ENV_APP_ROOT: JSON.stringify(process.env.APP_ROOT),
-    ENV_API_ROOT: JSON.stringify(process.env.API_ROOT),
-    ENV_LOGIN_ROOT: JSON.stringify(process.env.LOGIN_ROOT),
-    ENV_LISH_ROOT: JSON.stringify(process.env.LISH_ROOT),
-    ENV_GA_ID: JSON.stringify(process.env.GA_ID),
-    ENV_SENTRY_URL: JSON.stringify(process.env.SENTRY_URL),
-    ENV_VERSION: JSON.stringify(_package.version),
-  }),
+  parts.envVariables('production'),
+
   new webpack.optimize.UglifyJsPlugin({
     sourceMap: true,
     compressor: {

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,14 +1,20 @@
+const path = require('path');
 const webpack = require('webpack');
 const _ = require('./webpack.config.dev.js');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const autoprefixer = require('autoprefixer');
+
 const parts = require('./config/webpack.parts');
 const paths = require('./config/paths');
 
+const cssFilename = '[name].[contenthash:8].css';
 _.entry = './src/index';
 _.plugins = [
-  /** Will not work if ExtractTextPlugin is removed from module.ruls */
-  new ExtractTextPlugin('[name]-[hash].css'),
+
+  new ExtractTextPlugin({
+    filename: cssFilename,
+  }),
 
   new HtmlWebpackPlugin({
     inject: true,
@@ -45,5 +51,83 @@ _.plugins = [
   }),
   new webpack.optimize.AggressiveMergingPlugin(),
 ];
+
+_.module = {
+  rules: [
+    {
+      oneOf: [
+        {
+          test: /\.md$/,
+          use: ['ignore-loader'],
+        },
+        {
+          test: /\.json$/,
+          use: ['json-loader'],
+        },
+        {
+          test: /\.s?css$/,
+          loader: ExtractTextPlugin.extract({
+            fallback: {
+              loader: require.resolve('style-loader'),
+              options: {
+                hmr: false,
+              },
+            },
+            use: [
+              {
+                loader: require.resolve('css-loader'),
+                options: {
+                  importLoaders: 1,
+                  minimize: true,
+                  sourceMap: false,
+                },
+              },
+              {
+                loader: require.resolve('postcss-loader'),
+                options: {
+                  // Necessary for external CSS imports to work
+                  // https://github.com/facebookincubator/create-react-app/issues/2677
+                  ident: 'postcss',
+                  plugins: () => [
+                    autoprefixer({
+                      browsers: [
+                        '>1%',
+                        'last 4 versions',
+                        'Firefox ESR',
+                        'not ie < 9', // React doesn't support IE8 anyway
+                      ],
+                      flexbox: 'no-2009',
+                    }),
+                  ],
+                },
+              },
+              {
+                loader: 'sass-loader',
+                options: {
+                  includePaths: [
+                    path.resolve(__dirname, './node_modules/bootstrap/scss/'),
+                  ],
+                },
+              },
+            ],
+          }),
+        },
+        {
+          test: /\.jsx?/,
+          loader: require.resolve('babel-loader'),
+          include: [
+            path.resolve(__dirname, 'src'),
+            path.resolve(__dirname, 'node_modules/react-vnc-display'),
+          ],
+        },
+        {
+          exclude: [/\.js$/, /\.html$/, /\.json$/],
+          use: ['file-loader'],
+          include: path.join(__dirname, 'node_modules'),
+        },
+      ],
+    },
+  ],
+};
 
 module.exports = _;


### PR DESCRIPTION
## Purpose
Additional build refactoring across both development and production builds. Essentially using some of the best practices found in the create-react-app build system, DRYing up build code, additional bundle splitting, and some general maintenance. 

- 4ec7db2 ~Used CommonChunkPlugin to extract chartjs to its own bundle. This is only an immediate load reduction on a feature which doesn't use charts (images, volumes, stackscripts, etc., basically anyone other than Linodes and NodeBalancers). In a future PR I'll attempt to load the files using the charts via react-loadable. This _should_ creating another split point which would decrease initial load further.~ This commit made obsolete by 6f0d2a7 and e572d11.

- 6f0d2a7 Use react-loadable to defer loading LineGraph.js (which contains the only reference to chartjs).

- 4ad1604 Stripped momentjs locale data from bundles. Should we choose to offer translations and localization we can selectively bundle and import bundles based on user settings.

- Using `config/parts.webpack.js` as a location for common parts of the build.

- Centralizing paths in the `config/paths.js` file.

- 06a128c Used react-loadable to load CodeEditor (significant reduction in initial page load due to brace, react-ace).

- 2ef7658 Split S?CSS.
  - Development; SCSS is compiled down to CSS and injected into the head of the HTML.
  - Production; SCSS is compiled down to CSS and a file is generated with a hashed filename.

- 97899ee HTML minification because every bit counts.

- 08a7b81 Corrected a manifest import. We need to be aware that importing an index and destructuring it results in unnecessary bundle bloating.


## Reporting
Based on my early numbers when we first started this effort our bundle.js was 949KB (minified and compressed). Additionally we were statically loading zxcvbn which was 340KB (compressed). So in javascript assets alone, when loading `/linodes` we were seeing 1.2MB over the wire. After this effort, depending on exact compression results, we should be at apx ~473KB~ 290KB.

This was achieved mostly by deferring the loading of script files until they were actually needed. Notably zxcvbn, chartjs, and brace. All rather large libraries that arent required on the initial page load.

![image](https://user-images.githubusercontent.com/12218651/36262229-d0a11c0a-1234-11e8-9a99-85e37f084b90.png)

![no-idea-what-to-do](https://user-images.githubusercontent.com/12218651/36262306-0ea3e2d0-1235-11e8-9752-0c597e847a74.gif)
