### PR TITLE
Fix grid spacing for select image type panel

### DIFF
--- a/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
@@ -94,7 +94,7 @@ const CreateFromImage: React.StatelessComponent<Props> = (props) => {
           title: 'Public Images',
           render: () => (
             <React.Fragment>
-              <Grid container spacing={8}>
+              <Grid container spacing={16}>
                 {publicImages.length
                 && publicImages.map((image: Linode.Image, idx: number) => (
                   <SelectionCard


### PR DESCRIPTION
Tiny PR to fix the grid spacing on the create new linode select image type panel