### PR TITLE
M3-630 NodeBalancer Charts Unit Filter

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.test.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.test.tsx
@@ -1,0 +1,24 @@
+import { isMuchTraffic } from './TablesPanel';
+
+describe('TablesPanel', () => {
+  describe('isMuchTraffic', () => {
+    it('should return true if any stat is >= 1GB', () => {
+      const traffic: [number, number][] = [
+        [0, 1],
+        [0, 1073741824],
+        [0, 3],
+      ];
+
+      expect(isMuchTraffic(traffic)).toBeTruthy();
+    });
+    it('should return false if no stat is >= 1GB', () => {
+      const traffic: [number, number][] = [
+        [0, 1],
+        [0, 2],
+        [0, 3],
+      ];
+
+      expect(isMuchTraffic(traffic)).toBeFalsy();
+    });
+  });
+});

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -5,10 +5,17 @@ import {
   WithStyles,
 } from 'material-ui';
 import Typography from 'material-ui/Typography';
+import { InputLabel } from 'material-ui/Input';
+import { FormControl } from 'material-ui/Form';
+import { MenuItem } from 'material-ui/Menu';
+import { compose, over, lensPath, map } from 'ramda';
 
 import LineGraph from 'src/components/LineGraph';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import { getNodeBalancerStats } from 'src/services/nodebalancers';
+import Select from 'src/components/Select';
+
+import { convertBitsToUnit } from 'src/utilities/convertBitsToUnit';
 
 type ClassNames = 'chart'
   | 'leftLegend'
@@ -19,6 +26,8 @@ type ClassNames = 'chart'
   | 'green'
   | 'red'
   | 'yellow';
+
+type StatsUnit = 'bits' | 'bytes' | 'KB' | 'MB' | 'GB';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => {
   return {
@@ -92,17 +101,77 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => {
   };
 };
 
+const dummyStats: Linode.NodeBalancerStats  = {
+  title: 'dummy stats',
+  data: {
+    connections: [
+      [1, 2],
+      [2, 3],
+    ],
+    traffic: {
+      in: [
+        [1527705900000, 11.45],
+        [1527706200000, 33.66],
+        [1527706500000, 5.34],
+        [1527706800000, 7.14],
+        [1527707100000, 3.44],
+        [1527707400000, 1547.94],
+        [1527707700000, 1642.49],
+        [1527708000000, 1133.22],
+        [1527708300000, 20423442423434.81],
+        [1527708600000, 1812.56],
+        [1527708900000, 3595.13],
+        [1527709200000, 3158.39],
+        [1527709500000, 3158.39],
+        [1527709800000, 678.62],
+        [1527710100000, 3456.4],
+        [1527710400000, 3324.1],
+        [1527710700000, 2942.17],
+        [1527711000000, 50.55],
+        [1527711300000, 50.55],
+        [1527711600000, 1229.14],
+        [1527711900000, 2814.53],
+      ],
+      out: [
+        [1527705900000, 11.45],
+        [1527706200000, 33.66],
+        [1527706500000, 5.34],
+        [1527706800000, 7.14],
+        [1527707100000, 3.44],
+        [1527707400000, 1547.94],
+        [1527707700000, 1642.49],
+        [1527708000000, 1133.22],
+        [1527708300000, 2034.81],
+        [1527708600000, 1812.56],
+        [1527708900000, 3595.13],
+        [1527709200000, 3158.39],
+        [1527709500000, 3158.39],
+        [1527709800000, 678.62],
+        [1527710100000, 3456.4],
+        [1527710400000, 3324.1],
+        [1527710700000, 2942.17],
+        [1527711000000, 50.55],
+        [1527711300000, 50.55],
+        [1527711600000, 1229.14],
+        [1527711900000, 2814.53],
+      ],
+    },
+  },
+};
+
 interface Props {
   nodeBalancer: Linode.ExtendedNodeBalancer;
 }
 
 interface State {
   stats: Linode.NodeBalancerStats | null;
+  selectedUnit: string;
+  convertedStats: Linode.NodeBalancerStats | null;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const statsFetchInterval = 30000;
+// const statsFetchInterval = 30000;
 
 class TablesPanel extends React.Component<CombinedProps, State> {
   statsInterval?: number = undefined;
@@ -110,6 +179,8 @@ class TablesPanel extends React.Component<CombinedProps, State> {
 
   state: State = {
     stats: null,
+    selectedUnit: 'bits',
+    convertedStats: null,
   };
 
   getStats = () => {
@@ -117,17 +188,56 @@ class TablesPanel extends React.Component<CombinedProps, State> {
     getNodeBalancerStats(nodeBalancer.id)
       .then((response: Linode.NodeBalancerStats) => {
         if (!this.mounted) { return; }
-        this.setState({ stats: response });
+        this.setState({ stats: dummyStats });
       })
       .catch((errorResponse) => {
         if (!this.mounted) { return; }
       });
   }
 
+  handleUnitChange = (value: StatsUnit) => {
+    const { stats } = this.state;
+    if (!stats) { return; }
+
+    const convertStats = compose<
+      Linode.NodeBalancerStats,
+      Linode.NodeBalancerStats,
+      Linode.NodeBalancerStats
+      >(
+        over(
+          lensPath(['data', 'traffic', 'in']),
+          map(stat => [stat[0], convertBitsToUnit(stat[1], value)]),
+        ),
+        over(
+          lensPath(['data', 'traffic', 'out']),
+          map(stat => [stat[0], convertBitsToUnit(stat[1], value)]),
+        ),
+    );
+
+    console.log(value);
+
+    this.setState({
+      selectedUnit: value,
+      convertedStats: convertStats(stats!),
+    });
+  }
+
+  isMuchTraffic = (stats: Linode.NodeBalancerStats) => {
+    const isHighTraffic = (stat: [number, number][]) => stat.map((substat) => {
+      if (substat[1] >= 1073741824) { // if the traffic at any given time is greater than 1GB
+        return true;
+      }
+      return false; // otherwise, the traffic isn't that great
+    });
+    return [...isHighTraffic(stats.data.traffic.in), ...isHighTraffic(stats.data.traffic.out)]
+      .some(isHigh => isHigh);
+    // return whether or not we have high traffic in either in or out traffic
+  }
+
   componentDidMount() {
     this.mounted = true;
     this.getStats();
-    this.statsInterval = window.setInterval(() => this.getStats(), statsFetchInterval);
+    // this.statsInterval = window.setInterval(() => this.getStats(), statsFetchInterval);
   }
 
   componentWillUnmount() {
@@ -137,10 +247,25 @@ class TablesPanel extends React.Component<CombinedProps, State> {
 
   render() {
     const { classes } = this.props;
-    const { stats } = this.state;
+    const { stats, selectedUnit, convertedStats } = this.state;
+
+    // if we made a conversion, show the converted stats. Otherwise,
+    // show the original statsToDisplay
+    const statsToDisplay = (convertedStats) ? convertedStats : stats;
+
+    // the reason for limiting which filters are available is because when a site has little
+    // traffic, converting bits to GB may leave us with an exponential which doesn't render
+    // properly in the chart component and displays an empty chart, so we need to limit
+    // the choices available based on how much traffic the NodeBalancer has
+    const trafficUnits = (stats && this.isMuchTraffic(stats))
+      ? ['KB', 'MB', 'GB'] // we have a lot of traffic, so don't show bits or bytes
+      : ['bits', 'bytes', 'KB', 'MB']; // we have little traffic, so don't show GB
+
+    console.log(statsToDisplay);
+
     return (
       <React.Fragment>
-        {stats &&
+        {statsToDisplay &&
           <React.Fragment>
             <div className={classes.graphControls}>
               <Typography variant="title" className={classes.graphTitle}>Graphs</Typography>
@@ -160,7 +285,7 @@ class TablesPanel extends React.Component<CombinedProps, State> {
                       {
                         label: 'Connections',
                         borderColor: '#3683dc',
-                        data: stats.data.connections,
+                        data: statsToDisplay.data.connections,
                       },
                     ]}
                   />
@@ -173,9 +298,26 @@ class TablesPanel extends React.Component<CombinedProps, State> {
               heading="Traffic (5 min avg.)"
             >
               <React.Fragment>
+                <Typography variant="subheading">Units</Typography>
+                <FormControl style={{ martginTop: 0 }}>
+                  <InputLabel htmlFor="chartRange" disableAnimation hidden>
+                    Select Time Range
+                </InputLabel>
+                  <Select
+                    value={trafficUnits[0]}
+                    // e.target.value will always come back as a StatsUnit below
+                    onChange={e => this.handleUnitChange(e.target.value as StatsUnit)}
+                    inputProps={{ name: 'unitType', id: 'unitType' }}
+                  >
+                    {trafficUnits.map((unit, index) => {
+                      return <MenuItem key={index} value={unit}>{unit}</MenuItem>;
+                    })
+                    }
+                  </Select>
+                </FormControl>
                 <div className={classes.chart}>
                   <div className={classes.leftLegend}>
-                    bits/sec
+                    {`${selectedUnit}/sec`}
                   </div>
                   <LineGraph
                     showToday={true}
@@ -183,12 +325,12 @@ class TablesPanel extends React.Component<CombinedProps, State> {
                       {
                         label: 'Traffic In',
                         borderColor: '#3683dc',
-                        data: stats.data.traffic.in,
+                        data: statsToDisplay.data.traffic.in,
                       },
                       {
                         label: 'Traffic Out',
                         borderColor: '#01b159',
-                        data: stats.data.traffic.out,
+                        data: statsToDisplay.data.traffic.out,
                       },
                     ]}
                   />

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -101,105 +101,65 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => {
   };
 };
 
-const dummyStats: Linode.NodeBalancerStats  = {
-  title: 'dummy stats',
-  data: {
-    connections: [
-      [1, 2],
-      [2, 3],
-    ],
-    traffic: {
-      in: [
-        [1527705900000, 11.45],
-        [1527706200000, 33.66],
-        [1527706500000, 5.34],
-        [1527706800000, 7.14],
-        [1527707100000, 3.44],
-        [1527707400000, 1547.94],
-        [1527707700000, 1642.49],
-        [1527708000000, 1133.22],
-        [1527708300000, 20423442423434.81],
-        [1527708600000, 1812.56],
-        [1527708900000, 3595.13],
-        [1527709200000, 3158.39],
-        [1527709500000, 3158.39],
-        [1527709800000, 678.62],
-        [1527710100000, 3456.4],
-        [1527710400000, 3324.1],
-        [1527710700000, 2942.17],
-        [1527711000000, 50.55],
-        [1527711300000, 50.55],
-        [1527711600000, 1229.14],
-        [1527711900000, 2814.53],
-      ],
-      out: [
-        [1527705900000, 11.45],
-        [1527706200000, 33.66],
-        [1527706500000, 5.34],
-        [1527706800000, 7.14],
-        [1527707100000, 3.44],
-        [1527707400000, 1547.94],
-        [1527707700000, 1642.49],
-        [1527708000000, 1133.22],
-        [1527708300000, 2034.81],
-        [1527708600000, 1812.56],
-        [1527708900000, 3595.13],
-        [1527709200000, 3158.39],
-        [1527709500000, 3158.39],
-        [1527709800000, 678.62],
-        [1527710100000, 3456.4],
-        [1527710400000, 3324.1],
-        [1527710700000, 2942.17],
-        [1527711000000, 50.55],
-        [1527711300000, 50.55],
-        [1527711600000, 1229.14],
-        [1527711900000, 2814.53],
-      ],
-    },
-  },
-};
-
 interface Props {
   nodeBalancer: Linode.ExtendedNodeBalancer;
 }
 
 interface State {
-  stats: Linode.NodeBalancerStats | null;
-  selectedUnit: string;
+  statsAsBits: Linode.NodeBalancerStats | null;
+  selectedUnit: StatsUnit | '';
+  trafficUnits: StatsUnit[] | null;
   convertedStats: Linode.NodeBalancerStats | null;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-// const statsFetchInterval = 30000;
+const statsFetchInterval = 30000;
 
 class TablesPanel extends React.Component<CombinedProps, State> {
   statsInterval?: number = undefined;
   mounted: boolean = false;
 
   state: State = {
-    stats: null,
-    selectedUnit: 'bits',
+    statsAsBits: null,
+    selectedUnit: '',
     convertedStats: null,
+    trafficUnits: null,
   };
 
   getStats = () => {
     const { nodeBalancer } = this.props;
+    const { selectedUnit } = this.state;
+
     getNodeBalancerStats(nodeBalancer.id)
       .then((response: Linode.NodeBalancerStats) => {
         if (!this.mounted) { return; }
-        this.setState({ stats: dummyStats });
+        // the reason for limiting which filters are available is because when a site has little
+        // traffic, converting bits to GB may leave us with an exponential which doesn't render
+        // properly in the chart component and displays an empty chart, so we need to limit
+        // the choices available based on how much traffic the NodeBalancer has
+        const trafficUnits: StatsUnit[] = (response && this.isMuchTraffic(response))
+          ? ['KB', 'MB', 'GB'] // we have a lot of traffic, so don't show bits or bytes
+          : ['bits', 'bytes', 'KB', 'MB']; // we have little traffic, so don't show GB
+        this.setState({
+          trafficUnits,
+          // getStats runs on an interval, so first check if we didn't already select a filter
+          selectedUnit: selectedUnit || trafficUnits[0],
+          statsAsBits: response, // original source of truth
+          convertedStats: (trafficUnits[0] === 'bits' && selectedUnit === 'bits')
+            ? response // don't do any converting since we're already getting bits from the API
+            : this.convertStats(response, selectedUnit || trafficUnits[0]),
+        });
       })
       .catch((errorResponse) => {
         if (!this.mounted) { return; }
       });
   }
 
-  handleUnitChange = (value: StatsUnit) => {
-    const { stats } = this.state;
-    if (!stats) { return; }
-
-    const convertStats = compose<
+  convertStats = (stats: Linode.NodeBalancerStats, value: StatsUnit) => {
+    // map over each inbound and outbound traffic value and convert it from
+    // one unit to another and return the new stats object
+    return compose<
       Linode.NodeBalancerStats,
       Linode.NodeBalancerStats,
       Linode.NodeBalancerStats
@@ -212,13 +172,18 @@ class TablesPanel extends React.Component<CombinedProps, State> {
           lensPath(['data', 'traffic', 'out']),
           map(stat => [stat[0], convertBitsToUnit(stat[1], value)]),
         ),
-    );
+    )(stats);
+  }
 
-    console.log(value);
+  handleUnitChange = (value: StatsUnit) => {
+    const { statsAsBits } = this.state;
+    if (!statsAsBits) { return; }
+
+    const convertedStats = this.convertStats(statsAsBits!, value);
 
     this.setState({
       selectedUnit: value,
-      convertedStats: convertStats(stats!),
+      convertedStats,
     });
   }
 
@@ -229,15 +194,18 @@ class TablesPanel extends React.Component<CombinedProps, State> {
       }
       return false; // otherwise, the traffic isn't that great
     });
-    return [...isHighTraffic(stats.data.traffic.in), ...isHighTraffic(stats.data.traffic.out)]
-      .some(isHigh => isHigh);
     // return whether or not we have high traffic in either in or out traffic
+    return [
+      ...isHighTraffic(stats.data.traffic.in),
+      ...isHighTraffic(stats.data.traffic.out),
+    ]
+      .some(isHigh => isHigh);
   }
 
   componentDidMount() {
     this.mounted = true;
     this.getStats();
-    // this.statsInterval = window.setInterval(() => this.getStats(), statsFetchInterval);
+    this.statsInterval = window.setInterval(() => this.getStats(), statsFetchInterval);
   }
 
   componentWillUnmount() {
@@ -247,25 +215,11 @@ class TablesPanel extends React.Component<CombinedProps, State> {
 
   render() {
     const { classes } = this.props;
-    const { stats, selectedUnit, convertedStats } = this.state;
-
-    // if we made a conversion, show the converted stats. Otherwise,
-    // show the original statsToDisplay
-    const statsToDisplay = (convertedStats) ? convertedStats : stats;
-
-    // the reason for limiting which filters are available is because when a site has little
-    // traffic, converting bits to GB may leave us with an exponential which doesn't render
-    // properly in the chart component and displays an empty chart, so we need to limit
-    // the choices available based on how much traffic the NodeBalancer has
-    const trafficUnits = (stats && this.isMuchTraffic(stats))
-      ? ['KB', 'MB', 'GB'] // we have a lot of traffic, so don't show bits or bytes
-      : ['bits', 'bytes', 'KB', 'MB']; // we have little traffic, so don't show GB
-
-    console.log(statsToDisplay);
+    const { selectedUnit, convertedStats, trafficUnits } = this.state;
 
     return (
       <React.Fragment>
-        {statsToDisplay &&
+        {convertedStats &&
           <React.Fragment>
             <div className={classes.graphControls}>
               <Typography variant="title" className={classes.graphTitle}>Graphs</Typography>
@@ -285,7 +239,7 @@ class TablesPanel extends React.Component<CombinedProps, State> {
                       {
                         label: 'Connections',
                         borderColor: '#3683dc',
-                        data: statsToDisplay.data.connections,
+                        data: convertedStats.data.connections,
                       },
                     ]}
                   />
@@ -304,12 +258,12 @@ class TablesPanel extends React.Component<CombinedProps, State> {
                     Select Time Range
                 </InputLabel>
                   <Select
-                    value={trafficUnits[0]}
+                    value={selectedUnit}
                     // e.target.value will always come back as a StatsUnit below
                     onChange={e => this.handleUnitChange(e.target.value as StatsUnit)}
                     inputProps={{ name: 'unitType', id: 'unitType' }}
                   >
-                    {trafficUnits.map((unit, index) => {
+                    {trafficUnits!.map((unit, index) => {
                       return <MenuItem key={index} value={unit}>{unit}</MenuItem>;
                     })
                     }
@@ -325,12 +279,12 @@ class TablesPanel extends React.Component<CombinedProps, State> {
                       {
                         label: 'Traffic In',
                         borderColor: '#3683dc',
-                        data: statsToDisplay.data.traffic.in,
+                        data: convertedStats.data.traffic.in,
                       },
                       {
                         label: 'Traffic Out',
                         borderColor: '#01b159',
-                        data: statsToDisplay.data.traffic.out,
+                        data: convertedStats.data.traffic.out,
                       },
                     ]}
                   />

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -25,7 +25,8 @@ type ClassNames = 'chart'
   | 'blue'
   | 'green'
   | 'red'
-  | 'yellow';
+  | 'yellow'
+  | 'dropdown';
 
 type StatsUnit = 'bits' | 'bytes' | 'KB' | 'MB' | 'GB';
 
@@ -97,6 +98,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => {
       '&:before': {
         backgroundColor: theme.color.yellow,
       },
+    },
+    dropdown: {
+      marginBottom: theme.spacing.unit * 3,
     },
   };
 };
@@ -253,7 +257,7 @@ class TablesPanel extends React.Component<CombinedProps, State> {
             >
               <React.Fragment>
                 <Typography variant="subheading">Units</Typography>
-                <FormControl style={{ martginTop: 0 }}>
+                <FormControl className={classes.dropdown} style={{ martginTop: 0 }}>
                   <InputLabel htmlFor="chartRange" disableAnimation hidden>
                     Select Time Range
                 </InputLabel>

--- a/src/types/NodeBalancer.ts
+++ b/src/types/NodeBalancer.ts
@@ -12,12 +12,12 @@ namespace Linode {
     transfer: BalancerTransfer;
   }
 
-  export interface NodesStatus{
+  export interface NodesStatus {
     up: number;
     down: number;
   }
 
-  export interface BalancerTransfer{
+  export interface BalancerTransfer {
     in: number;
     out: number;
     total: number;
@@ -32,7 +32,7 @@ namespace Linode {
     mode?: NodeBalancerConfigNodeMode;
   }
 
-  export interface NodeBalancerConfig{
+  export interface NodeBalancerConfig {
     id: number;
     nodebalancer_id: number;
     port: number;
@@ -54,13 +54,13 @@ namespace Linode {
     cipher_suite: string;
   }
 
-  export interface ExtendedNodeBalancer extends NodeBalancer{
+  export interface ExtendedNodeBalancer extends NodeBalancer {
     up: number;
     down: number;
     ports: number[];
   }
 
-  export interface NodeBalancerStats{
+  export interface NodeBalancerStats {
     title: string;
     data: {
       connections: [number, number][];

--- a/src/utilities/convertBitsToUnit.tsx
+++ b/src/utilities/convertBitsToUnit.tsx
@@ -21,5 +21,5 @@ export const convertBitsToUnit = (value: number, unitType: UnitType) => {
     default:
       break; // just bits
   }
-  return +convertedValue.toFixed(20);
+  return +convertedValue.toFixed(10);
 };

--- a/src/utilities/convertBitsToUnit.tsx
+++ b/src/utilities/convertBitsToUnit.tsx
@@ -1,0 +1,25 @@
+type UnitType = 'bits' | 'bytes' | 'KB' | 'MB' | 'GB';
+
+// calls to /:linodeID/stats and /:nodeBalancer/stats
+// returns units in bits, so we want to transform it
+// in whatever unit we please
+export const convertBitsToUnit = (value: number, unitType: UnitType) => {
+  let convertedValue = value;
+  switch (unitType) {
+    case 'bytes':
+      convertedValue = value / 8; // bits to bytes
+      break;
+    case 'KB':
+      convertedValue = (value / 8) / 1024; // bits to KB
+      break;
+    case 'MB':
+      convertedValue = (value / 8) / 1024 / 1024; // bits to MB
+      break;
+    case 'GB':
+      convertedValue = (value / 8) / 1024 / 1024 / 1024; // bits to GB
+      break;
+    default:
+      break; // just bits
+  }
+  return +convertedValue.toFixed(20);
+};


### PR DESCRIPTION
### Purpose

Give user ability to display his incoming and outgoing traffic in the following units: bits, bytes, KB, MB, GB

### Notes

This code is a little tricky. I did my best to comment what was going on and I'll elaborate here.
* First, the user doesn't get the ability to convert his traffic into any unit he wants. There's a check to see if any of the traffic values returned from the `stats` endpoint (inbound or outbound) are at least 1GB of data. If so, the user will see the options to view their traffic in KB, MB, and GB. Otherwise, they get bit, byte, KB, and MB
  * the reason for this is because of the limitations of the chartjs package we're using. It doesn't appear that it can parse exponential values, so if a user were to convert an extremely small amount of traffic to GB and get back `8.3e-8`, the chart would just be blank and wouldn't provide any useful  info
* Secondly, the call to `/stats` is happening on an interval, so if we have converted the data from the default unit type after initial page load, we need to make sure that it's converted again when the data is returned from the API each subsequent time. 