### PR TITLE
M3-579

### DIFF
--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -86,6 +86,7 @@ type CombinedProps = Props
 interface State {
   selectedTab: number;
   selectedLinodeID?: number;
+  selectedLinodeRegion?: string;
   selectedBackupID?: number;
   selectedBackupInfo?: Info;
   selectedDiskSize?: number;
@@ -356,7 +357,11 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
                       linodesWithBackups,
                     )(this.props.linodes.response)}
                     selectedLinodeID={this.state.selectedLinodeID}
-                    handleSelection={this.updateStateFor}
+                    handleSelection={linode => this.setState({
+                      selectedLinodeID: linode.id,
+                      selectedTypeID: null,
+                      selectedDiskSize: linode.specs.disk,
+                    })}
                   />
                   <SelectBackupPanel
                     error={hasErrorFor('backup_id')}
@@ -413,8 +418,12 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
               error={hasErrorFor('linode_id')}
               linodes={this.extendLinodes(this.props.linodes.response)}
               selectedLinodeID={this.state.selectedLinodeID}
-              handleSelection={this.updateStateFor}
               header={'Select Linode to Clone From'}
+              handleSelection={linode => this.setState({
+                selectedLinodeID: linode.id,
+                selectedTypeID: null,
+                selectedDiskSize: linode.specs.disk,
+              })}
             />
             <React.Fragment>
               <SelectRegionPanel

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -361,6 +361,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
                       selectedLinodeID: linode.id,
                       selectedTypeID: null,
                       selectedDiskSize: linode.specs.disk,
+                      selectedBackupID: undefined,
                     })}
                   />
                   <SelectBackupPanel

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -220,7 +220,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
 
   getLinodesWithBackups = (linodes: Linode.Linode[]) => {
     this.setState({ isGettingBackups: true });
-    return Promise.map(linodes, (linode: Linode.Linode) => {
+    return Promise.map(linodes.filter(l => l.backups.enabled), (linode: Linode.Linode) => {
       return getLinodeBackups(linode.id)
         .then((backups) => {
           return {

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -86,7 +86,6 @@ type CombinedProps = Props
 interface State {
   selectedTab: number;
   selectedLinodeID?: number;
-  selectedLinodeRegion?: string;
   selectedBackupID?: number;
   selectedBackupInfo?: Info;
   selectedDiskSize?: number;
@@ -362,6 +361,7 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
                       selectedTypeID: null,
                       selectedDiskSize: linode.specs.disk,
                       selectedBackupID: undefined,
+                      selectedRegionID: linode.region,
                     })}
                   />
                   <SelectBackupPanel
@@ -373,12 +373,6 @@ class LinodeCreate extends React.Component<CombinedProps, State> {
                     selectedLinodeID={this.state.selectedLinodeID}
                     selectedBackupID={this.state.selectedBackupID}
                     handleSelection={this.updateStateFor}
-                  />
-                  <SelectRegionPanel
-                    error={hasErrorFor('region')}
-                    regions={this.props.regions.response}
-                    handleSelection={this.updateStateFor}
-                    selectedID={this.state.selectedRegionID}
                   />
                   <SelectPlanPanel
                     error={hasErrorFor('type')}

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -41,8 +41,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 interface Props {
   linodes: ExtendedLinode[];
   selectedLinodeID?: number;
-  handleSelection: (key: string) =>
-    (event: React.SyntheticEvent<HTMLElement>, value?: string | null) => void;
+  handleSelection: (linode: Linode.Linode) => void;
   error?: string;
   header?: string;
 }
@@ -52,20 +51,14 @@ type StyledProps = Props & WithStyles<ClassNames>;
 type CombinedProps = StyledProps;
 
 class SelectLinodePanel extends React.Component<CombinedProps> {
-  handleTypeSelect = this.props.handleSelection('selectedTypeID');
-  handleSelectedDiskSize = this.props.handleSelection('selectedDiskSize');
-  handleSelection = this.props.handleSelection('selectedLinodeID');
+
 
   renderCard(linode: ExtendedLinode) {
-    const { selectedLinodeID } = this.props;
+    const { selectedLinodeID, handleSelection } = this.props;
     return (
       <SelectionCard
         key={linode.id}
-        onClick={(e) => {
-          this.handleSelection(e, `${linode.id}`);
-          this.handleTypeSelect(e, undefined);
-          this.handleSelectedDiskSize(e, `${linode.specs.disk}`);
-        }}
+        onClick={(e) => { handleSelection(linode); }}
         checked={linode.id === Number(selectedLinodeID)}
         heading={linode.heading}
         subheadings={linode.subHeadings}


### PR DESCRIPTION
## Purpose
Linodes cannot be created from a backup of a Linode across regions. This PR assigns the selectedRegionID to that of the Linode selected.

## Additional fixes;
- Resets selectedBackupID when Linode is changed.
- Moves handler logic out of SelectLinodePanel to consumer. (On going effort across these panels)