### PR TITLE
Add pre-commit bash script, add storybook tests to pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ e2e/test-results/*.xml
 localStorage.json
 e2e/drivers
 storybook-test-results/*.xml
+.tmp*.status

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,19 @@ language: node_js
 node_js:
   - "8.4.0"
 
-before_install: sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
+before_install: sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++ google-chrome-stable
 
 install:
     - yarn
+
+before_script:
+  - yarn storybook &
 
 script:
       - yarn build
       - yarn run lint
       - yarn test --coverage --maxWorkers=2
+      - yarn storybook:e2e
+      - pkill -f selenium-standalone
+      - pkill -f storybook
       - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls

--- a/e2e/config/wdio.storybook.conf.js
+++ b/e2e/config/wdio.storybook.conf.js
@@ -3,19 +3,32 @@ const { argv } = require('yargs');
 const { browserCommands } = require('./custom-commands');
 const wdioMaster = require('./wdio.conf.js');
 const { constants } = require('../constants');
+const { browserConf } = require('./browser-config');
+const selectedBrowser = () => {
+    if (argv.b) {
+        return browserConf[argv.b];
+    }
+    if (process.env.DOCKER || argv.debug) {
+     return browserConf['chrome'];
+    }
+    return browserConf['headlessChrome'];
+}
 const specsToRun = argv.file ? [ argv.file ] : ['./src/components/**/*.spec.js'];
 const servicesToStart = process.env.DOCKER || argv.debug ? [] : ['selenium-standalone'];
 
 exports.config = merge(wdioMaster.config, {
     specs: specsToRun,
     baseUrl: process.env.DOCKER ? 'http://manager-storybook:6006' : 'http://localhost:6006',
-    maxInstances: process.env.DOCKER ? 1 : 3,
+    capabilities: [selectedBrowser()],
+    maxInstances: process.env.DOCKER || argv.debug ?  1 : 4,
     reporterOptions: {
         junit: {
             outputDir: './storybook-test-results'
         }
     },
     services: servicesToStart,
+    seleniumInstallArgs: { config: './selenium-config.js' },
+    seleniumArgs: { config: './selenium-config.js' },
     before: function (capabilities, specs) {
         browserCommands();
         browser.url(constants.routes.storybook);

--- a/e2e/config/wdio.storybook.conf.js
+++ b/e2e/config/wdio.storybook.conf.js
@@ -4,6 +4,7 @@ const { browserCommands } = require('./custom-commands');
 const wdioMaster = require('./wdio.conf.js');
 const { constants } = require('../constants');
 const specsToRun = argv.file ? [ argv.file ] : ['./src/components/**/*.spec.js'];
+const servicesToStart = process.env.DOCKER || argv.debug ? [] : ['selenium-standalone'];
 
 exports.config = merge(wdioMaster.config, {
     specs: specsToRun,
@@ -14,6 +15,7 @@ exports.config = merge(wdioMaster.config, {
             outputDir: './storybook-test-results'
         }
     },
+    services: servicesToStart,
     before: function (capabilities, specs) {
         browserCommands();
         browser.url(constants.routes.storybook);

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "start": "node scripts/start.js",
     "lint": "tslint 'src/**/*.ts' 'src/**/*.tsx'",
     "build": "node scripts/build.js",
+    "precommit": "./scripts/pre-commit.sh",
     "test": "node scripts/test.js --env=jsdom",
     "storybook": "start-storybook -p 6006",
     "storybook:e2e": "./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js",
@@ -99,8 +100,7 @@
     "e2e:all": "./node_modules/.bin/wdio ./e2e/config/wdio.conf.js; ./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js"
   },
   "pre-commit": [
-    "lint",
-    "test"
+    "precommit"
   ],
   "devDependencies": {
     "@storybook/addon-actions": "^3.3.15",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "typeface-lato": "^0.0.54",
     "typeface-ubuntu-mono": "^0.0.54",
     "url-loader": "0.6.2",
+    "wdio-selenium-standalone-service": "^0.0.10",
     "webpack": "3.8.1",
     "webpack-dev-server": "2.9.4",
     "webpack-manifest-plugin": "1.3.2",

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -2,20 +2,40 @@
 
 # Get files changed in commit
 changes=$( git diff --cached --name-status | awk '$1 != "D" { print $2 }' )
+status=0
 
+(
 yarn lint
-status=$?
-
+status=$(($status + $?))
+) &
+(
 yarn test
 status=$(($status + $?))
+) &
 
 # Run storybook tests if components are changed
 if [[ $changes =~ .*src\/components.* ]]; then
-    yarn storybook:e2e
+(
+    # Check if storybook is running
+    nc -z -w5 localhost 6006 > /dev/null 2>&1
+    storybookRunning=$?
+
+    if [[ $storybookRunning -eq "0" ]]; then
+        yarn storybook:e2e
+    else 
+        yarn storybook > /dev/null 2>&1 &
+        yarn storybook:e2e
+    fi
     status=$(($status + $?))
 
-    # Ensure we cleanup any leftover selenium processes
+    # Ensure we cleanup any leftover processes
     $( pkill -f selenium-standalone )
+    
+    if [[ $storybookRunning -eq "1" ]]; then
+        $( pkill -f storybook )
+    fi
+) &
 fi
 
+wait
 exit $status

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Get files changed in commit
+changes=$( git diff --cached --name-status | awk '$1 != "D" { print $2 }' )
+
+yarn lint
+status=$?
+
+yarn test
+status=$(($status + $?))
+
+# Run storybook tests if components are changed
+if [[ $changes =~ .*src\/components.* ]]; then
+    yarn storybook:e2e
+    status=$(($status + $?))
+
+    # Ensure we cleanup any leftover selenium processes
+    $( pkill -f selenium-standalone )
+fi
+
+exit $status

--- a/src/components/ErrorState/ErrorState.spec.js
+++ b/src/components/ErrorState/ErrorState.spec.js
@@ -22,7 +22,7 @@ describe('Error State Component Suite', () => {
         browser.click(navChild);
 
         waitForFocus('[data-qa-error-icon]');
-
+        console.log('balasdfg');
         const errorIcon = $(icon);
         const errorText = $(errorMsg);
 

--- a/src/components/ErrorState/ErrorState.spec.js
+++ b/src/components/ErrorState/ErrorState.spec.js
@@ -22,7 +22,7 @@ describe('Error State Component Suite', () => {
         browser.click(navChild);
 
         waitForFocus('[data-qa-error-icon]');
-        console.log('balasdfg');
+
         const errorIcon = $(icon);
         const errorText = $(errorMsg);
 

--- a/src/components/IconTextLink/IconTextLink.spec.js
+++ b/src/components/IconTextLink/IconTextLink.spec.js
@@ -39,7 +39,7 @@ describe('Icon Text Link Suite', () => {
     it('should display IconTextLink with link text', () => {
         const iconTextLinks = $$(iconTextLinkTitle);
 
-        iconTextLinks.forEach(e => expect(e.getTagName()).toBe('a'));
+        iconTextLinks.forEach(e => expect(e.getTagName()).toBe('button'));
         iconTextLinks.forEach(e => expect(e.getText()).toMatch(/([A-Z])/ig));
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10435,6 +10435,13 @@ wdio-junit-reporter@^0.4.2:
     junit-report-builder "~1.3.0"
     mkdirp "~0.5.1"
 
+wdio-selenium-standalone-service@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/wdio-selenium-standalone-service/-/wdio-selenium-standalone-service-0.0.10.tgz#cdb64d9a53fa3ea0ed3cf0ebf4fd3bdca93dcf05"
+  dependencies:
+    fs-extra "^0.30.0"
+    selenium-standalone "^6.13.0"
+
 wdio-sync@0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/wdio-sync/-/wdio-sync-0.7.0.tgz#2fb07d250121dc81f5635316542c3c49a1220168"


### PR DESCRIPTION
* Adds a pre-commit script that runs `yarn lint`, `yarn test` and selectively runs `yarn storybook:e2e` (determined by if files in your commit match `src/components/`)

* Autostart selenium-standalone to run storybook:e2e tests (thanks to a service plugin)

# To Test

```bash
yarn storybook
yarn storybook:e2e # in a separate shell
```
selenium should auto start and run the tests!

# To Test pre-commit hook:
1. Make a change to a file in `src/components`
2. Commit this change
3. Observe, lint, test and storybook:e2e run!
4. Make a change to files not in `src/components`
5. Commit this change
6. Observe, only lint and test run

🎆 🍾 🍾 🎈 🎉 🎉 🌮 