### PR TITLE
Convert notifications to ReplaySubject

### DIFF
--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,9 +1,10 @@
 import { getNotifications } from 'src/services/account';
-import { Observable } from 'rxjs/Rx';
+import { ReplaySubject } from 'rxjs/ReplaySubject';
 
-const notifications$: Observable<Linode.Notification[]> =
-  Observable.defer(() => getNotifications()
-    .then(response => response.data),
-  );
+getNotifications()
+  .then(response => notifications$.next(response.data))
+  .catch(errorResponse => notifications$.error(errorResponse));
+
+const notifications$ = new ReplaySubject<Linode.Notification[]>();
 
 export default notifications$;


### PR DESCRIPTION
## Purpose
It was found that notifications was being called repeatedly. This was a result of the default export being a function, which was being called repeatedly. I converted the default export to a [ReplaySubject](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/subjects/replaysubject.md).