### PR TITLE
Front end fixes

### DIFF
--- a/src/components/HelpIcon/HelpIcon.tsx
+++ b/src/components/HelpIcon/HelpIcon.tsx
@@ -27,6 +27,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => ({
     '& .helpPaper': {
       padding: theme.spacing.unit * 2,
       backgroundColor: theme.bg.offWhite,
+      maxWidth: 300,
       '&::after': {
         content: 'poo',
         display: 'block',
@@ -79,8 +80,8 @@ class HelpIcon extends React.Component<CombinedProps, State> {
           open={this.state.open}
           anchorEl={this.state.anchorEl}
           onClose={this.handleClose}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'left' }}
           className={classes.root}
           classes={{ paper: 'helpPaper' }}
         >

--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -15,7 +15,6 @@ import {
 import { Subscription } from 'rxjs/Subscription';
 
 import { withStyles, StyleRulesCallback, Theme, WithStyles } from 'material-ui';
-import Button from 'material-ui/Button';
 import Paper from 'material-ui/Paper';
 import Grid from 'material-ui/Grid';
 import TableBody from 'material-ui/Table/TableBody';
@@ -25,6 +24,7 @@ import TableRow from 'material-ui/Table/TableRow';
 
 import { deleteDomainRecord } from 'src/services/domains';
 import Table from 'src/components/Table';
+import Button from 'src/components/Button';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -501,14 +501,18 @@ class DomainRecords extends React.Component<CombinedProps, State> {
           title="Confirm Deletion"
           actions={({ onClose }) =>
             <ActionsPanel>
-              <Button onClick={onClose}>Cancel</Button>
               <Button
-                variant="raised"
-                color="secondary"
-                className="destructive"
+                type="secondary"
+                destructive
                 onClick={() => this.deleteDomainRecord()}
               >
                 Delete
+              </Button>
+              <Button
+                type="cancel"
+                onClick={onClose}
+              >
+                Cancel
               </Button>
             </ActionsPanel>
           }

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -301,8 +301,7 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
               </Button>
               <Button
                 onClick={() => onClose()}
-                type="secondary"
-                className="cancel"
+                type="cancel"
                 data-qa-cancel-cancel
               >
                 Cancel

--- a/src/features/Volumes/DestructiveVolumeDialog.tsx
+++ b/src/features/Volumes/DestructiveVolumeDialog.tsx
@@ -7,7 +7,8 @@ import {
 } from 'material-ui';
 
 import Typography from 'material-ui/Typography';
-import Button from 'material-ui/Button';
+
+import Button from 'src/components/Button';
 import ActionsPanel from 'src/components/ActionsPanel';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 
@@ -46,9 +47,8 @@ const DestructiveVolumeDialog: React.StatelessComponent<CombinedProps> = (props)
       actions={() =>
         <ActionsPanel style={{ padding: 0 }}>
           <Button
-            variant="raised"
-            color="secondary"
-            className="destructive"
+            type="secondary"
+            destructive
             onClick={method}
             data-qa-confirm
           >
@@ -56,9 +56,7 @@ const DestructiveVolumeDialog: React.StatelessComponent<CombinedProps> = (props)
           </Button>
           <Button
             onClick={props.onClose}
-            variant="raised"
-            color="secondary"
-            className="cancel"
+            type="cancel"
             data-qa-cancel
           >
             Cancel

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/AttachVolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/AttachVolumeDrawer.tsx
@@ -6,12 +6,12 @@ import {
   Theme,
   WithStyles,
 } from 'material-ui';
-import Button from 'material-ui/Button';
 import InputLabel from 'material-ui/Input/InputLabel';
 import MenuItem from 'material-ui/Menu/MenuItem';
 import FormControl from 'material-ui/Form/FormControl';
 import FormHelperText from 'material-ui/Form/FormHelperText';
 
+import Button from 'src/components/Button';
 import Select from 'src/components/Select';
 import Drawer from 'src/components/Drawer';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -95,8 +95,7 @@ const AttachVolumeDrawer: React.StatelessComponent<CombinedProps> = (props) => {
       </FormControl>
       <ActionsPanel>
         <Button
-          variant="raised"
-          color="primary"
+          type="primary"
           onClick={() => onSubmit()}
           data-qa-confirm-attach
         >
@@ -105,6 +104,7 @@ const AttachVolumeDrawer: React.StatelessComponent<CombinedProps> = (props) => {
         <Button
           onClick={onClose}
           data-qa-cancel
+          type="cancel"
         >
           Cancel
         </Button>

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -8,7 +8,6 @@ import {
   Theme,
   WithStyles,
 } from 'material-ui';
-import Button from 'material-ui/Button';
 import Paper from 'material-ui/Paper';
 import Typography from 'material-ui/Typography';
 import TableHead from 'material-ui/Table/TableHead';
@@ -26,6 +25,8 @@ import {
   update as updateVolume,
   resize as resizeVolume,
 } from 'src/services/volumes';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
 import Table from 'src/components/Table';
 import Grid from 'src/components/Grid';
 import Placeholder, { PlaceholderProps } from 'src/components/Placeholder';
@@ -327,24 +328,23 @@ class LinodeVolumes extends React.Component<CombinedProps, State> {
       <ConfirmationDialog
         onClose={this.closeUpdateDialog}
         actions={() => <div>
-          <Button
-            variant="raised"
-            color="secondary"
-            className="destructive"
-            onClick={method}
-            data-qa-confirm
-          >
-            Confirm
-          </Button>
-          <Button
-            onClick={this.closeUpdateDialog}
-            variant="raised"
-            color="secondary"
-            className="cancel"
-            data-qa-cancel
-          >
-            Cancel
-          </Button>
+          <ActionsPanel style={{ padding: 0 }}>
+            <Button
+              type="secondary"
+              destructive
+              onClick={method}
+              data-qa-confirm
+            >
+              Confirm
+            </Button>
+            <Button
+              onClick={this.closeUpdateDialog}
+              type="cancel"
+              data-qa-cancel
+            >
+              Cancel
+            </Button>
+          </ActionsPanel>
         </div>}
         open={open}
         title={title}

--- a/src/features/profile/APITokens/APITokenDrawer.test.tsx
+++ b/src/features/profile/APITokens/APITokenDrawer.test.tsx
@@ -8,6 +8,7 @@ describe('API Token Drawer', () => {
     <APITokenDrawer
       classes={{
         permsTable: '',
+        selectCell: '',
         accessCell: '',
         noneCell: '',
         readOnlyCell: '',

--- a/src/features/profile/APITokens/APITokenDrawer.tsx
+++ b/src/features/profile/APITokens/APITokenDrawer.tsx
@@ -43,14 +43,20 @@ export const genExpiryTups = (): Expiry[] => {
 };
 
 type ClassNames = 'permsTable'
+  | 'selectCell'
   | 'accessCell'
   | 'noneCell'
   | 'readOnlyCell'
   | 'readWritecell';
 
-const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   permsTable: {
     marginTop: theme.spacing.unit * 3,
+  },
+  selectCell: {
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    fontSize: '.9rem',
   },
   accessCell: {
     width: '31%',
@@ -171,10 +177,10 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
         </TableHead>
         <TableBody>
           {mode === 'create' &&
-            <TableRow data-qa-row="Select All">
-              <TableCell padding="checkbox" className={classes.accessCell}>
+            <TableRow data-qa-row="Select All" className={classes.selectCell}>
+              <TableCell padding="checkbox">
                 Select All
-            </TableCell>
+              </TableCell>
               <TableCell padding="checkbox" className={classes.noneCell}>
                 <Radio
                   name="Select All"

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -450,6 +450,7 @@ const LinodeTheme: Linode.Theme = {
         backgroundColor: '#fff',
         lineHeight: 2.3,
         minHeight: 46,
+        minWidth: 150,
         '&:focus': {
           backgroundColor: '#fff',
         },


### PR DESCRIPTION
This PR tackles small regressions and fixes through the app:

- help tooltip needed a max width and better positioning (ex: /linodes/[id]/settings or /linodes/[id]/rebuild)
- select menu min width for small ones (ex: Graphs at /linodes/[id]/summary)
- better styling of select All radio table (/profile/tokens)
- cancel buttons through the app in modals and drawers (using our abstracted component) 