### PR TITLE
Style disabled inputs for consistency

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -37,6 +37,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     [theme.breakpoints.down('xs')]: {
       minWidth: 200,
     },
+    '&::-webkit-scrollbar-track': {
+      background: theme.palette.divider,
+    },
   },
   dropDown: {
     boxShadow: 'none',

--- a/src/darkTheme.ts
+++ b/src/darkTheme.ts
@@ -363,10 +363,9 @@ const LinodeTheme: Linode.Theme = {
       root: {
         '&.selectHeader': {
           opacity: 1,
-          paddingBottom: 4,
           fontWeight: 700,
           fontSize: '1rem',
-          color: '#ddd',
+          color: '#fff',
         },
       },
       disabled: {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -294,7 +294,9 @@ const LinodeTheme: Linode.Theme = {
         borderColor: '#CA0813',
       },
       disabled: {
-        borderColor: '#f4f4f4',
+        borderColor: '#ccc',
+        color: '#666',
+        opacity: .5,
       },
       input: {
         padding: '12px 12px 13px',
@@ -328,7 +330,6 @@ const LinodeTheme: Linode.Theme = {
       root: {
         '&.selectHeader': {
           opacity: 1,
-          paddingBottom: 4,
           fontWeight: 700,
           fontSize: '1rem',
         },


### PR DESCRIPTION
The styling for the disabled inputs was inconsistent across various elements (text inputs, selects etc)

before
![screen shot 2018-05-07 at 9 54 01 am](https://user-images.githubusercontent.com/205353/39707348-28c217da-51e2-11e8-8834-bf13c2d64fe4.png)

after
![screen shot 2018-05-07 at 10 14 04 am](https://user-images.githubusercontent.com/205353/39707347-28ae6b68-51e2-11e8-9db3-b6de9bee1de3.png)

