### PR TITLE
Refresh OAuth token only on user interaction

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -15,7 +15,7 @@ export const EVENT_POLLING_DELAY = (5 * 1000); // milliseconds
 export const RESULTS_PER_PAGE = 100;
 
 export const LOGIN_SESSION_LIFETIME_MS = 45 * 60 * 1000;
-export const OAUTH_TOKEN_REFRESH_INTERVAL = LOGIN_SESSION_LIFETIME_MS / 2;
+export const OAUTH_TOKEN_REFRESH_TIMEOUT = LOGIN_SESSION_LIFETIME_MS / 2;
 
 export const LinodeStates = {
   pending: [

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ import AuthenticationWrapper from '~/components/AuthenticationWrapper';
 import Banners from '~/components/Banners';
 
 import handleError from '~/handleError';
-import { GA_ID, ENVIRONMENT, SENTRY_URL, OAUTH_TOKEN_REFRESH_INTERVAL } from '~/constants';
+import { GA_ID, ENVIRONMENT, SENTRY_URL } from '~/constants';
 import { init as initAnalytics } from '~/analytics';
 import * as session from '~/session';
 import { store, history } from '~/store';
@@ -108,7 +108,10 @@ history.listen(({ pathname }) => {
 window.handleError = handleError(history);
 
 store.dispatch(session.initialize);
-setTimeout(() => store.dispatch(session.refreshOAuthToken), OAUTH_TOKEN_REFRESH_INTERVAL);
+if (!(isPathOneOf(['/oauth', '/null', '/login'], window.location.pathname))) {
+  store.dispatch(session.refreshOAuthToken);
+}
+session.refreshOAuthOnUserInteraction();
 
 if (SENTRY_URL) {
   Raven


### PR DESCRIPTION
This mitigates a clear security concern. Rather than refresh the OAuth token as long as the window is open, only refresh if there has been some recent user interaction (within the past 22.5 minutes).