### PR TITLE
Don't show or allow edit of client secret for public OAuth clients

### DIFF
--- a/src/components/TimeDisplay.js
+++ b/src/components/TimeDisplay.js
@@ -13,6 +13,7 @@ export default function TimeDisplay(props) {
   const aLongTimeFromNow = moment.utc(new Date()).tz(timezone).add(100, 'year');
   const label = utcTime > aLongTimeFromNow ? 'never' : utcTime.fromNow();
 
+
   return (
     <span
       title={utcTime.format('MMM D YYYY h:mm A z')}

--- a/src/components/TimeDisplay.spec.js
+++ b/src/components/TimeDisplay.spec.js
@@ -7,10 +7,11 @@ describe('components/TimeDisplay', () => {
   it('renders properly', () => {
     const timeIso = '2017-03-30T16:48:10';
     const tDisplay = shallow(<TimeDisplay time={timeIso} />);
-    const timeLong = moment.utc(timeIso, moment.ISO_8601).format('MMM D YYYY h:mm A z');
-    const timeRelative = moment.utc(timeIso, moment.ISO_8601).fromNow();
+    const timeLong = moment.utc(timeIso, moment.ISO_8601).tz('UTC');
+    const timeRelative = timeLong.fromNow();
+    const timeFormatted = timeLong.format('MMM D YYYY h:mm A z');
 
-    expect(tDisplay.html()).toBe(`<span title="${timeLong}">${timeRelative}</span>`);
+    expect(tDisplay.html()).toBe(`<span title="${timeFormatted}">${timeRelative}</span>`);
   });
 });
 

--- a/src/profile/components/CreateOrEditApplication.js
+++ b/src/profile/components/CreateOrEditApplication.js
@@ -67,7 +67,7 @@ export default class CreateOrEditApplication extends Component {
           }) };
         }
       },
-      ({ secret }) => id ? close() :
+      ({ secret }) => id || secret === null ? close() :
         renderSecret('client', 'created', secret, close),
     ]));
   }

--- a/src/profile/layouts/MyAPIClientsPage.js
+++ b/src/profile/layouts/MyAPIClientsPage.js
@@ -48,9 +48,13 @@ export class MyAPIClientsPage extends Component {
     const groups = [
       { elements: [{ name: 'Edit', action: () =>
         CreateOrEditApplication.trigger(dispatch, editClient) }] },
-      { elements: [{ name: 'Reset Secret', action: () => this.resetAction(editClient) }] },
       { elements: [{ name: 'Delete', action: () => this.deleteClients(editClient) }] },
     ];
+    if (client.secret !== null) {
+      groups.splice(1, 0, {
+        elements: [{ name: 'Reset Secret', action: () => this.resetAction(editClient) }],
+      });
+    }
     return groups;
   }
 


### PR DESCRIPTION
Clients that are requested to be "public" will use only the implicit OAuth flow, so they don't need a client secret. Soon, they will not be issued a client secret.

This PR stops showing the client secret modal upon creation of a "public" client, and hides the option for resetting the client secret.