### PR TITLE
M3-429 No preselected option on Linode resize

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -70,7 +70,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 class LinodeResize extends React.Component<CombinedProps, State> {
   state: State = {
-    selectedId: this.props.type.id,
+    selectedId: '',
   };
 
   onSubmit = () => {


### PR DESCRIPTION
previously when resizing a Linode, the option that was preselected was the size of the Linode currently. Now, no option should be preselected