### PR TITLE
M3-485 multiple requests made on settings

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
@@ -144,7 +144,7 @@ interface State {
 }
 
 interface Props {
-  linodeDisks: PromiseLoaderResponse<Linode.Disk[]>;
+  linodeDisks: Linode.Disk[];
   linodeConfigs: Linode.Config[];
   linodeId: number;
   linodeLabel: string;
@@ -216,7 +216,7 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
     const updatedDisks = compose(
       // add the _id property to each disk
       map((disk: Linode.Disk) => assoc('_id', `disk-${disk.id}`, disk)),
-    )(this.props.linodeDisks.response);
+    )(this.props.linodeDisks);
 
     this.state = {
       submitting: false,

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
@@ -5,6 +5,7 @@ import {
   append,
   assoc,
   compose,
+  defaultTo,
   filter,
   findIndex,
   lensPath,
@@ -210,31 +211,25 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
     errors: undefined,
   };
 
-  constructor(props: CombinedProps) {
-    super(props);
-
-    const updatedDisks = compose(
-      // add the _id property to each disk
-      map((disk: Linode.Disk) => assoc('_id', `disk-${disk.id}`, disk)),
-    )(this.props.linodeDisks);
-
-    this.state = {
+  state: State = {
+    submitting: false,
+    linodeConfigs: this.props.linodeConfigs,
+    linodeStatus: this.props.linodeStatus,
+    devices: {
+      disks: compose(
+        map<Linode.Disk, ExtendedDisk>(disk => assoc('_id', `disk-${disk.id}`, disk)),
+        defaultTo([]),
+      )(this.props.linodeDisks),
+      volumes: this.props.volumes.response || [],
+    },
+    confirmDelete: {
+      open: false,
       submitting: false,
-      linodeConfigs: this.props.linodeConfigs,
-      linodeStatus: this.props.linodeStatus,
-      devices: {
-        disks: updatedDisks || [],
-        volumes: this.props.volumes.response || [],
-      },
-      confirmDelete: {
-        open: false,
-        submitting: false,
-      },
-      configDrawer: this.defaultConfigDrawerState,
-      diskDrawer: this.defaultDiskDrawerState,
-      confirmDiskDelete: this.defaultConfirmDiskDeleteState,
-    };
-  }
+    },
+    configDrawer: this.defaultConfigDrawerState,
+    diskDrawer: this.defaultDiskDrawerState,
+    confirmDiskDelete: this.defaultConfirmDiskDeleteState,
+  };
 
   componentWillReceiveProps(nextProps: Props) {
     this.setState({

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -8,12 +8,6 @@ import {
   Typography,
 } from 'material-ui';
 
-import { compose } from 'ramda';
-
-import { getLinodeDisks } from 'src/services/linodes';
-
-import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader';
-
 import LinodeSettingsLabelPanel from './LinodeSettingsLabelPanel';
 import LinodeSettingsPasswordPanel from './LinodeSettingsPasswordPanel';
 import LinodeSettingsAlertsPanel from './LinodeSettingsAlertsPanel';
@@ -37,13 +31,10 @@ interface Props {
   linodeRegion: string;
   linodeMemory: number;
   linodeStatus: string;
+  linodeDisks: Linode.Disk[];
 }
 
-interface PromiseLoaderProps {
-  linodeDisks: PromiseLoaderResponse<Linode.Disk[]>;
-}
-
-type CombinedProps = Props & PromiseLoaderProps & WithStyles<ClassNames>;
+type CombinedProps = Props & WithStyles<ClassNames>;
 
 const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
   const {
@@ -66,7 +57,7 @@ const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
         linodeId={linodeId}
       />
       <LinodeSettingsPasswordPanel
-        linodeDisks={linodeDisks.response}
+        linodeDisks={linodeDisks}
         linodeLabel={linodeLabel}
         linodeId={linodeId}
       />
@@ -76,7 +67,7 @@ const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
         linodeAlerts={linodeAlerts}
       />
       <LinodeConfigsPanel
-        linodeDisks={linodeDisks.response}
+        linodeDisks={linodeDisks}
         linodeId={linodeId}
         linodeLabel={linodeLabel}
         linodeRegion={linodeRegion}
@@ -93,11 +84,6 @@ const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
 
 const styled = withStyles(styles, { withTheme: true });
 
-const loaded = PromiseLoader<Props>({
-  linodeDisks: ({ linodeId }): Promise<Linode.Disk[]> => getLinodeDisks(linodeId)
-    .then(response => response.data),
-});
-
-export default compose(styled, loaded)(LinodeSettings) as React.ComponentType<Props>;
+export default styled(LinodeSettings);
 
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -8,6 +8,8 @@ import {
   Typography,
 } from 'material-ui';
 
+import { getLinodeDisks } from 'src/services/linodes';
+
 import LinodeSettingsLabelPanel from './LinodeSettingsLabelPanel';
 import LinodeSettingsPasswordPanel from './LinodeSettingsPasswordPanel';
 import LinodeSettingsAlertsPanel from './LinodeSettingsAlertsPanel';
@@ -33,52 +35,69 @@ interface Props {
   linodeStatus: string;
 }
 
+interface State {
+  linodeDisks: Linode.Disk[];
+}
+
 type CombinedProps = Props
   & WithStyles<ClassNames>;
 
-const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
-  const {
-    classes,
-    linodeAlerts,
-    linodeConfigs,
-    linodeId,
-    linodeLabel,
-    linodeMemory,
-    linodeRegion,
-    linodeStatus,
-  } = props;
+class LinodeSettings extends React.Component<CombinedProps, State> {
+  state: State = {
+    linodeDisks: [],
+  };
 
-  return (
-    <React.Fragment>
-      <Typography variant="headline" className={classes.title}>Settings</Typography>
-      <LinodeSettingsLabelPanel
-        linodeLabel={linodeLabel}
-        linodeId={linodeId}
-      />
-      <LinodeSettingsPasswordPanel
-        linodeLabel={linodeLabel}
-        linodeId={linodeId}
-      />
-      <LinodeSettingsAlertsPanel
-        linodeId={linodeId}
-        linodeLabel={linodeLabel}
-        linodeAlerts={linodeAlerts}
-      />
-      <LinodeConfigsPanel
-        linodeId={linodeId}
-        linodeLabel={linodeLabel}
-        linodeRegion={linodeRegion}
-        linodeConfigs={linodeConfigs}
-        linodeMemory={linodeMemory}
-        linodeStatus={linodeStatus}
-      />
-      <LinodeSettingsDeletePanel
-        linodeId={linodeId}
-      />
-    </React.Fragment >
-  );
-};
+  componentDidMount() {
+    // do call for linode disks here
+    const { linodeId } = this.props;
+    getLinodeDisks(linodeId).then(disk => console.log(disk.data));
+  }
+
+  render() {
+    const {
+      classes,
+      linodeAlerts,
+      linodeConfigs,
+      linodeId,
+      linodeLabel,
+      linodeMemory,
+      linodeRegion,
+      linodeStatus,
+    } = this.props;
+
+    return (
+      <React.Fragment>
+        <Typography variant="headline" className={classes.title}>Settings</Typography>
+        <LinodeSettingsLabelPanel
+          linodeLabel={linodeLabel}
+          linodeId={linodeId}
+        />
+        <LinodeSettingsPasswordPanel
+          linodeLabel={linodeLabel}
+          linodeId={linodeId}
+        />
+        <LinodeSettingsAlertsPanel
+          linodeId={linodeId}
+          linodeLabel={linodeLabel}
+          linodeAlerts={linodeAlerts}
+        />
+        <LinodeConfigsPanel
+          linodeId={linodeId}
+          linodeLabel={linodeLabel}
+          linodeRegion={linodeRegion}
+          linodeConfigs={linodeConfigs}
+          linodeMemory={linodeMemory}
+          linodeStatus={linodeStatus}
+        />
+        <LinodeSettingsDeletePanel
+          linodeId={linodeId}
+        />
+      </React.Fragment >
+    );
+  }
+}
 
 const styled = withStyles(styles, { withTheme: true });
 
 export default styled(LinodeSettings);
+

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -8,7 +8,11 @@ import {
   Typography,
 } from 'material-ui';
 
+import { compose } from 'ramda';
+
 import { getLinodeDisks } from 'src/services/linodes';
+
+import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader';
 
 import LinodeSettingsLabelPanel from './LinodeSettingsLabelPanel';
 import LinodeSettingsPasswordPanel from './LinodeSettingsPasswordPanel';
@@ -35,69 +39,65 @@ interface Props {
   linodeStatus: string;
 }
 
-interface State {
-  linodeDisks: Linode.Disk[];
+interface PromiseLoaderProps {
+  linodeDisks: PromiseLoaderResponse<Linode.Disk[]>;
 }
 
-type CombinedProps = Props
-  & WithStyles<ClassNames>;
+type CombinedProps = Props & PromiseLoaderProps & WithStyles<ClassNames>;
 
-class LinodeSettings extends React.Component<CombinedProps, State> {
-  state: State = {
-    linodeDisks: [],
-  };
+const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
+  const {
+    classes,
+    linodeAlerts,
+    linodeConfigs,
+    linodeId,
+    linodeLabel,
+    linodeMemory,
+    linodeRegion,
+    linodeStatus,
+    linodeDisks,
+  } = props;
 
-  componentDidMount() {
-    // do call for linode disks here
-    const { linodeId } = this.props;
-    getLinodeDisks(linodeId).then(disk => console.log(disk.data));
-  }
-
-  render() {
-    const {
-      classes,
-      linodeAlerts,
-      linodeConfigs,
-      linodeId,
-      linodeLabel,
-      linodeMemory,
-      linodeRegion,
-      linodeStatus,
-    } = this.props;
-
-    return (
-      <React.Fragment>
-        <Typography variant="headline" className={classes.title}>Settings</Typography>
-        <LinodeSettingsLabelPanel
-          linodeLabel={linodeLabel}
-          linodeId={linodeId}
-        />
-        <LinodeSettingsPasswordPanel
-          linodeLabel={linodeLabel}
-          linodeId={linodeId}
-        />
-        <LinodeSettingsAlertsPanel
-          linodeId={linodeId}
-          linodeLabel={linodeLabel}
-          linodeAlerts={linodeAlerts}
-        />
-        <LinodeConfigsPanel
-          linodeId={linodeId}
-          linodeLabel={linodeLabel}
-          linodeRegion={linodeRegion}
-          linodeConfigs={linodeConfigs}
-          linodeMemory={linodeMemory}
-          linodeStatus={linodeStatus}
-        />
-        <LinodeSettingsDeletePanel
-          linodeId={linodeId}
-        />
-      </React.Fragment >
-    );
-  }
-}
+  return (
+    <React.Fragment>
+      <Typography variant="headline" className={classes.title}>Settings</Typography>
+      <LinodeSettingsLabelPanel
+        linodeLabel={linodeLabel}
+        linodeId={linodeId}
+      />
+      <LinodeSettingsPasswordPanel
+        linodeDisks={linodeDisks}
+        linodeLabel={linodeLabel}
+        linodeId={linodeId}
+      />
+      <LinodeSettingsAlertsPanel
+        linodeId={linodeId}
+        linodeLabel={linodeLabel}
+        linodeAlerts={linodeAlerts}
+      />
+      <LinodeConfigsPanel
+        linodeDisks={linodeDisks}
+        linodeId={linodeId}
+        linodeLabel={linodeLabel}
+        linodeRegion={linodeRegion}
+        linodeConfigs={linodeConfigs}
+        linodeMemory={linodeMemory}
+        linodeStatus={linodeStatus}
+      />
+      <LinodeSettingsDeletePanel
+        linodeId={linodeId}
+      />
+    </React.Fragment >
+  );
+};
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled(LinodeSettings);
+const loaded = PromiseLoader<Props>({
+  linodeDisks: ({ linodeId }): Promise<Linode.Disk[]> => getLinodeDisks(linodeId)
+    .then(response => response.data),
+});
+
+export default compose(styled, loaded)(LinodeSettings) as React.ComponentType<Props>;
+
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -66,7 +66,7 @@ const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
         linodeId={linodeId}
       />
       <LinodeSettingsPasswordPanel
-        linodeDisks={linodeDisks}
+        linodeDisks={linodeDisks.response}
         linodeLabel={linodeLabel}
         linodeId={linodeId}
       />
@@ -76,7 +76,7 @@ const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
         linodeAlerts={linodeAlerts}
       />
       <LinodeConfigsPanel
-        linodeDisks={linodeDisks}
+        linodeDisks={linodeDisks.response}
         linodeId={linodeId}
         linodeLabel={linodeLabel}
         linodeRegion={linodeRegion}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -21,8 +21,6 @@ import FormHelperText from 'material-ui/Form/FormHelperText';
 import { changeLinodeDiskPassword } from 'src/services/linodes';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 
-import { PromiseLoaderResponse } from 'src/components/PromiseLoader';
-
 import PasswordInput from 'src/components/PasswordInput';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -38,7 +36,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 interface Props {
   linodeId: number;
   linodeLabel: string;
-  linodeDisks: PromiseLoaderResponse<Linode.Disk[]>;
+  linodeDisks: Linode.Disk[];
 }
 
 interface State {
@@ -54,7 +52,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> {
   state: State = {
-    linodeDisks: this.props.linodeDisks.response
+    linodeDisks: this.props.linodeDisks
       .filter((disk: Linode.Disk) => disk.filesystem !== 'swap'),
     value: '',
     diskId: pathOr('', ['disks', 'response', 0, 'id'], this.props),

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -18,9 +18,10 @@ import MenuItem from 'material-ui/Menu/MenuItem';
 import FormControl from 'material-ui/Form/FormControl';
 import FormHelperText from 'material-ui/Form/FormHelperText';
 
-import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader';
-import { changeLinodeDiskPassword, getLinodeDisks } from 'src/services/linodes';
+import { changeLinodeDiskPassword } from 'src/services/linodes';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+
+import { PromiseLoaderResponse } from 'src/components/PromiseLoader';
 
 import PasswordInput from 'src/components/PasswordInput';
 import ExpansionPanel from 'src/components/ExpansionPanel';
@@ -37,14 +38,11 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 interface Props {
   linodeId: number;
   linodeLabel: string;
-}
-
-interface PromiseLoaderProps {
-  disks: PromiseLoaderResponse<Linode.Disk[]>;
+  linodeDisks: PromiseLoaderResponse<Linode.Disk[]>;
 }
 
 interface State {
-  disks: Linode.Disk[];
+  linodeDisks: Linode.Disk[];
   value: string;
   diskId: string | number;
   submitting: boolean;
@@ -52,11 +50,12 @@ interface State {
   errors?: Linode.ApiFieldError[];
 }
 
-type CombinedProps = Props & PromiseLoaderProps & WithStyles<ClassNames>;
+type CombinedProps = Props & WithStyles<ClassNames>;
 
 class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> {
   state: State = {
-    disks: this.props.disks.response,
+    linodeDisks: this.props.linodeDisks.response
+      .filter((disk: Linode.Disk) => disk.filesystem !== 'swap'),
     value: '',
     diskId: pathOr('', ['disks', 'response', 0, 'id'], this.props),
     submitting: false,
@@ -101,25 +100,25 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
           <ActionsPanel>
             {
               (submitting && !passwordError)
-              ? (
-                <Button
-                  variant="raised"
-                  color="secondary"
-                  disabled
-                  className="loading"
-                >
-                  <Reload />
+                ? (
+                  <Button
+                    variant="raised"
+                    color="secondary"
+                    disabled
+                    className="loading"
+                  >
+                    <Reload />
+                  </Button>
+                )
+                : (
+                  <Button
+                    variant="raised"
+                    color="primary"
+                    onClick={this.changeDiskPassword}
+                  >
+                    Save
                 </Button>
-              )
-              : (
-                <Button
-                  variant="raised"
-                  color="primary"
-                  onClick={this.changeDiskPassword}
-                >
-                Save
-                </Button>
-              )
+                )
             }
           </ActionsPanel>
         }
@@ -141,7 +140,7 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
             error={Boolean(diskIdError)}
           >
             {
-              this.state.disks.map(disk =>
+              this.state.linodeDisks.map(disk =>
                 <MenuItem key={disk.id} value={disk.id}>{disk.label}</MenuItem>)
             }
           </Select>
@@ -162,11 +161,6 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
     );
   }
 }
-const loaded = PromiseLoader<Props>({
-  disks: ({ linodeId }) => getLinodeDisks(linodeId)
-    .then(response => response.data)
-    .then(disks => disks.filter(disk => disk.filesystem !== 'swap')),
-});
 
 const styled = withStyles(styles, { withTheme: true });
 
@@ -174,6 +168,5 @@ const errorBoundary = PanelErrorBoundary({ heading: 'Reset Root Password' });
 
 export default compose(
   errorBoundary,
-  loaded,
   styled,
 )(LinodeSettingsPasswordPanel) as React.ComponentType<Props>;


### PR DESCRIPTION
### Purpose

Previously, both `LinodeSettingsPasswordPanel` and `LinodeConfigsPanel` were making calls to `linode/instances/:id/disks`. Changed to make one call in `LinodeSettings` and pass results down as props to both components.