### PR TITLE
M3-336 prevent token labels from being blank

### DIFF
--- a/src/features/profile/APITokens/APITokenDrawer.tsx
+++ b/src/features/profile/APITokens/APITokenDrawer.tsx
@@ -181,7 +181,7 @@ class APITokenDrawer extends React.Component<CombinedProps, State> {
   }
 
   errorResources = {
-    label: 'A label',
+    label: 'label',
   };
 
   render() {

--- a/src/features/profile/APITokens/APITokens.test.tsx
+++ b/src/features/profile/APITokens/APITokens.test.tsx
@@ -82,6 +82,15 @@ describe('APITokens', () => {
         website: 'http://localhost:3000',
         label: 'test-app-4',
       },
+      {
+        created: '2028-04-26T14:45:07',
+        expiry: moment.utc().add(3, 'months').format(),
+        thumbnail_url: null,
+        id: 5,
+        scopes: '*',
+        website: 'http://localhost:3000',
+        label: '',
+      },
     ]));
 
   const component = mount(
@@ -109,11 +118,86 @@ describe('APITokens', () => {
 
   it('should expect tokens to show in ascending order by created date', () => {
     const find = component.find('tr[data-qa-table-row]');
-    expect(find.at(0).prop('data-qa-table-row')).toEqual('test-app-3');
-    expect(find.at(1).prop('data-qa-table-row')).toEqual('test-app-2');
-    expect(find.at(2).prop('data-qa-table-row')).toEqual('test-app-4');
-    expect(find.at(3).prop('data-qa-table-row')).toEqual('test-3');
-    expect(find.at(4).prop('data-qa-table-row')).toEqual('test-2');
-    expect(find.at(5).prop('data-qa-table-row')).toEqual('test-4');
+    expect(find.at(0).prop('data-qa-table-row')).toEqual('');
+    expect(find.at(1).prop('data-qa-table-row')).toEqual('test-app-3');
+    expect(find.at(2).prop('data-qa-table-row')).toEqual('test-app-2');
+    expect(find.at(3).prop('data-qa-table-row')).toEqual('test-app-4');
+    expect(find.at(4).prop('data-qa-table-row')).toEqual('test-3');
+    expect(find.at(5).prop('data-qa-table-row')).toEqual('test-2');
+  });
+});
+
+describe('create and edit tokens', () => {
+  const pats: PromiseLoaderResponse<Linode.ResourcePage<Linode.Token>> =
+    createPromiseLoaderResponse(createResourcePage([
+      {
+        created: '2018-04-09T20:00:00',
+        expiry: moment.utc().subtract(1, 'day').format(),
+        id: 1,
+        token: 'aa588915b6368b80',
+        scopes: 'account:read_write',
+        label: 'test-1',
+      },
+    ]));
+
+  const appTokens: PromiseLoaderResponse<Linode.ResourcePage<Linode.Token>> =
+    createPromiseLoaderResponse(createResourcePage([
+      {
+        created: '2018-04-26T20:00:00',
+        expiry: moment.utc().subtract(1, 'day').format(),
+        thumbnail_url: null,
+        id: 1,
+        scopes: '*',
+        website: 'http://localhost:3000',
+        label: 'test-app-1',
+      },
+    ]));
+
+  const component = mount(
+    <APITokens
+      classes={{
+        headline: '',
+        paper: '',
+        labelCell: '',
+        typeCell: '',
+        createdCell: '',
+      }}
+      pats={pats}
+      appTokens={appTokens}
+    />,
+  );
+
+  it('create token submit form should return false if label is blank', () => {
+    (component.instance() as APITokens).createToken('*');
+    const errorsExist = (!!component.state().form.errors);
+    expect(errorsExist).toBeTruthy();
+  });
+
+  it('edit token submit form should return false if label is blank', () => {
+    (component.instance() as APITokens).editToken();
+    const errorsExist = (!!component.state().form.errors);
+    expect(errorsExist).toBeTruthy();
+  });
+
+  it('create token submit form should return no error state if label exists', () => {
+    component.setState({
+      form: {
+        ...component.state().form,
+        errors: undefined, // important that we reset the errors here after the previous tests
+        values: {
+          ...component.state().form.values,
+          label: 'test label',
+        },
+      },
+    });
+    (component.instance() as APITokens).createToken('*');
+    const errorsExist = (!!component.state().form.errors);
+    expect(errorsExist).toBeFalsy();
+  });
+
+  it('edit token submit form should return no error state if label exists', () => {
+    (component.instance() as APITokens).editToken();
+    const errorsExist = (!!component.state().form.errors);
+    expect(errorsExist).toBeFalsy();
   });
 });

--- a/src/features/profile/APITokens/APITokens.tsx
+++ b/src/features/profile/APITokens/APITokens.tsx
@@ -321,6 +321,17 @@ export class APITokens extends React.Component<CombinedProps, State> {
       });
       return;
     }
+    if (!this.state.form.values.label) { // if no label
+      this.setState({
+        form: {
+          ...this.state.form,
+          errors: [
+            { reason: 'You must give your token a label.', field: 'label' },
+          ],
+        },
+      });
+      return;
+    }
 
     const { form } = this.state;
     this.setState({ form: { ...form, values: { ...form.values, scopes } } }, () => {
@@ -341,10 +352,22 @@ export class APITokens extends React.Component<CombinedProps, State> {
           });
         });
     });
+    return;
   }
 
   editToken = () => {
     const { form } = this.state;
+    if (!form.values.label) {
+      this.setState({
+        form: {
+          ...this.state.form,
+          errors: [
+            { reason: 'You must give your token a label.', field: 'label' },
+          ],
+        },
+      });
+      return;
+    }
     Axios.put(`${API_ROOT}/profile/tokens/${form.id}`, { label: form.values.label })
       .then(() => { this.closeDrawer(); })
       .then(() => this.requestTokens())
@@ -358,6 +381,7 @@ export class APITokens extends React.Component<CombinedProps, State> {
           },
         });
       });
+    return;
   }
 
   componentDidMount() {


### PR DESCRIPTION
## Reason
Tokens previously did not require that a user fill out a label before submitting either the editing or adding form