### PR TITLE
M3-302 kebob menu dropdown first item focus

### DIFF
--- a/src/components/ActionMenu/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/ActionMenu.test.tsx
@@ -30,6 +30,6 @@ describe('ActionMenu', () => {
     expect(result.find('WithStyles(ActionMenu)')).toHaveLength(1);
 
     result.find('IconButton').simulate('click');
-    expect(result.find('WithStyles(MenuItem)')).toHaveLength(3);
+    expect(result.find('WithStyles(MenuItem)')).toHaveLength(4);
   });
 });

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -12,7 +12,10 @@ export interface Action {
   onClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
-type CSSClasses = 'root' | 'item' | 'button';
+type CSSClasses = 'root'
+  | 'item'
+  | 'button'
+  | 'hidden';
 
 const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -40,6 +43,10 @@ const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => 
     '& svg': {
       fontSize: '28px',
     },
+  },
+  hidden: {
+    height: 0,
+    padding: 0,
   },
 });
 
@@ -112,6 +119,7 @@ class ActionMenu extends React.Component<CombinedProps, State> {
           open={Boolean(anchorEl)}
           onClose={this.handleClose}
         >
+          <MenuItem key="placeholder" className={classes.hidden} />
           {(actions as Action[]).map((a, idx) =>
             <MenuItem
               key={idx}

--- a/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
@@ -80,6 +80,6 @@ describe('ListLinodes', () => {
     kabobButton.simulate('click');
 
     const menuItems = component.find('MenuItem');
-    expect(menuItems.length).toBe(7);
+    expect(menuItems.length).toBe(8);
   });
 });


### PR DESCRIPTION
Material UI has an `onEnter` function to focus on the menu upon entering it. Since I did not want to loose the ability to have a visual focus while navigating with the keyboard arrows, I added a placeholder item that is hidden and does not provide any action, keeping both focus and hover available to the user while not showing any relevant item focused on `menuOpen`