### PR TITLE
Fix - Resize/Rebuild Test Suites, lock docker version

### DIFF
--- a/e2e/config/wdio.storybook.conf.js
+++ b/e2e/config/wdio.storybook.conf.js
@@ -36,6 +36,9 @@ exports.config = merge(wdioMaster.config, {
         browser.url(constants.routes.storybook);
 
         // Collapse first story
+        browser.waitUntil(function() {
+            return $$('[data-name]').length > 0;
+        }, 5000, 'Stories not displaying. Is storybook running?');
         const defaultChildStories = $$('[data-name]')[0].$('[data-name]');
         $$('[data-name]')[0].click();
         defaultChildStories.waitForVisible(3000, true);

--- a/e2e/pageobjects/linode-detail-rebuild.page.js
+++ b/e2e/pageobjects/linode-detail-rebuild.page.js
@@ -6,7 +6,7 @@ class Rebuild {
     get imagesSelect() { return $('[data-qa-rebuild-image]'); }
     get password() { return $('[data-qa-hide] input'); }
     get submit() { return $('[data-qa-rebuild]'); }
-    get imageSelectHeader() { return $$('[data-qa-select-header]'); }
+    get imageSelectHeader() { return $('[data-qa-select-header]'); }
     get imageOptions() { return $$('[data-qa-image-option]'); }
     get imageError() { return $('[data-qa-image-error]'); }
 

--- a/e2e/pageobjects/linode-detail-resize.page.js
+++ b/e2e/pageobjects/linode-detail-resize.page.js
@@ -20,7 +20,7 @@ class Resize extends Page {
         expect(this.currentSelection.isVisible()).toBe(true);
         expect(this.submit.isVisible()).toBe(true);
         expect(this.planCards.length).toBeGreaterThan(0);
-        expect(checkedCards.length).toBe(1);
+        expect(checkedCards.length).toBe(0);
         expect(selectedPlanTab[0].getAttribute('data-qa-tab')).toBe('Standard');
     }
 }

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -26,6 +26,7 @@ export default class Page {
         const displayedMsg = browser.getText('[data-qa-toast-message]');
         expect(displayedMsg).toBe(expectedMessage);
         browser.click('[data-qa-toast] button');
+        browser.waitForExist('[data-qa-toast]', 5000, true);
     }
 
     dismissToast() {

--- a/e2e/specs/linodes/detail/backups.spec.js
+++ b/e2e/specs/linodes/detail/backups.spec.js
@@ -41,6 +41,7 @@ describe('Linode Detail - Backups Suite', () => {
 
         const toastMsg = 'Snapshot label must be a string of 1 to 255 characters';
         Backups.toastDisplays(toastMsg);
+        browser.waitForExist('[data-qa-toast]', 5000, true);
     });
 
     it('should cancel backups', () => {

--- a/e2e/specs/linodes/detail/rebuild.spec.js
+++ b/e2e/specs/linodes/detail/rebuild.spec.js
@@ -33,7 +33,8 @@ describe('Linode Detail - Rebuild Suite', () => {
 
     it('should display image options in the select', () => {
         Rebuild.imagesSelect.click();
-        Rebuild.imageSelectHeader.forEach(header => expect(header.isVisible()).toBe(true));
+
+        expect(Rebuild.imageSelectHeader.isVisible()).toBe(true);
         Rebuild.imageOptions.forEach(option => expect(option.isVisible()).toBe(true));
     });
 

--- a/e2e/specs/linodes/detail/resize.spec.js
+++ b/e2e/specs/linodes/detail/resize.spec.js
@@ -11,7 +11,7 @@ describe('Linode Detail - Resize Suite', () => {
         browser.url(constants.routes.linodes);
         browser.waitForVisible('[data-qa-add-new-menu-button]');
         createGenericLinode(linodeName);
-        browser.click(`[data-qa-linode=${linodeName}] [data-qa-label]`);
+        browser.click(`[data-qa-linode="${linodeName}"] [data-qa-label]`);
         LinodeDetail
             .landingElemsDisplay()
             .changeTab('Resize');
@@ -28,15 +28,16 @@ describe('Linode Detail - Resize Suite', () => {
 
     it('should fail to resize on the same plan selection', () => {
         const toastMsg = 'Linode is already running this service plan.';
+        
+        Resize.planCards[0].click();
         Resize.submit.click();
         Resize.toastDisplays(toastMsg);
     });
 
     it('should display toast message on resize', () => {
-        const uncheckedPlans = Resize.planCards.filter(p => !p.getAttribute('class').includes('checked'));
         const toastMsg = 'Linode resize started.';
 
-        uncheckedPlans[0].click();
+        Resize.planCards[1].click();
         Resize.submit.click();
         Resize.toastDisplays(toastMsg);
     });

--- a/integration-test.yml
+++ b/integration-test.yml
@@ -1,11 +1,11 @@
 version: '3.1'
 services: 
   selenium-hub:
-    image: selenium/hub:3.11.0-bismuth
+    image: selenium/hub:3.4.0-francium
     ports:
       - "4444:4444"
   chrome:
-    image: selenium/node-chrome:3.11.0-bismuth
+    image: selenium/node-chrome:3.4.0-francium
     depends_on:
       - selenium-hub
     volumes:


### PR DESCRIPTION
* Update resize and rebuild tests to account for new behavior
* Add a wait for a toast message to no longer display after dismissing. This resolved issues where a toast would be dismissed and another action would be taken that expected a toast message..
* Pin the version of selenium in docker compose file to the one we use across the project (3.4.0)

## To Test
```bash
yarn && yarn start
yarn selenium # in a new shell
yarn e2e --file e2e/specs/linodes/detail/backups.spec.js
yarn e2e --file e2e/specs/linodes/detail/rebuild.spec.js
yarn e2e --file e2e/specs/linodes/detail/resize.spec.js
```
