### PR TITLE
M3-387 hide edit and revoke functions if APIToken is an App Token

### DIFF
--- a/src/features/profile/APITokens/APITokenMenu.tsx
+++ b/src/features/profile/APITokens/APITokenMenu.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
+  isAppTokenMenu: boolean;
   openViewDrawer: () => void;
   openEditDrawer: () => void;
   openRevokeDialog: () => void;
@@ -12,32 +13,42 @@ type CombinedProps = Props;
 
 class APITokenMenu extends React.Component<CombinedProps> {
   createActions = () => {
-    const { openViewDrawer, openEditDrawer, openRevokeDialog } = this.props;
+    const { isAppTokenMenu, openViewDrawer, openEditDrawer, openRevokeDialog } = this.props;
 
     return function (closeMenu: Function): Action[] {
-      const actions = [
-        {
-          title: 'View Token Scopes',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            openViewDrawer();
-            closeMenu();
+      const actions = (!isAppTokenMenu)
+        ? [
+          {
+            title: 'View Token Scopes',
+            onClick: (e: React.MouseEvent<HTMLElement>) => {
+              openViewDrawer();
+              closeMenu();
+            },
           },
-        },
-        {
-          title: 'Edit',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            openEditDrawer();
-            closeMenu();
+          {
+            title: 'Edit',
+            onClick: (e: React.MouseEvent<HTMLElement>) => {
+              openEditDrawer();
+              closeMenu();
+            },
           },
-        },
-        {
-          title: 'Revoke',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            openRevokeDialog();
-            closeMenu();
+          {
+            title: 'Revoke',
+            onClick: (e: React.MouseEvent<HTMLElement>) => {
+              openRevokeDialog();
+              closeMenu();
+            },
           },
-        },
-      ];
+        ]
+        : [
+          {
+            title: 'View Token Scopes',
+            onClick: (e: React.MouseEvent<HTMLElement>) => {
+              openViewDrawer();
+              closeMenu();
+            },
+          },
+        ];
       return actions;
     };
   }

--- a/src/features/profile/APITokens/APITokenMenu.tsx
+++ b/src/features/profile/APITokens/APITokenMenu.tsx
@@ -48,6 +48,13 @@ class APITokenMenu extends React.Component<CombinedProps> {
               closeMenu();
             },
           },
+          {
+            title: 'Revoke',
+            onClick: (e: React.MouseEvent<HTMLElement>) => {
+              openRevokeDialog();
+              closeMenu();
+            },
+          },
         ];
       return actions;
     };

--- a/src/features/profile/APITokens/APITokens.tsx
+++ b/src/features/profile/APITokens/APITokens.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import * as moment from 'moment';
 import Axios from 'axios';
+import { getPersonalAccessTokens, getAppTokens, removePersonalAccessToken, removeAppToken }
+  from 'src/services/profile';
 import { compose, filter, path, pathOr, sort } from 'ramda';
 
 import { withStyles, Theme, WithStyles, StyleRulesCallback } from 'material-ui/styles';
@@ -53,9 +55,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => {
 };
 
 const preloaded = PromiseLoader<Props>({
-  pats: () => Axios.get(`${API_ROOT}/profile/tokens`)
+  pats: () => getPersonalAccessTokens()
     .then(response => response.data),
-  appTokens: () => Axios.get(`${API_ROOT}/profile/apps`)
+  appTokens: () => getAppTokens()
     .then(response => response.data),
 });
 
@@ -195,7 +197,7 @@ export class APITokens extends React.Component<CombinedProps, State> {
                   </TableCell>
                   <TableCell>
                     <APITokenMenu
-                      isAppTokenMenu={(title === 'Apps') ? true : false}
+                      isAppTokenMenu={(title === 'Apps')}
                       openViewDrawer={() => { this.openViewDrawer(token); }}
                       openEditDrawer={() => { this.openEditDrawer(token); }}
                       openRevokeDialog={() => {
@@ -227,7 +229,7 @@ export class APITokens extends React.Component<CombinedProps, State> {
   }
 
   requestTokens = () => {
-    Axios.get(`${API_ROOT}/profile/tokens`)
+    getPersonalAccessTokens()
       .then(response => response.data.data)
       .then((data) => {
         if (!this.mounted) { return; }
@@ -308,14 +310,14 @@ export class APITokens extends React.Component<CombinedProps, State> {
 
   revokePersonalAccessToken = () => {
     const { dialog } = this.state;
-    Axios.delete(`${API_ROOT}/profile/tokens/${dialog.id}`)
+    removePersonalAccessToken(dialog.id)
       .then(() => { this.closeRevokeDialog(); })
       .then(() => this.requestTokens());
   }
 
   revokeAppToken = () => {
     const { dialog } = this.state;
-    Axios.delete(`${API_ROOT}/profile/apps/${dialog.id}`)
+    removeAppToken(dialog.id)
       .then(() => { this.closeRevokeDialog(); })
       .then(() => this.requestTokens());
   }

--- a/src/features/profile/APITokens/APITokens.tsx
+++ b/src/features/profile/APITokens/APITokens.tsx
@@ -194,6 +194,7 @@ export class APITokens extends React.Component<CombinedProps, State> {
                   </TableCell>
                   <TableCell>
                     <APITokenMenu
+                      isAppTokenMenu={(title === 'Apps') ? true : false}
                       openViewDrawer={() => { this.openViewDrawer(token); }}
                       openEditDrawer={() => { this.openEditDrawer(token); }}
                       openRevokeDialog={() => { this.openRevokeDialog(token.label, token.id); }}
@@ -481,7 +482,7 @@ export class APITokens extends React.Component<CombinedProps, State> {
           }}
           onClose={() => this.closeRevokeDialog()}
         >
-         <Typography>Are you sure you want to revoke this API Token?</Typography>
+          <Typography>Are you sure you want to revoke this API Token?</Typography>
         </ConfirmationDialog>
 
         <ConfirmationDialog

--- a/src/features/profile/APITokens/APITokens.tsx
+++ b/src/features/profile/APITokens/APITokens.tsx
@@ -113,6 +113,7 @@ export class APITokens extends React.Component<CombinedProps, State> {
       open: false,
       id: undefined,
       label: undefined,
+      type: '',
     },
     token: {
       open: false,
@@ -197,7 +198,9 @@ export class APITokens extends React.Component<CombinedProps, State> {
                       isAppTokenMenu={(title === 'Apps') ? true : false}
                       openViewDrawer={() => { this.openViewDrawer(token); }}
                       openEditDrawer={() => { this.openEditDrawer(token); }}
-                      openRevokeDialog={() => { this.openRevokeDialog(token.label, token.id); }}
+                      openRevokeDialog={() => {
+                        this.openRevokeDialog(token.label, token.id, type);
+                      }}
                     />
                   </TableCell>
                 </TableRow>,
@@ -287,8 +290,8 @@ export class APITokens extends React.Component<CombinedProps, State> {
     });
   }
 
-  openRevokeDialog = (label: string, id: number) => {
-    this.setState({ dialog: { open: true, label, id } });
+  openRevokeDialog = (label: string, id: number, type: string) => {
+    this.setState({ dialog: { open: true, label, id, type } });
   }
 
   closeRevokeDialog = () => {
@@ -303,9 +306,16 @@ export class APITokens extends React.Component<CombinedProps, State> {
     this.setState({ token: { open: false, value: undefined } });
   }
 
-  revokeToken = () => {
+  revokePersonalAccessToken = () => {
     const { dialog } = this.state;
     Axios.delete(`${API_ROOT}/profile/tokens/${dialog.id}`)
+      .then(() => { this.closeRevokeDialog(); })
+      .then(() => this.requestTokens());
+  }
+
+  revokeAppToken = () => {
+    const { dialog } = this.state;
+    Axios.delete(`${API_ROOT}/profile/apps/${dialog.id}`)
       .then(() => { this.closeRevokeDialog(); })
       .then(() => this.requestTokens());
   }
@@ -464,7 +474,9 @@ export class APITokens extends React.Component<CombinedProps, State> {
                   className="destructive"
                   onClick={() => {
                     this.closeRevokeDialog();
-                    this.revokeToken();
+                    (dialog.type === 'OAuth Client Token')
+                      ? this.revokeAppToken()
+                      : this.revokePersonalAccessToken();
                   }}
                   data-qa-button-confirm>
                   Yes

--- a/src/features/profile/APITokens/APITokens.tsx
+++ b/src/features/profile/APITokens/APITokens.tsx
@@ -113,7 +113,7 @@ export class APITokens extends React.Component<CombinedProps, State> {
     },
     dialog: {
       open: false,
-      id: undefined,
+      id: 0,
       label: undefined,
       type: '',
     },

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -1,0 +1,22 @@
+import { API_ROOT } from 'src/constants';
+import Request, { setURL, setMethod } from '.';
+
+export const getPersonalAccessTokens = () => Request(
+  setURL(`${API_ROOT}/profile/tokens`),
+  setMethod('GET'),
+);
+
+export const getAppTokens = () => Request(
+  setURL(`${API_ROOT}/profile/apps`),
+  setMethod('GET'),
+);
+
+export const removePersonalAccessToken = (tokenId: number | undefined) => Request(
+  setURL(`${API_ROOT}/profile/tokens/${tokenId}`),
+  setMethod('DELETE'),
+);
+
+export const removeAppToken = (tokenId: number | undefined) => Request(
+  setURL(`${API_ROOT}/profile/apps/${tokenId}`),
+  setMethod('DELETE'),
+);

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -11,12 +11,12 @@ export const getAppTokens = () => Request(
   setMethod('GET'),
 );
 
-export const removePersonalAccessToken = (tokenId: number | undefined) => Request(
+export const removePersonalAccessToken = (tokenId: number) => Request(
   setURL(`${API_ROOT}/profile/tokens/${tokenId}`),
   setMethod('DELETE'),
 );
 
-export const removeAppToken = (tokenId: number | undefined) => Request(
+export const removeAppToken = (tokenId: number) => Request(
   setURL(`${API_ROOT}/profile/apps/${tokenId}`),
   setMethod('DELETE'),
 );


### PR DESCRIPTION
## Purpose

Editing and revoking individual tokens don't exist in the API, so for now, we can't give the user the ability to edit and revoke API tokens