### PR TITLE
M3-391 Implement Backup Actions

### DIFF
--- a/src/components/EventListItem/EventListItem.tsx
+++ b/src/components/EventListItem/EventListItem.tsx
@@ -5,7 +5,7 @@ import { ListItemText } from 'material-ui/List';
 import { MenuItem, MenuItemProps } from 'material-ui/Menu';
 
 import { withStyles, StyleRulesCallback, WithStyles } from 'material-ui';
-import LinodeTheme from '../../../src/theme';
+import LinodeTheme from 'src/theme';
 
 type ClassNames = 'root'
   | 'error'

--- a/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -7,7 +7,7 @@ import Typography from 'material-ui/Typography';
 import Grid from 'src/components/Grid';
 import Divider from 'material-ui/Divider';
 
-import CheckBox from '../../../components/CheckBox';
+import CheckBox from 'src/components/CheckBox';
 import { FormControlLabel } from 'material-ui/Form';
 
 import LinodeTheme from 'src/theme';

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -473,6 +473,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
           Please note that when you cancel backups associated with this
           Linode, this will remove all existing backups.
         </Typography>
+
       </React.Fragment>
     );
   }

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -165,12 +165,14 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
         'backups_cancel',
         'backups_restore',
       ].includes(e.action))
-      .filter(e => !e._initial)
-      .filter(e => e.status === 'finished')
+      .filter(e => !e._initial && e.status === 'finished')
       .subscribe((e) => {
         getLinodeBackups(this.props.linodeID)
           .then((data) => {
             this.setState({ backups: data });
+          })
+          .catch(() => {
+            /* @todo: how do we want to display this error? */
           });
       });
   }

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -36,6 +36,8 @@ import { resetEventsPolling } from 'src/events';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import ActionsPanel from 'src/components/ActionsPanel';
 
+import LinodeBackupActionMenu from './LinodeBackupActionMenu';
+
 type ClassNames =
   'paper'
   | 'title'
@@ -129,8 +131,8 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
       label: '',
     },
     settingsForm: {
-      window: this.props.backupsSchedule.window,
-      day: this.props.backupsSchedule.day,
+      window: this.props.backupsSchedule.window || 'Scheduling',
+      day: this.props.backupsSchedule.day || 'Scheduling',
     },
   };
 
@@ -301,7 +303,12 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                         acc + disk.size
                       ), 0)}MB
                     </TableCell>
-                    <TableCell></TableCell>
+                    <TableCell>
+                      <LinodeBackupActionMenu
+                        onRestore={() => console.log(`restore ${backup.id}`)}
+                        onDeploy={() => console.log(`deploy ${backup.id}`)}
+                      />
+                    </TableCell>
                   </TableRow>
                 );
               })}
@@ -420,10 +427,10 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
             >
               Save Schedule
             </Button>
-            {getErrorFor('none') &&
-              <FormHelperText error>{getErrorFor('none')}</FormHelperText>
-            }
           </ActionsPanel>
+          {getErrorFor('none') &&
+            <FormHelperText error>{getErrorFor('none')}</FormHelperText>
+          }
         </Paper>
       </React.Fragment>
     );

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import * as moment from 'moment-timezone';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { path, sortBy, pathOr } from 'ramda';
+
 import {
   withStyles,
   StyleRulesCallback,
@@ -120,7 +122,7 @@ interface State {
   };
 }
 
-type CombinedProps = Props & PreloadedProps & WithStyles<ClassNames>;
+type CombinedProps = Props & PreloadedProps & WithStyles<ClassNames> & RouteComponentProps<{}>;
 
 const typeMap = {
   auto: 'Automatic',
@@ -287,7 +289,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
   }
 
   Table = ({ backups }: { backups: Linode.LinodeBackup[]}): JSX.Element | null => {
-    const { classes } = this.props;
+    const { classes, history } = this.props;
 
     return (
       <React.Fragment>
@@ -334,7 +336,9 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                           backup.id,
                           this.formatBackupDate(backup.created),
                         )}
-                        onDeploy={() => console.log(`deploy ${backup.id}`)}
+                        onDeploy={() => {
+                          history.push(`/linodes/create?type=fromBackup&backupID=${backup.id}`);
+                        }}
                       />
                     </TableCell>
                   </TableRow>
@@ -537,4 +541,4 @@ const preloaded = PromiseLoader<Props>({
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default preloaded(styled(LinodeBackup));
+export default preloaded(styled(withRouter(LinodeBackup)));

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+
+import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+
+interface Props {
+  onRestore: () => void;
+  onDeploy: () => void;
+}
+
+type CombinedProps = Props & RouteComponentProps<{}>;
+
+class LinodeBackupActionMenu extends React.Component<CombinedProps> {
+  createActions = () => {
+    const {
+      onRestore,
+      onDeploy,
+    } = this.props;
+
+    return function (closeMenu: Function): Action[] {
+      const actions = [
+        {
+          title: 'Restore to Existing Linode',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onRestore();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+        {
+          title: 'Deploy New Linode',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onDeploy();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+      ];
+      return actions;
+    };
+  }
+
+  render() {
+    return (
+      <ActionMenu createActions={this.createActions()} />
+    );
+  }
+}
+
+export default withRouter(LinodeBackupActionMenu);

--- a/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+import Button from 'material-ui/Button';
+import InputLabel from 'material-ui/Input/InputLabel';
+import MenuItem from 'material-ui/Menu/MenuItem';
+import FormControl from 'material-ui/Form/FormControl';
+import FormHelperText from 'material-ui/Form/FormHelperText';
+
+import { getLinodesPage } from 'src/services/linode';
+import Select from 'src/components/Select';
+import Drawer from 'src/components/Drawer';
+import ActionsPanel from 'src/components/ActionsPanel';
+import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+import CheckBox from 'src/components/CheckBox';
+import { FormControlLabel } from 'material-ui/Form';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {
+  open: boolean;
+  backupCreated: string;
+  onClose: () => void;
+  onSubmit: () => void;
+}
+
+interface State {
+  linodes: [string, string][];
+  overwrite: boolean;
+  selectedLinode?: string;
+  errors?: Linode.ApiFieldError[];
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class RestoreToLinodeDrawer extends React.Component<CombinedProps, State> {
+  state: State = {
+    linodes: [],
+    overwrite: false,
+    selectedLinode: '',
+  };
+
+  onComponentDidMount() {
+    getLinodesPage(1)
+      .then((response) => {
+        response.data.map((linode) => {
+          return [`${linode.id}`, linode.label];
+        });
+      });
+  }
+
+  errorResources = {
+    linode_id: 'Linode',
+    overwrite: 'Overwrite',
+  };
+
+  render() {
+    const { open, backupCreated, onClose, onSubmit } = this.props;
+    const { linodes, selectedLinode, overwrite, errors } = this.state;
+
+    const hasErrorFor = getAPIErrorsFor(this.errorResources, errors);
+    const linodeError = hasErrorFor('linode_id');
+    const overwriteError = hasErrorFor('overwrite');
+
+    return (
+      <Drawer
+        open={open}
+        onClose={onClose}
+        title={`Restore Backup from ${backupCreated}`}
+      >
+        <FormControl fullWidth>
+          <InputLabel
+            htmlFor="linode"
+            disableAnimation
+            shrink={true}
+            error={Boolean(linodeError)}
+          >
+            Linode
+          </InputLabel>
+          <Select
+            value={selectedLinode || ''}
+            onChange={e => this.setState({ selectedLinode: e.target.value })}
+            inputProps={{ name: 'linode', id: 'linode' }}
+            error={Boolean(linodeError)}
+          >
+            <MenuItem value="" disabled>Select a Linode</MenuItem>
+            {
+              linodes && linodes.map((l) => {
+                return <MenuItem key={l[0]} value={l[0]}>{l[1]}</MenuItem>;
+              })
+            }
+          </Select>
+          { Boolean(linodeError) && <FormHelperText error>{ linodeError }</FormHelperText> }
+        </FormControl>
+        <FormControlLabel
+          control={
+            <CheckBox
+              checked={overwrite}
+              onChange={e => this.setState({ overwrite: !overwrite })}
+            />
+          }
+          label="Overwrite Linode"
+        />
+        { Boolean(overwriteError) && <FormHelperText error>{ overwriteError }</FormHelperText> }
+        <ActionsPanel>
+          <Button variant="raised" color="primary" onClick={() => onSubmit()}>Restore</Button>
+          <Button onClick={onClose}>Cancel</Button>
+        </ActionsPanel>
+      </Drawer>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(RestoreToLinodeDrawer);

--- a/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -15,7 +15,7 @@ import FormHelperText from 'material-ui/Form/FormHelperText';
 import { FormControlLabel } from 'material-ui/Form';
 
 import Notice from 'src/components/Notice';
-import { getLinodesPage, restoreBackup } from 'src/services/linodes';
+import { getLinodes, restoreBackup } from 'src/services/linodes';
 import Select from 'src/components/Select';
 import Drawer from 'src/components/Drawer';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -63,10 +63,9 @@ class RestoreToLinodeDrawer extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     const { linodeRegion } = this.props;
-    getLinodesPage(1)
+    getLinodes({ page: 1 }, { region: linodeRegion })
       .then((response) => {
-        const thisRegionLinodes = response.data.filter(linode => linode.region === linodeRegion);
-        const linodeChoices = thisRegionLinodes.map((linode) => {
+        const linodeChoices = response.data.map((linode) => {
           return [`${linode.id}`, linode.label];
         });
         this.setState({ linodes: linodeChoices });

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -329,6 +329,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
           <Route exact path={`${url}/backup`} render={() => (
             <LinodeBackup
               linodeID={linode.id}
+              linodeRegion={linode.region}
               backupsEnabled={linode.backups.enabled}
               backupsSchedule={linode.backups.schedule}
               backupsMonthlyPrice={

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,8 @@
+import * as Axios from 'axios';
+
+export function genAxiosConfig(params: any, filter?: any) {
+  const config: Axios.AxiosRequestConfig = {};
+  config.params = params && params;
+  config.headers = filter && { 'X-Filter': JSON.stringify(filter) };
+  return config;
+}

--- a/src/services/linodes.ts
+++ b/src/services/linodes.ts
@@ -31,7 +31,7 @@ export const getLinodeDisks = (id: number): GetLinodeDisksType =>
   Axios.get(`${API_ROOT}/linode/instances/${id}/disks`)
     .then(response => response.data);
 
-type GetLinodeBackupsType = Promise<Linode.ResourcePage<Linode.LinodeBackup>>;
+type GetLinodeBackupsType = Promise<Linode.LinodeBackupsResponse>;
 export const getLinodeBackups = (id: number): GetLinodeBackupsType =>
   Axios.get(`${API_ROOT}/linode/instances/${id}/backups`)
     .then(response => response.data);

--- a/src/services/linodes.ts
+++ b/src/services/linodes.ts
@@ -1,7 +1,7 @@
 import Axios, { AxiosPromise } from 'axios';
 import { omit } from 'ramda';
 import { API_ROOT } from 'src/constants';
-
+import { genAxiosConfig } from '.';
 
 /* tslint:disable-next-line */
 export type RescueRequestObject = Pick<Linode.Devices, 'sda' | 'sdb' | 'sdc' | 'sdd' | 'sde' | 'sdf' | 'sdg'>
@@ -57,9 +57,14 @@ export const rebuildLinode = (id: number, image: string, password: string): Rebu
 export const resizeLinode = (id: number, type: string): Promise<{}> => Axios
   .post(`${API_ROOT}/linode/instances/${id}/resize`, { type });
 
+type GetLinodes = Promise<Linode.ResourcePage<Linode.Linode>>;
+export const getLinodes = (params: any, filter: any): GetLinodes =>
+  Axios.get(`${API_ROOT}/linode/instances/`, genAxiosConfig(params, filter))
+    .then(response => response.data);
+
 type GetLinodesPage = Promise<Linode.ResourcePage<Linode.Linode>>;
 export const getLinodesPage = (page: number): GetLinodesPage =>
-  Axios.get(`${API_ROOT}/linode/instances/?page=${page}`)
+  Axios.get(`${API_ROOT}/linode/instances/`, genAxiosConfig({ page }))
     .then(response => response.data);
 
 export const createLinode = (data: any): Promise<Linode.SingleResourceState<Linode.Linode>> =>

--- a/src/services/linodes.ts
+++ b/src/services/linodes.ts
@@ -88,3 +88,14 @@ export const getLinodeStats = (linodeId: number, year?: string, month?: string) 
 
   return Axios.get(`${API_ROOT}/linode/instances/${linodeId}/stats`);
 };
+
+export const restoreBackup = (
+  linodeID: number,
+  backupID: number,
+  targetLinodeID: number,
+  overwrite: boolean,
+) => {
+  return Axios.post(`${API_ROOT}/linode/instances/${linodeID}/backups/${backupID}/restore`,
+    { linode_id: targetLinodeID, overwrite })
+    .then(response => response.data);
+};


### PR DESCRIPTION
- Implement restore Linode from backup
- Drawer requests only Linodes in the same region with X-Filter
- "Overwrite" option warns the user that it will delete all disks on the target Linode
- Deploy from backup navigates to the Create flow with appropriate query paramters