### PR TITLE
M3-428 center placeholder title text

### DIFF
--- a/src/components/Placeholder/Placeholder.tsx
+++ b/src/components/Placeholder/Placeholder.tsx
@@ -60,6 +60,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     },
   },
   title: {
+    textAlign: 'center',
     fontWeight: 700,
   },
   button: {},


### PR DESCRIPTION
Small PR to center placeholder text on mobile. 

Best way to test this is to go to any empty section and replace the placeholder text with a long string in the dom with the inspector