### PR TITLE
M3 257 - Add Testing Docs, Bring Contributing docs up to date

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,30 +13,39 @@ The following buzzwords are involved in this project:
 * ES6/ES7 (via [Babel](https://babeljs.io/))
 * [SCSS](http://sass-lang.com)
 * [Yarn](https://yarnpkg.com/)
+* [WebdriverIO](https://webdriver.io/)
 
 ## Setup
 
     git clone https://github.com/Linode/manager.git
     cd manager
-    node --version # should be 8.4.0
-    (cd components && yarn link) # brew install yarn # on mac
+    node --version # should be Node 8 LTS
+    brew install yarn # on mac
     yarn
-    yarn link linode-components
+
+##### Setup w/Docker
+    git clone https://github.com/Linode/manager.git
+    cd manager
+    docker build -f Dockerfile . -t 'linode-manager'
+
 
 This application communicates with Linode via the
 [Linode APIv4](https://developers.linode.com). You'll need to [register an OAuth
-client](https://cloud.linode.com/profile/tokens), then create a file at
-`src/secrets.js` with your client ID and client secret set appropriately:
+client](https://cloud.linode.com/profile/tokens), then create a file in the base
+of hte manager repository entitled `.env` with your client ID and client secret set appropriately:
 
-    export const clientId = 'change me';
-    export const clientSecret = 'change me';
+    REACT_APP_CLIENT_ID='CHANGE_ME'
+    REACT_APP_LOGIN_ROOT='https://login.linode.com'
+    REACT_APP_API_ROOT='https://api.linode.com/v4'
+    REACT_APP_APP_ROOT='http://localhost:3000'
 
 Be sure to set your callback URL to something like
 `http://localhost:3000/oauth/callback` when you register your OAuth client.
 
 Note: if you pick a callback url that is not on localhost:3000, you will need to
-update the APP_ROOT variable in src/constants.js to point to the different
-server.
+update the REACT_APP_APP_ROOT variable in `.env` to point to the different
+server. Non-localhost callback urls must also be HTTPS. To enable HTTPS, you must
+also include `HTTPS='true'` in your `.env` file.
 
 ## Development Flow
 
@@ -63,11 +72,20 @@ adding features/elements/components that don't have a clear precedent. If this
 is the case, you will need to submit an issue with a mockup and send a request
 for comments to the [(#linode-next channel on irc.oftc.net)](https://webchat.oftc.net/?channels=linode-next&uio=d4).
 
-## Development
+## Development 
 
 Run:
 
     yarn start
+
+Or, using Docker:
+    
+    docker run --rm -p 3000:3000 -v $(pwd)/src:/src/src linode-manager start
+    
+    ## OR If you have installed yarn, 
+    ## you can call the following convenience script:
+
+    yarn docker:local
 
 to start the development server. Connect to
 [localhost:3000](https://localhost:3000) to try it out. Most of the changes you
@@ -80,6 +98,7 @@ around the screen if necessary. If you'd rather disable the devtools, you can
 set the NODE_ENV flag to "production" or set the DEVTOOLS_DISABLED flag to false:
 
     DEVTOOLS_DISABLED=true yarn start
+
 
 ## Git workflows
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,10 +166,12 @@ chmod +x .git/hooks/pre-commit
 ```
 
 ## Testing
-This project uses [Jest](https://facebook.github.io/jest/docs/en/api.html) for unit testing, snapshot testing, assertions, and mocking. [Sinon](http://sinonjs.org/) is still found throughout the project, however is being phased out in favor of Jest mocking.
+This project uses [Jest](https://facebook.github.io/jest/docs/en/api.html) for unit testing, snapshot testing, assertions, and mocking. [Sinon](http://sinonjs.org/) is still found throughout the project, however is being phased out in favor of Jest mocking. 
+
+End-to-end tests are written using WebdriverIO. More documentation on running these tests can be found in the testing [docs](/TESTING.md)
 
 ### Naming
-Test files are collocated with their target file and are suffixed "spec.js" (ie `myFile.js` and `myFile.spec.js`).
+Test files are collocated with their target file and are suffixed "spec.js" (ie `myFile.js` and `myFile.spec.js`). 
 
 ### Commands
 To run tests:
@@ -188,6 +190,13 @@ We haven't assigned an artibrary coverage requirement. Coverage and testing are 
 To generate a coverage report:
 
     yarn test --coverage
+
+## Testing React Components
+
+React Components are testable using [storybook](https://github.com/storybooks/storybook). To access
+the manager storybook:
+
+    yarn storybook
 
 ## Coding Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ The following buzzwords are involved in this project:
 This application communicates with Linode via the
 [Linode APIv4](https://developers.linode.com). You'll need to [register an OAuth
 client](https://cloud.linode.com/profile/tokens), then create a file in the base
-of hte manager repository entitled `.env` with your client ID and client secret set appropriately:
+of the manager repository entitled `.env` with your client ID and client secret set appropriately:
 
     REACT_APP_CLIENT_ID='CHANGE_ME'
     REACT_APP_LOGIN_ROOT='https://login.linode.com'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Or, using Docker:
     
     docker run --rm -p 3000:3000 -v $(pwd)/src:/src/src linode-manager start
     
-    ## OR If you have installed yarn, 
+    ## If you have installed yarn, 
     ## you can call the following convenience script:
 
     yarn docker:local
@@ -197,6 +197,16 @@ React Components are testable using [storybook](https://github.com/storybooks/st
 the manager storybook:
 
     yarn storybook
+
+Or, using Docker:
+
+    docker build -f Dockerfile . -t 'storybook'
+    docker run -it --rm -p 6006:6006 -v $(pwd)/src:/src/src storybook storybook
+
+    ## If you have installed yarn, 
+    ## you can call the following convenience script:
+
+    yarn docker:storybook
 
 ## Coding Style
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,12 +1,11 @@
 # Testing Linode Manager
 
-Testing the Linode Manager can be done by utilizing orchestrated docker containers
-(docker-compose) or locally by running selenium & node.JS alongside the local development environment.
+End-to-end Testing of the Linode Manager can be done locally by running Selenium & WebdriverIO tests
+alongside the local development environment, or by running multiple containers via docker-compose.
 
 The Manager application has a suite of automated browser tests that live in the `e2e/specs`
 directory. These browser tests are written in Node.js using the [WebdriverIO](https://webdriver.io)
-selenium language bindings framework. The configuration files for the WDIO test runner can be found
-in `e2e/config`.
+selenium framework. The configuration files for the WDIO test runner can be found in `e2e/config`.
 
 
 ##### Dependencies

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,101 @@
+# Testing Linode Manager
+
+Testing the Linode Manager can be done by utilizing orchestrated docker containers
+(docker-compose) or locally by running selenium & node.JS alongside the local development environment.
+
+The Manager application has a suite of automated browser tests that live in the `e2e/specs`
+directory. These browser tests are written in Node.js using the [WebdriverIO](https://webdriver.io)
+selenium language bindings framework. The configuration files for the WDIO test runner can be found
+in `e2e/config`.
+
+
+##### Dependencies
+
+* Java JDK 8+ (`brew cask install java`)
+* Node.js 8 LTS (`brew install node@8`)
+* Google Chrome v60+ (`brew cask install google-chrome`)
+* Yarn  (`brew install yarn`)
+
+#### Run Suite
+
+     yarn && yarn start  # Starts the local development environment
+
+     ## New shell
+
+     yarn selenium  # Starts selenium (Must be running to execute tests)
+
+     ## New shell
+
+     yarn e2e  # Executes specs matching e2e/specs/**/*.spec.js
+
+### Command Line Arguments
+
+The `yarn e2e` command accepts a number of helpful command line arguments that faciliate
+writing and running tests locally.
+
+Running an individual spec file:
+
+    yarn e2e --file [/path/to/test.spec.js]
+
+Running E2E suite in a non-default browser
+
+    yarn e2e -b [chrome,firefox,headlessChrome,safari]
+
+#### Run Suite in Docker Local Dev Environment
+
+##### Dependencies
+
+* Docker v18+
+* Docker-Compose v1.20.1+
+
+##### Prerequisites
+
+In order to run the tests via docker-compose, you will need to update your OAuth Client Redirect URL
+to: `https://manager-local:3000/oauth/callback`. The recommendation is to generate a new OAuth
+client in the [Manager](https://cloud.linode.com), set the redirect url to the above, and set the
+`REACT_APP_CLIENT_ID=` to the new OAuth Client ID in the `.env` file.
+
+##### Running the Suite
+
+    docker-compose -f integration-test.yml up --build --exit-code-from manager-e2e
+
+    # OR if Yarn is installed:
+
+    yarn docker:e2e
+
+
+# Testing React Storybook Components
+
+In addition to the Linode Manager E2E tests, there are also UI tests for the ReactJS components.
+The components are tested via [Storybook](https://github.com/storybooks/storybook) and the test specs
+live in `src/components/ComponentName/ComponentName.spec.js`. The WDIO config lives in `e2e/config/wdio.storybook.conf.js`
+
+##### Dependencies
+
+* Same as Testing Manager
+
+#### Run Suite
+
+     yarn storybook  # Starts storybook
+
+     ## New shell
+
+     yarn selenium  # Starts selenium (Must be running to execute tests)
+
+     ## New shell
+
+     yarn storybook:e2e  # Executes specs matching src/components/**/*.spec.js
+
+#### Run Suite in Docker Environment
+
+##### Dependencies
+
+* Same as Testing Manager
+
+##### Running the Suite
+
+    docker-compose -f integration-test.yml up --build --exit-code-from manager-e2e
+
+    # OR if Yarn is installed:
+
+    yarn docker:e2e

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   },
   "scripts": {
     "docker:e2e": "docker-compose -f integration-test.yml up --build --exit-code-from manager-e2e",
-    "docker:local": "docker build -f Dockerfile . -t 'manager' && docker run --rm -p 3000:3000 -v $(pwd)/src:/src/src manager start",
-    "docker:storybook": "docker build -f Dockerfile . -t 'storybook' && docker run --rm -p 6006:6006 -v $(pwd)/src:/src/src storybook storybook",
+    "docker:local": "docker build -f Dockerfile . -t 'manager' && docker run -it --rm -p 3000:3000 -v $(pwd)/src:/src/src manager start",
+    "docker:storybook": "docker build -f Dockerfile . -t 'storybook' && docker run -it --rm -p 6006:6006 -v $(pwd)/src:/src/src storybook storybook",
     "start": "node scripts/start.js",
     "lint": "tslint 'src/**/*.ts' 'src/**/*.tsx'",
     "build": "node scripts/build.js",


### PR DESCRIPTION
* Added Documentation for running end-to-end tests on the manager app using a standard setup and a dockerized setup (TESTING.md)
* Added instructions for running storybook
* Updated the documentation for running local development environment
* Added `-it` flag to docker commands to remove container on `ctrl-c`

This documentation is by no means perfect or complete, but it is certainly an improvement on our currently outdated documentation. Please provide any feedback and I will try to address it in this PR. 