### PR TITLE
Consolidate styles for selects and textFields as selects

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -15,8 +15,6 @@ import { MenuProps } from 'material-ui/Menu';
 import HelpIcon from 'src/components/HelpIcon';
 
 type ClassNames = 'root'
-  | 'menu'
-  | 'dropDown'
   | 'inputSucess'
   | 'inputError';
 
@@ -25,29 +23,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     '&[class*="focused"]': {
       borderColor: '#666',
     },
-  },
-  menu: {
-    maxHeight: 250,
-    overflowY: 'auto',
-    overflowX: 'hidden',
-    boxSizing: 'content-box',
-    '& li': {
-      color: theme.palette.text.primary,
-    },
-    [theme.breakpoints.down('xs')]: {
-      minWidth: 200,
-    },
-    '&::-webkit-scrollbar-track': {
-      background: theme.palette.divider,
-    },
-  },
-  dropDown: {
-    boxShadow: 'none',
-    position: 'absolute',
-    boxSizing: 'content-box',
-    border: '1px solid #666',
-    margin: '0 0 0 -1px',
-    outline: 0,
   },
   inputError: {
     borderColor: theme.color.red,
@@ -86,8 +61,8 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
     getContentAnchorEl: undefined,
     anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
     transformOrigin: { vertical: 'top', horizontal: 'left' },
-    MenuListProps: { className: classes.menu },
-    PaperProps: { className: classes.dropDown },
+    MenuListProps: { className: 'selectMenuList' },
+    PaperProps: { className: 'selectMenuDropdown' },
   };
 
   const inputProps: InputProps = {

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -40,6 +40,13 @@ const LinodeTextField: React.StatelessComponent<Props> = (props) => {
         disableUnderline: true,
       }}
       fullWidth
+      SelectProps={{ MenuProps: {
+        getContentAnchorEl: undefined,
+        anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
+        transformOrigin: { vertical: 'top', horizontal: 'left' },
+        MenuListProps: { className: 'selectMenuList' },
+        PaperProps: { className: 'selectMenuDropdown' },
+      }}}
     >
       {props.children}
     </TextField>

--- a/src/darkTheme.ts
+++ b/src/darkTheme.ts
@@ -443,6 +443,9 @@ const LinodeTheme: Linode.Theme = {
         color: '#C9CACB',
         lineHeight: 2.2,
         minHeight: 46,
+        '& em': {
+          fontStyle: 'normal',
+        },
       },
       select: {
         '&[aria-pressed="true"]': {

--- a/src/darkTheme.ts
+++ b/src/darkTheme.ts
@@ -378,6 +378,27 @@ const LinodeTheme: Linode.Theme = {
         lineHeight: '1.2em',
       },
     },
+    MuiMenu: {
+      paper: {
+        '&.selectMenuDropdown': {
+          boxShadow: 'none',
+          position: 'absolute',
+          boxSizing: 'content-box',
+          border: '1px solid #666',
+          margin: '0 0 0 -1px',
+          outline: 0,
+        },
+        '& .selectMenuList': {
+          maxHeight: 250,
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          boxSizing: 'content-box',
+          [breakpoints.down('xs')]: {
+            minWidth: 200,
+          },
+        },
+      },
+    },
     MuiMenuItem: {
       root: {
         height: 'auto',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -417,6 +417,9 @@ const LinodeTheme: Linode.Theme = {
         '&:focus': {
           backgroundColor: '#fff',
         },
+        '& em': {
+          fontStyle: 'normal',
+        },
       },
       select: {
         '&[aria-pressed="true"]': {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -361,7 +361,7 @@ const LinodeTheme: Linode.Theme = {
           boxSizing: 'content-box',
           '& li': {
             color: '#666',
-            '&:hover': {
+            '&:hover, &:focus': {
               color: 'white',
             },
           },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -344,6 +344,33 @@ const LinodeTheme: Linode.Theme = {
         lineHeight: '1.2em',
       },
     },
+    MuiMenu: {
+      paper: {
+        '&.selectMenuDropdown': {
+          boxShadow: 'none',
+          position: 'absolute',
+          boxSizing: 'content-box',
+          border: '1px solid #666',
+          margin: '0 0 0 -1px',
+          outline: 0,
+        },
+        '& .selectMenuList': {
+          maxHeight: 250,
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          boxSizing: 'content-box',
+          '& li': {
+            color: '#666',
+            '&:hover': {
+              color: 'white',
+            },
+          },
+          [breakpoints.down('xs')]: {
+            minWidth: 200,
+          },
+        },
+      },
+    },
     MuiMenuItem: {
       root: {
         height: 'auto',


### PR DESCRIPTION
The dropDown styles for textFields with the select={true} prop were not picking our theme's select styles since they are not not select fields. (ex: /linodes/[id]/settings) > "Add a configuration"

![screen shot 2018-05-07 at 4 43 18 pm](https://user-images.githubusercontent.com/205353/39724110-d5483e7a-5215-11e8-9a80-8183e7969cd0.png)

I added classes that I styled in our theme.ts (and dark theme) files in order to cover both dropDown styles instances without repeating ourselves for the textFields.

To test: existing selects and textField as selects