### PR TITLE
fix getEURegions filter

### DIFF
--- a/scripts/storybook_entrypoint.sh
+++ b/scripts/storybook_entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 $PWD/scripts/wait-for-it.sh -t 250 -s manager-storybook:6006 -- yarn storybook:e2e --log
-status=$? # save it
-pwd
-ls -lah
-chown -R jenkins:jenkins **/storybook-test-results **/e2e **/src
+status=$? # save previous command return status
+chmod 777 /src/storybook-test-results/*.xml
 exit $status

--- a/src/features/linodes/LinodesCreate/SelectRegionPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectRegionPanel.tsx
@@ -36,7 +36,7 @@ const getNARegions = (regions: ExtendedRegion[]) =>
   regions.filter(r => /us/.test(r.country));
 
 const getEURegions = (regions: ExtendedRegion[]) =>
-  regions.filter(r => /uk/.test(r.country));
+  regions.filter(r => /(de|uk)/.test(r.country));
 
 const getASRegions = (regions: ExtendedRegion[]) =>
   regions.filter(r => /(jp|sg)/.test(r.country));


### PR DESCRIPTION
The countries for Frankfurt and London are `de` and `uk`. We just left out `de`.

Resolves M3-426.