### PR TITLE
Add remaining tabs and routes for LinodeDetail

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {}
+
+interface State {}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class LinodeBackup extends React.Component<CombinedProps, State> {
+  state = {};
+
+  render() {
+    return (<h1>Backup</h1>);
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(LinodeBackup);

--- a/src/features/linodes/LinodesDetail/LinodeBackup/index.ts
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/index.ts
@@ -1,0 +1,2 @@
+import LinodeBackup from './LinodeBackup';
+export default LinodeBackup;

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {}
+
+interface State {}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class LinodeNetworking extends React.Component<CombinedProps, State> {
+  state = {};
+
+  render() {
+    return (<h1>Networking</h1>);
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(LinodeNetworking);

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/index.ts
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/index.ts
@@ -1,0 +1,2 @@
+import LinodeNetworking from './LinodeNetworking';
+export default LinodeNetworking;

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {}
+
+interface State {}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class LinodeRebuild extends React.Component<CombinedProps, State> {
+  state = {};
+
+  render() {
+    return (<h1>Rebuild</h1>);
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(LinodeRebuild);

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/index.ts
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/index.ts
@@ -1,0 +1,2 @@
+import LinodeRebuild from './LinodeRebuild';
+export default LinodeRebuild;

--- a/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {}
+
+interface State {}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class LinodeRescue extends React.Component<CombinedProps, State> {
+  state = {};
+
+  render() {
+    return (<h1>Rescue</h1>);
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(LinodeRescue);

--- a/src/features/linodes/LinodesDetail/LinodeRescue/index.ts
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/index.ts
@@ -1,0 +1,2 @@
+import LinodeRescue from './LinodeRescue';
+export default LinodeRescue;

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {}
+
+interface State {}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class LinodeResize extends React.Component<CombinedProps, State> {
+  state = {};
+
+  render() {
+    return (<h1>Resize</h1>);
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(LinodeResize);

--- a/src/features/linodes/LinodesDetail/LinodeResize/index.ts
+++ b/src/features/linodes/LinodesDetail/LinodeResize/index.ts
@@ -1,0 +1,2 @@
+import LinodeResize from './LinodeResize';
+export default LinodeResize;

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {}
+
+interface State {}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class LinodeSettings extends React.Component<CombinedProps, State> {
+  state = {};
+
+  render() {
+    return (<h1>Settings</h1>);
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(LinodeSettings);

--- a/src/features/linodes/LinodesDetail/LinodeSettings/index.ts
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/index.ts
@@ -1,0 +1,2 @@
+import LinodeSettings from './LinodeSettings';
+export default LinodeSettings;

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {}
+
+interface State {}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class LinodeVolumes extends React.Component<CombinedProps, State> {
+  state = {};
+
+  render() {
+    return (<h1>Volumes</h1>);
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(LinodeVolumes);

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/index.ts
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/index.ts
@@ -1,0 +1,2 @@
+import LinodeVolumes from './LinodeVolumes';
+export default LinodeVolumes;

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -21,6 +21,13 @@ import { newLinodeEvents } from 'src/features/linodes/events';
 import { API_ROOT } from 'src/constants';
 import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader/PromiseLoader';
 import LinodeSummary from './LinodeSummary';
+import LinodeVolumes from './LinodeVolumes';
+import LinodeNetworking from './LinodeNetworking';
+import LinodeRebuild from './LinodeRebuild';
+import LinodeRescue from './LinodeRescue';
+import LinodeResize from './LinodeResize';
+import LinodeBackup from './LinodeBackup';
+import LinodeSettings from './LinodeSettings';
 import LinodePowerControl from './LinodePowerControl';
 import LinodeConfigSelectionDrawer from 'src/features/LinodeConfigSelectionDrawer';
 
@@ -117,6 +124,13 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
   tabs = [
     /* NB: These must correspond to the routes inside the Switch */
     { routeName: `${this.props.match.url}/summary`, title: 'Summary' },
+    { routeName: `${this.props.match.url}/volumes`, title: 'Volumes' },
+    { routeName: `${this.props.match.url}/networking`, title: 'Networking' },
+    { routeName: `${this.props.match.url}/resize`, title: 'Resize' },
+    { routeName: `${this.props.match.url}/rescue`, title: 'Rescue' },
+    { routeName: `${this.props.match.url}/rebuild`, title: 'Rebuild' },
+    { routeName: `${this.props.match.url}/backup`, title: 'Backup' },
+    { routeName: `${this.props.match.url}/settings`, title: 'Setttings' },
   ];
 
   openConfigDrawer = (configs: Linode.Config[], action: (id: number) => void) => {
@@ -160,7 +174,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { match: { path, url } } = this.props;
+    const { match: { url } } = this.props;
     const { type, image, volumes } = this.props.data.response;
     const { linode, configDrawer } = this.state;
     const matches = (p: string) => Boolean(matchPath(p, { path: this.props.location.pathname }));
@@ -196,7 +210,15 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
           <Route exact path={`${url}/summary`} render={() => (
             <LinodeSummary linode={linode} type={type} image={image} volumes={volumes}/>
           )} />
-          <Route exact path={`${path}/`} render={() => (<Redirect to={`${url}/summary`} />)} />
+          <Route exact path={`${url}/volumes`} render={() => (<LinodeVolumes/>)} />
+          <Route exact path={`${url}/networking`} render={() => (<LinodeNetworking/>)} />
+          <Route exact path={`${url}/rescue`} render={() => (<LinodeRescue/>)} />
+          <Route exact path={`${url}/resize`} render={() => (<LinodeResize/>)} />
+          <Route exact path={`${url}/rebuild`} render={() => (<LinodeRebuild/>)} />
+          <Route exact path={`${url}/backup`} render={() => (<LinodeBackup/>)} />
+          <Route exact path={`${url}/settings`} render={() => (<LinodeSettings/>)} />
+          {/* 404 */}
+          <Route exact render={() => (<Redirect to={`${url}/summary`} />)} />
         </Switch>
         <LinodeConfigSelectionDrawer
           onClose={this.closeConfigDrawer}


### PR DESCRIPTION
## Purpose
Adds the remaining tabs and stubbed routes to the LinodeDetail feature.

## Notes
I've added a catch-all route and removed the explicit root level redirect to summary.