### PR TITLE
remove userWrapper margin for small viewports

### DIFF
--- a/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -67,6 +67,7 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
     height: '46px',
     transition: theme.transitions.create(['box-shadow']),
     [theme.breakpoints.down('sm')]: {
+      margin: 0,
       width: '40px',
       height: '40px',
     },


### PR DESCRIPTION
There is an unused right margin for small viewports, which is visible during the on-click ripple effect. This PR removes this margin.