### PR TITLE
Provide intuitive indexing of IP arrays

### DIFF
--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -6,7 +6,7 @@ import {
   StyleRulesCallback,
 } from 'material-ui/styles';
 import * as copy from 'copy-to-clipboard';
-import { tail } from 'ramda';
+import { tail, test } from 'ramda';
 
 import ShowMore from 'src/components/ShowMore';
 import CopyTooltip from 'src/components/CopyTooltip';
@@ -121,7 +121,9 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
 
   render() {
     const { classes, ips, copyRight } = this.props;
-    const formattedIPS = ips.map(ip => ip.replace('/64', ''));
+    const formattedIPS = ips
+      .map(ip => ip.replace('/64', ''))
+      .sort(ip => test(/^192\.168\./, ip) ? 1 : 0);
 
     return (
       <div className={`dif ${classes.root}`}>

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -6,7 +6,7 @@ import {
   StyleRulesCallback,
 } from 'material-ui/styles';
 import * as copy from 'copy-to-clipboard';
-import { tail, test } from 'ramda';
+import { tail } from 'ramda';
 
 import ShowMore from 'src/components/ShowMore';
 import CopyTooltip from 'src/components/CopyTooltip';
@@ -121,9 +121,10 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
 
   render() {
     const { classes, ips, copyRight } = this.props;
+    const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
     const formattedIPS = ips
       .map(ip => ip.replace('/64', ''))
-      .sort(ip => test(/^192\.168\./, ip) ? 1 : 0);
+      .sort(ip => !!ip.match(privateIPRegex) ? 1 : 0);
 
     return (
       <div className={`dif ${classes.root}`}>


### PR DESCRIPTION
Currently, IPs aren't indexed to sort public and private IPs. This can lead to instances where a private IP has a zero index and appears in a Linode's summary:

<img width="853" alt="screen shot 2018-05-18 at 11 01 24 am" src="https://user-images.githubusercontent.com/12750110/40274174-3be82262-5b9e-11e8-9030-88a4640d53d7.png">

Because private IPs are an add-on, I argue that they should be sorted to the end of the array. This will provide users a better experience, as they may not be able to tell the difference between public and private IPs just from seeing the first two octets. Furthermore, it may be worth exploring ways to better differentiate between public and private IPs outside of the Networking tab. 