### PR TITLE
M3-133 Linode Volumes Section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # production
 /dist
+/build
 
 # editor configuration
 .vscode

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -28,8 +28,19 @@ class Example extends React.Component {
             placeholder="This is a placeholder"
           />
           <ActionsPanel>
-            <Button variant="raised" color="primary">Save</Button>
-            <Button>Cancel</Button>
+            <Button
+              variant="raised"
+              color="primary"
+            >
+              Save
+            </Button>
+            <Button
+              variant="raised"
+              color="secondary"
+              className="cancel"
+            >
+              Cancel
+            </Button>
           </ActionsPanel>
         </Drawer>
       </React.Fragment>

--- a/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
@@ -27,7 +27,13 @@ storiesOf('ExpansionPanel', module)
       actions={props => (
           <ActionsPanel>
             <Button variant="raised" color="primary">Save</Button>
-            <Button>Cancel</Button>
+            <Button
+              variant="raised"
+              color="secondary"
+              className="cancel"
+            >
+              Cancel
+            </Button>
           </ActionsPanel>
         )
       }
@@ -40,7 +46,13 @@ storiesOf('ExpansionPanel', module)
       actions={props => (
           <ActionsPanel>
             <Button variant="raised" color="primary">Save</Button>
-            <Button>Cancel</Button>
+            <Button
+              variant="raised"
+              color="secondary"
+              className="cancel"
+            >
+              Cancel
+            </Button>
           </ActionsPanel>
         )
       }
@@ -57,7 +69,13 @@ storiesOf('ExpansionPanel', module)
       actions={props => (
           <ActionsPanel>
             <Button variant="raised" color="primary">Save</Button>
-            <Button>Cancel</Button>
+            <Button
+              variant="raised"
+              color="secondary"
+              className="cancel"
+            >
+              Cancel
+            </Button>
           </ActionsPanel>
         )
       }
@@ -70,7 +88,13 @@ storiesOf('ExpansionPanel', module)
       actions={props => (
           <ActionsPanel>
             <Button variant="raised" color="primary">Save</Button>
-            <Button>Cancel</Button>
+            <Button
+              variant="raised"
+              color="secondary"
+              className="cancel"
+            >
+              Cancel
+            </Button>
           </ActionsPanel>
         )
       }
@@ -87,7 +111,13 @@ storiesOf('ExpansionPanel', module)
       actions={props => (
           <ActionsPanel>
             <Button variant="raised" color="primary">Save</Button>
-            <Button>Cancel</Button>
+            <Button
+              variant="raised"
+              color="secondary"
+              className="cancel"
+            >
+              Cancel
+            </Button>
           </ActionsPanel>
         )
       }
@@ -100,7 +130,13 @@ storiesOf('ExpansionPanel', module)
       actions={props => (
           <ActionsPanel>
             <Button variant="raised" color="primary">Save</Button>
-            <Button>Cancel</Button>
+            <Button
+              variant="raised"
+              color="secondary"
+              className="cancel"
+            >
+              Cancel
+            </Button>
           </ActionsPanel>
         )
       }

--- a/src/components/IconTextLink/IconTextLink.tsx
+++ b/src/components/IconTextLink/IconTextLink.tsx
@@ -52,7 +52,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => 
   },
 });
 
-interface Props {
+export interface Props {
   SideIcon: typeof SvgIcon | React.ComponentClass;
   text: string;
   onClick: () => void;

--- a/src/components/IconTextLink/index.ts
+++ b/src/components/IconTextLink/index.ts
@@ -1,2 +1,7 @@
-import IconTextLink from './IconTextLink';
+import IconTextLink, { Props as IconTextLinkProps } from './IconTextLink';
+
+export {
+  IconTextLinkProps,
+};
+
 export default IconTextLink;

--- a/src/components/Placeholder/Placeholder.tsx
+++ b/src/components/Placeholder/Placeholder.tsx
@@ -62,9 +62,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   title: {
     fontWeight: 700,
   },
-  button: {
-    borderRadius: '4px',
-  },
+  button: {},
 });
 
 export interface Props {

--- a/src/components/Placeholder/Placeholder.tsx
+++ b/src/components/Placeholder/Placeholder.tsx
@@ -7,14 +7,15 @@ import {
 } from 'material-ui';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import Typography from 'material-ui/Typography';
-
+import Button, { ButtonProps } from 'material-ui/Button';
 import Grid from 'src/components/Grid';
 import LinodeTheme from 'src/theme';
 
 type ClassNames = 'root'
   | 'title'
   | 'copy'
-  | 'icon';
+  | 'icon'
+  | 'button';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   '@keyframes scaleIn': {
@@ -61,18 +62,22 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   title: {
     fontWeight: 700,
   },
+  button: {
+    borderRadius: '4px',
+  },
 });
 
-interface Props {
+export interface Props {
   icon?: React.ComponentType<any>;
   copy?: string;
   title?: string;
+  buttonProps?: ButtonProps;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const Placeholder: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, copy, title, icon: Icon } = props;
+  const { classes, copy, title, icon: Icon, buttonProps } = props;
   return (
     <Grid
       container
@@ -95,6 +100,16 @@ const Placeholder: React.StatelessComponent<CombinedProps> = (props) => {
       <Grid item xs={12} lg={10} className={classes.copy}>
         <Typography variant="body1">{copy}</Typography>
       </Grid>
+      {buttonProps &&
+        <Grid item xs={12} lg={10} className={classes.copy}>
+          <Button
+            variant="raised"
+            color="primary"
+            className={classes.button}
+            {...buttonProps}
+          />
+        </Grid>
+      }
     </Grid >
   );
 };

--- a/src/components/Placeholder/index.ts
+++ b/src/components/Placeholder/index.ts
@@ -1,2 +1,7 @@
-import Placeholder from './Placeholder';
+import Placeholder, { Props as PlaceholderProps } from './Placeholder';
+
+export {
+  PlaceholderProps,
+};
+
 export default Placeholder;

--- a/src/components/SectionErrorBoundary/SectionErrorBoundary.tsx
+++ b/src/components/SectionErrorBoundary/SectionErrorBoundary.tsx
@@ -17,7 +17,7 @@ const wrapper = <T extends {}>(Component: React.ComponentType) => {
     render() {
       if (this.state.error) {
         return (
-          <ErrorState errorText="I honestly have no idea what just happened..." />
+          <ErrorState errorText="" />
         );
       }
 

--- a/src/components/SectionErrorBoundary/SectionErrorBoundary.tsx
+++ b/src/components/SectionErrorBoundary/SectionErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import ErrorState from 'src/components/ErrorState';
+
+interface State {
+  error?: Error;
+  info?: any;
+}
+
+const wrapper = <T extends {}>(Component: React.ComponentType) => {
+  class SectionErrorBoundary extends React.Component<T> {
+    state: State = {};
+
+    componentDidCatch(error: Error, info: any) {
+      this.setState({ error, info });
+    }
+
+    render() {
+      if (this.state.error) {
+        return (
+          <ErrorState errorText="I honestly have no idea what just happened..." />
+        );
+      }
+
+      return <Component {...this.props} />;
+    }
+  }
+
+
+  return SectionErrorBoundary;
+};
+
+export default wrapper;

--- a/src/components/SectionErrorBoundary/index.ts
+++ b/src/components/SectionErrorBoundary/index.ts
@@ -1,0 +1,2 @@
+import SectionErrorBoundary from './SectionErrorBoundary';
+export default SectionErrorBoundary;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,3 +35,22 @@ export const ZONES = {
   'ap-south': 'singapore',
   'ap-south-1a': 'singapore',
 };
+
+export const dcDisplayNames = {
+  'us-east-1a': 'Newark, NJ',
+  'us-south-1a': 'Dallas, TX',
+  'us-west-1a': 'Fremont, CA',
+  'us-southeast-1a': 'Atlanta, GA',
+  'eu-central-1a': 'Frankfurt, DE',
+  'eu-west-1a': 'London, UK',
+  'ap-northeast-1a': 'Tokyo',
+  'ap-northeast-1b': 'Tokyo 2, JP',
+  'us-central': 'Dallas, TX',
+  'us-west': 'Fremont, CA',
+  'us-southeast': 'Atlanta, GA',
+  'us-east': 'Newark, NJ',
+  'eu-west': 'London, UK',
+  'ap-south': 'Singapore, SG',
+  'eu-central': 'Frankfurt, DE',
+  'ap-northeast': 'Tokyo 2, JP',
+};

--- a/src/features/LinodeConfigSelectionDrawer/LinodeConfigSelectionDrawer.tsx
+++ b/src/features/LinodeConfigSelectionDrawer/LinodeConfigSelectionDrawer.tsx
@@ -59,10 +59,21 @@ const LinodeConfigSelectionDrawer: React.StatelessComponent<CombinedProps> = (pr
     }
       </Grid>
       <ActionsPanel>
-        <Button variant="raised" color="primary" onClick={onSubmit}>
+        <Button
+          variant="raised"
+          color="primary"
+          onClick={onSubmit}
+        >
           Submit
         </Button>
-        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={onClose}
+          variant="raised"
+          color="secondary"
+          className="cancel"
+        >
+          Cancel
+        </Button>
       </ActionsPanel>
     </Drawer>
   );

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -17,7 +17,7 @@ import Typography from 'material-ui/Typography';
 import AppBar from 'material-ui/AppBar';
 import Tabs, { Tab } from 'material-ui/Tabs';
 
-import { API_ROOT } from 'src/constants';
+import { API_ROOT, dcDisplayNames } from 'src/constants';
 
 import PromiseLoader from 'src/components/PromiseLoader';
 import SelectImagePanel from './SelectImagePanel';
@@ -111,28 +111,9 @@ const preloaded = PromiseLoader<Props>({
   regions: () => Axios.get(`${API_ROOT}/regions`)
     .then(response => response.data)
     .then((response) => {
-      const display = {
-        'us-east-1a': 'Newark, NJ',
-        'us-south-1a': 'Dallas, TX',
-        'us-west-1a': 'Fremont, CA',
-        'us-southeast-1a': 'Atlanta, GA',
-        'eu-central-1a': 'Frankfurt, DE',
-        'eu-west-1a': 'London, UK',
-        'ap-northeast-1a': 'Tokyo',
-        'ap-northeast-1b': 'Tokyo 2, JP',
-        'us-central': 'Dallas, TX',
-        'us-west': 'Fremont, CA',
-        'us-southeast': 'Atlanta, GA',
-        'us-east': 'Newark, NJ',
-        'eu-west': 'London, UK',
-        'ap-south': 'Singapore, SG',
-        'eu-central': 'Frankfurt, DE',
-        'ap-northeast': 'Tokyo 2, JP',
-      };
-
       return response.data.map((region: Linode.Region) => ({
         ...region,
-        display: display[region.id],
+        display: dcDisplayNames[region.id],
       })) || [];
     }),
 });

--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -99,7 +99,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 });
 
 interface Props {
-  id: string | number;
+  id: number;
   label: string;
   status: 'running' | 'offline' | string;
   openConfigDrawer: (config: Linode.Config[], action: (id: number) => void) => void;

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -54,7 +54,6 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 const SummaryPanel: React.StatelessComponent<CombinedProps> = (props) => {
   const { classes, linode, image, type, volumes } = props;
-
   return (
     <Paper className={classes.root}>
       <Grid container>

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -17,7 +17,8 @@ import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
 type ClassNames = 'root'
 | 'title'
 | 'section'
-| 'region';
+| 'region'
+| 'volumeLink';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
@@ -40,7 +41,13 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
       },
     },
   },
-  volume: {},
+  volumeLink: {
+    color: theme.palette.primary.main,
+    fontSize: '1rem',
+    '&:hover, &:focus': {
+      textDecoration: 'underline',
+    },
+  },
 });
 
 interface Props {
@@ -92,7 +99,7 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = (props) => {
           </Typography>
           <Typography className={classes.section} variant="caption">
             Volumes: <Link
-              className="btnLink"
+              className={classes.volumeLink}
               to={`/linodes/${linode.id}/volumes`}>{volumes.length}</Link>
           </Typography>
         </Grid>

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/AttachVolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/AttachVolumeDrawer.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+import Button from 'material-ui/Button';
+import InputLabel from 'material-ui/Input/InputLabel';
+import MenuItem from 'material-ui/Menu/MenuItem';
+import FormControl from 'material-ui/Form/FormControl';
+import FormHelperText from 'material-ui/Form/FormHelperText';
+
+import Select from 'src/components/Select';
+import Drawer from 'src/components/Drawer';
+import ActionsPanel from 'src/components/ActionsPanel';
+import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {
+  open: boolean;
+  linodeLabel: string;
+  errors?: Linode.ApiFieldError[];
+  volumes: Linode.Volume[];
+  selectedVolume: null | number;
+  onClose: () => void;
+  onSubmit: () => void;
+  onChange: (k: string, v: any) => void;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const errorResources = {
+  volume: 'Volume',
+};
+
+const AttachVolumeDrawer: React.StatelessComponent<CombinedProps> = (props) => {
+  const {
+    open,
+    linodeLabel,
+    volumes,
+    selectedVolume,
+    errors,
+    onClose,
+    onSubmit,
+    onChange,
+  } = props;
+
+  const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+  const volumeError = hasErrorFor('volume');
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      title={`Attach Volume to ${linodeLabel}`}
+    >
+      <FormControl fullWidth>
+        <InputLabel
+          htmlFor="volumes"
+          disableAnimation
+          shrink={true}
+          error={Boolean(volumeError)}
+        >
+          Volume
+          </InputLabel>
+        <Select
+          value={selectedVolume || ''}
+          onChange={e => onChange('selectedVolume', e.target.value)}
+          inputProps={{ name: 'volumes', id: 'volumes' }}
+          error={Boolean(volumeError)}
+        >
+          <MenuItem value="" disabled><em>Select a Volume</em></MenuItem>
+          {
+            volumes && volumes.map((v: Linode.Volume) => {
+              return <MenuItem key={v.id} value={v.id}>{v.label}</MenuItem>;
+            })
+          }
+        </Select>
+        { Boolean(volumeError) && <FormHelperText error>{ volumeError }</FormHelperText> }
+      </FormControl>
+      <ActionsPanel>
+        <Button variant="raised" color="primary" onClick={() => onSubmit()}>Attach</Button>
+        <Button onClick={onClose}> Cancel </Button>
+      </ActionsPanel>
+    </Drawer>
+  );
+};
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(AttachVolumeDrawer);

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -41,7 +41,7 @@ import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import AttachVolumeDrawer from './AttachVolumeDrawer';
 import UpdateVolumeDrawer, { Props as UpdateVolumeDrawerProps } from './UpdateVolumeDrawer';
 import ActionMenu from './LinodeVolumesActionMenu';
-import { events$ } from 'src/events';
+import { events$, resetEventsPolling } from 'src/events';
 
 type ClassNames = 'title';
 
@@ -138,18 +138,18 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
     this.eventSubscription = events$
       /** @todo filter on mount time. */
       .filter(e => [
-          'volume_attach',
-          'volume_clone',
-          'volume_create',
-          'volume_delete',
-          'volume_detach',
-          'volume_resize',
-        ].includes(e.action))
+        'volume_attach',
+        'volume_clone',
+        'volume_create',
+        'volume_delete',
+        'volume_detach',
+        'volume_resize',
+      ].includes(e.action))
       .subscribe((v) => {
         getLinodeVolumes(this.props.linodeID)
           .then(response => response.data)
           .then((attachedVolumes) => {
-            this.setState({ attachedVolumes });
+            this.getAllVolumes();
           })
           .catch(err => console.error(err));
       });
@@ -210,7 +210,7 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
     attachtoLinode(Number(selectedVolume))(Number(linodeID))
       .then((response) => {
         this.closeAttachmentDrawer();
-        this.getAllVolumes();
+        resetEventsPolling();
       })
       .catch((error) => {
         this.setState({
@@ -276,7 +276,7 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
     detachVolume(id)
       .then((response) => {
         this.closeUpdateDialog();
-        this.getAllVolumes();
+        resetEventsPolling();
       })
       .catch((response) => {
         /** @todo Error handling. */
@@ -290,9 +290,10 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
     deleteVolume(id)
       .then((response) => {
         this.closeUpdateDialog();
-        this.getAllVolumes();
+        resetEventsPolling();
       })
       .catch((response) => {
+        this.closeUpdateDialog();
         /** @todo Error handling */
       });
   }
@@ -489,8 +490,8 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
 
     createVolume(label, Number(size), region, linodeId)
       .then(() => {
-        this.closeUpdatingDrawer();
         this.getAllVolumes();
+        resetEventsPolling();
       })
       .catch((errorResponse) => {
         this.setState({
@@ -563,7 +564,7 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
     resizeVolume(id, Number(size))
       .then(() => {
         this.closeUpdatingDrawer();
-        this.getAllVolumes();
+        resetEventsPolling();
       })
       .catch((errorResponse: any) => {
         this.setState({
@@ -600,7 +601,7 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
          * @todo Now what? Per CF parity the volume is not automagically attached.
         */
         this.closeUpdatingDrawer();
-        this.getAllVolumes();
+        resetEventsPolling();
       })
       .catch((error) => {
         /** @todo Error handling. */

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -499,6 +499,7 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
 
     createVolume(label, Number(size), region, linodeId)
       .then(() => {
+        this.closeUpdatingDrawer();
         this.getAllVolumes();
         resetEventsPolling();
       })

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -247,7 +247,6 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
       })
       .catch((response) => {
         /** @todo Error handling. */
-        console.error(response);
       });
   }
 
@@ -262,7 +261,6 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
       })
       .catch((response) => {
         /** @todo Error handling */
-        console.error(response);
       });
   }
 

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -22,7 +22,7 @@ import {
   getVolumes,
   attach as attachtoLinode,
   detach as detachVolume,
-  ddelete as deleteVolume,
+  _delete as deleteVolume,
   clone as cloneVolume,
   create as createVolume,
   update as updateVolume,
@@ -151,7 +151,9 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
           .then((attachedVolumes) => {
             this.getAllVolumes();
           })
-          .catch(err => console.error(err));
+          .catch(() => {
+            /** @todo Error handling. */
+          });
       });
   }
 
@@ -411,7 +413,7 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
             open: true,
             id,
             label: label!,
-            title: 'Resize a Volume',
+            title: 'Clone a Volume',
             cloning: true,
             cloneLabel: '',
             linodeLabel,

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -1,32 +1,792 @@
 import * as React from 'react';
+import { pathOr, compose } from 'ramda';
+
 import {
   withStyles,
   StyleRulesCallback,
   Theme,
   WithStyles,
 } from 'material-ui';
+import Button from 'material-ui/Button';
+import Grid from 'material-ui/Grid';
+import Paper from 'material-ui/Paper';
+import Typography from 'material-ui/Typography';
+import Table from 'material-ui/Table';
+import TableHead from 'material-ui/Table/TableHead';
+import TableBody from 'material-ui/Table/TableBody';
+import TableRow from 'material-ui/Table/TableRow';
+import TableCell from 'material-ui/Table/TableCell';
 
+import {
+  getVolumes,
+  attach as attachtoLinode,
+  detach as detachVolume,
+  ddelete as deleteVolume,
+  clone as cloneVolume,
+  create as createVolume,
+  update as updateVolume,
+  resize as resizeVolume,
+} from 'src/services/volumes';
+import Placeholder, { PlaceholderProps } from 'src/components/Placeholder';
+import IconTextLink, { IconTextLinkProps } from 'src/components/IconTextLink';
+import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
+import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader';
+import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
+import PlusSquare from 'src/assets/icons/plus-square.svg';
+import { getLinodeConfigs, getLinodeVolumes } from 'src/services/linode';
+import ErrorState from 'src/components/ErrorState';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
 
-type ClassNames = 'root';
+import AttachVolumeDrawer from './AttachVolumeDrawer';
+import UpdateVolumeDrawer from './UpdateVolumeDrawer';
+import ActionMenu from './LinodeVolumesActionMenu';
+
+type ClassNames = 'title';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
-  root: {},
+  title: {
+    marginTop: theme.spacing.unit * 2,
+    marginBottom: theme.spacing.unit * 2,
+  },
 });
 
-interface Props {}
+interface Props {
+  linodeVolumes: Linode.Volume[];
+  linodeLabel: string;
+  linodeRegion: string;
+  linodeID: number;
 
-interface State {}
+  /** PromiseLoader */
+  volumes: PromiseLoaderResponse<Linode.Volume[]>;
+  linodeConfigs: PromiseLoaderResponse<Linode.Config[]>;
+}
+
+interface AttachVolumeDrawerState {
+  open: boolean;
+  errors?: Linode.ApiFieldError[];
+  selectedVolume: null | number;
+}
+
+interface UpdateDialogState {
+  open: boolean;
+  mode?: 'detach' | 'delete';
+  id?: number;
+}
+
+interface UpdateVolumeDrawerState {
+  open: boolean;
+  mode?: 'create' | 'edit' | 'resize' | 'clone';
+  errors?: Linode.ApiFieldError[];
+  id?: number;
+  label?: string;
+  size?: number;
+  region?: string;
+  linodeId?: number;
+}
+
+interface State {
+  attachedVolumes: Linode.Volume[];
+  attachableVolumes: Linode.Volume[];
+  attachVolumeDrawer: AttachVolumeDrawerState;
+  updateDialog: UpdateDialogState;
+  updateVolumeDrawer: UpdateVolumeDrawerState;
+}
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 class LinodeVolumes extends React.Component<CombinedProps, State> {
-  state = {};
+  static defaultProps = {
+    volumes: [],
+    linodeConfigs: [],
+  };
 
+  static attachVolumeDrawerDefaultState = {
+    open: false,
+    selectedVolume: null,
+  };
+
+  static updateDialogDefaultState = {
+    open: false,
+  };
+
+  static updateVolumeDrawerDefaultState = {
+    open: false,
+  };
+
+  constructor(props: CombinedProps) {
+    super(props);
+    const { linodeVolumes } = props;
+
+    this.state = {
+      attachedVolumes: linodeVolumes,
+      attachableVolumes: props.volumes.response,
+      attachVolumeDrawer: LinodeVolumes.attachVolumeDrawerDefaultState,
+      updateDialog: LinodeVolumes.updateDialogDefaultState,
+      updateVolumeDrawer: LinodeVolumes.updateVolumeDrawerDefaultState,
+    };
+  }
+
+  getAllVolumes = () => {
+    const { linodeRegion } = this.props;
+    const getAttachedVolumes = getLinodeVolumes(this.props.linodeID)
+      .then(response => response.data);
+    const getAttachableVolumes = getVolumes()
+      .then(response => response
+        .data
+        .filter(volume => volume.region === linodeRegion && volume.linode_id === null));
+
+    Promise
+      .all([
+        getAttachedVolumes,
+        getAttachableVolumes,
+      ])
+      .then(([attachedVolumes, attachableVolumes]) => {
+        this.setState({
+          attachedVolumes,
+          attachableVolumes,
+        });
+      });
+  }
+
+  /** Attachment */
+  openAttachmentDrawer = () => this.setState(prevState => ({
+    attachVolumeDrawer: {
+      ...prevState.attachVolumeDrawer,
+      open: true,
+    },
+  }))
+
+  closeAttachmentDrawer = () => this.setState(prevState => ({
+    attachVolumeDrawer: LinodeVolumes.attachVolumeDrawerDefaultState,
+  }))
+
+  attachVolume = () => {
+    const { linodeID } = this.props;
+    const { attachVolumeDrawer: { selectedVolume } } = this.state;
+
+    if (!selectedVolume) {
+      this.setState({
+        attachVolumeDrawer: {
+          ...this.state.attachVolumeDrawer,
+          errors: [{ field: 'volume', reason: 'volume cannot be blank.' }],
+        },
+      });
+      return;
+    }
+
+    attachtoLinode(Number(selectedVolume))(Number(linodeID))
+      .then((response) => {
+        this.closeAttachmentDrawer();
+        this.getAllVolumes();
+      })
+      .catch((error) => {
+        this.setState({
+          attachVolumeDrawer: {
+            ...this.state.attachVolumeDrawer,
+            errors: [{ field: 'volume', reason: 'Could not attach volume.' }],
+          },
+        });
+      });
+  }
+
+  AttachVolumeDrawer = (): JSX.Element => {
+    const { linodeLabel } = this.props;
+    const {
+      attachableVolumes,
+      attachVolumeDrawer: {
+        selectedVolume,
+        open,
+        errors,
+      },
+    } = this.state;
+
+    return (
+      <AttachVolumeDrawer
+        open={open}
+        linodeLabel={linodeLabel}
+        volumes={attachableVolumes}
+        errors={errors}
+        selectedVolume={selectedVolume}
+        onClose={this.closeAttachmentDrawer}
+        onChange={(key, value) => this.setState({
+          attachVolumeDrawer: {
+            ...this.state.attachVolumeDrawer,
+            [key]: value,
+          },
+        })}
+        onSubmit={this.attachVolume}
+      />
+    );
+  }
+
+  /** Detachment / Deletion */
+  openUpdateDialog = (mode: 'detach' | 'delete', id: number) => () => {
+    this.setState({
+      updateDialog: {
+        mode,
+        open: true,
+        id,
+      },
+    });
+  }
+
+  closeUpdateDialog = () => {
+    this.setState({
+      updateDialog: LinodeVolumes.updateDialogDefaultState,
+    });
+  }
+
+  detachVolume = () => {
+    const { updateDialog: { id } } = this.state;
+    if (!id) { return; }
+
+    detachVolume(id)
+      .then((response) => {
+        this.closeUpdateDialog();
+        this.getAllVolumes();
+      })
+      .catch((response) => {
+        /** @todo Error handling. */
+        console.error(response);
+      });
+  }
+
+  deleteVolume = () => {
+    const { updateDialog: { id } } = this.state;
+    if (!id) { return; }
+
+    deleteVolume(id)
+      .then((response) => {
+        this.closeUpdateDialog();
+        this.getAllVolumes();
+      })
+      .catch((response) => {
+        /** @todo Error handling */
+        console.error(response);
+      });
+  }
+
+  UpdateDialog = (): null | JSX.Element => {
+    const {
+      updateDialog: {
+        mode,
+        open,
+      },
+    } = this.state;
+
+    if (!mode) { return null; }
+
+    const method = (() => {
+      switch (mode) {
+        case 'detach': return this.detachVolume;
+        case 'delete': return this.deleteVolume;
+      }
+    })();
+
+    const title = (function () {
+      switch (mode) {
+        case 'detach': return 'Detach Volume';
+        case 'delete': return 'Delete Volume';
+      }
+    })();
+
+    return (
+      <ConfirmationDialog
+        onClose={this.closeUpdateDialog}
+        actions={() => <div>
+          <Button onClick={this.closeUpdateDialog}>Cancel</Button>
+          <Button
+            variant="raised"
+            color="secondary"
+            className="destructive"
+            onClick={method}
+          >
+            Confirm
+        </Button>
+        </div>}
+        open={open}
+        title={title}
+      >
+        Are you sure you want to {mode} this volume?
+    </ConfirmationDialog>
+    );
+  }
+
+  /** Create / Edit / Resize / Cloning */
+  openUpdatingDrawer = (
+    mode: 'create' | 'edit' | 'resize' | 'clone',
+    id?: number,
+    label?: string,
+    size?: number,
+  ) => () => this.setState(prevState => ({
+    updateVolumeDrawer: {
+      mode,
+      open: true,
+      id,
+      label,
+      size,
+      region: this.props.linodeRegion,
+      linodeId: this.props.linodeID,
+    },
+  }))
+
+  closeUpdatingDrawer = () => this.setState(prevState => ({
+    updateVolumeDrawer: LinodeVolumes.updateVolumeDrawerDefaultState,
+  }))
+
+  createVolume = () => {
+    const {
+      updateVolumeDrawer: {
+        label, size, region, linodeId,
+      },
+    } = this.state;
+
+    if (!region || !linodeId) { return; }
+
+    if (!label) {
+      return this.setState({
+        updateVolumeDrawer: {
+          ...this.state.updateVolumeDrawer,
+          errors: [{ field: 'label', reason: 'Label cannot be blank.' }],
+        },
+      });
+    }
+
+    if (!size) {
+      return this.setState({
+        updateVolumeDrawer: {
+          ...this.state.updateVolumeDrawer,
+          errors: [{ field: 'size', reason: 'cannot be blank.' }],
+        },
+      });
+    }
+
+    createVolume(label, Number(size), region, linodeId)
+      .then(() => {
+        this.closeUpdatingDrawer();
+        this.getAllVolumes();
+      })
+      .catch((errorResponse) => {
+        this.setState({
+          updateVolumeDrawer: {
+            ...this.state.updateVolumeDrawer,
+            errors: errorResponse.response.data.errors,
+          },
+        });
+      });
+  }
+
+  editVolume = () => {
+    const {
+      updateVolumeDrawer: {
+        id,
+        label,
+      },
+    } = this.state;
+
+
+    if (!id) {
+      return;
+    }
+
+    if (!label) {
+      return this.setState({
+        updateVolumeDrawer: {
+          ...this.state.updateVolumeDrawer,
+          errors: [{ field: 'label', reason: 'Label cannot be blank.' }],
+        },
+      });
+    }
+
+    updateVolume(id, label)
+      .then(() => {
+        this.closeUpdatingDrawer();
+        this.getAllVolumes();
+      })
+      .catch((errorResponse: any) => {
+        this.setState({
+          updateVolumeDrawer: {
+            ...this.state.updateVolumeDrawer,
+            errors: errorResponse.response.data.errors,
+          },
+        });
+      });
+  }
+
+  resizeVolume = () => {
+    const {
+      updateVolumeDrawer: {
+        id,
+        size,
+      },
+    } = this.state;
+
+
+    if (!id) {
+      return;
+    }
+
+    if (!size) {
+      return this.setState({
+        updateVolumeDrawer: {
+          ...this.state.updateVolumeDrawer,
+          errors: [{ field: 'size', reason: 'Size cannot be blank.' }],
+        },
+      });
+    }
+
+    resizeVolume(id, Number(size))
+      .then(() => {
+        this.closeUpdatingDrawer();
+        this.getAllVolumes();
+      })
+      .catch((errorResponse: any) => {
+        this.setState({
+          updateVolumeDrawer: {
+            ...this.state.updateVolumeDrawer,
+            errors: errorResponse.response.data.errors.map(({ reason }: Linode.ApiFieldError) => ({
+              field: 'size',
+              reason,
+            })),
+          },
+        });
+      });
+  }
+
+  cloneVolume = () => {
+    const { updateVolumeDrawer: { id, label } } = this.state;
+
+    if (!label) {
+      return this.setState({
+        updateVolumeDrawer: {
+          ...this.state.updateVolumeDrawer,
+          errors: [{ field: 'label', reason: 'Label cannot be blank.' }],
+        },
+      });
+    }
+
+    if (!id) {
+      return;
+    }
+
+    cloneVolume(id, label || '')
+      .then(() => {
+        /**
+         * @todo Now what? Per CF parity the volume is not automagically attached.
+        */
+        this.closeUpdatingDrawer();
+        this.getAllVolumes();
+      })
+      .catch((error) => {
+        /** @todo Error handling. */
+        this.setState({
+          updateVolumeDrawer: {
+            ...this.state.updateVolumeDrawer,
+            errors: error.response.data.errors,
+          },
+        });
+      });
+  }
+
+  UpdateVolumeDrawer = (): null | JSX.Element => {
+    const { updateVolumeDrawer: {
+      mode,
+      open,
+      id,
+      label = '',
+      size = 20,
+      region,
+      linodeId,
+      errors,
+    } } = this.state;
+
+    if (!mode) { return null; }
+
+    const bail = (function () {
+
+      switch (mode) {
+        case 'create': return !region || !linodeId;
+        case 'edit': return !id;
+        case 'resize': return !id;
+        case 'clone': return !id;
+      }
+    })();
+
+    if (bail) {
+      return null;
+    }
+
+    const method = (function (that) {
+      switch (mode) {
+        case 'create': return that.createVolume;
+        case 'edit': return that.editVolume;
+        case 'resize': return that.resizeVolume;
+        case 'clone': return that.cloneVolume;
+      }
+    })(this);
+
+    const disabled = (function () {
+      switch (mode) {
+        case 'create': return { region: true, linode: true };
+        case 'edit': return { region: true, linode: true, size: true };
+        case 'resize': return { region: true, linode: true, label: true };
+        case 'clone': return { size: true, region: true, linode: true };
+      }
+    })();
+
+    const title = (function () {
+      switch (mode) {
+        case 'create': return 'Create Volume';
+        case 'edit': return 'Edit Volume';
+        case 'resize': return 'Resize Volume';
+        case 'clone': return 'Clone Volume';
+      }
+    })();
+
+    return (
+      <UpdateVolumeDrawer
+        open={open}
+        title={title}
+        label={label}
+        size={size}
+        region={region}
+        linodeId={linodeId}
+        onClose={this.closeUpdatingDrawer}
+        disabled={disabled}
+        onChange={(key, value) => this.setState({
+          updateVolumeDrawer: {
+            ...this.state.updateVolumeDrawer,
+            [key]: value,
+          },
+        })}
+        onSubmit={method}
+        errors={errors}
+      />
+    );
+  }
+
+  /**
+   * Only ever show if the Linode has attached volumes.
+   *
+   * IconTextLink is
+   *  - If user has no configs, show null.
+   *  - Else
+   *    - If User has eligible volumes, show "Attach a Volume"
+   *    - Else show "Create a Volume"
+   */
+  IconTextLink = (): null | JSX.Element => {
+    const { linodeConfigs: { response: configs } } = this.props;
+    const { attachableVolumes } = this.state;
+
+    if (configs.length === 0) {
+      return null;
+    }
+
+    let IconTextLinkProps: IconTextLinkProps = {
+      SideIcon: PlusSquare,
+      onClick: this.openUpdatingDrawer('create'),
+      text: 'Create a Volume',
+      title: 'Create a Volume',
+    };
+
+    if (attachableVolumes.length > 0) {
+      IconTextLinkProps = {
+        SideIcon: PlusSquare,
+        onClick: this.openAttachmentDrawer,
+        text: 'Attach Existing Volume',
+        title: 'Attach Existing Volume',
+      };
+    }
+    return <IconTextLink {...IconTextLinkProps} />;
+  }
+
+  /**
+   * Placeholder is
+   * - If Linode has volumes, null.
+   *  - Else
+   *    - If user has no configs, show "View Linode Config"
+   *    - Else
+   *      - If user has eligible Volumes, show "Attach a Volume"
+   *      - Else, show "Create a Volume"
+   */
+  Placeholder = (): null | JSX.Element => {
+    const {
+      linodeConfigs: { response: configs },
+    } = this.props;
+    const { attachedVolumes, attachableVolumes } = this.state;
+    let props: PlaceholderProps;
+
+    if (attachedVolumes.length > 0) {
+      return null;
+    }
+
+    if (configs.length === 0) {
+      props = {
+        buttonProps: {
+          onClick: this.openAttachmentDrawer,
+          children: 'View Linode Config',
+        },
+        icon: VolumeIcon,
+        title: 'No configs available',
+        copy: 'This Linode has no configurations. Click below to create a configuration.',
+      };
+      return <Placeholder {...props} />;
+    }
+
+    if (attachableVolumes.length > 0) {
+      props = {
+        buttonProps: {
+          onClick: this.openAttachmentDrawer,
+          children: 'Attach a Volume',
+        },
+        icon: VolumeIcon,
+        title: 'No volumes attached',
+        copy: 'Click below to attach a volume.',
+      };
+      return < Placeholder {...props} />;
+    }
+
+    /** We have at least one config, but we have no volumes. */
+    props = {
+      buttonProps: {
+        onClick: this.openUpdatingDrawer('create'),
+        children: 'Create a Volume',
+      },
+      icon: VolumeIcon,
+      title: 'No volumes found',
+      copy: 'Click below to create a volume.',
+    };
+
+    return <Placeholder {...props} />;
+  }
+
+  /**
+   * Table is
+   * - If Linode has no volumes, null.
+   * - Else show rows of volumes.
+   */
+  Table = (): null | JSX.Element => {
+    const { classes } = this.props;
+    const { attachedVolumes } = this.state;
+
+    if (attachedVolumes.length === 0) {
+      return null;
+    }
+
+    return (
+      <React.Fragment>
+        <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }} >
+          <Grid item>
+            <Typography
+              variant="title"
+              className={classes.title}>
+              Volumes
+            </Typography>
+          </Grid>
+          <Grid item>
+            <this.IconTextLink />
+          </Grid>
+        </Grid>
+        <Paper>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Label</TableCell>
+                <TableCell>Size</TableCell>
+                <TableCell>File System Path</TableCell>
+                <TableCell></TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {
+                attachedVolumes!.map((volume) => {
+                  /** @todo Remove path defaulting when API releases filesystem_path. */
+                  const label = pathOr('', ['label'], volume);
+                  const size = pathOr('', ['size'], volume);
+                  const filesystem_path = pathOr(
+                    `/dev/disk/by-id/scsi-0Linode_Volume_${label}`,
+                    ['filesystem_path'],
+                    volume,
+                  );
+
+                  return <TableRow key={volume.id}>
+                    <TableCell>{label}</TableCell>
+                    <TableCell>{size} GiB</TableCell>
+                    <TableCell>{filesystem_path}</TableCell>
+                    <TableCell>
+                      <ActionMenu
+                        volumeId={volume.id}
+                        onDetach={this.openUpdateDialog('detach', volume.id)}
+                        onDelete={this.openUpdateDialog('delete', volume.id)}
+                        onClone={this.openUpdatingDrawer(
+                          'clone',
+                          volume.id,
+                        )}
+                        onEdit={this.openUpdatingDrawer(
+                          'edit',
+                          volume.id,
+                          volume.label,
+                          volume.size,
+                        )}
+                        onResize={this.openUpdatingDrawer(
+                          'resize',
+                          volume.id,
+                          volume.label,
+                          volume.size,
+                        )}
+                      />
+                    </TableCell>
+                  </TableRow>;
+                })
+              }
+            </TableBody>
+          </Table>
+        </Paper>
+        <this.UpdateDialog />
+      </React.Fragment>
+    );
+  }
+
+  /**
+   * Important numbers;
+   * number of configs
+   * number of this linodes volumes
+   * number of eligible volumes
+   */
   render() {
-    return (<h1>Volumes</h1>);
+    const {
+      volumes: { error: volumesError },
+      linodeConfigs: { error: linodeConfigsError },
+    } = this.props;
+
+    if (volumesError || linodeConfigsError) {
+      return <ErrorState errorText="An error has occured." />;
+    }
+
+    return (
+      <React.Fragment>
+        <this.Placeholder />
+        <this.Table />
+        <this.AttachVolumeDrawer />
+        <this.UpdateVolumeDrawer />
+      </React.Fragment>
+    );
   }
 }
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled(LinodeVolumes);
+const preloaded = PromiseLoader({
+  linodeConfigs: (props: Props) => getLinodeConfigs(props.linodeID)
+    .then(response => response.data),
+
+  volumes: (props: Props) => getVolumes()
+    .then(response => response.data
+      .filter(volume => volume.region === props.linodeRegion && volume.linode_id === null)),
+});
+
+export default compose<any, any, any, any>(
+  styled,
+  SectionErrorBoundary,
+  preloaded,
+)(LinodeVolumes);

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -328,7 +328,6 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
       <ConfirmationDialog
         onClose={this.closeUpdateDialog}
         actions={() => <div>
-          <Button onClick={this.closeUpdateDialog}>Cancel</Button>
           <Button
             variant="raised"
             color="secondary"
@@ -336,7 +335,15 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
             onClick={method}
           >
             Confirm
-        </Button>
+          </Button>
+          <Button
+            onClick={this.closeUpdateDialog}
+            variant="raised"
+            color="secondary"
+            className="cancel"
+          >
+            Cancel
+          </Button>
         </div>}
         open={open}
         title={title}

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumesActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumesActionMenu.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+
+import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+
+interface Props {
+  volumeId: number;
+  onDetach: () => void;
+  onDelete: () => void;
+  onClone: () => void;
+  onEdit: () => void;
+  onResize: () => void;
+}
+
+type CombinedProps = Props & RouteComponentProps<{}>;
+
+class LinodeActionMenu extends React.Component<CombinedProps> {
+  createLinodeActions = () => {
+    const {
+      onDetach,
+      onDelete,
+      onClone,
+      onEdit,
+      onResize,
+    } = this.props;
+
+    return function (closeMenu: Function): Action[] {
+      const actions = [
+        {
+          title: 'Edit',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onEdit();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+        {
+          title: 'Resize',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onResize();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+        {
+          title: 'Clone',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onClone();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+        {
+          title: 'Detach',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onDetach();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+        {
+          title: 'Delete',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onDelete();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+      ];
+      return actions;
+    };
+  }
+
+  render() {
+    return (
+      <ActionMenu createActions={this.createLinodeActions()} />
+    );
+  }
+}
+
+export default withRouter(LinodeActionMenu);

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/UpdateVolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/UpdateVolumeDrawer.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+import Button from 'material-ui/Button';
+
+import TextField from 'src/components/TextField';
+import Drawer from 'src/components/Drawer';
+import ActionsPanel from 'src/components/ActionsPanel';
+import { dcDisplayNames } from 'src/constants';
+import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {
+  open: boolean;
+  title: string;
+  label?: string;
+  size?: number;
+  region?: string;
+  linodeId?: number;
+  disabled?: {
+    label?: boolean;
+    size?: boolean;
+    region?: boolean;
+    linode?: boolean;
+  };
+  errors?: Linode.ApiFieldError[];
+
+  onClose: () => void;
+  onChange: (k: string, v: any) => void;
+  onSubmit: () => void;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const thingy = {
+  size: 'size',
+};
+
+const UpdateVolumeDrawer: React.StatelessComponent<CombinedProps> = (props) => {
+  const {
+    open,
+    title,
+    errors,
+    disabled,
+    label,
+    size,
+    region,
+    linodeId,
+
+    onClose,
+    onChange,
+    onSubmit,
+  } = props;
+
+  const hasErrorFor = getAPIErrorFor(thingy, errors);
+  const labelError = hasErrorFor('label');
+  const sizeError = hasErrorFor('size');
+  const regionError = hasErrorFor('region');
+  const linodeError = hasErrorFor('linode_id');
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      title={title}
+    >
+      <TextField
+        label="Label"
+        value={label}
+        onChange={e => onChange('label', e.target.value)}
+        error={Boolean(labelError)}
+        errorText={labelError}
+        disabled={disabled!.label}
+      />
+      <TextField
+        label="Size"
+        value={size}
+        onChange={e => onChange('size', e.target.value)}
+        error={Boolean(sizeError)}
+        errorText={sizeError}
+        disabled={disabled!.size}
+        />
+
+      {/** Needs to be Select */}
+      <TextField
+        label="Region"
+        onChange={e => onChange('region', e.target.value)}
+        value={dcDisplayNames[region!]}
+        error={Boolean(regionError)}
+        errorText={regionError}
+        disabled={disabled!.region}
+      />
+
+      {/** Needs to be Select */}
+      <TextField
+        label="Attached To"
+        onChange={e => onChange('linodeId', e.target.value)}
+        value={linodeId}
+        error={Boolean(linodeError)}
+        errorText={linodeError}
+        disabled={disabled!.linode}
+      />
+
+      <ActionsPanel>
+        <Button onClick={onSubmit} variant="raised" color="primary">Submit</Button>
+        <Button onClick={onClose}>Cancel</Button>
+      </ActionsPanel>
+    </Drawer>
+  );
+};
+
+UpdateVolumeDrawer.defaultProps = {
+  label: '',
+  region: '',
+  linodeId: 0,
+  size: 20,
+  disabled: {},
+};
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(UpdateVolumeDrawer);

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/UpdateVolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/UpdateVolumeDrawer.tsx
@@ -19,13 +19,15 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {},
 });
 
-interface Props {
+export interface Props {
   open: boolean;
   title: string;
-  label?: string;
-  size?: number;
-  region?: string;
-  linodeId?: number;
+  label: string;
+  cloneLabel?: string;
+  cloning?: boolean;
+  size: number;
+  region: string;
+  linodeId: number;
   disabled?: {
     label?: boolean;
     size?: boolean;
@@ -35,8 +37,12 @@ interface Props {
   errors?: Linode.ApiFieldError[];
 
   onClose: () => void;
-  onChange: (k: string, v: any) => void;
   onSubmit: () => void;
+  onLabelChange?: (id: string) => void;
+  onCloneLabelChange?: (id: string) => void;
+  onSizeChange?: (id: string) => void;
+  onRegionChange?: (id: string) => void;
+  onLinodeChange?: (id: string) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -52,12 +58,17 @@ const UpdateVolumeDrawer: React.StatelessComponent<CombinedProps> = (props) => {
     errors,
     disabled,
     label,
+    cloneLabel,
+    cloning,
     size,
     region,
     linodeId,
-
+    onLabelChange,
+    onCloneLabelChange,
+    onSizeChange,
+    onRegionChange,
+    onLinodeChange,
     onClose,
-    onChange,
     onSubmit,
   } = props;
 
@@ -73,41 +84,50 @@ const UpdateVolumeDrawer: React.StatelessComponent<CombinedProps> = (props) => {
       onClose={onClose}
       title={title}
     >
+      {cloning && <TextField
+        label="Cloned Label"
+        value={cloneLabel}
+        {...(onCloneLabelChange && { onChange: e => onCloneLabelChange(e.target.value) })}
+        error={Boolean(labelError)}
+        errorText={labelError}
+        />}
+
       <TextField
         label="Label"
         value={label}
-        onChange={e => onChange('label', e.target.value)}
+        {...(onLabelChange && { onChange: e => onLabelChange(e.target.value) })}
         error={Boolean(labelError)}
         errorText={labelError}
-        disabled={disabled!.label}
-      />
+        disabled={disabled && disabled.label}
+        />
+
       <TextField
         label="Size"
         value={size}
-        onChange={e => onChange('size', e.target.value)}
+        {...(onSizeChange && { onChange: e => onSizeChange(e.target.value) })}
         error={Boolean(sizeError)}
         errorText={sizeError}
-        disabled={disabled!.size}
+        disabled={disabled && disabled.size}
         />
 
       {/** Needs to be Select */}
       <TextField
         label="Region"
-        onChange={e => onChange('region', e.target.value)}
-        value={dcDisplayNames[region!]}
+        {...(onRegionChange && { onChange: e => onRegionChange(e.target.value) })}
+        value={region && dcDisplayNames[region]}
         error={Boolean(regionError)}
         errorText={regionError}
-        disabled={disabled!.region}
-      />
+        disabled={disabled && disabled.region}
+        />
 
       {/** Needs to be Select */}
       <TextField
         label="Attached To"
-        onChange={e => onChange('linodeId', e.target.value)}
+        {...(onLinodeChange && { onChange: e => onLinodeChange(e.target.value) })}
         value={linodeId}
         error={Boolean(linodeError)}
         errorText={linodeError}
-        disabled={disabled!.linode}
+        disabled={disabled && disabled.linode}
       />
 
       <ActionsPanel>
@@ -116,14 +136,6 @@ const UpdateVolumeDrawer: React.StatelessComponent<CombinedProps> = (props) => {
       </ActionsPanel>
     </Drawer>
   );
-};
-
-UpdateVolumeDrawer.defaultProps = {
-  label: '',
-  region: '',
-  linodeId: 0,
-  size: 20,
-  disabled: {},
 };
 
 const styled = withStyles(styles, { withTheme: true });

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/UpdateVolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/UpdateVolumeDrawer.tsx
@@ -131,8 +131,21 @@ const UpdateVolumeDrawer: React.StatelessComponent<CombinedProps> = (props) => {
       />
 
       <ActionsPanel>
-        <Button onClick={onSubmit} variant="raised" color="primary">Submit</Button>
-        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          onClick={onSubmit}
+          variant="raised"
+          color="primary"
+        >
+          Submit
+        </Button>
+        <Button
+          onClick={onClose}
+          variant="raised"
+          color="secondary"
+          className="cancel"
+        >
+          Cancel
+        </Button>
       </ActionsPanel>
     </Drawer>
   );

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { pathEq } from 'ramda';
 import * as moment from 'moment';
 import Axios from 'axios';
 import {
@@ -115,6 +116,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
     const mountTime = moment().subtract(5, 'seconds');
     this.subscription = events$
       .filter(newLinodeEvents(mountTime))
+      .filter(pathEq(['entity', 'id'], Number(this.props.match.params.linodeId)))
       .subscribe((linodeEvent) => {
         Axios.get(`${API_ROOT}/linode/instances/${(linodeEvent.entity as Linode.Entity).id}`)
           .then(response => response.data)

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -75,7 +75,7 @@ const preloaded = PromiseLoader<Props>({
           .catch(err => undefined);
 
         const volumesReq = Axios.get(`${API_ROOT}/linode/instances/${linode.id}/volumes`)
-          .then(response => response.data)
+          .then(response => response.data.data)
           .catch(err => []);
 
         return Promise.all([typeReq, imageReq, volumesReq])
@@ -114,8 +114,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
   componentDidMount() {
     const mountTime = moment().subtract(5, 'seconds');
     this.subscription = events$
-      /* TODO: factor out this filter using a higher-order function that
-         takes mountTime */
       .filter(newLinodeEvents(mountTime))
       .subscribe((linodeEvent) => {
         Axios.get(`${API_ROOT}/linode/instances/${(linodeEvent.entity as Linode.Entity).id}`)
@@ -238,13 +236,20 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
           <Route exact path={`${url}/summary`} render={() => (
             <LinodeSummary linode={linode} type={type} image={image} volumes={volumes} />
           )} />
-          <Route exact path={`${url}/volumes`} render={() => (<LinodeVolumes/>)} />
-          <Route exact path={`${url}/networking`} render={() => (<LinodeNetworking/>)} />
-          <Route exact path={`${url}/rescue`} render={() => (<LinodeRescue/>)} />
-          <Route exact path={`${url}/resize`} render={() => (<LinodeResize/>)} />
-          <Route exact path={`${url}/rebuild`} render={() => (<LinodeRebuild/>)} />
-          <Route exact path={`${url}/backup`} render={() => (<LinodeBackup/>)} />
-          <Route exact path={`${url}/settings`} render={() => (<LinodeSettings/>)} />
+          <Route exact path={`${url}/volumes`} render={() => (
+            <LinodeVolumes
+              linodeID={linode.id}
+              linodeLabel={linode.label}
+              linodeRegion={linode.region}
+              linodeVolumes={volumes}
+            />
+          )} />
+          <Route exact path={`${url}/networking`} render={() => (<LinodeNetworking />)} />
+          <Route exact path={`${url}/rescue`} render={() => (<LinodeRescue />)} />
+          <Route exact path={`${url}/resize`} render={() => (<LinodeResize />)} />
+          <Route exact path={`${url}/rebuild`} render={() => (<LinodeRebuild />)} />
+          <Route exact path={`${url}/backup`} render={() => (<LinodeBackup />)} />
+          <Route exact path={`${url}/settings`} render={() => (<LinodeSettings />)} />
           {/* 404 */}
           <Route exact render={() => (<Redirect to={`${url}/summary`} />)} />
         </Switch>

--- a/src/features/linodes/LinodesLanding/powerActions.ts
+++ b/src/features/linodes/LinodesLanding/powerActions.ts
@@ -1,4 +1,4 @@
-import Axios, { AxiosResponse } from 'axios';
+import Axios from 'axios';
 import * as moment from 'moment';
 
 import { API_ROOT } from 'src/constants';
@@ -6,6 +6,7 @@ import { events$, resetEventsPolling } from 'src/events';
 
 import { dateFormat } from 'src/time';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
+import { getLinodeConfigs } from 'src/services/linode';
 
 export const genEvent = (
   action: string,
@@ -60,13 +61,12 @@ const withAction = (
   action: LinodePowerAction,
 ) => (
   updateDrawer: DrawerFunction,
-  id: number | string,
+  id: number,
   label: string,
 ) => {
-  Axios
-    .get(`${API_ROOT}/linode/instances/${id}/configs`)
-    .then((response: AxiosResponse<Linode.ManyResourceState<Linode.Config>>) => {
-      const configs = response.data.data;
+  getLinodeConfigs(id)
+    .then((response: Linode.ManyResourceState<Linode.Config>) => {
+      const configs = response.data;
       const len = configs.length;
 
       if (len > 1) {

--- a/src/services/linode.ts
+++ b/src/services/linode.ts
@@ -1,0 +1,13 @@
+import Axios from 'axios';
+import { API_ROOT } from 'src/constants';
+
+
+type GetLinodeType = Promise<Linode.ManyResourceState<Linode.Config>>;
+export const getLinodeConfigs = (id: number): GetLinodeType =>
+Axios.get(`${API_ROOT}/linode/instances/${id}/configs`)
+  .then(response => response.data);
+
+type GetLinodeVolumesType = Promise<Linode.ManyResourceState<Linode.Volume>>;
+export const getLinodeVolumes = (id: number): GetLinodeVolumesType =>
+  Axios.get(`${API_ROOT}/linode/instances/${id}/volumes`)
+    .then(response => response.data);

--- a/src/services/volumes.ts
+++ b/src/services/volumes.ts
@@ -1,0 +1,41 @@
+import Axios from 'axios';
+import { API_ROOT } from 'src/constants';
+
+export const getVolumes = (): Promise<Linode.ManyResourceState<Linode.Volume>> =>
+  Axios
+    .get(`${API_ROOT}/volumes`)
+    .then(response => response.data);
+
+export const attach = (volumeId: number) => (linodeId: number): Promise<{}> =>
+  Axios
+    .post(`${API_ROOT}/volumes/${volumeId}/attach`, { linode_id: linodeId });
+
+export const detach = (volumeId: number): Promise<{}> =>
+  Axios
+    .post(`${API_ROOT}/volumes/${volumeId}/detach`);
+
+/* delete is a reserved word */
+export const ddelete = (volumeId: number): Promise<{}> =>
+  Axios
+    .delete(`${API_ROOT}/volumes/${volumeId}`);
+
+export const clone = (volumeId: number, label: string): Promise<{}> =>
+  Axios
+    .post(`${API_ROOT}/volumes/${volumeId}/clone`, { label });
+
+export const resize = (volumeId: number, size: number): Promise<{}> =>
+  Axios
+    .post(`${API_ROOT}/volumes/${volumeId}/resize`, { size });
+
+export const update = (volumeId: number, label: string): Promise<{}> =>
+  Axios
+    .put(`${API_ROOT}/volumes/${volumeId}`, { label });
+
+export const create = (
+  label: string,
+  size: number,
+  region: string,
+  linodeId?: number,
+): Promise<{}> =>
+  Axios
+    .post(`${API_ROOT}/volumes`, { label, size, region, linode_id: linodeId });

--- a/src/services/volumes.ts
+++ b/src/services/volumes.ts
@@ -15,7 +15,7 @@ export const detach = (volumeId: number): Promise<{}> =>
     .post(`${API_ROOT}/volumes/${volumeId}/detach`);
 
 /* delete is a reserved word */
-export const ddelete = (volumeId: number): Promise<{}> =>
+export const _delete = (volumeId: number): Promise<{}> =>
   Axios
     .delete(`${API_ROOT}/volumes/${volumeId}`);
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -43,6 +43,7 @@ const LinodeTheme: Linode.Theme = {
         color: '#3B85D9',
         border: '1px solid #3B85D9',
         padding: '11px 26px 13px',
+        transition: 'border 225ms ease-in-out, color 225ms ease-in-out',
         '&:hover, &:focus': {
           backgroundColor: 'transparent',
           color: '#5F99EA',
@@ -57,6 +58,13 @@ const LinodeTheme: Linode.Theme = {
           borderColor: '#C9CACB',
           backgroundColor: 'transparent',
           color: '#C9CACB',
+        },
+        '&.cancel': {
+          borderColor: 'transparent',
+          color: '#222',
+          '&:hover, &:focus': {
+            borderColor: '#222',
+          },
         },
         '&.destructive': {
           borderColor: '#C44742',

--- a/src/types/Linode.ts
+++ b/src/types/Linode.ts
@@ -1,6 +1,6 @@
 namespace Linode {
   export interface Linode {
-    id: string | number;
+    id: number;
     alerts: LinodeAlerts;
     backups: LinodeBackups;
     created: string;
@@ -90,6 +90,23 @@ namespace Linode {
     virt_mode: 'paravirt' | 'fullvirt';
     helpers: any;
     label: any;
-    devices: any;
+    devices: ConfigDevices;
+  }
+
+  export interface ConfigDevices {
+    sda: null | ConfigDevice;
+    sdb: null | ConfigDevice;
+    sdc: null | ConfigDevice;
+    sdd: null | ConfigDevice;
+    sde: null | ConfigDevice;
+    sdf: null | ConfigDevice;
+    sdg: null | ConfigDevice;
+    sdh: null | ConfigDevice;
+  }
+
+  interface ConfigDevice {
+    /* disk_id and volume_id are mutually exclusive. */
+    disk_id: null | number;
+    volume_id: null | number;
   }
 }

--- a/src/types/Volumes.ts
+++ b/src/types/Volumes.ts
@@ -8,6 +8,7 @@ namespace Linode {
     linode_id: number;
     created: string;
     updated: string;
+    filesystem_path: string;
   }
 
   type VolumeStatus =


### PR DESCRIPTION
_I'm truly sorry for the 1,000+ line PR._

## Purpose
- Attach, detach, delete, resize, edit, clone, and create a Volume from `linodes/#/volumes`

Detach and delete are combined into a single dialog component. Create, edit, resize, and clone are combined into a single drawer component. The props sent the the components are controlled by the "mode" on their respective states.

Error handling for detach, delete, and attach are not currently implemented as I believe they're best served using the NYI toast notification.
