### PR TITLE
M3-474 update power icon when a Linode is resized

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -59,6 +59,7 @@ interface Props {
   linodeId: number;
   type: Linode.LinodeType;
   types: { response: ExtendedType[] };
+  updatePowerStatus: (updatedPowerStatus: Linode.LinodeStatus) => void;
 }
 
 interface State {
@@ -74,10 +75,11 @@ class LinodeResize extends React.Component<CombinedProps, State> {
   };
 
   onSubmit = () => {
-    const { linodeId } = this.props;
+    const { linodeId, updatePowerStatus } = this.props;
     const { selectedId } = this.state;
     resizeLinode(linodeId, selectedId)
       .then((response) => {
+        updatePowerStatus('offline');
         sendToast('Linode resize started.');
         resetEventsPolling();
       })

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -59,7 +59,6 @@ interface Props {
   linodeId: number;
   type: Linode.LinodeType;
   types: { response: ExtendedType[] };
-  updatePowerStatus: (updatedPowerStatus: Linode.LinodeStatus) => void;
 }
 
 interface State {
@@ -75,11 +74,10 @@ class LinodeResize extends React.Component<CombinedProps, State> {
   };
 
   onSubmit = () => {
-    const { linodeId, updatePowerStatus } = this.props;
+    const { linodeId } = this.props;
     const { selectedId } = this.state;
     resizeLinode(linodeId, selectedId)
       .then((response) => {
-        updatePowerStatus('offline');
         sendToast('Linode resize started.');
         resetEventsPolling();
       })

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -183,7 +183,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       nextState,
       ['linode', 'type', 'image', 'volumes', 'configs', 'configDrawer'],
     )
-    || haveAnyBeenModified<Location>(location, nextLocation, ['pathname', 'search']);
+      || haveAnyBeenModified<Location>(location, nextLocation, ['pathname', 'search']);
   }
 
   componentWillUnmount() {
@@ -284,6 +284,11 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       });
   }
 
+  // @param updatedStatus - either 'running' or 'offline'
+  updatePowerStatus = (updatedStatus: Linode.LinodeStatus) => {
+    this.setState({ linode: { ...this.state.linode, status: updatedStatus } });
+  }
+
   render() {
     const { match: { url }, classes } = this.props;
     const {
@@ -369,6 +374,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
           )} />
           <Route exact path={`${url}/resize`} render={() => (
             <LinodeResize
+              updatePowerStatus={this.updatePowerStatus}
               linodeId={linode.id}
               type={type}
             />

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -284,11 +284,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       });
   }
 
-  // @param updatedStatus - either 'running' or 'offline'
-  updatePowerStatus = (updatedStatus: Linode.LinodeStatus) => {
-    this.setState({ linode: { ...this.state.linode, status: updatedStatus } });
-  }
-
   render() {
     const { match: { url }, classes } = this.props;
     const {
@@ -374,7 +369,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
           )} />
           <Route exact path={`${url}/resize`} render={() => (
             <LinodeResize
-              updatePowerStatus={this.updatePowerStatus}
               linodeId={linode.id}
               type={type}
             />


### PR DESCRIPTION
## Purpose

When a Linode was resized, the power icon was not properly updated to reflect that the Linode was powered down

https://jira.linode.com/browse/M3-474