### PR TITLE
Create from Backup

### DIFF
--- a/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/src/components/TabbedPanel/TabbedPanel.tsx
@@ -43,6 +43,7 @@ interface Props {
   header: string;
   error?: string;
   copy?: string;
+  rootClass?: string;
   tabs: Tab[];
   [index: string]: any;
   initTab?: number;
@@ -58,12 +59,12 @@ class TabbedPanel extends React.Component<CombinedProps> {
   }
 
   render() {
-    const { classes, header, tabs, copy, error, ...rest } = this.props;
+    const { classes, header, tabs, copy, error, rootClass, ...rest } = this.props;
     const { value } = this.state;
     const render = tabs[value].render;
 
     return (
-      <Paper className={classes.root} data-qa-tp={header}>
+      <Paper className={`${classes.root} ${rootClass}`} data-qa-tp={header}>
         <div className={classes.inner}>
           { error && <Notice text={error} error /> }
           <Typography variant="title" data-qa-tp-title>{header}</Typography>

--- a/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -25,7 +25,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   root: {
     flexGrow: 1,
     width: '100%',
-    marginTop: theme.spacing.unit * 2,
+    marginTop: theme.spacing.unit * 3,
     backgroundColor: theme.color.white,
   },
   flex: {

--- a/src/features/linodes/LinodesCreate/CheckoutBar.tsx
+++ b/src/features/linodes/LinodesCreate/CheckoutBar.tsx
@@ -9,6 +9,7 @@ import {
 import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
 
+import Notice from 'src/components/Notice';
 
 import { TypeInfo } from 'src/features/linodes/LinodesCreate/LinodesCreate';
 
@@ -70,6 +71,7 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
 
 interface Props {
   onDeploy: () => void;
+  error?: string;
   label: string | null;
   imageInfo: { name: string, details: string } | undefined;
   typeInfo: TypeInfo | undefined;
@@ -109,6 +111,7 @@ class CheckoutBar extends React.Component<CombinedProps> {
       classes,
       onDeploy,
       label,
+      error,
       backups,
       imageInfo,
       typeInfo,
@@ -184,6 +187,12 @@ class CheckoutBar extends React.Component<CombinedProps> {
             &nbsp;/mo
           </Typography>
         </div>
+
+        {error &&
+          <Notice error>
+            {error}
+          </Notice>
+        }
 
         <div className={`${classes.checkoutSection} ${classes.noBorder}`}>
           <Button

--- a/src/features/linodes/LinodesCreate/LabelAndTagsPanel.tsx
+++ b/src/features/linodes/LinodesCreate/LabelAndTagsPanel.tsx
@@ -8,7 +8,7 @@ import Typography from 'material-ui/Typography';
 import TextField from '../../../components/TextField';
 import Notice from '../../../components/Notice';
 
-type ClassNames = 'root' | 'inner' | 'panelBody';
+type ClassNames = 'root' | 'inner' ;
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -19,9 +19,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   inner: {
     padding: theme.spacing.unit * 3,
-  },
-  panelBody: {
-    padding: `${theme.spacing.unit * 3}px 0 ${theme.spacing.unit}px`,
   },
 });
 

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -78,6 +78,7 @@ interface State {
   selectedTab: number;
   selectedLinodeID?: number;
   selectedBackupID?: number;
+  selectedBackupInfo?: Info;
   requiredDiskSpace?: number;
   selectedImageID: string | null;
   selectedRegionID: string | null;
@@ -172,7 +173,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     this.setState({ selectedTab: value });
   }
 
-  updateStateFor = (key: string) => (event: ChangeEvents, value: string) => {
+  updateStateFor = (key: string) => (event: ChangeEvents, value: any) => {
     this.setState(() => ({ [key]: value }));
   }
 
@@ -341,6 +342,16 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         });
         return;
       }
+
+      if (!selectedBackupID) {
+        /* a backup selection is also required */
+        this.setState({
+          errors: [
+            { field: 'backup_id', reason: 'You must select a Backup' },
+          ],
+        });
+        return;
+      }
     }
 
     createLinode({
@@ -395,12 +406,16 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       selectedImageID,
       selectedTypeID,
       selectedRegionID,
+      selectedBackupInfo,
     } = this.state;
 
     const { classes } = this.props;
 
-    const imageInfo = this.getImageInfo(this.props.images.response.find(
-      image => image.id === selectedImageID));
+    const imageInfo = [
+      this.getImageInfo(this.props.images.response.find(
+          image => image.id === selectedImageID)),
+      selectedBackupInfo,
+    ][selectedTab];
 
     const typeInfo = this.getTypeInfo(this.props.types.response.find(
       type => type.id === selectedTypeID));

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -142,8 +142,12 @@ const getErrorFor = (field: string, arr: Linode.ApiFieldError[] = []): undefined
   return err.reason.replace(err.field, errorResources[err.field]);
 };
 
-const formatLinodeSubheading = (typeInfo: string, imageInfo: string) =>
-  [`${typeInfo}, ${imageInfo}`];
+const formatLinodeSubheading = (typeInfo: string, imageInfo: string) => {
+  const subheading = imageInfo
+    ? `${typeInfo}, ${imageInfo}`
+    : `${typeInfo}`;
+  return [subheading];
+};
 
 class LinodeCreate extends React.Component<CombinedProps, State> {
   state: State = {

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -26,6 +26,7 @@ import PromiseLoader from 'src/components/PromiseLoader';
 
 import SelectLinodePanel, { ExtendedLinode } from './SelectLinodePanel';
 import SelectImagePanel from './SelectImagePanel';
+import SelectBackupPanel from './SelectBackupPanel';
 import SelectRegionPanel, { ExtendedRegion } from './SelectRegionPanel';
 import SelectPlanPanel, { ExtendedType } from './SelectPlanPanel';
 import LabelAndTagsPanel from './LabelAndTagsPanel';
@@ -75,6 +76,7 @@ type CombinedProps = Props & WithStyles<Styles> & PreloadedProps & RouteComponen
 interface State {
   selectedTab: number;
   selectedLinodeID?: number;
+  selectedBackupID?: number;
   selectedImageID: string | null;
   selectedRegionID: string | null;
   selectedTypeID: string | null;
@@ -255,6 +257,12 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
               error={getErrorFor('linode_id', this.state.errors)}
               linodes={this.extendLinodes(this.props.linodes.response)}
               selectedLinodeID={this.state.selectedLinodeID}
+              handleSelection={this.updateStateFor}
+            />
+            <SelectBackupPanel
+              error={getErrorFor('backup_id', this.state.errors)}
+              selectedLinodeID={this.state.selectedLinodeID}
+              selectedBackupID={this.state.selectedBackupID}
               handleSelection={this.updateStateFor}
             />
             <SelectRegionPanel

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -204,6 +204,49 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         );
       },
     },
+    {
+      title: 'Create from Backup',
+      render: () => {
+        return (
+          <React.Fragment>
+            {/*
+              <SelectLinodePanel
+                selectedLinodeID={this.state.selectedLinodeID}
+                handleSelection={this.updateStateFor}
+              />
+            */}
+            <SelectRegionPanel
+              error={getErrorFor('region', this.state.errors)}
+              regions={this.props.regions.response}
+              handleSelection={this.updateStateFor}
+              selectedID={this.state.selectedRegionID}
+            />
+            <SelectPlanPanel
+              error={getErrorFor('type', this.state.errors)}
+              types={this.props.types.response}
+              onSelect={(id: string) => this.setState({ selectedTypeID: id })}
+              selectedID={this.state.selectedTypeID}
+            />
+            <LabelAndTagsPanel
+              error={getErrorFor('label', this.state.errors)}
+              label={this.state.label}
+              handleChange={this.updateStateFor}
+            />
+            <PasswordPanel
+              error={getErrorFor('root_pass', this.state.errors)}
+              password={this.state.password}
+              handleChange={v => this.setState({ password: v })}
+            />
+            <AddonsPanel
+              backups={this.state.backups}
+              backupsMonthly={this.getBackupsMonthlyPrice()}
+              privateIP={this.state.privateIP}
+              handleChange={this.updateStateFor}
+            />
+          </React.Fragment>
+        );
+      },
+    },
   ];
 
   componentDidMount() {

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { compose, set, propEq, prop, find, lensPath } from 'ramda';
 
 import {
   withRouter,
@@ -18,10 +19,12 @@ import AppBar from 'material-ui/AppBar';
 import Tabs, { Tab } from 'material-ui/Tabs';
 
 import { dcDisplayNames } from 'src/constants';
-import { createLinode, getLinodeTypes, allocatePrivateIP } from 'src/services/linodes';
+import { createLinode, getLinodeTypes, allocatePrivateIP, getLinodes } from 'src/services/linodes';
 import { getImages } from 'src/services/images';
 import { getRegions } from 'src/services/misc';
 import PromiseLoader from 'src/components/PromiseLoader';
+
+import SelectLinodePanel, { ExtendedLinode } from './SelectLinodePanel';
 import SelectImagePanel from './SelectImagePanel';
 import SelectRegionPanel, { ExtendedRegion } from './SelectRegionPanel';
 import SelectPlanPanel, { ExtendedType } from './SelectPlanPanel';
@@ -64,12 +67,14 @@ interface PreloadedProps {
   images: { response: Linode.Image[] };
   regions: { response: ExtendedRegion[] };
   types: { response: ExtendedType[] };
+  linodes: { response: Linode.Linode[] };
 }
 
 type CombinedProps = Props & WithStyles<Styles> & PreloadedProps & RouteComponentProps<{}>;
 
 interface State {
   selectedTab: number;
+  selectedLinodeID?: number;
   selectedImageID: string | null;
   selectedRegionID: string | null;
   selectedTypeID: string | null;
@@ -82,8 +87,15 @@ interface State {
 }
 
 const preloaded = PromiseLoader<Props>({
+  linodes: () => getLinodes()
+    /*
+     * @todo: We're only allowing the user to select from their first 100
+     * Linodes
+     */
+    .then(response => response.data || []),
+
   images: () => getImages()
-    .then(response => response.data.map(image => image) || []),
+    .then(response => response.data || []),
 
   types: () => getLinodeTypes()
     .then((response) => {
@@ -130,8 +142,11 @@ const getErrorFor = (field: string, arr: Linode.ApiFieldError[] = []): undefined
   return err.reason.replace(err.field, errorResources[err.field]);
 };
 
+const formatLinodeSubheading = (typeInfo: string, imageInfo: string) =>
+  [`${typeInfo}, ${imageInfo}`];
+
 class LinodeCreate extends React.Component<CombinedProps, State> {
-  state = {
+  state: State = {
     selectedTab: 0,
     selectedImageID: null,
     selectedRegionID: null,
@@ -159,6 +174,29 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     const type = this.props.types.response.find(type => type.id === selectedTypeID);
     if (!type) { return null; }
     return type.addons.backups.price.monthly;
+  }
+
+  extendLinodes(linodes: Linode.Linode[]): ExtendedLinode[] {
+    const images = this.props.images.response || [];
+    const types = this.props.types.response || [];
+    return linodes.map(linode =>
+      compose<Linode.Linode, Partial<ExtendedLinode>, Partial<ExtendedLinode>>(
+        set(lensPath(['heading']), linode.label),
+        set(lensPath(['subHeadings']),
+          (formatLinodeSubheading)(
+            compose<Linode.LinodeType[], Linode.LinodeType, number, string>(
+              (mem: number) => typeLabel(mem) || '',
+              prop('memory'),
+              find(propEq('id', linode.type)),
+            )(types),
+            compose<Linode.Image[], Linode.Image, string>(
+              prop('label'),
+              find(propEq('id', linode.image)),
+            )(images),
+          ),
+        ),
+      )(linode) as ExtendedLinode,
+    );
   }
 
   tabs = [
@@ -209,12 +247,12 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       render: () => {
         return (
           <React.Fragment>
-            {/*
-              <SelectLinodePanel
-                selectedLinodeID={this.state.selectedLinodeID}
-                handleSelection={this.updateStateFor}
-              />
-            */}
+            <SelectLinodePanel
+              error={getErrorFor('linode_id', this.state.errors)}
+              linodes={this.extendLinodes(this.props.linodes.response)}
+              selectedLinodeID={this.state.selectedLinodeID}
+              handleSelection={this.updateStateFor}
+            />
             <SelectRegionPanel
               error={getErrorFor('region', this.state.errors)}
               regions={this.props.regions.response}
@@ -260,14 +298,29 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
   onDeploy = () => {
     const { history } = this.props;
     const {
+      selectedTab,
+      selectedLinodeID,
       selectedImageID,
       selectedRegionID,
       selectedTypeID,
       label,
       password,
       backups,
-      // privateIP, /* This requires a separate API call! */
+      privateIP,
     } = this.state;
+
+    if (selectedTab === 1) {
+      /* we are creating from backup */
+      if (!selectedLinodeID) {
+        /* so a Linode selection is required */
+        this.setState({
+          errors: [
+            { field: 'linode_id', reason: 'You must select a Linode' },
+          ],
+        });
+      }
+      return;
+    }
 
     createLinode({
       region: selectedRegionID,
@@ -279,7 +332,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       booted: true,
     })
       .then((linode) => {
-        if (this.state.privateIP) allocatePrivateIP(linode.id);
+        if (privateIP) allocatePrivateIP(linode.id);
         resetEventsPolling();
         history.push('/linodes');
       })

--- a/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
@@ -81,21 +81,49 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     this.fetchBackups(this.props.selectedLinodeID);
+    this.updateBackupInfo();
   }
 
-  componentDidUpdate(prevProps: CombinedProps) {
+  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
     if (prevProps.selectedLinodeID !== this.props.selectedLinodeID) {
       this.fetchBackups(this.props.selectedLinodeID);
     }
+    if (prevProps.selectedBackupID !== this.props.selectedBackupID
+        || prevState.backups !== this.state.backups) {
+      this.updateBackupInfo();
+    }
   }
 
-  renderCard(backup: Linode.LinodeBackup) {
-    const { selectedBackupID } = this.props;
+  updateBackupInfo() {
+    const selectedBackup = this.state.backups && this.state.backups.filter(backup =>
+      backup.id === Number(this.props.selectedBackupID),
+    )[0];
+    if (selectedBackup) {
+      const backupInfo_ = this.getBackupInfo(selectedBackup);
+      const backupInfo = {
+        name: backupInfo_.infoName,
+        details: backupInfo_.subheading,
+      };
+      this.handleBackupInfoSelection(undefined as any, backupInfo);
+    }
+  }
+
+  getBackupInfo(backup: Linode.LinodeBackup) {
     const heading = backup.label ? backup.label : backup.type === 'auto' ? 'Automatic' : 'Snapshot';
     const subheading = formatBackupDate(backup.created);
     const infoName = heading === 'Automatic'
       ? 'From automatic backup'
       : `From backup ${heading}`;
+    return {
+      heading,
+      subheading,
+      infoName,
+    };
+  }
+
+  renderCard(backup: Linode.LinodeBackup) {
+    const { selectedBackupID } = this.props;
+    const backupInfo_ = this.getBackupInfo(backup);
     return (
       <SelectionCard
         key={backup.id}
@@ -105,15 +133,15 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
             acc + disk.size
           ), 0);
           const backupInfo = {
-            name: infoName,
-            details: subheading,
+            name: backupInfo_.infoName,
+            details: backupInfo_.subheading,
           };
           this.handleBackupSelection(e, `${backup.id}`);
           this.handleSizeSelection(e, `${totalBackupSize}`);
           this.handleBackupInfoSelection(e, backupInfo);
         }}
-        heading={heading}
-        subheadings={[subheading]}
+        heading={backupInfo_.heading}
+        subheadings={[backupInfo_.subheading]}
       />
     );
   }

--- a/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+import Paper from 'material-ui/Paper';
+import Typography from 'material-ui/Typography';
+
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
+import SelectionCard from 'src/components/SelectionCard';
+
+type ClassNames =
+'root'
+| 'inner'
+| 'panelBody';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  root: {
+    flexGrow: 1,
+    width: '100%',
+    backgroundColor: theme.color.white,
+  },
+  inner: {
+    padding: theme.spacing.unit * 3,
+  },
+  panelBody: {
+    padding: `${theme.spacing.unit * 2}px 0 0`,
+  },
+});
+
+interface Props {
+  selectedLinodeID?: number;
+  selectedBackupID?: number;
+  handleSelection: (key: string) =>
+    (event: React.SyntheticEvent<HTMLElement>, value: string) => void;
+  error?: string;
+}
+
+interface State {
+  backups?: Linode.LinodeBackup[];
+}
+
+type StyledProps = Props & WithStyles<ClassNames>;
+
+type CombinedProps = StyledProps;
+
+class SelectBackupPanel extends React.Component<CombinedProps, State> {
+  handleSelection = this.props.handleSelection('selectedBackupID');
+
+  renderCard(backup: Linode.LinodeBackup) {
+    const { selectedBackupID } = this.props;
+    return (
+      <SelectionCard
+        key={backup.id}
+        checked={backup.id === Number(selectedBackupID)}
+        onClick={e => this.handleSelection(e, `${backup.id}`)}
+        heading={backup.heading}
+        subheadings={backup.subHeadings}
+      />
+    );
+  }
+
+  render() {
+    const { error, classes, linodes } = this.props;
+
+    return (
+      <Paper className={`${classes.root}`}>
+        <div className={classes.inner}>
+          { error && <Notice text={error} error /> }
+          <Typography variant="title">
+            Select Linode
+          </Typography>
+          <Typography component="div" className={classes.panelBody}>
+            <Grid container>
+              {linodes.map((linode) => {
+                return (
+                  this.renderCard(linode)
+                );
+              })}
+            </Grid>
+          </Typography>
+        </div>
+      </Paper>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(SelectBackupPanel);

--- a/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
@@ -44,7 +44,7 @@ interface Props {
   selectedLinodeID?: number;
   selectedBackupID?: number;
   handleSelection: (key: string) =>
-    (event: React.SyntheticEvent<HTMLElement>, value: string) => void;
+    (event: React.SyntheticEvent<HTMLElement>, value: any) => void;
   error?: string;
 }
 
@@ -64,6 +64,7 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
 
   handleBackupSelection = this.props.handleSelection('selectedBackupID');
   handleSizeSelection = this.props.handleSelection('requiredDiskSpace');
+  handleBackupInfoSelection = this.props.handleSelection('selectedBackupInfo');
 
   fetchBackups(linodeID?: number) {
     if (linodeID) {
@@ -90,6 +91,11 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
 
   renderCard(backup: Linode.LinodeBackup) {
     const { selectedBackupID } = this.props;
+    const heading = backup.label ? backup.label : backup.type === 'auto' ? 'Automatic' : 'Snapshot';
+    const subheading = formatBackupDate(backup.created);
+    const infoName = heading === 'Automatic'
+      ? 'From automatic backup'
+      : `From backup ${heading}`;
     return (
       <SelectionCard
         key={backup.id}
@@ -98,11 +104,16 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
           const totalBackupSize = backup.disks.reduce((acc, disk) => (
             acc + disk.size
           ), 0);
+          const backupInfo = {
+            name: infoName,
+            details: subheading,
+          };
           this.handleBackupSelection(e, `${backup.id}`);
           this.handleSizeSelection(e, `${totalBackupSize}`);
+          this.handleBackupInfoSelection(e, backupInfo);
         }}
-        heading={backup.label ? backup.label : backup.type === 'auto' ? 'Automatic' : 'Snapshot'}
-        subheadings={[formatBackupDate(backup.created)]}
+        heading={heading}
+        subheadings={[subheading]}
       />
     );
   }

--- a/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
@@ -62,7 +62,8 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
     loading: false,
   };
 
-  handleSelection = this.props.handleSelection('selectedBackupID');
+  handleBackupSelection = this.props.handleSelection('selectedBackupID');
+  handleSizeSelection = this.props.handleSelection('requiredDiskSpace');
 
   fetchBackups(linodeID?: number) {
     if (linodeID) {
@@ -93,7 +94,13 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
       <SelectionCard
         key={backup.id}
         checked={backup.id === Number(selectedBackupID)}
-        onClick={e => this.handleSelection(e, `${backup.id}`)}
+        onClick={(e) => {
+          const totalBackupSize = backup.disks.reduce((acc, disk) => (
+            acc + disk.size
+          ), 0);
+          this.handleBackupSelection(e, `${backup.id}`);
+          this.handleSizeSelection(e, `${totalBackupSize}`);
+        }}
         heading={backup.label ? backup.label : backup.type === 'auto' ? 'Automatic' : 'Snapshot'}
         subheadings={[formatBackupDate(backup.created)]}
       />

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+import Paper from 'material-ui/Paper';
+import Typography from 'material-ui/Typography';
+
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
+import SelectionCard from 'src/components/SelectionCard';
+
+export interface ExtendedLinode extends Linode.Linode {
+  heading: string;
+  subHeadings: string[];
+}
+
+type ClassNames =
+'root'
+| 'inner'
+| 'panelBody';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  root: {
+    flexGrow: 1,
+    width: '100%',
+    backgroundColor: theme.color.white,
+  },
+  inner: {
+    padding: theme.spacing.unit * 3,
+  },
+  panelBody: {
+    padding: `${theme.spacing.unit * 2}px 0 0`,
+  },
+});
+
+interface Props {
+  linodes: ExtendedLinode[];
+  selectedLinodeID?: number;
+  handleSelection: (key: string) =>
+    (event: React.SyntheticEvent<HTMLElement>, value: string) => void;
+  error?: string;
+}
+
+type StyledProps = Props & WithStyles<ClassNames>;
+
+type CombinedProps = StyledProps;
+
+class SelectLinodePanel extends React.Component<CombinedProps> {
+  handleSelection = this.props.handleSelection('selectedLinodeID');
+
+  renderCard(linode: ExtendedLinode) {
+    const { selectedLinodeID } = this.props;
+    return (
+      <SelectionCard
+        key={linode.id}
+        checked={linode.id === Number(selectedLinodeID)}
+        onClick={e => this.handleSelection(e, `${linode.id}`)}
+        heading={linode.heading}
+        subheadings={linode.subHeadings}
+      />
+    );
+  }
+
+  render() {
+    const { error, classes, linodes } = this.props;
+
+    return (
+      <Paper className={`${classes.root}`}>
+        <div className={classes.inner}>
+          { error && <Notice text={error} error /> }
+          <Typography variant="title">
+            Select Linode
+          </Typography>
+          <Typography component="div" className={classes.panelBody}>
+            <Grid container>
+              {linodes.map((linode) => {
+                return (
+                  this.renderCard(linode)
+                );
+              })}
+            </Grid>
+          </Typography>
+        </div>
+      </Paper>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(SelectLinodePanel);

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -27,6 +27,7 @@ interface Props {
   error?: string;
   onSelect: (key: string) => void;
   selectedID: string | null;
+  requiredDiskSpace?: number;
 }
 
 const getNanodes = (types: ExtendedType[]) =>
@@ -38,18 +39,20 @@ const getStandard = (types: ExtendedType[]) =>
 const getHighMem = (types: ExtendedType[]) =>
   types.filter(t => /highmem/.test(t.class));
 
-const renderCard = (selectedID: string|null, handleSelection: Function) =>
-  (type: ExtendedType, idx: number) => (
-      <SelectionCard
+
+class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
+  renderCard = (selectedID: string|null, handleSelection: Function) =>
+    (type: ExtendedType, idx: number) => {
+      const requiredDiskSpace = this.props.requiredDiskSpace || 0;
+      return <SelectionCard
         key={idx}
         checked={type.id === String(selectedID)}
         onClick={e => handleSelection(type.id)}
         heading={type.heading}
         subheadings={type.subHeadings}
-      />
-    );
-
-class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
+        disabled={requiredDiskSpace > type.disk}
+      />;
+    }
 
   createTabs = () => {
     const { types } = this.props;
@@ -65,7 +68,7 @@ class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
 
           return (
             <Grid container spacing={8}>
-            { nanodes.map(renderCard(this.props.selectedID, this.props.onSelect))}
+            { nanodes.map(this.renderCard(this.props.selectedID, this.props.onSelect))}
             </Grid>
           );
         },
@@ -78,7 +81,7 @@ class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
         render: () => {
           return (
             <Grid container spacing={8}>
-              { standards.map(renderCard(this.props.selectedID, this.props.onSelect))}
+              { standards.map(this.renderCard(this.props.selectedID, this.props.onSelect))}
             </Grid>
           );
         },
@@ -91,7 +94,7 @@ class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
         render: () => {
           return (
             <Grid container spacing={8}>
-              { highmem.map(renderCard(this.props.selectedID, this.props.onSelect))}
+              { highmem.map(this.renderCard(this.props.selectedID, this.props.onSelect))}
             </Grid>
           );
         },

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { isEmpty } from 'ramda';
 
+import { withStyles, StyleRulesCallback, WithStyles, Theme } from 'material-ui';
+
 import Grid from 'src/components/Grid';
 
 import TabbedPanel from '../../../components/TabbedPanel';
@@ -11,6 +13,14 @@ export interface ExtendedType extends Linode.LinodeType {
   heading: string;
   subHeadings: [string, string];
 }
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  root: {
+    marginTop: theme.spacing.unit * 3,
+  },
+});
 
 interface Props {
   types: ExtendedType[];
@@ -39,11 +49,10 @@ const renderCard = (selectedID: string|null, handleSelection: Function) =>
       />
     );
 
-class SelectPlanPanel extends React.Component<Props> {
+class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
 
   createTabs = () => {
     const { types } = this.props;
-
     const tabs: Tab[] = [];
     const nanodes = getNanodes(types);
     const standards = getStandard(types);
@@ -95,6 +104,7 @@ class SelectPlanPanel extends React.Component<Props> {
   render() {
     return (
       <TabbedPanel
+        rootClass={this.props.classes.root}
         error={this.props.error}
         header="Linode Plan"
         tabs={this.createTabs()}
@@ -104,4 +114,6 @@ class SelectPlanPanel extends React.Component<Props> {
   }
 }
 
-export default SelectPlanPanel;
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(SelectPlanPanel);

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -39,13 +39,13 @@ const getHighMem = (types: ExtendedType[]) =>
   types.filter(t => /highmem/.test(t.class));
 
 const renderCard = (selectedID: string|null, handleSelection: Function) =>
-  (region: ExtendedType, idx: number) => (
+  (type: ExtendedType, idx: number) => (
       <SelectionCard
         key={idx}
-        checked={region.id === String(selectedID)}
-        onClick={e => handleSelection(region.id)}
-        heading={region.heading}
-        subheadings={region.subHeadings}
+        checked={type.id === String(selectedID)}
+        onClick={e => handleSelection(type.id)}
+        heading={type.heading}
+        subheadings={type.subHeadings}
       />
     );
 

--- a/src/features/linodes/LinodesCreate/SelectRegionPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectRegionPanel.tsx
@@ -6,6 +6,8 @@ import JP from 'flag-icon-css/flags/4x3/jp.svg';
 import UK from 'flag-icon-css/flags/4x3/gb.svg';
 import DE from 'flag-icon-css/flags/4x3/de.svg';
 
+import { withStyles, StyleRulesCallback, WithStyles, Theme } from 'material-ui';
+
 const flags = {
   us: () => <US width="32" height="24" viewBox="0 0 720 480"/>,
   sg: () => <SG width="32" height="24" viewBox="0 0 640 480"/>,
@@ -23,6 +25,14 @@ import SelectionCard from '../../../components/SelectionCard';
 export interface ExtendedRegion extends Linode.Region {
   display: string;
 }
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  root: {
+    marginTop: theme.spacing.unit * 3,
+  },
+});
 
 interface Props {
   regions: ExtendedRegion[];
@@ -53,7 +63,7 @@ const renderCard = (selectedID: string|null, handleSelection: Function) =>
       />
     );
 
-class SelectRegionPanel extends React.Component<Props> {
+class SelectRegionPanel extends React.Component<Props & WithStyles<ClassNames>> {
 
   createTabs = () => {
     const { regions } = this.props;
@@ -108,6 +118,7 @@ class SelectRegionPanel extends React.Component<Props> {
   render() {
     return (
       <TabbedPanel
+        rootClass={this.props.classes.root}
         error={this.props.error}
         header="Region"
         copy="Determine the best location for your Linode."
@@ -117,4 +128,6 @@ class SelectRegionPanel extends React.Component<Props> {
   }
 }
 
-export default SelectRegionPanel;
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(SelectRegionPanel);

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -135,6 +135,17 @@ const evenize = (n: number): number => {
   return (n % 2 === 0) ? n : n - 1;
 };
 
+export const aggregateBackups = (backups: Linode.LinodeBackupsResponse): Linode.LinodeBackup[] => {
+  const manualSnapshot = path(['status'], backups.snapshot.in_progress) === 'needsPostProcessing'
+    ? backups.snapshot.in_progress
+    : backups.snapshot.current;
+  return backups && [...backups.automatic, manualSnapshot].filter(b => Boolean(b));
+};
+
+export function formatBackupDate(backupDate: string) {
+  return moment.utc(backupDate).local().fromNow();
+}
+
 class LinodeBackup extends React.Component<CombinedProps, State> {
   state: State = {
     backups: this.props.backups.response,
@@ -221,9 +232,6 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
     ];
   }
 
-  formatBackupDate(backupDate: string) {
-    return moment.utc(backupDate).local().fromNow();
-  }
 
   enableBackups() {
     const { linodeID } = this.props;
@@ -251,13 +259,6 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
       });
   }
 
-  aggregateBackups = (): Linode.LinodeBackup[] => {
-    const { backups } = this.state;
-    const manualSnapshot = path(['status'], backups.snapshot.in_progress) === 'needsPostProcessing'
-      ? backups.snapshot.in_progress
-      : backups.snapshot.current;
-    return backups && [...backups.automatic, manualSnapshot].filter(b => Boolean(b));
-  }
 
   takeSnapshot = () => {
     const { linodeID } = this.props;
@@ -341,7 +342,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                 return (
                   <TableRow key={backup.id} data-qa-backup>
                     <TableCell>
-                      {this.formatBackupDate(backup.created)}
+                      {formatBackupDate(backup.created)}
                     </TableCell>
                     <TableCell data-qa-backup-name>
                       {backup.label || typeMap[backup.type]}
@@ -367,7 +368,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                       <LinodeBackupActionMenu
                         onRestore={() => this.openRestoreDrawer(
                           backup.id,
-                          this.formatBackupDate(backup.created),
+                          formatBackupDate(backup.created),
                         )}
                         onDeploy={() => {
                           history.push(`/linodes/create?type=fromBackup&backupID=${backup.id}`);
@@ -510,7 +511,8 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
 
   Management = (): JSX.Element | null => {
     const { classes, linodeID, linodeRegion } = this.props;
-    const backups = this.aggregateBackups();
+    const { backups: backupsResponse } = this.state;
+    const backups = aggregateBackups(backupsResponse);
 
     return (
       <React.Fragment>

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -321,7 +321,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
   }
 
   Table = ({ backups }: { backups: Linode.LinodeBackup[]}): JSX.Element | null => {
-    const { classes, history } = this.props;
+    const { classes, history, linodeID } = this.props;
 
     return (
       <React.Fragment>
@@ -371,7 +371,8 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                           formatBackupDate(backup.created),
                         )}
                         onDeploy={() => {
-                          history.push(`/linodes/create?type=fromBackup&backupID=${backup.id}`);
+                          history.push('/linodes/create'
+                            + `?type=fromBackup&backupID=${backup.id}&linodeID=${linodeID}`);
                         }}
                       />
                     </TableCell>

--- a/src/features/linodes/LinodesDetail/LinodeBackup/index.ts
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/index.ts
@@ -1,2 +1,3 @@
 import LinodeBackup from './LinodeBackup';
+export { aggregateBackups, formatBackupDate } from './LinodeBackup';
 export default LinodeBackup;

--- a/src/features/linodes/events.ts
+++ b/src/features/linodes/events.ts
@@ -8,6 +8,7 @@ export const newLinodeEvents = (mountTime: moment.Moment) =>
     'linode_shutdown',
     'backups_enable',
     'backups_cancel',
+    'backups_restore',
     'linode_snapshot',
     'linode_rebuild',
   ];


### PR DESCRIPTION
- Select backup panel, reloads based on Linode selection
- Checkout Bar displays backup label and create time where Image info is displayed
- Can land on the page with a query string that pre-selects the Create from Backup flow, Linode, and Backup
  - Our first instance of query string parsing, test this by visiting a Linode's backups and selecting "Deploy New Linode"
- Add Notice for general errors during the creation flow
- Handle errors for no Linode selected and no Backup selected
- Disable plan selection for plans that don't meet the disk size requirement for the backup when a backup is selected