### PR TITLE
M3-229 Linode Config Selection Drawer

### DIFF
--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -85,8 +85,8 @@ class ActionMenu extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { classes  } = this.props;
-    const { actions, anchorEl  } = this.state;
+    const { classes } = this.props;
+    const { actions, anchorEl } = this.state;
 
     if (typeof actions === 'undefined') { return null; }
 

--- a/src/features/LinodeConfigSelectionDrawer/LinodeConfigSelectionDrawer.tsx
+++ b/src/features/LinodeConfigSelectionDrawer/LinodeConfigSelectionDrawer.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+import Button from 'material-ui/Button';
+import InputLabel from 'material-ui/Input/InputLabel';
+import RadioGroup from 'material-ui/Radio/RadioGroup';
+import FormControl from 'material-ui/Form/FormControl';
+import FormControlLabel from 'material-ui/Form/FormControlLabel';
+
+import ActionsPanel from 'src/components/ActionsPanel';
+import Radio from 'src/components/Radio';
+import Drawer from 'src/components/Drawer';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+export interface LinodeConfigSelectionDrawerCallback {
+  (id: number): void;
+}
+
+interface Props {
+  onClose: () => void;
+  onSubmit: () => void;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  open: boolean;
+  configs: Linode.Config[];
+  selected?: string;
+  error?: string;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const LinodeConfigSelectionDrawer: React.StatelessComponent<CombinedProps> = (props) => {
+  const {
+    onClose, onSubmit, onChange, open, configs, selected, error,
+  } = props;
+
+  const hasError = Boolean(error);
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      title="Select a Linode Configuration"
+    >
+      <FormControl fullWidth>
+        <InputLabel
+          htmlFor="awesomeness"
+          disableAnimation
+          shrink={true}
+          error={hasError}
+        >
+          Config
+      </InputLabel>
+        <RadioGroup
+          aria-label="config"
+          name="config"
+          value={selected}
+          onChange={onChange}
+        >
+          {
+            configs.map(config =>
+              <FormControlLabel
+                key={config.id}
+                value={String(config.id)}
+                label={config.label}
+                control={<Radio />}
+              />)
+          }
+        </RadioGroup>
+      </FormControl>
+      <ActionsPanel>
+        <Button variant="raised" color="primary" onClick={onSubmit}>
+          Submit
+      </Button>
+        <Button onClick={onClose}>Cancel</Button>
+      </ActionsPanel>
+    </Drawer>
+  );
+};
+
+LinodeConfigSelectionDrawer.defaultProps = {
+  configs: [],
+  selected: '',
+  open: false,
+};
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled<Props>(LinodeConfigSelectionDrawer);

--- a/src/features/LinodeConfigSelectionDrawer/LinodeConfigSelectionDrawer.tsx
+++ b/src/features/LinodeConfigSelectionDrawer/LinodeConfigSelectionDrawer.tsx
@@ -51,7 +51,7 @@ const LinodeConfigSelectionDrawer: React.StatelessComponent<CombinedProps> = (pr
     >
       <FormControl fullWidth>
         <InputLabel
-          htmlFor="awesomeness"
+          htmlFor="config"
           disableAnimation
           shrink={true}
           error={hasError}
@@ -78,7 +78,7 @@ const LinodeConfigSelectionDrawer: React.StatelessComponent<CombinedProps> = (pr
       <ActionsPanel>
         <Button variant="raised" color="primary" onClick={onSubmit}>
           Submit
-      </Button>
+        </Button>
         <Button onClick={onClose}>Cancel</Button>
       </ActionsPanel>
     </Drawer>

--- a/src/features/LinodeConfigSelectionDrawer/index.ts
+++ b/src/features/LinodeConfigSelectionDrawer/index.ts
@@ -1,0 +1,9 @@
+import LinodeConfigSelectionDrawer, {
+  LinodeConfigSelectionDrawerCallback,
+} from './LinodeConfigSelectionDrawer';
+
+export {
+  LinodeConfigSelectionDrawerCallback,
+};
+
+export default LinodeConfigSelectionDrawer;

--- a/src/features/TopMenu/UserNotificationMenu/UserNotificationMenu.tsx
+++ b/src/features/TopMenu/UserNotificationMenu/UserNotificationMenu.tsx
@@ -78,7 +78,7 @@ class UserNotificationMenu extends React.Component<CombinedProps, State> {
 
           /** Create a map of the Events using Event.ID as the key. */
           .scan((events: EventsMap, event: Linode.Event) =>
-            assoc(String(event.id), event, events), {}),
+            assoc(String(event.id), event, events),{}),
     )
       /** Wait for the events to settle before calling setState. */
       .debounce(() => Observable.interval(250))

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -6,13 +6,14 @@ import { rebootLinode, powerOffLinode, powerOnLinode } from './powerActions';
 
 interface Props {
   linode: Linode.Linode;
+  openConfigDrawer: (configs: Linode.Config[], fn: (id: number) => void) => void;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}>;
 
 class LinodeActionMenu extends React.Component<CombinedProps> {
   createLinodeActions = () => {
-    const { linode, history: { push } } = this.props;
+    const { linode, openConfigDrawer, history: { push } } = this.props;
 
     return function (closeMenu: Function): Action[] {
       const actions = [
@@ -26,7 +27,8 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         {
           title: 'Reboot',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            rebootLinode(linode.id, linode.label);
+            e.preventDefault();
+            rebootLinode(openConfigDrawer, linode.id, linode.label);
             closeMenu();
           },
         },
@@ -64,7 +66,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         actions.unshift({
           title: 'Power On',
           onClick: (e) => {
-            powerOnLinode(linode.id, linode.label);
+            powerOnLinode(openConfigDrawer, linode.id, linode.label);
             closeMenu();
           },
         });

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -16,6 +16,7 @@ import Typography from 'material-ui/Typography';
 
 import Tag from 'src/components/Tag';
 import CircleProgress from 'src/components/CircleProgress';
+import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 
 import RegionIndicator from './RegionIndicator';
 import IPAddress from './IPAddress';
@@ -100,6 +101,7 @@ interface Props {
   linode: (Linode.Linode & { recentEvent?: Linode.Event });
   image?: Linode.Image;
   type?: Linode.LinodeType;
+  openConfigDrawer: (configs: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
 }
 
 class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
@@ -183,7 +185,7 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
   }
 
   render() {
-    const { classes, linode } = this.props;
+    const { classes, linode, openConfigDrawer } = this.props;
     const loading = transitionStatus.includes(linode.status);
 
     return (
@@ -193,7 +195,10 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
             subheader={this.renderTitle()}
             action={
               <div style={{ position: 'relative', top: 6 }}>
-                <LinodeActionMenu linode={linode} />
+                <LinodeActionMenu
+                 linode={linode}
+                 openConfigDrawer={openConfigDrawer}
+                />
               </div>
             }
           />
@@ -206,7 +211,7 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
             <Button
               className={`${classes.button}
               ${classes.rebootButton}`}
-              onClick={() => rebootLinode(linode.id, linode.label)}
+              onClick={() => rebootLinode(openConfigDrawer, linode.id, linode.label)}
             >
               <span className="btnLink">Reboot</span>
             </Button>

--- a/src/features/linodes/LinodesLanding/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow.tsx
@@ -14,6 +14,7 @@ import TableCell from 'material-ui/Table/TableCell';
 
 import Tag from 'src/components/Tag';
 import LinearProgress from 'src/components/LinearProgress';
+import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 
 import LinodeStatusIndicator from './LinodeStatusIndicator';
 import RegionIndicator from './RegionIndicator';
@@ -75,6 +76,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => {
 interface Props {
   linode: (Linode.Linode & { recentEvent?: Linode.Event });
   type?: Linode.LinodeType;
+  openConfigDrawer: (configs: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
 }
 
 type PropsWithStyles = Props & WithStyles<ClassNames>;
@@ -123,7 +125,7 @@ class LinodeRow extends React.Component<PropsWithStyles> {
   }
 
   loadedState = () => {
-    const { linode, classes } = this.props;
+    const { linode, classes, openConfigDrawer } = this.props;
 
     /**
      * @todo Until tags are implemented we're using the group as a faux tag.
@@ -146,7 +148,10 @@ class LinodeRow extends React.Component<PropsWithStyles> {
           <RegionIndicator region={linode.region} />
         </TableCell>
         <TableCell className={classes.actionCell}>
-          <LinodeActionMenu linode={linode} />
+          <LinodeActionMenu
+            linode={linode}
+            openConfigDrawer={openConfigDrawer}
+          />
         </TableCell>
     </TableRow>
     );

--- a/src/features/linodes/LinodesLanding/LinodesGridView.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesGridView.test.tsx
@@ -13,6 +13,7 @@ describe('LinodesGridView', () => {
           linodes={linodes as Linode.Linode[]}
           images={images as Linode.Image[]}
           types={types as Linode.LinodeType[]}
+          openConfigDrawer={e => null}
         />
       </StaticRouter>,
     );

--- a/src/features/linodes/LinodesLanding/LinodesGridView.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesGridView.tsx
@@ -3,15 +3,17 @@ import * as React from 'react';
 import Grid from 'src/components/Grid';
 
 import LinodeCard from './LinodeCard';
+import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 
 interface Props {
   linodes: (Linode.Linode & { recentEvent?: Linode.Event })[];
   images: Linode.Image[];
   types: Linode.LinodeType[];
+  openConfigDrawer: (c: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
 }
 
 const LinodesGridView: React.StatelessComponent<Props> = (props) => {
-  const { linodes, images, types } = props;
+  const { linodes, types, images, openConfigDrawer } = props;
 
   return (
     <Grid container>
@@ -21,6 +23,7 @@ const LinodesGridView: React.StatelessComponent<Props> = (props) => {
           linode={linode}
           image={images.find(image => linode.image === image.id)}
           type={types.find(type => linode.type === type.id)}
+          openConfigDrawer={openConfigDrawer}
         />,
       )}
     </Grid>

--- a/src/features/linodes/LinodesLanding/LinodesListView.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesListView.tsx
@@ -9,15 +9,17 @@ import TableHead from 'material-ui/Table/TableHead';
 import TableRow from 'material-ui/Table/TableRow';
 
 import LinodeRow from './LinodeRow';
+import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 
 interface Props {
   linodes: (Linode.Linode & { recentEvent?: Linode.Event })[];
   images: Linode.Image[];
   types: Linode.LinodeType[];
+  openConfigDrawer: (c: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
 }
 
 const LinodesListView: React.StatelessComponent<Props> = (props) => {
-  const { linodes, types } = props;
+  const { linodes, types, openConfigDrawer } = props;
 
   return (
     <Paper>
@@ -39,6 +41,7 @@ const LinodesListView: React.StatelessComponent<Props> = (props) => {
                   key={linode.id}
                   linode={linode}
                   type={types.find(type => linode.type === type.id)}
+                  openConfigDrawer={openConfigDrawer}
                 />,
               )}
             </TableBody>

--- a/src/types/Linode.ts
+++ b/src/types/Linode.ts
@@ -57,7 +57,7 @@ namespace Linode {
   type LinodeBackupType = 'auto' | 'snapshot';
 
   type LinodeBackupStatus =
-      'pending'
+    'pending'
     | 'running'
     | 'needsPostProcessing'
     | 'successful'
@@ -66,7 +66,7 @@ namespace Linode {
 
 
   export type LinodeStatus =
-      'offline'
+    'offline'
     | 'booting'
     | 'running'
     | 'shutting_down'
@@ -74,4 +74,17 @@ namespace Linode {
     | 'provisioning'
     | 'deleting'
     | 'migrating';
+
+  export interface Config {
+    id: number;
+    kernel: string;
+    comments: string;
+    memory_limit: number;
+    root_device_ro: boolean;
+    run_level: 'default' | 'single' | 'binbash';
+    virt_mode: 'paravirt' | 'fullvirt';
+    helpers: any;
+    label: any;
+    devices: any;
+  }
 }


### PR DESCRIPTION
## Changes
### Adds
- Add LinodeConfigSelectionDrawer feature.
- Users are now prompted with the LinodeConfigSelectionDrawer when selecting (re)boot from the LinodesLanding feature if the Linode has more than one configuration.

### Notes
I've had to pass the `openConfigDrawer` function from LinodesLanding -> LinodesListView/LinodesCardView -> LinodeRow/LinodeCard -> LinodeActionMenu. `openConfigDrawer` accepts an array of configs and a `action` function. The configs and action are stored  on the `state.configDrawer` as `configs` and `actions. The configs are used to populate the radio list, which when changed updates `configDrawer.selected`. When the onSubmit handler is called, the `action` is called with `configDrawer.selected`.

TL;DR We should refactor this to user the Context API!