### PR TITLE
M3 175 - Create integration test docker-compose file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:8.10.0-wheezy
+
+VOLUME ["/src"]
+
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash
+RUN $HOME/.yarn/bin/yarn install
+
+WORKDIR /src
+
+# Install Deps
+RUN yarn
+
+EXPOSE 6006
+EXPOSE 3000
+
+ENTRYPOINT ["yarn"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,4 @@ WORKDIR /src
 # Install Deps
 RUN yarn
 
-EXPOSE 6006
-EXPOSE 3000
-
 ENTRYPOINT ["yarn"]

--- a/Dockerfile-Storybook
+++ b/Dockerfile-Storybook
@@ -1,0 +1,17 @@
+FROM node:8.10.0-wheezy
+
+VOLUME ["/src"]
+
+RUN apt-get update
+RUN apt-get install -y apt-transport-https ca-certificates
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash
+RUN $HOME/.yarn/bin/yarn install
+
+WORKDIR /src
+
+# Install Deps
+RUN yarn
+
+EXPOSE 6006
+
+ENTRYPOINT ["yarn", "storybook"]

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -11,7 +11,9 @@ const username = process.env.MANAGER_USER;
 const password = process.env.MANAGER_PASS;
 
 exports.config = {
-
+    // Selenium Host/Port
+    host: process.env.DOCKER ? 'selenium-hub' : 'localhost',
+    port: 4444,
     //
     // ==================
     // Specify Test Files
@@ -82,7 +84,7 @@ exports.config = {
     // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
     // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
     // gets prepended directly.
-    baseUrl: 'http://localhost:3000',
+    baseUrl: process.env.DOCKER ? 'https://manager-local:3000' : 'http://localhost:3000',
     //
     // Default timeout for all waitFor* commands.
     waitforTimeout: 10000,

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -50,17 +50,21 @@ export const getTokenIfNeeded = (user, pass) => {
 */
 export const loadToken = () => {
     const tokenPath = '../../localStorage.json';
-    const localStorageObj = require(tokenPath);
-    const keys = Object.keys(localStorageObj);
+    try {
+        const localStorageObj = require(tokenPath);
+        const keys = Object.keys(localStorageObj);
 
-    const storageObj = keys.map(key => {
-        return { [key]: localStorageObj[key] }
-    });
-    browser.url('/null');
-    browser.execute(function(storageObj) {
-        storageObj.forEach(item => {
-            localStorage.setItem(Object.keys(item)[0], Object.values(item)[0]);
+        const storageObj = keys.map(key => {
+            return { [key]: localStorageObj[key] }
         });
-    }, storageObj);
-    browser.url(constants.routes.dashboard);
+        browser.url('/null');
+        browser.execute(function(storageObj) {
+            storageObj.forEach(item => {
+                localStorage.setItem(Object.keys(item)[0], Object.values(item)[0]);
+            });
+        }, storageObj);
+        browser.url(constants.routes.dashboard);
+    } catch (err) {
+        console.log(`${err} \n ensure that your local manager environment is running!`);
+    }
 }

--- a/integration-test.yaml
+++ b/integration-test.yaml
@@ -1,0 +1,47 @@
+version: '3.1'
+services: 
+  selenium-hub:
+    image: selenium/hub
+    ports:
+      - "4444:4444"
+  chrome:
+    image: selenium/node-chrome
+    depends_on:
+      - selenium-hub
+    volumes:
+      - /dev/shm:/dev/shm # Mitigates the Chromium issue described at https://code.google.com/p/chromium/issues/detail?id=519952
+    environment:
+      - HUB_PORT_4444_TCP_ADDR=selenium-hub
+      - HUB_PORT_4444_TCP_PORT=4444
+  manager-storybook:
+    container_name: manager_storybook
+    ports:
+      - "6006:6006"
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: yarn storybook
+    volumes:
+      - ./:/src
+    depends_on:
+      - chrome
+  manager-e2e:
+    container_name: manager_e2e
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: yarn e2e
+    volumes:
+      - ./:/src
+    depends_on:
+      - manager-storybook
+  manager-local:
+    container_name: manager_local
+    ports:
+      - "3000:3000"
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: yarn start
+    volumes:
+      - ./:/src

--- a/integration-test.yml
+++ b/integration-test.yml
@@ -25,23 +25,29 @@ services:
       - ./:/src
     depends_on:
       - chrome
-  manager-e2e:
-    container_name: manager_e2e
-    build:
-      context: .
-      dockerfile: Dockerfile
-    entrypoint: yarn e2e
-    volumes:
-      - ./:/src
-    depends_on:
-      - manager-storybook
   manager-local:
     container_name: manager_local
     ports:
       - "3000:3000"
+    environment:
+      - HTTPS=true
+      - REACT_APP_APP_ROOT=https://manager-local:3000
     build:
       context: .
       dockerfile: Dockerfile
     entrypoint: yarn start
     volumes:
       - ./:/src
+  manager-e2e:
+    container_name: manager_e2e
+    environment:
+      - DOCKER=true
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: ["./scripts/wait-for-it.sh", "-t", "250", "-s", "manager-local:3000", "--", "yarn", "e2e"]
+    volumes:
+      - ./:/src
+    depends_on:
+      - manager-storybook
+      - manager-local

--- a/scripts/wait-for-it.sh
+++ b/scripts/wait-for-it.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -z $HOST $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH =~ "busybox" ]]; then
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+else
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec "${CLI[@]}"
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
* Adds integration-test.yml docker-compose file for starting containers with selenium, chromedriver, local development and storybook.
* Takes Dockerfile-storybook and makes it a more generic dockerfile for local development + storybook + integration tests
* Add logic for when running tests in a docker container to wdio.conf.js
* Add more helpful error logging when attempting to use saved tokens
* Adds `wait-for-it.sh` (taken from [here](https://github.com/vishnubob/wait-for-it) to poll for the local development service to be started until proceeding with a command (`yarn e2e` in this case)

## To Test:

1. Have Docker for Mac running.
2. Ensure you are not running a local dev setup. Docker will start one for you.
3. Have `MANAGER_USER=YOUR-USERNAME` & `MANAGER_PASS=YOUR_PASSWORD` defined in your `.env` file.
4. On cloud.linode.com update your oauth token redirect uri to: `https://manager-local:3000/oauth/callback` OR create a new one that redirects to that url and update your .env `CLIENT_ID` accordingly
5. Run the following command: `docker-compose -f integration-test.yml up --build --exit-code-from manager-e2e`.
6. Test should pass and generate a `localStorage.json` file.