### PR TITLE
Clone existing linode

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/Linode/manager.git"
   },
   "dependencies": {
+    "@types/promise.prototype.finally": "^2.0.2",
     "autoprefixer": "7.1.6",
     "axios": "^0.18.0",
     "bluebird": "^3.5.1",
@@ -48,6 +49,7 @@
     "postcss-loader": "2.0.8",
     "pre-commit": "^1.2.2",
     "promise": "8.0.1",
+    "promise.prototype.finally": "^3.1.0",
     "raf": "3.4.0",
     "ramda": "^0.25.0",
     "raven-js": "^3.22.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import { compose, bindActionCreators } from 'redux';
 import Axios from 'axios';
 import { append, pathOr, range, flatten } from 'ramda';
 import * as Promise from 'bluebird';
+import { shim } from 'promise.prototype.finally';
+shim(); // allows for .finally() usage
 
 import {
   withStyles,

--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -20,7 +20,7 @@ const styles: StyleRulesCallback = (theme: Linode.Theme) => {
 
   return {
     root: {
-      marginBottom: theme.spacing.unit,
+      marginBottom: theme.spacing.unit * 2,
       padding: theme.spacing.unit * 2,
       maxWidth: '100%',
       display: 'flex',

--- a/src/features/AccountLevelNotifications/AccountLevelNotifications.tsx
+++ b/src/features/AccountLevelNotifications/AccountLevelNotifications.tsx
@@ -21,6 +21,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
     marginLeft: theme.spacing.unit,
     marginRight: theme.spacing.unit,
+    marginBottom: theme.spacing.unit,
     justifyContent: 'center',
     padding: theme.spacing.unit,
     textAlign: 'center',

--- a/src/features/Domains/index.tsx
+++ b/src/features/Domains/index.tsx
@@ -23,7 +23,7 @@ class DomainsRoutes extends React.Component<Props> {
 
     return (
       <Switch>
-        <Route component={DomainDetails} path={`${path}/:domainId`}/>
+        <Route component={DomainDetails} path={`${path}/:domainId`} />
         <Route component={DomainsLanding} path={path} exact />
       </Switch>
     );

--- a/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -11,15 +11,15 @@ import CheckBox from 'src/components/CheckBox';
 import { FormControlLabel } from 'material-ui/Form';
 
 type ClassNames = 'root'
-| 'flex'
-| 'title'
-| 'divider'
-| 'lastItem'
-| 'inner'
-| 'panelBody'
-| 'label'
-| 'subLabel'
-| 'caption';
+  | 'flex'
+  | 'title'
+  | 'divider'
+  | 'lastItem'
+  | 'inner'
+  | 'panelBody'
+  | 'label'
+  | 'subLabel'
+  | 'caption';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -104,7 +104,7 @@ class AddonsPanel extends React.Component<CombinedProps> {
     return (
       <Paper className={classes.root} data-qa-add-ons>
         <div className={classes.inner}>
-          <Typography variant="title"className={classes.title} >Optional Add-ons</Typography>
+          <Typography variant="title" className={classes.title} >Optional Add-ons</Typography>
           <Grid container>
             <Grid item xs={12}>
               <FormControlLabel
@@ -145,7 +145,7 @@ class AddonsPanel extends React.Component<CombinedProps> {
             </Grid>
           </Grid>
         </div>
-    </Paper>
+      </Paper>
     );
   }
 }

--- a/src/features/linodes/LinodesCreate/CheckoutBar.tsx
+++ b/src/features/linodes/LinodesCreate/CheckoutBar.tsx
@@ -14,12 +14,12 @@ import Notice from 'src/components/Notice';
 import { TypeInfo } from 'src/features/linodes/LinodesCreate/LinodesCreate';
 
 type ClassNames = 'root'
-| 'checkoutSection'
-| 'noBorder'
-| 'sidebarTitle'
-| 'detail'
-| 'price'
-| 'per';
+  | 'checkoutSection'
+  | 'noBorder'
+  | 'sidebarTitle'
+  | 'detail'
+  | 'price'
+  | 'per';
 
 const styles = (theme: Theme & Linode.Theme): StyleRules => ({
   '@keyframes fadeIn': {
@@ -78,6 +78,7 @@ interface Props {
   regionName: string | undefined;
   backups: boolean;
   isSticky?: boolean;
+  disabled?: boolean;
 }
 
 type CombinedProps = Props & StickyProps & WithStyles<ClassNames>;
@@ -116,6 +117,7 @@ class CheckoutBar extends React.Component<CombinedProps> {
       imageInfo,
       typeInfo,
       regionName,
+      disabled,
     } = this.props;
 
     let finalStyle;
@@ -198,6 +200,7 @@ class CheckoutBar extends React.Component<CombinedProps> {
           <Button
             variant="raised"
             color="primary"
+            disabled={disabled}
             fullWidth
             onClick={onDeploy}
             data-qa-deploy-linode

--- a/src/features/linodes/LinodesCreate/CheckoutBar.tsx
+++ b/src/features/linodes/LinodesCreate/CheckoutBar.tsx
@@ -205,7 +205,7 @@ class CheckoutBar extends React.Component<CombinedProps> {
             onClick={onDeploy}
             data-qa-deploy-linode
           >
-            Deploy Linode
+            {!disabled ? 'Deploy Linode' : 'Deploying...'}
           </Button>
         </div>
 

--- a/src/features/linodes/LinodesCreate/CheckoutBar.tsx
+++ b/src/features/linodes/LinodesCreate/CheckoutBar.tsx
@@ -9,8 +9,6 @@ import {
 import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
 
-import Notice from 'src/components/Notice';
-
 import { TypeInfo } from 'src/features/linodes/LinodesCreate/LinodesCreate';
 
 type ClassNames = 'root'
@@ -71,7 +69,6 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
 
 interface Props {
   onDeploy: () => void;
-  error?: string;
   label: string | null;
   imageInfo: { name: string, details: string } | undefined;
   typeInfo: TypeInfo | undefined;
@@ -112,7 +109,6 @@ class CheckoutBar extends React.Component<CombinedProps> {
       classes,
       onDeploy,
       label,
-      error,
       backups,
       imageInfo,
       typeInfo,
@@ -189,12 +185,6 @@ class CheckoutBar extends React.Component<CombinedProps> {
             &nbsp;/mo
           </Typography>
         </div>
-
-        {error &&
-          <Notice error>
-            {error}
-          </Notice>
-        }
 
         <div className={`${classes.checkoutSection} ${classes.noBorder}`}>
           <Button

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -13,7 +13,6 @@ import {
   Theme,
   StyleRules,
 } from 'material-ui/styles';
-import Grid from 'src/components/Grid';
 import Typography from 'material-ui/Typography';
 import AppBar from 'material-ui/AppBar';
 import Tabs, { Tab } from 'material-ui/Tabs';
@@ -23,6 +22,9 @@ import { dcDisplayNames } from 'src/constants';
 import { createLinode, getLinodeTypes, allocatePrivateIP, getLinodes } from 'src/services/linodes';
 import { getImages } from 'src/services/images';
 import { getRegions } from 'src/services/misc';
+
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
 import PromiseLoader from 'src/components/PromiseLoader';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 
@@ -327,6 +329,46 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
               error={hasErrorFor('root_pass')}
               password={this.state.password}
               handleChange={v => this.setState({ password: v })}
+            />
+            <AddonsPanel
+              backups={this.state.backups}
+              backupsMonthly={this.getBackupsMonthlyPrice()}
+              privateIP={this.state.privateIP}
+              handleChange={this.updateStateFor}
+            />
+          </React.Fragment>
+        );
+      },
+    },
+    {
+      title: 'Clone From Existing',
+      render: () => {
+        return (
+          <React.Fragment>
+            <Notice text={`This newly created Linode wil be created with
+            the same root password as the original Linode`} warning={true} />
+            <SelectLinodePanel
+              error={getErrorFor('linode_id', this.state.errors)}
+              linodes={this.extendLinodes(this.props.linodes.response)}
+              selectedLinodeID={this.state.selectedLinodeID}
+              handleSelection={this.updateStateFor}
+            />
+            <SelectRegionPanel
+              error={getErrorFor('region', this.state.errors)}
+              regions={this.props.regions.response}
+              handleSelection={this.updateStateFor}
+              selectedID={this.state.selectedRegionID}
+            />
+            <SelectPlanPanel
+              error={getErrorFor('type', this.state.errors)}
+              types={this.props.types.response}
+              onSelect={(id: string) => this.setState({ selectedTypeID: id })}
+              selectedID={this.state.selectedTypeID}
+            />
+            <LabelAndTagsPanel
+              error={getErrorFor('label', this.state.errors)}
+              label={this.state.label}
+              handleChange={this.updateStateFor}
             />
             <AddonsPanel
               backups={this.state.backups}

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -83,6 +83,7 @@ interface State {
   selectedBackupID?: number;
   selectedBackupInfo?: Info;
   smallestType?: string;
+  selectedTargetLinodeID?: number | null;
   selectedImageID: string | null;
   selectedRegionID: string | null;
   selectedTypeID: string | null;
@@ -343,30 +344,40 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     {
       title: 'Clone From Existing',
       render: () => {
+        const hasErrorFor = getAPIErrorsFor(errorResources, this.state.errors);
         return (
           <React.Fragment>
             <Notice text={`This newly created Linode wil be created with
             the same root password as the original Linode`} warning={true} />
             <SelectLinodePanel
-              error={getErrorFor('linode_id', this.state.errors)}
+              error={hasErrorFor('linode_id')}
               linodes={this.extendLinodes(this.props.linodes.response)}
               selectedLinodeID={this.state.selectedLinodeID}
               handleSelection={this.updateStateFor}
+              header={'Select Linode to Clone From'}
+            />
+            <SelectLinodePanel
+              error={hasErrorFor('linode_id')}
+              linodes={this.extendLinodes(this.props.linodes.response)}
+              selectedTargetLinodeID={this.state.selectedTargetLinodeID}
+              handleSelection={this.updateStateFor}
+              header={'Select Target Linode'}
+              isTarget={true}
             />
             <SelectRegionPanel
-              error={getErrorFor('region', this.state.errors)}
+              error={hasErrorFor('region')}
               regions={this.props.regions.response}
               handleSelection={this.updateStateFor}
               selectedID={this.state.selectedRegionID}
             />
             <SelectPlanPanel
-              error={getErrorFor('type', this.state.errors)}
+              error={hasErrorFor('type')}
               types={this.props.types.response}
               onSelect={(id: string) => this.setState({ selectedTypeID: id })}
               selectedID={this.state.selectedTypeID}
             />
             <LabelAndTagsPanel
-              error={getErrorFor('label', this.state.errors)}
+              error={hasErrorFor('label')}
               label={this.state.label}
               handleChange={this.updateStateFor}
             />
@@ -487,7 +498,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     let imageInfo: Info;
     if (selectedTab === this.imageTabIndex) {
       imageInfo = this.getImageInfo(this.props.images.response.find(
-          image => image.id === selectedImageID));
+        image => image.id === selectedImageID));
     } else if (selectedTab === this.backupTabIndex) {
       imageInfo = selectedBackupInfo;
     }

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -86,6 +86,7 @@ interface State {
   selectedBackupInfo?: Info;
   smallestType?: string;
   selectedTargetLinodeID?: number | null;
+  selectedCloneTargetLinodeID?: number | null;
   selectedImageID: string | null;
   selectedRegionID: string | null;
   selectedTypeID: string | null;
@@ -362,7 +363,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
               error={hasErrorFor('linode_id')}
               linodes={this.extendLinodes(this.props.linodes.response)}
               selectedLinodeID={this.state.selectedLinodeID}
-              selectedTargetLinodeID={this.state.selectedTargetLinodeID}
+              selectedCloneTargetLinodeID={this.state.selectedCloneTargetLinodeID}
               handleSelection={this.updateStateFor}
               header={'Select Linode to Clone From'}
             />
@@ -370,28 +371,31 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
               error={hasErrorFor('linode_id')}
               linodes={this.extendLinodes(this.props.linodes.response)}
               selectedLinodeID={this.state.selectedLinodeID}
-              selectedTargetLinodeID={this.state.selectedTargetLinodeID}
+              selectedCloneTargetLinodeID={this.state.selectedCloneTargetLinodeID}
               handleSelection={this.updateStateFor}
               header={'Select Target Linode'}
-              isTarget={true}
+              isCloneTarget={true}
             />
-            <SelectRegionPanel
-              error={hasErrorFor('region')}
-              regions={this.props.regions.response}
-              handleSelection={this.updateStateFor}
-              selectedID={this.state.selectedRegionID}
-            />
-            <SelectPlanPanel
-              error={hasErrorFor('type')}
-              types={this.props.types.response}
-              onSelect={(id: string) => this.setState({ selectedTypeID: id })}
-              selectedID={this.state.selectedTypeID}
-            />
-            <LabelAndTagsPanel
-              error={hasErrorFor('label')}
-              label={this.state.label}
-              handleChange={this.updateStateFor}
-            />
+            {this.state.selectedCloneTargetLinodeID === null &&
+              <React.Fragment>
+                <SelectRegionPanel
+                  error={hasErrorFor('region')}
+                  regions={this.props.regions.response}
+                  handleSelection={this.updateStateFor}
+                  selectedID={this.state.selectedRegionID}
+                />
+                <SelectPlanPanel
+                  error={hasErrorFor('type')}
+                  types={this.props.types.response}
+                  onSelect={(id: string) => this.setState({ selectedTypeID: id })}
+                  selectedID={this.state.selectedTypeID}
+                />
+                <LabelAndTagsPanel
+                  error={hasErrorFor('label')}
+                  label={this.state.label}
+                  handleChange={this.updateStateFor}
+                />
+              </React.Fragment>}
             <AddonsPanel
               backups={this.state.backups}
               backupsMonthly={this.getBackupsMonthlyPrice()}
@@ -417,7 +421,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       selectedTab,
       selectedLinodeID,
       selectedBackupID,
-      selectedTargetLinodeID,
+      selectedCloneTargetLinodeID,
     } = this.state;
 
     if (selectedTab === this.backupTabIndex) {
@@ -449,9 +453,9 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     }
     // we are cloning to another Linode
     if (selectedTab === 2) {
-      // if selectedTargetLinode is 'undefined,' no target Linode has been selected
-      // if selectedTargetLinode is null, that means we're cloning to a new Linode
-      if (!selectedLinodeID || typeof selectedTargetLinodeID === 'undefined') {
+      // if selectedCloneTargetLinode is 'undefined,' no target Linode has been selected
+      // if selectedCloneTargetLinode is null, that means we're cloning to a new Linode
+      if (!selectedLinodeID || typeof selectedCloneTargetLinodeID === 'undefined') {
         window.scroll({
           top: 0,
           left: 0,
@@ -511,7 +515,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       selectedRegionID,
       selectedTypeID,
       selectedLinodeID,
-      selectedTargetLinodeID,
+      selectedCloneTargetLinodeID,
       label, // optional
       backups, // optional
       privateIP,
@@ -522,7 +526,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     cloneLinode(selectedLinodeID!, {
       region: selectedRegionID,
       type: selectedTypeID,
-      linode_id: (!!selectedTargetLinodeID) ? +selectedTargetLinodeID : null,
+      linode_id: (!!selectedCloneTargetLinodeID) ? +selectedCloneTargetLinodeID : null,
       label,
       backups_enabled: backups,
     })
@@ -558,23 +562,23 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
   }
 
   getTypeInfo = (): TypeInfo => {
-    const { selectedTargetLinodeID, selectedTypeID } = this.state;
+    const { selectedCloneTargetLinodeID, selectedTypeID } = this.state;
 
     const { linodes } = this.props;
 
     // we have to add a conditional check here to see if we're cloning to
     // an existing Linode. If so, we need to get the type from that Linode and
     // so that we can display the accurate price
-    const cloningToExistingLinode = !!selectedTargetLinodeID;
-    const selectedTargetLinode = linodes.response.find((linode) => {
-      return Number(selectedTargetLinodeID) === linode.id;
+    const cloningToExistingLinode = !!selectedCloneTargetLinodeID;
+    const selectedCloneTargetLinode = linodes.response.find((linode) => {
+      return Number(selectedCloneTargetLinodeID) === linode.id;
     });
 
     const typeInfo = (!cloningToExistingLinode)
       ? this.reshapeTypeInfo(this.props.types.response.find(
         type => type.id === selectedTypeID))
       : this.reshapeTypeInfo(this.props.types.response.find(
-        type => type.id === selectedTargetLinode!.type));
+        type => type.id === selectedCloneTargetLinode!.type));
 
     return typeInfo;
   }

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -451,6 +451,8 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     }
     // we are cloning to another Linode
     if (selectedTab === 2) {
+      // if selectedTargetLinode is 'undefined,' no target Linode has been selected
+      // if selectedTargetLinode is null, that means we're cloning to a new Linode
       if (!selectedLinodeID || typeof selectedTargetLinodeID === 'undefined') {
         window.scroll({
           top: 0,
@@ -467,13 +469,6 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       this.cloneLinode();
     }
   }
-
-  // checkFieldIsEmpty = (fieldValue: any) => {
-  //   if (!fieldValue) {
-  //     return true;
-  //   }
-  //   return false;
-  // }
 
   createNewLinode = () => {
     const { history } = this.props;
@@ -586,9 +581,10 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       selectedTypeID,
       selectedRegionID,
       selectedBackupInfo,
+      selectedTargetLinodeID,
     } = this.state;
 
-    const { classes } = this.props;
+    const { classes, linodes } = this.props;
 
     let imageInfo: Info;
     if (selectedTab === this.imageTabIndex) {
@@ -598,8 +594,21 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       imageInfo = selectedBackupInfo;
     }
 
-    const typeInfo = this.getTypeInfo(this.props.types.response.find(
-      type => type.id === selectedTypeID));
+    // we have to add a conditional check here to see if we're cloning to
+    // an existing Linode. If so, we need to get the type from that Linode and
+    // so that we can display the accurate price
+    const cloningToExistingLinode = !!selectedTargetLinodeID;
+    const selectedTargetLinode = linodes.response.find((linode) => {
+      return Number(selectedTargetLinodeID) === linode.id;
+    });
+
+    const typeInfo = (!cloningToExistingLinode)
+      ? this.getTypeInfo(this.props.types.response.find(
+        type => type.id === selectedTypeID))
+      : this.getTypeInfo(this.props.types.response.find(
+        type => type.id === selectedTargetLinode!.type));
+
+    console.log(typeInfo);
 
     const regionName = this.getRegionName(this.props.regions.response.find(
       region => region.id === selectedRegionID));

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -243,6 +243,10 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     );
   }
 
+  // disableLinodeCard() { // disable a certain card inside a Linodes list
+  //   // do stuff
+  // }
+
   tabs = [
     {
       title: 'Create from Image',
@@ -353,12 +357,14 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
               error={hasErrorFor('linode_id')}
               linodes={this.extendLinodes(this.props.linodes.response)}
               selectedLinodeID={this.state.selectedLinodeID}
+              selectedTargetLinodeID={this.state.selectedTargetLinodeID}
               handleSelection={this.updateStateFor}
               header={'Select Linode to Clone From'}
             />
             <SelectLinodePanel
               error={hasErrorFor('linode_id')}
               linodes={this.extendLinodes(this.props.linodes.response)}
+              selectedLinodeID={this.state.selectedLinodeID}
               selectedTargetLinodeID={this.state.selectedTargetLinodeID}
               handleSelection={this.updateStateFor}
               header={'Select Target Linode'}

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -247,6 +247,14 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     );
   }
 
+  scrollToTop = () => {
+    window.scroll({
+      top: 0,
+      left: 0,
+      behavior: 'smooth',
+    });
+  }
+
   tabs = [
     {
       title: 'Create from Image',
@@ -255,7 +263,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         const generalError = hasErrorFor('none');
         return (
           <React.Fragment>
-            {!!generalError &&
+            {generalError &&
               <Notice text={generalError} error={true} />
             }
             <SelectImagePanel
@@ -302,7 +310,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         const generalError = hasErrorFor('none');
         return (
           <React.Fragment>
-            {!!generalError &&
+            {generalError &&
               <Notice text={generalError} error={true} />
             }
             <SelectLinodePanel
@@ -360,7 +368,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         const generalError = hasErrorFor('none');
         return (
           <React.Fragment>
-            {!!generalError &&
+            {generalError &&
               <Notice text={generalError} error={true} />
             }
             <Notice text={`This newly created Linode wil be created with
@@ -433,11 +441,6 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     if (selectedTab === this.backupTabIndex) {
       /* we are creating from backup */
       if (!selectedLinodeID) {
-        window.scroll({
-          top: 0,
-          left: 0,
-          behavior: 'smooth',
-        });
         this.setState({
           errors: [
             { field: 'linode_id', reason: 'You must select a Linode' },
@@ -447,11 +450,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       }
       if (!selectedBackupID) {
         /* a backup selection is also required */
-        window.scroll({
-          top: 0,
-          left: 0,
-          behavior: 'smooth',
-        });
+        this.scrollToTop();
         this.setState({
           errors: [
             { field: 'backup_id', reason: 'You must select a Backup' },
@@ -465,11 +464,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       // if selectedCloneTargetLinode is 'undefined,' no target Linode has been selected
       // if selectedCloneTargetLinode is null, that means we're cloning to a new Linode
       if (!selectedLinodeID || typeof selectedCloneTargetLinodeID === 'undefined') {
-        window.scroll({
-          top: 0,
-          left: 0,
-          behavior: 'smooth',
-        });
+        this.scrollToTop();
         this.setState({
           errors: [
             { field: 'linode_id', reason: 'You must select both a source and target Linode' },
@@ -550,11 +545,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       .catch((error) => {
         if (!this.mounted) { return; }
 
-        window.scroll({
-          top: 0,
-          left: 0,
-          behavior: 'smooth',
-        });
+        this.scrollToTop();
 
         this.setState(() => ({
           errors: error.response && error.response.data && error.response.data.errors,

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -41,8 +41,6 @@ import AddonsPanel from './AddonsPanel';
 import { typeLabelDetails, typeLabel } from '../presentation';
 import CheckoutBar from './CheckoutBar';
 import { resetEventsPolling } from 'src/events';
-import { shim } from 'promise.prototype.finally';
-shim();
 
 type ChangeEvents = React.MouseEvent<HTMLElement> | React.ChangeEvent<HTMLInputElement>;
 

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -453,8 +453,8 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         });
         return;
       }
-      this.createNewLinode();
     }
+    this.createNewLinode();
     // we are cloning to another Linode
     if (selectedTab === this.cloneTabIndex) {
       // if selectedCloneTargetLinode is 'undefined,' no target Linode has been selected

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -368,7 +368,6 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
               header={'Select Linode to Clone From'}
             />
             <SelectLinodePanel
-              error={hasErrorFor('linode_id')}
               linodes={this.extendLinodes(this.props.linodes.response)}
               selectedLinodeID={this.state.selectedLinodeID}
               selectedCloneTargetLinodeID={this.state.selectedCloneTargetLinodeID}

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -438,7 +438,6 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         });
         return;
       }
-
       if (!selectedBackupID) {
         /* a backup selection is also required */
         window.scroll({
@@ -453,10 +452,9 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         });
         return;
       }
-    }
-    this.createNewLinode();
-    // we are cloning to another Linode
-    if (selectedTab === this.cloneTabIndex) {
+      this.createNewLinode();
+    } else if (selectedTab === this.cloneTabIndex) {
+      // creating a clone
       // if selectedCloneTargetLinode is 'undefined,' no target Linode has been selected
       // if selectedCloneTargetLinode is null, that means we're cloning to a new Linode
       if (!selectedLinodeID || typeof selectedCloneTargetLinodeID === 'undefined') {
@@ -473,6 +471,9 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         return;
       }
       this.cloneLinode();
+    } else {
+      // creating from image
+      this.createNewLinode();
     }
   }
 

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -94,7 +94,6 @@ interface State {
   backups: boolean;
   privateIP: boolean;
   errors?: Linode.ApiFieldError[];
-  responseError: string;
   isMakingRequest: boolean;
   [index: string]: any;
 }
@@ -174,7 +173,6 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
     backups: false,
     privateIP: false,
     errors: undefined,
-    responseError: '',
     isMakingRequest: false,
   };
 
@@ -254,8 +252,12 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       title: 'Create from Image',
       render: () => {
         const hasErrorFor = getAPIErrorsFor(errorResources, this.state.errors);
+        const generalError = hasErrorFor('none');
         return (
           <React.Fragment>
+            {!!generalError &&
+              <Notice text={generalError} error={true} />
+            }
             <SelectImagePanel
               images={this.props.images.response}
               handleSelection={this.updateStateFor}
@@ -297,8 +299,12 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       title: 'Create from Backup',
       render: () => {
         const hasErrorFor = getAPIErrorsFor(errorResources, this.state.errors);
+        const generalError = hasErrorFor('none');
         return (
           <React.Fragment>
+            {!!generalError &&
+              <Notice text={generalError} error={true} />
+            }
             <SelectLinodePanel
               error={hasErrorFor('linode_id')}
               linodes={compose(
@@ -351,10 +357,11 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       title: 'Clone From Existing',
       render: () => {
         const hasErrorFor = getAPIErrorsFor(errorResources, this.state.errors);
+        const generalError = hasErrorFor('none');
         return (
           <React.Fragment>
-            {!!this.state.responseError &&
-              <Notice text={this.state.responseError} error={true} />
+            {!!generalError &&
+              <Notice text={generalError} error={true} />
             }
             <Notice text={`This newly created Linode wil be created with
             the same root password as the original Linode`} warning={true} />
@@ -415,7 +422,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
   }
 
   onDeploy = () => {
-    this.setState({ errors: [], responseError: '' });
+    this.setState({ errors: [] });
     const {
       selectedTab,
       selectedLinodeID,
@@ -550,7 +557,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
         });
 
         this.setState(() => ({
-          responseError: error.response.data.errors[0].reason,
+          errors: error.response && error.response.data && error.response.data.errors,
         }));
       })
       .finally(() => {
@@ -628,9 +635,6 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
 
     const tabRender = this.tabs[selectedTab].render;
 
-    const hasErrorFor = getAPIErrorsFor(errorResources, this.state.errors);
-    const generalError = hasErrorFor('none');
-
     return (
       <StickyContainer>
         <Grid container>
@@ -658,7 +662,6 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
                 (props: StickyProps) => {
                   const combinedProps = {
                     ...props,
-                    error: generalError,
                     label,
                     imageInfo,
                     typeInfo,

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -410,6 +410,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
 
   imageTabIndex = this.tabs.findIndex(tab => tab.title.toLowerCase().includes('image'));
   backupTabIndex = this.tabs.findIndex(tab => tab.title.toLowerCase().includes('backup'));
+  cloneTabIndex = this.tabs.findIndex(tab => tab.title.toLowerCase().includes('clone'));
 
   componentWillUnmount() {
     this.mounted = false;
@@ -442,6 +443,11 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
 
       if (!selectedBackupID) {
         /* a backup selection is also required */
+        window.scroll({
+          top: 0,
+          left: 0,
+          behavior: 'smooth',
+        });
         this.setState({
           errors: [
             { field: 'backup_id', reason: 'You must select a Backup' },
@@ -452,7 +458,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
       this.createNewLinode();
     }
     // we are cloning to another Linode
-    if (selectedTab === 2) {
+    if (selectedTab === this.cloneTabIndex) {
       // if selectedCloneTargetLinode is 'undefined,' no target Linode has been selected
       // if selectedCloneTargetLinode is null, that means we're cloning to a new Linode
       if (!selectedLinodeID || typeof selectedCloneTargetLinodeID === 'undefined') {

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -85,7 +85,6 @@ interface State {
   selectedBackupID?: number;
   selectedBackupInfo?: Info;
   smallestType?: string;
-  selectedTargetLinodeID?: number | null;
   selectedCloneTargetLinodeID?: number | null;
   selectedImageID: string | null;
   selectedRegionID: string | null;

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.test.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.test.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import SelectLinodePanel, { ExtendedLinode } from './SelectLinodePanel';
+import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
+
+describe('SelectLinodePanel', () => {
+  const testLinodes: ExtendedLinode[] = [
+    {
+      ipv4: [
+        '192.168.213.172',
+        '45.79.179.173',
+      ],
+      backups: {
+        schedule: {
+          window: 'blah',
+          day: 'blah',
+        },
+        enabled: false,
+      },
+      ipv6: '2600:3c03::f03c:91ff:fe05:7758/64',
+      specs: {
+        transfer: 3000,
+        memory: 4096,
+        disk: 49152,
+        vcpus: 2,
+      },
+      group: '',
+      image: 'linode/centos7',
+      region: 'us-east',
+      id: 7843027,
+      updated: '2018-05-04T15:04:41',
+      hypervisor: 'kvm',
+      type: 'g5-standard-2',
+      label: 'marty_test',
+      heading: 'marty_test',
+      subHeadings: ['blah'],
+      created: '2018-05-02T12:33:19',
+      status: 'offline',
+      alerts: {
+        transfer_quota: 80,
+        io: 10000,
+        network_in: 10,
+        network_out: 10,
+        cpu: 90,
+      },
+    },
+    {
+      ipv4: [
+        '45.79.156.70',
+      ],
+      backups: {
+        schedule: {
+          window: 'blah',
+          day: 'blah',
+        },
+        enabled: false,
+      },
+      ipv6: '2600:3c03::f03c:91ff:fe05:54a7/64',
+      specs: {
+        transfer: 2000,
+        memory: 2048,
+        disk: 30720,
+        vcpus: 1,
+      },
+      group: '',
+      image: 'linode/centos7',
+      region: 'us-east',
+      id: 7843080,
+      updated: '2018-05-04T14:58:15',
+      hypervisor: 'kvm',
+      type: 'g5-standard-1',
+      label: 'linode7843080',
+      heading: 'linode7843080',
+      subHeadings: ['blah'],
+      created: '2018-05-02T12:42:11',
+      status: 'running',
+      alerts: {
+        transfer_quota: 80,
+        io: 10000,
+        network_in: 10,
+        network_out: 10,
+        cpu: 90,
+      },
+    },
+  ];
+
+  const dummyPropsNotTarget = {
+    linodes: testLinodes,
+    isTarget: false,
+    handleSelection: jest.fn(),
+  };
+
+  const dummyPropsIsTarget = {
+    linodes: testLinodes,
+    isTarget: true,
+    handleSelection: jest.fn(),
+  };
+
+  it('select Linode Panel must show all Linodes if isTarget prop is false', () => {
+    const component = mount(
+      <LinodeThemeWrapper>
+        <SelectLinodePanel {...dummyPropsNotTarget} />
+      </LinodeThemeWrapper>,
+    );
+
+    const amountOfSelectionsRendered = component.find('SelectionCard').length;
+    expect(amountOfSelectionsRendered).toBe(2);
+  });
+
+  it('select Linode Panel must show all Linodes and new option if isTarget prop is true', () => {
+    const component = mount(
+      <LinodeThemeWrapper>
+        <SelectLinodePanel {...dummyPropsIsTarget} />
+      </LinodeThemeWrapper>,
+    );
+
+    const amountOfSelectionsRendered = component.find('SelectionCard').length;
+    expect(amountOfSelectionsRendered).toBe(3);
+  });
+});

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.test.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.test.tsx
@@ -85,22 +85,22 @@ describe('SelectLinodePanel', () => {
     },
   ];
 
-  const dummyPropsNotTarget = {
+  const dummyPropsNotCloneTarget = {
     linodes: testLinodes,
-    isTarget: false,
+    isCloneTarget: false,
     handleSelection: jest.fn(),
   };
 
-  const dummyPropsIsTarget = {
+  const dummyPropsIsCloneTarget = {
     linodes: testLinodes,
-    isTarget: true,
+    isCloneTarget: true,
     handleSelection: jest.fn(),
   };
 
   it('select Linode Panel must show all Linodes if isTarget prop is false', () => {
     const component = mount(
       <LinodeThemeWrapper>
-        <SelectLinodePanel {...dummyPropsNotTarget} />
+        <SelectLinodePanel {...dummyPropsNotCloneTarget} />
       </LinodeThemeWrapper>,
     );
 
@@ -111,7 +111,7 @@ describe('SelectLinodePanel', () => {
   it('select Linode Panel must show all Linodes and new option if isTarget prop is true', () => {
     const component = mount(
       <LinodeThemeWrapper>
-        <SelectLinodePanel {...dummyPropsIsTarget} />
+        <SelectLinodePanel {...dummyPropsIsCloneTarget} />
       </LinodeThemeWrapper>,
     );
 

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -43,7 +43,7 @@ interface Props {
   selectedLinodeID?: number;
   selectedCloneTargetLinodeID?: number | null;
   handleSelection: (key: string) =>
-    (event: React.SyntheticEvent<HTMLElement>, value: any) => void;
+    (event: React.SyntheticEvent<HTMLElement>, value?: string | null) => void;
   error?: string;
   header?: string;
   isCloneTarget?: boolean;

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -40,12 +40,12 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 interface Props {
   linodes: ExtendedLinode[];
   selectedLinodeID?: number;
-  selectedTargetLinodeID?: number | null;
+  selectedCloneTargetLinodeID?: number | null;
   handleSelection: (key: string) =>
     (event: React.SyntheticEvent<HTMLElement>, value: any) => void;
   error?: string;
   header?: string;
-  isTarget?: boolean;
+  isCloneTarget?: boolean;
 }
 
 type StyledProps = Props & WithStyles<ClassNames>;
@@ -55,12 +55,12 @@ type CombinedProps = StyledProps;
 class SelectLinodePanel extends React.Component<CombinedProps> {
   handleTypeSelect = this.props.handleSelection('selectedTypeID');
   handleSmallestType = this.props.handleSelection('smallestType');
-  handleSelection = (!this.props.isTarget)
+  handleSelection = (!this.props.isCloneTarget)
     ? this.props.handleSelection('selectedLinodeID')
-    : this.props.handleSelection('selectedTargetLinodeID');
+    : this.props.handleSelection('selectedCloneTargetLinodeID');
 
   renderCard(linode: ExtendedLinode) {
-    const { selectedLinodeID, selectedTargetLinodeID, isTarget } = this.props;
+    const { selectedLinodeID, selectedCloneTargetLinodeID, isCloneTarget } = this.props;
     return (
       <SelectionCard
         key={linode.id}
@@ -69,11 +69,11 @@ class SelectLinodePanel extends React.Component<CombinedProps> {
           this.handleTypeSelect(e, undefined);
           this.handleSmallestType(e, `${linode.type}`);
         }}
-        disabled={(!!isTarget)
+        disabled={(!!isCloneTarget)
           ? linode.id === Number(selectedLinodeID)
-          : linode.id === Number(selectedTargetLinodeID)}
-        checked={(!!isTarget)
-          ? linode.id === Number(selectedTargetLinodeID)
+          : linode.id === Number(selectedCloneTargetLinodeID)}
+        checked={(!!isCloneTarget)
+          ? linode.id === Number(selectedCloneTargetLinodeID)
           : linode.id === Number(selectedLinodeID)}
         heading={linode.heading}
         subheadings={linode.subHeadings}
@@ -82,7 +82,8 @@ class SelectLinodePanel extends React.Component<CombinedProps> {
   }
 
   render() {
-    const { error, classes, linodes, header, isTarget, selectedTargetLinodeID } = this.props;
+    const { error, classes, linodes, header,
+      isCloneTarget, selectedCloneTargetLinodeID } = this.props;
 
     return (
       <Paper className={`${classes.root}`}>
@@ -93,9 +94,9 @@ class SelectLinodePanel extends React.Component<CombinedProps> {
           </Typography>
           <Typography component="div" className={classes.panelBody}>
             <Grid container>
-              {isTarget &&
+              {isCloneTarget &&
                 <SelectionCard
-                  checked={selectedTargetLinodeID === null}
+                  checked={selectedCloneTargetLinodeID === null}
                   onClick={e => this.handleSelection(e, null)}
                   heading={'New Linode'}
                   subheadings={[]}

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -69,7 +69,10 @@ class SelectLinodePanel extends React.Component<CombinedProps> {
           this.handleTypeSelect(e, undefined);
           this.handleSmallestType(e, `${linode.type}`);
         }}
-        checked={(isTarget)
+        disabled={(!!isTarget)
+          ? linode.id === Number(selectedLinodeID)
+          : linode.id === Number(selectedTargetLinodeID)}
+        checked={(!!isTarget)
           ? linode.id === Number(selectedTargetLinodeID)
           : linode.id === Number(selectedLinodeID)}
         heading={linode.heading}

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -19,9 +19,9 @@ export interface ExtendedLinode extends Linode.Linode {
 }
 
 type ClassNames =
-'root'
-| 'inner'
-| 'panelBody';
+  'root'
+  | 'inner'
+  | 'panelBody';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -40,9 +40,12 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 interface Props {
   linodes: ExtendedLinode[];
   selectedLinodeID?: number;
+  selectedTargetLinodeID?: number | null;
   handleSelection: (key: string) =>
-    (event: React.SyntheticEvent<HTMLElement>, value?: string) => void;
+    (event: React.SyntheticEvent<HTMLElement>, value: any) => void;
   error?: string;
+  header?: string;
+  isTarget?: boolean;
 }
 
 type StyledProps = Props & WithStyles<ClassNames>;
@@ -50,21 +53,25 @@ type StyledProps = Props & WithStyles<ClassNames>;
 type CombinedProps = StyledProps;
 
 class SelectLinodePanel extends React.Component<CombinedProps> {
-  handleSelection = this.props.handleSelection('selectedLinodeID');
   handleTypeSelect = this.props.handleSelection('selectedTypeID');
   handleSmallestType = this.props.handleSelection('smallestType');
+  handleSelection = (!this.props.isTarget)
+    ? this.props.handleSelection('selectedLinodeID')
+    : this.props.handleSelection('selectedTargetLinodeID');
 
   renderCard(linode: ExtendedLinode) {
-    const { selectedLinodeID } = this.props;
+    const { selectedLinodeID, selectedTargetLinodeID, isTarget } = this.props;
     return (
       <SelectionCard
         key={linode.id}
-        checked={linode.id === Number(selectedLinodeID)}
         onClick={(e) => {
           this.handleSelection(e, `${linode.id}`);
           this.handleTypeSelect(e, undefined);
           this.handleSmallestType(e, `${linode.type}`);
         }}
+        checked={(isTarget)
+          ? linode.id === Number(selectedTargetLinodeID)
+          : linode.id === Number(selectedLinodeID)}
         heading={linode.heading}
         subheadings={linode.subHeadings}
       />
@@ -72,17 +79,25 @@ class SelectLinodePanel extends React.Component<CombinedProps> {
   }
 
   render() {
-    const { error, classes, linodes } = this.props;
+    const { error, classes, linodes, header, isTarget, selectedTargetLinodeID } = this.props;
 
     return (
       <Paper className={`${classes.root}`}>
         <div className={classes.inner}>
-          { error && <Notice text={error} error /> }
+          {error && <Notice text={error} error />}
           <Typography variant="title">
-            Select Linode
+            {(!!header) ? header : 'Select Linode'}
           </Typography>
           <Typography component="div" className={classes.panelBody}>
             <Grid container>
+              {isTarget &&
+                <SelectionCard
+                  checked={selectedTargetLinodeID === null}
+                  onClick={e => this.handleSelection(e, null)}
+                  heading={'New Linode'}
+                  subheadings={[]}
+                />
+              }
               {linodes.map((linode) => {
                 return (
                   this.renderCard(linode)

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -28,6 +28,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     flexGrow: 1,
     width: '100%',
     backgroundColor: theme.color.white,
+    marginBottom: theme.spacing.unit * 3,
   },
   inner: {
     padding: theme.spacing.unit * 3,

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -354,7 +354,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
             variant="headline"
             className={this.props.classes.title}
             data-qa-title
-            >
+          >
             Linodes
           </Typography>
           <Hidden smDown>

--- a/src/services/linodes.ts
+++ b/src/services/linodes.ts
@@ -220,3 +220,19 @@ export const deleteLinodeDisk = (
   setMethod('DELETE'),
   );
 
+export interface LinodeCloneData {
+  region: string | null;
+  type: string | null;
+  linode_id?: number | null;
+  label?: string | null;
+  backups_enabled?: boolean | null;
+}
+
+export const cloneLinode = (source_linode_id: number, data: LinodeCloneData) => {
+  return Request(
+    setURL(`${API_ROOT}/linode/instances/${source_linode_id}/clone`),
+    setMethod('POST'),
+    setData(data),
+  );
+};
+

--- a/src/services/linodes.ts
+++ b/src/services/linodes.ts
@@ -221,8 +221,8 @@ export const deleteLinodeDisk = (
   );
 
 export interface LinodeCloneData {
-  region: string | null;
-  type: string | null;
+  region?: string | null;
+  type?: string | null;
   linode_id?: number | null;
   label?: string | null;
   backups_enabled?: boolean | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,6 +806,10 @@
   version "9.4.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.6.tgz#d8176d864ee48753d053783e4e463aec86b8d82e"
 
+"@types/promise.prototype.finally@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/promise.prototype.finally/-/promise.prototype.finally-2.0.2.tgz#68fefb8f0e23f21893a33740c931c79f44be3499"
+
 "@types/ramda@^0.25.18":
   version "0.25.18"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.18.tgz#a026777d780226a08a50a50a353ce901490f0b92"


### PR DESCRIPTION
## Purpose
adds functionality to clone a Linode to either a new Linode or existing Linode. Added onto the Create Linode flow

## Functionality
* On success, the user is directed back to the Linodes landing
* On API Error, an error appears at the top of the form with the response returned from the API.
* Front-end validates that a source and target Linode have been selected - nothing else
* On form submit, checkout button is disabled, and re-enabled if an error returns
* On any error, form will auto-scroll to top
* Source Linodes cannot be cloned into Target Linodes. When a source is selected, the target counterpart will be disabled (and vice-versa)
* If cloning to new Linode, region, type, and label are disallowed, as per the API

## Other notes
* added the promise.prototype.finally package in order to set state, regardless of whether Promise resolves or rejects
* Decided against making the SelectClonePanel component and instead just re-used the SelectLinodePanel, since there weren't going to be many differences