### PR TITLE
M3-392 & M3-393 - Volume actions tests

### DIFF
--- a/e2e/config/custom-commands.js
+++ b/e2e/config/custom-commands.js
@@ -47,10 +47,23 @@ exports.browserCommands = () => {
     * @param { String } selector to wait for/click
     * @returns { null } Returns nothing
     */
-    browser.addCommand('waitClick', function(elementToClick) {
+    browser.addCommand('waitClick', function(elementToClick, timeout=10000) {
         browser.waitUntil(function() {
             browser.waitForVisible(elementToClick);
             return browser.click(elementToClick).state === 'success';
-        }, 10000);
+        }, timeout);
+    });
+
+    /* Continuously try to set a value on a given selector
+    *  for a given timeout. Returns once the value has been successfully set
+    * @param { String } selector to target (usually an input)
+    * @param { String } value to set input of
+    * @param { Number } timeout
+    */
+    browser.addCommand('trySetValue', function(selector, value, timeout=10000) {
+        browser.waitUntil(function() {
+            browser.setValue(selector, value);
+            return browser.getValue(selector) === value;
+        }, timeout);
     });
 }

--- a/e2e/specs/linodes/detail/detach-attach-volumes.spec.js
+++ b/e2e/specs/linodes/detail/detach-attach-volumes.spec.js
@@ -1,0 +1,61 @@
+const { constants } = require('../../../constants');
+
+import VolumeDetail from '../../../pageobjects/volume-detail.page';
+import ListLinodes from '../../../pageobjects/list-linodes';
+import LinodeDetail from '../../../pageobjects/linode-detail.page';
+
+describe('Linode - Volumes - Attach, Detach, Delete Suite', () => {
+    let linodeName,
+        volume;
+
+    const testVolume = {
+        label: `test-volume-${new Date().getTime()}`,
+        size: '20',
+    }
+
+    beforeAll(() => {
+        browser.url(constants.routes.linodes);
+        ListLinodes.linodeElem.waitForVisible();
+        linodeName = ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).getText();
+        ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).click();
+        LinodeDetail.landingElemsDisplay();
+        LinodeDetail.changeTab('Volumes');
+        
+        VolumeDetail.createVolume(testVolume);
+        browser.waitForVisible('[data-qa-volume-cell]', 25000);
+    });
+
+    it('should display detach linode dialog', () => {
+        volume = VolumeDetail.volumeCell[0];
+        testVolume['id'] = volume.getAttribute('data-qa-volume-cell');
+        testVolume['label'] = volume.$(VolumeDetail.volumeCellLabel.selector).getText();
+
+        VolumeDetail.detachVolume(volume);
+    });
+
+    it('should detach the volume', () => {
+        VolumeDetail.detachConfirm(testVolume.id);
+
+        if (VolumeDetail.placeholderText.isVisible()) {
+            const placeholderMsg = VolumeDetail.placeholderText.getText();
+            const expectedMsg = 'No volumes attached';
+            expect(placeholderMsg).toBe(expectedMsg);
+        }
+    });
+
+    it('should display attach drawer', () => {
+        const createButton = 
+            VolumeDetail.placeholderText.isVisible() ? VolumeDetail.createButton : VolumeDetail.createIconLink;
+
+        createButton.click();
+        // assert placeholder elems appear
+    });
+
+    it('should attach to linode', () => {
+        VolumeDetail.attachVolume(linodeName, testVolume);
+    });
+
+    it('should remove the volume', () => {
+        VolumeDetail.removeVolume($(`[data-qa-volume-cell="${testVolume.id}"]`));
+    });
+});

--- a/e2e/specs/linodes/detail/detach-attach-volumes.spec.js
+++ b/e2e/specs/linodes/detail/detach-attach-volumes.spec.js
@@ -5,8 +5,7 @@ import ListLinodes from '../../../pageobjects/list-linodes';
 import LinodeDetail from '../../../pageobjects/linode-detail.page';
 
 describe('Linode - Volumes - Attach, Detach, Delete Suite', () => {
-    let linodeName,
-        volume;
+    let linodeName;
 
     const testVolume = {
         label: `test-volume-${new Date().getTime()}`,
@@ -26,7 +25,7 @@ describe('Linode - Volumes - Attach, Detach, Delete Suite', () => {
     });
 
     it('should display detach linode dialog', () => {
-        volume = VolumeDetail.volumeCell[0];
+        const volume = VolumeDetail.volumeCell[0];
         testVolume['id'] = volume.getAttribute('data-qa-volume-cell');
         testVolume['label'] = volume.$(VolumeDetail.volumeCellLabel.selector).getText();
 
@@ -48,7 +47,7 @@ describe('Linode - Volumes - Attach, Detach, Delete Suite', () => {
             VolumeDetail.placeholderText.isVisible() ? VolumeDetail.createButton : VolumeDetail.createIconLink;
 
         createButton.click();
-        // assert placeholder elems appear
+        VolumeDetail.drawerTitle.waitForVisible();
     });
 
     it('should attach to linode', () => {

--- a/e2e/specs/linodes/detail/edit-clone-resize-volumes.spec.js
+++ b/e2e/specs/linodes/detail/edit-clone-resize-volumes.spec.js
@@ -1,0 +1,88 @@
+const { constants } = require('../../../constants');
+
+import VolumeDetail from '../../../pageobjects/volume-detail.page';
+import ListLinodes from '../../../pageobjects/list-linodes';
+import LinodeDetail from '../../../pageobjects/linode-detail.page';
+
+xdescribe('Edit - Clone - Resize Volumes Suite', () => {
+    let linodeName,
+        volume;
+
+    const testVolume = {
+        label: `test-volume-${new Date().getTime()}`,
+        size: '20',
+    }
+
+    beforeAll(() => {
+        browser.url(constants.routes.linodes);
+        ListLinodes.linodeElem.waitForVisible();
+        
+        if (ListLinodes.getStatus(ListLinodes.linode[0]) !== 'offline') {
+            ListLinodes.powerOff(ListLinodes.linode[0]);
+        }
+    });
+
+    afterAll(() => {
+        browser.url(constants.routes.linodes);
+
+        ListLinodes.linodeElem.waitForVisible();
+        ListLinodes.powerOn(ListLinodes.linode[0]);
+    });
+
+    beforeEach(() => {
+        browser.url(constants.routes.linodes);
+        ListLinodes.linodeElem.waitForVisible();
+        linodeName = ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).getText();
+
+        ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).click();
+        LinodeDetail.landingElemsDisplay();
+        LinodeDetail.changeTab('Volumes');
+        
+        VolumeDetail.createVolume(testVolume);
+        browser.waitForVisible('[data-qa-volume-cell]', 25000);
+
+        testVolume['id'] = VolumeDetail.volumeCell[0].getAttribute('data-qa-volume-cell');
+        volume = $(`[data-qa-volume-cell="${testVolume.id}"]`);
+    });
+
+    afterEach(() => {
+        browser.waitForVisible(`[data-qa-volume-cell="${testVolume.id}"] [data-qa-action-menu]`);
+        VolumeDetail.removeVolume($(`[data-qa-volume-cell="${testVolume.id}"]`));
+    });
+
+    it('should edit the volume label', () => {
+        VolumeDetail.selectActionMenuItem(volume, 'Edit');
+        VolumeDetail.editVolume(testVolume, 'new-name');
+    });
+
+    it('should dispay resize', () => {
+        VolumeDetail.selectActionMenuItem(volume, 'Resize');
+        const newSize = '30';
+
+        VolumeDetail.size.$('input').setValue(newSize);
+        VolumeDetail.submit.click();
+        VolumeDetail.drawerTitle.waitForVisible(10000, true);
+        
+        browser.waitUntil(function() {
+            return browser.getText(`[data-qa-volume-cell="${testVolume.id}"] [data-qa-volume-size]`).includes(newSize);
+        }, 10000);
+    });
+
+    it('should clone the volume', () => {
+        const getPath = /linodes\/\d.*/
+        const currentUrl = browser.getUrl();
+        const linodeId = currentUrl.match(getPath)[0].match(/\d/g).join('');
+        const numberOfVolumes = VolumeDetail.volumeCell.length;
+
+        VolumeDetail.selectActionMenuItem(volume, 'Clone');
+        VolumeDetail.drawerTitle.waitForVisible();
+
+        expect(VolumeDetail.size.$('input').getValue()).toBe(testVolume.size);
+        expect(VolumeDetail.attachedTo.$('input').getValue()).toBe(linodeId);
+
+        browser.trySetValue('[data-qa-clone-from] input', 'new-clone');
+
+        VolumeDetail.submit.click();
+        VolumeDetail.drawerTitle.waitForVisible(10000, true);
+    });
+});

--- a/e2e/specs/linodes/detail/edit-clone-resize-volumes.spec.js
+++ b/e2e/specs/linodes/detail/edit-clone-resize-volumes.spec.js
@@ -4,9 +4,8 @@ import VolumeDetail from '../../../pageobjects/volume-detail.page';
 import ListLinodes from '../../../pageobjects/list-linodes';
 import LinodeDetail from '../../../pageobjects/linode-detail.page';
 
-xdescribe('Edit - Clone - Resize Volumes Suite', () => {
-    let linodeName,
-        volume;
+describe('Edit - Clone - Resize Volumes Suite', () => {
+    let volume;
 
     const testVolume = {
         label: `test-volume-${new Date().getTime()}`,
@@ -22,17 +21,9 @@ xdescribe('Edit - Clone - Resize Volumes Suite', () => {
         }
     });
 
-    afterAll(() => {
-        browser.url(constants.routes.linodes);
-
-        ListLinodes.linodeElem.waitForVisible();
-        ListLinodes.powerOn(ListLinodes.linode[0]);
-    });
-
     beforeEach(() => {
         browser.url(constants.routes.linodes);
         ListLinodes.linodeElem.waitForVisible();
-        linodeName = ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).getText();
 
         ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).click();
         LinodeDetail.landingElemsDisplay();
@@ -48,6 +39,13 @@ xdescribe('Edit - Clone - Resize Volumes Suite', () => {
     afterEach(() => {
         browser.waitForVisible(`[data-qa-volume-cell="${testVolume.id}"] [data-qa-action-menu]`);
         VolumeDetail.removeVolume($(`[data-qa-volume-cell="${testVolume.id}"]`));
+    });
+
+    afterAll(() => {
+        browser.url(constants.routes.linodes);
+
+        ListLinodes.linodeElem.waitForVisible();
+        ListLinodes.powerOn(ListLinodes.linode[0]);
     });
 
     it('should edit the volume label', () => {
@@ -74,6 +72,7 @@ xdescribe('Edit - Clone - Resize Volumes Suite', () => {
         const linodeId = currentUrl.match(getPath)[0].match(/\d/g).join('');
         const numberOfVolumes = VolumeDetail.volumeCell.length;
 
+        browser.waitForVisible(`[data-qa-volume-cell="${testVolume.id}"] [data-qa-action-menu]`);
         VolumeDetail.selectActionMenuItem(volume, 'Clone');
         VolumeDetail.drawerTitle.waitForVisible();
 

--- a/e2e/specs/search/search.spec.js
+++ b/e2e/specs/search/search.spec.js
@@ -1,10 +1,15 @@
 import SearchBar from '../../pageobjects/search.page';
+import ListLinodes from '../../pageobjects/list-linodes';
 
 const { constants } = require('../../constants');
 
 describe('Header - Search Suite', () => {
+    let testLinode;
+
     beforeAll(() => {
-        browser.url(constants.routes.dashboard);
+        browser.url(constants.routes.linodes);
+        ListLinodes.linodesDisplay();
+        testLinode = ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).getText();
     });
 
     describe('Search Displays Suite', () => {
@@ -33,7 +38,7 @@ describe('Header - Search Suite', () => {
     });
 
     it('should display search suggestions on a legitmate search', () => {
-        SearchBar.executeSearch('test');
+        SearchBar.executeSearch(testLinode);
         SearchBar.assertSuggestions();
     });
 
@@ -54,7 +59,7 @@ describe('Header - Search Suite', () => {
         browser.url(constants.routes.dashboard);
         const currentUrl = browser.getUrl();
         
-        SearchBar.executeSearch('test');
+        SearchBar.executeSearch(testLinode);
         browser.waitForVisible('[data-qa-suggestion]');
 
         SearchBar.suggestions[0].click();

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/AttachVolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/AttachVolumeDrawer.tsx
@@ -76,19 +76,38 @@ const AttachVolumeDrawer: React.StatelessComponent<CombinedProps> = (props) => {
           onChange={e => onChange('selectedVolume', e.target.value)}
           inputProps={{ name: 'volumes', id: 'volumes' }}
           error={Boolean(volumeError)}
+          data-qa-volume-select
         >
           <MenuItem value="" disabled><em>Select a Volume</em></MenuItem>
           {
             volumes && volumes.map((v: Linode.Volume) => {
-              return <MenuItem key={v.id} value={v.id}>{v.label}</MenuItem>;
+              return <MenuItem
+                key={v.id}
+                value={v.id}
+                data-qa-volume-option
+              >
+                {v.label}
+              </MenuItem>;
             })
           }
         </Select>
         { Boolean(volumeError) && <FormHelperText error>{ volumeError }</FormHelperText> }
       </FormControl>
       <ActionsPanel>
-        <Button variant="raised" color="primary" onClick={() => onSubmit()}>Attach</Button>
-        <Button onClick={onClose}> Cancel </Button>
+        <Button
+          variant="raised"
+          color="primary"
+          onClick={() => onSubmit()}
+          data-qa-confirm-attach
+        >
+          Attach
+        </Button>
+        <Button
+          onClick={onClose}
+          data-qa-cancel
+        >
+          Cancel
+        </Button>
       </ActionsPanel>
     </Drawer>
   );

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -772,7 +772,7 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
                     volume,
                   );
 
-                  return <TableRow key={volume.id} data-qa-volume-cell>
+                  return <TableRow key={volume.id} data-qa-volume-cell={volume.id}>
                     <TableCell data-qa-volume-cell-label>{label}</TableCell>
                     <TableCell data-qa-volume-size>{size} GiB</TableCell>
                     <TableCell data-qa-fs-path>{filesystem_path}</TableCell>


### PR DESCRIPTION
* Added tests for the following volume actions: attach, detach, clone, resize
* Added a custom command "trySetValue" to attempt to setvalue on a given element for a given timeout. Needed because occasionally, setvalue fails on the first try :( 
* Added optional timeout override to waitClick command
* Added additional action methods to volume detail page object
* Added `data-qa` tags to volume tsx files
* Fixed: search suggestion test had hardcoded a search query. Changed it to base the search query on the name of the first linode on List Linodes page.

## Testing

1. Test only the new specs
2. Test on your local pointed at production services
3. Have >= 1 test linode created (this will get powered down in order to run a few of the tests) but your account **cannot have any volumes.**
```bash
yarn start
yarn selenium # in a new tab
yarn e2e --file e2e/specs/linodes/detail/edit-clone-resize-volumes.spec.js
yarn e22 --file e2e/specs/linodes/detail/edit-clone-resize-volumes.spec.js
```

Due to rate limiting [SE-199](https://jira.linode.com/browse/SE-199) & a known api issue related to creating volumes on production ([ARB-672](https://jira.linode.com/browse/ARB-672)) you may have problems running these specs (unable to login or test volumes don't get cleaned up or are unable to be created). Because of these issues, I may commit these tests in a disabled state to the repo. 
