### PR TITLE
M3-590 Close Button on Domain Delete Modal Crashing Page 

### DIFF
--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -138,13 +138,13 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
     }
   }
 
-  openRemoveDialog(domain: string, domainID: number) {
+  openRemoveDialog = (domain: string, domainID: number) => {
     this.setState({
       removeDialog: { open: true, domain, domainID },
     });
   }
 
-  closeRemoveDialog() {
+  closeRemoveDialog = () => {
     this.setState({
       removeDialog: { open: false, domain: undefined, domainID: undefined },
     });


### PR DESCRIPTION
### Purpose

Previously when opening up the domain delete confirmation dialog, clicking 'cancel' would crash the page instead of closing the modal. Changed the function responsible for that logic to a fat arrow function, and now all is well.

#JavaScript