### PR TITLE
Filter events for Linode Detail using _initial rather than heuristic

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -12,10 +12,7 @@ function createInitialDatestamp() {
   return moment('1970-01-01 00:00:00.000Z').utc().format(dateFormat);
 }
 
-export interface EventStreamType extends Linode.Event {
-  _initial?: boolean;
-}
-export const events$ = new Rx.Subject<EventStreamType>();
+export const events$ = new Rx.Subject<Linode.Event>();
 
 let filterDatestamp = createInitialDatestamp();
 const pollIDs: { [key: string]: boolean } = {};

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -157,7 +157,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       .filter(newLinodeEvents(mountTime))
       .debounce(() => Observable.timer(1000))
       .subscribe((linodeEvent) => {
-
         const { match: { params: { linodeId } } } = this.props;
         requestAllTheThings(linodeId!)
           .then(({ linode, type, image, volumes }) => {

--- a/src/features/linodes/events.ts
+++ b/src/features/linodes/events.ts
@@ -21,14 +21,11 @@ export const newLinodeEvents = (mountTime: moment.Moment) =>
   ];
 
   const isLinodeEvent = linodeEvent.entity !== null && linodeEvent.entity.type === 'linode';
-  const createdAfterMountTime = moment(linodeEvent.created + 'Z') > mountTime;
-  const isPendingCompletion = linodeEvent.percent_complete !== null
-    && linodeEvent.percent_complete < 100;
 
   const result = isLinodeEvent
     && statusWhitelist.includes(linodeEvent.status)
     && actionWhitelist.includes(linodeEvent.action)
-    && (createdAfterMountTime || isPendingCompletion);
+    && (!linodeEvent._initial);
 
   return result;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,6 +131,7 @@ namespace Linode {
     status: EventStatus;
     time_remaining: null | number;
     username: string;
+    _initial?: boolean;
   }
 
   export interface ApiFieldError {


### PR DESCRIPTION
Filter events for Linode Detail using _initial rather than heuristic

This fixes the progress bar "stuck" issue.