### PR TITLE
M3-569 - Replace hardcoded timeouts, editDnsAction

### DIFF
--- a/e2e/constants.js
+++ b/e2e/constants.js
@@ -2,6 +2,13 @@ exports.constants = {
 	testAccounts: {
 
 	},
+	wait: {
+		short: 5000,
+		normal: 12000,
+		long: 30000,
+		minute: 60000,
+		custom: (milliseconds) => milliseconds,
+	},
 	routes: {
 		storybook: process.env.DOCKER ? 'http://manager-storybook:6006/' : '/',
 		dashboard: process.env.DOCKER ? 'https://manager-local:3000/' : '/',

--- a/e2e/pageobjects/domain-detail/domain-details.page.js
+++ b/e2e/pageobjects/domain-detail/domain-details.page.js
@@ -1,0 +1,9 @@
+const { constants } = require('../../constants');
+
+import Page from '../page';
+
+class DomainDetail extends Page {
+    get domainTitle() { return $('[data-qa-domain-title]'); }
+}
+
+export default new DomainDetail();

--- a/e2e/pageobjects/linode-detail/linode-detail-backups.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-backups.page.js
@@ -1,3 +1,5 @@
+const { constants } = require('../../constants');
+
 import Page from '../page';
 
 class Backups extends Page {
@@ -65,7 +67,7 @@ class Backups extends Page {
                 browser.click('[data-qa-toast] button');
                 return true;
             }
-        }, 10000);
+        }, constants.wait.normal);
     }
 
     takeSnapshot(label) {
@@ -78,12 +80,12 @@ class Backups extends Page {
         browser.waitUntil(function() {
             return browser
                 .getText('[data-qa-toast-message]') === toastMsg;
-        }, 10000);
+        }, constants.wait.normal);
         return this;
     }
 
     assertSnapshot(label) {
-        browser.waitForVisible('[data-qa-backup]', 45000);
+        browser.waitForVisible('[data-qa-backup]', constants.wait.veryLong);
 
         const backupInstance = this.backupInstances.map(i => {
             return i.$(this.label.selector).getText();

--- a/e2e/pageobjects/linode-detail/linode-detail-networking.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-networking.page.js
@@ -1,3 +1,5 @@
+const { constants } = require('../../constants');
+
 import Page from '../page';
 
 class Networking extends Page {
@@ -132,7 +134,7 @@ class Networking extends Page {
         browser.click(`[data-qa-ip="${ip}"] [data-qa-action-menu]`);
         browser.waitForVisible(menuItem);
         browser.click(menuItem)
-        browser.waitForVisible(menuItem, 10000, true);
+        browser.waitForVisible(menuItem, constants.wait.normal, true);
     }
 
     editRdns(ip) {

--- a/e2e/pageobjects/linode-detail/linode-detail-rebuild.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-rebuild.page.js
@@ -1,3 +1,5 @@
+const { constants } = require('../../constants');
+
 class Rebuild {
     get title() { return $('[data-qa-title]'); }
     get description() { return $('[data-qa-rebuild-desc]'); }
@@ -49,7 +51,7 @@ class Rebuild {
         browser.waitUntil(function() {
             return browser
                 .getText('[data-qa-toast-message]') === toastMessage;
-        }, 15000);
+        }, constants.wait.normal);
     }
 }
 

--- a/e2e/pageobjects/linode-detail/linode-detail-settings.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-settings.page.js
@@ -1,3 +1,5 @@
+const { constants } = require('../../constants');
+
 import Page from '../page';
 
 class Settings extends Page {
@@ -43,7 +45,7 @@ class Settings extends Page {
         this.confirm.waitForVisible();
         this.cancel.waitForVisible();
         this.confirm.click();
-        browser.waitForVisible(`[data-qa-config="${configLabel}"]`, 5000, true);
+        browser.waitForVisible(`[data-qa-config="${configLabel}"]`, constants.wait.short, true);
     }
 
     remove() {
@@ -61,7 +63,7 @@ class Settings extends Page {
         expect(this.deleteDialogContent.getText()).toBe(confirmContent);
 
         this.confirm.click();
-        browser.waitForVisible('[data-qa-circle-progress]', 15000, true);
+        browser.waitForVisible('[data-qa-circle-progress]', constants.wait.normal, true);
         
         browser.waitUntil(function() {
             if (browser.isVisible('[data-qa-placeholder-title]')) {
@@ -73,7 +75,7 @@ class Settings extends Page {
                 return !labels.include(linodeLabel);
             }
             return false;
-        }, 10000, 'Linode failed to be removed');
+        }, constants.wait.normal, 'Linode failed to be removed');
     }
 
     updateLabel(label) {
@@ -90,7 +92,7 @@ class Settings extends Page {
         const disks = this.disks.map(d => d.getText());
         // Refactor this to use the actions api when chrome supports
         browser.keys('\uE00C');
-        this.disk.waitForVisible(5000, true);
+        this.disk.waitForVisible(constants.wait.short, true);
         return disks;
     }
 
@@ -100,7 +102,7 @@ class Settings extends Page {
         this.disk.waitForVisible();
         browser.jsClick(`[data-qa-disk="${diskLabel}"]`);
 
-        this.disk.waitForVisible(5000, true);
+        this.disk.waitForVisible(constants.wait.short, true);
         this.password.setValue(newPassword);
         this.passwordSave.click();
 
@@ -115,7 +117,7 @@ class Settings extends Page {
             const labelNotice = $$('[data-qa-notice]')
                 .filter(n => n.getText().includes(noticeMsg));
             return labelNotice.length === 1;
-        }, 10000);
+        }, constants.wait.normal);
     }
 
     allAlertsEnabled() {

--- a/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
@@ -1,3 +1,5 @@
+const { constants } = require('../../constants');
+
 import Page from '../page';
 
 export class VolumeDetail extends Page {
@@ -34,7 +36,7 @@ export class VolumeDetail extends Page {
                 .filter(e => e.$('[data-qa-volume-cell-attachment]')
                     .getText().includes(linodeLabel));
             return attachedToLinode.length > 0;
-        }, 10000);
+        }, constants.wait.normal);
     }
 
     removeAllVolumes() {
@@ -47,8 +49,8 @@ export class VolumeDetail extends Page {
 
     closeVolumeDrawer() {
         this.drawerClose.click();
-        this.drawerTitle.waitForVisible(5000, true);
-        browser.waitForExist('[data-qa-drawer]', 10000, true);
+        this.drawerTitle.waitForVisible(constants.wait.short, true);
+        browser.waitForExist('[data-qa-drawer]', constants.wait.normal, true);
         this.globalCreate.waitForVisible();
     }
 
@@ -98,11 +100,11 @@ export class VolumeDetail extends Page {
             const selectedRegion = this.attachRegions[volume.regionIndex].getText();
             this.attachRegions[volume.regionIndex].click();
             
-            browser.waitForVisible('[data-qa-attach-to-region]', 5000, true);
+            browser.waitForVisible('[data-qa-attach-to-region]', constants.wait.short, true);
             
             browser.waitUntil(function() {
                 return $('[data-qa-select-region]').getText() === selectedRegion;
-            }, 5000);
+            }, constants.wait.short);
         }
 
         if (volume.hasOwnProperty('attachedLinode')) {
@@ -110,7 +112,7 @@ export class VolumeDetail extends Page {
             browser.waitForVisible('[data-qa-attached-linode]');
             const linodeToAttach = this.volumeAttachedLinodes.filter(v => v.getText() === volume.attachedLinode);
             linodeToAttach[0].click();
-            browser.waitForVisible('[data-qa-attached-linode]', 5000, true);
+            browser.waitForVisible('[data-qa-attached-linode]', constants.wait.short, true);
         }
         // this.region.setValue(volume.region); 
         this.submit.click();
@@ -120,11 +122,11 @@ export class VolumeDetail extends Page {
                 const volsAttachedToLinode = $$('[data-qa-volume-cell-attachment]')
                     .filter(v => v.getText() === volume.attachedLinode);
                 return volsAttachedToLinode.length > 0;
-            }, 15000, 'Volume failed to attach');
+            }, constants.wait.normal, 'Volume failed to attach');
         }
 
         if (volume.hasOwnProperty('regionIndex')) {
-            browser.waitForExist('[data-qa-drawer]', 10000, true);
+            browser.waitForExist('[data-qa-drawer]', constants.wait.normal, true);
         }
     }
 
@@ -132,13 +134,13 @@ export class VolumeDetail extends Page {
         browser.waitForVisible('[data-qa-drawer-title]');
         const drawerTitle = browser.getText('[data-qa-drawer-title]');
 
-        browser.trySetValue('[data-qa-volume-label] input', newLabel, 10000);
+        browser.trySetValue('[data-qa-volume-label] input', newLabel, constants.wait.normal);
 
         this.submit.click();
 
         browser.waitUntil(function() {
             return newLabel === $(`[data-qa-volume-cell="${volume.id}"]`).$('[data-qa-volume-cell-label]').getText();
-        }, 10000);
+        }, constants.wait.normal);
     }
 
     resizeVolume(volume, newSize) {
@@ -181,8 +183,9 @@ export class VolumeDetail extends Page {
     }
 
     detachConfirm(volumeId) {
+        this.dialogTitle.waitForVisible();
         browser.click('[data-qa-confirm]');
-        browser.waitForVisible(`[data-qa-volume-cell="${volumeId}"]`, 10000, true);
+        browser.waitForVisible(`[data-qa-volume-cell="${volumeId}"]`, constants.wait.long, true);
     }
 
     cloneVolume(volume, newLabel) {
@@ -199,7 +202,7 @@ export class VolumeDetail extends Page {
             browser.waitForVisible('[data-qa-dialog-title]');
             browser.waitUntil(function() {
                 return volumeElement.$('[data-qa-volume-cell-attachment]').getText() === '';
-            }, 45000, 'Volume failed to detach');
+            }, constants.wait.long, 'Volume failed to detach');
         }
         const numberOfVolumes = this.volumeCell.length;
         volumeElement.$('[data-qa-action-menu]').click();
@@ -222,11 +225,11 @@ export class VolumeDetail extends Page {
 
         // Confirm remove
         dialogConfirm.click();
-        dialogConfirm.waitForVisible(10000, true);
+        dialogConfirm.waitForVisible(constants.wait.normal, true);
 
         browser.waitUntil(function(volumeElement) {
             return $$('[data-qa-volume-cell]').length === (numberOfVolumes-1)
-        }, 30000, 'Volume failed to be removed');
+        }, constants.wait.long, 'Volume failed to be removed');
     }
 
     assertVolumeInTable(volume) {

--- a/e2e/pageobjects/linode-detail/linode-detail.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail.page.js
@@ -1,3 +1,5 @@
+const { constants } = require('../../constants');
+
 import Page from '../page';
 
 class LinodeDetail extends Page {
@@ -23,8 +25,8 @@ class LinodeDetail extends Page {
         browser.waitUntil(function() {
             return browser
                 .getAttribute(`[data-qa-tab="${tab}"]`, 'aria-selected').includes('true');
-        }, 5000, 'Failed to change tab');
-        browser.waitForVisible('[data-qa-circle-progress]', 10000, true);
+        }, constants.wait.short, 'Failed to change tab');
+        browser.waitForVisible('[data-qa-circle-progress]', constants.wait.normal, true);
         return this;
     }
 
@@ -35,7 +37,7 @@ class LinodeDetail extends Page {
         browser.click('[data-qa-save-edit]');
         browser.waitUntil(function() {
             return this.linodeLabel.getText() === name;
-        }, 5000);
+        }, constants.wait.short);
     }
 
     setPower(powerState) {
@@ -48,7 +50,7 @@ class LinodeDetail extends Page {
             return
                 this.powerControl.isEnabled() &&
                 this.powerControl.getAttribute('data-qa-power-control') !== currentPowerState;
-        }, 20000);
+        }, constants.wait.long);
     }
 
     landingElemsDisplay() {

--- a/e2e/pageobjects/list-domains.page.js
+++ b/e2e/pageobjects/list-domains.page.js
@@ -85,7 +85,10 @@ class ListDomains extends Page {
 
     editDnsRecord(domain) {
         this.selectActionMenuItem(domain, 'Edit DNS Records');
-        // wait until DNS Records tabbed panel displays
+        browser.waitUntil(function() {
+            return browser.getUrl().includes('/records');
+        }, constants.wait.normal);
+        browser.waitForVisible('[data-qa-domain-title]');
     }
 
     cloneDrawerElemsDisplay() {

--- a/e2e/pageobjects/list-domains.page.js
+++ b/e2e/pageobjects/list-domains.page.js
@@ -1,3 +1,5 @@
+const { constants } = require('../constants');
+
 import Page from './page.js';
 
 class ListDomains extends Page {
@@ -77,7 +79,7 @@ class ListDomains extends Page {
         } else {
             browser.waitUntil(function() {
                 return $$('[data-qa-domain-cell]').length > existingDomainsCount;
-            }, 10000);
+            }, constants.wait.normal);
         }
     }
 
@@ -90,6 +92,7 @@ class ListDomains extends Page {
         this.drawerTitle.waitForVisible();
         this.drawerClose.waitForVisible();
         expect(this.drawerTitle.getText()).toBe('Add a new Domain');
+        expect(this.cloneDomainName.isVisible()).toBe(true);
     }
 
     clone(newDomainName) {
@@ -103,7 +106,7 @@ class ListDomains extends Page {
             const domainLabels = domains.map(d => d.getText());
 
             return domainLabels.includes(newDomainName);
-        }, 10000);
+        }, constants.wait.normal);
     }
 
     remove(domain, domainName) {
@@ -113,11 +116,9 @@ class ListDomains extends Page {
         expect(this.cancel.isVisible()).toBe(true);
 
         this.submit.click();
-
-        this.dialogTitle.waitForVisible(10000, true);
-        domain.waitForVisible(10000, true);
+        this.dialogTitle.waitForVisible(constants.wait.normal, true);
+        domain.waitForVisible(constants.wait.normal, true);
     }
-
 }
 
 export default new ListDomains();

--- a/e2e/pageobjects/list-linodes.js
+++ b/e2e/pageobjects/list-linodes.js
@@ -1,3 +1,5 @@
+const { constants } = require('../constants');
+
 import Page from './page';
 
 export class ListLinodes extends Page {
@@ -39,7 +41,7 @@ export class ListLinodes extends Page {
         try {
             browser.waitUntil(function() {
                 return browser.waitForVisible('[data-qa-linode]') && $$('[data-qa-linode]').length > 0;
-            }, 10000);
+            }, constants.wait.normal);
             return true;
         } catch (err) {
             if ($(this.placeholderText).isVisible()) {
@@ -114,11 +116,11 @@ export class ListLinodes extends Page {
         
         browser.waitUntil(function() {
             return linode.$(this.status.selector).getAttribute('data-qa-status') === 'rebooting';
-        }, 30000);
+        }, constants.wait.long);
         
         browser.waitUntil(function() {
             return linode.$(this.status).getAttribute('data-qa-status') === 'running';
-        }, 30000);
+        }, constants.wait.long);
     }
 
     powerOff(linode) {
@@ -128,7 +130,7 @@ export class ListLinodes extends Page {
         
         browser.waitUntil(function() {
             return browser.isVisible('[data-qa-status="offline"]');
-        }, 60000 * 3, 'Failed to power down linode');
+        }, constants.wait.minute * 3, 'Failed to power down linode');
     }
 
     powerOn(linode) {
@@ -137,7 +139,7 @@ export class ListLinodes extends Page {
 
         browser.waitUntil(function() {
             return browser.isVisible('[data-qa-status="running"]');
-        }, 60000 * 2);
+        }, constants.wait.minute * 2);
     }
 
     shutdownIfRunning(linode) {
@@ -158,13 +160,13 @@ export class ListLinodes extends Page {
         browser.click(`[data-qa-view="${view}"]`);
         browser.waitUntil(function() {
             return browser.isVisible(`[data-qa-active-view="${view}"]`);
-        }, 5000);
+        }, constants.wait.short);
     }
 
     waitUntilBooted(label) {
-        browser.waitForVisible('[data-qa-circle-progress]', 15000, true);
-        browser.waitForVisible('[data-qa-loading="true"]', 30000, true);
-        browser.waitForExist(`[data-qa-linode="${label}"] [data-qa-status="running"]`, 60000 * 2);
+        browser.waitForVisible('[data-qa-circle-progress]', constants.wait.normal, true);
+        browser.waitForVisible('[data-qa-loading="true"]', constants.wait.long, true);
+        browser.waitForExist(`[data-qa-linode="${label}"] [data-qa-status="running"]`, constants.wait.minute * 2);
     }
 
     acceptDialog(dialogTitle) {
@@ -173,7 +175,7 @@ export class ListLinodes extends Page {
         this.confirmDialogSubmit.waitForVisible();
         expect(this.confirmDialogTitle.getText()).toBe(dialogTitle);
         this.confirmDialogSubmit.click();
-        this.confirmDialogTitle.waitForVisible(10000, true);
+        this.confirmDialogTitle.waitForVisible(constants.wait.normal, true);
     }
 
     assertDocsDrawer() {

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -1,3 +1,5 @@
+const { constants } = require('../constants');
+
 export default class Page {
     get dialogTitle() { return $('[data-qa-dialog-title]'); }
     get sidebarTitle() { return $('[data-qa-sidebar-title]'); }
@@ -32,12 +34,12 @@ export default class Page {
         this.userMenu.click();
         this.logoutButton.waitForVisible();
         this.logoutButton.click();
-        this.logoutButton.waitForVisible(5000, true);
-        this.globalCreate.waitForVisible(5000, true);
+        this.logoutButton.waitForVisible(constants.wait.short, true);
+        this.globalCreate.waitForVisible(constants.wait.short, true);
 
         browser.waitUntil(function() {
             return browser.getUrl().includes('/login');
-        }, 10000, 'Failed to redirect to login page on log out');
+        }, constants.wait.normal, 'Failed to redirect to login page on log out');
     }
 
     waitForNotice(noticeMsg) {
@@ -63,7 +65,7 @@ export default class Page {
         const displayedMsg = browser.getText('[data-qa-toast-message]');
         expect(displayedMsg).toBe(expectedMessage);
         browser.click('[data-qa-toast] button');
-        browser.waitForExist('[data-qa-toast]', 5000, true);
+        browser.waitForExist('[data-qa-toast]', constants.wait.short, true);
     }
 
     dismissToast() {
@@ -74,7 +76,17 @@ export default class Page {
                 return dismissed;
             }
             return true;
-        }, 10000);
+        }, constants.wait.normal);
+    }
+
+    selectActionMenuItem(tableCell, item) {
+        tableCell.$(this.actionMenu.selector).click();
+        browser.jsClick(`[data-qa-action-menu-item="${item}"]`);
+    }
+
+    closeDrawer() {
+        this.drawerClose.click();
+        this.drawerTitle.waitForVisible(constants.wait.normal, true);
     }
 
     selectActionMenuItem(tableCell, item) {

--- a/e2e/pageobjects/profile.js
+++ b/e2e/pageobjects/profile.js
@@ -1,3 +1,5 @@
+const { constants } = require('../constants');
+
 import Page from './page';
 
 export const dialogMap = {
@@ -27,7 +29,7 @@ export class OauthCreateDrawer {
             } catch (err) {
                 return false;
             }
-        }, 15000);
+        }, constants.wait.normal);
     }
 }
 
@@ -169,7 +171,7 @@ export class Profile extends Page {
             const deleteButton = $(dialogMap.confirm);
             deleteButton.click();
 
-            browser.waitForVisible(`[data-qa-table-row="${row}"]`, 10000, true);
+            browser.waitForVisible(`[data-qa-table-row="${row}"]`, constants.wait.normal, true);
         }
 
         if (type == 'token') {

--- a/e2e/pageobjects/search.page.js
+++ b/e2e/pageobjects/search.page.js
@@ -1,3 +1,5 @@
+const { constants } = require('../constants');
+
 import Page from './page';
 
 class SearchBar extends Page {
@@ -40,7 +42,7 @@ class SearchBar extends Page {
         browser.waitForVisible('[data-qa-suggestion]');
 
         suggestion.click();
-        browser.waitForVisible('[data-qa-circle-progress]', 15000, true);
+        browser.waitForVisible('[data-qa-circle-progress]', constants.wait.normal, true);
     }
 
     selectByKeyDown() {

--- a/e2e/pageobjects/volumes.page.js
+++ b/e2e/pageobjects/volumes.page.js
@@ -1,3 +1,5 @@
+const { constants } = require('../constants');
+
 import Page from './page';
 
 class Volumes extends Page {
@@ -42,7 +44,7 @@ class Volumes extends Page {
 
         browser.waitUntil(function(volumeElement) {
             return $$('[data-qa-volume-cell]').length === (numberOfVolumes-1)
-        }, 30000);
+        }, constants.wait.long);
     }
 
     isAttached(volumeElement) {

--- a/e2e/setup/setup.spec.js
+++ b/e2e/setup/setup.spec.js
@@ -6,7 +6,7 @@ import { createGenericLinode } from '../utils/common';
 describe('Setup Tests Suite', () => {
     beforeAll(() => {
         browser.url(constants.routes.linodes);
-        browser.waitForVisible('[data-qa-circle-progress]', 15000, true);
+        browser.waitForVisible('[data-qa-circle-progress]', constants.wait.normal, true);
     });
 
     it('should remove all account data', () => {
@@ -20,16 +20,16 @@ describe('Setup Tests Suite', () => {
         // Wait for all linodes to be removed
         browser.waitUntil(function() {
             browser.refresh();
-            browser.waitForVisible('[data-qa-add-new-menu-button]', 15000);
-            browser.waitForVisible('[data-qa-circle-progress]', 15000, true);
+            browser.waitForVisible('[data-qa-add-new-menu-button]');
+            browser.waitForVisible('[data-qa-circle-progress]', constants.wait.normal, true);
             
             try {
-                browser.waitForVisible('[data-qa-placeholder-title]', 5000);
+                browser.waitForVisible('[data-qa-placeholder-title]', constants.wait.short);
                 return true;
             } catch (err) {
                 return false;
             }
-        }, 25000);
+        }, constants.wait.long);
 
         createGenericLinode(testLabel);
     });

--- a/e2e/specs/domains/list-domains.spec.js
+++ b/e2e/specs/domains/list-domains.spec.js
@@ -10,7 +10,7 @@ describe('List Domains Suite', () => {
     beforeAll(() => {
         browser.url(constants.routes.domains);
         ListDomains.globalCreate.waitForVisible();
-        ListDomains.progressBar.waitForVisible(15000, true);
+        ListDomains.progressBar.waitForVisible(constants.wait.normal, true);
     });
 
     it('should display domains base elements', () => {
@@ -27,7 +27,7 @@ describe('List Domains Suite', () => {
         } catch (err) {
             ListDomains.createDomainName.$('p').waitForVisible();
             ListDomains.cancel.click();
-            ListDomains.drawerTitle.waitForVisible(5000, true);
+            ListDomains.drawerTitle.waitForVisible(constants.wait.short, true);
         }
     });
 
@@ -53,7 +53,7 @@ describe('List Domains Suite', () => {
         // Hit escape to get rid of action menu
         // Refactor once Chrome implements actions api
         browser.keys('\uE00C');
-        ListDomains.actionMenuItem.waitForVisible(5000, true);
+        ListDomains.actionMenuItem.waitForVisible(constants.wait.short, true);
     });
 
     it('should display clone domain drawer', () => {
@@ -85,7 +85,7 @@ describe('List Domains Suite', () => {
     afterAll(() => {
         ListDomains.domains
             .forEach(d => {
-                ListDomains.drawerTitle.waitForExist(5000, true);
+                ListDomains.drawerTitle.waitForExist(constants.wait.short, true);
                 ListDomains.selectActionMenuItem(d, 'Remove');
                 ListDomains.remove(d, d.$(ListDomains.label.selector).getText());
             });

--- a/e2e/specs/domains/list-domains.spec.js
+++ b/e2e/specs/domains/list-domains.spec.js
@@ -77,7 +77,7 @@ describe('List Domains Suite', () => {
     });
 
     it('should remove domain', () => {
-        ListDomains.drawerTitle.waitForExist(10000, true);
+        ListDomains.drawerTitle.waitForExist(constants.wait.normal, true);
         ListDomains.selectActionMenuItem($(domainElement), 'Remove');
         ListDomains.remove($(domainElement), initialDomain);
     });

--- a/e2e/specs/linodes/detail/backups.spec.js
+++ b/e2e/specs/linodes/detail/backups.spec.js
@@ -42,7 +42,7 @@ describe('Linode Detail - Backups Suite', () => {
 
         const toastMsg = 'Snapshot label must be a string of 1 to 255 characters';
         Backups.toastDisplays(toastMsg);
-        browser.waitForExist('[data-qa-toast]', 5000, true);
+        browser.waitForExist('[data-qa-toast]', constants.wait.short, true);
     });
 
     it('should cancel backups', () => {

--- a/e2e/specs/linodes/detail/create-volumes.spec.js
+++ b/e2e/specs/linodes/detail/create-volumes.spec.js
@@ -61,7 +61,7 @@ describe('Linode Detail - Volumes Suite', () => {
 
         it('should close on cancel', () => {
             VolumeDetail.cancel.click();
-            drawerElems.forEach(e => expect(e.waitForVisible(5000, true)).toBe(true));
+            drawerElems.forEach(e => expect(e.waitForVisible(constants.wait.short, true)).toBe(true));
         });
 
         it('should prepopulate size with 20 gigs', () => {
@@ -86,7 +86,7 @@ describe('Linode Detail - Volumes Suite', () => {
             VolumeDetail.size.$('input').setValue('5');
             VolumeDetail.submit.click();
 
-            browser.waitForVisible('[data-qa-size] p', 15000);
+            browser.waitForVisible('[data-qa-size] p', constants.wait.normal);
 
             const sizeError = VolumeDetail.size.$('p').getText();
             expect(sizeError.includes('Must be 10-1024')).toBe(true);

--- a/e2e/specs/linodes/detail/detach-attach-volumes.spec.js
+++ b/e2e/specs/linodes/detail/detach-attach-volumes.spec.js
@@ -16,12 +16,13 @@ describe('Linode - Volumes - Attach, Detach, Delete Suite', () => {
         browser.url(constants.routes.linodes);
         ListLinodes.linodeElem.waitForVisible();
         linodeName = ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).getText();
+        ListLinodes.powerOff(ListLinodes.linode[0]);
         ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).click();
         LinodeDetail.landingElemsDisplay();
         LinodeDetail.changeTab('Volumes');
         
         VolumeDetail.createVolume(testVolume);
-        browser.waitForVisible('[data-qa-volume-cell]', 25000);
+        browser.waitForVisible('[data-qa-volume-cell]', constants.wait.long);
     });
 
     it('should display detach linode dialog', () => {
@@ -34,7 +35,6 @@ describe('Linode - Volumes - Attach, Detach, Delete Suite', () => {
 
     it('should detach the volume', () => {
         VolumeDetail.detachConfirm(testVolume.id);
-
         if (VolumeDetail.placeholderText.isVisible()) {
             const placeholderMsg = VolumeDetail.placeholderText.getText();
             const expectedMsg = 'No volumes attached';

--- a/e2e/specs/linodes/detail/edit-clone-resize-volumes.spec.js
+++ b/e2e/specs/linodes/detail/edit-clone-resize-volumes.spec.js
@@ -30,7 +30,7 @@ describe('Edit - Clone - Resize Volumes Suite', () => {
         LinodeDetail.changeTab('Volumes');
         
         VolumeDetail.createVolume(testVolume);
-        browser.waitForVisible('[data-qa-volume-cell]', 25000);
+        browser.waitForVisible('[data-qa-volume-cell]', constants.wait.long);
 
         testVolume['id'] = VolumeDetail.volumeCell[0].getAttribute('data-qa-volume-cell');
         volume = $(`[data-qa-volume-cell="${testVolume.id}"]`);
@@ -42,8 +42,11 @@ describe('Edit - Clone - Resize Volumes Suite', () => {
     });
 
     afterAll(() => {
-        browser.url(constants.routes.linodes);
+        browser.url(constants.routes.volumes);
+        browser.waitForVisible('[data-qa-volume-cell]');
+        VolumeDetail.removeAllVolumes();
 
+        browser.url(constants.routes.linodes);
         ListLinodes.linodeElem.waitForVisible();
         ListLinodes.powerOn(ListLinodes.linode[0]);
     });
@@ -59,11 +62,11 @@ describe('Edit - Clone - Resize Volumes Suite', () => {
 
         VolumeDetail.size.$('input').setValue(newSize);
         VolumeDetail.submit.click();
-        VolumeDetail.drawerTitle.waitForVisible(10000, true);
+        VolumeDetail.drawerTitle.waitForVisible(constants.wait.normal, true);
         
         browser.waitUntil(function() {
             return browser.getText(`[data-qa-volume-cell="${testVolume.id}"] [data-qa-volume-size]`).includes(newSize);
-        }, 10000);
+        }, constants.wait.normal);
     });
 
     it('should clone the volume', () => {
@@ -82,6 +85,7 @@ describe('Edit - Clone - Resize Volumes Suite', () => {
         browser.trySetValue('[data-qa-clone-from] input', 'new-clone');
 
         VolumeDetail.submit.click();
-        VolumeDetail.drawerTitle.waitForVisible(10000, true);
+        VolumeDetail.drawerTitle.waitForVisible(constants.wait.normal, true);
+        browser.waitForVisible('[data-qa-icon-text-link="Attach Existing Volume"]', constants.wait.normal);
     });
 });

--- a/e2e/specs/linodes/detail/networking.spec.js
+++ b/e2e/specs/linodes/detail/networking.spec.js
@@ -32,7 +32,7 @@ describe('Linode Detail - Networking Suite', () => {
 
         it('should dismiss drawer on close', () => {
             Networking.cancel.click();
-            Networking.drawerTitle.waitForVisible(10000, true);
+            Networking.drawerTitle.waitForVisible(constants.wait.normal, true);
         });
 
         it('should display ipv6 drawer', () => {
@@ -46,7 +46,7 @@ describe('Linode Detail - Networking Suite', () => {
 
         afterAll(() => {
             Networking.cancel.click();
-            Networking.drawerTitle.waitForVisible(10000, true);
+            Networking.drawerTitle.waitForVisible(constants.wait.normal, true);
         });
     });
 
@@ -87,7 +87,7 @@ describe('Linode Detail - Networking Suite', () => {
 
         afterEach(() => {
             Networking.cancel.click();
-            Networking.drawerTitle.waitForVisible(10000, true);
+            Networking.drawerTitle.waitForVisible(constants.wait.normal, true);
         });
     });
 
@@ -118,7 +118,7 @@ describe('Linode Detail - Networking Suite', () => {
         it('should reset rdns on empty entry', () => {
             Networking.domainName.$('input').setValue([' ','\uE003']);
             Networking.submit.click();
-            Networking.drawerTitle.waitForVisible(10000, true);
+            Networking.drawerTitle.waitForVisible(constants.wait.normal, true);
         });
 
         it('should display edit rdns ipv6 drawer', () => {

--- a/e2e/specs/linodes/detail/rebuild.spec.js
+++ b/e2e/specs/linodes/detail/rebuild.spec.js
@@ -39,7 +39,7 @@ describe('Linode Detail - Rebuild Suite', () => {
     });
 
     it('should display error on create an image without selecting an image', () => {
-        browser.waitForVisible('[data-qa-image-option]', 10000, true);
+        browser.waitForVisible('[data-qa-image-option]', constants.wait.normal, true);
         
         Rebuild.submit.click();
 
@@ -51,14 +51,14 @@ describe('Linode Detail - Rebuild Suite', () => {
 
     it('should display error on create image without setting a password', () => {
         Rebuild.selectImage();
-        Rebuild.imageOptions.forEach(opt => opt.waitForVisible(5000, true));
+        Rebuild.imageOptions.forEach(opt => opt.waitForVisible(constants.wait.short, true));
         Rebuild.submit.click();
     });
 
     it('should rebuild linode on valid image and password', () => {
         const testPassword = '~/4gNgmV$_J3vREN'
         Rebuild.selectImage();
-        Rebuild.imageOptions.forEach(opt => opt.waitForVisible(5000, true));
+        Rebuild.imageOptions.forEach(opt => opt.waitForVisible(constants.wait.short, true));
         Rebuild.password.setValue(testPassword);
         Rebuild.rebuild();
     });

--- a/e2e/specs/linodes/linodes.spec.js
+++ b/e2e/specs/linodes/linodes.spec.js
@@ -1,4 +1,5 @@
 const { constants } = require('../../constants');
+
 import { flatten } from 'ramda';
 import ListLinodes from '../../pageobjects/list-linodes';
 

--- a/e2e/specs/linodes/reboot-linodes.spec.js
+++ b/e2e/specs/linodes/reboot-linodes.spec.js
@@ -1,9 +1,10 @@
 const { constants } = require('../../constants');
+
 import { flatten } from 'ramda';
 import ListLinodes from '../../pageobjects/list-linodes';
 
 describe('List Linodes - Actions - Reboot Suite', () => {
-    const rebootTimeout = 120000;
+    const rebootTimeout = constants.wait.minute * 3;
 
     beforeAll(() => {
         browser.url(constants.routes.linodes);

--- a/e2e/specs/profile/clients.spec.js
+++ b/e2e/specs/profile/clients.spec.js
@@ -35,7 +35,7 @@ describe('Profile - OAuth Clients Suite', () => {
 
         it('should close create drawer on cancel', () => {
             createDrawer.cancel.click();
-            browser.waitForVisible('[data-qa-drawer-title]', 10000, true);
+            browser.waitForVisible('[data-qa-drawer-title]', constants.wait.normal, true);
         });
 
         it('should display dialog with secret on submit', () => {
@@ -51,7 +51,7 @@ describe('Profile - OAuth Clients Suite', () => {
             expect(secret).not.toBe(null);
 
             browser.click(dialogClose);
-            browser.waitForVisible(dialogTitle, 10000, true);
+            browser.waitForVisible(dialogTitle, constants.wait.normal, true);
         });
 
         it('should display new client in table', () => {
@@ -127,7 +127,7 @@ describe('Profile - OAuth Clients Suite', () => {
 
         it('should close on cancel', () => {
             browser.click(dialogCancel);
-            browser.waitForVisible(dialogTitle, 10000, true);
+            browser.waitForVisible(dialogTitle, constants.wait.normal, true);
         });
 
         it('should display new secret on reset', () => {
@@ -138,7 +138,7 @@ describe('Profile - OAuth Clients Suite', () => {
             browser.waitUntil(function() {
                 browser.waitForVisible(dialogTitle);
                 return browser.getText(dialogTitle).includes('Client Secret');
-            }, 5000);
+            }, constants.wait.short);
 
             const content = $(dialogContent).getText();
             expect(content).toContain('Here is your client secret! Store it securely, as it won\'t be shown again.');
@@ -169,7 +169,7 @@ describe('Profile - OAuth Clients Suite', () => {
 
         it('should not delete client on cancel', () => {
             cancelButton.click();
-            browser.waitForVisible(dialogTitle, 10000, true);
+            browser.waitForVisible(dialogTitle, constants.wait.normal, true);
 
             expect($(editedRow).isVisible()).toBe(true);
         });

--- a/e2e/specs/profile/tokens.spec.js
+++ b/e2e/specs/profile/tokens.spec.js
@@ -1,4 +1,5 @@
 const { constants} = require('../../constants');
+
 import { Profile, TokenCreateDrawer, dialogMap } from '../../pageobjects/profile';
 
 const profile = new Profile();
@@ -83,7 +84,7 @@ describe('View - Personal Access Tokens', () => {
             expect(eventsPermission.getAttribute('class').includes('checked')).toBe(true);
             expect(imagesPermission.getAttribute('class').includes('checked')).toBe(true);
             browser.click('[data-qa-close-drawer]');
-            browser.waitForVisible('[data-qa-close-drawer]', 5000, true);
+            browser.waitForVisible('[data-qa-close-drawer]', constants.wait.short, true);
         });
 
         describe('Edit - Personal Access Tokens', () => {
@@ -108,7 +109,7 @@ describe('View - Personal Access Tokens', () => {
                     } catch (err) {
                         return false;
                     }
-                }, 15000);
+                }, constants.wait.normal);
                 tokenCreateDrawer.submit.click();
 
                 browser.waitForVisible(updatedSelector);
@@ -119,7 +120,7 @@ describe('View - Personal Access Tokens', () => {
             it('should close on close icon click', () => {
                 profile.create('token');
                 tokenCreateDrawer.cancel.click();
-                browser.waitForVisible('[data-qa-drawer-title]', 10000, true);
+                browser.waitForVisible('[data-qa-drawer-title]', constants.wait.normal, true);
             });
         });
 
@@ -141,7 +142,7 @@ describe('View - Personal Access Tokens', () => {
 
             it('should revoke on remove', () => {
                 browser.click(dialogConfirm);
-                browser.waitForVisible(updatedSelector, 10000, true);
+                browser.waitForVisible(updatedSelector, constants.wait.normal, true);
             });
         });
     });

--- a/e2e/specs/search/search-volumes.spec.js
+++ b/e2e/specs/search/search-volumes.spec.js
@@ -47,7 +47,7 @@ describe('Header - Search - Volumes Suite', () => {
         // Wait until the volume is created before searching for it
         browser.waitUntil(function() {
             return VolumeDetail.volumeCell.length === volumeCount + 1;
-        }, 25000, 'Volume failed to be created');
+        }, constants.wait.long, 'Volume failed to be created');
 
         testVolume['id'] = VolumeDetail.getVolumeId(testVolume.label);
     });
@@ -56,7 +56,7 @@ describe('Header - Search - Volumes Suite', () => {
         browser.url(constants.routes.linodes);
         SearchBar.assertSearchDisplays();
         SearchBar.executeSearch(testVolume.label);
-        browser.waitForVisible('[data-qa-suggestion]', 5000);
+        browser.waitForVisible('[data-qa-suggestion]', constants.wait.short);
     });
 
     it('should navigate to linode detail volume page', () => {
@@ -72,6 +72,6 @@ describe('Header - Search - Volumes Suite', () => {
 
     it('should not display suggestion after removal', () => {
         SearchBar.executeSearch(testVolume.label);
-        browser.waitForVisible('[data-qa-suggestion]', 5000, true);
+        browser.waitForVisible('[data-qa-suggestion]', constants.wait.short, true);
     });
 });

--- a/e2e/specs/search/search.spec.js
+++ b/e2e/specs/search/search.spec.js
@@ -34,7 +34,7 @@ describe('Header - Search Suite', () => {
 
     it('should not display suggestions when no matching results found', () => {
         SearchBar.executeSearch('blahlblahblah');
-        browser.waitForVisible('[data-qa-suggestion]', 5000, true);
+        browser.waitForVisible('[data-qa-suggestion]', constants.wait.short, true);
     });
 
     it('should display search suggestions on a legitmate search', () => {
@@ -52,7 +52,7 @@ describe('Header - Search Suite', () => {
         
         browser.waitUntil(function() {
             return browser.getUrl() !== currentUrl;
-        }, 10000);
+        }, constants.wait.normal);
     });
 
     it('should navigate to result on click', () => {
@@ -66,6 +66,6 @@ describe('Header - Search Suite', () => {
 
         browser.waitUntil(function() {
             return browser.getUrl() !== currentUrl;
-        }, 10000);
+        }, constants.wait.normal);
     });
 });

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -157,7 +157,7 @@ class DomainDetail extends React.Component<CombinedProps, State> {
             >
               <KeyboardArrowLeft />
             </IconButton>
-            <Typography variant="headline">{domain.domain}</Typography>
+            <Typography variant="headline" data-qa-domain-title>{domain.domain}</Typography>
           </Grid>
         </Grid>
         <AppBar position="static" color="default">


### PR DESCRIPTION
* Refactored tests to use standardized waitFor timeouts configured in the constants.js file.
* Added `editDNS` domains page object utility method.