### PR TITLE
m3-68-user-menu-shift

### DIFF
--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -25,6 +25,7 @@ const styles = (theme: Theme): StyleRules => ({
     color: theme.palette.text.primary,
     backgroundColor: 'white',
     position: 'relative',
+    paddingRight: '0 !important',
   },
   toolbar: {
     minHeight: 64,


### PR DESCRIPTION
simple bug as the MUI was adding a padding to the header once the overlay is fired