### PR TITLE
M3-292 Linode Disk: List, create, update, and delete.

### DIFF
--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -4,11 +4,13 @@ import {
   withStyles, WithStyles, StyleRulesCallback, Theme,
 } from 'material-ui';
 import IconButton from 'material-ui/IconButton';
-import Menu, { MenuItem } from 'material-ui/Menu';
+import Menu from 'material-ui/Menu';
+import MenuItem from 'material-ui/Menu/MenuItem';
 import MoreHoriz from 'material-ui-icons/MoreHoriz';
 
 export interface Action {
   title: string;
+  disabled?: boolean;
   onClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
@@ -98,7 +100,7 @@ class ActionMenu extends React.Component<CombinedProps, State> {
 
     return actions.length === 1
       ? (actions as Action[]).map((a, idx) =>
-          <a href="#" key={idx} onClick={e => a.onClick(e)}>{a.title}</a>)
+        <a href="#" key={idx} onClick={e => a.onClick(e)}>{a.title}</a>)
       : (<div className={classes.root}>
         <IconButton
           aria-owns={anchorEl ? 'action-menu' : undefined}
@@ -125,6 +127,7 @@ class ActionMenu extends React.Component<CombinedProps, State> {
               onClick={a.onClick}
               className={classes.item}
               data-qa-action-menu-item={a.title}
+              disabled={a.disabled}
             >{a.title}</MenuItem>,
           )}
         </Menu>

--- a/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -18,7 +18,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 });
 
 interface Props extends DialogProps {
-  actions: () => JSX.Element;
+  actions: (props: any) => JSX.Element;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -28,11 +28,11 @@ const ConfirmationDialog: React.StatelessComponent<CombinedProps> = (props) => {
     title,
     children,
     actions,
-    ...rest,
+    ...dialogProps,
   } = props;
   return (
     <Dialog
-      { ...rest }
+      { ...dialogProps }
       disableBackdropClick={true}
     >
       <DialogTitle id="alert-dialog-title" data-qa-dialog-title>{title}</DialogTitle>
@@ -40,7 +40,7 @@ const ConfirmationDialog: React.StatelessComponent<CombinedProps> = (props) => {
         { children }
       </DialogContent>
       <DialogActions>
-        { actions() }
+        { actions(dialogProps) }
       </DialogActions>
     </Dialog>
   );

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskActionMenu.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+
+import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+
+interface Props {
+  linodeStatus: string;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+type CombinedProps = Props;
+
+class DiskActionMenu extends React.Component<CombinedProps> {
+  createActions = () => (closeMenu: Function): Action[] => {
+    const { linodeStatus } = this.props;
+    const actions = [
+      {
+        title: 'Edit',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+          this.props.onEdit();
+          closeMenu();
+        },
+      },
+      {
+        title: 'Delete',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+          this.props.onDelete();
+          closeMenu();
+        },
+        disabled: linodeStatus !== 'offline',
+      },
+    ];
+
+    return actions;
+  }
+
+  render() {
+    return (
+      <ActionMenu createActions={this.createActions()} />
+    );
+  }
+}
+
+export default DiskActionMenu;

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react';
+
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+  MenuItem,
+} from 'material-ui';
+import Button from 'material-ui/Button';
+
+import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+import Grid from 'src/components/Grid';
+import Drawer from 'src/components/Drawer';
+import TextField from 'src/components/TextField';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Notice from 'src/components/Notice';
+
+type ClassNames = 'root'
+  | 'section'
+  | 'divider';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+  section: {
+    marginTop: theme.spacing.unit * 2,
+  },
+  divider: {
+    margin: `${theme.spacing.unit * 2}px ${theme.spacing.unit}px 0 `,
+    width: `calc(100% - ${theme.spacing.unit * 2}px)`,
+  },
+});
+
+interface EditableFields {
+  label: string;
+  filesystem: string;
+  size: number;
+}
+
+interface Props extends EditableFields {
+  mode: 'create' | 'edit';
+  open: boolean;
+  errors?: Linode.ApiFieldError[];
+  onClose: () => void;
+  onSubmit: () => void;
+  onChange: (k: keyof EditableFields, v: any) => void;
+}
+
+interface State { }
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
+  state: State = {};
+
+  render() {
+    const {
+      errors,
+      open,
+      mode,
+
+      // Editable Values
+      label,
+      filesystem,
+      size,
+
+      // Handlers
+      onSubmit,
+      onClose,
+      onChange,
+
+      classes,
+    } = this.props;
+    const title = mode === 'create' ? 'Add Disk' : 'Edit Disk';
+    const errorFor = getAPIErrorsFor({}, errors);
+    const generalError = errorFor('none');
+    const labelError = errorFor('label');
+    const filesystemError = errorFor('filesystem');
+    const sizeError = errorFor('size');
+
+    return (
+      <Drawer
+        title={title}
+        open={open}
+        onClose={onClose}
+      >
+        <Grid container direction="row">
+          {generalError && <Notice error text={generalError} />}
+          <Grid item xs={12} className={classes.section}>
+
+            <TextField
+              label="Label"
+              required
+              value={label}
+              onChange={e => onChange('label', e.target.value)}
+              errorText={labelError}
+            />
+
+            {mode === 'create' && <TextField
+              label="Filesystem"
+              select
+              value={filesystem}
+              onChange={e => onChange('filesystem', e.target.value)}
+              errorText={filesystemError}
+            >
+              <MenuItem value="_none_"><em>Select a Filesystem</em></MenuItem>
+              {
+                ['raw', 'swap', 'ext3', 'ext4', 'initrd'].map(fs =>
+                  <MenuItem value={fs} key={fs}>{fs}</MenuItem>)
+              }
+            </TextField>}
+
+            {mode === 'create' && <TextField
+              label="Size"
+              type="number"
+              required
+              value={size}
+              onChange={e => onChange('size', +e.target.value)}
+              errorText={sizeError}
+            />}
+          </Grid>
+          <Grid item className={classes.section}>
+            <ActionsPanel>
+              <Button onClick={onSubmit} variant="raised" color="primary">Submit</Button>
+              <Button onClick={onClose}>Cancel</Button>
+            </ActionsPanel>
+          </Grid>
+        </Grid>
+      </Drawer>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(LinodeDiskDrawer);

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -30,6 +30,7 @@ interface Props {
   linodeConfigs: Linode.Config[];
   linodeRegion: string;
   linodeMemory: number;
+  linodeStatus: string;
 }
 
 type CombinedProps = Props
@@ -44,6 +45,7 @@ const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
     linodeLabel,
     linodeMemory,
     linodeRegion,
+    linodeStatus,
   } = props;
 
   return (
@@ -68,6 +70,7 @@ const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
         linodeRegion={linodeRegion}
         linodeConfigs={linodeConfigs}
         linodeMemory={linodeMemory}
+        linodeStatus={linodeStatus}
       />
       <LinodeSettingsDeletePanel
         linodeId={linodeId}

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -395,6 +395,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
               linodeConfigs={configs || []}
               linodeMemory={type.memory}
               linodeRegion={linode.region}
+              linodeStatus={linode.status}
             />
           )} />
           {/* 404 */}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -28,7 +28,7 @@ export const setMethod = (method: 'GET'|'POST'|'PUT'|'DELETE') => set(L.method, 
 export const setParams = (params: any) => set(L.params, params);
 
 /** Data */
-export const setData = <T>(data: T) => set(L.data, data);
+export const setData = (data: any) => set(L.data, data);
 
 /** Generator */
 export default (...fns: Function[]) => {

--- a/src/services/linodes.ts
+++ b/src/services/linodes.ts
@@ -154,7 +154,7 @@ export interface LinodeConfigCreationData {
 export const createLinodeConfig = (linodeId: number, data: LinodeConfigCreationData) => Request(
   setURL(`${API_ROOT}/linode/instances/${linodeId}/configs`),
   setMethod('POST'),
-  setData<LinodeConfigCreationData>(data),
+  setData(data),
 );
 
 export const deleteLinodeConfig = (linodeId: number, configId: number) => Request(
@@ -169,5 +169,54 @@ export const updateLinodeConfig = (
 ) => Request(
   setURL(`${API_ROOT}/linode/instances/${linodeId}/configs/${configId}`),
   setMethod('PUT'),
-  setData<LinodeConfigCreationData>(data),
-);
+  setData(data),
+  );
+
+export interface LinodeDiskCreationData {
+  label: string;
+  size: number;
+  filesystem?: string;
+}
+
+export const listLinodeDisks = (
+  linodeId: number,
+) => Request(
+  setURL(`${API_ROOT}/linode/instances/${linodeId}/disks`),
+  setMethod('GET'),
+  );
+
+export const createLinodeDisk = (
+  linodeId: number,
+  data: LinodeDiskCreationData,
+) => Request(
+  setURL(`${API_ROOT}/linode/instances/${linodeId}/disks`),
+  setMethod('POST'),
+  setData(data),
+  );
+
+export const getLinodeDisk = (
+  linodeId: number,
+  diskId: number,
+) => Request(
+  setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}`),
+  setMethod('GET'),
+  );
+
+export const updateLinodeDisk = (
+  linodeId: number,
+  diskId: number,
+  data: Pick<LinodeDiskCreationData, 'label'>,
+) => Request(
+  setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}`),
+  setMethod('PUT'),
+  setData(data),
+  );
+
+export const deleteLinodeDisk = (
+  linodeId: number,
+  diskId: number,
+) => Request(
+  setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}`),
+  setMethod('DELETE'),
+  );
+

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -333,7 +333,7 @@ const LinodeTheme: Linode.Theme = {
         },
       },
       disabled: {
-        opacity: 1,
+        opacity: .5,
       },
     },
     MuiListItemText: {
@@ -364,6 +364,7 @@ const LinodeTheme: Linode.Theme = {
         backgroundColor: 'white !important',
         color: '#3B85D9 !important',
         cursor: 'initial',
+        opacity: 1,
       },
     },
     MuiPopover: {


### PR DESCRIPTION
## Purpose
Allow users to list, create, update, and delete Disks attached to a given Linode.

- Additionally added prop to Action to allow ActionMenu items to be disabled.
- Removed type argument from setData as it provided no value.