### PR TITLE
Expansion Panel - Fix component test

### DIFF
--- a/src/components/ExpansionPanel/ExpansionPanel.spec.js
+++ b/src/components/ExpansionPanel/ExpansionPanel.spec.js
@@ -81,7 +81,7 @@ describe('Expansion Panel Suite', () => {
 
         it('should display save and cancel buttons', () => {
             const buttons = $$('button');
-            const visibleButtons = buttons.filter(b => b.isVisible());
+            const visibleButtons = buttons.filter(b => b.isVisible() && b.getText() !== '');
             expect(visibleButtons.length).toBe(2);
         });
 
@@ -107,7 +107,7 @@ describe('Expansion Panel Suite', () => {
 
         it('should display save and cancel buttons', () => {
             const buttons = $$('button');
-            const visibleButtons = buttons.filter(b => b.isVisible());
+            const visibleButtons = buttons.filter(b => b.isVisible() && b.getText() !== '');
             expect(visibleButtons.length).toBe(2);
         });
 
@@ -133,7 +133,7 @@ describe('Expansion Panel Suite', () => {
 
         it('should display save and cancel buttons', () => {
             const buttons = $$('button');
-            const visibleButtons = buttons.filter(b => b.isVisible());
+            const visibleButtons = buttons.filter(b => b.isVisible() && b.getText() !== '');
             expect(visibleButtons.length).toBe(2);
         });
 

--- a/src/components/ExpansionPanel/ExpansionPanel.spec.js
+++ b/src/components/ExpansionPanel/ExpansionPanel.spec.js
@@ -81,7 +81,7 @@ describe('Expansion Panel Suite', () => {
 
         it('should display save and cancel buttons', () => {
             const buttons = $$('button');
-            const visibleButtons = buttons.filter(b => b.isVisible() && b.getText() !== '');
+            const visibleButtons = buttons.filter(b => b.isVisible() && !!b.getText());
             expect(visibleButtons.length).toBe(2);
         });
 
@@ -107,7 +107,7 @@ describe('Expansion Panel Suite', () => {
 
         it('should display save and cancel buttons', () => {
             const buttons = $$('button');
-            const visibleButtons = buttons.filter(b => b.isVisible() && b.getText() !== '');
+            const visibleButtons = buttons.filter(b => b.isVisible() && !!b.getText());
             expect(visibleButtons.length).toBe(2);
         });
 
@@ -133,7 +133,7 @@ describe('Expansion Panel Suite', () => {
 
         it('should display save and cancel buttons', () => {
             const buttons = $$('button');
-            const visibleButtons = buttons.filter(b => b.isVisible() && b.getText() !== '');
+            const visibleButtons = buttons.filter(b => b.isVisible() && !!b.getText());
             expect(visibleButtons.length).toBe(2);
         });
 


### PR DESCRIPTION
For some reason, selenium was picking up 4 buttons inside each expansion panel, instead of 2.. The buttons did not contain any text and are not visible.  The Fix: filter buttons without text. 

This fixes development build failures

## To Test

```bash
yarn storybook
yarn selenium # run this in a new shell
yarn storybook:e2e # run this in a new shell
```