### PR TITLE
M3-486 Allow for deletion of default value in size field in add disk form

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
@@ -318,7 +318,7 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
           })}
           onClose={() => this.setDiskDrawer(this.defaultDiskDrawerState)}
           onSubmit={() =>
-              this.state.diskDrawer.mode === 'create'
+            this.state.diskDrawer.mode === 'create'
               ? this.createDisk()
               : this.updateDisk()
           }
@@ -654,10 +654,12 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
 
     updateLinodeDisk(linodeId, diskId, { label })
       .then(({ data }) => {
-        this.setState({ devices: {
-          ...this.state.devices,
-          disks: replaceById(data, data.id, this.state.devices.disks),
-        }});
+        this.setState({
+          devices: {
+            ...this.state.devices,
+            disks: replaceById(data, data.id, this.state.devices.disks),
+          },
+        });
         this.setDiskDrawer(this.defaultDiskDrawerState);
       })
       .catch((error) => {

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
@@ -115,7 +115,7 @@ class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
               type="number"
               required
               value={size}
-              onChange={e => onChange('size', +e.target.value)}
+              onChange={e => onChange('size', e.target.value === '' ? '' : +e.target.value)}
               errorText={sizeError}
             />}
           </Grid>


### PR DESCRIPTION
previously, user could not delete the defaut 0 value without Ctrl+A and replacing with another number. Now allows user to delete value just by backspacing