### PR TITLE
Docker - Use volumes for src/e2e directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@ node_modules
 dist
 build
 localStorage.json
+src
+e2e

--- a/integration-test.yml
+++ b/integration-test.yml
@@ -20,6 +20,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    volumes:
+      - ./src:/src/src
     entrypoint: yarn storybook
     depends_on:
       - chrome
@@ -33,6 +35,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    volumes:
+      - ./src:/src/src
     entrypoint: yarn start
   manager-e2e:
     container_name: manager_e2e
@@ -41,6 +45,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    volumes:
+      - ./src:/src/src
+      - ./e2e:/src/e2e
     entrypoint: ["./scripts/wait-for-it.sh", "-t", "250", "-s", "manager-local:3000", "--", "yarn","e2e"]
     depends_on:
       - manager-storybook

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   },
   "scripts": {
     "docker:e2e": "docker-compose -f integration-test.yml up --build --exit-code-from manager-e2e",
-    "docker:local": "docker build -f Dockerfile . -t 'manager' && docker run --name manager-local -p 3000:3000 manager start",
-    "docker:storybook": "docker build -f Dockerfile . -t 'storybook' && docker run --name storybook-local -p 6006:6006 storybook storybook",
+    "docker:local": "docker build -f Dockerfile . -t 'manager' && docker run --rm -p 3000:3000 -v $(pwd)/src:/src/src manager start",
+    "docker:storybook": "docker build -f Dockerfile . -t 'storybook' && docker run --rm -p 6006:6006 -v $(pwd)/src:/src/src storybook storybook",
     "start": "node scripts/start.js",
     "lint": "tslint 'src/**/*.ts' 'src/**/*.tsx'",
     "build": "node scripts/build.js",

--- a/src/components/AddNewMenu/AddNewMenuItem.tsx
+++ b/src/components/AddNewMenu/AddNewMenuItem.tsx
@@ -96,7 +96,7 @@ class AddNewMenuItem extends React.Component<PropsWithStyles, State> {
 
     return (
       <React.Fragment>
-        <li data-qa-menu-item={title} onClick={onClick} className={classes.root}>
+        <li onClick={onClick} className={classes.root}>
           <div className={classes.iconWrapper}>
             <ItemIcon />
           </div>

--- a/src/components/AddNewMenu/AddNewMenuItem.tsx
+++ b/src/components/AddNewMenu/AddNewMenuItem.tsx
@@ -96,7 +96,7 @@ class AddNewMenuItem extends React.Component<PropsWithStyles, State> {
 
     return (
       <React.Fragment>
-        <li onClick={onClick} className={classes.root}>
+        <li data-qa-menu-item={title} onClick={onClick} className={classes.root}>
           <div className={classes.iconWrapper}>
             <ItemIcon />
           </div>


### PR DESCRIPTION
* Mount volumes in containers for src and e2e directories
* Updated docker yarn scripts to remove containers on exit, no longer hard code container names, and mounte volumes.
* Added src & e2e to docker ignore file, this way `COPY . .` will not copy these files.

Now you can develop locally  and docker will pick up your changes 👏  

## To Test
1. Run `yarn docker:local` 
2. Make changes to code in `src`
3. Observe, changes are reflected on your local environment
4. Run `yarn docker:storybook`
5. Make changes to story files in `src`
6. Observe, changes are reflected on your local environment