### PR TITLE
M3-268 nodebalancer summary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,6 +88,11 @@ const styles: StyleRulesCallback = (theme: Theme & Linode.Theme) => ({
     flex: 1,
     maxWidth: '100%',
     position: 'relative',
+    '&.mlMain': {
+      [theme.breakpoints.up('lg')]: {
+        maxWidth: '78.8%',
+      },
+    },
   },
 });
 
@@ -192,6 +197,7 @@ export class App extends React.Component<CombinedProps, State> {
   render() {
     const { menuOpen } = this.state;
     const { classes, longLivedLoaded, documentation, toggleTheme } = this.props;
+    const hasDoc = documentation.length > 0;
 
     return (
       <React.Fragment>
@@ -204,7 +210,7 @@ export class App extends React.Component<CombinedProps, State> {
                 <TopMenu toggleSideMenu={this.toggleMenu} />
                 <div className={classes.wrapper}>
                   <Grid container spacing={0} className={classes.grid}>
-                    <Grid item className={classes.switchWrapper}>
+                    <Grid item className={`${classes.switchWrapper} ${hasDoc ? 'mlMain' : ''}`}>
                       <Switch>
                         <Route exact path="/dashboard" render={() =>
                           <Placeholder title="Dashboard" />} />

--- a/src/components/LineGraph/LineGraph.tsx
+++ b/src/components/LineGraph/LineGraph.tsx
@@ -1,0 +1,167 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+import { Line } from 'react-chartjs-2';
+import { clone } from 'ramda';
+import { setUpCharts } from 'src/utilities/charts';
+
+setUpCharts();
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface DataSet {
+  label: string;
+  borderColor: string;
+  // this data property type might not be the perfect fit, but it works for
+  // the data returned from /linodes/:linodeID/stats and
+  // /nodebalancers/:nodebalancer/stats
+  data: [number, number][];
+}
+
+interface Props {
+  chartHeight?: number;
+  showToday: boolean;
+  suggestedMax?: number;
+  data: DataSet[];
+}
+
+interface State { }
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const chartOptions: any = {
+  maintainAspectRatio: false,
+  animation: {
+    duration: 0,
+  },
+  legend: {
+    display: false,
+  },
+  scales: {
+    yAxes: [{
+      gridLines: {
+        borderDash: [3, 6],
+        zeroLineWidth: 1,
+        zeroLineBorderDashOffset: 2,
+      },
+      ticks: {
+        beginAtZero: true,
+        callback(value: number, index: number) {
+          if (value >= 1000000) {
+            return (value / 1000000) + 'M';
+          }
+          if (value >= 1000) {
+            return (value / 1000) + 'K';
+          }
+          return value;
+        },
+      },
+    }],
+    xAxes: [{
+      type: 'time',
+      gridLines: {
+        display: false,
+      },
+      time: {
+        displayFormats: {
+          hour: 'HH:00',
+          minute: 'HH:00',
+        },
+      },
+    }],
+  },
+  tooltips: {
+    cornerRadius: 0,
+    backgroundColor: '#fbfbfb',
+    bodyFontColor: '#333',
+    displayColors: false,
+    titleFontColor: '#666',
+    xPadding: 16,
+    yPadding: 10,
+    borderWidth: .5,
+    borderColor: '#999',
+    caretPadding: 10,
+    position: 'nearest',
+  },
+};
+
+const lineOptions = {
+  backgroundColor: 'rgba(0, 0, 0, 0)',
+  borderWidth: 1,
+  borderJoinStyle: 'miter',
+  lineTension: 0,
+  pointRadius: 0,
+  pointHitRadius: 10,
+};
+
+class LineGraph extends React.Component<CombinedProps, State> {
+  state: State = {};
+
+  getChartOptions = (suggestedMax?: number) => {
+    const finalChartOptions = clone(chartOptions);
+    const { showToday } = this.props;
+
+    if (showToday) {
+      finalChartOptions.scales.xAxes[0].time.displayFormats = {
+        hour: 'HH:00',
+        minute: 'HH:00',
+      };
+    } else {
+      finalChartOptions.scales.xAxes[0].time.displayFormats = {
+        hour: 'MMM DD',
+        minute: 'MMM DD',
+      };
+    }
+
+    if (suggestedMax) {
+      finalChartOptions.scales.yAxes[0].ticks.suggestedMax = suggestedMax;
+    }
+
+    return finalChartOptions;
+  }
+
+  formatData = () => {
+    const { data } = this.props;
+
+    return data.map((dataSet) => {
+      const timeData = dataSet.data.reduce((acc: any, point: any) => {
+        acc.push({ t: point[0], y: point[1] });
+        return acc;
+      }, []);
+
+      return {
+        label: dataSet.label,
+        borderColor: dataSet.borderColor,
+        data: timeData,
+        ...lineOptions,
+      };
+    });
+  }
+
+  render() {
+    const { chartHeight, suggestedMax } = this.props;
+    return (
+      <Line
+        height={chartHeight || 300}
+        options={this.getChartOptions(suggestedMax)}
+        data={{
+          datasets: this.formatData(),
+        }}
+      />
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(LineGraph);
+
+

--- a/src/components/LineGraph/LineGraph.tsx
+++ b/src/components/LineGraph/LineGraph.tsx
@@ -23,6 +23,7 @@ interface DataSet {
   // this data property type might not be the perfect fit, but it works for
   // the data returned from /linodes/:linodeID/stats and
   // /nodebalancers/:nodebalancer/stats
+  // the first number will be a UTC data and the second will be the amount per second
   data: [number, number][];
 }
 

--- a/src/components/LineGraph/index.tsx
+++ b/src/components/LineGraph/index.tsx
@@ -1,0 +1,2 @@
+import LineGraph from './LineGraph';
+export default LineGraph;

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
@@ -20,24 +20,19 @@ interface Props {
   nodeBalancer: Linode.ExtendedNodeBalancer;
 }
 
-interface State { }
-
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-class NodeBalancerSummary extends React.Component<CombinedProps, State> {
-  state: State = {};
-
-  render() {
-    const { nodeBalancer } = this.props;
-    return (
-      <React.Fragment>
-        <SummaryPanel nodeBalancer={nodeBalancer} />
-        <TablesPanel nodeBalancer={nodeBalancer} />
-      </React.Fragment>
-    );
-  }
-}
+const NodeBalancerSummary: React.StatelessComponent<CombinedProps> = (props) => {
+  const { nodeBalancer } = props;
+  return (
+    <React.Fragment>
+      <SummaryPanel nodeBalancer={nodeBalancer} />
+      <TablesPanel nodeBalancer={nodeBalancer} />
+    </React.Fragment>
+  );
+};
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled(NodeBalancerSummary);
+export default styled<Props>(NodeBalancerSummary);
+

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+import SummaryPanel from './SummaryPanel';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {
+  nodeBalancer: Linode.ExtendedNodeBalancer;
+}
+
+interface State { }
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class NodeBalancerSummary extends React.Component<CombinedProps, State> {
+  state: State = {};
+
+  render() {
+    const { nodeBalancer } = this.props;
+    return (
+      <React.Fragment>
+        <SummaryPanel nodeBalancer={nodeBalancer} />
+      </React.Fragment>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(NodeBalancerSummary);

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
@@ -7,6 +7,7 @@ import {
 } from 'material-ui';
 
 import SummaryPanel from './SummaryPanel';
+import TablesPanel from './TablesPanel';
 
 
 type ClassNames = 'root';
@@ -31,6 +32,7 @@ class NodeBalancerSummary extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <SummaryPanel nodeBalancer={nodeBalancer} />
+        <TablesPanel nodeBalancer={nodeBalancer} />
       </React.Fragment>
     );
   }

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -15,10 +15,18 @@ import { formatRegion } from 'src/features/linodes/presentation';
 
 import { convertMegabytesTo } from 'src/utilities/convertMegabytesTo';
 
-type ClassNames = 'root';
+type ClassNames = 'root'
+| 'title';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
-  root: {},
+  root: {
+    padding: theme.spacing.unit * 3,
+    paddingBottom: 20,
+    marginTop: theme.spacing.unit * 2,
+  },
+  title: {
+    marginBottom: theme.spacing.unit * 2,
+  },
 });
 
 interface Props {
@@ -28,26 +36,36 @@ interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const SummaryPanel: React.StatelessComponent<CombinedProps> = (props) => {
-  const { nodeBalancer } = props;
+  const { nodeBalancer, classes } = props;
   return (
-    <Paper>
+    <Paper className={classes.root}>
       <Grid container>
         <Grid item xs={12}>
-          <Typography variant="headline">Summary</Typography>
+          <Typography
+            variant="headline"
+            className={classes.title}
+            data-qa-title
+          >
+            Summary
+          </Typography>
         </Grid>
         <Grid item xs={6}>
-          <Typography variant="caption">
+          <Typography
+            variant="caption"
+          >
             <strong>Host Name:</strong> {nodeBalancer.hostname}
           </Typography>
         </Grid>
         <Grid item xs={6}>
           <Typography variant="caption">
-            <strong>Ports:</strong> {nodeBalancer.ports.map((port, index, ports) => {
-              // we want a comma after the port number as long as the ports array
-              // has multiple values and the current index isn't the last
-              // element in the array
-              return (ports.length > 1 && index + 1 !== ports.length) ? `${port}, ` : port;
-            })}
+            <strong>
+              Ports: </strong> {nodeBalancer.ports.length === 0 && 'None'}
+              {nodeBalancer.ports.map((port, index, ports) => {
+                // we want a comma after the port number as long as the ports array
+                // has multiple values and the current index isn't the last
+                // element in the array
+                return (ports.length > 1 && index + 1 !== ports.length) ? `${port}, ` : port;
+              })}
           </Typography>
         </Grid>
         <Grid item xs={3}>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+
+import Paper from 'material-ui/Paper';
+import Typography from 'material-ui/Typography';
+
+import Grid from 'src/components/Grid';
+import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
+import { formatRegion } from 'src/features/linodes/presentation';
+
+import { convertMegabytesTo } from 'src/utilities/convertMegabytesTo';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {
+  nodeBalancer: Linode.ExtendedNodeBalancer;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const SummaryPanel: React.StatelessComponent<CombinedProps> = (props) => {
+  const { nodeBalancer } = props;
+  return (
+    <Paper>
+      <Grid container>
+        <Grid item xs={12}>
+          <Typography variant="headline">Summary</Typography>
+        </Grid>
+        <Grid item xs={6}>
+          <Typography variant="caption">
+            <strong>Host Name:</strong> {nodeBalancer.hostname}
+          </Typography>
+        </Grid>
+        <Grid item xs={6}>
+          <Typography variant="caption">
+            <strong>Ports:</strong> {nodeBalancer.ports.map((port, index, ports) => {
+              // we want a comma after the port number as long as the ports array
+              // has multiple values and the current index isn't the last
+              // element in the array
+              return (ports.length > 1 && index + 1 !== ports.length) ? `${port}, ` : port;
+            })}
+          </Typography>
+        </Grid>
+        <Grid item xs={3}>
+          <Typography variant="caption">
+            <strong>Node Status:</strong> {`${nodeBalancer.up} up, ${nodeBalancer.down} down`}
+          </Typography>
+        </Grid>
+        <Grid item xs={3}>
+          <Typography variant="caption">
+            <strong>Transferred:</strong> {convertMegabytesTo(nodeBalancer.transfer.total)}
+          </Typography>
+        </Grid>
+        <Grid item xs={6}>
+          <IPAddress ips={[nodeBalancer.ipv4]} copyRight />
+          {nodeBalancer.ipv6 && <IPAddress ips={[nodeBalancer.ipv6]} copyRight />}
+        </Grid>
+        <Grid item xs={6}>
+          <Typography variant="caption">
+            {formatRegion(nodeBalancer.region)}
+          </Typography>
+        </Grid>
+      </Grid>
+    </Paper >
+  );
+};
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled<Props>(SummaryPanel);
+

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -60,12 +60,7 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = (props) => {
           <Typography variant="caption">
             <strong>
               Ports: </strong> {nodeBalancer.ports.length === 0 && 'None'}
-              {nodeBalancer.ports.map((port, index, ports) => {
-                // we want a comma after the port number as long as the ports array
-                // has multiple values and the current index isn't the last
-                // element in the array
-                return (ports.length > 1 && index + 1 !== ports.length) ? `${port}, ` : port;
-              })}
+              {nodeBalancer.ports.join(', ')}
           </Typography>
         </Grid>
         <Grid item xs={12} sm={6} lg={3}>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -49,14 +49,14 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = (props) => {
             Summary
           </Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={12} sm={6}>
           <Typography
             variant="caption"
           >
             <strong>Host Name:</strong> {nodeBalancer.hostname}
           </Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={12} sm={6}>
           <Typography variant="caption">
             <strong>
               Ports: </strong> {nodeBalancer.ports.length === 0 && 'None'}
@@ -68,21 +68,21 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = (props) => {
               })}
           </Typography>
         </Grid>
-        <Grid item xs={3}>
+        <Grid item xs={12} sm={6} lg={3}>
           <Typography variant="caption">
             <strong>Node Status:</strong> {`${nodeBalancer.up} up, ${nodeBalancer.down} down`}
           </Typography>
         </Grid>
-        <Grid item xs={3}>
+        <Grid item xs={12} sm={6} lg={3}>
           <Typography variant="caption">
             <strong>Transferred:</strong> {convertMegabytesTo(nodeBalancer.transfer.total)}
           </Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={12} sm={6}>
           <IPAddress ips={[nodeBalancer.ipv4]} copyRight />
           {nodeBalancer.ipv6 && <IPAddress ips={[nodeBalancer.ipv6]} copyRight />}
         </Grid>
-        <Grid item xs={6}>
+        <Grid item xs={12} sm={6}>
           <Typography variant="caption">
             {formatRegion(nodeBalancer.region)}
           </Typography>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -140,11 +140,11 @@ class TablesPanel extends React.Component<CombinedProps, State> {
     const { stats } = this.state;
     return (
       <React.Fragment>
-        <div className={classes.graphControls}>
-          <Typography variant="title" className={classes.graphTitle}>Graphs</Typography>
-        </div>
         {stats &&
           <React.Fragment>
+            <div className={classes.graphControls}>
+              <Typography variant="title" className={classes.graphTitle}>Graphs</Typography>
+            </div>
             <ExpansionPanel
               defaultExpanded
               heading="Connections (5 min avg.)"

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -24,14 +24,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => {
   return {
     chart: {
       position: 'relative',
-      width: 'calc(100vw - 80px)',
+      width: '100%',
       paddingLeft: theme.spacing.unit * 4,
-      [theme.breakpoints.up('md')]: {
-        width: 'calc(100vw - 310px)',
-      },
-      [theme.breakpoints.up('xl')]: {
-        width: 'calc(100vw - 370px)',
-      },
     },
     leftLegend: {
       position: 'absolute',

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -1,0 +1,143 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+import Typography from 'material-ui/Typography';
+
+import ExpansionPanel from 'src/components/ExpansionPanel';
+import { getNodeBalancerStats } from 'src/services/nodebalancers';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {
+  nodeBalancer: Linode.ExtendedNodeBalancer;
+}
+
+interface State {
+  stats: Linode.NodeBalancerStats | null;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+// const chartOptions: any = {
+//   maintainAspectRatio: false,
+//   animation: {
+//     duration: 0,
+//   },
+//   legend: {
+//     display: false,
+//   },
+//   scales: {
+//     yAxes: [{
+//       gridLines: {
+//         borderDash: [3, 6],
+//         zeroLineWidth: 1,
+//         zeroLineBorderDashOffset: 2,
+//       },
+//       ticks: {
+//         beginAtZero: true,
+//         callback(value: number, index: number) {
+//           if (value >= 1000000) {
+//             return (value / 1000000) + 'M';
+//           }
+//           if (value >= 1000) {
+//             return (value / 1000) + 'K';
+//           }
+//           return value;
+//         },
+//       },
+//     }],
+//     xAxes: [{
+//       type: 'time',
+//       gridLines: {
+//         display: false,
+//       },
+//       time: {
+//         displayFormats: {
+//           hour: 'HH:00',
+//           minute: 'HH:00',
+//         },
+//       },
+//     }],
+//   },
+//   tooltips: {
+//     cornerRadius: 0,
+//     backgroundColor: '#fbfbfb',
+//     bodyFontColor: '#333',
+//     displayColors: false,
+//     titleFontColor: '#666',
+//     xPadding: 16,
+//     yPadding: 10,
+//     borderWidth: .5,
+//     borderColor: '#999',
+//     caretPadding: 10,
+//     position: 'nearest',
+//   },
+// };
+
+// const statToColor = {
+//   connections: '#428ade',
+//   in: '#3683dc',
+//   out: '#01b159',
+// };
+
+// looking at LinodeSummary as a point of reference
+
+class TablesPanel extends React.Component<CombinedProps, State> {
+  statsInterval?: number = undefined;
+  mounted: boolean = false;
+
+  state: State = {
+    stats: null,
+  };
+
+  getStats = () => {
+    const { nodeBalancer } = this.props;
+    getNodeBalancerStats(nodeBalancer.id)
+      .then((response: Linode.NodeBalancerStats) => {
+        if (!this.mounted) { return; }
+        console.log(response);
+        this.setState({ stats: response });
+      })
+      .catch((errorResponse) => {
+        if (!this.mounted) { return; }
+      });
+  }
+
+  componentDidMount() {
+    this.mounted = true;
+    this.getStats();
+    // this.statsInterval = window.setInterval(() => this.getStats(), statsFetchInterval);
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+    // window.clearInterval(this.statsInterval as number);
+  }
+
+  render() {
+    console.log(this.state.stats);
+    return (
+      <React.Fragment>
+        <Typography variant="title">Graphs</Typography>
+        <ExpansionPanel heading="Connections">
+        </ExpansionPanel>
+        <ExpansionPanel heading="Traffic">
+        </ExpansionPanel>
+      </React.Fragment>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(TablesPanel);
+

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -71,7 +71,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => {
       marginRight: theme.spacing.unit * 2,
     },
     graphControls: {
-      marginTop: theme.spacing.unit * 2,
+      margin: `${theme.spacing.unit * 2}px 0`,
       display: 'flex',
       alignItems: 'center',
     },
@@ -146,15 +146,20 @@ class TablesPanel extends React.Component<CombinedProps, State> {
     const { stats } = this.state;
     return (
       <React.Fragment>
-        <Typography variant="title">Graphs</Typography>
+        <div className={classes.graphControls}>
+          <Typography variant="title" className={classes.graphTitle}>Graphs</Typography>
+        </div>
         {stats &&
           <React.Fragment>
-            <ExpansionPanel defaultExpanded heading="Connections (5 min avg.)">
+            <ExpansionPanel
+              defaultExpanded
+              heading="Connections (5 min avg.)"
+            >
               <React.Fragment>
                 <div className={classes.chart}>
-                  <div className={classes.leftLegend}>
+                  <div className={classes.leftLegend} style={{ left: -34, bottom: 60 }}>
                     connections/sec
-                          </div>
+                  </div>
                   <LineGraph
                     showToday={true}
                     data={[
@@ -168,7 +173,11 @@ class TablesPanel extends React.Component<CombinedProps, State> {
                 </div>
               </React.Fragment>
             </ExpansionPanel>
-            <ExpansionPanel defaultExpanded heading="Traffic (5 min avg.)">
+
+            <ExpansionPanel
+              defaultExpanded
+              heading="Traffic (5 min avg.)"
+            >
               <React.Fragment>
                 <div className={classes.chart}>
                   <div className={classes.leftLegend}>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
-// import * as moment from 'moment';
 import {
   withStyles,
   StyleRulesCallback,
-  // Theme,
   WithStyles,
 } from 'material-ui';
 import Typography from 'material-ui/Typography';
@@ -112,8 +110,6 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 const statsFetchInterval = 30000;
 
-// looking at LinodeSummary as a point of reference
-
 class TablesPanel extends React.Component<CombinedProps, State> {
   statsInterval?: number = undefined;
   mounted: boolean = false;
@@ -148,43 +144,64 @@ class TablesPanel extends React.Component<CombinedProps, State> {
   render() {
     const { classes } = this.props;
     const { stats } = this.state;
-    stats && console.log(stats);
+    console.log(stats);
     return (
       <React.Fragment>
         <Typography variant="title">Graphs</Typography>
         {stats &&
-          <ExpansionPanel defaultExpanded heading="Traffic">
-            <React.Fragment>
-              <div className={classes.chart}>
-                <div className={classes.leftLegend}>
-                  bits/sec
+          <React.Fragment>
+            <ExpansionPanel defaultExpanded heading="Connections (5 min avg.)">
+              <React.Fragment>
+                <div className={classes.chart}>
+                  <div className={classes.leftLegend}>
+                    connections/sec
+                          </div>
+                  <LineGraph
+                    showToday={true}
+                    data={[
+                      {
+                        label: 'Connections',
+                        borderColor: '#3683dc',
+                        data: stats.data.connections,
+                      },
+                    ]}
+                  />
+                </div>
+              </React.Fragment>
+            </ExpansionPanel>
+            <ExpansionPanel defaultExpanded heading="Traffic (5 min avg.)">
+              <React.Fragment>
+                <div className={classes.chart}>
+                  <div className={classes.leftLegend}>
+                    bits/sec
                   </div>
-                <LineGraph
-                  showToday={false}
-                  data={[
-                    {
-                      label: 'Traffic In',
-                      borderColor: '#3683dc',
-                      data: stats.data.traffic.in,
-                    },
-                    {
-                      label: 'Traffic Out',
-                      borderColor: '#01b159',
-                      data: stats.data.traffic.out,
-                    },
-                  ]}
-                />
-              </div>
-              <div className={classes.bottomLegend}>
-                <div className={classes.blue}>
-                  Inbound
+                  <LineGraph
+                    showToday={true}
+                    data={[
+                      {
+                        label: 'Traffic In',
+                        borderColor: '#3683dc',
+                        data: stats.data.traffic.in,
+                      },
+                      {
+                        label: 'Traffic Out',
+                        borderColor: '#01b159',
+                        data: stats.data.traffic.out,
+                      },
+                    ]}
+                  />
+                </div>
+                <div className={classes.bottomLegend}>
+                  <div className={classes.blue}>
+                    Inbound
                   </div>
-                <div className={classes.green}>
-                  Outbound
+                  <div className={classes.green}>
+                    Outbound
                   </div>
-              </div>
-            </React.Fragment>
-          </ExpansionPanel>
+                </div>
+              </React.Fragment>
+            </ExpansionPanel>
+          </React.Fragment>
         }
       </React.Fragment>
     );

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -144,7 +144,6 @@ class TablesPanel extends React.Component<CombinedProps, State> {
   render() {
     const { classes } = this.props;
     const { stats } = this.state;
-    console.log(stats);
     return (
       <React.Fragment>
         <Typography variant="title">Graphs</Typography>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/index.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/index.tsx
@@ -1,0 +1,2 @@
+import NodeBalancerSummary from './NodeBalancerSummary';
+export default NodeBalancerSummary;

--- a/src/features/NodeBalancers/NodeBalancerDetail/index.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/index.tsx
@@ -1,0 +1,2 @@
+import NodeBalancerDetail from './NodeBalancerDetail';
+export default NodeBalancerDetail;

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -173,12 +173,9 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
                     <TableCell>
                       {convertMegabytesTo(nodeBalancer.transfer.total)}
                     </TableCell>
-                    <TableCell>{nodeBalancer.ports.map((port, index, ports) => {
-                      // we want a comma after the port number as long as the ports array
-                      // has multiple values and the current index isn't the last
-                      // element in the array
-                      return (ports.length > 1 && index + 1 !== ports.length) ? `${port}, ` : port;
-                    })}
+                    <TableCell>
+                      {nodeBalancer.ports.length === 0 && 'None'}
+                      {nodeBalancer.ports.join(', ')}
                     </TableCell>
                     <TableCell>
                       <IPAddress ips={[nodeBalancer.ipv4]} copyRight />

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -13,6 +13,8 @@ import TableRow from 'material-ui/Table/TableRow';
 import { getNodeBalancers, getNodeBalancerConfigs } from 'src/services/nodebalancers';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
 import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
+import { convertMegabytesTo } from 'src/utilities/convertMegabytesTo';
+
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import Grid from 'src/components/Grid';
 import Table from 'src/components/Table';
@@ -103,25 +105,6 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
     },
   ];
 
-  formatTransferData = (transferTotal: number) => {
-    // API v4 always returns nodebalancer transfer in MB, so we want to clean it up if it's too
-    // big or too small
-    const gb = 1073741824;
-    const mb = 1048576;
-    const kb = 1024;
-    const totalToBytes = transferTotal * 1024 * 1024; // convert the MB to Bytes
-    if (totalToBytes >= gb) { // convert bytes to GB
-      return `${Math.max(Math.ceil(totalToBytes / gb)).toFixed(2)} GB`;
-    }
-    if (totalToBytes >= mb) { // convert bytes to MB
-      return `${Math.max(Math.ceil(totalToBytes / mb * 100) / 100).toFixed(2)} MB`;
-    }
-    if (totalToBytes >= kb) { // convert bytes to KB
-      return `${Math.max(Math.ceil(totalToBytes / kb * 100) / 100).toFixed(2)} KB`;
-    }
-    return `${totalToBytes} bytes`;
-  }
-
   renderEmptyState = () => {
     return <Placeholder />;
   }
@@ -188,7 +171,7 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
                     </TableCell>
                     <TableCell>{`${nodeBalancer.up} up, ${nodeBalancer.down} down`}</TableCell>
                     <TableCell>
-                      {this.formatTransferData(nodeBalancer.transfer.total)}
+                      {convertMegabytesTo(nodeBalancer.transfer.total)}
                     </TableCell>
                     <TableCell>{nodeBalancer.ports.map((port, index, ports) => {
                       // we want a comma after the port number as long as the ports array

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -83,7 +83,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => {
       marginRight: theme.spacing.unit * 2,
     },
     graphControls: {
-      marginTop: theme.spacing.unit * 2,
+      margin: `${theme.spacing.unit * 2}px 0`,
       display: 'flex',
       alignItems: 'center',
     },

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -308,8 +308,6 @@ class LinodeSummary extends React.Component<CombinedProps, State> {
       return acc;
     }, []);
 
-    console.log(timeData);
-
     return {
       label: statToLabel[stat],
       borderColor: statToColor[stat],

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -308,6 +308,8 @@ class LinodeSummary extends React.Component<CombinedProps, State> {
       return acc;
     }, []);
 
+    console.log(timeData);
+
     return {
       label: statToLabel[stat],
       borderColor: statToColor[stat],

--- a/src/services/nodebalancers.ts
+++ b/src/services/nodebalancers.ts
@@ -80,3 +80,13 @@ export const createNodeBalancer = (data: any) =>
     validateRequestData(data, createNodeBalancerSchema),
   )
     .then(response => response.data);
+
+export const getNodeBalancerStats = (nodeBalancerId: number, month?: string, year?: string) => {
+  const endpoint = (year && month)
+    ? `${API_ROOT}/nodebalancers/${nodeBalancerId}/stats/${year}/${month}`
+    : `${API_ROOT}/nodebalancers/${nodeBalancerId}/stats`;
+  return Request(
+    setURL(endpoint),
+    setMethod('GET'),
+  ).then(response => response.data);
+};

--- a/src/types/NodeBalancer.ts
+++ b/src/types/NodeBalancer.ts
@@ -50,4 +50,15 @@ namespace Linode {
     down: number;
     ports: number[];
   }
+
+  export interface NodeBalancerStats{
+    title: string;
+    data: {
+      connections: [number, number][];
+      traffic: {
+        out: [number, number][];
+        in: [number, number][];
+      }
+    };
+  }
 }

--- a/src/utilities/convertMegabytesTo.tsx
+++ b/src/utilities/convertMegabytesTo.tsx
@@ -1,0 +1,18 @@
+export const convertMegabytesTo = (data: number) => {
+  // API v4 always returns nodebalancer transfer in MB, so we want to clean it up if it's too
+  // big or too small
+  const gb = 1073741824;
+  const mb = 1048576;
+  const kb = 1024;
+  const totalToBytes = data * 1024 * 1024; // convert the MB to Bytes
+  if (totalToBytes >= gb) { // convert bytes to GB
+    return `${Math.max(Math.ceil(totalToBytes / gb)).toFixed(2)} GB`;
+  }
+  if (totalToBytes >= mb) { // convert bytes to MB
+    return `${Math.max(Math.ceil(totalToBytes / mb * 100) / 100).toFixed(2)} MB`;
+  }
+  if (totalToBytes >= kb) { // convert bytes to KB
+    return `${Math.max(Math.ceil(totalToBytes / kb * 100) / 100).toFixed(2)} KB`;
+  }
+  return `${totalToBytes} bytes`;
+};


### PR DESCRIPTION
### Purpose

Add nodebalancer summary information
* contains basic info about the nodebalancer
* contains connections/second and incoming and outcoming traffic/second graphs

### Notes

* Created a new LineGraph component
* No errors appear for bad requests to `nodebalancer/stats`, as per review notes on Linode stats errors
* No filtering yet