### PR TITLE
M3-450 Expansion panel icons

### DIFF
--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -115,7 +115,7 @@ class EExpansionPanel extends React.Component<CombinedProps> {
       >
         <ExpansionPanelSummary
           onClick={this.handleClick}
-          expandIcon={this.state.open ? <Minus /> : <Plus />}
+          expandIcon={this.state.open ? <Plus /> : <Minus />}
           {...summaryProps}
           className={classNames({
             [classes.success]: Boolean(this.props.success),


### PR DESCRIPTION
There was a regression with the expansion panels where the plus and minus icons had been reversed. This is fixed in this PR, can be tested at linode/[id]/summary