### PR TITLE
Styling of seen/unseen user notification cards

### DIFF
--- a/src/features/TopMenu/UserNotificationMenu/UserNotificationListItem.tsx
+++ b/src/features/TopMenu/UserNotificationMenu/UserNotificationListItem.tsx
@@ -5,29 +5,25 @@ import {
   withStyles,
   StyleRulesCallback,
   WithStyles,
+  Theme,
 } from 'material-ui';
 
 
 type ClassNames = 'root'
   | 'title'
   | 'content'
-  | 'warning'
-  | 'success'
-  | 'error';
+  | 'unread';
 
 
-const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => {
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => {
   const { palette: { status } } = theme;
 
   return {
     root: {
-      padding: `${theme.spacing.unit * 2}px
-      ${theme.spacing.unit * 4}px
-      ${theme.spacing.unit * 2}px
-      ${theme.spacing.unit * 3 - 1}px`,
+      padding: `${theme.spacing.unit * 2}px ${theme.spacing.unit * 3}px`,
       borderBottom: `1px solid ${theme.palette.divider}`,
-      borderLeft: '5px solid transparent',
-      transition: theme.transitions.create(['border-color']),
+      opacity: .7,
+      transition: theme.transitions.create(['border-color', 'opacity']),
     },
     title: {
       ...theme.typography.subheading,
@@ -35,8 +31,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => {
     content: {
       ...theme.typography.caption,
     },
-    error: {
-      borderLeftColor: status.errorDark,
+    unread: {
+      backgroundColor: theme.bg.offWhite,
+      opacity: 1,
     },
     warning: {
       borderLeftColor: status.warningDark,
@@ -62,9 +59,7 @@ const UserNotificationListItem: React.StatelessComponent<CombinedProps> = (props
   return (
   <div className={classNames({
     [classes.root]: true,
-    [classes.error]: error,
-    [classes.warning]: warning,
-    [classes.success]: success,
+    [classes.unread]: error || warning || success,
   })}>
     <div className={classes.title}>{title}</div>
     { content && <div className={classes.content}>{content}</div> }


### PR DESCRIPTION
This add styling for the user notification cards.

unseen: light grey background with 100% opacity
seen: white background with a 70% opacity