### PR TITLE
Reinit initialRequest. Filter initial in consumers.

### DIFF
--- a/scripts/storybook_entrypoint.sh
+++ b/scripts/storybook_entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 $PWD/scripts/wait-for-it.sh -t 250 -s manager-storybook:6006 -- yarn storybook:e2e --log
-status=$? # save it
-pwd
-ls -lah
-chown -R jenkins:jenkins **/storybook-test-results **/e2e **/src
+status=$? # save previous command return status
+chmod 777 /src/storybook-test-results/*.xml
 exit $status

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,9 +1,8 @@
-import * as Rx from 'rxjs/Rx';
-import { API_ROOT } from 'src/constants';
 import Axios, { AxiosResponse } from 'axios';
 import * as moment from 'moment';
 import { assoc, compose, when } from 'ramda';
-
+import * as Rx from 'rxjs/Rx';
+import { API_ROOT } from 'src/constants';
 import { dateFormat } from 'src/time';
 
 let initialRequest: boolean = true;
@@ -29,6 +28,7 @@ export function resetEventsPolling() {
   currentPollIntervalMultiplier = 1;
 }
 export const init = () => {
+  initialRequest = true;
   filterDatestamp = createInitialDatestamp();
   resetEventsPolling();
 };

--- a/src/features/TopMenu/UserNotificationMenu/UserNotificationMenu.tsx
+++ b/src/features/TopMenu/UserNotificationMenu/UserNotificationMenu.tsx
@@ -74,7 +74,7 @@ class UserNotificationMenu extends React.Component<CombinedProps, State> {
         notifications$,
         events$
           /** Filter the fuax event used to kick off the progress bars. */
-          .filter((event: Linode.Event) => event.id !== 1)
+          .filter(event => event.id !== 1)
 
           /** Create a map of the Events using Event.ID as the key. */
           .scan((events: EventsMap, event: Linode.Event) =>

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -145,6 +145,7 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
         'volume_detach',
         'volume_resize',
       ].includes(e.action))
+      .filter(e => !e._initial)
       .subscribe((v) => {
         getLinodeVolumes(this.props.linodeID)
           .then(response => response.data)

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -155,6 +155,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
     this.subscription = events$
       .filter(pathEq(['entity', 'id'], Number(this.props.match.params.linodeId)))
       .filter(newLinodeEvents(mountTime))
+      .filter(e => !e._initial)
       .debounce(() => Observable.timer(1000))
       .subscribe((linodeEvent) => {
 

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -124,6 +124,7 @@ class ListLinodes extends React.Component<CombinedProps, State> {
 
     this.eventsSub = events$
       .filter(newLinodeEvents(mountTime))
+      .filter(e => !e._initial)
       .subscribe((linodeEvent) => {
         Axios.get(`${API_ROOT}/linode/instances/${(linodeEvent.entity as Linode.Entity).id}`)
           .then(response => response.data)

--- a/src/features/linodes/events.ts
+++ b/src/features/linodes/events.ts
@@ -1,7 +1,7 @@
 import * as moment from 'moment';
 
 export const newLinodeEvents = (mountTime: moment.Moment) =>
-(linodeEvent : Linode.Event): boolean => {
+(linodeEvent : Linode.Event & { _initial?: boolean }): boolean => {
   const actionWhitelist = [
     'linode_boot',
     'linode_reboot',


### PR DESCRIPTION
## Purpose
Prevent initial event requests from being sent to non-notification subscribers.