### PR TITLE
Add back link to linode detail

### DIFF
--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -152,7 +152,7 @@ class DomainDetail extends React.Component<CombinedProps, State> {
         <Grid container justify="space-between">
           <Grid item className={classes.titleWrapper}>
             <IconButton
-              onClick={() => history.goBack()}
+              onClick={() => history.push('/domains')}
               className={classes.backButton}
             >
               <KeyboardArrowLeft />

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -174,7 +174,7 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
         <Grid container justify="space-between">
           <Grid item className={classes.titleWrapper}>
             <IconButton
-              onClick={() => history.goBack()}
+              onClick={() => history.push('/nodebalancers')}
               className={classes.backButton}
             >
               <KeyboardArrowLeft />

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -3,11 +3,13 @@ import { pathEq, pathOr, filter, has, allPass } from 'ramda';
 import * as moment from 'moment';
 
 import { withStyles, StyleRulesCallback, Theme, WithStyles } from 'material-ui';
-import { matchPath, Route, Switch, RouteComponentProps, Redirect } from 'react-router-dom';
+import { matchPath, Route, Switch, RouteComponentProps, Redirect, Link } from 'react-router-dom';
 import { Location } from 'history';
 import { Subscription, Observable } from 'rxjs/Rx';
 import AppBar from 'material-ui/AppBar';
 import Tabs, { Tab } from 'material-ui/Tabs';
+import IconButton from 'material-ui/IconButton';
+import KeyboardArrowLeft from 'material-ui-icons/KeyboardArrowLeft';
 import Button from 'material-ui/Button';
 
 import notifications$ from 'src/notifications';
@@ -77,10 +79,23 @@ interface PreloadedProps {
   data: PromiseLoaderResponse<Data>;
 }
 
-type ClassNames = 'cta'
+type ClassNames = 'titleWrapper'
+  | 'backButton'
+  | 'cta'
   | 'launchButton';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  titleWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  backButton: {
+    margin: '2px 0 0 -16px',
+    '& svg': {
+      width: 34,
+      height: 34,
+    },
+  },
   cta: {
     marginTop: theme.spacing.unit,
     [theme.breakpoints.down('sm')]: {
@@ -317,13 +332,20 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
           container
           justify="space-between"
         >
-          <Grid item style={{ flex: 1 }}>
-            <EditableText
-              variant="headline"
-              text={linode.label}
-              onEdit={this.updateLabel}
-              data-qa-label
-            />
+          <Grid item className={classes.titleWrapper}>
+            <Link to={`/linodes`}>
+              <IconButton
+                className={classes.backButton}
+              >
+                <KeyboardArrowLeft />
+              </IconButton>
+            </Link>
+              <EditableText
+                variant="headline"
+                text={linode.label}
+                onEdit={this.updateLabel}
+                data-qa-label
+              />
           </Grid>
           <Grid item className={classes.cta}>
             <Button


### PR DESCRIPTION
This PR adds the back link to the Linode detail view (as per the mockup) similarly to the current domains, node balancers and volumes detail views.

**Note:** This implementation varies from the others as i believe using ```onClick={() => history.goBack()}``` is the wrong approach considering it will affect the tab navigation within the detail view. Additionally, in case of bookmarking a detail page, the history back would produce the wrong behavior. 