### PR TITLE
M3-461 disabled menu item tooltip

### DIFF
--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -5,12 +5,14 @@ import {
 } from 'material-ui';
 import IconButton from 'material-ui/IconButton';
 import Menu from 'material-ui/Menu';
-import MenuItem from 'material-ui/Menu/MenuItem';
 import MoreHoriz from 'material-ui-icons/MoreHoriz';
+
+import MenuItem from 'src/components/MenuItem';
 
 export interface Action {
   title: string;
   disabled?: boolean;
+  tooltip?: string;
   onClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
@@ -128,7 +130,10 @@ class ActionMenu extends React.Component<CombinedProps, State> {
               className={classes.item}
               data-qa-action-menu-item={a.title}
               disabled={a.disabled}
-            >{a.title}</MenuItem>,
+              tooltip={a.tooltip}
+            >
+              {a.title}
+            </MenuItem>,
           )}
         </Menu>
       </div >);

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import {
+  withStyles,
+  WithStyles,
+  StyleRulesCallback,
+  Theme,
+} from 'material-ui';
+
+import MenuItem, { MenuItemProps } from 'material-ui/Menu/MenuItem';
+
+type CSSClasses = 'root'
+  | 'toolTip';
+
+interface Props {
+  tooltip?: string;
+  className?: string;
+}
+
+const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => ({
+  root: {
+    position: 'relative',
+  },
+  toolTip: {
+    display: 'block',
+    width: '100%',
+  },
+});
+
+type CombinedProps = MenuItemProps & Props & WithStyles<CSSClasses>;
+
+const WrapperMenuItem: React.StatelessComponent<CombinedProps> = (props) => {
+  const { tooltip, classes, className, ...rest } = props;
+
+  return (
+    <MenuItem {...rest} className={`${classes.root} ${className}`}>
+      {tooltip && <span className={classes.toolTip}>{tooltip}</span>}
+      {props.children}
+    </MenuItem>
+  );
+};
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(WrapperMenuItem);

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -4,12 +4,18 @@ import {
   WithStyles,
   StyleRulesCallback,
   Theme,
+  IconButton,
 } from 'material-ui';
 
 import MenuItem, { MenuItemProps } from 'material-ui/Menu/MenuItem';
+import HelpOutline from 'material-ui-icons/HelpOutline';
 
 type CSSClasses = 'root'
-  | 'toolTip';
+  | 'toolTip'
+  | 'labelWrapper'
+  | 'label'
+  | 'helpButton'
+  | 'helpIcon';
 
 interface Props {
   tooltip?: string;
@@ -19,10 +25,50 @@ interface Props {
 const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => ({
   root: {
     position: 'relative',
+    flexWrap: 'wrap',
+    '&.hasTooltip': {
+      opacity: 1,
+      '&:hover, &:focus': {
+        background: 'transparent',
+        color: theme.palette.primary.main,
+        '& $toolTip': {
+          marginTop: theme.spacing.unit,
+          maxHeight: 200,
+          opacity: 1,
+        },
+      },
+    },
+  },
+  labelWrapper: {
+    display: 'flex',
+    flexBasis: '100%',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  label: {
+    opacity: .5,
   },
   toolTip: {
+    transition: theme.transitions.create(['max-height', 'opacity', 'margin']),
+    maxHeight: 0,
     display: 'block',
-    width: '100%',
+    flexBasis: '100%',
+    color: theme.palette.text.primary,
+    maxWidth: 200,
+    opacity: 0,
+  },
+  helpButton: {
+    width: 28,
+    height: 28,
+    color: theme.palette.primary.main,
+    pointerEvents: 'initial',
+    '&:hover, &:focus': {
+      color: theme.palette.primary.light,
+    },
+  },
+  helpIcon: {
+    width: 20,
+    height: 20,
   },
 });
 
@@ -32,9 +78,16 @@ const WrapperMenuItem: React.StatelessComponent<CombinedProps> = (props) => {
   const { tooltip, classes, className, ...rest } = props;
 
   return (
-    <MenuItem {...rest} className={`${classes.root} ${className}`}>
+    <MenuItem {...rest} className={`${classes.root} ${className} ${tooltip && 'hasTooltip'}`}>
+      <span className={tooltip && classes.labelWrapper}>
+        <span className={tooltip && classes.label}>{props.children}</span>
+        {tooltip &&
+          <IconButton className={classes.helpButton}>
+            <HelpOutline className={classes.helpIcon}/>
+          </IconButton>
+        }
+      </span>
       {tooltip && <span className={classes.toolTip}>{tooltip}</span>}
-      {props.children}
     </MenuItem>
   );
 };

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -82,7 +82,7 @@ const WrapperMenuItem: React.StatelessComponent<CombinedProps> = (props) => {
       <span className={tooltip && classes.labelWrapper}>
         <span className={tooltip && classes.label}>{props.children}</span>
         {tooltip &&
-          <IconButton className={classes.helpButton}>
+          <IconButton className={classes.helpButton} onClick={e => e.stopPropagation()}>
             <HelpOutline className={classes.helpIcon}/>
           </IconButton>
         }

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -1,0 +1,2 @@
+import MenuItem from './MenuItem';
+export default MenuItem;

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskActionMenu.tsx
@@ -30,6 +30,7 @@ class DiskActionMenu extends React.Component<CombinedProps> {
           closeMenu();
         },
         disabled: linodeStatus !== 'offline',
+        tooltip: 'You can\'t delete this disk because we don\'t want you to.',
       },
     ];
 


### PR DESCRIPTION
See example on the action menu in the Linode adv config.

One known issue is if the action menu is positioned at the very bottom of the window. The tooltip will be offscreen as the popOver won't re-render to compensate for the extra height. Not sure how we'd want to address that. 