### PR TITLE
Implement perpetual sessions based on activity timeout

### DIFF
--- a/src/components/AuthenticationWrapper.spec.js
+++ b/src/components/AuthenticationWrapper.spec.js
@@ -19,7 +19,7 @@ describe('AuthenticationWrapper', () => {
       <StaticRouter>
         <AuthenticationWrapper
           isAuthenticated={false}
-          redirectToLogin={mockRedirect}
+          loginRedirect={mockRedirect}
           location={location}
           history={mockHistory}
         />
@@ -36,7 +36,7 @@ describe('AuthenticationWrapper', () => {
       <StaticRouter>
         <AuthenticationWrapper
           isAuthenticated={false}
-          redirectToLogin={mockRedirect}
+          loginRedirect={mockRedirect}
           location={location}
           history={mockHistory}
         >
@@ -55,7 +55,7 @@ describe('AuthenticationWrapper', () => {
       <StaticRouter>
         <AuthenticationWrapper
           isAuthenticated
-          redirectToLogin={mockRedirect}
+          loginRedirect={mockRedirect}
           location={location}
           history={mockHistory}
         >

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,9 @@ export const EVENT_POLLING_DELAY = (5 * 1000); // milliseconds
 
 export const RESULTS_PER_PAGE = 100;
 
+export const LOGIN_SESSION_LIFETIME_MS = 45 * 60 * 1000;
+export const OAUTH_TOKEN_REFRESH_INTERVAL = LOGIN_SESSION_LIFETIME_MS / 2;
+
 export const LinodeStates = {
   pending: [
     'booting',

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
             <p>Please enable JavaScript in your browser and refresh the page.</p>
         </div>
     </noscript>
+    <div id="session-iframe"></div>
     <div id="root" class="full-height"></div>
     <div id="emergency-modal"></div>
     <div id="portal-modal"></div>

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ import AuthenticationWrapper from '~/components/AuthenticationWrapper';
 import Banners from '~/components/Banners';
 
 import handleError from '~/handleError';
-import { GA_ID, ENVIRONMENT, SENTRY_URL } from '~/constants';
+import { GA_ID, ENVIRONMENT, SENTRY_URL, OAUTH_TOKEN_REFRESH_INTERVAL } from '~/constants';
 import { init as initAnalytics } from '~/analytics';
 import * as session from '~/session';
 import { store, history } from '~/store';
@@ -108,14 +108,13 @@ history.listen(({ pathname }) => {
 window.handleError = handleError(history);
 
 store.dispatch(session.initialize);
-
+setTimeout(() => store.dispatch(session.refreshOAuthToken), OAUTH_TOKEN_REFRESH_INTERVAL);
 
 if (ENVIRONMENT === 'production') {
   Raven
     .config(SENTRY_URL)
     .install();
 }
-
 
 try {
   render(
@@ -126,6 +125,7 @@ try {
             <Route exact path="/linodes/:linodeLabel/glish" component={Glish} />
             <Route exact path="/linodes/:linodeLabel/weblish" component={Weblish} />
             <Route exact path="/oauth/callback" component={OAuthComponent} />
+            <Route exact path="/null" render={() => <span>null route</span>} />
             <Route exact path="/logout" component={Logout} />
             <Route
               render={() => (

--- a/src/session.js
+++ b/src/session.js
@@ -2,22 +2,13 @@ import { stringify } from 'querystring';
 import { v4 } from 'uuid';
 
 import { setToken } from '~/actions/authentication';
-import { APP_ROOT, LOGIN_ROOT } from '~/constants';
+import { APP_ROOT, LOGIN_ROOT, OAUTH_TOKEN_REFRESH_INTERVAL } from '~/constants';
 import { clientId } from '~/secrets';
 import { getStorage, setStorage } from '~/storage';
 
 const AUTH_TOKEN = 'authentication/oauth-token';
 const AUTH_SCOPES = 'authentication/scopes';
 const AUTH_EXPIRES = 'authentication/expires';
-
-
-export function expire(dispatch) {
-  // Remove these from local storage so if login fails, next time we jump to login sooner.
-  setStorage(AUTH_TOKEN, '');
-  setStorage(AUTH_SCOPES, '');
-  setStorage(AUTH_EXPIRES, '');
-  dispatch(setToken(null, null));
-}
 
 export function start(oauthToken = '', scopes = '', expires) {
   return (dispatch) => {
@@ -31,27 +22,18 @@ export function start(oauthToken = '', scopes = '', expires) {
   };
 }
 
-export const genOAuthEndpoint = (redirectUri, scope = '*', nonce) => {
-  const query = {
-    client_id: clientId,
-    scope,
-    response_type: 'token',
-    redirect_uri: `${APP_ROOT}/oauth/callback?returnTo=${redirectUri}`,
-    state: nonce,
-  };
+export function refresh(dispatch) {
+  const authToken = getStorage(AUTH_TOKEN);
+  const scopes = getStorage(AUTH_SCOPES);
+  dispatch(setToken(authToken, scopes));
+}
 
-  return `${LOGIN_ROOT}/oauth/authorize?${stringify(query)}`;
-};
-
-export const prepareOAuthEndpoint = (redirectUri, scope = '*') => {
-  const nonce = v4();
-  setStorage('authentication/nonce', nonce);
-  genOAuthEndpoint(redirectUri, scope, nonce);
-};
-
-export function redirectToLogin(path, querystring) {
-  const redirectUri = `${path}${querystring && `%3F${querystring}`}`;
-  window.location = prepareOAuthEndpoint(redirectUri);
+export function expire(dispatch) {
+  // Remove these from local storage so if login fails, next time we jump to login sooner.
+  setStorage(AUTH_TOKEN, '');
+  setStorage(AUTH_SCOPES, '');
+  setStorage(AUTH_EXPIRES, '');
+  dispatch(setToken(null, null));
 }
 
 export function initialize(dispatch) {
@@ -65,4 +47,46 @@ export function initialize(dispatch) {
   const scopes = getStorage(AUTH_SCOPES) || null;
   // Calling this makes sure AUTH_EXPIRES is always set.
   dispatch(start(token, scopes, expires));
+}
+
+export function genOAuthEndpoint(redirectUri, scope = '*', nonce) {
+  const query = {
+    client_id: clientId,
+    scope,
+    response_type: 'token',
+    redirect_uri: `${APP_ROOT}/oauth/callback?returnTo=${redirectUri}`,
+    state: nonce,
+  };
+
+  return `${LOGIN_ROOT}/oauth/authorize?${stringify(query)}`;
+}
+
+export function prepareOAuthEndpoint(redirectUri, scope = '*') {
+  const nonce = v4();
+  setStorage('authentication/nonce', nonce);
+  return genOAuthEndpoint(redirectUri, scope, nonce);
+}
+
+export function redirectToLogin(path, querystring) {
+  const redirectUri = `${path}${querystring && `%3F${querystring}`}`;
+  window.location = prepareOAuthEndpoint(redirectUri);
+}
+
+export function refreshOAuthToken(dispatch) {
+  /**
+   * Open an iframe for two purposes
+   * 1. Hits the login service (extends the lifetime of login session)
+   * 2. Refreshes our OAuth token in localStorage
+   */
+  const iframe = document.createElement('iframe');
+  iframe.src = prepareOAuthEndpoint('/null');
+  iframe.style.display = 'none';
+  const iframeContainer = document.getElementById('session-iframe');
+  iframeContainer.appendChild(iframe);
+  // Remove the iframe once it refreshes OAuth token in localStorage
+  setTimeout(() => iframeContainer.removeChild(iframe), 5000);
+  // Move the OAuth token from localStorage into Redux
+  dispatch(refresh);
+  // Do this again in a little while
+  setTimeout(() => dispatch(refreshOAuthToken), OAUTH_TOKEN_REFRESH_INTERVAL);
 }


### PR DESCRIPTION
This implements perpetual sessions with an inactivity timeout using the technique of 'silent authentication' as presented by Auth0. See: https://auth0.com/docs/api-auth/tutorials/silent-authentication and 

https://auth0.com/docs/api-auth/tutorials/silent-authentication#renew-expired-tokens
> Within a hidden iframe

As long as the page is open, a hidden iframe is opened every one-half lifetime of the login service session, in order to extend the lifetime of that session. The `/oauth/authorize` endpoint is then hit within that iframe to update our authentication tokens.