### PR TITLE
M3-506 action panels refactor

### DIFF
--- a/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/src/components/ActionsPanel/ActionsPanel.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as classNames from 'classnames';
 
 import {
   withStyles,
@@ -7,29 +8,37 @@ import {
   WithStyles,
 } from 'material-ui';
 
-import {
-  ExpansionPanelActions,
-  ExpansionPanelActionsProps,
-} from 'material-ui/ExpansionPanel';
-
 type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
-  root: {},
+  root: {
+    paddingTop: 16,
+    paddingBottom: 16,
+    '& > :not(:first-child)': {
+      marginLeft: 8,
+    },
+  },
 });
 
-interface Props extends ExpansionPanelActionsProps {}
+interface Props {
+  className?: string;
+  style?: any;
+}
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const ActionPanel: React.StatelessComponent<CombinedProps> = (props) => {
+  const { classes, className } = props;
+
   return (
-    <ExpansionPanelActions
-      className={`${props.classes.root} actionPanel`}
-      {...props}
+    <div className={classNames({
+      [classes.root]: true,
+      ...(className && { [className]: true }),
+      actionPanel: true,
+    })}
     >
       { props.children }
-    </ExpansionPanelActions>
+    </div>
   );
 };
 

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -24,9 +24,6 @@ const styles: StyleRulesCallback = (theme: Theme) => ({
       width: 480,
     },
     '& .actionPanel': {
-      paddingLeft: 0,
-      paddingRight: 0,
-      marginLeft: -theme.spacing.unit,
       marginTop: theme.spacing.unit * 2,
     },
     '& .selectionCard': {

--- a/src/features/Volumes/VolumeConfigDrawer.tsx
+++ b/src/features/Volumes/VolumeConfigDrawer.tsx
@@ -14,12 +14,16 @@ import Drawer from 'src/components/Drawer';
 import CopyableTextField from './CopyableTextField';
 
 type ClassNames = 'root'
-|  'copyField';
+| 'copySection'
+| 'copyField';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {},
+  copySection: {
+    marginTop: theme.spacing.unit * 2,
+  },
   copyField: {
-    margin: `${theme.spacing.unit}px 0 ${theme.spacing.unit * 2}px`,
+    marginTop: theme.spacing.unit,
   },
 });
 
@@ -42,39 +46,47 @@ const VolumeConfigDrawer: React.StatelessComponent<CombinedProps> = (props) => {
     >
       {(props.volumePath && props.volumeLabel) &&
         <React.Fragment>
-          <Typography variant="body1">
-            To get started with a new volume, you'll want to create a filesystem on it:
-          </Typography>
-          <CopyableTextField
-            className={classes.copyField}
-            value={`mkfs.ext4 "${props.volumePath}"`}
-          />
+          <div className={classes.copySection}>
+            <Typography variant="body1">
+              To get started with a new volume, you'll want to create a filesystem on it:
+            </Typography>
+            <CopyableTextField
+              className={classes.copyField}
+              value={`mkfs.ext4 "${props.volumePath}"`}
+            />
+          </div>
 
-          <Typography variant="body1">
-            Once the volume has a filesystem, you can create a mountpoint for it:
-          </Typography>
-          <CopyableTextField
-            className={classes.copyField}
-            value={`mkdir "/mnt/${props.volumeLabel}"`}
-          />
+          <div className={classes.copySection}>
+            <Typography variant="body1">
+              Once the volume has a filesystem, you can create a mountpoint for it:
+            </Typography>
+            <CopyableTextField
+              className={classes.copyField}
+              value={`mkdir "/mnt/${props.volumeLabel}"`}
+            />
+          </div>
 
-          <Typography variant="body1">
-            Then you can mount the new volume:
-          </Typography>
-          <CopyableTextField
-            className={classes.copyField}
-            value={`mount "${props.volumePath}" "/mnt/${props.volumeLabel}"`}
-          />
+          <div className={classes.copySection}>
+            <Typography variant="body1">
+              Then you can mount the new volume:
+            </Typography>
+            <CopyableTextField
+              className={classes.copyField}
+              value={`mount "${props.volumePath}" "/mnt/${props.volumeLabel}"`}
+            />
+          </div>
 
-          <Typography variant="body1">
-            If you want the volume to automatically mount every time your
-            Linode boots, you'll want to add a line like the following to
-            your /etc/fstab file:
-          </Typography>
-          <CopyableTextField
-            className={classes.copyField}
-            value={`${props.volumePath} /mnt/${props.volumeLabel}`}
-          />
+          <div className={classes.copySection}>
+            <Typography variant="body1">
+              If you want the volume to automatically mount every time your
+              Linode boots, you'll want to add a line like the following to
+              your /etc/fstab file:
+            </Typography>
+            <CopyableTextField
+              className={classes.copyField}
+              value={`${props.volumePath} /mnt/${props.volumeLabel}`}
+            />
+          </div>
 
           <ActionsPanel>
             <Button

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -31,12 +31,12 @@ type ClassNames = 'root'
  | 'title'
  | 'intro'
  | 'imageControl'
- | 'actionPanel';
+ | 'image';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
     padding: theme.spacing.unit * 3,
-    paddingBottom: theme.spacing.unit * 1,
+    paddingBottom: theme.spacing.unit * 3,
   },
   title: {
     marginBottom: theme.spacing.unit * 2,
@@ -47,9 +47,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   imageControl: {
     display: 'flex',
   },
-  actionPanel: {
-    padding: theme.spacing.unit * 2,
-    paddingBottom: theme.spacing.unit * 3,
+  image: {
+    display: 'flex',
+    flexWrap: 'wrap',
   },
 });
 
@@ -184,7 +184,7 @@ class LinodeRebuild extends React.Component<CombinedProps, State> {
             value={this.state.password || ''}
           />
         </Paper>
-        <ActionsPanel className={classes.actionPanel}>
+        <ActionsPanel>
           <Button
             variant="raised"
             color="secondary"

--- a/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
@@ -94,7 +94,6 @@ describe('LinodeRescue', () => {
             root: '',
             title: '',
             intro: '',
-            actionPanel: '',
           }}
           disks={disks}
           linodeId={7843027}

--- a/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -36,13 +36,12 @@ import createDevicesFromStrings, { DevicesAsStrings } from 'src/utilities/create
 
 type ClassNames = 'root'
   | 'title'
-  | 'intro'
-  | 'actionPanel';
+  | 'intro';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
     padding: theme.spacing.unit * 3,
-    paddingBottom: theme.spacing.unit * 1,
+    paddingBottom: theme.spacing.unit * 3,
     '& .iconTextLink': {
       display: 'inline-flex',
       margin: `${theme.spacing.unit * 3}px 0 0 0`,
@@ -53,10 +52,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   },
   intro: {
     marginBottom: theme.spacing.unit * 2,
-  },
-  actionPanel: {
-    padding: theme.spacing.unit * 2,
-    paddingBottom: theme.spacing.unit * 3,
   },
 });
 
@@ -202,7 +197,7 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
             disabled={this.state.counter >= 6}
           />
         </Paper>
-        <ActionsPanel className={classes.actionPanel}>
+        <ActionsPanel>
           <Button onClick={this.onSubmit} variant="raised" color="primary">Submit</Button>
         </ActionsPanel>
       </React.Fragment>

--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -21,7 +21,6 @@ describe('LinodeResize', () => {
             title: '',
             subTitle: '',
             currentPlanContainer: '',
-            actionPanel: '',
           }}
           linodeId={12}
           linodeType={null}
@@ -48,7 +47,6 @@ describe('LinodeResize', () => {
                 title: '',
                 subTitle: '',
                 currentPlanContainer: '',
-                actionPanel: '',
               }}
               linodeId={12}
               linodeType={null}
@@ -77,7 +75,6 @@ describe('LinodeResize', () => {
                 title: '',
                 subTitle: '',
                 currentPlanContainer: '',
-                actionPanel: '',
               }}
               linodeId={12}
               linodeType={'_something_unexpected_'}

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -18,8 +18,7 @@ import { sendToast } from 'src/features/ToastNotifications/toasts';
 type ClassNames = 'root'
   | 'title'
   | 'subTitle'
-  | 'currentPlanContainer'
-  | 'actionPanel';
+  | 'currentPlanContainer';
 
 interface Props {
   linodeId: number;
@@ -129,7 +128,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
           onSelect={(id: string) => this.setState({ selectedId: id })}
           selectedID={this.state.selectedId}
         />
-        <ActionsPanel className={classes.actionPanel}>
+        <ActionsPanel>
           <Button
             variant="raised"
             color="primary"
@@ -164,10 +163,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
         borderColor: theme.color.border2,
       },
     },
-  },
-  actionPanel: {
-    padding: theme.spacing.unit * 2,
-    paddingBottom: theme.spacing.unit * 3,
   },
 });
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -330,7 +330,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               </FormGroup>
             </FormControl>
           </Grid>
-          <Grid item className={classes.section}>
+          <Grid item>
             <ActionsPanel>
               <Button onClick={onSubmit} variant="raised" color="primary">Submit</Button>
               <Button

--- a/src/features/profile/APITokens/APITokenDrawer.tsx
+++ b/src/features/profile/APITokens/APITokenDrawer.tsx
@@ -50,7 +50,7 @@ type ClassNames = 'permsTable'
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   permsTable: {
-    margin: `${theme.spacing.unit * 3}px 0`,
+    marginTop: theme.spacing.unit * 3,
   },
   accessCell: {
     width: '31%',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -78,7 +78,6 @@ const LinodeTheme: Linode.Theme = {
         },
         '&.cancel': {
           borderColor: 'transparent',
-          marginLeft: 0,
           '&:hover, &:focus': {
             borderColor: '#5F99EA',
             backgroundColor: 'transparent',
@@ -150,14 +149,8 @@ const LinodeTheme: Linode.Theme = {
         margin: 0,
         padding: '0 24px 24px 24px',
         justifyContent: 'flex-start',
-        '& button': {
-          marginRight: 8,
-          '&:first-child': {
-            marginLeft: 0,
-          },
-          '&:last-child': {
-            marginRight: 0,
-          },
+        '& .actionPanel': {
+          padding: 0,
         },
       },
       action: {
@@ -180,15 +173,11 @@ const LinodeTheme: Linode.Theme = {
         },
       },
     },
-    MuiExpansionPanel: {},
-    MuiExpansionPanelActions: {
+    MuiExpansionPanel: {
       root: {
-        display: 'block',
-        backgroundColor: 'white',
-      },
-      action: {
-        '&:first-child': {
-          marginRight: 8,
+        '& .actionPanel': {
+          paddingLeft: 16,
+          paddingRight: 16,
         },
       },
     },
@@ -261,7 +250,7 @@ const LinodeTheme: Linode.Theme = {
     },
     MuiFormControl: {
       root: {
-        minHeight: 50,
+        // minHeight: 50,
         marginTop: 16,
         minWidth: 200,
         '&.copy > div': {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -250,7 +250,6 @@ const LinodeTheme: Linode.Theme = {
     },
     MuiFormControl: {
       root: {
-        // minHeight: 50,
         marginTop: 16,
         minWidth: 200,
         '&.copy > div': {


### PR DESCRIPTION
We have been using <ExpansionPanelActions /> within our ActionPanel component site-wide so I refactored the markup to use a more versatile markup in order to avoid repeated styles and overrides all over the app. This PR simplifies much the use of the ActionPanel as it now behaves contextually (if in a form, drawer, expanded panel or dialog)