### PR TITLE
Fix buttons with old props and new imports

### DIFF
--- a/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
+++ b/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
@@ -31,7 +31,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
       ${theme.spacing.unit * 4}px
       ${theme.spacing.unit}px
       ${0}
-      -${theme.spacing.unit}px
+      -${theme.spacing.unit * 2}px
     `,
   },
 });

--- a/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
+++ b/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
@@ -80,9 +80,8 @@ class InfoPanel extends React.Component<CombinedProps> {
             {!!expansion.action &&
               <ActionsPanel className={expansion ? classes.expPanelButton : ''}>
                 <Button
-                  variant="raised"
                   onClick={expansion.action}
-                  color="primary"
+                  type="primary"
                   disabled={expansion.isSubmitting}
                   data-qa-label-save
                 >

--- a/src/features/NodeBalancers/ClientConnectionThrottlePanel.tsx
+++ b/src/features/NodeBalancers/ClientConnectionThrottlePanel.tsx
@@ -79,9 +79,8 @@ class ClientConnectionThrottlePanel extends React.Component<CombinedProps> {
               <ActionsPanel className={expansion ? classes.expPanelButton : ''}>
                 <Button
                   onClick={expansion.action}
-                  variant="raised"
                   disabled={expansion.isSubmitting}
-                  color="primary"
+                  type="primary"
                   data-qa-label-save
                 >
                   Save

--- a/src/features/NodeBalancers/ClientConnectionThrottlePanel.tsx
+++ b/src/features/NodeBalancers/ClientConnectionThrottlePanel.tsx
@@ -30,7 +30,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
       ${theme.spacing.unit * 4}px
       ${theme.spacing.unit}px
       ${0}
-      -${theme.spacing.unit}px
+      -${theme.spacing.unit * 2}px
     `,
   },
 });

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -337,8 +337,7 @@ class LinodeSettingsAlertsPanel extends React.Component<CombinedProps, State> {
         actions={() =>
           <ActionsPanel>
             <Button
-              variant="raised"
-              color="primary"
+              type="primary"
               onClick={this.setLinodeAlertThresholds}
               disabled={noError}
               loading={noError}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
@@ -80,8 +80,7 @@ class LinodeSettingsLabelPanel extends React.Component<CombinedProps, State> {
           <ActionsPanel>
             <Button
               onClick={this.changeLabel}
-              variant="raised"
-              color="primary"
+              type="primary"
               disabled={submitting && !labelError}
               loading={submitting && !labelError}
               data-qa-label-save

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -95,8 +95,7 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
         actions={() =>
           <ActionsPanel>
             <Button
-              variant="raised"
-              color="primary"
+              type="primary"
               onClick={this.changeDiskPassword}
               loading={submitting && !passwordError}
               disabled={submitting && !passwordError}


### PR DESCRIPTION
We had a few instances where we imported the new button component but had the old props in place (variant instead of type). This resulted in buttons having the wrong styles.

I did a search for the new imports and replaced the wrong instances. Hopefully that should cover it all.