### PR TITLE
Make Storybook tests GREAT again

### DIFF
--- a/e2e/config/wdio.storybook.conf.js
+++ b/e2e/config/wdio.storybook.conf.js
@@ -33,12 +33,6 @@ exports.config = merge(wdioMaster.config, {
     seleniumArgs: seleniumSettings,
     before: function (capabilities, specs) {
         browserCommands();
-        browser.url(constants.routes.storybook);
-
-        // Collapse first story
-        const defaultChildStories = $$('[data-name]')[0].$('[data-name]');
-        $$('[data-name]')[0].click();
-        defaultChildStories.waitForVisible(3000, true);
     },
     beforeSuite: function(suite) {
         // Do nothing before suites

--- a/e2e/utils/storybook.js
+++ b/e2e/utils/storybook.js
@@ -1,22 +1,5 @@
-/*
-* Sets focus to storybook preview iframe
-* @returns { null } returns nothing
-*/
-exports.previewFocus = () => {
-    // Shift focus to storybook preview iFrame
-    const storybookPreviewFrame = $('#storybook-preview-iframe').value;
-    browser.frame(storybookPreviewFrame);
-}
-
-/*
-* Poll the DOM for 10 seconds for a element and repeats set-frame focus each time
-* @returns { Boolean } returns true or false
-*/
-exports.waitForFocus = (elementToBeFocused) => {
-    return browser.waitUntil(function() {
-        exports.previewFocus();
-        return browser.isExisting(elementToBeFocused) !== false;
-    }, 10000)
+exports.navigateToStory = (component, story) => {
+    browser.url(`/iframe.html?selectedKind=${component}&selectedStory=${story}`);
 }
 
 /*
@@ -26,14 +9,9 @@ exports.waitForFocus = (elementToBeFocused) => {
 * @param { Function } function containing actions to take in each story
 * @returns { null } returns nothing
 */
-exports.executeInAllStories = (storyArray, callback) => {
+exports.executeInAllStories = (component, storyArray, callback) => {
     storyArray.forEach(story => {
-        browser.click(story);
-        browser.waitUntil(function() {
-            return browser.getAttribute(story, 'href').includes('?selectedKind');
-        }, 5000);
-        exports.previewFocus();
+        exports.navigateToStory(component, story);
         callback();
-        browser.frame();
     });
 }

--- a/src/components/Button/button.spec.js
+++ b/src/components/Button/button.spec.js
@@ -1,13 +1,13 @@
-const { waitForFocus, previewFocus, executeInAllStories } = require('../../../e2e/utils/storybook');
+const { navigateToStory, executeInAllStories } = require('../../../e2e/utils/storybook');
 
 describe('Button Suite', () => {
-    const menuItem = '[data-name="Button"]';
+    const component = 'Button';
     const childStories = [
-        '[data-name="Types"]',
-        '[data-name="Disabled"]',
-        '[data-name="Primary Dropdown"]',
-        '[data-name="Secondary Dropdown"]',
-        '[data-name="Destructive"]'
+        'Types',
+        'Disabled',
+        'Primary Dropdown',
+        'Secondary Dropdown',
+        'Destructive',
     ]
     const button = {
         generic: '[data-qa-button]',
@@ -18,21 +18,9 @@ describe('Button Suite', () => {
         destructive: '[data-qa-button="Destructive"]',
     }
 
-    it('should display button component in navigation', () => {
-        const buttonNavItem = $(menuItem);
-        expect(buttonNavItem.isVisible()).toBe(true);
-    });
-
-    it('should display child stories in navigation', () => {
-        browser.click(menuItem);
-
-        childStories.forEach(story => {
-            expect($(story).waitForVisible()).toBe(true)
-        });
-    });
-
     it('should display buttons in each story', () => {
-        executeInAllStories(childStories, () => {
+        executeInAllStories(component, childStories, () => {
+            browser.waitForVisible('[data-qa-button]');
             const buttons = $$(button.generic);
             buttons.forEach(b => expect(b.isVisible()).toBe(true));
         });
@@ -42,11 +30,11 @@ describe('Button Suite', () => {
         let primaryButtons, secondaryButtons;
 
         beforeAll(() => {
-            browser.click(childStories[0]);
-        })
+            navigateToStory(component, childStories[1]);
+        });
 
         it('should display primary button', () => {
-            waitForFocus(button.primary);
+            browser.waitForVisible(button.primary);
 
             primaryButtons = $$(button.primary);
             expect(primaryButtons.length).toBe(1);
@@ -89,9 +77,8 @@ describe('Button Suite', () => {
         let primaryDowndowns;
 
         beforeAll(() => {
-            browser.frame();
-            browser.click(childStories[2]);
-            previewFocus();
+            navigateToStory(component, childStories[2]);
+            browser.waitForVisible(button.generic);
         });
 
         it('should display dropdown buttons with carat', () => {
@@ -112,9 +99,8 @@ describe('Button Suite', () => {
         let secondaryDropdowns;
 
         beforeAll(() => {
-            browser.frame();
-            browser.click(childStories[3]);
-            previewFocus();
+            navigateToStory(component, childStories[3]);
+            browser.waitForVisible(button.generic);
         })
 
         it('should display dropdown buttons with carat', () => {
@@ -134,9 +120,7 @@ describe('Button Suite', () => {
     xdescribe('Destructive Button', () => {
 
         beforeAll(() => {
-            browser.frame();
-            browser.click(childStories[4]);
-            waitForFocus(button.destructive);
+            navigateToStory(component, childStories[4]);
         });
         
         let destructiveButtons;

--- a/src/components/CheckBox/CheckBox.spec.js
+++ b/src/components/CheckBox/CheckBox.spec.js
@@ -1,25 +1,16 @@
 const { constants } = require('../../../e2e/constants');
-const { waitForFocus } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
+
+const component = 'CheckBox';
+const stories = ['Interactive'];
+
 
 describe('Checkbox Component Suite', () => {
     beforeAll(() => {
-        browser.waitForVisible('html body div#root div div div.SplitPane.vertical div.Pane.vertical.Pane1 div div div div a h3');
-    });
-
-    it('should display checkbox component in navigation', () => {
-        const checkboxNavItem = $('[data-name="CheckBox"]');
-        expect(checkboxNavItem.getText()).toBe('CheckBox');
-    });
-
-    it('should have an interactive story', () => {
-        $('[data-name="CheckBox"]').click();
-        const interactive = $('[data-name="Interactive"]');
-        expect(interactive.getText()).toBe('Interactive');
+        navigateToStory(component, stories[0]);
     });
 
     it('should display checkboxes on interactive story', () => {
-        browser.click('[data-name="Interactive"]');
-        waitForFocus('[data-qa-checked]');
         const checkboxes = $$('[data-qa-checked]'); 
         checkboxes.forEach(e => expect(e.isVisible()).toBe(true));
     });
@@ -28,8 +19,6 @@ describe('Checkbox Component Suite', () => {
         const initialChecked = $$('[data-qa-checked="true"]');
         const enabledCheckboxes = $$('[data-qa-checked]').filter(e => !e.getAttribute('class').includes('disabled'));
         enabledCheckboxes.forEach(e => e.click());
-
-        waitForFocus('[data-qa-checked]');
 
         const updatedCheckboxValues = $$('[data-qa-checked="true"]');
         
@@ -40,8 +29,7 @@ describe('Checkbox Component Suite', () => {
         const enabledAndChecked = $$('[data-qa-checked="true"]').filter(e => !e.getAttribute('class').includes('disabled'));
 
         enabledAndChecked.forEach(e => e.click());
-
-        waitForFocus('[data-qa-checked]');
+        
         const updatedCheckboxValues = $$('[data-qa-checked="true"]').filter(e => !e.getAttribute('class').includes('disabled'));
 
         expect(updatedCheckboxValues).toEqual([]);
@@ -49,7 +37,6 @@ describe('Checkbox Component Suite', () => {
 
     it('should display different variants of checkboxes', () => {
         const checkboxes = $$('[data-qa-checked]');
-        waitForFocus('[data-qa-checked]');
 
         const variants = checkboxes.map(e => e.getAttribute('variant'));
         
@@ -62,10 +49,8 @@ describe('Checkbox Component Suite', () => {
 
         // Click on all checked disabled boxes
         // Use jsClickAll to avoid other element would receive click error
-        waitForFocus('[data-qa-checked]');
+        
         browser.jsClickAll('[data-qa-checked="true"]:disabled');
-
-        waitForFocus('[data-qa-checked]');
 
         const afterClick = $$('[data-qa-checked="true"]').filter(e => e.getAttribute('class').includes('disabled'));
         expect(afterClick.length).toBe(checkedDisabledBoxes.length);
@@ -77,8 +62,6 @@ describe('Checkbox Component Suite', () => {
         // Click on all unchecked disabled boxes
         // Use jsClickAll to avoid other element would receive click error
         browser.jsClickAll('[data-qa-checked="false"]:disabled');
-
-        waitForFocus('[data-qa-checked]');
 
         const afterClick = $$('[data-qa-checked="false"]').filter(e => e.getAttribute('class').includes('disabled'));
 

--- a/src/components/CircleProgress/CircleProgress.spec.js
+++ b/src/components/CircleProgress/CircleProgress.spec.js
@@ -1,23 +1,18 @@
 const { constants } = require('../../../e2e/constants');
-const { waitForFocus } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Circle Progress Indicator Component Suite', () => {
-    it('should display circle progess Indicator in the navigation', () => {
-        const navigationItem = $('[data-name="Circle Progress Indicator"]');
-        expect(navigationItem.isVisible()).toBe(true);
-    });
+    const component = 'Circle Progress Indicator';
+    const childStory = [
+        'Indefinite',
+    ]
 
-    it('should display indefinite story', () => {
-        browser.click('[data-name="Circle Progress Indicator"]');
-        waitForFocus('[data-name="Indefinite"]');
-
-        const indefiniteStory = $('[data-name="Indefinite"]');
-        expect(indefiniteStory.isVisible()).toBe(true);
+    beforeAll(() => {
+        navigateToStory(component, childStory[0]);
     });
 
     it('should display indefinite progress indicator', () => {
-        browser.click('[data-name="Indefinite"]');
-        waitForFocus('[data-qa-circle-progress]');
+        browser.waitForVisible('[data-qa-circle-progress]');
 
         const progressIndicator = $('[data-qa-circle-progress]');
         const role = progressIndicator.getAttribute('role');
@@ -27,13 +22,11 @@ describe('Circle Progress Indicator Component Suite', () => {
     });
 
     it('should contain an svg child element', () => {
-        waitForFocus('[data-qa-circle-progress]');
         const svg = $('[data-qa-circle-progress] > svg' );
         expect(svg.isVisible()).toBe(true);
     });
 
     it('should be indefinite variant', () => {
-        waitForFocus('[data-qa-circle-progress]');
         const svgClasses = $('[data-qa-circle-progress] > svg' ).getAttribute('class');
         expect(svgClasses).toContain('Indeterminate');
     });

--- a/src/components/Drawer/Drawer.spec.js
+++ b/src/components/Drawer/Drawer.spec.js
@@ -1,19 +1,19 @@
-const { previewFocus } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Drawer Suite', () => {
-    const menuItem = '[data-name="Drawer"]';
-    const childStory = '[data-name="Example"]';
+    const component = 'Drawer';
+    const childStories = [
+        'Example',
+    ];
     const drawerElem = '[data-qa-drawer]';
     const toggleDrawer = '[data-qa-toggle-drawer]';
 
     beforeAll(() => {
-        browser.click(menuItem);
-        browser.waitForVisible(childStory);
-        browser.click(childStory);
-        previewFocus();
+        navigateToStory(component, childStories[0]);
     });
 
     it('should display the drawer on click', () => {
+        browser.waitForVisible(toggleDrawer);
         browser.click(toggleDrawer);
         browser.waitForVisible(drawerElem);
     });

--- a/src/components/ErrorState/ErrorState.spec.js
+++ b/src/components/ErrorState/ErrorState.spec.js
@@ -1,31 +1,25 @@
 const { constants } = require('../../../e2e/constants');
-const { waitForFocus } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Error State Component Suite', () => {
-    const navItem = '[data-name="Error Display"]';
-    const navChild = '[data-name="with text"]';
+    const component = 'Error Display';
+    const childStories = [
+        'with text'
+    ]
     const icon = '[data-qa-error-icon]';
     const errorMsg = '[data-qa-error-msg]';
 
-    it('should display error states in the navigation', () => {
-        const errorState = $(navItem);
-        expect(errorState.isVisible()).toBe(true);
-    });
-
-    it('should display error state "with text" story', () => {
-        browser.click(navItem);
-        const withTextStory = $(navChild);
-        expect(withTextStory.isVisible()).toBe(true);
+    beforeAll(() => {
+        navigateToStory(component, childStories[0]);
     });
 
     it('should display error state with text elements', () => {
-        browser.click(navChild);
-
-        waitForFocus('[data-qa-error-icon]');
+        browser.waitForVisible('[data-qa-error-icon]');
 
         const errorIcon = $(icon);
         const errorText = $(errorMsg);
 
+        expect(errorIcon.getTagName()).toBe('svg');
         expect(errorIcon.isVisible()).toBe(true);
         expect(errorText.getText()).toBe('An error has occured.');
     });

--- a/src/components/ExpansionPanel/ExpansionPanel.spec.js
+++ b/src/components/ExpansionPanel/ExpansionPanel.spec.js
@@ -1,12 +1,12 @@
-const { waitForFocus, previewFocus } = require('../../../e2e/utils/storybook');
+const { navigateToStory, executeInAllStories } = require('../../../e2e/utils/storybook');
 
 describe('Expansion Panel Suite', () => {
-    const navItem = '[data-name="ExpansionPanel"]';
+    const component = 'ExpansionPanel';
     const childStories = [
-        '[data-name="Interactive"]',
-        '[data-name="Success!"]',
-        '[data-name="Warning!"]',
-        '[data-name="Error!"]',
+        'Interactive',
+        'Success!',
+        'Warning!',
+        'Error!',
     ];
 
     const panel = '[data-qa-panel]';
@@ -26,35 +26,21 @@ describe('Expansion Panel Suite', () => {
         browser.waitForVisible(gridItem, 5000, opposite)
     }
 
-    it('should display expansion panel story in navigation', () => {
-        const nav = $(navItem);
-        expect(nav.isVisible()).toBe(true);
-    });
-
-    it('should display child stories', () => {
-        $(navItem).click();
-        childElements = childStories.map((c) => $(c));
-        childElements.forEach(c => c.click());
-    });
-
     it('should display expansion panels', () => {
-        childElements.forEach(c => {
-            c.click();
-            waitForFocus(panel);
+        executeInAllStories(component, childStories, () => {
+            browser.waitForVisible(panel);
 
             const expansionPanel = $(panel);
             const expansionPanelText = $(panelSubheading);
             expect(expansionPanel.isVisible()).toBe(true);
             expect(expansionPanelText.getText()).toMatch(/([a-z])/ig);
-            browser.frame();
         });
     });
 
     describe('Interactive Suite', () => {
         beforeAll(() => {
-            browser.frame();
-            childElements[0].click();
-            previewFocus();
+            navigateToStory(component, childStories[0]);
+            browser.waitForVisible(panel);
         });
 
         it('should expand and display message text', () => {
@@ -68,9 +54,8 @@ describe('Expansion Panel Suite', () => {
 
     describe('Success Suite', () => {
         beforeAll(() => {
-            browser.frame();
-            childElements[1].click();
-            previewFocus();
+            navigateToStory(component, childStories[1]);
+            browser.waitForVisible(panel);
         });
 
         it('should expand on click and display message text', () => {
@@ -94,9 +79,8 @@ describe('Expansion Panel Suite', () => {
 
     describe('Warning Suite', () => {
         beforeAll(() => {
-            browser.frame();
-            childElements[2].click();
-            previewFocus();
+            navigateToStory(component, childStories[1]);
+            browser.waitForVisible(panel);
         });
 
         it('should expand on click and display message text', () => {
@@ -120,9 +104,8 @@ describe('Expansion Panel Suite', () => {
 
     describe('Error Suite', () => {
         beforeAll(() => {
-            browser.frame();
-            childElements[3].click();
-            previewFocus();
+            navigateToStory(component, childStories[2]);
+            browser.waitForVisible(panel);
         });
 
         it('should expand on click and display message text', () => {

--- a/src/components/HelpIcon/HelpIcon.spec.js
+++ b/src/components/HelpIcon/HelpIcon.spec.js
@@ -1,64 +1,46 @@
-const { constants } = require('../../../e2e/constants');
-const { waitForFocus } = require('../../../e2e/utils/storybook');
+const { executeInAllStories } = require('../../../e2e/utils/storybook');
 
 describe('Help Icon Component Suite', () => {
-    const navItem = '[data-name="HelpIcon"]';
-    const navChildren = [
-        '[data-name="default"]',
-        '[data-name="center"]',
-        '[data-name="left"]',
-        '[data-name="right"]' ];
+    const component = 'HelpIcon';
+    const childStories = [
+        'default',
+        'center',
+        'left',
+        'right',
+    ]
 
     const helpButton = '[data-qa-help-button]';
     const popoverText = '[data-qa-popover-text]';
     
-    it('should display help icon in the navigation', () => {
-        const helpIcon = $(navItem);
-        expect(helpIcon.isVisible()).toBe(true);
-    });
-
-    it('should display icon positioning stories', () => {
-        browser.click(navItem);
-
-        navChildren.forEach(e => expect(browser.isExisting(e)).toBe(true));
-    });
-
     it('should display icon on the page', () => {
-        navChildren.forEach(c => {
-            browser.frame();
-            browser.click(c);
-            waitForFocus(helpButton);
-
-            const buttonElement = $(helpButton);
-            expect(buttonElement.isVisible()).toBe(true);
+        executeInAllStories(component, childStories, () => {
+            browser.waitForVisible(helpButton);
         });
     });
 
     it('should display popover text on click', () => {
-        navChildren.forEach(c => {
-            browser.frame();
-            browser.click(c);
-            waitForFocus(helpButton);
+        executeInAllStories(component, childStories, () => {
+            browser.waitForVisible(helpButton);
 
             browser.click(helpButton);
             const popOver = $(popoverText);
+
             expect(popOver.isVisible()).toBe(true);
             expect(popOver.getText()).toBe('There is some help text! Yada, yada, yada...');
         });
     });
 
     it('should hide popover text on outside click', () => {
-        navChildren.forEach(c => {
-            browser.frame();
-            browser.click(c);
-            waitForFocus(helpButton);
+        executeInAllStories(component, childStories, () => {
+            browser.waitForVisible(helpButton);
 
             browser.click(helpButton);
             const popOver = $(popoverText);
             expect(popOver.isVisible()).toBe(true);
             
             browser.jsClick(helpButton);
-            waitForFocus(helpButton);
+
+            browser.waitForVisible(helpButton);
             const popOverTextHidden = browser.isVisible(popoverText);
             
             expect(popOverTextHidden).toBe(true);

--- a/src/components/IconTextLink/IconTextLink.spec.js
+++ b/src/components/IconTextLink/IconTextLink.spec.js
@@ -1,32 +1,19 @@
 const { constants } = require('../../../e2e/constants');
-const { waitForFocus } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Icon Text Link Suite', () => {
-    const parentMenuItem = '[data-name="IconTextLink"]';
-    const childMenuItem = '[data-name="Interactive"]';
+    const component = 'IconTextLink';
+    const childStories = [
+        'Interactive',
+    ]
     const iconTextLinkTitle = '[data-qa-icon-text-link="Link title"]';
 
-    it('should display icon text link in navigation', () => {
-        const iconTextLink = $(parentMenuItem);
-        expect(iconTextLink.isVisible()).toBe(true);
-    });
-
-    it('should display interactive in navigation', () => {
-        browser.click(parentMenuItem);
-
-        const interactive = $(childMenuItem);
-        expect(interactive.isVisible()).toBe(true);
+    beforeAll(() => {
+        navigateToStory(component, childStories[0]);
     });
 
     it('should display IconLinkText Components', () => {
-        // Wait until only one child menu displays before proceeding
-        browser.waitUntil(function() {
-            return $$(childMenuItem).length === 1;
-        }, 5000);
-
-        browser.click(childMenuItem);
-
-        waitForFocus(iconTextLinkTitle);
+        browser.waitForVisible(iconTextLinkTitle);
 
         const iconTextLinks = $$(iconTextLinkTitle);
         iconTextLinks.forEach(e => expect(e.isVisible()).toBe(true));
@@ -66,7 +53,7 @@ describe('Icon Text Link Suite', () => {
     });
 
     it('should show a disabled IconTextLink', () => {
-        waitForFocus(iconTextLinkTitle);
+        browser.waitForVisible(iconTextLinkTitle);
 
         const iconTextLinks = $$(iconTextLinkTitle);
         const disabledLinks = iconTextLinks.map(e => e.getAttribute('class').includes('disabled'));

--- a/src/components/LinearProgress/LinearProgress.spec.js
+++ b/src/components/LinearProgress/LinearProgress.spec.js
@@ -1,29 +1,18 @@
-const { constants } = require('../../../e2e/constants');
-const { waitForFocus } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Linear Progress Bar Suite', () => {
-    const parentMenuItem = '[data-name="Linear Progress Indicator"]';
-    const childMenuItem = '[data-name="Indefinite"]';
     const linearProgress = '[data-qa-linear-progress]';
+    const component = 'Linear Progress Indicator';
+    const childStories = [
+        'Indefinite',
+    ]
 
-    beforeAll(() => browser.url(constants.routes.storybook));
-
-    it('should display linear progress bar story in navigation', () => {
-        const progressMenuStory = $(parentMenuItem);
-        expect(progressMenuStory.isVisible()).toBe(true);
-    });
-
-    it('should display the indefinite progress story in navigation', () => {
-        browser.click(parentMenuItem);
-
-        const indefinite = $(childMenuItem);
-        expect(indefinite.isVisible()).toBe(true);
+    beforeAll(() => {
+        navigateToStory(component, childStories[0]);
     });
 
     it('should display indefinite linear bar on the page', () => {
-        browser.click(childMenuItem);
-
-        waitForFocus(linearProgress);
+        browser.waitForVisible(linearProgress);
 
         const progressBar = $(linearProgress);
         const role = progressBar.getAttribute('role');

--- a/src/components/PaginationControls/PaginationControls.spec.js
+++ b/src/components/PaginationControls/PaginationControls.spec.js
@@ -1,30 +1,18 @@
-const { constants } = require('../../../e2e/constants');
-const { waitForFocus } = require('../../../e2e/utils/storybook');
+const { executeInAllStories } = require('../../../e2e/utils/storybook');
 
 describe('Pagination Controls Suite', () => {
-    const menuItem = '[data-name="Pagination Controls"]';
-    const childMenuItems = ['[data-name="With even range."]', '[data-name="With odd range."]'];
+    const component = 'Pagination Controls';
+    const childStories = [
+        'With even range.',
+        'With odd range.',
+    ]
     const previous = '[data-qa-previous-page]';
     const jumpToPage = page => `[data-qa-page-to="${page}"]`;
     const next = '[data-qa-next-page]';
 
-    it('should display pagination controls in navigation', () => {
-        const paginationMenuStory = $(menuItem);
-        expect(paginationMenuStory.isVisible()).toBe(true);
-    });
-
-    it('should display pagination controls stories', () => {
-        browser.click(menuItem);
-        childMenuItems.forEach(e => browser.waitForVisible(e));
-    });
-
     it('should display pagination controls in each story', () => {
-        childMenuItems.forEach(story => {
-            // Reset frame on each story
-            browser.frame();
-            browser.click(story);
-
-            waitForFocus(next);
+        executeInAllStories(component, childStories, () => {
+            browser.waitForVisible(next);
 
             const prevPageElem = $(previous);
             const nextPageElem = $(next);
@@ -37,11 +25,8 @@ describe('Pagination Controls Suite', () => {
     });
 
     it('should default to page one', () => {
-        childMenuItems.forEach(item => {
-            browser.frame();
-            browser.click(item);
-
-            waitForFocus(next);
+        executeInAllStories(component, childStories, () => {
+            browser.waitForVisible(next);
             const activePage = $$('[data-qa-page-to]').filter(e => e.getAttribute('class').includes('active'));
 
             expect(activePage.length).toBe(1);
@@ -50,12 +35,8 @@ describe('Pagination Controls Suite', () => {
     });
 
     it('should page forward through all', () => {
-        childMenuItems.forEach(story => {
-            // Reset frame on each story
-            browser.frame();
-            browser.click(story);
-
-            waitForFocus(next);
+        executeInAllStories(component, childStories, () => {
+            browser.waitForVisible(next);
             let currentPage = 1;
 
             const canPage = (nextOrPrevious) => {
@@ -75,15 +56,8 @@ describe('Pagination Controls Suite', () => {
     });
     
     it('should page enable previous button after paging forward', () => {
-        browser.url(constants.routes.storybook);
-        browser.click(menuItem);
-
-        childMenuItems.forEach(story => {
-            //Reset frame on each story
-            browser.frame();
-            browser.click(story);
-
-            waitForFocus(next);
+        executeInAllStories(component, childStories, () => {
+            browser.waitForVisible(next);
 
             let previousDisabled = browser.getAttribute(previous, 'class').includes('disabled');
             expect(previousDisabled).toBe(true);

--- a/src/components/PasswordInput/PasswordInput.spec.js
+++ b/src/components/PasswordInput/PasswordInput.spec.js
@@ -1,9 +1,10 @@
-const { constants } = require('../../../e2e/constants');
-const { waitForFocus } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Password Input Suite', () => {
-    const menuItem = '[data-name="Password Input"]';
-    const childMenuItem = '[data-name="Example"]';
+    const component = 'Password Input';
+    const childStories = [
+        'Example',
+    ]
     const strengthIndicator = '[data-qa-strength]';
     const passwordInput = '[data-qa-hide] input';
 
@@ -21,21 +22,12 @@ describe('Password Input Suite', () => {
         }
     }
 
-    it('should display password input in navigation', () => {
-        const navItem = $(menuItem);
-        expect(navItem.isVisible()).toBe(true);
-    });
-
-    it('should display Example story', () => {
-        browser.click(menuItem);
-        
-        const exampleStory = $(childMenuItem);
-        expect(exampleStory.isVisible()).toBe(true);
+    beforeAll(() => {
+        navigateToStory(component, childStories[0]);
     });
 
     it('should display password input with strength indicator', () => {
-        browser.click(childMenuItem);
-        waitForFocus(passwordInput);
+        browser.waitForVisible(passwordInput);
 
         const input = $(passwordInput);
 

--- a/src/components/Radio/Radio.spec.js
+++ b/src/components/Radio/Radio.spec.js
@@ -1,31 +1,19 @@
-const { waitForFocus, executeInAllStories } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Radio Suite', () => {
-    const menuItem = '[data-name="Radio"]';
-    const childStory = '[data-name="Interactive"]';
+    const component = 'Radio';
+    const childStories = [
+        'Interactive',
+    ]
     const radio = '[data-qa-radio]';
     let radios;
 
-    it('should display radio component in navigation', () => {
-        const radioStory = $(menuItem);
-        expect(radioStory.isVisible()).toBe(true);
-    });
-
-    it('should display interactive child story', () => {
-        browser.click(menuItem);
-        expect($(childStory).waitForVisible()).toBe(true);
+    beforeAll(() => {
+        navigateToStory(component, childStories[0]);
     });
 
     it('should display radio buttons', () => {
-        browser.waitUntil(function() {
-            try {
-                browser.click(childStory);
-                return true;
-            } catch (err) {
-                return false;
-            }
-        }, 5000);
-        waitForFocus(radio);
+        browser.waitForVisible(radio);
         radios = $$(radio);
 
         radios.forEach(r => expect(r.isVisible()).toBe(true));

--- a/src/components/SelectionCard/SelectionCard.spec.js
+++ b/src/components/SelectionCard/SelectionCard.spec.js
@@ -1,24 +1,22 @@
-const { constants } = require('../../../e2e/constants');
-const { waitForFocus, executeInAllStories } = require('../../../e2e/utils/storybook');
+const { navigateToStory , executeInAllStories } = require('../../../e2e/utils/storybook');
 
 describe('Selection Card Suite', () => {
-    const menuItem = '[data-name="SelectionCard"]';
-    const childStories = {
-        "Interactive example" : '[data-name="Interactive example"]',
-        "Default with SvgIcon" : '[data-name="Default with SvgIcon"]',
-        "Default with plain SVG" : '[data-name="Default with plain SVG"]',
-        "Default with font Icon" : '[data-name="Default with font Icon"]',
-        "Default with no Icon" : '[data-name="Default with no Icon"]',
-        "Checked with SvgIcon" : '[data-name="Checked with SvgIcon"]',
-        "Checked with plain SVG" : '[data-name="Checked with plain SVG"]',
-        "Checked with font icon" : '[data-name="Checked with font Icon"]',
-        "Checked with no Icon" : '[data-name="Checked with no Icon"]',
-    }
+    const component = 'SelectionCard';
+    const childStories = [
+        'Interactive example',
+        'Default with SvgIcon',
+        'Default with plain SVG',
+        'Default with font Icon',
+        'Default with no Icon',
+        'Checked with SvgIcon',
+        'Checked with plain SVG',
+        'Checked with font Icon',
+        'Checked with no Icon',
+    ]
 
     const selectionCard = '[data-qa-selection-card]';
     const heading = '[data-qa-select-card-heading]';
     const subheading = '[data-qa-select-card-subheading]';
-    const childStoryArray = Object.values(childStories);
 
     const assertCardsChecked = () => {
         const selectionCardElems = $$(selectionCard);
@@ -56,28 +54,8 @@ describe('Selection Card Suite', () => {
         fontIcons.forEach(icon => expect(icon).toBe(false));
     }
 
-    const navigateToStory = (story) => {
-        browser.frame();
-        browser.click(story);
-        waitForFocus(selectionCard);
-    }
-
-    it('should display selection card in navigation', () => {
-        const selectionCardElemstory = $(menuItem);
-        expect(selectionCardElemstory.isVisible()).toBe(true);
-    });
-
-    it('should display selection card child stories', () => {
-        browser.click(menuItem);
-
-        browser.waitForVisible(childStoryArray[0]);
-        childStoryArray.forEach(story => {
-            expect(browser.isVisible(story)).toBe(true);
-        });
-    });
-
     it('should display selection cards', () => {
-        executeInAllStories(childStoryArray, () => {
+        executeInAllStories(component, childStories, () => {
             browser.jsClick(selectionCard);
 
             const selectionCardElems = $$(selectionCard);
@@ -88,7 +66,7 @@ describe('Selection Card Suite', () => {
     });
 
     it('should display headings on all selection cards', () => {
-        executeInAllStories(childStoryArray, () => {
+        executeInAllStories(component, childStories, () => {
             const headingElems = $$(heading);
             headingElems.forEach(e => expect(e.isVisible()).toBe(true));
         });
@@ -96,7 +74,7 @@ describe('Selection Card Suite', () => {
 
     describe('Interactive Example Suite', () => {
         beforeAll(() => {
-            navigateToStory(childStories["Interactive example"]);
+            navigateToStory(component, childStories[0]);
         });
 
         it('should display three selection card with one disabled', () => {
@@ -127,7 +105,7 @@ describe('Selection Card Suite', () => {
 
     describe('Default with SVGicon Suite', () => {
         beforeAll(() => {
-            navigateToStory(childStories["Default with SvgIcon"]);
+            navigateToStory(component, childStories[1]);
         });
 
         it('should display svg icons for all selection cards', () => {
@@ -137,7 +115,7 @@ describe('Selection Card Suite', () => {
 
     describe('Default with plain SVG', () => {
         beforeAll(() => {
-            navigateToStory(childStories["Default with plain SVG"]);
+            navigateToStory(component, childStories[2]);
         });
 
         it('should display plain svgs for all selection cards', () => {
@@ -147,7 +125,7 @@ describe('Selection Card Suite', () => {
 
     describe('Default with font Icon', () => {
         beforeAll(() => {
-            navigateToStory(childStories["Default with font Icon"]);
+            navigateToStory(component, childStories[3]);
         });
 
         it('should display a font icon on each selection card', () => {
@@ -157,7 +135,7 @@ describe('Selection Card Suite', () => {
 
     describe('Default with no icon', () => {
         beforeAll(() => {
-            navigateToStory(childStories["Default with no Icon"]);
+            navigateToStory(component, childStories[4]);
         });
 
         it('should not display svgs or font icons', () => {
@@ -167,7 +145,7 @@ describe('Selection Card Suite', () => {
 
     describe('Checked with SvgIcon Suite', () => {
         beforeAll(() => {
-            navigateToStory(childStories["Checked with SvgIcon"]);
+            navigateToStory(component, childStories[5]);
         });
 
         it('should display all selection cards as checked', () => {
@@ -182,7 +160,7 @@ describe('Selection Card Suite', () => {
 
     describe('Checked with plain SVG', () => {
         beforeAll(() => {
-            navigateToStory(childStories["Checked with plain SVG"]);
+            navigateToStory(component, childStories[6]);
         });
 
         it('should display plain svg', () => {
@@ -196,7 +174,7 @@ describe('Selection Card Suite', () => {
 
     describe('Checked with font icon', () => {
         beforeAll(() => {
-            navigateToStory(childStories["Checked with font icon"]);
+            navigateToStory(component, childStories[7]);
         });
 
         it('should display font icon', () => {
@@ -210,7 +188,7 @@ describe('Selection Card Suite', () => {
 
     describe('Checked with no Icon', () => {
         beforeAll(() => {
-            navigateToStory(childStories["Checked with no Icon"]);
+            navigateToStory(component, childStories[8]);
         });
 
         it('should be checked', () => {

--- a/src/components/ShowMoreExpansion/ShowMoreExpansion.spec.js
+++ b/src/components/ShowMoreExpansion/ShowMoreExpansion.spec.js
@@ -1,26 +1,19 @@
-const { constants } = require('../../../e2e/constants');
-const { waitForFocus } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Show More Expansion Suite', () => {
-    const menuItem = '[data-name="ShowMoreExpansion"]';
-    const childItem = '[data-name="default"';
+    const component = 'ShowMoreExpansion';
+    const childStories = [
+        'default',
+    ]
     const showMoreExpanded = '[data-qa-show-more-expanded]';
     const showMoreToggle = '[data-qa-show-more-toggle]';
 
-    it('should display show more expansion in the navigation', () => {
-        const showMoreExpandedMenu = $(menuItem);
-        expect(showMoreExpandedMenu.isVisible()).toBe(true);
-    });
-
-    it('should display the default show more story', () => {
-        browser.click(menuItem);
-        const defaultStory = $(childItem);
-        expect(defaultStory.isVisible()).toBe(true);
+    beforeAll(() => {
+        navigateToStory(component, childStories[0]);
     });
 
     it('should display show more expansion', () => {
-        browser.click(childItem);
-        waitForFocus(showMoreExpanded);
+        browser.waitForVisible(showMoreExpanded);
 
         const showMoreExpandedElem = $(showMoreExpanded);
 

--- a/src/components/TabbedPanel/TabbedPanel.spec.js
+++ b/src/components/TabbedPanel/TabbedPanel.spec.js
@@ -1,30 +1,22 @@
-const { constants } = require('../../../e2e/constants');
-const { waitForFocus } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Tabbed Panel Suite', () => {
-    const menuItem = '[data-name="TabbedPanel"]';
-    const childStory = '[data-name="default"]';
+    const component = 'TabbedPanel';
+    const childStories = [
+        'default',
+    ]
     const tabbedPanel = '[data-qa-tp]';
     const header = '[data-qa-tp-title]';
     const copy = '[data-qa-tp-copy]';
     const tab = '[data-qa-tab]';
     const tabBody = '[data-qa-tab-body]';
 
-    it('should display tabbed panel in navigation', () => {
-        const tabbedPanelMenu = $(menuItem);
-        expect(tabbedPanelMenu.isVisible()).toBe(true);
-    });
-
-    it('should display default panel story', () => {
-        browser.click('[data-name="TabbedPanel"]');
-        const story = $(childStory);
-
-        expect(story.isVisible()).toBe(true);
+    beforeAll(() => {
+        navigateToStory(component, childStories[0]);
     });
 
     it('should display tabbed panel', () => {
-      browser.click(childStory);
-      waitForFocus(tabbedPanel);
+      browser.waitForVisible(tabbedPanel);
 
       const tabbedPanelElem = $(tabbedPanel);
       expect(tabbedPanelElem.isVisible()).toBe(true);

--- a/src/components/Tag/Tag.spec.js
+++ b/src/components/Tag/Tag.spec.js
@@ -1,27 +1,17 @@
-const { waitForFocus, executeInAllStories } = require('../../../e2e/utils/storybook');
+const { navigateToStory, executeInAllStories } = require('../../../e2e/utils/storybook');
 
 describe('Tags Suite', () => {
-    const menuItem = '[data-name="Tags"]';
+    const component = 'Tags';
     const childStories = [
-        '[data-name="primary"]',
-        '[data-name="white"]',
-        '[data-name="gray"]',
-        '[data-name="editable"]',
+        'primary',
+        'white',
+        'gray',
+        'editable',
     ];
     const tag = '[data-qa-tag]';
 
-    it('should display tag component in navigation', () => {
-        const tagNavItem = $(menuItem);
-        expect(tagNavItem.isVisible()).toBe(true);
-    });
-
-    it('should display child stories in navigation', () => {
-        browser.click(menuItem);
-        browser.waitForVisible(childStories[0]);
-    });
-
     it('should display tag in each story', () => {
-        executeInAllStories(childStories, () => {
+        executeInAllStories(component, childStories, () => {
             const tagElem = $(tag);
             expect(tagElem.isVisible()).toBe(true);
         });
@@ -29,8 +19,7 @@ describe('Tags Suite', () => {
 
     describe('Editable Tag Suite', () => {
         beforeAll(() => {
-           browser.click('[data-name="editable"]');
-           waitForFocus(tag);
+           navigateToStory(component, childStories[3]);
            browser.waitForVisible(tag);
         });
 


### PR DESCRIPTION
(Apologies for this PR title)

* Navigate directly to iframe in storybook tests
* Removed tests that verified stories existed in storybook navigation
* Removed iframe related test code

Tests now run a LOT faster and will be much more stable, since the UI in storybook was causing tests to randomly fail.  Like, this issue was happening randomly:

![this was happening a lot](https://user-images.githubusercontent.com/12736578/40026158-40b0a468-57a2-11e8-8d4a-62f5c4e43c2f.png)



I ran this PR and got the following result:
94 passing (36.70s)