### PR TITLE
M3-161 Account-level Notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import Placeholder from 'src/components/Placeholder';
 import NodeBalancerIcon from 'src/assets/addnewmenu/nodebalancer.svg';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import ToastNotifications from 'src/features/ToastNotifications';
+import AccountLevelNotifications from 'src/features/AccountLevelNotifications';
 
 import BetaNotification from './BetaNotification';
 import DocsSidebar from 'src/components/DocsSidebar';
@@ -174,6 +175,7 @@ export class App extends React.Component<CombinedProps, State> {
           <MuiThemeProvider theme={theme}>
             <CssBaseline />
             <div className={classes.appFrame}>
+              <AccountLevelNotifications />
               <SideMenu open={menuOpen} toggle={this.toggleMenu} />
               <main className={classes.content}>
                 <TopMenu toggleSideMenu={this.toggleMenu} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,9 +175,9 @@ export class App extends React.Component<CombinedProps, State> {
           <MuiThemeProvider theme={theme}>
             <CssBaseline />
             <div className={classes.appFrame}>
-              <AccountLevelNotifications />
               <SideMenu open={menuOpen} toggle={this.toggleMenu} />
               <main className={classes.content}>
+                <AccountLevelNotifications />
                 <TopMenu toggleSideMenu={this.toggleMenu} />
                 <div className={classes.wrapper}>
                   <Grid container className={classes.grid}>

--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -39,21 +39,23 @@ interface Props {
   warning?: boolean;
   success?: boolean;
   typeProps?: TypographyProps;
+  className?: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const Notice: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, text, error, warning, success, typeProps } = props;
+  const { classes, text, error, warning, success, typeProps, className } = props;
 
   return (
-    <div className={classNames({
+    <div className={`${classNames({
       [classes.error]: error,
       [classes.warning]: warning,
       [classes.success]: success,
       [classes.root]: true,
       notice: true,
-    })}>
+    })}
+    ${className}`}>
       <Typography {...typeProps}>{text}</Typography>
     </div>
   );

--- a/src/features/AccountLevelNotifications/AccountLevelNotifications.tsx
+++ b/src/features/AccountLevelNotifications/AccountLevelNotifications.tsx
@@ -7,6 +7,7 @@ import {
   filter,
   propSatisfies,
   uniqBy,
+  pathOr,
 } from 'ramda';
 import {
   withStyles,
@@ -72,17 +73,24 @@ class AccountLevelNotifications extends React.Component<CombinedProps, State> {
   render() {
     const { classes } = this.props;
 
-    return (this.state.notifications || [])
-      .map(notification =>
-        <Notice
-          key={notification.type}
-          text={notification.message}
-          warning
-          className={classes.root}
-        />,
-      );
+    return (this.state.notifications || []).map((n) => {
+      const level = pathOr('warning', [n.severity], severityMap);
+
+      return React.createElement(Notice, {
+        key: n.type,
+        text: n.message,
+        className: classes.root,
+        [level]: true,
+      });
+    });
   }
 }
+
+const severityMap = {
+  minor: 'success',
+  major: 'warning',
+  critical: 'error',
+};
 
 const styled = withStyles(styles, { withTheme: true });
 

--- a/src/features/AccountLevelNotifications/AccountLevelNotifications.tsx
+++ b/src/features/AccountLevelNotifications/AccountLevelNotifications.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { Subscription } from 'rxjs/Rx';
+import {
+  compose,
+  prop,
+  contains,
+  filter,
+  propSatisfies,
+  uniqBy,
+} from 'ramda';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+import notifications$ from 'src/notifications';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props { }
+
+interface State {
+  notifications?: Linode.Notification[];
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const filterNotifications: (v: Linode.Notification[]) => Linode.Notification[] =
+  compose<Linode.Notification[], Linode.Notification[], Linode.Notification[]>(
+    uniqBy(prop('type')),
+    filter<Linode.Notification>(
+      propSatisfies(v => contains(v, AccountLevelNotifications.displayedEvents), 'type'),
+    ),
+  );
+
+class AccountLevelNotifications extends React.Component<CombinedProps, State> {
+  state: State = {
+  };
+
+  subscription: Subscription;
+
+  static displayedEvents = [
+    'ticket_abuse',
+  ];
+
+  componentDidMount() {
+    this.subscription = notifications$
+      .map(filterNotifications)
+      .subscribe(notifications => this.setState({ notifications }));
+  }
+
+  componentWillUnmount() {
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+    }
+  }
+
+  render() {
+    return (this.state.notifications || [])
+      .map(notification =>
+        <div key={notification.type}>{notification.message}</div>,
+      );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(AccountLevelNotifications);

--- a/src/features/AccountLevelNotifications/AccountLevelNotifications.tsx
+++ b/src/features/AccountLevelNotifications/AccountLevelNotifications.tsx
@@ -16,14 +16,22 @@ import {
 } from 'material-ui';
 
 import notifications$ from 'src/notifications';
+import Notice from 'src/components/Notice';
 
 type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
-  root: {},
+  root: {
+    margin: 0,
+    textAlign: 'center',
+    '& p': {
+      fontSize: '1.1rem',
+      color: '#333',
+    },
+  },
 });
 
-interface Props { }
+interface Props {}
 
 interface State {
   notifications?: Linode.Notification[];
@@ -62,9 +70,16 @@ class AccountLevelNotifications extends React.Component<CombinedProps, State> {
   }
 
   render() {
+    const { classes } = this.props;
+
     return (this.state.notifications || [])
       .map(notification =>
-        <div key={notification.type}>{notification.message}</div>,
+        <Notice
+          key={notification.type}
+          text={notification.message}
+          warning
+          className={classes.root}
+        />,
       );
   }
 }

--- a/src/features/AccountLevelNotifications/AccountLevelNotifications.tsx
+++ b/src/features/AccountLevelNotifications/AccountLevelNotifications.tsx
@@ -55,7 +55,11 @@ class AccountLevelNotifications extends React.Component<CombinedProps, State> {
   subscription: Subscription;
 
   static displayedEvents = [
+    'outage',
+    'payment_due',
+    'ticket_important',
     'ticket_abuse',
+    'notice',
   ];
 
   componentDidMount() {

--- a/src/features/AccountLevelNotifications/index.ts
+++ b/src/features/AccountLevelNotifications/index.ts
@@ -1,0 +1,2 @@
+import AccountLevelNotifications from './AccountLevelNotifications';
+export default AccountLevelNotifications;

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -5,18 +5,18 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import Axios, { AxiosResponse } from 'axios';
 import * as moment from 'moment';
 import {
+  allPass,
   clone,
-  ifElse,
   compose,
-  prop,
-  propEq,
-  isEmpty,
+  filter,
   gte,
+  has,
+  ifElse,
+  isEmpty,
   pathEq,
   pathOr,
-  filter,
-  has,
-  allPass,
+  prop,
+  propEq,
   uniqBy,
 } from 'ramda';
 
@@ -174,13 +174,13 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
     this.notificationSub = Observable
       .combineLatest(
         notifications$
-          .map(notifications => notifications.filter(n => n.entity.type === 'linode')),
+          .map(notifications => notifications.filter(pathEq(['entity', 'type'], 'linode'))),
         Observable.of(this.props.linodes),
     )
       .map(([notifications, linodes]) => {
         /** Imperative and gross a/f. Ill fix it. */
         linodes.response.data = linodes.response.data.map((linode) => {
-          const notification = notifications.find(n => n.entity.id === linode.id);
+          const notification = notifications.find(pathEq(['entity', 'id'], linode.id));
           if (notification) {
             linode.notification = notification.message;
             return linode;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,7 +71,7 @@ namespace Linode {
     'notice';
 
   export interface Notification {
-    entity: Entity;
+    entity: null | Entity;
     label: string;
     message: string;
     type: NotificationType;


### PR DESCRIPTION
## Purpose
Add account level notifications to a top-level banner. Consuming the notifications$ stream, filtering by abuse ticket (for now).