### PR TITLE
Update _initial events logic with tests.

### DIFF
--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -7,11 +7,128 @@ import {
   generateInFilter,
   generatePollingFilter,
   requestEvents,
+  setInitialEvents,
 } from 'src/events';
 
 Date.now = jest.fn(() => 1234567890);
 
+function mockResponse(data: any[], headers: any = {}) {
+  return {
+    data: {
+      data,
+      page: 1,
+      pages: 1,
+      results: 100,
+    },
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: {
+      headers,
+    },
+  };
+}
+
 describe('events module', () => {
+
+  describe('setInitialEvents', () => {
+    it('should set events as _initial if X-Filter is the "beginning of time". ', () => {
+      const response = mockResponse(
+        [
+          {
+            id: 123,
+            action: 'linode_boot',
+            created: '1970-01-01T00:00:00',
+            entity: null,
+            percent_complete: null,
+            rate: null,
+            read: false,
+            seen: false,
+            status: 'notification',
+            time_remaining: null,
+            username: 'somefella',
+          },
+        ],
+        { 'X-Filter': JSON.stringify({ created: { '+gt': '1970-01-01T00:00:00' } }) },
+      );
+
+      const expected = mockResponse(
+        [
+          {
+            id: 123,
+            action: 'linode_boot',
+            created: '1970-01-01T00:00:00',
+            entity: null,
+            percent_complete: null,
+            rate: null,
+            read: false,
+            seen: false,
+            status: 'notification',
+            time_remaining: null,
+            username: 'somefella',
+            _initial: true,
+          },
+        ],
+        { 'X-Filter': JSON.stringify({ created: { '+gt': '1970-01-01T00:00:00' } }) },
+      );
+
+      const result = setInitialEvents(response);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should return unmodified if X-Filter is not set.', () => {
+      const response = mockResponse([
+        {
+          id: 123,
+          action: 'linode_boot',
+          created: '1970-01-01T00:00:00',
+          entity: null,
+          percent_complete: null,
+          rate: null,
+          read: false,
+          seen: false,
+          status: 'notification',
+          time_remaining: null,
+          username: 'somefella',
+        },
+      ]);
+
+      const expected = response;
+
+      const result = setInitialEvents(response);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('should return unmodified if X-Filter is after "the beginning of time".', () => {
+      const response = mockResponse(
+        [
+          {
+            id: 123,
+            action: 'linode_boot',
+            created: '1970-01-01T00:00:00',
+            entity: null,
+            percent_complete: null,
+            rate: null,
+            read: false,
+            seen: false,
+            status: 'notification',
+            time_remaining: null,
+            username: 'somefella',
+          },
+        ],
+        { 'X-Filter': JSON.stringify({ created: { '+gt': '1971-01-01T00:00:00' } }) },
+      );
+
+      const expected = response;
+
+      const result = setInitialEvents(response);
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe('resetEventsPolling', () => {
     it('resets both the request deadline and poll multiplier', () => {
       resetEventsPolling();

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -154,6 +154,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
 
     this.eventsSub = events$
       .filter(newLinodeEvents(mountTime))
+      .filter(e => !e._initial)
       .subscribe((linodeEvent) => {
         Axios.get(`${API_ROOT}/linode/instances/${(linodeEvent.entity as Linode.Entity).id}`)
           .then(response => response.data)

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -1,6 +1,6 @@
-import Axios from 'axios';
+import Axios, { AxiosPromise } from 'axios';
 import { API_ROOT } from 'src/constants';
 
-export const getEvents = (headers: any): Promise<Linode.ResourcePage<Linode.Event>> =>
-  Axios.get(`${API_ROOT}/account/events`, { headers })
-  .then(response => response.data);
+export type EventsPromise = AxiosPromise<Linode.ResourcePage<Linode.Event>>;
+export const getEvents = (headers: any): EventsPromise =>
+  Axios.get(`${API_ROOT}/account/events`, { headers });


### PR DESCRIPTION
## Purpose
When viewing the LinodesLanding page and given a situation where API response exceeded the interval for the next request, events were not being filtered using the _initial flag. This resulted in 100+ simultaneous requests being made to API.

I've removed the external state that made an events "initial" and instead used the AxiosResponse object. I check for the parsed value of config.headers['x-filter'].created['+gt'], which if it is not greater than the "beginning of time", then we set the _initial flag to true for events in that response.