### PR TITLE
M3 8 Add profile menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ class App extends React.Component<Props> {
                 <Route exact path="/longview" render={() => 'LongView'} />
                 <Route exact path="/stackscripts" render={() => 'StackScripts'} />
                 <Route exact path="/images" render={() => 'Images'} />
+                <Route exact path="/profile" render={() => 'Profile'} />
                 <Route exact path="/" render={() => (<Redirect to="/dashboard" />)} />
               </Switch>
             </Typography>

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -9,12 +9,15 @@ import {
 import AppBar from 'material-ui/AppBar';
 import Typography from 'material-ui/Typography';
 import Toolbar from 'material-ui/Toolbar';
+import Button from 'material-ui/Button';
 import IconButton from 'material-ui/IconButton';
+import Menu, { MenuItem } from 'material-ui/Menu';
 
 import MenuIcon from 'material-ui-icons/Menu';
+import AccountCircle from 'material-ui-icons/AccountCircle';
 
 import { menuWidth } from 'src/components/SideMenu';
-import UserMenu from 'src/components/UserMenu';
+// import UserMenu from 'src/components/UserMenu';
 import { TodoAny } from 'src/utils';
 
 const styles = (theme: Theme): StyleRules => ({
@@ -34,15 +37,32 @@ const styles = (theme: Theme): StyleRules => ({
       display: 'none',
     },
   },
+  leftIcon: {
+    marginRight: theme.spacing.unit,
+  },
 });
 
-interface Props extends WithStyles<'appBar' | 'navIconHide' | 'flex'> {
+interface Props extends WithStyles<'appBar' | 'navIconHide' | 'flex' | 'leftIcon'> {
   toggleSideMenu: () => void;
 }
 
 class TopMenu extends React.Component<Props> {
+  state = {
+    anchorEl: undefined,
+  };
+
+  handleMenu = (event: any) => {
+    this.setState({ anchorEl: event.currentTarget });
+  }
+
+  handleClose = () => {
+    this.setState({ anchorEl: undefined });
+  }
+
   render() {
     const { classes, toggleSideMenu } = this.props;
+    const { anchorEl } = this.state;
+    const open = Boolean(anchorEl);
 
     return (
       <AppBar className={classes.appBar}>
@@ -58,7 +78,31 @@ class TopMenu extends React.Component<Props> {
           <Typography variant="title" color="inherit" className={classes.flex}>
             Linode Manager
           </Typography>
-          <UserMenu />
+          <div>
+            <Button
+              onClick={this.handleMenu}
+              color="inherit"
+            >
+              <AccountCircle className={classes.leftIcon}/>
+              jsmith
+            </Button>
+            <Menu
+              anchorEl={anchorEl}
+              anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'right',
+              }}
+              transformOrigin={{
+                vertical: 'bottom',
+                horizontal: 'right',
+              }}
+              open={open}
+              onClose={this.handleClose}
+            >
+              <MenuItem onClick={this.handleClose}>Edit Profile</MenuItem>
+              <MenuItem onClick={this.handleClose}>Log Out</MenuItem>
+            </Menu>
+          </div>
         </Toolbar>
       </AppBar>
     );

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -9,15 +9,13 @@ import {
 import AppBar from 'material-ui/AppBar';
 import Typography from 'material-ui/Typography';
 import Toolbar from 'material-ui/Toolbar';
-import Button from 'material-ui/Button';
+
 import IconButton from 'material-ui/IconButton';
-import Menu, { MenuItem } from 'material-ui/Menu';
 
 import MenuIcon from 'material-ui-icons/Menu';
-import AccountCircle from 'material-ui-icons/AccountCircle';
 
 import { menuWidth } from 'src/components/SideMenu';
-// import UserMenu from 'src/components/UserMenu';
+import UserMenu from 'src/components/UserMenu';
 import { TodoAny } from 'src/utils';
 
 const styles = (theme: Theme): StyleRules => ({
@@ -37,9 +35,6 @@ const styles = (theme: Theme): StyleRules => ({
       display: 'none',
     },
   },
-  leftIcon: {
-    marginRight: theme.spacing.unit,
-  },
 });
 
 interface Props extends WithStyles<'appBar' | 'navIconHide' | 'flex' | 'leftIcon'> {
@@ -47,22 +42,8 @@ interface Props extends WithStyles<'appBar' | 'navIconHide' | 'flex' | 'leftIcon
 }
 
 class TopMenu extends React.Component<Props> {
-  state = {
-    anchorEl: undefined,
-  };
-
-  handleMenu = (event: any) => {
-    this.setState({ anchorEl: event.currentTarget });
-  }
-
-  handleClose = () => {
-    this.setState({ anchorEl: undefined });
-  }
-
   render() {
     const { classes, toggleSideMenu } = this.props;
-    const { anchorEl } = this.state;
-    const open = Boolean(anchorEl);
 
     return (
       <AppBar className={classes.appBar}>
@@ -78,31 +59,7 @@ class TopMenu extends React.Component<Props> {
           <Typography variant="title" color="inherit" className={classes.flex}>
             Linode Manager
           </Typography>
-          <div>
-            <Button
-              onClick={this.handleMenu}
-              color="inherit"
-            >
-              <AccountCircle className={classes.leftIcon}/>
-              jsmith
-            </Button>
-            <Menu
-              anchorEl={anchorEl}
-              anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'right',
-              }}
-              transformOrigin={{
-                vertical: 'bottom',
-                horizontal: 'right',
-              }}
-              open={open}
-              onClose={this.handleClose}
-            >
-              <MenuItem onClick={this.handleClose}>Edit Profile</MenuItem>
-              <MenuItem onClick={this.handleClose}>Log Out</MenuItem>
-            </Menu>
-          </div>
+          <UserMenu />
         </Toolbar>
       </AppBar>
     );

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 
 import {
   withStyles,
-  StyledComponentProps,
+  WithStyles,
+  Theme,
+  StyleRules,
 } from 'material-ui/styles';
 import AppBar from 'material-ui/AppBar';
 import Typography from 'material-ui/Typography';
@@ -12,9 +14,13 @@ import IconButton from 'material-ui/IconButton';
 import MenuIcon from 'material-ui-icons/Menu';
 
 import { menuWidth } from 'src/components/SideMenu';
+import UserMenu from 'src/components/UserMenu';
 import { TodoAny } from 'src/utils';
 
-const styles = (theme: any): any => ({
+const styles = (theme: Theme): StyleRules => ({
+  flex: {
+    flex: 1,
+  },
   appBar: {
     backgroundColor: '#333',
     position: 'absolute',
@@ -30,17 +36,13 @@ const styles = (theme: any): any => ({
   },
 });
 
-type Props = StyledComponentProps & {
-  toggleSideMenu: () => void, 
-};
+interface Props extends WithStyles<'appBar' | 'navIconHide' | 'flex'> {
+  toggleSideMenu: () => void;
+}
 
 class TopMenu extends React.Component<Props> {
   render() {
     const { classes, toggleSideMenu } = this.props;
-
-    if (!classes) {
-      return null;
-    }
 
     return (
       <AppBar className={classes.appBar}>
@@ -53,15 +55,16 @@ class TopMenu extends React.Component<Props> {
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="title" color="inherit" noWrap>
+          <Typography variant="title" color="inherit" className={classes.flex}>
             Linode Manager
           </Typography>
+          <UserMenu />
         </Toolbar>
       </AppBar>
     );
   }
 }
 
-export default withStyles(styles, { withTheme: true })(
-  TopMenu as TodoAny,
+export default withStyles(styles, { withTheme: true })<Props>(
+  TopMenu,
 ) as TodoAny;

--- a/src/components/UserMenu.test.tsx
+++ b/src/components/UserMenu.test.tsx
@@ -1,0 +1,14 @@
+import { mount } from 'enzyme';
+
+import * as React from 'react';
+import { StaticRouter } from 'react-router-dom';
+
+import UserMenu from './UserMenu';
+
+it('renders without crashing', () => {
+  mount(
+    <StaticRouter location="/" context={{}}>
+      <UserMenu />
+    </StaticRouter>,
+  );
+});

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+
+import {
+  withStyles,
+  StyledComponentProps,
+} from 'material-ui/styles';
+import Typography from 'material-ui/Typography';
+
+import { menuWidth } from 'src/components/SideMenu';
+import { TodoAny } from 'src/utils';
+
+const styles = (theme: any): any => ({
+  appBar: {
+    backgroundColor: '#333',
+    position: 'absolute',
+    marginLeft: menuWidth,
+    [theme.breakpoints.up('md')]: {
+      width: `calc(100% - ${menuWidth}px)`,
+    },
+  },
+  navIconHide: {
+    [theme.breakpoints.up('md')]: {
+      display: 'none',
+    },
+  },
+});
+
+type Props = StyledComponentProps & {
+  toggleSideMenu: () => void, 
+};
+
+class TopMenu extends React.Component<Props> {
+  render() {
+    const { classes } = this.props;
+
+    if (!classes) {
+      return null;
+    }
+
+    return (
+      <div>
+        <Typography variant="button" align="right">
+          Hello
+        </Typography>
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles, { withTheme: true })(
+  TopMenu as TodoAny,
+) as TodoAny;

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,52 +1,107 @@
 import * as React from 'react';
+import {
+  withRouter,
+  RouteComponentProps,
+} from 'react-router-dom';
+import { compose } from 'redux';
 
 import {
   withStyles,
-  StyledComponentProps,
+  WithStyles,
+  Theme,
+  StyleRules,
 } from 'material-ui/styles';
-import Typography from 'material-ui/Typography';
+import Button from 'material-ui/Button';
+import Menu, { MenuItem } from 'material-ui/Menu';
+import AccountCircle from 'material-ui-icons/AccountCircle';
 
-import { menuWidth } from 'src/components/SideMenu';
 import { TodoAny } from 'src/utils';
 
-const styles = (theme: any): any => ({
-  appBar: {
-    backgroundColor: '#333',
-    position: 'absolute',
-    marginLeft: menuWidth,
-    [theme.breakpoints.up('md')]: {
-      width: `calc(100% - ${menuWidth}px)`,
-    },
-  },
-  navIconHide: {
-    [theme.breakpoints.up('md')]: {
-      display: 'none',
-    },
+type MenuLink = {
+  display: string,
+  href: string,
+};
+
+const menuLinks: MenuLink[] = [
+  { display: 'Edit Profile', href: '/profile' },
+  { display: 'Log Out', href: '/logout' },
+];
+
+const styles = (theme: Theme): StyleRules => ({
+  leftIcon: {
+    marginRight: theme.spacing.unit,
   },
 });
 
-type Props = StyledComponentProps & {
-  toggleSideMenu: () => void, 
-};
+type Props = WithStyles<'leftIcon'> & RouteComponentProps<{}>;
 
-class TopMenu extends React.Component<Props> {
+interface State {
+  anchorEl?: HTMLElement;
+}
+
+class UserMenu extends React.Component<Props, State> {
+  state = {
+    anchorEl: undefined,
+  };
+
+  handleMenu = (event: React.MouseEvent<HTMLElement>) => {
+    this.setState({ anchorEl: event.currentTarget });
+  }
+
+  handleClose = () => {
+    this.setState({ anchorEl: undefined });
+  }
+
+  navigate(href: string) {
+    const { history } = this.props;
+    history.push(href);
+    this.handleClose();
+  }
+
+  renderMenuLink(menuLink: MenuLink) {
+    return (
+      <MenuItem key={menuLink.display} onClick={() => this.navigate(menuLink.href)}>
+        {menuLink.display}
+      </MenuItem>
+    );
+  }
+
   render() {
     const { classes } = this.props;
-
-    if (!classes) {
-      return null;
-    }
+    const { anchorEl } = this.state;
+    const open = Boolean(anchorEl);
 
     return (
-      <div>
-        <Typography variant="button" align="right">
-          Hello
-        </Typography>
-      </div>
+      <React.Fragment>
+        <Button
+          onClick={this.handleMenu}
+          color="inherit"
+        >
+          <AccountCircle className={classes.leftIcon}/>
+          jsmith
+        </Button>
+        <Menu
+          anchorEl={anchorEl}
+          getContentAnchorEl={undefined}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          open={open}
+          onClose={this.handleClose}
+        >
+          {menuLinks.map(menuLink => this.renderMenuLink(menuLink))}
+        </Menu>
+      </React.Fragment>
     );
   }
 }
 
-export default withStyles(styles, { withTheme: true })(
-  TopMenu as TodoAny,
-) as TodoAny;
+export default compose<TodoAny, TodoAny, TodoAny>(
+  withStyles(styles, { withTheme: true }),
+  withRouter,
+)(UserMenu) as TodoAny;


### PR DESCRIPTION
Adds the user profile menu with [Popover](https://material-ui-next.com/api/popover/) dropdown menu.

A [Button with icon](https://material-ui-next.com/demos/buttons/#buttons-with-icons-and-label) is used to open the menu, which is attached to the bottom of this button using the `anchorOrigin` and `transformOrigin` props of the `Popover`.

Routes for the two links as well as a simple test are also included.