### PR TITLE
M3-3 Add uncaught exception reporting via ravenjs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "pre-commit": "^1.2.2",
     "promise": "8.0.1",
     "raf": "3.4.0",
+    "raven-js": "^3.22.3",
     "react": "^16.2.0",
     "react-dev-utils": "4.2.1",
     "react-dom": "^16.2.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const SENTRY_URL = process.env.REACT_APP_SENTRY_URL;

--- a/src/exceptionReporting.ts
+++ b/src/exceptionReporting.ts
@@ -1,0 +1,8 @@
+import * as Raven from 'raven-js';
+import { SENTRY_URL } from 'src/constants';
+
+if (SENTRY_URL) {
+  Raven
+    .config(SENTRY_URL)
+    .install();
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,8 +2,10 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
-import store from './store';
 
+import 'src/exceptionReporting';
+
+import store from './store';
 import App from './App';
 import './index.css';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4473,6 +4473,10 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
+raven-js@^3.22.3:
+  version "3.22.3"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.22.3.tgz#8330dcc102b699ffbc2f48790978b997bf4d8f75"
+
 raw-body@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"


### PR DESCRIPTION
## Purpose
Add basic uncaught error reporting via ravenjs.

This simply mimics the behavior of Manager 2.0. We certainly need to expand on this utilizing React 16s error boundaries. Sentry has an integration doc providing a basic example of a wrapper component. https://docs.sentry.io/clients/javascript/integrations/react/