### PR TITLE
Compensate content with scrollbar

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,14 @@ html {
   -moz-osx-font-smoothing: grayscale;
 }
 
+@media screen and (min-width: 960px) {
+  html {
+    /* fix for scrollbar compoensation */
+    width:100vw;
+    overflow-x:hidden;
+  }
+}
+
 body {
   height: 100%;
   margin: 0;


### PR DESCRIPTION
This is a small css hack to avoid the content shifting when scrollbar is active/inactive. I only activated it above our ```lg``` breakpoint value. It really helps not having the jitter when jumping from a page with no scrollbar to a page with one.

The only possible downfall with this is having ```overflow-x: hidden``` on the html but i have not found any issue with our app as the horizontal scrolling is purposefully given on containers whose role is to do that (tables & tabs on mobile for instance)