### PR TITLE
Fix select scroll issue

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -27,16 +27,22 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     },
   },
   menu: {
-  },
-  dropDown: {
-    border: '1px solid #bbb',
-    boxShadow: 'none',
-    position: 'absolute',
+    maxHeight: 250,
     overflowY: 'auto',
     overflowX: 'hidden',
     background: LinodeTheme.bg.offWhite,
-    margin: '8px 0 0 -1px',
     boxSizing: 'content-box',
+    [theme.breakpoints.down('xs')]: {
+      minWidth: 200,
+    },
+  },
+  dropDown: {
+    boxShadow: 'none',
+    position: 'absolute',
+    boxSizing: 'content-box',
+    border: '1px solid #bbb',
+    margin: '0 0 0 -1px',
+    outline: 0,
   },
   inputError: {
     borderColor: LinodeTheme.color.red,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -233,6 +233,9 @@ const LinodeTheme: Linode.Theme = {
         minHeight: 44,
         boxSizing: 'border-box',
         backgroundColor: 'white',
+        [breakpoints.down('xs')]: {
+          maxWidth: 250,
+        },
         '& svg': {
           fontSize: 18,
           marginLeft: 8,
@@ -331,7 +334,8 @@ const LinodeTheme: Linode.Theme = {
         padding: '7px 32px 7px 10px',
         color: '#666',
         backgroundColor: '#fff',
-        lineHeight: .9,
+        lineHeight: 2.2,
+        minHeight: 46,
         '&:focus': {
           backgroundColor: '#fff',
           borderColor: 'pink',


### PR DESCRIPTION
We previously had an issue where we could not scroll within the select dropdown when it opens. It is fixed in this PR. I also added a max height for deep menus and fixed the mobile styling (pls reload for mobile styles after resizing window)

Good case for testing is the select menu on the linode detail rescue page