### PR TITLE
fixes for API53 breaking changes (networking)

### DIFF
--- a/src/api/ad-hoc/networking.js
+++ b/src/api/ad-hoc/networking.js
@@ -26,7 +26,7 @@ export function ipv4s(region) {
         const currentLinode = linodes[id] || {};
 
         const currentIPv6s = Object.keys(currentLinode._ips || {}).filter(
-          key => currentLinode._ips[key].version !== 'ipv4');
+          key => currentLinode._ips[key].type !== 'ipv4');
 
         currentIPv6s.forEach(function (key) {
           _ipsByLinode[id][key] = currentLinode._ips[key];
@@ -37,7 +37,6 @@ export function ipv4s(region) {
         ..._ipsByLinode[id],
         [ip.address]: {
           ...ip,
-          version: 'ipv4',
         },
       };
     });
@@ -82,7 +81,7 @@ export function assignIPs(region, assignments) {
       };
     });
 
-    await dispatch(fetch.post('/networking/ip-assign', data));
+    await dispatch(fetch.post('/networking/ipv4/assign', data));
 
     // Only change state after post above succeeds.
     await Promise.all(Object.keys(_ipsByLinode).map(function (id) {
@@ -91,7 +90,7 @@ export function assignIPs(region, assignments) {
       // The ipv4 list on the linode needs to be updated for the Linode list
       // and dashboard pages.
       const ipv4 = Object.values(_ips).filter(
-        ip => ip.version === 'ipv4').map(({ address }) => address);
+        ip => ip.type === 'ipv4').map(({ address }) => address);
 
       dispatch(actions.one({ _ips, ipv4 }, id));
     }));
@@ -100,7 +99,7 @@ export function assignIPs(region, assignments) {
 
 export function setRDNS(ip, linodeId, rdns) {
   return async function (dispatch, getState) {
-    const { address, version } = ip;
+    const { address } = ip;
     const rawAddress = address.split('/')[0].trim();
     let _ip = await dispatch(fetch.put(`/networking/ips/${rawAddress}`,
       { rdns }));
@@ -115,26 +114,27 @@ export function setRDNS(ip, linodeId, rdns) {
         ..._ips,
         [_ip.address]: {
           ..._ip,
-          version: version,
         },
       },
     }, linodeId));
   };
 }
 
-export function addIP(linodeId, type) {
+export function addIP(linodeId, visibility) {
   return async (dispatch, getState) => {
     const { _ips } = getState().api.linodes.linodes[linodeId];
 
     const ip = await dispatch(
-      fetch.post(`/linode/instances/${linodeId}/ips`, { type }));
+      fetch.post(`/linode/instances/${linodeId}/ips`, {
+        type: 'ipv4',
+        public: (visibility === 'public')
+      }));
 
     return dispatch(actions.one({
       _ips: {
         ..._ips,
         [ip.address]: {
           ...ip,
-          version: 'ipv4',
         },
       },
     }, linodeId));
@@ -144,45 +144,36 @@ export function addIP(linodeId, type) {
 export function getIPs(linodeId) {
   return async function (dispatch) {
     const ips = await dispatch(fetch.get(`/linode/instances/${linodeId}/ips`));
-
     const _ips = {};
     [...ips.ipv4.public, ...ips.ipv4.private].forEach(function (ip) {
       _ips[ip.address] = {
         ...ip,
-        version: 'ipv4',
+        key: ip.public ? 'public' : 'private',
       };
     });
 
     if (ips.ipv6.link_local) {
       _ips[ips.ipv6.link_local.address] = {
         address: ips.ipv6.link_local.address,
-        type: 'link-local',
-        version: 'ipv6',
+        key: 'link-local',
       };
     }
 
     if (ips.ipv6.slaac) {
       _ips[ips.ipv6.slaac.address] = {
         ...ips.ipv6.slaac,
-        type: 'slaac',
-        version: 'ipv6',
+        key: 'slaac',
       };
     }
 
     ips.ipv6.global.forEach(function (ip) {
       _ips[ip.range] = {
         ...ip,
-        type: 'pool',
-        version: 'ipv6',
+        key: 'addresses',
       };
     });
 
-    ips.ipv6.addresses.forEach(function (ip) {
-      _ips[ip.address] = {
-        ...ip,
-        version: 'ipv6',
-      };
-    });
+    // @TODO should the api provide networking/ips filtering for pool lookups, include them here
 
     dispatch(actions.one({ _ips, _shared: ips.ipv4.shared }, linodeId));
   };
@@ -194,7 +185,7 @@ export function setShared(linodeId, ips) {
       linode_id: linodeId,
       ips: ips.map(({ address }) => address),
     };
-    await dispatch(fetch.post('/networking/ip-sharing', data));
+    await dispatch(fetch.post('/networking/ipv4/share', data));
 
     dispatch(actions.one({ _shared: ips }, linodeId));
   };

--- a/src/components/SessionMenu.js
+++ b/src/components/SessionMenu.js
@@ -30,7 +30,7 @@ export default function SessionMenu(props) {
         <hr />
         <li className="SessionMenu-header">Resources</li>
         <li className="SessionMenu-item">
-          <ExternalLink to="https://forum.linode.com/">Community Forum</ExternalLink>
+          <ExternalLink to="https://www.linode.com/community">Community</ExternalLink>
         </li>
         <li className="SessionMenu-item">
           <ExternalLink to="https://linode.com/docs">User Documentation</ExternalLink>

--- a/src/components/session/index.js
+++ b/src/components/session/index.js
@@ -41,7 +41,7 @@ const Menu = ({ open }) => {
         <hr />
         <li className="SessionMenu-header">Resources</li>
         <li className="SessionMenu-item">
-          <ExternalLink to="https://forum.linode.com/">Community Forum</ExternalLink>
+          <ExternalLink to="https://www.linode.com/community">Community</ExternalLink>
         </li>
         <li className="SessionMenu-item">
           <ExternalLink to="https://linode.com/docs">User Documentation</ExternalLink>

--- a/src/data/linodes.js
+++ b/src/data/linodes.js
@@ -27,16 +27,16 @@ function createTestStats() {
 }
 
 let usedIPv4UpTo = 0;
-function createTestIPv4(linodeId, type = 'public') {
+function createTestIPv4(linodeId, visibility = 'public') {
   const address = `97.107.143.${usedIPv4UpTo++}`;
   return {
     address,
-    type,
-    version: 'ipv4',
+    type: 'ipv4',
     linode_id: linodeId,
     gateway: '97.107.143.0',
     rdns: 'li1-1.members.linode.com',
-    prefix: type === 'public' ? 24 : 17,
+    prefix: (visibility === 'public') ? 24 : 17,
+    public: (visibility === 'public'),
     key: address,
   };
 }
@@ -47,12 +47,12 @@ function createTestIPv6(linodeId) {
 
   return {
     address,
-    key: address,
     linode_id: linodeId,
     gateway: 'fe80::1',
     rdns: 'li1-1.members.linode.com',
-    type: 'public',
-    version: 'ipv6',
+    public: true,
+    key: 'global',
+    type: 'ipv6',
     prefix: '64',
   };
 }
@@ -62,10 +62,9 @@ function createTestLinkLocal(linodeId) {
 
   return {
     address,
-    key: address,
     linode_id: linodeId,
-    type: 'link-local',
-    version: 'ipv6',
+    key: 'link-local',
+    type: 'ipv6',
   };
 }
 
@@ -74,7 +73,7 @@ function createTestSlaac(linodeId) {
 
   return {
     ...ipv6,
-    type: 'slaac',
+    key: 'slaac',
   };
 }
 

--- a/src/layouts/Footer.js
+++ b/src/layouts/Footer.js
@@ -11,7 +11,7 @@ const Footer = ({ source }) => (
       <span>Version {VERSION}</span>
     </div>
 
-    {source && (
+    {source && source.source && (
       <ExternalLink
         to={`https://github.com/linode/manager/blob/${VERSION ? `v${VERSION}` : 'master'}/${source.source}`}
       >Page Source</ExternalLink>

--- a/src/linodes/linode/networking/components/EditRDNS.spec.js
+++ b/src/linodes/linode/networking/components/EditRDNS.spec.js
@@ -17,7 +17,7 @@ describe('linodes/linode/networking/components/EditRDNS', () => {
 
   const dispatch = sandbox.stub();
   const ip = Object.values(testLinode._ips).filter(
-    ip => ip.type === 'public' && ip.version === 'ipv4')[0];
+    ip => ip.public && ip.type === 'ipv4')[0];
 
   it.skip('renders fields correctly', () => {
     const page = mount(

--- a/src/linodes/linode/networking/components/IPList.js
+++ b/src/linodes/linode/networking/components/IPList.js
@@ -13,7 +13,7 @@ export default function IPList(props) {
   if (!ips) return null;
 
   const transferableIps = Object.values(ips).filter(
-    ip => ip.version === 'ipv4' && ip.type === 'public');
+    ip => ip.type === 'ipv4' && ip.public);
 
   return (
     <div>

--- a/src/linodes/linode/networking/components/MoreInfo.js
+++ b/src/linodes/linode/networking/components/MoreInfo.js
@@ -77,7 +77,7 @@ export default class MoreInfo extends Component {
     return (
       <div>
         <p>For more information, see this <ExternalLink to="https://www.linode.com/docs/networking/linux-static-ip-configuration">guide</ExternalLink> on static IP configuration and this <ExternalLink to="https://www.linode.com/docs/networking/native-ipv6-networking">guide</ExternalLink> on IPv6 networking.</p>
-        <ModalFormGroup label={ip.type.toLowerCase() === 'pool' ? 'Range' : 'Address'}>
+        <ModalFormGroup label={ip.key.toLowerCase() === 'pool' ? 'Range' : 'Address'}>
           <Input disabled value={ip.address} />
         </ModalFormGroup>
         {this.renderGateway()}

--- a/src/linodes/linode/networking/layouts/IPSharingPage.js
+++ b/src/linodes/linode/networking/layouts/IPSharingPage.js
@@ -91,7 +91,7 @@ export class IPSharingPage extends Component {
       .filter((linode) => linode.id !== thisLinode.id)
       .map(function (linode) {
         const shareableIps = Object.values(linode._ips).filter(
-          ip => ip.type === 'public' && ip.version === 'ipv4');
+          ip => ip.public && ip.type === 'ipv4');
 
         return shareableIps.map((ip) => {
           return { ip: ip, linode: linode };

--- a/src/linodes/linode/networking/layouts/IPSharingPage.spec.js
+++ b/src/linodes/linode/networking/layouts/IPSharingPage.spec.js
@@ -22,7 +22,7 @@ describe('linodes/linode/networking/layouts/IPSharingPage', () => {
   linodesInRegion.forEach(linode => {
     if (linode.id !== testLinode.id) {
       const publicIPv4s = Object.values(linode._ips).filter(
-        ip => ip.type === 'public' && ip.version === 'ipv4');
+        ip => ip.public && ip.type === 'ipv4');
 
       publicIPv4s.forEach(ip => {
         allIps[ip.address] = ip;
@@ -58,7 +58,7 @@ describe('linodes/linode/networking/layouts/IPSharingPage', () => {
     );
 
     const someIP = Object.values(linodesInRegion[0]._ips).filter(
-      ({ version, type }) => type === 'public' && version === 'ipv4')[0];
+      ({ type, public }) => public && type === 'ipv4')[0];
     page.instance().setState({ checked: { [someIP.address]: true } });
 
     dispatch.reset();
@@ -66,7 +66,7 @@ describe('linodes/linode/networking/layouts/IPSharingPage', () => {
 
     expect(dispatch.callCount).toBe(1);
     await expectDispatchOrStoreErrors(dispatch.firstCall.args[0], [
-      ([fn]) => expectRequest(fn, '/networking/ip-sharing', {
+      ([fn]) => expectRequest(fn, '/networking/ipv4/share', {
         method: 'POST',
         body: { linode_id: testLinode.id, ips: [someIP.address] },
       }),

--- a/src/linodes/linode/networking/layouts/IPTransferPage.spec.js
+++ b/src/linodes/linode/networking/layouts/IPTransferPage.spec.js
@@ -21,7 +21,7 @@ describe('linodes/linode/networking/layouts/IPTransferPage', () => {
   const allIps = {};
   Object.values(linodesInRegion).forEach(linode => {
     const publicIPv4s = Object.values(linode._ips).filter(
-      ip => ip.type === 'public' && ip.version === 'ipv4');
+      ip => ip.public && ip.type === 'ipv4');
 
     publicIPv4s.forEach(ip => {
       allIps[ip.address] = ip;
@@ -44,7 +44,7 @@ describe('linodes/linode/networking/layouts/IPTransferPage', () => {
     const sectionA = page.find('#sectionA');
     const rowsA = sectionA.find('.TableRow');
     expect(rowsA.length).toBe(Object.values(testLinode._ips).filter(
-      ({ type, version }) => type === 'public' && version === 'ipv4').length);
+      ({ type, public }) => public && type === 'ipv4').length);
     rowsA.forEach(row => {
       const address = row.find('.TableCell').at(1).text();
       const ip = allIps[address.split.skip(' ')[0]];
@@ -55,7 +55,7 @@ describe('linodes/linode/networking/layouts/IPTransferPage', () => {
     const linodeB = linodes[page.find('[name="selectedOtherLinode"]').props().value];
     const rowsB = sectionB.find('.TableRow');
     expect(rowsB.length).toBe(Object.values(linodeB._ips).filter(
-      ({ type, version }) => type === 'public' && version === 'ipv4').length);
+      ({ type, public }) => public && type === 'ipv4').length);
     rowsB.forEach(row => {
       const address = row.find('.TableCell').at(1).text();
       const ip = allIps[address.split.skip(' ')[0]];
@@ -81,7 +81,7 @@ describe('linodes/linode/networking/layouts/IPTransferPage', () => {
 
     const rowsB = sectionB.find('.TableRow');
     expect(rowsB.length).toBe(Object.values(notLinodeB._ips).filter(
-      ({ type, version }) => type === 'public' && version === 'ipv4').length);
+      ({ type, public }) => public && type === 'ipv4').length);
     rowsB.forEach(row => {
       const address = row.find('.TableCell').at(1).text();
       const ip = allIps[address.split.skip(' ')[0]];
@@ -120,7 +120,7 @@ describe('linodes/linode/networking/layouts/IPTransferPage', () => {
 
     expect(dispatch.callCount).toBe(1);
     await expectDispatchOrStoreErrors(dispatch.firstCall.args[0], [
-      ([fn]) => expectRequest(fn, '/networking/ip-assign', {
+      ([fn]) => expectRequest(fn, '/networking/ipv4/assign', {
         method: 'POST',
         body: {
           region: testLinode.region,

--- a/src/linodes/linode/networking/layouts/SummaryPage.js
+++ b/src/linodes/linode/networking/layouts/SummaryPage.js
@@ -58,7 +58,7 @@ export class SummaryPage extends Component {
     const addIPModal = () => AddIP.trigger(dispatch, linode);
 
     const privateIPv4s = Object.values(linode._ips).filter(
-      ip => ip.version === 'ipv4' && ip.type === 'private');
+      ip => ip.type === 'ipv4' && !ip.pubic);
     if (privateIPv4s.length) {
       return (
         <PrimaryButton
@@ -96,9 +96,9 @@ export class SummaryPage extends Component {
     ];
 
     const numPublicIPv4 = Object.values(linode._ips).filter(
-      ip => ip.type === 'public' && ip.version === 'ipv4').length;
+      ip => ip.public && ip.type === 'ipv4').length;
 
-    if (['slaac', 'link-local', 'private'].indexOf(record.type.toLowerCase()) !== -1
+    if (['slaac', 'link-local', 'private'].indexOf(record.key.toLowerCase()) !== -1
       || numPublicIPv4 === 1) {
       // Cannot delete slaac, link-local, private, or last public IPv4 address.
       groups.pop();
@@ -112,7 +112,7 @@ export class SummaryPage extends Component {
       });
 
       if (record.rdns && ! /\.members\.linode\.com$/.test(record.rdns)) {
-        const name = record.version === 'ipv4' ? 'Reset RDNS' : 'Remove RDNS';
+        const name = record.type === 'ipv4' ? 'Reset RDNS' : 'Remove RDNS';
         groups[1].elements.push({
           name, action: () => this.resetRDNS(record, linode.id),
         });
@@ -129,9 +129,9 @@ export class SummaryPage extends Component {
     );
   }
 
-  renderIPSection(ips, type) {
+  renderIPSection(ips, key) {
     return (
-      <ListGroup name={type} key={type}>
+      <ListGroup name={key} key={key}>
         <Table
           className="Table--secondary"
           columns={[
@@ -149,7 +149,7 @@ export class SummaryPage extends Component {
               tooltipEnabled: true,
             },
             {
-              dataKey: 'type',
+              dataKey: 'key',
               label: 'Type',
             },
             {
@@ -158,7 +158,7 @@ export class SummaryPage extends Component {
             },
           ]}
           data={ips}
-          noDataMessage={`You have no ${type} addresses.`}
+          noDataMessage={`You have no ${key} addresses.`}
         />
       </ListGroup>
     );
@@ -167,22 +167,22 @@ export class SummaryPage extends Component {
   render() {
     const { linode } = this.props;
 
-    const ipv4s = Object.values(linode._ips).filter(ip => ip.version === 'ipv4').map(ip => ({
+    const ipv4s = Object.values(linode._ips).filter(ip => ip.type === 'ipv4').map(ip => ({
       ...ip,
-      type: capitalize(ip.type),
+      key: capitalize(ip.key),
     }));
 
-    const ipv6s = Object.values(linode._ips).filter(ip => ip.version === 'ipv6').map(ip => {
-      let type = capitalize(ip.type);
+    const ipv6s = Object.values(linode._ips).filter(ip => ip.type === 'ipv6').map(ip => {
+      let key = capitalize(ip.key);
       let address = `${ip.address} / ${ip.prefix}`;
-      if (ip.type === 'slaac') {
-        type = 'SLAAC';
-      } else if (ip.type === 'link-local') {
-        type = 'Link-Local';
+      if (ip.key === 'slaac') {
+        key = 'SLAAC';
+      } else if (ip.key === 'link-local') {
+        key = 'Link-Local';
         address = ip.address;
       }
 
-      return { ...ip, type, address };
+      return { ...ip, key, address };
     });
 
     return (

--- a/src/linodes/linode/networking/layouts/SummaryPage.spec.js
+++ b/src/linodes/linode/networking/layouts/SummaryPage.spec.js
@@ -19,9 +19,9 @@ describe('linodes/linode/networking/layouts/SummaryPage', () => {
   });
 
   const ipv4s = Object.values(testLinode._ips).filter(
-    ip => ip.version === 'ipv4');
+    ip => ip.type === 'ipv4');
   const ipv6s = Object.values(testLinode._ips).filter(
-    ip => ip.version === 'ipv6');
+    ip => ip.type === 'ipv6');
 
   it.skip('renders ipv4 addresses', function () {
     const page = mount(
@@ -42,7 +42,7 @@ describe('linodes/linode/networking/layouts/SummaryPage', () => {
       const ip = testLinode._ips[address];
 
       expect(columns.at(1).text()).toBe(ip.rdns);
-      expect(columns.at(2).text().toLowerCase()).toBe(ip.type);
+      expect(columns.at(2).text().toLowerCase()).toBe(ip.key);
     });
   });
 
@@ -65,7 +65,7 @@ describe('linodes/linode/networking/layouts/SummaryPage', () => {
       const ip = testLinode._ips[address.split.skip('/')[0].trim()];
 
       expect(columns.at(1).text()).toBe(ip.rdns || '');
-      expect(columns.at(2).text().toLowerCase()).toBe(ip.type);
+      expect(columns.at(2).text().toLowerCase()).toBe(ip.key);
     });
   });
 

--- a/src/support/components/TicketHelper.js
+++ b/src/support/components/TicketHelper.js
@@ -110,7 +110,7 @@ export default class TicketHelper extends Component {
         <h3 className="sub-header">Resources</h3>
         <ul className="list-unstyled">
           <li>
-            <ExternalLink to="https://forum.linode.com/">Community forum</ExternalLink>
+            <ExternalLink to="https://www.linode.com/community">Community</ExternalLink>
           </li>
           <li>
             <ExternalLink to="https://www.linode.com/docs/">

--- a/src/users/components/AddUser.js
+++ b/src/users/components/AddUser.js
@@ -5,7 +5,6 @@ import isEmpty from 'lodash/isEmpty';
 import Checkboxes from 'linode-components/dist/forms/Checkboxes';
 import Input from 'linode-components/dist/forms/Input';
 import ModalFormGroup from 'linode-components/dist/forms/ModalFormGroup';
-import PasswordInput from 'linode-components/dist/forms/PasswordInput';
 import Radio from 'linode-components/dist/forms/Radio';
 import { onChange } from 'linode-components/dist/forms/utilities';
 import FormModalBody from 'linode-components/dist/modals/FormModalBody';
@@ -34,18 +33,10 @@ export default class AddUser extends Component {
       errors: {},
       username: '',
       email: '',
-      password: '',
       restricted: 'yes',
     };
 
     this.onChange = onChange.bind(this);
-  }
-
-  componentDidMount() {
-    import('zxcvbn')
-      .then((zxcvbn) => {
-        this.passwordStrengthCalculator = (v) => isEmpty(v) ? null : zxcvbn(v).score;
-      });
   }
 
   onSubmit = () => {
@@ -54,7 +45,6 @@ export default class AddUser extends Component {
       username: this.state.username,
       email: this.state.email,
       restricted: this.state.restricted === 'yes',
-      password: this.state.password,
     };
 
     return dispatch(dispatchOrStoreErrors.call(this, [
@@ -65,9 +55,7 @@ export default class AddUser extends Component {
 
   render() {
     const { close } = this.props;
-    const { errors, username, email, restricted, password } = this.state;
-    const passwordStrength = this.passwordStrengthCalculator
-      && this.passwordStrengthCalculator(password);
+    const { errors, username, email, restricted } = this.state;
 
     return (
       <FormModalBody
@@ -93,15 +81,6 @@ export default class AddUser extends Component {
               id="email"
               value={email}
               onChange={this.onChange}
-            />
-          </ModalFormGroup>
-          <ModalFormGroup label="Password" errors={errors} id="password" apiKey="password">
-            <PasswordInput
-              name="password"
-              id="password"
-              value={password}
-              onChange={this.onChange}
-              strength={passwordStrength}
             />
           </ModalFormGroup>
           <ModalFormGroup label="Restricted" errors={errors} id="restricted" apiKey="restricted">

--- a/src/users/components/AddUser.spec.js
+++ b/src/users/components/AddUser.spec.js
@@ -30,9 +30,6 @@ describe('users/components/AddUser', () => {
     modal.find('input[name="email"]')
       .simulate('change', createSimulatedEvent('email', 'user@example.com'));
 
-    modal.find('input[name="password"]')
-      .simulate('change', createSimulatedEvent('password', 'password'));
-
     modal.find('input#restricted')
       .simulate('click');
 
@@ -45,7 +42,6 @@ describe('users/components/AddUser', () => {
         body: {
           username: 'theUser',
           email: 'user@example.com',
-          password: 'password',
           restricted: true,
         },
       }),

--- a/src/users/components/UserForm.js
+++ b/src/users/components/UserForm.js
@@ -92,6 +92,7 @@ export class UserForm extends Component {
               id="email"
               value={email}
               onChange={this.onChange}
+              readOnly
               className="float-sm-left"
             />
             <FormGroupError errors={errors} name="email" className="float-sm-left" />

--- a/src/users/components/UserForm.js
+++ b/src/users/components/UserForm.js
@@ -5,7 +5,6 @@ import Form from 'linode-components/dist/forms/Form';
 import FormGroup from 'linode-components/dist/forms/FormGroup';
 import FormGroupError from 'linode-components/dist/forms/FormGroupError';
 import FormSummary from 'linode-components/dist/forms/FormSummary';
-import PasswordInput from 'linode-components/dist/forms/PasswordInput';
 import Checkboxes from 'linode-components/dist/forms/Checkboxes';
 import Radio from 'linode-components/dist/forms/Radio';
 import SubmitButton from 'linode-components/dist/forms/SubmitButton';
@@ -15,7 +14,6 @@ import { onChange } from 'linode-components/dist/forms/utilities';
 import api from '~/api';
 import { dispatchOrStoreErrors } from '~/api/util';
 import { actions } from '~/api/generic/users';
-import withZxcvbn from '~/decorators/withZxcvbn';
 
 
 export class UserForm extends Component {
@@ -26,7 +24,6 @@ export class UserForm extends Component {
       username: props.user.username,
       email: props.user.email,
       restricted: props.user.restricted ? 'yes' : 'no',
-      password: '',
       loading: false,
       errors: {},
     };
@@ -40,12 +37,7 @@ export class UserForm extends Component {
       username: this.state.username,
       email: this.state.email,
       restricted: this.state.restricted === 'yes',
-      password: this.state.password,
     };
-
-    if (oldUsername) {
-      delete data.password;
-    }
 
     const creating = !oldUsername;
 
@@ -62,9 +54,8 @@ export class UserForm extends Component {
   }
 
   render() {
-    const { user: { username: oldUsername }, passwordStrengthCalculator } = this.props;
-    const { username, email, restricted, password, loading, errors } = this.state;
-    const passwordStrength = passwordStrengthCalculator(password);
+    const { user: { username: oldUsername } } = this.props;
+    const { username, email, restricted, loading, errors } = this.state;
 
     return (
       <Form
@@ -98,21 +89,6 @@ export class UserForm extends Component {
             <FormGroupError errors={errors} name="email" className="float-sm-left" />
           </div>
         </FormGroup>
-        {this.props.user.username ? null :
-          <FormGroup errors={errors} name="password" className="row">
-            <label htmlFor="password" className="col-sm-2 col-form-label">Password</label>
-            <div className="col-sm-10 clearfix">
-              <PasswordInput
-                name="password"
-                id="password"
-                value={password}
-                onChange={this.onChange}
-                strength={passwordStrength}
-              />
-              <FormGroupError errors={errors} name="password" className="float-sm-left" />
-            </div>
-          </FormGroup>
-        }
         <FormGroup errors={errors} name="restricted" className="row">
           <label className="col-sm-2 col-form-label">Restricted</label>
           <div className="col-sm-10 clearfix">
@@ -157,7 +133,6 @@ export class UserForm extends Component {
 UserForm.propTypes = {
   user: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired,
-  passwordStrengthCalculator: PropTypes.func.isRequired,
 };
 
 UserForm.defaultProps = {
@@ -167,4 +142,4 @@ UserForm.defaultProps = {
     restricted: true,
   },
 };
-export default withZxcvbn(UserForm);
+export default UserForm;

--- a/src/users/components/UserForm.spec.js
+++ b/src/users/components/UserForm.spec.js
@@ -21,7 +21,6 @@ describe('users/layouts/UserForm', () => {
       <UserForm
         dispatch={dispatch}
         user={testUser}
-        passwordStrengthCalculator={jest.fn()}
       />
     );
 


### PR DESCRIPTION
This PR intends to cope with the relevant breaking changes:

 * [x] Unify IPv4, IPv6 GET/POST use "type" "public"
 * [x] Password no longer accepted in POST /account/users
   * [x] You may no longer provide a password when creating a new user
   * [x] New users will immediately receive password reset email to set their password
 * [ ] Removed "addresses" from GET /linode/instances/:id/ips response
   * [ ] These addresses are now returned in GET /networking/ips
 * [ ] Moved GET/PUT for range/pool v6 addresses to /networking/ips
   * [ ] GET /networking/ipv6/:address move to GET /networking/ips/:address
   * [ ] PUT /networking/ipv6/:address move to GET /networking/ips/:address
 * [x] /linode/instances/$id/rebuild returns a Linode
 * [ ] Fixed inconsistent responses for action endpoints
   * [x] POST /linode/instances/:id/backups/enable now returns {} on success
   * [x] POST /linode/instances/:id/backups/disable now returns {} on success
   * [x] POST /networking/ip-assign now returns {} on success
 * [ ] Creating a payment now returns the new payment
   * [ ] POST /account/payments now returns a Payment object
 * [x] Removed the ability to change another user's email address
   * [x] PUT /account/users/:username no longer accepts "email"
   * [x] PUT /profile can still be used to change your own email address
 * [ ] Moved ipv4-specific networking endpoints
   * [x] POST /networking/ip-assign moved to POST /networking/ipv4/assign
   * [x] POST /networking/ip-sharing moved to POST /networking/ipv4/share