### PR TITLE
M3-248 - Add storybook dockerfile, add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile-Storybook
+++ b/Dockerfile-Storybook
@@ -1,0 +1,17 @@
+FROM node:8.10.0-wheezy
+
+VOLUME ["/src"]
+
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash
+RUN $HOME/.yarn/bin/yarn install
+
+WORKDIR /src
+
+# Install Deps
+RUN yarn
+
+EXPOSE 6006
+
+ENTRYPOINT ["yarn", "storybook"]


### PR DESCRIPTION
* Adds Dockerfile for storybook
* Adds dockerignore file to not include `node_modules` (we'll install these with yarn inside the container)

* This will be used by the upcoming integration-test.yml docker compose file to run storybook locally for webdriverIO tests.

## Testing

0. Have Docker for Mac running
1. Build the image:  `docker build -f=Dockerfile-Storybook . -t 'manager-storybook'`
2. Run the image: `docker run -v /path/to/local/manager:/src --name storybook -p 6006:6006 manager-storybook`
