### PR TITLE
Unnecessary rerenders

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -41,6 +41,7 @@ import LinodeConfigSelectionDrawer from 'src/features/LinodeConfigSelectionDrawe
 import { sendToast } from 'src/features/ToastNotifications/toasts';
 import { getLinode, getType, getLinodeVolumes, renameLinode } from 'src/services/linodes';
 import { getImage } from 'src/services/images';
+import haveAnyBeenModified from 'src/utilities/haveAnyBeenModified';
 
 interface Data {
   linode: Linode.Linode;
@@ -81,7 +82,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     [theme.breakpoints.down('sm')]: {
       display: 'flex',
       margin: `${theme.spacing.unit * 2}px 0`,
-      flexBasis:  '100%',
+      flexBasis: '100%',
     },
   },
   launchButton: {
@@ -156,6 +157,14 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       action: (id: number) => null,
     },
   };
+
+  shouldComponentUpdate(nextProps: CombinedProps, nextState: State) {
+    return haveAnyBeenModified<State>(
+      this.state,
+      nextState,
+      ['linode', 'type', 'image', 'volumes'],
+    );
+  }
 
   componentWillUnmount() {
     this.mounted = false;

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -15,6 +15,7 @@ import {
   RouteComponentProps,
   Redirect,
 } from 'react-router-dom';
+import { Location } from 'history';
 import { Subscription, Observable } from 'rxjs/Rx';
 
 import AppBar from 'material-ui/AppBar';
@@ -159,11 +160,14 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
   };
 
   shouldComponentUpdate(nextProps: CombinedProps, nextState: State) {
+    const { location } = this.props;
+    const { location: nextLocation } = nextProps;
+
     return haveAnyBeenModified<State>(
       this.state,
       nextState,
       ['linode', 'type', 'image', 'volumes'],
-    );
+    ) || haveAnyBeenModified<Location>(location, nextLocation, ['pathname', 'search']);
   }
 
   componentWillUnmount() {

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -5,7 +5,9 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 import { rebootLinode, powerOffLinode, powerOnLinode } from './powerActions';
 
 interface Props {
-  linode: Linode.Linode;
+  linodeId: number;
+  linodeLabel: string;
+  linodeStatus: string;
   openConfigDrawer: (configs: Linode.Config[], fn: (id: number) => void) => void;
 }
 
@@ -13,14 +15,14 @@ type CombinedProps = Props & RouteComponentProps<{}>;
 
 class LinodeActionMenu extends React.Component<CombinedProps> {
   createLinodeActions = () => {
-    const { linode, openConfigDrawer, history: { push } } = this.props;
+    const { linodeId, linodeLabel, linodeStatus, openConfigDrawer, history: { push } } = this.props;
 
     return function (closeMenu: Function): Action[] {
       const actions = [
         {
           title: 'Launch Console',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            push(`/linodes/${linode.id}/glish`);
+            push(`/linodes/${linodeId}/glish`);
             e.preventDefault();
           },
         },
@@ -28,55 +30,55 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
           title: 'Reboot',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             e.preventDefault();
-            rebootLinode(openConfigDrawer, linode.id, linode.label);
+            rebootLinode(openConfigDrawer, linodeId, linodeLabel);
             closeMenu();
           },
         },
         {
           title: 'View Graphs',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            push(`/linodes/${linode.id}/summary`);
+            push(`/linodes/${linodeId}/summary`);
             e.preventDefault();
           },
         },
         {
           title: 'Resize',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            push(`/linodes/${linode.id}/resize`);
+            push(`/linodes/${linodeId}/resize`);
             e.preventDefault();
           },
         },
         {
           title: 'View Backups',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            push(`/linodes/${linode.id}/backups`);
+            push(`/linodes/${linodeId}/backups`);
             e.preventDefault();
           },
         },
         {
           title: 'Settings',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            push(`/linodes/${linode.id}/settings`);
+            push(`/linodes/${linodeId}/settings`);
             e.preventDefault();
           },
         },
       ];
 
-      if (linode.status === 'offline') {
+      if (linodeStatus === 'offline') {
         actions.unshift({
           title: 'Power On',
           onClick: (e) => {
-            powerOnLinode(openConfigDrawer, linode.id, linode.label);
+            powerOnLinode(openConfigDrawer, linodeId, linodeLabel);
             closeMenu();
           },
         });
       }
 
-      if (linode.status === 'running') {
+      if (linodeStatus === 'running') {
         actions.unshift({
           title: 'Power Off',
           onClick: (e) => {
-            powerOffLinode(linode.id, linode.label);
+            powerOffLinode(linodeId, linodeLabel);
             closeMenu();
           },
         });

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -10,15 +10,16 @@ import {
 import Button from 'material-ui/Button';
 import Card, { CardHeader, CardContent, CardActions } from 'material-ui/Card';
 import Divider from 'material-ui/Divider';
-import Grid from 'src/components/Grid';
-import LinodeTheme from 'src/theme';
 import Typography from 'material-ui/Typography';
 import Tooltip from 'material-ui/Tooltip';
 
-import CircleProgress from 'src/components/CircleProgress';
-import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
+import LinodeTheme from 'src/theme';
 import Flag from 'src/assets/icons/flag.svg';
+import haveAnyBeenModified from 'src/utilities/haveAnyBeenModified';
+import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 import { weblishLaunch } from 'src/features/Weblish';
+import Grid from 'src/components/Grid';
+import CircleProgress from 'src/components/CircleProgress';
 
 import RegionIndicator from './RegionIndicator';
 import IPAddress from './IPAddress';
@@ -120,7 +121,14 @@ const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => 
 });
 
 interface Props {
-  linode: Linode.EnhancedLinode;
+  linodeId: number;
+  linodeStatus: Linode.LinodeStatus;
+  linodeIpv4: string[];
+  linodeIpv6: string;
+  linodeRegion: string;
+  linodeNotification?: string;
+  linodeLabel: string;
+  linodeRecentEvent?: Linode.Event;
   image?: Linode.Image;
   type?: Linode.LinodeType;
   openConfigDrawer: (configs: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
@@ -128,23 +136,23 @@ interface Props {
 
 class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
   renderTitle() {
-    const { linode, classes } = this.props;
+    const { classes, linodeStatus, linodeId, linodeLabel, linodeNotification } = this.props;
 
     return (
       <Grid container alignItems="center">
         <Grid item className={'py0'}>
-          <LinodeStatusIndicator status={linode.status} />
+          <LinodeStatusIndicator status={linodeStatus} />
         </Grid>
         <Grid item className={classes.cardHeader + ' py0'}>
-          <Link to={`/linodes/${linode.id}`}>
+          <Link to={`/linodes/${linodeId}`}>
             <Typography variant="subheading" data-qa-label>
-              {linode.label}
+              {linodeLabel}
             </Typography>
           </Link>
         </Grid>
-        {linode.notification &&
+        {linodeNotification &&
           <Grid item className="py0">
-            <Tooltip title={linode.notification}><Flag className={classes.flag} /></Tooltip>
+            <Tooltip title={linodeNotification}><Flag className={classes.flag} /></Tooltip>
           </Grid>
         }
       </Grid>
@@ -153,8 +161,8 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
 
 
   loadingState = () => {
-    const { linode, classes } = this.props;
-    const value = (linode.recentEvent && linode.recentEvent.percent_complete) || 1;
+    const { classes, linodeRecentEvent, linodeStatus } = this.props;
+    const value = (linodeRecentEvent && linodeRecentEvent.percent_complete) || 1;
 
     return (
       <CardContent className={classes.cardContent}>
@@ -164,7 +172,7 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
           </Grid>
           <Grid item xs={12}>
             <Typography align="center" className={classes.loadingStatusText}>
-              {linode.status.replace('_', ' ')}
+              {linodeStatus.replace('_', ' ')}
             </Typography>
           </Grid>
         </Grid>
@@ -173,7 +181,7 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
   }
 
   loadedState = () => {
-    const { classes, image, type, linode } = this.props;
+    const { classes, image, type, linodeIpv4, linodeIpv6, linodeRegion } = this.props;
 
     return (
       <CardContent className={`${classes.cardContent} ${classes.customeMQ}`}>
@@ -184,11 +192,11 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
         </div>
         }
         <div className={classes.cardSection} data-qa-region>
-          <RegionIndicator region={linode.region} />
+          <RegionIndicator region={linodeRegion} />
         </div>
         <div className={classes.cardSection} data-qa-ips>
-          <IPAddress ips={linode.ipv4} copyRight />
-          <IPAddress ips={[linode.ipv6]} copyRight />
+          <IPAddress ips={linodeIpv4} copyRight />
+          <IPAddress ips={[linodeIpv6]} copyRight />
         </div>
         {image && type &&
         <div className={classes.cardSection} data-qa-image>
@@ -200,9 +208,25 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
     );
   }
 
+  shouldComponentUpdate(nextProps: Props) {
+    return haveAnyBeenModified<Props>(
+      nextProps,
+      this.props,
+      [
+        'type',
+        'linodeStatus',
+        'linodeRegion',
+        'linodeNotification',
+        'linodeLabel',
+        'linodeIpv6',
+        'linodeIpv4',
+      ],
+    );
+  }
+
   render() {
-    const { classes, linode, openConfigDrawer } = this.props;
-    const loading = transitionStatus.includes(linode.status);
+    const { classes, openConfigDrawer, linodeId, linodeLabel, linodeStatus } = this.props;
+    const loading = transitionStatus.includes(linodeStatus);
 
     return (
       <Grid item xs={12} sm={6} lg={4} xl={3} data-qa-linode>
@@ -212,9 +236,9 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
             action={
               <div style={{ position: 'relative', top: 6 }}>
                 <LinodeActionMenu
-                 linodeId={linode.id}
-                 linodeLabel={linode.label}
-                 linodeStatus={linode.status}
+                 linodeId={linodeId}
+                 linodeLabel={linodeLabel}
+                 linodeStatus={linodeStatus}
                  openConfigDrawer={openConfigDrawer}
                 />
               </div>
@@ -226,7 +250,7 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
           <CardActions className={classes.cardActions}>
             <Button
               className={`${classes.button} ${classes.consoleButton}`}
-              onClick={() => weblishLaunch(`${linode.id}`)}
+              onClick={() => weblishLaunch(`${linodeId}`)}
               data-qa-console
             >
               <span className="btnLink">Launch Console</span>
@@ -234,7 +258,7 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
             <Button
               className={`${classes.button}
               ${classes.rebootButton}`}
-              onClick={() => rebootLinode(openConfigDrawer, linode.id, linode.label)}
+              onClick={() => rebootLinode(openConfigDrawer, linodeId, linodeLabel)}
               data-qa-reboot
             >
               <span className="btnLink">Reboot</span>

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -212,7 +212,9 @@ class LinodeCard extends React.Component<Props & WithStyles<CSSClasses> > {
             action={
               <div style={{ position: 'relative', top: 6 }}>
                 <LinodeActionMenu
-                 linode={linode}
+                 linodeId={linode.id}
+                 linodeLabel={linode.label}
+                 linodeStatus={linode.status}
                  openConfigDrawer={openConfigDrawer}
                 />
               </div>

--- a/src/features/linodes/LinodesLanding/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow.tsx
@@ -11,10 +11,12 @@ import Grid from 'src/components/Grid';
 import Typography from 'material-ui/Typography';
 import TableRow from 'material-ui/Table/TableRow';
 import TableCell from 'material-ui/Table/TableCell';
+import Tooltip from 'material-ui/Tooltip';
 
-import LinearProgress from 'src/components/LinearProgress';
-import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
+import haveAnyBeenModified from 'src/utilities/haveAnyBeenModified';
 import Flag from 'src/assets/icons/flag.svg';
+import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
+import LinearProgress from 'src/components/LinearProgress';
 
 import LinodeStatusIndicator from './LinodeStatusIndicator';
 import RegionIndicator from './RegionIndicator';
@@ -22,17 +24,16 @@ import IPAddress from './IPAddress';
 import { displayLabel } from '../presentation';
 import LinodeActionMenu from './LinodeActionMenu';
 import transitionStatus from '../linodeTransitionStatus';
-import Tooltip from 'material-ui/Tooltip';
 
 type ClassNames = 'bodyRow'
-| 'linodeCell'
-| 'tagsCell'
-| 'ipCell'
-| 'regionCell'
-| 'actionCell'
-| 'actionInner'
-| 'flag'
-| 'status';
+  | 'linodeCell'
+  | 'tagsCell'
+  | 'ipCell'
+  | 'regionCell'
+  | 'actionCell'
+  | 'actionInner'
+  | 'flag'
+  | 'status';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => {
   return ({
@@ -80,7 +81,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => {
 };
 
 interface Props {
-  linode: Linode.EnhancedLinode;
+  linodeId: number;
+  linodeStatus: Linode.LinodeStatus;
+  linodeIpv4: string[];
+  linodeIpv6: string;
+  linodeRegion: string;
+  linodeNotification?: string;
+  linodeLabel: string;
+  linodeRecentEvent?: Linode.Event;
   type?: Linode.LinodeType;
   openConfigDrawer: (configs: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
 }
@@ -88,20 +96,36 @@ interface Props {
 type PropsWithStyles = Props & WithStyles<ClassNames>;
 
 class LinodeRow extends React.Component<PropsWithStyles> {
+  shouldComponentUpdate(nextProps: PropsWithStyles) {
+    return haveAnyBeenModified<Props>(
+      nextProps,
+      this.props,
+      [
+        'type',
+        'linodeStatus',
+        'linodeRegion',
+        'linodeNotification',
+        'linodeLabel',
+        'linodeIpv6',
+        'linodeIpv4',
+      ],
+    );
+  }
+
   headCell = () => {
-    const { type, linode, classes } = this.props;
+    const { type, linodeId, linodeStatus, linodeLabel, classes } = this.props;
     const specsLabel = type && displayLabel(type.memory);
 
-    return(
+    return (
       <TableCell className={classes.linodeCell}>
         <Grid container alignItems="center">
           <Grid item className="py0">
-            <LinodeStatusIndicator status={linode.status} />
+            <LinodeStatusIndicator status={linodeStatus} />
           </Grid>
           <Grid item className="py0">
-            <Link to={`/linodes/${linode.id}`}>
+            <Link to={`/linodes/${linodeId}`}>
               <Typography variant="subheading" data-qa-label>
-                {linode.label}
+                {linodeLabel}
               </Typography>
             </Link>
             {specsLabel && <div>{specsLabel}</div>}
@@ -112,14 +136,14 @@ class LinodeRow extends React.Component<PropsWithStyles> {
   }
 
   loadingState = () => {
-    const { linode, classes } = this.props;
-    const value = (linode.recentEvent && linode.recentEvent.percent_complete) || 1;
-    return(
-      <TableRow key={linode.id} className={classes.bodyRow} data-qa-loading>
+    const { linodeId, linodeStatus, linodeRecentEvent, classes } = this.props;
+    const value = (linodeRecentEvent && linodeRecentEvent.percent_complete) || 1;
+    return (
+      <TableRow key={linodeId} className={classes.bodyRow} data-qa-loading>
         {this.headCell()}
         <TableCell colSpan={4}>
           {typeof value === 'number' &&
-            <div className={classes.status}>{linode.status.replace('_', ' ')}: {value}%</div>
+            <div className={classes.status}>{linodeStatus.replace('_', ' ')}: {value}%</div>
           }
           <LinearProgress value={value} />
         </TableCell>
@@ -128,37 +152,47 @@ class LinodeRow extends React.Component<PropsWithStyles> {
   }
 
   loadedState = () => {
-    const { linode, classes, openConfigDrawer } = this.props;
+    const {
+      linodeId,
+      linodeStatus,
+      linodeIpv4,
+      linodeIpv6,
+      linodeRegion,
+      linodeNotification,
+      linodeLabel,
+      classes,
+      openConfigDrawer,
+    } = this.props;
 
-    return(
-      <TableRow key={linode.id} data-qa-linode>
+    return (
+      <TableRow key={linodeId} data-qa-linode>
         {this.headCell()}
         <TableCell className={classes.ipCell} data-qa-ips>
-          <IPAddress ips={linode.ipv4} copyRight />
-          <IPAddress ips={[linode.ipv6]} copyRight />
+          <IPAddress ips={linodeIpv4} copyRight />
+          <IPAddress ips={[linodeIpv6]} copyRight />
         </TableCell>
         <TableCell className={classes.regionCell} data-qa-region>
-          <RegionIndicator region={linode.region} />
+          <RegionIndicator region={linodeRegion} />
         </TableCell>
         <TableCell className={classes.actionCell} data-qa-notifications>
           <div className={classes.actionInner}>
-            {linode.notification &&
-              <Tooltip title={linode.notification}><Flag className={classes.flag} /></Tooltip>
+            {linodeNotification &&
+              <Tooltip title={linodeNotification}><Flag className={classes.flag} /></Tooltip>
             }
             <LinodeActionMenu
-              linodeId={linode.id}
-              linodeLabel={linode.label}
-              linodeStatus={linode.status}
+              linodeId={linodeId}
+              linodeLabel={linodeLabel}
+              linodeStatus={linodeStatus}
               openConfigDrawer={openConfigDrawer}
             />
           </div>
         </TableCell>
-    </TableRow>
+      </TableRow>
     );
   }
 
   render() {
-    const loading = transitionStatus.includes(this.props.linode.status);
+    const loading = transitionStatus.includes(this.props.linodeStatus);
 
     return loading
       ? this.loadingState()

--- a/src/features/linodes/LinodesLanding/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow.tsx
@@ -146,7 +146,9 @@ class LinodeRow extends React.Component<PropsWithStyles> {
               <Tooltip title={linode.notification}><Flag className={classes.flag} /></Tooltip>
             }
             <LinodeActionMenu
-              linode={linode}
+              linodeId={linode.id}
+              linodeLabel={linode.label}
+              linodeStatus={linode.status}
               openConfigDrawer={openConfigDrawer}
             />
           </div>

--- a/src/features/linodes/LinodesLanding/LinodesGridView.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesGridView.tsx
@@ -20,7 +20,14 @@ const LinodesGridView: React.StatelessComponent<Props> = (props) => {
       {linodes.map(linode =>
         <LinodeCard
           key={linode.id}
-          linode={linode}
+          linodeId={linode.id}
+          linodeStatus={linode.status}
+          linodeIpv4={linode.ipv4}
+          linodeIpv6={linode.ipv6}
+          linodeRegion={linode.region}
+          linodeNotification={linode.notification}
+          linodeLabel={linode.label}
+          linodeRecentEvent={linode.recentEvent}
           image={images.find(image => linode.image === image.id)}
           type={types.find(type => linode.type === type.id)}
           openConfigDrawer={openConfigDrawer}

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -315,21 +315,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
     }
 
 
-    const displayGrid: 'grid' | 'list' = ifElse(
-      compose(isEmpty, prop('hash')),
-      /* is empty */
-      ifElse(
-        compose(gte(3), prop('length')),
-        () => 'grid',
-        () => 'list',
-      ),
-      /* is not empty */
-      ifElse(
-        propEq('hash', '#grid'),
-        () => 'grid',
-        () => 'list',
-      ),
-    )({ hash, length: linodes.length });
+    const displayGrid: 'grid' | 'list' = getDisplayFormat({ hash, length: linodes.length });
 
     return (
       <Grid container>
@@ -378,6 +364,22 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
     );
   }
 }
+
+const getDisplayFormat = ifElse(
+  compose(isEmpty, prop('hash')),
+  /* is empty */
+  ifElse(
+    compose(gte(3), prop('length')),
+    () => 'grid',
+    () => 'list',
+  ),
+  /* is not empty */
+  ifElse(
+    propEq('hash', '#grid'),
+    () => 'grid',
+    () => 'list',
+  ),
+);
 
 export const styled = withStyles(styles, { withTheme: true });
 

--- a/src/features/linodes/LinodesLanding/LinodesListView.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesListView.tsx
@@ -38,7 +38,14 @@ const LinodesListView: React.StatelessComponent<Props> = (props) => {
               {linodes.map(linode =>
                 <LinodeRow
                   key={linode.id}
-                  linode={linode}
+                  linodeId={linode.id}
+                  linodeStatus={linode.status}
+                  linodeIpv4={linode.ipv4}
+                  linodeIpv6={linode.ipv6}
+                  linodeRegion={linode.region}
+                  linodeNotification={linode.notification}
+                  linodeLabel={linode.label}
+                  linodeRecentEvent={linode.recentEvent}
                   type={types.find(type => linode.type === type.id)}
                   openConfigDrawer={openConfigDrawer}
                 />,

--- a/src/utilities/haveAnyBeenModified.ts
+++ b/src/utilities/haveAnyBeenModified.ts
@@ -1,0 +1,20 @@
+import { equals } from 'ramda';
+
+let haveAnyBeenModified: <S>(state: S, nextState: S, keys: (keyof S)[]) => boolean;
+
+haveAnyBeenModified = (state, nextState, keys) => {
+  let idx = 0;
+  const len = keys.length;
+
+  while (idx < len) {
+    const key = keys[idx];
+    if (!equals(state[key], nextState[key])) {
+      return true;
+    }
+
+    idx += 1;
+  }
+  return false;
+};
+
+export default haveAnyBeenModified;

--- a/src/utilities/haveAnyBeenModified.ts
+++ b/src/utilities/haveAnyBeenModified.ts
@@ -1,6 +1,6 @@
 import { equals } from 'ramda';
 
-let haveAnyBeenModified: <S>(state: S, nextState: S, keys: (keyof S)[]) => boolean;
+let haveAnyBeenModified: <T>(objA: T, objB: T, keys: (keyof T)[]) => boolean;
 
 haveAnyBeenModified = (state, nextState, keys) => {
   let idx = 0;


### PR DESCRIPTION
## Purpose
There were some really heavy and unnecessary re-renders on LinodesLanding and LinodeDetails. This PR addresses that by A) Not sending objects as props unless required, B) Deep comparing those objects in a shouldComponentUpdate lifecycle method.

Additional follow-up; M3-454