### PR TITLE
M3-566 change labels

### DIFF
--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -570,8 +570,8 @@ const modeMap = {
 };
 
 const typeMap = {
-  master: 'Master',
-  slave: 'Slave',
+  master: 'SOA',
+  slave: 'SOA',
   A: 'A',
   AAAA: 'AAAA',
   CAA: 'CAA',

--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -532,7 +532,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         : isCreating
           ? this.onRecordCreate
           : this.onRecordEdit,
-      children: isCreating ? 'Add' : 'Edit',
+      children: 'Save',
     };
 
     const otherErrors = [


### PR DESCRIPTION
### Purpose

Changes confirmation button in the Domain drawers. Regardless of whether you're editing or saving, the button will read "Save"

Also changes header text in the _edit SOA record_ drawer. to read "Edit SOA record" instead of "Edit Master Record" or "Edit Slave Record"

### Misc

closes M3-566 and M3-564