### PR TITLE
Fix: ui testing framework - get fresh token date logic

### DIFF
--- a/e2e/config/browser-config.js
+++ b/e2e/config/browser-config.js
@@ -1,4 +1,4 @@
-export const browserConf = {
+exports.browserConf = {
     chrome: {
         browserName: 'chrome',
         maxInstances: 5,

--- a/e2e/config/custom-commands.js
+++ b/e2e/config/custom-commands.js
@@ -1,4 +1,4 @@
-export const browserCommands = () => {
+exports.browserCommands = () => {
     /* Overwrite the native getText function
     * Get text from specified selector and ensure padding whitespace is removed
     * @param {String} the selector to look for on the DOM

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -1,11 +1,9 @@
-// Require Babel-Register to use ES6 in jasmine specs
 require('dotenv').config();
-require('babel-register');
+const { argv } = require('yargs');
 
 const { getTokenIfNeeded, loadToken } = require('../utils/common');
 const { browserCommands } = require('./custom-commands');
 const { browserConf } = require('./browser-config');
-const { argv } = require('yargs');
 const selectedBrowser = argv.b ? browserConf[argv.b] : browserConf['chrome'];
 const username = process.env.MANAGER_USER;
 const password = process.env.MANAGER_PASS;
@@ -178,9 +176,6 @@ exports.config = {
      * @param {Array.<String>} specs List of spec file paths that are to be run
      */
     before: function (capabilities, specs) {
-        // Require Babel-Register to use ES6 in jasmine specs
-        // require('babel-register');
-
         // Load up our custom commands
         browserCommands();
         getTokenIfNeeded(username, password);

--- a/e2e/constants.js
+++ b/e2e/constants.js
@@ -1,4 +1,4 @@
-export const constants = {
+exports.constants = {
 	testAccounts: {
 
 	},

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -36,7 +36,7 @@ exports.getTokenIfNeeded = (user, pass) => {
         currentTime = moment().format();
     }
     
-    const getNewToken = tokenExists ? expirationTime > currentTime : true;
+    const getNewToken = tokenExists ? expirationTime < currentTime : true;
 
     if (getNewToken) {
         exports.login(user, pass);

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -1,5 +1,6 @@
 import { constants } from '../constants';
 import { existsSync, writeFileSync, statSync } from 'fs';
+import moment from 'moment';
 
 /*
 * Navigates to baseUrl, inputs username and password
@@ -27,8 +28,8 @@ export const login = (username, password) => {
 export const getTokenIfNeeded = (user, pass) => {
     const tokenPath = './localStorage.json';
     const tokenExists = existsSync(tokenPath);
-    const expirationDate = new Date().getHours() + 2 // Current Time + 2 hours;
-    const getNewToken = tokenExists ? new Date(statSync(tokenPath).mtime).getHours() > expirationDate: true;
+    const expirationDate = moment().add('2', 'hours').format();
+    const getNewToken = tokenExists ? moment(new Date(statSync(tokenPath).mtime)).format() > expirationDate: true;
 
     if (getNewToken) {
         exports.login(user, pass);

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -1,6 +1,6 @@
-import { constants } from '../constants';
-import { existsSync, writeFileSync, statSync } from 'fs';
-import moment from 'moment';
+const moment = require('moment');
+const { existsSync, statSync, writeFileSync } = require('fs');
+const { constants } = require('../constants');
 
 /*
 * Navigates to baseUrl, inputs username and password
@@ -9,7 +9,7 @@ import moment from 'moment';
 * @param { String } password
 * @returns {null} returns nothing
 */
-export const login = (username, password) => {
+exports.login = (username, password) => {
     browser.url(constants.routes.dashboard);
     browser.setValue('#username', username);
     browser.setValue('#password', password);
@@ -25,11 +25,18 @@ export const login = (username, password) => {
 * and write them out to a file for use in other tests
 * @returns { String } stringified local storage object
 */
-export const getTokenIfNeeded = (user, pass) => {
+exports.getTokenIfNeeded = (user, pass) => {
+    let expirationTime, currentTime;
     const tokenPath = './localStorage.json';
     const tokenExists = existsSync(tokenPath);
-    const expirationDate = moment().add('2', 'hours').format();
-    const getNewToken = tokenExists ? moment(new Date(statSync(tokenPath).mtime)).format() > expirationDate: true;
+
+    if (tokenExists)  {
+        const lastModifiedTime = new Date(statSync(tokenPath).mtime);
+        expirationTime = moment(lastModifiedTime).add('2', 'hours').format();
+        currentTime = moment().format();
+    }
+    
+    const getNewToken = tokenExists ? expirationTime > currentTime : true;
 
     if (getNewToken) {
         exports.login(user, pass);
@@ -49,7 +56,7 @@ export const getTokenIfNeeded = (user, pass) => {
 * Navigate back to the homepage to be logged in
 * @returns {Null} returns nothing
 */
-export const loadToken = () => {
+exports.loadToken = () => {
     const tokenPath = '../../localStorage.json';
     try {
         const localStorageObj = require(tokenPath);

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "@types/uuid": "^3.4.3",
     "@types/zxcvbn": "^4.4.0",
     "babel-core": "^6.26.0",
-    "babel-register": "^6.26.0",
     "eslint": "4.19.1",
     "selenium-standalone": "^6.13.0",
     "svgr": "^1.9.0",


### PR DESCRIPTION
* Use moment js to compare exact dates when checking if a token is expired. (dateModified > dateTwoHoursinFuture)

* Previously it was just comparing the hours (16 vs. 14) wouldn't get a new token, even if it was 16:50 vs. 14:01.

