### PR TITLE
adds support for upcoming abbreviated region response and renames the south region to central

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -18,14 +18,23 @@ import sg from 'flag-icon-css/flags/4x3/sg.svg';
 import jp from 'flag-icon-css/flags/4x3/jp.svg';
 
 export const flags = {
+  'us-east': us,
   'us-east-1a': us,
+  'us-south': us,
   'us-south-1a': us,
+  'us-west': us,
   'us-west-1a': us,
+  'us-central': us,
+  'us-southeast': us,
   'us-southeast-1a': us,
+  'eu-central': de,
   'eu-central-1a': de,
+  'eu-west': gb,
   'eu-west-1a': gb,
+  'ap-northeast': jp,
   'ap-northeast-1a': jp,
   'ap-northeast-1b': jp,
+  'ap-south': sg,
   'ap-south-1a': sg,
 };
 

--- a/src/components/Banners.spec.js
+++ b/src/components/Banners.spec.js
@@ -150,7 +150,7 @@ describe('components/Banners', () => {
     );
 
     expect(banner.find('.Banner')).toHaveLength(1);
-    const expected = expect.stringMatching('us-east-1a, us-south-1a');
+    const expected = expect.stringMatching('us-east, us-central');
     expect(banner.find('.Banner > div').text()).toEqual(expected);
   });
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,21 +32,30 @@ export const LinodeStates = {
 };
 
 export const REGION_MAP = {
-  'North America': ['us-east-1a', 'us-south-1a', 'us-west-1a', 'us-southeast-1a'],
-  Europe: ['eu-central-1a', 'eu-west-1a'],
-  Asia: ['ap-northeast-1a', 'ap-south-1a', 'ap-northeast-1b'],
+  'North America': ['us-east', 'us-central', 'us-west', 'us-southeast'],
+  Europe: ['eu-central', 'eu-west'],
+  Asia: ['ap-northeast', 'ap-south', 'ap-northeast'],
 };
 
 // Still necessary for older DNS lookups.
 export const ZONES = {
+  'us-east': 'newark',
   'us-east-1a': 'newark',
+  'us-south': 'dallas',
   'us-south-1a': 'dallas',
+  'us-west': 'fremont',
   'us-west-1a': 'fremont',
+  'us-central': 'dallas',
+  'us-southeast': 'atlanta',
   'us-southeast-1a': 'atlanta',
+  'eu-central': 'frankfurt',
   'eu-central-1a': 'frankfurt',
+  'eu-west': 'london',
   'eu-west-1a': 'london',
+  'ap-northeast': 'shinagawa1',
   'ap-northeast-1a': 'tokyo',
   'ap-northeast-1b': 'shinagawa1',
+  'ap-south': 'singapore',
   'ap-south-1a': 'singapore',
 };
 
@@ -72,7 +81,7 @@ export const NodebalancerStatusReadable = {
 };
 
 export const ipv4ns = {
-  'us-south-1a': [
+  'us-central': [
     '173.255.199.5',
     '66.228.53.5',
     '96.126.122.5',
@@ -83,7 +92,7 @@ export const ipv4ns = {
     '23.239.24.5',
     '72.14.179.5',
     '72.14.188.5'],
-  'us-west-1a': [
+  'us-west': [
     '173.230.145.5',
     '173.230.147.5',
     '173.230.155.5',
@@ -94,7 +103,7 @@ export const ipv4ns = {
     '173.255.244.5',
     '74.207.241.5',
     '74.207.242.5'],
-  'us-southeast-1a': [
+  'us-southeast': [
     '173.230.129.5',
     '173.230.136.5',
     '173.230.140.5',
@@ -105,7 +114,7 @@ export const ipv4ns = {
     '23.239.18.5',
     '75.127.97.6',
     '75.127.97.7'],
-  'us-east-1a': [
+  'us-east': [
     '66.228.42.5',
     '96.126.106.5',
     '50.116.53.5',
@@ -116,7 +125,7 @@ export const ipv4ns = {
     '97.107.133.4',
     '207.192.69.4',
     '207.192.69.5'],
-  'eu-west-1a': [
+  'eu-west': [
     '178.79.182.5',
     '176.58.107.5',
     '176.58.116.5',
@@ -127,7 +136,7 @@ export const ipv4ns = {
     '109.74.192.20',
     '109.74.193.20',
     '109.74.194.20'],
-  'eu-central-1a': [
+  'eu-central': [
     '139.162.130.5',
     '139.162.131.5',
     '139.162.132.5',
@@ -149,7 +158,7 @@ export const ipv4ns = {
     '106.187.34.20',
     '106.187.35.20',
     '106.187.36.20'],
-  'ap-northeast-1b': [
+  'ap-northeast': [
     '139.162.66.5',
     '139.162.67.5',
     '139.162.68.5',
@@ -160,7 +169,7 @@ export const ipv4ns = {
     '139.162.73.5',
     '139.162.74.5',
     '139.162.75.5'],
-  'ap-south-1a': [
+  'ap-south': [
     '139.162.11.5',
     '139.162.13.5',
     '139.162.14.5',
@@ -173,15 +182,33 @@ export const ipv4ns = {
     '103.3.60.20'],
 };
 
+// Temporary Aliases to handle south -> central rename
+ipv4ns['us-south-1a'] = ipv4ns['us-central'];
+ipv4ns['us-west-1a'] = ipv4ns['us-west'];
+ipv4ns['us-southeast-1a'] = ipv4ns['us-southeast'];
+ipv4ns['us-east-1a'] = ipv4ns['us-east'];
+ipv4ns['eu-west-1a'] = ipv4ns['eu-west'];
+ipv4ns['eu-central-1a'] = ipv4ns['eu-central'];
+ipv4ns['ap-northeast-1b'] = ipv4ns['ap-northeast'];
+ipv4ns['ap-south-1a'] = ipv4ns['ap-south'];
+
 export const ipv6ns = {
+  'us-central': '2600:3c00::',
   'us-south-1a': '2600:3c00::',
+  'us-west': '2600:3c01::',
   'us-west-1a': '2600:3c01::',
+  'us-southeast': '2600:3c02::',
   'us-southeast-1a': '2600:3c02::',
+  'us-east': '2600:3c03::',
   'us-east-1a': '2600:3c03::',
+  'eu-west': '2a01:7e00::',
   'eu-west-1a': '2a01:7e00::',
+  'eu-central': '2a01:7e01::',
   'eu-central-1a': '2a01:7e01::',
   'ap-northeast-1a': '2400:8900::',
+  'ap-northeast': '2400:8902::',
   'ap-northeast-1b': '2400:8902::',
+  'ap-south': '2400:8901::',
   'ap-south-1a': '2400:8901::',
 };
 
@@ -265,7 +292,7 @@ export const DISTRIBUTION_DISPLAY_ORDER = [
 
 export const DEFAULT_DISTRIBUTION = 'linode/Ubuntu16.04LTS';
 
-export const AVAILABLE_VOLUME_REGIONS = ['us-east-1a', 'us-west-1a', 'us-south-1a'];
+export const AVAILABLE_VOLUME_REGIONS = ['us-east', 'us-central', 'us-west'];
 
 export const BANNER_TYPES = {
   OUTAGE: 'outage',

--- a/src/data/banners.js
+++ b/src/data/banners.js
@@ -68,9 +68,9 @@ const testOutageBanner1 = {
   when: null,
   entity: {
     label: null,
-    id: 'us-east-1a',
+    id: 'us-east',
     type: 'region',
-    url: '/regions/us-east-1a',
+    url: '/regions/us-east',
   },
   type: OUTAGE,
 };
@@ -79,8 +79,8 @@ const testOutageBanner2 = {
   ...testOutageBanner1,
   entity: {
     ...testOutageBanner1.entity,
-    id: 'us-south-1a',
-    url: '/regions/us-south-1a',
+    id: 'us-central',
+    url: '/regions/us-central',
   },
 };
 

--- a/src/data/linodes.js
+++ b/src/data/linodes.js
@@ -185,7 +185,7 @@ function createTestLinode(id) {
           linode_id: null,
           status: 'active',
           created: '2017-08-08T13:55:16',
-          region: 'us-east-1a',
+          region: 'us-east',
           updated: '2017-08-08T04:00:00',
           size: 20,
         },

--- a/src/data/regions.js
+++ b/src/data/regions.js
@@ -1,5 +1,5 @@
 export const apiTestRegion = {
-  id: 'us-east-1a',
+  id: 'us-east',
   country: 'US',
   label: 'Newark, NJ',
 };
@@ -10,7 +10,7 @@ export const testRegion = {
 };
 
 export const regions = {
-  'us-east-1a': testRegion,
+  'us-east': testRegion,
   // TODO: The alpha env only has Newark, but maybe we want to add more DCs
   // here later anyway
 };

--- a/src/linodes/linode/backups/components/BackupDetails.spec.js
+++ b/src/linodes/linode/backups/components/BackupDetails.spec.js
@@ -44,7 +44,7 @@ describe('linodes/linode/backups/components/BackupDetails', () => {
     expect(duration.text()).toBe('(1 minute)');
 
     const region = page.find('#region');
-    expect(region.text()).toBe('us-east-1a');
+    expect(region.text()).toBe('us-east');
 
     const configs = page.find('#configs');
     expect(configs.text()).toBe('Ubuntu Disk');


### PR DESCRIPTION
Adds support for upcoming abbreviated region responses and renames the `us-south-1a` region to `us-central`.

This should not be deployed until after Linode APIv4 accepts the future and current names (with backward compatibility for the old names).

The PR maintains the existing names so that it may be deployed in advance of the API changing response values to the abbreviate names.

Old | New
---|---
us-east-1a | us-east
**us-south-1a** | **us-central**
us-west-1a | us-west
us-southeast-1a | us-southeast
eu-central-1a | eu-central
eu-west-1a | eu-west
*ap-northeast-1a* | *ap-northeast-1a*
ap-south-1a | ap-south
**ap-northeast-1b** | **ap-northeast**
