### PR TITLE
M3-580 hide edit action from SOA record if on a slave domain detail page

### DIFF
--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -230,14 +230,17 @@ class DomainRecords extends React.Component<CombinedProps, State> {
         },
         {
           title: '',
-          render: (d: Linode.Domain) =>
-            <ActionMenu
-              onEdit={() => {
-                d.type === 'master'
-                  ? this.openForEditMasterDomain(d)
-                  : this.openForEditSlaveDomain(d);
-              }}
-            />,
+          render: (d: Linode.Domain) => {
+            return d.type === 'master'
+              ? <ActionMenu
+                onEdit={() => {
+                  d.type === 'master'
+                    ? this.openForEditMasterDomain(d)
+                    : this.openForEditSlaveDomain(d);
+                }}
+              />
+              : <React.Fragment />;
+          },
         },
       ],
     },


### PR DESCRIPTION
### Purpose

*temporary fix* Editing SOA record for a slave domain renders white screen and crashes the app locally, so we now prevent editing SOA records until the Slave domain detail page is fully fleshed out