### PR TITLE
M3-409 - Global Volume Create Drawer Tests

### DIFF
--- a/e2e/specs/create/create-volume.spec.js
+++ b/e2e/specs/create/create-volume.spec.js
@@ -56,7 +56,8 @@ describe('Create - Volume Suite', () => {
     it('should create attached to a linode', () => {
         testVolume['label'] = `ASD${new Date().getTime()}`,
         testVolume['attachedLinode'] = linodeLabel;
-        // create menu
+
+        VolumeDetail.createVolume(testVolume, true);
         // select linode
         // create volume
         // navigate to /volumes
@@ -64,7 +65,7 @@ describe('Create - Volume Suite', () => {
         // assert volume attached
     });
 
-    afterAll(() => {
+    it('should remove all volumes', () => {
         browser.url(constants.routes.volumes);
         VolumeDetail.volumeCellElem.waitForVisible();
         VolumeDetail.removeAllVolumes();

--- a/e2e/specs/create/create-volume.spec.js
+++ b/e2e/specs/create/create-volume.spec.js
@@ -58,11 +58,6 @@ describe('Create - Volume Suite', () => {
         testVolume['attachedLinode'] = linodeLabel;
 
         VolumeDetail.createVolume(testVolume, true);
-        // select linode
-        // create volume
-        // navigate to /volumes
-        // assert volume in table
-        // assert volume attached
     });
 
     it('should remove all volumes', () => {

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -456,7 +456,13 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
                   );
                 })
                 .map(linode =>
-                  <MenuItem key={linode.id} value={`${linode.id}`}>{linode.label}</MenuItem>,
+                  <MenuItem
+                    key={linode.id}
+                    value={`${linode.id}`}
+                    data-qa-attached-linode={linode.label}
+                  >
+                    {linode.label}
+                  </MenuItem>,
               )}
               {(mode === modes.EDITING
                 || mode === modes.RESIZING) &&


### PR DESCRIPTION
* Added tests that test creating a volume via the global create drawer (creating with a region, no linode, creating with a region + lionde, removing all volumes after the test).
* Added additional `data-qa` attributes to volume drawer for tests

## To Test

```bash
yarn && yarn start
yarn selenium # in a separate shell
yarn e2e --file e2e/specs/create/create-volume.spec.js # in a separate shell
```

