### PR TITLE
Opacity change on drawer backdrop

### DIFF
--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -13,7 +13,8 @@ interface Props extends DrawerProps {
 type ClassNames = 'drawer'
 | 'button'
 | 'drawerHeader'
-| 'drawerContent';
+| 'drawerContent'
+| 'backDrop';
 
 const styles: StyleRulesCallback = (theme: Theme) => ({
   paper: {
@@ -50,6 +51,9 @@ const styles: StyleRulesCallback = (theme: Theme) => ({
       backgroundColor: theme.palette.primary.main,
     },
   },
+  backDrop: {
+    backgroundColor: 'rgba(255, 255, 255, 0.5)',
+  },
 });
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -63,7 +67,7 @@ const DDrawer: React.StatelessComponent<CombinedProps> = (props) => {
       {...rest}
       classes={{ paper: classes.paper }}
       ModalProps={{
-        BackdropProps: { invisible: true },
+        BackdropProps: { className: classes.backDrop },
         disableBackdropClick: true,
       }}
       >


### PR DESCRIPTION
Now that we have changed the backdrop click behavior on the drawer (forcing to close the drawer from within), we need to make it a bit more clear that the action has to be taken from the drawer itself.

I decreased the opacity of the page to put more focus on the drawer to achieve a better UX