### PR TITLE
M3-184 Show user feedback immediately upon Linode power action

### DIFF
--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -26,7 +26,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         {
           title: 'Reboot',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            rebootLinode(linode);
+            rebootLinode(linode.id, linode.label);
             closeMenu();
           },
         },
@@ -64,7 +64,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         actions.unshift({
           title: 'Power On',
           onClick: (e) => {
-            powerOnLinode(linode);
+            powerOnLinode(linode.id, linode.label);
             closeMenu();
           },
         });
@@ -74,7 +74,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         actions.unshift({
           title: 'Power Off',
           onClick: (e) => {
-            powerOffLinode(linode);
+            powerOffLinode(linode.id, linode.label);
             closeMenu();
           },
         });

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -1,11 +1,8 @@
 import * as React from 'react';
-import Axios from 'axios';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
-import { API_ROOT } from 'src/constants';
-import { resetEventsPolling } from 'src/events';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
-import { rebootLinode } from './powerActions';
+import { rebootLinode, powerOffLinode, powerOnLinode } from './powerActions';
 
 interface Props {
   linode: Linode.Linode;
@@ -29,9 +26,8 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         {
           title: 'Reboot',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            rebootLinode(`${linode.id}`);
+            rebootLinode(linode);
             closeMenu();
-            // TODO, catch errors and show them with a snackbar
           },
         },
         {
@@ -68,10 +64,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         actions.unshift({
           title: 'Power On',
           onClick: (e) => {
-            Axios.post(`${API_ROOT}/linode/instances/${linode.id}/boot`)
-            .then((response) => {
-              resetEventsPolling();
-            });
+            powerOnLinode(linode);
             closeMenu();
           },
         });
@@ -81,12 +74,8 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         actions.unshift({
           title: 'Power Off',
           onClick: (e) => {
-            Axios.post(`${API_ROOT}/linode/instances/${linode.id}/shutdown`)
-            .then((response) => {
-              resetEventsPolling();
-            });
+            powerOffLinode(linode);
             closeMenu();
-            // TODO, catch errors and show them with a snackbar
           },
         });
       }

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -199,7 +199,7 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
             <Button
               className={`${classes.button}
               ${classes.rebootButton}`}
-              onClick={() => rebootLinode(`${linode.id}`)}
+              onClick={() => rebootLinode(linode)}
             >
               <span className="btnLink">Reboot</span>
             </Button>

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -199,7 +199,7 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
             <Button
               className={`${classes.button}
               ${classes.rebootButton}`}
-              onClick={() => rebootLinode(linode)}
+              onClick={() => rebootLinode(linode.id, linode.label)}
             >
               <span className="btnLink">Reboot</span>
             </Button>

--- a/src/features/linodes/LinodesLanding/powerActions.ts
+++ b/src/features/linodes/LinodesLanding/powerActions.ts
@@ -30,26 +30,35 @@ export const genEvent = (
   } as Linode.Event;
 };
 
-export const rebootLinode = (linode: Linode.Linode) => {
-  Axios.post(`${API_ROOT}/linode/instances/${linode.id}/reboot`)
+export const rebootLinode = (
+  linodeID: string | number,
+  linodeLabel: string,
+) => {
+  Axios.post(`${API_ROOT}/linode/instances/${linodeID}/reboot`)
   .then((response) => {
-    linodeEvents$.next(genEvent('linode_reboot', linode.id, linode.label));
+    linodeEvents$.next(genEvent('linode_reboot', linodeID, linodeLabel));
     resetEventsPolling();
   });
 };
 
-export const powerOffLinode = (linode: Linode.Linode) => {
-  Axios.post(`${API_ROOT}/linode/instances/${linode.id}/shutdown`)
+export const powerOffLinode = (
+  linodeID: string | number,
+  linodeLabel: string,
+) => {
+  Axios.post(`${API_ROOT}/linode/instances/${linodeID}/shutdown`)
   .then((response) => {
-    linodeEvents$.next(genEvent('linode_shutdown', linode.id, linode.label));
+    linodeEvents$.next(genEvent('linode_shutdown', linodeID, linodeLabel));
     resetEventsPolling();
   });
 };
 
-export const powerOnLinode = (linode: Linode.Linode) => {
-  Axios.post(`${API_ROOT}/linode/instances/${linode.id}/boot`)
+export const powerOnLinode = (
+  linodeID: string | number,
+  linodeLabel: string,
+) => {
+  Axios.post(`${API_ROOT}/linode/instances/${linodeID}/boot`)
   .then((response) => {
-    linodeEvents$.next(genEvent('linode_boot', linode.id, linode.label));
+    linodeEvents$.next(genEvent('linode_boot', linodeID, linodeLabel));
     resetEventsPolling();
   });
 };

--- a/src/features/linodes/LinodesLanding/powerActions.ts
+++ b/src/features/linodes/LinodesLanding/powerActions.ts
@@ -1,12 +1,55 @@
 import Axios from 'axios';
 
 import { API_ROOT } from 'src/constants';
-import { resetEventsPolling } from 'src/events';
+import { linodeEvents$, resetEventsPolling } from 'src/events';
+import * as moment from 'moment';
 
-export const rebootLinode = (linodeID: string) => {
-  Axios.post(`${API_ROOT}/linode/instances/${linodeID}/reboot`)
+const dateFormat = 'YYYY-MM-DDTHH:mm:ss';
+
+export const genEvent = (
+  action: string,
+  linodeID: string | number,
+  linodeLabel: string,
+) => {
+  return {
+    read: false,
+    rate: null,
+    time_remaining: null,
+    created: moment.utc().format(dateFormat),
+    action,
+    status: 'scheduled',
+    id: 1, /* NB: fake but valid Event ID */
+    percent_complete: 0,
+    seen: false,
+    entity: {
+      url: `/v4/linode/instances/${linodeID}`,
+      label: `${linodeLabel}`,
+      type: 'linode',
+      id: linodeID,
+    },
+  } as Linode.Event;
+};
+
+export const rebootLinode = (linode: Linode.Linode) => {
+  Axios.post(`${API_ROOT}/linode/instances/${linode.id}/reboot`)
   .then((response) => {
+    linodeEvents$.next(genEvent('linode_reboot', linode.id, linode.label));
     resetEventsPolling();
   });
-  // TODO, catch errors and show them with a snackbar
+};
+
+export const powerOffLinode = (linode: Linode.Linode) => {
+  Axios.post(`${API_ROOT}/linode/instances/${linode.id}/shutdown`)
+  .then((response) => {
+    linodeEvents$.next(genEvent('linode_shutdown', linode.id, linode.label));
+    resetEventsPolling();
+  });
+};
+
+export const powerOnLinode = (linode: Linode.Linode) => {
+  Axios.post(`${API_ROOT}/linode/instances/${linode.id}/boot`)
+  .then((response) => {
+    linodeEvents$.next(genEvent('linode_boot', linode.id, linode.label));
+    resetEventsPolling();
+  });
 };


### PR DESCRIPTION
Transition the state of the UI immediately upon a power action by injecting a fake event into the event stream.