### PR TITLE
M3-494 reversed DNS drawer error styling

### DIFF
--- a/src/darkTheme.ts
+++ b/src/darkTheme.ts
@@ -336,9 +336,6 @@ const LinodeTheme: Linode.Theme = {
       },
     },
     MuiFormHelperText: {
-      root: {
-        flexBasis: '100%',
-      },
       error: {
         color: '#CA0813',
       },

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
@@ -88,11 +88,15 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
             errorText={hasErrorFor('rdns')}
             onChange={e => this.setState({ rdns: e.target.value })}
           />
-          { hasErrorFor('none') && <FormHelperText error>{ hasErrorFor('none') }</FormHelperText> }
-
           <Typography variant="caption">
             Leave this field blank to reset RDNS
           </Typography>
+
+          { hasErrorFor('none') &&
+            <FormHelperText error style={{ marginTop: 16 }}>
+              { hasErrorFor('none') }
+            </FormHelperText>
+          }
 
           <ActionsPanel style={{ marginTop: 16 }}>
             <Button

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -251,9 +251,6 @@ const LinodeTheme: Linode.Theme = {
       },
     },
     MuiFormHelperText: {
-      root: {
-        flexBasis: '100%',
-      },
       error: {
         color: '#CA0813',
       },


### PR DESCRIPTION
I placed the error message under the field helper and added some margin for better readability 