### PR TITLE
Styling for webkit scrollbars

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,17 @@ a {
   text-decoration: none;
   color: #3B85D9;
 }
+/* Scrollbars (webkit only) */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: #ccc;
+}
+::-webkit-scrollbar-thumb {
+  background: #3B85D9;
+}
 
 /* Reusable Classes */
 .mlMain {


### PR DESCRIPTION
This PR adds basic styling to override the  native webkit scrollbars. This will show in Chrome and Safari, but will have no effect in FF