### PR TITLE
M3-412 - Linode Settings Spec

### DIFF
--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -15,7 +15,7 @@ const password = process.env.MANAGER_PASS;
 
 const specsToRun = () => {
     if (argv.file) {
-        return [argv.file];
+        return ['./e2e/setup/setup.spec.js', argv.file];
     }
     if (argv.dir || argv.d) {
         return ['./e2e/setup/setup.spec.js', `./e2e/specs/${argv.dir || argv.d}/**/*.spec.js`]
@@ -295,7 +295,6 @@ exports.config = {
             })
             .catch(err => {
                 console.log(err);
-                reject(err);
             });
     }
 }

--- a/e2e/pageobjects/linode-detail-networking.page.js
+++ b/e2e/pageobjects/linode-detail-networking.page.js
@@ -12,7 +12,6 @@ class Networking extends Page {
     get actionMenu() { return $('[data-qa-action-menu]'); }
     get addIcons() { return $$('[data-qa-icon-text-link]'); }
     get viewButton() { return $('[data-qa-action]'); }
-    get notice() { return $('[data-qa-notice]'); }
 
     // drawer elements
     get serviceNotice() { return $('[data-qa-service-notice]'); }

--- a/e2e/pageobjects/linode-detail-settings.page.js
+++ b/e2e/pageobjects/linode-detail-settings.page.js
@@ -1,11 +1,50 @@
 import Page from './page';
 
 class Settings extends Page {
+    get actionPanels() { return $$('[data-qa-panel-summary]'); }
+    get actionPanelSubheading() { return $('[data-qa-panel-subheading]'); }
     get delete() { return $('[data-qa-delete-linode]'); }
     get deleteDialogTitle() { return $('[data-qa-dialog-title]'); }
     get deleteDialogContent() { return $('[data-qa-dialog-content]'); }
     get confirm() { return $('[data-qa-confirm-delete]'); }
     get cancel() { return $('[data-qa-cancel-delete]'); }
+    get label() { return $('[data-qa-label] input'); }
+    get labelSave() { return $('[data-qa-label-save]'); }
+    get notice() { return $('[data-qa-notice]'); }
+    get notices() { return $$('[data-qa-notice]'); }
+    get selectDisk() { return $('[data-qa-select-disk]'); }
+    get disk() { return $('[data-qa-disk]'); }
+    get disks() { return $$('[data-qa-disk]'); }
+    get password() { return $('[data-qa-hide] input'); }
+    get passwordSave() { return $('[data-qa-password-save]'); }
+    get alerts() { return $$('[data-qa-alert]'); }
+    get alert() { return $('data-qa-alert] > input'); }
+    get alertSave() { return $('[data-qa-alerts-save]'); }
+    get linodeConfigs() { return $$('[data-qa-config]'); }
+    get actionMenu() { return $('[data-qa-action-menu]'); }
+
+    getConfigLabels() {
+        return this.linodeConfigs.map(c => c.getAttribute('data-qa-config'));
+    }
+
+    deleteConfig(configLabel) {
+        const confirmMsg = `Are you sure you want to delete "${configLabel}"`;
+
+        browser.click(`[data-qa-config="${configLabel}"] [data-qa-action-menu]`);
+        browser.waitForVisible('[data-qa-action-menu-item]');
+        
+        // Click action menu item, regardless of anything blocking it
+        browser.jsClick('[data-qa-action-menu-item="Delete"]');
+        browser.waitForVisible('[data-qa-dialog-title]');
+        browser.waitForVisible('[data-qa-dialog-content]');
+
+        expect(browser.getText('[data-qa-dialog-content]')).toBe(confirmMsg);
+
+        this.confirm.waitForVisible();
+        this.cancel.waitForVisible();
+        this.confirm.click();
+        browser.waitForVisible(`[data-qa-config="${configLabel}"]`, 5000, true);
+    }
 
     remove() {
         const linodeLabel = browser.getText('[data-qa-label]');
@@ -23,17 +62,76 @@ class Settings extends Page {
 
         this.confirm.click();
         browser.waitForVisible('[data-qa-circle-progress]', 15000, true);
-        try {
-            browser.waitForVisible('[data-qa-label]');
-            const labels = $$('[data-qa-label]').map(l => l.getText());
-            expect(labels).not.toContain(linodeLabel);
-        } catch (e) {
-            const placeholderDisplays = browser.waitForVisible('[data-qa-placeholder-title]');
-            if (!placeholderDisplays) {
-                throw new Error(e)
+        
+        browser.waitUntil(function() {
+            if (browser.isVisible('[data-qa-placeholder-title]')) {
+                return true;
             }
-        }
+
+            if (browser.isVisible('[data-qa-view]')) {
+                const labels = $$('[data-qa-label]').map(l => l.getText());
+                return !labels.include(linodeLabel);
+            }
+            return false;
+        }, 10000, 'Linode failed to be removed');
     }
+
+    updateLabel(label) {
+        const successMsg = 'Linode label changed successfully.';
+        this.label.waitForVisible();
+        this.label.setValue(label);
+        this.labelSave.click();
+        this.waitForNotice(successMsg);
+    }
+
+    getDiskLabels() {
+        this.selectDisk.click();
+        this.disk.waitForVisible();
+        const disks = this.disks.map(d => d.getText());
+        // Refactor this to use the actions api when chrome supports
+        browser.keys('\uE00C');
+        this.disk.waitForVisible(5000, true);
+        return disks;
+    }
+
+    resetPassword(newPassword, diskLabel) {
+        const successMsg = 'Linode password changed successfully.';
+        this.selectDisk.click();
+        this.disk.waitForVisible();
+        browser.jsClick(`[data-qa-disk="${diskLabel}"]`);
+
+        this.disk.waitForVisible(5000, true);
+        this.password.setValue(newPassword);
+        this.passwordSave.click();
+
+        this.waitForNotice(successMsg);
+    }
+
+    waitForNotice(noticeMsg) {
+        browser.waitUntil(function() {
+            browser.waitForVisible('[data-qa-notice');
+
+            // Get all notices, since more than one may appear on the page
+            const labelNotice = $$('[data-qa-notice]')
+                .filter(n => n.getText().includes(noticeMsg));
+            return labelNotice.length === 1;
+        }, 10000);
+    }
+
+    allAlertsEnabled() {
+        const checkedAlerts = $$('[data-qa-alert] :checked');
+        const alerts = $$('[data-qa-alert]');
+        expect(checkedAlerts.length).toBe(checkedAlerts.length);
+        expect(alerts.length).toBe(5);
+    }
+
+    toggleAlert(alert) {
+        const successMsg = 'Linode alert thresholds changed successfully.';
+        browser.click(`[data-qa-alert="${alert}"]`);
+        this.alertSave.click();
+        this.waitForNotice(successMsg);
+    }
+
 }
 
 export default new Settings();

--- a/e2e/pageobjects/linode-detail-volume.page.js
+++ b/e2e/pageobjects/linode-detail-volume.page.js
@@ -11,6 +11,7 @@ export class VolumeDetail extends Page {
     get region() { return $('[data-qa-select-region]'); }
     get attachToLinode() { return $('[data-qa-select-linode]'); }
     get attachedTo() { return $('[data-qa-attach-to]'); }
+    get attachRegions() { return $$('[data-qa-attach-to-region]'); }
     get submit() { return $('[data-qa-submit]'); }
     get cancel() { return $('[data-qa-cancel]'); }
     get volumeCell() { return $$('[data-qa-volume-cell]'); }
@@ -25,6 +26,14 @@ export class VolumeDetail extends Page {
     get attachButton() { return $('[data-qa-confirm-attach]'); }
     get cancelButton() { return $('[data-qa-cancel]'); }
     get cloneLabel() { return $('[data-qa-clone-from] input'); }
+
+    removeAllVolumes() {
+        const pageObject = this;
+
+        this.volumeCell.forEach(function(v) {
+            pageObject.removeVolume(v);
+        });
+    }
 
     closeVolumeDrawer() {
         this.drawerClose.click();
@@ -69,18 +78,32 @@ export class VolumeDetail extends Page {
         }
         this.drawerTitle.waitForVisible();
 
-        this.label.$('input').setValue(volume.label);
+        browser.trySetValue('[data-qa-volume-label] input', volume.label);
         this.size.$('input').setValue(volume.size);
 
-        if (volume.region) {
-
+        if (volume.hasOwnProperty('regionIndex')) {
+            this.region.waitForVisible();
+            this.region.click();
+            browser.waitForVisible('[data-qa-attach-to-region]');
+            const selectedRegion = this.attachRegions[volume.regionIndex].getText();
+            this.attachRegions[volume.regionIndex].click();
+            
+            browser.waitForVisible('[data-qa-attach-to-region]', 5000, true);
+            
+            browser.waitUntil(function() {
+                return $('[data-qa-select-region]').getText() === selectedRegion;
+            }, 5000);
         }
 
-        if (volume.attachedLinode) {
+        if (volume.hasOwnProperty('attachedLinode')) {
 
         }
         // this.region.setValue(volume.region); 
         this.submit.click();
+
+        if (volume.hasOwnProperty('regionIndex')) {
+            browser.waitForExist('[data-qa-drawer]', 10000, true);
+        }
     }
 
     editVolume(volume, newLabel) {

--- a/e2e/pageobjects/linode-detail-volume.page.js
+++ b/e2e/pageobjects/linode-detail-volume.page.js
@@ -1,11 +1,15 @@
-class VolumeDetail {
+import Page from './page';
+
+export class VolumeDetail extends Page {
     get drawerTitle() { return $('[data-qa-drawer-title]'); }
+    get drawerClose() { return $('[data-qa-close-drawer]'); }
     get placeholderText() { return $('[data-qa-placeholder-title]'); }
     get createButton() { return $('[data-qa-placeholder-button]'); }
     get createIconLink() { return $('[data-qa-icon-text-link="Create a Volume"]'); }
     get label() { return $('[data-qa-volume-label]'); }
     get size() { return $('[data-qa-size]'); }
-    get region() { return $('[data-qa-region]'); }
+    get region() { return $('[data-qa-select-region]'); }
+    get attachToLinode() { return $('[data-qa-select-linode]'); }
     get attachedTo() { return $('[data-qa-attach-to]'); }
     get submit() { return $('[data-qa-submit]'); }
     get cancel() { return $('[data-qa-cancel]'); }
@@ -22,6 +26,27 @@ class VolumeDetail {
     get cancelButton() { return $('[data-qa-cancel]'); }
     get cloneLabel() { return $('[data-qa-clone-from] input'); }
 
+    closeVolumeDrawer() {
+        this.drawerClose.click();
+        this.drawerTitle.waitForVisible(5000, true);
+        browser.waitForExist('[data-qa-drawer]', 10000, true);
+        this.globalCreate.waitForVisible();
+    }
+
+    defaultDrawerElemsDisplay() {
+        const volumeDrawerTitle = 'Create a Volume';
+
+        this.drawerTitle.waitForVisible();
+
+        expect(this.drawerTitle.getText()).toBe(volumeDrawerTitle);
+        expect(this.size.$('input').getValue()).toContain(20);
+        expect(this.label.$('input').getText()).toBe('');
+        expect(this.region.getText()).toBe('Select a Region');
+        expect(this.submit.isVisible()).toBe(true);
+        expect(this.cancel.isVisible()).toBe(true);
+        expect(this.attachToLinode.getText()).toBe('Select a Linode');
+    }
+
     getVolumeId(label) {
         const volumesWithLabel = this.volumeCell.filter(v => v.$(this.volumeCellLabel.selector).getText() === label);
 
@@ -32,8 +57,12 @@ class VolumeDetail {
         return volumesWithLabel.map(v => v.getAttribute('data-qa-volume-cell'));
     }
 
-    createVolume(volume) {
-        if (this.placeholderText.isVisible()) {
+    createVolume(volume, menuCreate) {
+        if (menuCreate) {
+            this.globalCreate.click();
+            this.addVolumeMenu.waitForVisible();
+            this.addVolumeMenu.click();
+        } else if (this.placeholderText.isVisible()) {
             this.createButton.click();
         } else {
             this.createIconLink.click();
@@ -42,7 +71,15 @@ class VolumeDetail {
 
         this.label.$('input').setValue(volume.label);
         this.size.$('input').setValue(volume.size);
-        // this.region.setValue(volume.region);
+
+        if (volume.region) {
+
+        }
+
+        if (volume.attachedLinode) {
+
+        }
+        // this.region.setValue(volume.region); 
         this.submit.click();
     }
 

--- a/e2e/pageobjects/list-linodes.js
+++ b/e2e/pageobjects/list-linodes.js
@@ -59,25 +59,22 @@ export class ListLinodes extends Page {
 
     gridElemsDisplay() {
         const header = this.subheader;
-        const linodeDisplays = this.linode.map(l => l.isVisible());
-        const labelDisplays = this.linode.map(l => l.$(this.linodeLabel.selector).isVisible());
-        const hardwareSummaryDisplays = this.linode.map(l => l.$(this.hardwareSummary.selector).isVisible());
-        const regionDisplays = this.linode.map(l => l.$(this.region.selector).isVisible());
-        const imageDisplays = this.linode.map(l => l.$(this.image.selector).isVisible());
-        const ipDisplays = this.linode.map(l => l.$(this.ip.selector).isVisible());
-        const rebootButtonDisplays = this.linode.map(l => l.$(this.rebootButton.selector).isVisible());
-        const launchConsoleDisplays = this.linode.map(l => l.$(this.linodeActionMenu.selector).isVisible());
+        this.linode.forEach(l => {
+            expect(l.isVisible()).toBe(true);
+            expect(l.$(this.linodeLabel.selector).isVisible()).toBe(true);
+            expect(l.$(this.hardwareSummary.selector).isVisible()).toBe(true);
+            expect(l.$(this.region.selector).isVisible()).toBe(true);
+            expect(l.$(this.image.selector).isVisible()).toBe(true);
+            expect(l.$(this.ip.selector).isVisible()).toBe(true);
+            expect(l.$(this.rebootButton.selector).isVisible()).toBe(true);
+            expect(l.$(this.linodeActionMenu.selector).isVisible()).toBe(true);
+            expect(l.$(this.image.selector).isVisible()).toBe(true);
+            expect(l.$(this.rebootButton.selector).isVisible()).toBe(true);
+            expect(l.$(this.linodeActionMenu.selector).isVisible()).toBe(true);
+        });
 
         expect(header.isVisible()).toBe(true);
         expect(header.getText()).not.toBe(null);
-        linodeDisplays.forEach(l => expect(l).toBe(true));
-        labelDisplays.forEach(l => expect(l).toBe(true));
-        hardwareSummaryDisplays.forEach(l => expect(l).toBe(true));
-        regionDisplays.forEach(l => expect(l).toBe(true));
-        imageDisplays.forEach(l => expect(l).toBe(true));
-        ipDisplays.forEach(l => expect(l).toBe(true));
-        rebootButtonDisplays.forEach(l => expect(l).toBe(true));
-        launchConsoleDisplays.forEach(l => expect(l).toBe(true));
     }
 
     listElemsDisplay() {

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -3,6 +3,11 @@ export default class Page {
     get docs() { return $$('[data-qa-doc]'); }
     get toast() { return $('[data-qa-toast]'); }
     get toastMsg() { return $('[data-qa-toast-message]'); }
+    get globalCreate() { return $('[data-qa-add-new-menu-button]'); }
+    get addVolumeMenu() { return $('[data-qa-add-new-menu="Volume"]'); }
+    get addLinodeMenu() { return $('[data-qa-add-new-menu="Linode"]'); }
+    get addNodeBalancerMenu() { return $('[data-qa-add-new-menu="NodeBalancer"]'); }
+    get notice() { return $('[data-qa-notice]'); }
 
     constructor() {
         this.pageTitle = 'Base page';

--- a/e2e/pageobjects/profile.js
+++ b/e2e/pageobjects/profile.js
@@ -94,7 +94,7 @@ export class TokenCreateDrawer {
     setPermission(row, permission) {
         const elem = row.$(permission.selector);
         elem.click();
-        expect(elem.getAttribute('class').includes('checked')).toBe(true);
+        expect(elem.getAttribute('data-qa-radio')).toBe('true');
     }
 
 }

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -17,7 +17,7 @@ exports.deleteAll = (token) => {
                 rejectUnauthorized: false
             }),
             baseURL: API_ROOT,
-            timeout: 1000,
+            timeout: 5000,
             headers: { 'Authorization': `Bearer ${token}`},
         });
 
@@ -95,7 +95,7 @@ exports.removeAllLinodes = (token) => {
                 rejectUnauthorized: false
             }),
             baseURL: API_ROOT,
-            timeout: 1000,
+            timeout: 5000,
             headers: { 'Authorization': `Bearer ${token}`},
         });
 

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -1,3 +1,4 @@
+const https = require('https');
 const axios = require('axios');
 const API_ROOT = process.env.REACT_APP_API_ROOT;
 
@@ -12,6 +13,9 @@ exports.deleteAll = (token) => {
         ];
 
         const instance = axios.create({
+            httpsAgent: new https.Agent({
+                rejectUnauthorized: false
+            }),
             baseURL: API_ROOT,
             timeout: 1000,
             headers: { 'Authorization': `Bearer ${token}`},
@@ -87,9 +91,12 @@ exports.removeAllLinodes = (token) => {
         const linodesEndpoint = '/linode/instances';
 
         const instance = axios.create({
-                baseURL: API_ROOT,
-                timeout: 1000,
-                headers: { 'Authorization': `Bearer ${token}`},
+            httpsAgent: new https.Agent({
+                rejectUnauthorized: false
+            }),
+            baseURL: API_ROOT,
+            timeout: 1000,
+            headers: { 'Authorization': `Bearer ${token}`},
         });
 
         const removeInstance = (res, endpoint) => {

--- a/e2e/specs/create/configure.linode.spec.js
+++ b/e2e/specs/create/configure.linode.spec.js
@@ -26,7 +26,7 @@ describe('Create Linode - Configure Linode Suite', () => {
     it('should configure a generic linode and update cost summary', () => {
         const genericPrice = /\$.*\/mo/ig;
         const genericImage = ConfigureLinode.images[0].getText();
-        const genericType = 'Linode 2G\n1 CPU, 30G Storage, 2G RAM';
+        const genericType = 'Linode 2G\n1 CPU, 50G Storage, 2G RAM';
 
         ConfigureLinode.generic();
 

--- a/e2e/specs/create/create-volume.spec.js
+++ b/e2e/specs/create/create-volume.spec.js
@@ -1,0 +1,72 @@
+const { constants } = require('../../constants');
+
+import ListLinodes from '../../pageobjects/list-linodes';
+import VolumeDetail from '../../pageobjects/linode-detail-volume.page';
+
+describe('Create - Volume Suite', () => {
+    let linodeLabel;
+    const testVolume = {
+        label: ``,
+        size: '10',
+    }
+
+    beforeAll(() => {
+        browser.url(constants.routes.linodes);
+        ListLinodes.linodesDisplay();
+        linodeLabel = ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).getText();
+    });
+
+    it('should display create volumes option in global create menu', () => {
+        ListLinodes.globalCreate.click();
+        ListLinodes.addVolumeMenu.waitForVisible();
+    });
+
+    it('should display global volume create drawer', () => {
+        ListLinodes.addVolumeMenu.click();
+
+        VolumeDetail.defaultDrawerElemsDisplay();
+        VolumeDetail.closeVolumeDrawer();
+    });
+
+    it('should display form error on create without a label', () => {
+        VolumeDetail.createVolume(testVolume, true);
+        VolumeDetail.label.$('p').waitForText();
+        VolumeDetail.closeVolumeDrawer();
+    });
+
+    it('should display a error notice on create without region', () => {
+        testVolume['label'] = `ASD${new Date().getTime()}`;
+        VolumeDetail.createVolume(testVolume, true);
+        VolumeDetail.notice.waitForVisible();
+        VolumeDetail.closeVolumeDrawer();
+    });
+
+    it('should create without attaching to a linode', () => {
+        testVolume['label'] = `ASD${new Date().getTime()}`;
+        testVolume['regionIndex'] = 0;
+        
+        VolumeDetail.createVolume(testVolume, true);
+        browser.url(constants.routes.volumes);
+        
+        browser.waitUntil(function() {
+            return VolumeDetail.getVolumeId(testVolume.label).length > 0;
+        }, 10000);
+    });
+
+    it('should create attached to a linode', () => {
+        testVolume['label'] = `ASD${new Date().getTime()}`,
+        testVolume['attachedLinode'] = linodeLabel;
+        // create menu
+        // select linode
+        // create volume
+        // navigate to /volumes
+        // assert volume in table
+        // assert volume attached
+    });
+
+    afterAll(() => {
+        browser.url(constants.routes.volumes);
+        VolumeDetail.volumeCellElem.waitForVisible();
+        VolumeDetail.removeAllVolumes();
+    });
+});

--- a/e2e/specs/linodes/detail/settings.spec.js
+++ b/e2e/specs/linodes/detail/settings.spec.js
@@ -1,0 +1,81 @@
+const crypto = require('crypto');
+const { constants } = require('../../../constants');
+const { createGenericLinode, createLinodeIfNone } = require('../../../utils/common');
+
+import ListLinodes from '../../../pageobjects/list-linodes';
+import LinodeDetail from '../../../pageobjects/linode-detail.page';
+import Settings from '../../../pageobjects/linode-detail-settings.page';
+
+describe('Linode Detail - Settings Suite', () =>{
+    beforeAll(() => {
+        createLinodeIfNone();
+        ListLinodes.linodesDisplay();
+        ListLinodes.navigateToDetail(ListLinodes.linodeElem);
+        LinodeDetail.landingElemsDisplay();
+        LinodeDetail.changeTab('Settings');
+    });
+
+    describe('Label Suite', () => {
+        it('should display label editable text field', () => {
+            Settings.label.waitForVisible();
+            Settings.labelSave.waitForVisible();
+        });
+
+        it('should edit on save', () => {
+            Settings.updateLabel('Some-New-Label');
+        });
+    });
+
+    describe('Reset Root Password Suite', () => {
+        it('should display a disk in the select, password field and save button', () => {
+            Settings.selectDisk.waitForVisible();
+            Settings.password.waitForVisible();
+            Settings.passwordSave.waitForVisible();
+        });
+
+        it('should successfully change root password', () => {
+            const newPassword = crypto.randomBytes(20).toString('hex');
+            const disks = Settings.getDiskLabels();
+            Settings.resetPassword(newPassword, disks[0]);
+        });
+    });
+
+    describe('Notification Thresholds Suite', () => {
+        it('should display all the alert toggles and default to enabled', () => {
+            Settings.allAlertsEnabled();
+        });
+
+        it('should disable a notification threshold on toggle off', () => {
+            const initialEnabledAlerts = $$('[data-qa-alert] :checked');
+            const alertLabels = Settings.alerts.map(a => a.getAttribute('data-qa-alert'));
+            
+            Settings.toggleAlert(alertLabels[0]);
+            
+            const enabledAlerts = $$('[data-qa-alert] :checked');
+
+            expect(enabledAlerts.length).not.toEqual(initialEnabledAlerts.length);
+        });
+
+        it('should enable a notification on toggle on', () => {
+            const alertLabels = Settings.alerts.map(a => a.getAttribute('data-qa-alert'));
+            Settings.toggleAlert(alertLabels[0]);
+        });
+    });
+
+    describe('Advanced Configurations Suite', () => {
+        xit('should add a configuration', () => {
+            
+        });
+
+        it('should remove a configuration', () => {
+            const configs = Settings.getConfigLabels();
+            Settings.deleteConfig(configs[0]);
+        });
+    });
+
+    describe('Delete Suite', () => {
+        it('should remove the linode', () => {
+            Settings.remove();
+        });
+    });
+});

--- a/e2e/specs/profile/clients.spec.js
+++ b/e2e/specs/profile/clients.spec.js
@@ -81,7 +81,7 @@ describe('Profile - OAuth Clients Suite', () => {
         });
 
         it('should display public checkbox as disabled', () => {
-            expect(createDrawer.public.getAttribute('class').includes('disabled')).toBe(true);
+            expect(!!createDrawer.public.$('input').getAttribute('disabled')).toBe(true);
         });
 
         it('should update table on edit submit', () => {

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -22,3 +22,10 @@ export const deleteLinode = (label) => {
     LinodeDetail.changeTab('Settings');
     Settings.remove();
 }
+
+
+export const createLinodeIfNone = () => {
+    if (!ListLinodes.linodesDisplay()) {
+        createGenericLinode(new Date().getTime());
+    }
+}

--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -99,6 +99,7 @@ const Notice: React.StatelessComponent<CombinedProps> = (props) => {
         notice: true,
         ...(className && { [className]: true }),
       })}
+      data-qa-notice
     >
       {
         flag &&

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -327,6 +327,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
           <Notice
             error
             text={generalError}
+            data-qa-notice
           />
         }
 
@@ -391,6 +392,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
             }}
             inputProps={{ name: 'region', id: 'region' }}
             error={Boolean(regionError)}
+            data-qa-select-region
           >
             <MenuItem key="none" value="none">Select a Region</MenuItem>,
             {regions && regions.map(region =>
@@ -430,6 +432,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
               }}
               inputProps={{ name: 'linode', id: 'linode' }}
               error={Boolean(linodeError)}
+              data-qa-select-linode
             >
               <MenuItem key="none" value="0">
                 {mode !== modes.CLONING

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -396,7 +396,13 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
           >
             <MenuItem key="none" value="none">Select a Region</MenuItem>,
             {regions && regions.map(region =>
-              <MenuItem key={region.id} value={region.id}>{dcDisplayNames[region.id]}</MenuItem>,
+              <MenuItem
+                key={region.id}
+                value={region.id}
+                data-qa-attach-to-region={region.id}
+              >
+                {dcDisplayNames[region.id]}
+              </MenuItem>,
             )}
           </Select>
           {regionError &&

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -218,7 +218,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                 const regionID = pathOr('', ['region'], volume);
                 const region = dcDisplayNames[regionID];
                 return (
-                  <TableRow key={volume.id} data-qa-volume-cell>
+                  <TableRow key={volume.id} data-qa-volume-cell={volume.id}>
                     <TableCell data-qa-volume-cell-label>{label}</TableCell>
                     <TableCell data-qa-volume-cell-attachment>{linodeLabel}</TableCell>
                     <TableCell data-qa-volume-size>{size} GB</TableCell>

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
@@ -337,6 +337,7 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
                 variant="raised"
                 color="secondary"
                 className="destructive"
+                data-qa-confirm-delete
               >
                 Delete
               </Button>
@@ -345,6 +346,7 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
                 variant="raised"
                 color="secondary"
                 className="cancel"
+                data-qa-cancel-delete
               >
                 Cancel
               </Button>
@@ -366,6 +368,7 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
                 variant="raised"
                 color="secondary"
                 className="destructive"
+                data-qa-confirm-delete
               >
                 Delete
               </Button>
@@ -374,6 +377,7 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
                 variant="raised"
                 color="secondary"
                 className="cancel"
+                data-qa-cancel-delete
               >
                 Cancel
               </Button>
@@ -525,7 +529,7 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
         <TableBody>
           {
             this.state.linodeConfigs.map(config => (
-              <TableRow key={config.id}>
+              <TableRow key={config.id} data-qa-config={config.label}>
                 <TableCell>{config.label}</TableCell>
                 <TableCell>
                   <LinodeConfigActionMenu

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -176,12 +176,14 @@ class LinodeSettingsAlertsPanel extends React.Component<CombinedProps, State> {
           container
           alignItems="flex-start"
           className={classes.root}
+          data-qa-alerts-panel
         >
           <Grid item className={classes.switch}>
             <FormControlLabel
               className="toggleLabel"
               control={<Toggle checked={props.state} onChange={props.onStateChange} />}
               label={props.title}
+              data-qa-alert={props.title}
             />
           </Grid>
           <Grid item className={classes.copy}>
@@ -340,6 +342,7 @@ class LinodeSettingsAlertsPanel extends React.Component<CombinedProps, State> {
               onClick={this.setLinodeAlertThresholds}
               disabled={noError}
               loading={noError}
+              data-qa-alerts-save
             >
               Save
             </Button>

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
@@ -84,6 +84,7 @@ class LinodeSettingsLabelPanel extends React.Component<CombinedProps, State> {
               color="primary"
               disabled={submitting && !labelError}
               loading={submitting && !labelError}
+              data-qa-label-save
             >
               Save
             </Button>
@@ -97,6 +98,7 @@ class LinodeSettingsLabelPanel extends React.Component<CombinedProps, State> {
             this.setState(set(lensPath(['updatedValue']), e.target.value))}
           errorText={labelError}
           error={Boolean(labelError)}
+          data-qa-label
         />
       </ExpansionPanel>
     );

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -100,6 +100,7 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
               onClick={this.changeDiskPassword}
               loading={submitting && !passwordError}
               disabled={submitting && !passwordError}
+              data-qa-password-save
             >
               Save
             </Button>
@@ -121,10 +122,17 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
               this.setState(set(lensPath(['diskId']), Number(e.target.value)))}
             inputProps={{ name: 'disk', id: 'disk' }}
             error={Boolean(diskIdError)}
+            data-qa-select-disk
           >
             {
               this.state.linodeDisks.map(disk =>
-                <MenuItem key={disk.id} value={disk.id}>{disk.label}</MenuItem>)
+                <MenuItem
+                  key={disk.id}
+                  value={disk.id}
+                  data-qa-disk={disk.label}
+                >
+                  {disk.label}
+                </MenuItem>)
             }
           </Select>
           {


### PR DESCRIPTION
* Added data-qa attributes to linode detail - settings page
* Created first set of tests for Linode Detail - Settings page
* Added linode settings page object actions/selectors
* Updated wdio.conf.js to run the setup script when running individual specs, also removed unnecessary `reject()`.
* Updated setup script to allow unauthorized certificates

## To Test

```
yarn && yarn start
yarn selenium
yarn e2e --file e2e/specs/linodes/detail/settings.spec.js
```