### PR TITLE
Extend material-ui Checkbox.

### DIFF
--- a/src/components/CheckBox/CheckBox.stories.tsx
+++ b/src/components/CheckBox/CheckBox.stories.tsx
@@ -21,58 +21,58 @@ class InteractiveCheckboxes extends React.Component {
         <CheckBox
           disabled
           checked={false}
-          onClick={() => this.handleClick('checkedDefault')}
+          onChange={() => this.handleClick('checkedDefault')}
         />
         <span style={{ marginLeft: '8px' }} />
         <CheckBox
           disabled
           checked={true}
-          onClick={() => this.handleClick('checkedDefault')}
+          onChange={() => this.handleClick('checkedDefault')}
         />
         <span style={{ marginLeft: '8px' }} />
         <CheckBox
           checked={this.state.checkedDefault}
-          onClick={() => this.handleClick('checkedDefault')}
+          onChange={() => this.handleClick('checkedDefault')}
         />
         <br /><br />
         <CheckBox
           variant="warning"
           disabled
           checked={false}
-          onClick={() => this.handleClick('checkedWarning')}
+          onChange={() => this.handleClick('checkedWarning')}
         />
         <span style={{ marginLeft: '8px' }} />
         <CheckBox
           disabled
           variant="warning"
           checked={true}
-          onClick={() => this.handleClick('checkedDefault')}
+          onChange={() => this.handleClick('checkedDefault')}
         />
         <span style={{ marginLeft: '8px' }} />
         <CheckBox
           variant="warning"
           checked={this.state.checkedWarning}
-          onClick={() => this.handleClick('checkedWarning')}
+          onChange={() => this.handleClick('checkedWarning')}
         />
         <br /><br />
         <CheckBox
           variant="error"
           disabled
           checked={false}
-          onClick={() => this.handleClick('checkedError')}
+          onChange={() => this.handleClick('checkedError')}
         />
         <span style={{ marginLeft: '8px' }} />
         <CheckBox
           disabled
           variant="error"
           checked={true}
-          onClick={() => this.handleClick('checkedDefault')}
+          onChange={() => this.handleClick('checkedDefault')}
         />
         <span style={{ marginLeft: '8px' }} />
         <CheckBox
           variant="error"
           checked={this.state.checkedError}
-          onClick={() => this.handleClick('checkedError')}
+          onChange={() => this.handleClick('checkedError')}
         />
       </React.Fragment>
     );

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -7,7 +7,7 @@ import {
   WithStyles,
   Theme,
 } from 'material-ui';
-import Checkbox from 'material-ui/Checkbox';
+import Checkbox, { CheckboxProps } from 'material-ui/Checkbox';
 import CheckboxIcon from '../../assets/icons/checkbox.svg';
 import CheckboxCheckedIcon from '../../assets/icons/checkboxChecked.svg';
 
@@ -69,40 +69,29 @@ const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => 
   },
 });
 
-interface Props {
-  onClick: (e: React.ChangeEvent<HTMLInputElement>) => void;
+interface Props extends CheckboxProps {
   variant?: 'warning' | 'error';
-  checked: boolean;
-  disabled?: boolean;
 }
 
 type FinalProps = Props & WithStyles<CSSClasses>;
 
 const LinodeCheckBox: React.StatelessComponent<FinalProps> = (props) => {
-  const {
-    onClick,
-    classes,
-    variant,
-    checked,
-    disabled,
-  } = props;
+  const { classes, ...rest } = props;
 
   const classnames = classNames({
     [classes.root]: true,
-    [classes.disabled]: disabled === true,
-    [classes.checked]: checked,
-    [classes.warning]: variant === 'warning',
-    [classes.error]: variant === 'error',
+    [classes.disabled]: props.disabled === true,
+    [classes.checked]: Boolean(props.checked),
+    [classes.warning]: props.variant === 'warning',
+    [classes.error]: props.variant === 'error',
   });
 
   return (
     <Checkbox
       className={classnames}
-      onChange={onClick}
-      checked={checked}
-      disabled={disabled}
       icon={<CheckboxIcon />}
       checkedIcon={<CheckboxCheckedIcon />}
+      { ...rest }
     >
     </Checkbox>
   );

--- a/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -109,7 +109,7 @@ class AddonsPanel extends React.Component<CombinedProps> {
                 control={
                   <CheckBox
                     checked={this.props.backups}
-                    onClick={e => setBackups(e, !this.props.backups)}
+                    onChange={e => setBackups(e, !this.props.backups)}
                   />
                 }
                 label="Backups"
@@ -136,7 +136,7 @@ class AddonsPanel extends React.Component<CombinedProps> {
                 control={
                   <CheckBox
                     checked={this.props.privateIP}
-                    onClick={e => setPrivateIP(e, !this.props.privateIP)}
+                    onChange={e => setPrivateIP(e, !this.props.privateIP)}
                   />
                 }
                 label="Private IP (Free!)"


### PR DESCRIPTION
## Change
I noticed checkboxes weren't extending the MaterialUI props and unnecessarily declaring their own.
- Renamed onClick to match MaterialUI CheckBoxProps onChange function.
- Used spread operator to add all props, except classes, to the extended component.