### PR TITLE
M3-636 - Add Nodebalancer settings, configurations e2e specs

### DIFF
--- a/e2e/pageobjects/linode-detail/linode-detail.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail.page.js
@@ -20,16 +20,6 @@ class LinodeDetail extends Page {
     get linodeLabel() { return $('[data-qa-label]'); }
     get editLabel() { return $('[data-qa-label] button'); }
 
-    changeTab(tab) {
-        browser.jsClick(`[data-qa-tab="${tab}"]`);
-        browser.waitUntil(function() {
-            return browser
-                .getAttribute(`[data-qa-tab="${tab}"]`, 'aria-selected').includes('true');
-        }, constants.wait.short, 'Failed to change tab');
-        browser.waitForVisible('[data-qa-circle-progress]', constants.wait.normal, true);
-        return this;
-    }
-
     changeName(name) {
         this.linodeLabel.waitForVisible();
         this.editLabel.click();

--- a/e2e/pageobjects/nodebalancer-detail/settings.page.js
+++ b/e2e/pageobjects/nodebalancer-detail/settings.page.js
@@ -1,0 +1,36 @@
+const { constants } = require('../../constants');
+
+import Page from '../page';
+
+class NodeBalancerSettings extends Page {
+    get tabPanels() { return $$('[data-qa-panel-summary]'); }
+    get gridItems() { return $$('[data-qa-grid-item]'); }
+    get panelSubheadings() { return $$('[data-qa-panel-subheading="true"]'); }
+    get label() { return $('[data-qa-label-panel] input'); }
+    get save() { return $('[data-qa-label-save]'); }
+    get connectionThrottle() { return $('[data-qa-connection-throttle] input'); }
+
+    baseElemsDisplay() {
+        expect(this.tabPanels.length).toBe(2);
+        expect(this.panelSubheadings.length).toBe(2);
+        expect(this.connectionThrottle.isVisible()).toBe(true);
+        expect(this.connectionThrottle.getValue()).toBe('0');
+        expect($$('[data-qa-label-save]').length).toBe(2);   
+    }
+
+    changeLabel(label) {
+        this.label.setValue(label);
+        this.gridItems[0].$(this.save.selector).click();
+        this.waitForNotice('Label updated successfully');
+        expect(this.label.getValue()).toBe(label);
+    }
+
+    setConnectionThrottle(connections) {
+        this.connectionThrottle.setValue(connections);
+        this.gridItems[1].$(this.save.selector).click();
+        this.waitForNotice('Client Connection Throttle updated successfully');
+        expect(this.connectionThrottle.getValue()).toBe(String(connections));
+    }
+}
+
+export default new NodeBalancerSettings();

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -3,6 +3,8 @@ const { constants } = require('../constants');
 export default class Page {
     get dialogTitle() { return $('[data-qa-dialog-title]'); }
     get dialogContent() { return $('[data-qa-dialog-content]'); }
+    get dialogConfirm() { return $('[data-qa-confirm-cancel]'); }
+    get dialogCancel() { return $('[data-qa-cancel-cancel]'); }
     get sidebarTitle() { return $('[data-qa-sidebar-title]'); }
     get drawerTitle() { return $('[data-qa-drawer-title]'); }
     get drawerClose() { return $('[data-qa-close-drawer]'); }
@@ -95,5 +97,15 @@ export default class Page {
     closeDrawer() {
         this.drawerClose.click();
         this.drawerTitle.waitForVisible(constants.wait.normal, true);
+    }
+
+    changeTab(tab) {
+        browser.jsClick(`[data-qa-tab="${tab}"]`);
+        browser.waitUntil(function() {
+            return browser
+                .getAttribute(`[data-qa-tab="${tab}"]`, 'aria-selected').includes('true');
+        }, constants.wait.short, 'Failed to change tab');
+        browser.waitForVisible('[data-qa-circle-progress]', constants.wait.normal, true);
+        return this;
     }
 }

--- a/e2e/specs/nodebalancers/configurations.spec.js
+++ b/e2e/specs/nodebalancers/configurations.spec.js
@@ -1,0 +1,60 @@
+import NodeBalancers from '../../pageobjects/nodebalancers.page';
+import {
+    createNodeBalancer,
+    removeNodeBalancers,
+} from '../../utils/common';
+
+describe('NodeBalancer - Configurations Suite', () => {
+    let nodeLabel,
+        nodeIp;
+
+    beforeAll(() => {
+        createNodeBalancer();
+        NodeBalancers.changeTab('Configurations');
+    });
+
+    afterAll(() => {
+        removeNodeBalancers();
+    });
+
+    it('should display default configuration', () => {
+        NodeBalancers.configElemsDisplay();
+    });
+
+    it('should update the algorithm', () => {
+        NodeBalancers.selectMenuOption(NodeBalancers.algorithmSelect, 'leastconn');
+        NodeBalancers.configSave();
+    });
+
+    it('should display attached node', () => {
+        const attachedNodes = NodeBalancers.nodes
+            .filter(n => n.$('[data-qa-backend-ip-label] input').getValue() !== '');
+        nodeLabel = attachedNodes[0].$(NodeBalancers.backendIpLabel.selector).getValue();
+        nodeIp = attachedNodes[0].$(NodeBalancers.backendIpAddress.selector).getValue();
+        const nodeWeight = attachedNodes[0].$(NodeBalancers.backendIpWeight.selector).getValue();
+        const nodeMode = attachedNodes[0].$(NodeBalancers.backendIpMode.selector).getText();
+
+        expect(nodeLabel).toMatch(/\w/ig);
+        expect(nodeIp).toMatch(/(^127\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^192\.168\.)/g);
+        expect(nodeWeight).toBe('100');
+        expect(nodeMode).toContain('Accept');
+    });
+
+    it('should remove attached node', () => {
+        NodeBalancers.configRemoveNode(nodeLabel);
+        NodeBalancers.configSave();
+    });
+
+    it('should attach a new node', () => {
+        const nodeConfig = {
+            label: nodeLabel,
+            ip: nodeIp,
+        }
+        NodeBalancers.configAddNode(nodeConfig);
+        NodeBalancers.configSave();
+    });
+
+    it('should remove the config', () => {
+        NodeBalancers.configDelete();
+    });
+});

--- a/e2e/specs/nodebalancers/create.spec.js
+++ b/e2e/specs/nodebalancers/create.spec.js
@@ -2,7 +2,10 @@ const { constants } = require('../../constants');
 
 import NodeBalancers from '../../pageobjects/nodebalancers.page';
 import NodeBalancerDetail from '../../pageobjects/nodebalancer-detail/details.page';
-import { apiCreateLinode, apiDeleteAllLinodes } from '../../utils/common';
+import {
+    apiCreateLinode,
+    removeNodeBalancers,
+} from '../../utils/common';
 
 describe('Nodebalancer - Create Suite', () => {
     let linode,
@@ -17,9 +20,7 @@ describe('Nodebalancer - Create Suite', () => {
     });
 
     afterAll(() => {
-        apiDeleteAllLinodes();
-        const availableNodeBalancers = browser.getNodeBalancers(token);
-        availableNodeBalancers.data.forEach(nb => browser.removeNodeBalancer(token, nb.id));
+        removeNodeBalancers();
     });
 
     it('should display placeholder message with create button', () => {

--- a/e2e/specs/nodebalancers/error-handling.spec.js
+++ b/e2e/specs/nodebalancers/error-handling.spec.js
@@ -1,16 +1,15 @@
 const { constants } = require('../../constants');
 
 import NodeBalancers from '../../pageobjects/nodebalancers.page';
-import { apiCreateLinode, apiDeleteAllLinodes } from '../../utils/common';
+import {
+    apiCreateLinode,
+    removeNodeBalancers,
+} from '../../utils/common';
 
 describe('NodeBalancer - Negative Tests Suite', () => {
-    let linode,
-        privateIp,
-        token;
-
     beforeAll(() => {
-        token = browser.readToken();
-        linode = apiCreateLinode();
+        const token = browser.readToken();
+        const linode = apiCreateLinode();
         linode['privateIp'] = browser.allocatePrivateIp(token, linode.id).address;
         browser.url(constants.routes.nodeBalancers);
         NodeBalancers.baseElemsDisplay(true);
@@ -18,9 +17,7 @@ describe('NodeBalancer - Negative Tests Suite', () => {
     });
 
     afterAll(() => {
-        apiDeleteAllLinodes();
-        const availableNodeBalancers = browser.getNodeBalancers(token);
-        availableNodeBalancers.data.forEach(nb => browser.removeNodeBalancer(token, nb.id));
+        removeNodeBalancers();
     });
 
     it('should display a service error msg on create with an invalid node', () => {

--- a/e2e/specs/nodebalancers/list.spec.js
+++ b/e2e/specs/nodebalancers/list.spec.js
@@ -1,31 +1,19 @@
 const { constants } = require('../../constants');
 
-import NodeBalancers from '../../pageobjects/nodebalancers.page';
 import ListNodeBalancers from '../../pageobjects/list-nodebalancers.page';
-import NodeBalancerDetail from '../../pageobjects/nodebalancer-detail/details.page';
-import { apiCreateLinode, apiDeleteAllLinodes } from '../../utils/common';
+import {
+    createNodeBalancer,
+    removeNodeBalancers,
+} from '../../utils/common';
 
-describe('Nodebalancer - List Suite', () => {
-    let linode,
-        privateIp,
-        token;
-
+describe('NodeBalancer - List Suite', () => {
     beforeAll(() => {
-        token = browser.readToken();
-        linode = apiCreateLinode();
-        linode['privateIp'] = browser.allocatePrivateIp(token, linode.id).address;
-        browser.url(constants.routes.nodeBalancers);
-        NodeBalancers.baseElemsDisplay(true);
-        NodeBalancers.create();
-        NodeBalancers.configure(linode);
-        NodeBalancerDetail.baseElemsDisplay();
+        createNodeBalancer();
         browser.url(constants.routes.nodeBalancers);
     });
 
     afterAll(() => {
-        apiDeleteAllLinodes();
-        const availableNodeBalancers = browser.getNodeBalancers(token);
-        availableNodeBalancers.data.forEach(nb => browser.removeNodeBalancer(token, nb.id));
+        removeNodeBalancers();
     });
 
     it('should display nodebalancer in list', () => {

--- a/e2e/specs/nodebalancers/settings.spec.js
+++ b/e2e/specs/nodebalancers/settings.spec.js
@@ -1,0 +1,31 @@
+import NodeBalancerDetail from '../../pageobjects/nodebalancer-detail/details.page';
+import NodeBalancerSettings from '../../pageobjects/nodebalancer-detail/settings.page';
+import {
+    createNodeBalancer,
+    removeNodeBalancers,
+} from '../../utils/common';
+
+describe('NodeBalancer - Settings Suite', () => { 
+    beforeAll(() => {
+        createNodeBalancer();
+    });
+
+    afterAll(() => {
+        removeNodeBalancers();
+    });
+
+    it('should display base elements', () => {
+        NodeBalancerDetail.changeTab('Settings');
+        NodeBalancerSettings.baseElemsDisplay();
+    });
+
+    it('should update the label', () => {
+        const newLabel = 'NewLabel1';
+        NodeBalancerSettings.changeLabel(newLabel);
+    });
+
+    it('should update the connection throttle', () => {
+        const connections = 5;
+        NodeBalancerSettings.setConnectionThrottle(connections);
+    });
+});

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -7,6 +7,8 @@ import ListLinodes from '../pageobjects/list-linodes';
 import Create from '../pageobjects/create';
 import Settings from '../pageobjects/linode-detail/linode-detail-settings.page';
 import LinodeDetail from '../pageobjects/linode-detail/linode-detail.page';
+import NodeBalancers from '../pageobjects/nodebalancers.page';
+import NodeBalancerDetail from '../pageobjects/nodebalancer-detail/details.page';
 
 export const createGenericLinode = (label) => {
     Create.menuButton.click();
@@ -65,4 +67,22 @@ export const apiDeleteAllDomains = () => {
     const token = readToken();
     const domains = browser.getDomains(token);
     domains.data.forEach(domain => browser.removeDomain(token, domain.id));
+}
+
+export const createNodeBalancer = () => {
+    const token = readToken();
+    const linode = apiCreateLinode();
+    linode['privateIp'] = browser.allocatePrivateIp(token, linode.id).address;
+    browser.url(constants.routes.nodeBalancers);
+    NodeBalancers.baseElemsDisplay(true);
+    NodeBalancers.create();
+    NodeBalancers.configure(linode);
+    NodeBalancerDetail.baseElemsDisplay();
+}
+
+export const removeNodeBalancers = () => {
+    const token = readToken();
+    apiDeleteAllLinodes();
+    const availableNodeBalancers = browser.getNodeBalancers(token);
+    availableNodeBalancers.data.forEach(nb => browser.removeNodeBalancer(token, nb.id));
 }

--- a/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
+++ b/src/components/LabelAndTagsPanel/LabelAndTagsPanel.tsx
@@ -75,7 +75,7 @@ class InfoPanel extends React.Component<CombinedProps> {
           >
             <div className={!expansion ? classes.inner : ''}>
               {error && <Notice text={error} error />}
-              <TextField {...labelFieldProps} />
+              <TextField data-qa-label-panel {...labelFieldProps} />
             </div>
             {!!expansion.action &&
               <ActionsPanel className={expansion ? classes.expPanelButton : ''}>

--- a/src/features/NodeBalancers/ClientConnectionThrottlePanel.tsx
+++ b/src/features/NodeBalancers/ClientConnectionThrottlePanel.tsx
@@ -73,7 +73,7 @@ class ClientConnectionThrottlePanel extends React.Component<CombinedProps> {
           >
             <div className={!expansion ? classes.inner : ''}>
               {error && <Notice text={error} error />}
-              <TextField {...textFieldProps} />
+              <TextField data-qa-connection-throttle {...textFieldProps} />
             </div>
             {expansion.action &&
               <ActionsPanel className={expansion ? classes.expPanelButton : ''}>

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -671,6 +671,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                       type="primary"
                       onClick={this.onSave}
                       loading={submitting}
+                      data-qa-save-config
                     >
                       Save
                     </Button>
@@ -686,6 +687,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                     onClick={this.onDelete}
                     type="secondary"
                     destructive
+                    data-qa-delete-config
                   >
                     Delete
                   </Button>
@@ -729,6 +731,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                           errors,
                         ]}
                         container
+                        alignItems="flex-end"
+                        data-qa-node
                       >
                         {idx !== 0 &&
                           <Grid item xs={12}>


### PR DESCRIPTION
* Moved "changetab" method into global `page.js` page object
* Created `settings.page.js` for nodebalancer settings with utility methods and element getters for the page
* Added nodebalancer configurations elements and utilities to `nodebalancers.page.js` page object (many of these elements are shared across the create / edit pages, so it made sense to consolidate them)
* Added specs for configurations, settings
* Refactored existing nodebalancers tests to use common utilities for creating a nodebalancer and removing all nodebalancers
* added `data-qa` attributes for nodebalancer config/settings tests

To Test:

```bash
yarn && yarn start
yarn selenium # in a new shell
yarn e2e -d nodebalancers 
```

My results were as follows:
20 passing (220.80s)
