### PR TITLE
M3-542

### DIFF
--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -130,7 +130,7 @@ const preloaded = PromiseLoader<Props>({
 
         return ({
           ...type,
-          heading: typeLabel(memory),
+          heading: type.label,
           subHeadings: [
             `$${monthly}/mo ($${hourly}/hr)`,
             typeLabelDetails(memory, disk, vcpus),


### PR DESCRIPTION
## Purpose
LinodeType.label are being updated in the DB to reflect actual package names. Use them. Sans the munging.