### PR TITLE
M3-332 close expansion panel only if the header is clicked

### DIFF
--- a/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
+++ b/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
@@ -13,7 +13,7 @@ import KeyboardArrowRight from 'material-ui-icons/KeyboardArrowRight';
 
 
 
-type CSSClasses = 'root' | 'header' | 'caret' ;
+type CSSClasses = 'root' | 'header' | 'caret';
 
 const styles: StyleRulesCallback = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -79,17 +79,20 @@ class ShowMoreExpansion extends React.Component<CombinedProps, State> {
       <ListItem
         className={classes.root}
         button
-        onClick={this.handleNameClick}
         disableRipple
         aria-haspopup="true"
         aria-expanded={open ? 'true' : 'false'}
         role="menu"
         data-qa-show-more-expanded={open ? 'true' : 'false'}
+      >
+        <div
+          onClick={this.handleNameClick}
+          className={`${classes.header} ${open ? 'hOpen' : ''}`}
+          data-qa-show-more-toggle
         >
-        <div className={`${classes.header} ${open ? 'hOpen' : '' }`} data-qa-show-more-toggle>
           {open
             ? <KeyboardArrowRight className={classes.caret + ' rotate'} />
-            : <KeyboardArrowRight className={classes.caret}  />
+            : <KeyboardArrowRight className={classes.caret} />
           }
           <span>{name}</span>
         </div>


### PR DESCRIPTION
## Purpose

Previously, when selecting an older image in the create Linode flow, it would automatically close the ShowMoreExpansion panel. Now, only clicking the header of the ShowMoreExpansion panel will open/close it