### PR TITLE
Create from Backup

### DIFF
--- a/src/features/linodes/LinodesCreate/CheckoutBar.tsx
+++ b/src/features/linodes/LinodesCreate/CheckoutBar.tsx
@@ -9,6 +9,7 @@ import {
 import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
 
+import Notice from 'src/components/Notice';
 
 import { TypeInfo } from 'src/features/linodes/LinodesCreate/LinodesCreate';
 
@@ -70,6 +71,7 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
 
 interface Props {
   onDeploy: () => void;
+  error?: string;
   label: string | null;
   imageInfo: { name: string, details: string } | undefined;
   typeInfo: TypeInfo | undefined;
@@ -109,6 +111,7 @@ class CheckoutBar extends React.Component<CombinedProps> {
       classes,
       onDeploy,
       label,
+      error,
       backups,
       imageInfo,
       typeInfo,
@@ -184,6 +187,12 @@ class CheckoutBar extends React.Component<CombinedProps> {
             &nbsp;/mo
           </Typography>
         </div>
+
+        {error &&
+          <Notice error>
+            {error}
+          </Notice>
+        }
 
         <div className={`${classes.checkoutSection} ${classes.noBorder}`}>
           <Button

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -78,6 +78,7 @@ interface State {
   selectedTab: number;
   selectedLinodeID?: number;
   selectedBackupID?: number;
+  selectedBackupInfo?: Info;
   requiredDiskSpace?: number;
   selectedImageID: string | null;
   selectedRegionID: string | null;
@@ -172,7 +173,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     this.setState({ selectedTab: value });
   }
 
-  updateStateFor = (key: string) => (event: ChangeEvents, value: string) => {
+  updateStateFor = (key: string) => (event: ChangeEvents, value: any) => {
     this.setState(() => ({ [key]: value }));
   }
 
@@ -341,6 +342,16 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         });
         return;
       }
+
+      if (!selectedBackupID) {
+        /* a backup selection is also required */
+        this.setState({
+          errors: [
+            { field: 'backup_id', reason: 'You must select a Backup' },
+          ],
+        });
+        return;
+      }
     }
 
     createLinode({
@@ -395,12 +406,16 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       selectedImageID,
       selectedTypeID,
       selectedRegionID,
+      selectedBackupInfo,
     } = this.state;
 
     const { classes } = this.props;
 
-    const imageInfo = this.getImageInfo(this.props.images.response.find(
-      image => image.id === selectedImageID));
+    const imageInfo = [
+      this.getImageInfo(this.props.images.response.find(
+          image => image.id === selectedImageID)),
+      selectedBackupInfo,
+    ][selectedTab];
 
     const typeInfo = this.getTypeInfo(this.props.types.response.find(
       type => type.id === selectedTypeID));

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -26,6 +26,7 @@ import PromiseLoader from 'src/components/PromiseLoader';
 
 import SelectLinodePanel, { ExtendedLinode } from './SelectLinodePanel';
 import SelectImagePanel from './SelectImagePanel';
+import SelectBackupPanel from './SelectBackupPanel';
 import SelectRegionPanel, { ExtendedRegion } from './SelectRegionPanel';
 import SelectPlanPanel, { ExtendedType } from './SelectPlanPanel';
 import LabelAndTagsPanel from './LabelAndTagsPanel';
@@ -75,6 +76,7 @@ type CombinedProps = Props & WithStyles<Styles> & PreloadedProps & RouteComponen
 interface State {
   selectedTab: number;
   selectedLinodeID?: number;
+  selectedBackupID?: number;
   selectedImageID: string | null;
   selectedRegionID: string | null;
   selectedTypeID: string | null;
@@ -255,6 +257,12 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
               error={getErrorFor('linode_id', this.state.errors)}
               linodes={this.extendLinodes(this.props.linodes.response)}
               selectedLinodeID={this.state.selectedLinodeID}
+              handleSelection={this.updateStateFor}
+            />
+            <SelectBackupPanel
+              error={getErrorFor('backup_id', this.state.errors)}
+              selectedLinodeID={this.state.selectedLinodeID}
+              selectedBackupID={this.state.selectedBackupID}
               handleSelection={this.updateStateFor}
             />
             <SelectRegionPanel

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -194,7 +194,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     const options: QueryStringOptions =
       parseQueryParams(search.replace('?', '')) as QueryStringOptions;
     if (options.type === 'fromBackup') {
-      this.setState({ selectedTab: 1 });
+      this.setState({ selectedTab: this.backupTabIndex });
     }
 
     if (options.linodeID) {
@@ -345,6 +345,9 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     },
   ];
 
+  imageTabIndex = this.tabs.findIndex(tab => tab.title.toLowerCase().includes('image'));
+  backupTabIndex = this.tabs.findIndex(tab => tab.title.toLowerCase().includes('backup'));
+
   componentWillUnmount() {
     this.mounted = false;
   }
@@ -364,7 +367,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       privateIP,
     } = this.state;
 
-    if (selectedTab === 1) {
+    if (selectedTab === this.backupTabIndex) {
       /* we are creating from backup */
       if (!selectedLinodeID) {
         /* so a Linode selection is required */
@@ -444,11 +447,13 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
 
     const { classes } = this.props;
 
-    const imageInfo = [
-      this.getImageInfo(this.props.images.response.find(
-          image => image.id === selectedImageID)),
-      selectedBackupInfo,
-    ][selectedTab];
+    let imageInfo: Info;
+    if (selectedTab === this.imageTabIndex) {
+      imageInfo = this.getImageInfo(this.props.images.response.find(
+          image => image.id === selectedImageID));
+    } else if (selectedTab === this.backupTabIndex) {
+      imageInfo = selectedBackupInfo;
+    }
 
     const typeInfo = this.getTypeInfo(this.props.types.response.find(
       type => type.id === selectedTypeID));

--- a/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
@@ -23,7 +23,8 @@ import {
 type ClassNames =
 'root'
 | 'inner'
-| 'panelBody';
+| 'panelBody'
+| 'wrapper';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -36,7 +37,12 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     padding: theme.spacing.unit * 3,
   },
   panelBody: {
+    width: '100%',
     padding: `${theme.spacing.unit * 2}px 0 0`,
+  },
+  wrapper: {
+    padding: theme.spacing.unit,
+    minHeight: 120,
   },
 });
 
@@ -158,23 +164,31 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
             Select Backup
           </Typography>
           {(!loading)
-            ? <React.Fragment>
+            ? <Grid container alignItems="center" className={classes.wrapper}>
                 {backups
-                  ? <Typography component="div" className={classes.panelBody}>
-                      <Grid container>
-                        {backups.map((backup) => {
-                          return (
-                            this.renderCard(backup)
-                          );
-                        })}
-                      </Grid>
-                    </Typography>
+                  ? <React.Fragment>
+                      {backups.length !== 0
+                        ? <Typography component="div" className={classes.panelBody}>
+                            <Grid container>
+                            {}
+                              {backups.map((backup) => {
+                                return (
+                                  this.renderCard(backup)
+                                );
+                              })}
+                            </Grid>
+                          </Typography>
+                        : <Typography variant="body1">
+                            No backup available
+                          </Typography>
+                      }
+                    </React.Fragment>
                   : <Typography variant="body1">
                       First, select a Linode
                     </Typography>
                 }
-              </React.Fragment>
-            : <Grid container justify="center" alignItems="center">
+              </Grid>
+            : <Grid container justify="center" alignItems="center" className={classes.wrapper}>
                 <Grid item>
                   <CircularProgress
                     size={75}

--- a/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
@@ -81,21 +81,49 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     this.fetchBackups(this.props.selectedLinodeID);
+    this.updateBackupInfo();
   }
 
-  componentDidUpdate(prevProps: CombinedProps) {
+  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
     if (prevProps.selectedLinodeID !== this.props.selectedLinodeID) {
       this.fetchBackups(this.props.selectedLinodeID);
     }
+    if (prevProps.selectedBackupID !== this.props.selectedBackupID
+        || prevState.backups !== this.state.backups) {
+      this.updateBackupInfo();
+    }
   }
 
-  renderCard(backup: Linode.LinodeBackup) {
-    const { selectedBackupID } = this.props;
+  updateBackupInfo() {
+    const selectedBackup = this.state.backups && this.state.backups.filter(backup =>
+      backup.id === Number(this.props.selectedBackupID),
+    )[0];
+    if (selectedBackup) {
+      const backupInfo_ = this.getBackupInfo(selectedBackup);
+      const backupInfo = {
+        name: backupInfo_.infoName,
+        details: backupInfo_.subheading,
+      };
+      this.handleBackupInfoSelection(undefined as any, backupInfo);
+    }
+  }
+
+  getBackupInfo(backup: Linode.LinodeBackup) {
     const heading = backup.label ? backup.label : backup.type === 'auto' ? 'Automatic' : 'Snapshot';
     const subheading = formatBackupDate(backup.created);
     const infoName = heading === 'Automatic'
       ? 'From automatic backup'
       : `From backup ${heading}`;
+    return {
+      heading,
+      subheading,
+      infoName,
+    };
+  }
+
+  renderCard(backup: Linode.LinodeBackup) {
+    const { selectedBackupID } = this.props;
+    const backupInfo_ = this.getBackupInfo(backup);
     return (
       <SelectionCard
         key={backup.id}
@@ -105,15 +133,15 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
             acc + disk.size
           ), 0);
           const backupInfo = {
-            name: infoName,
-            details: subheading,
+            name: backupInfo_.infoName,
+            details: backupInfo_.subheading,
           };
           this.handleBackupSelection(e, `${backup.id}`);
           this.handleSizeSelection(e, `${totalBackupSize}`);
           this.handleBackupInfoSelection(e, backupInfo);
         }}
-        heading={heading}
-        subheadings={[subheading]}
+        heading={backupInfo_.heading}
+        subheadings={[backupInfo_.subheading]}
       />
     );
   }

--- a/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+import Paper from 'material-ui/Paper';
+import Typography from 'material-ui/Typography';
+
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
+import SelectionCard from 'src/components/SelectionCard';
+
+type ClassNames =
+'root'
+| 'inner'
+| 'panelBody';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  root: {
+    flexGrow: 1,
+    width: '100%',
+    backgroundColor: theme.color.white,
+  },
+  inner: {
+    padding: theme.spacing.unit * 3,
+  },
+  panelBody: {
+    padding: `${theme.spacing.unit * 2}px 0 0`,
+  },
+});
+
+interface Props {
+  selectedLinodeID?: number;
+  selectedBackupID?: number;
+  handleSelection: (key: string) =>
+    (event: React.SyntheticEvent<HTMLElement>, value: string) => void;
+  error?: string;
+}
+
+interface State {
+  backups?: Linode.LinodeBackup[];
+}
+
+type StyledProps = Props & WithStyles<ClassNames>;
+
+type CombinedProps = StyledProps;
+
+class SelectBackupPanel extends React.Component<CombinedProps, State> {
+  handleSelection = this.props.handleSelection('selectedBackupID');
+
+  renderCard(backup: Linode.LinodeBackup) {
+    const { selectedBackupID } = this.props;
+    return (
+      <SelectionCard
+        key={backup.id}
+        checked={backup.id === Number(selectedBackupID)}
+        onClick={e => this.handleSelection(e, `${backup.id}`)}
+        heading={backup.heading}
+        subheadings={backup.subHeadings}
+      />
+    );
+  }
+
+  render() {
+    const { error, classes, linodes } = this.props;
+
+    return (
+      <Paper className={`${classes.root}`}>
+        <div className={classes.inner}>
+          { error && <Notice text={error} error /> }
+          <Typography variant="title">
+            Select Linode
+          </Typography>
+          <Typography component="div" className={classes.panelBody}>
+            <Grid container>
+              {linodes.map((linode) => {
+                return (
+                  this.renderCard(linode)
+                );
+              })}
+            </Grid>
+          </Typography>
+        </div>
+      </Paper>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(SelectBackupPanel);

--- a/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
@@ -12,7 +12,7 @@ import Typography from 'material-ui/Typography';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import SelectionCard from 'src/components/SelectionCard';
-import CircleProgress from 'src/components/CircleProgress';
+import CircularProgress from 'material-ui/Progress/CircularProgress';
 
 import { getLinodeBackups } from 'src/services/linodes';
 import {
@@ -174,7 +174,15 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
                     </Typography>
                 }
               </React.Fragment>
-            : <CircleProgress />
+            : <Grid container justify="center" alignItems="center">
+                <Grid item>
+                  <CircularProgress
+                    size={75}
+                    variant="indeterminate"
+                    thickness={2}
+                  />
+                </Grid>
+              </Grid>
           }
         </div>
       </Paper>

--- a/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
@@ -44,7 +44,7 @@ interface Props {
   selectedLinodeID?: number;
   selectedBackupID?: number;
   handleSelection: (key: string) =>
-    (event: React.SyntheticEvent<HTMLElement>, value: string) => void;
+    (event: React.SyntheticEvent<HTMLElement>, value: any) => void;
   error?: string;
 }
 
@@ -64,6 +64,7 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
 
   handleBackupSelection = this.props.handleSelection('selectedBackupID');
   handleSizeSelection = this.props.handleSelection('requiredDiskSpace');
+  handleBackupInfoSelection = this.props.handleSelection('selectedBackupInfo');
 
   fetchBackups(linodeID?: number) {
     if (linodeID) {
@@ -90,6 +91,11 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
 
   renderCard(backup: Linode.LinodeBackup) {
     const { selectedBackupID } = this.props;
+    const heading = backup.label ? backup.label : backup.type === 'auto' ? 'Automatic' : 'Snapshot';
+    const subheading = formatBackupDate(backup.created);
+    const infoName = heading === 'Automatic'
+      ? 'From automatic backup'
+      : `From backup ${heading}`;
     return (
       <SelectionCard
         key={backup.id}
@@ -98,11 +104,16 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
           const totalBackupSize = backup.disks.reduce((acc, disk) => (
             acc + disk.size
           ), 0);
+          const backupInfo = {
+            name: infoName,
+            details: subheading,
+          };
           this.handleBackupSelection(e, `${backup.id}`);
           this.handleSizeSelection(e, `${totalBackupSize}`);
+          this.handleBackupInfoSelection(e, backupInfo);
         }}
-        heading={backup.label ? backup.label : backup.type === 'auto' ? 'Automatic' : 'Snapshot'}
-        subheadings={[formatBackupDate(backup.created)]}
+        heading={heading}
+        subheadings={[subheading]}
       />
     );
   }

--- a/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectBackupPanel.tsx
@@ -62,7 +62,8 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
     loading: false,
   };
 
-  handleSelection = this.props.handleSelection('selectedBackupID');
+  handleBackupSelection = this.props.handleSelection('selectedBackupID');
+  handleSizeSelection = this.props.handleSelection('requiredDiskSpace');
 
   fetchBackups(linodeID?: number) {
     if (linodeID) {
@@ -93,7 +94,13 @@ class SelectBackupPanel extends React.Component<CombinedProps, State> {
       <SelectionCard
         key={backup.id}
         checked={backup.id === Number(selectedBackupID)}
-        onClick={e => this.handleSelection(e, `${backup.id}`)}
+        onClick={(e) => {
+          const totalBackupSize = backup.disks.reduce((acc, disk) => (
+            acc + disk.size
+          ), 0);
+          this.handleBackupSelection(e, `${backup.id}`);
+          this.handleSizeSelection(e, `${totalBackupSize}`);
+        }}
         heading={backup.label ? backup.label : backup.type === 'auto' ? 'Automatic' : 'Snapshot'}
         subheadings={[formatBackupDate(backup.created)]}
       />

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -27,6 +27,7 @@ interface Props {
   error?: string;
   onSelect: (key: string) => void;
   selectedID: string | null;
+  requiredDiskSpace?: number;
 }
 
 const getNanodes = (types: ExtendedType[]) =>
@@ -38,18 +39,20 @@ const getStandard = (types: ExtendedType[]) =>
 const getHighMem = (types: ExtendedType[]) =>
   types.filter(t => /highmem/.test(t.class));
 
-const renderCard = (selectedID: string|null, handleSelection: Function) =>
-  (type: ExtendedType, idx: number) => (
-      <SelectionCard
+
+class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
+  renderCard = (selectedID: string|null, handleSelection: Function) =>
+    (type: ExtendedType, idx: number) => {
+      const requiredDiskSpace = this.props.requiredDiskSpace || 0;
+      return <SelectionCard
         key={idx}
         checked={type.id === String(selectedID)}
         onClick={e => handleSelection(type.id)}
         heading={type.heading}
         subheadings={type.subHeadings}
-      />
-    );
-
-class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
+        disabled={requiredDiskSpace > type.disk}
+      />;
+    }
 
   createTabs = () => {
     const { types } = this.props;
@@ -65,7 +68,7 @@ class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
 
           return (
             <Grid container spacing={8}>
-            { nanodes.map(renderCard(this.props.selectedID, this.props.onSelect))}
+            { nanodes.map(this.renderCard(this.props.selectedID, this.props.onSelect))}
             </Grid>
           );
         },
@@ -78,7 +81,7 @@ class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
         render: () => {
           return (
             <Grid container spacing={8}>
-              { standards.map(renderCard(this.props.selectedID, this.props.onSelect))}
+              { standards.map(this.renderCard(this.props.selectedID, this.props.onSelect))}
             </Grid>
           );
         },
@@ -91,7 +94,7 @@ class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
         render: () => {
           return (
             <Grid container spacing={8}>
-              { highmem.map(renderCard(this.props.selectedID, this.props.onSelect))}
+              { highmem.map(this.renderCard(this.props.selectedID, this.props.onSelect))}
             </Grid>
           );
         },

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -67,7 +67,7 @@ class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
         render: () => {
 
           return (
-            <Grid container spacing={8}>
+            <Grid container spacing={16}>
             { nanodes.map(this.renderCard(this.props.selectedID, this.props.onSelect))}
             </Grid>
           );
@@ -80,7 +80,7 @@ class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
         title: 'Standard',
         render: () => {
           return (
-            <Grid container spacing={8}>
+            <Grid container spacing={16}>
               { standards.map(this.renderCard(this.props.selectedID, this.props.onSelect))}
             </Grid>
           );
@@ -93,7 +93,7 @@ class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNames>> {
         title: 'High Memory',
         render: () => {
           return (
-            <Grid container spacing={8}>
+            <Grid container spacing={16}>
               { highmem.map(this.renderCard(this.props.selectedID, this.props.onSelect))}
             </Grid>
           );

--- a/src/features/linodes/LinodesCreate/SelectRegionPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectRegionPanel.tsx
@@ -78,7 +78,7 @@ class SelectRegionPanel extends React.Component<Props & WithStyles<ClassNames>> 
         render: () => {
 
           return (
-            <Grid container spacing={8}>
+            <Grid container spacing={16}>
             { na.map(renderCard(this.props.selectedID, this.props.handleSelection))}
             </Grid>
           );
@@ -91,7 +91,7 @@ class SelectRegionPanel extends React.Component<Props & WithStyles<ClassNames>> 
         title: 'Europe',
         render: () => {
           return (
-            <Grid container spacing={8}>
+            <Grid container spacing={16}>
               { eu.map(renderCard(this.props.selectedID, this.props.handleSelection))}
             </Grid>
           );

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -135,6 +135,17 @@ const evenize = (n: number): number => {
   return (n % 2 === 0) ? n : n - 1;
 };
 
+export const aggregateBackups = (backups: Linode.LinodeBackupsResponse): Linode.LinodeBackup[] => {
+  const manualSnapshot = path(['status'], backups.snapshot.in_progress) === 'needsPostProcessing'
+    ? backups.snapshot.in_progress
+    : backups.snapshot.current;
+  return backups && [...backups.automatic, manualSnapshot].filter(b => Boolean(b));
+};
+
+export function formatBackupDate(backupDate: string) {
+  return moment.utc(backupDate).local().fromNow();
+}
+
 class LinodeBackup extends React.Component<CombinedProps, State> {
   state: State = {
     backups: this.props.backups.response,
@@ -221,9 +232,6 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
     ];
   }
 
-  formatBackupDate(backupDate: string) {
-    return moment.utc(backupDate).local().fromNow();
-  }
 
   enableBackups() {
     const { linodeID } = this.props;
@@ -251,13 +259,6 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
       });
   }
 
-  aggregateBackups = (): Linode.LinodeBackup[] => {
-    const { backups } = this.state;
-    const manualSnapshot = path(['status'], backups.snapshot.in_progress) === 'needsPostProcessing'
-      ? backups.snapshot.in_progress
-      : backups.snapshot.current;
-    return backups && [...backups.automatic, manualSnapshot].filter(b => Boolean(b));
-  }
 
   takeSnapshot = () => {
     const { linodeID } = this.props;
@@ -341,7 +342,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                 return (
                   <TableRow key={backup.id} data-qa-backup>
                     <TableCell>
-                      {this.formatBackupDate(backup.created)}
+                      {formatBackupDate(backup.created)}
                     </TableCell>
                     <TableCell data-qa-backup-name>
                       {backup.label || typeMap[backup.type]}
@@ -367,7 +368,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                       <LinodeBackupActionMenu
                         onRestore={() => this.openRestoreDrawer(
                           backup.id,
-                          this.formatBackupDate(backup.created),
+                          formatBackupDate(backup.created),
                         )}
                         onDeploy={() => {
                           history.push(`/linodes/create?type=fromBackup&backupID=${backup.id}`);
@@ -510,7 +511,8 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
 
   Management = (): JSX.Element | null => {
     const { classes, linodeID, linodeRegion } = this.props;
-    const backups = this.aggregateBackups();
+    const { backups: backupsResponse } = this.state;
+    const backups = aggregateBackups(backupsResponse);
 
     return (
       <React.Fragment>

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -321,7 +321,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
   }
 
   Table = ({ backups }: { backups: Linode.LinodeBackup[]}): JSX.Element | null => {
-    const { classes, history } = this.props;
+    const { classes, history, linodeID } = this.props;
 
     return (
       <React.Fragment>
@@ -371,7 +371,8 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                           formatBackupDate(backup.created),
                         )}
                         onDeploy={() => {
-                          history.push(`/linodes/create?type=fromBackup&backupID=${backup.id}`);
+                          history.push('/linodes/create'
+                            + `?type=fromBackup&backupID=${backup.id}&linodeID=${linodeID}`);
                         }}
                       />
                     </TableCell>

--- a/src/features/linodes/LinodesDetail/LinodeBackup/index.ts
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/index.ts
@@ -1,2 +1,3 @@
 import LinodeBackup from './LinodeBackup';
+export { aggregateBackups, formatBackupDate } from './LinodeBackup';
 export default LinodeBackup;

--- a/src/features/linodes/events.ts
+++ b/src/features/linodes/events.ts
@@ -8,6 +8,7 @@ export const newLinodeEvents = (mountTime: moment.Moment) =>
     'linode_shutdown',
     'backups_enable',
     'backups_cancel',
+    'backups_restore',
     'linode_snapshot',
     'linode_rebuild',
   ];


### PR DESCRIPTION
- Select backup panel, reloads based on Linode selection
- Checkout Bar displays backup label and create time where Image info is displayed
- Can land on the page with a query string that pre-selects the Create from Backup flow, Linode, and Backup
  - Our first instance of query string parsing, test this by visiting a Linode's backups and selecting "Deploy New Linode"
- Add Notice for general errors during the creation flow
- Handle errors for no Linode selected and no Backup selected
- Disable plan selection for plans that don't meet the disk size requirement for the backup when a backup is selected