### PR TITLE
Linode Detail - Backups - Fix column regression

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -329,7 +329,6 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell>Name</TableCell>
                 <TableCell>Date Created</TableCell>
                 <TableCell>Label</TableCell>
                 <TableCell>Duration</TableCell>


### PR DESCRIPTION
* when i merged some changes adding `data-qa` attributes it looks like i accidentally added back a table row that I had removed in the previous PR. This removes it again. 
* I did not revert because I had data attributes in the original commit. 
* Yes, i understand the irony of the QA guy creating a bug. 