### PR TITLE
Create from stackscript Review Feedback

### DIFF
--- a/src/components/PasswordInput/HideShowText.tsx
+++ b/src/components/PasswordInput/HideShowText.tsx
@@ -10,7 +10,9 @@ interface State {
   hidden: Boolean;
 }
 
-interface Props extends TextFieldProps { }
+interface Props extends TextFieldProps {
+  required?: boolean;
+ }
 
 class HideShowText extends React.Component<Props, State> {
   state = {
@@ -23,12 +25,14 @@ class HideShowText extends React.Component<Props, State> {
 
   render() {
     const { hidden } = this.state;
+    const { required } = this.props;
 
     return (
       <TextField
         {...this.props}
         data-qa-hide={hidden}
         type={hidden ? 'password' : 'text'}
+        required={required}
         InputProps={{
           startAdornment: hidden
             ? <Visibility onClick={this.toggleHidden} style={{ marginLeft: 14 }} />

--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -16,6 +16,7 @@ import HideShowText from './HideShowText';
 
 interface Props extends TextFieldProps {
   value?: string;
+  required?: boolean;
 }
 
 interface State {
@@ -58,7 +59,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
 
   render() {
     const { strength } = this.state;
-    const { classes, value, ...rest } = this.props;
+    const { classes, value, required, ...rest } = this.props;
 
     return (
       <Grid container className={classes.container}>
@@ -68,6 +69,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
             {...rest}
             onChange={this.onChange}
             fullWidth
+            required={required}
           />
         </Grid>
         {

--- a/src/components/SelectionRow/SelectionRow.tsx
+++ b/src/components/SelectionRow/SelectionRow.tsx
@@ -85,7 +85,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     maxWidth: '200px',
   },
   stackScriptUsername: {
-    color: 'grey',
+    color: theme.color.grey1,
   },
 });
 

--- a/src/components/SelectionRow/SelectionRow.tsx
+++ b/src/components/SelectionRow/SelectionRow.tsx
@@ -22,7 +22,8 @@ type ClassNames = 'root'
   | 'libTitleLink'
   | 'libDescription'
   | 'colImages'
-  | 'stackScriptCell';
+  | 'stackScriptCell'
+  | 'stackScriptUsername';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -83,6 +84,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   stackScriptCell: {
     maxWidth: '200px',
   },
+  stackScriptUsername: {
+    color: 'grey',
+  },
 });
 
 export interface Props {
@@ -95,6 +99,7 @@ export interface Props {
   checked?: boolean;
   showDeployLink?: boolean;
   stackScriptID?: number;
+  stackScriptUsername?: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -111,6 +116,7 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
     updated,
     showDeployLink,
     stackScriptID,
+    stackScriptUsername,
   } = props;
 
   /** onSelect and showDeployLink should not be used simultaneously */
@@ -129,8 +135,18 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
         }
         <TableCell className={classes.stackScriptCell}>
           <Typography variant="subheading">
-            <label htmlFor={`${stackScriptID}`} className={classes.libRadioLabel}>{label}
+          {stackScriptUsername &&
+                <label
+                  htmlFor={`${stackScriptID}`}
+                  className={`${classes.libRadioLabel} ${classes.stackScriptUsername}`}>
+                  {stackScriptUsername} /&nbsp;
             </label>
+              }
+              <label
+                htmlFor={`${stackScriptID}`}
+                className={classes.libRadioLabel}>
+                 {label}
+              </label>
           </Typography>
           <Typography>{description}</Typography>
         </TableCell>

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -190,18 +190,21 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     isSorting: false,
   };
 
+  mounted: boolean = false;
+
   getDataAtPage = (page: number,
     filter: any = this.state.currentFilter,
     isSorting: boolean = false) => {
     const { request } = this.props;
     this.setState({ gettingMoreStackScripts: true, isSorting });
-
+    
     request({ page, page_size: 50 }, filter)
       .then((response) => {
-        if (!response.data.length) {
+        if (!response.data.length || response.data.length < 50) {
           this.setState({ showMoreButtonVisible: false });
         }
         const newData = (isSorting) ? response.data : [...this.state.data, ...response.data];
+        if (!this.mounted) { return; }
         this.setState({
           data: newData,
           gettingMoreStackScripts: false,
@@ -216,9 +219,15 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
 
   componentDidMount() {
     this.getDataAtPage(0);
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
   }
 
   getNext = () => {
+    if (!this.mounted) { return; }
     this.setState(
       { currentPage: this.state.currentPage + 1 },
       () => this.getDataAtPage(this.state.currentPage),

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -101,7 +101,7 @@ interface Props {
   selectedId: number | null;
   error?: string;
   shrinkPanel?: boolean;
-  onSelect: (id: number, label: string, images: string[],
+  onSelect: (id: number, label: string, username: string, images: string[],
     userDefinedFields: Linode.StackScript.UserDefinedField[]) => void;
 }
 
@@ -156,7 +156,7 @@ interface Params {
 interface ContainerProps {
   request: (params: Params, filter: any) =>
     Promise<Linode.ResourcePage<Linode.StackScript.Response>>;
-  onSelect: (id: number, label: string, images: string[],
+  onSelect: (id: number, label: string, username: string, images: string[],
     userDefinedFields: Linode.StackScript.UserDefinedField[]) => void;
 }
 
@@ -229,6 +229,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     this.props.onSelect(
       stackscript.id,
       stackscript.label,
+      stackscript.username,
       stackscript.images,
       stackscript.user_defined_fields,
     );

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -101,7 +101,7 @@ interface Props {
   selectedId: number | null;
   error?: string;
   shrinkPanel?: boolean;
-  onSelect: (id: number, images: string[],
+  onSelect: (id: number, label: string, images: string[],
     userDefinedFields: Linode.StackScript.UserDefinedField[]) => void;
 }
 
@@ -156,7 +156,7 @@ interface Params {
 interface ContainerProps {
   request: (params: Params, filter: any) =>
     Promise<Linode.ResourcePage<Linode.StackScript.Response>>;
-  onSelect: (id: number, images: string[],
+  onSelect: (id: number, label: string, images: string[],
     userDefinedFields: Linode.StackScript.UserDefinedField[]) => void;
 }
 
@@ -228,6 +228,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
   handleSelectStackScript = (stackscript: Linode.StackScript.Response) => {
     this.props.onSelect(
       stackscript.id,
+      stackscript.label,
       stackscript.images,
       stackscript.user_defined_fields,
     );

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -352,7 +352,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
             </TableRow>
           </TableHead>
           <StackScriptsSection
-            isSorting={isSorting}
+            // isSorting={isSorting}
             onSelect={this.handleSelectStackScript}
             selectedId={this.state.selected}
             data={this.state.data}

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -352,7 +352,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
             </TableRow>
           </TableHead>
           <StackScriptsSection
-            // isSorting={isSorting}
+            isSorting={isSorting}
             onSelect={this.handleSelectStackScript}
             selectedId={this.state.selected}
             data={this.state.data}

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -69,8 +69,8 @@ const stripImageName = (images: string[]) => {
 
 const formatDate = (utcDate: string) => {
   const formattedDate = moment.utc(utcDate).toISOString();
-  const startOfTimeStamp = formattedDate.indexOf('T'); // beginning of timestamp
-  return formattedDate.substring(0, startOfTimeStamp);
+  // const startOfTimeStamp = formattedDate.indexOf('T'); // beginning of timestamp
+  return formattedDate.replace('T', ' ').replace('.000Z', '');
 };
 
 const stackScript: (fn: (s: Linode.StackScript.Response) => void, id?: number) =>

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as moment from 'moment';
 import { withStyles, StyleRulesCallback, Theme, WithStyles } from 'material-ui';
 import TableBody from 'material-ui/Table/TableBody';
 import TableRow from 'material-ui/Table/TableRow';
@@ -7,6 +6,8 @@ import TableCell from 'material-ui/Table/TableCell';
 
 import SelectionRow from 'src/components/SelectionRow';
 import CircleProgress from 'src/components/CircleProgress';
+
+import { formatDate } from 'src/utilities/format-date-iso8601';
 
 type ClassNames = 'root' | 'loadingWrapper' | 'username';
 
@@ -67,12 +68,6 @@ const stripImageName = (images: string[]) => {
   });
 };
 
-const formatDate = (utcDate: string) => {
-  const formattedDate = moment.utc(utcDate).toISOString();
-  // const startOfTimeStamp = formattedDate.indexOf('T'); // beginning of timestamp
-  return formattedDate.replace('T', ' ').replace('.000Z', '');
-};
-
 const stackScript: (fn: (s: Linode.StackScript.Response) => void, id?: number) =>
   (s: Linode.StackScript.Response) => JSX.Element =
   (onSelect, selectedId) => s => (
@@ -83,7 +78,7 @@ const stackScript: (fn: (s: Linode.StackScript.Response) => void, id?: number) =
       description={truncateDescription(s.description)}
       images={stripImageName(s.images)}
       deploymentsActive={s.deployments_active}
-      updated={formatDate(s.updated)}
+      updated={formatDate(s.updated, false)}
       onSelect={() => onSelect(s)}
       checked={selectedId === s.id}
       updateFor={[selectedId === s.id]}

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -7,13 +7,16 @@ import TableCell from 'material-ui/Table/TableCell';
 import SelectionRow from 'src/components/SelectionRow';
 import CircleProgress from 'src/components/CircleProgress';
 
-type ClassNames = 'root' | 'loadingWrapper';
+type ClassNames = 'root' | 'loadingWrapper' | 'username';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {},
   loadingWrapper: {
     border: 0,
     paddingTop: 100,
+  },
+  username: {
+    color: 'grey',
   },
 });
 
@@ -69,6 +72,7 @@ const stackScript: (fn: (s: Linode.StackScript.Response) => void, id?: number) =
     <SelectionRow
       key={s.id}
       label={s.label}
+      stackScriptUsername={s.username}
       description={truncateDescription(s.description)}
       images={stripImageName(s.images)}
       deploymentsActive={s.deployments_active}

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as moment from 'moment';
 import { withStyles, StyleRulesCallback, Theme, WithStyles } from 'material-ui';
 import TableBody from 'material-ui/Table/TableBody';
 import TableRow from 'material-ui/Table/TableRow';
@@ -66,6 +67,12 @@ const stripImageName = (images: string[]) => {
   });
 };
 
+const formatDate = (utcDate: string) => {
+  const formattedDate = moment.utc(utcDate).toISOString();
+  const startOfTimeStamp = formattedDate.indexOf('T'); // beginning of timestamp
+  return formattedDate.substring(0, startOfTimeStamp);
+};
+
 const stackScript: (fn: (s: Linode.StackScript.Response) => void, id?: number) =>
   (s: Linode.StackScript.Response) => JSX.Element =
   (onSelect, selectedId) => s => (
@@ -76,7 +83,7 @@ const stackScript: (fn: (s: Linode.StackScript.Response) => void, id?: number) =
       description={truncateDescription(s.description)}
       images={stripImageName(s.images)}
       deploymentsActive={s.deployments_active}
-      updated={s.updated}
+      updated={formatDate(s.updated)}
       onSelect={() => onSelect(s)}
       checked={selectedId === s.id}
       updateFor={[selectedId === s.id]}

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -9,16 +9,13 @@ import CircleProgress from 'src/components/CircleProgress';
 
 import { formatDate } from 'src/utilities/format-date-iso8601';
 
-type ClassNames = 'root' | 'loadingWrapper' | 'username';
+type ClassNames = 'root' | 'loadingWrapper';
 
-const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {},
   loadingWrapper: {
     border: 0,
     paddingTop: 100,
-  },
-  username: {
-    color: 'grey',
   },
 });
 

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedMultiSelect.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedMultiSelect.tsx
@@ -89,8 +89,8 @@ class UserDefinedMultiSelect extends React.Component<CombinedProps, State> {
       <div className={classes.root}>
         <Typography variant="subheading" >
           {field.label}
-          {isOptional &&
-            ' (Optional)'
+          {!isOptional &&
+            ' *'
           }
         </Typography>
         <Grid container>

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedMultiSelect.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedMultiSelect.tsx
@@ -30,6 +30,7 @@ interface Props {
   updateFormState: (key: string, value: any) => void;
   udf_data: Linode.StackScript.UserDefinedField;
   field: Linode.StackScript.UserDefinedField;
+  isOptional: boolean;
 }
 
 interface State {
@@ -78,7 +79,7 @@ class UserDefinedMultiSelect extends React.Component<CombinedProps, State> {
 
   render() {
     const { manyof } = this.state;
-    const { udf_data, field, classes } = this.props;
+    const { udf_data, field, classes, isOptional } = this.props;
 
     // we are setting default values in the parent component, so we want to use these
     // default values to determine what will be checked upon initial render
@@ -88,6 +89,9 @@ class UserDefinedMultiSelect extends React.Component<CombinedProps, State> {
       <div className={classes.root}>
         <Typography variant="subheading" >
           {field.label}
+          {isOptional &&
+            ' (Optional)'
+          }
         </Typography>
         <Grid container>
           {manyof.map((choice: string, index) => {

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.tsx
@@ -26,6 +26,7 @@ interface Props {
   updateFormState: (key: string, value: any) => void;
   udf_data: Linode.StackScript.UserDefinedField;
   field: Linode.StackScript.UserDefinedField;
+  isOptional: boolean;
 }
 
 interface State {
@@ -48,12 +49,15 @@ class UserDefinedSelect extends React.Component<CombinedProps, State> {
 
   render() {
     const { oneof } = this.state;
-    const { udf_data, field, classes } = this.props;
+    const { udf_data, field, classes, isOptional } = this.props;
 
     return (
       <div className={classes.root}>
         <Typography variant="subheading" >
           {field.label}
+          {isOptional &&
+            ' (Optional)'
+          }
         </Typography>
         {oneof.map((choice: string, index) => {
           return (

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.tsx
@@ -55,8 +55,8 @@ class UserDefinedSelect extends React.Component<CombinedProps, State> {
       <div className={classes.root}>
         <Typography variant="subheading" >
           {field.label}
-          {isOptional &&
-            ' (Optional)'
+          {!isOptional &&
+            ' *'
           }
         </Typography>
         {oneof.map((choice: string, index) => {

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
@@ -27,6 +27,7 @@ interface Props {
   field: Linode.StackScript.UserDefinedField;
   updateFormState: (key: string, value: any) => void;
   udf_data: Linode.StackScript.UserDefinedField;
+  isOptional: boolean;
 }
 
 interface State { }
@@ -37,12 +38,15 @@ class UserDefinedText extends React.Component<CombinedProps, State> {
   state: State = {};
 
   renderTextField = () => {
-    const { udf_data, field } = this.props;
+    const { udf_data, field, isOptional } = this.props;
 
     return (
       <React.Fragment>
         <Typography variant="subheading" >
           {field.label}
+          {isOptional &&
+            ' (Optional)'
+          }
         </Typography>
         <TextField
           onChange={this.handleUpdateText}

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
@@ -44,11 +44,9 @@ class UserDefinedText extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <Typography variant="subheading" >
           {field.label}
-          {isOptional &&
-            ' (Optional)'
-          }
         </Typography>
         <TextField
+          required={!isOptional}
           onChange={this.handleUpdateText}
           label={field.label}
           value={udf_data[field.name] || ''}
@@ -58,10 +56,11 @@ class UserDefinedText extends React.Component<CombinedProps, State> {
   }
 
   renderPasswordField = () => {
-    const { udf_data, field } = this.props;
+    const { udf_data, field, isOptional } = this.props;
 
     return (
       <PasswordPanel
+        required={!isOptional}
         password={udf_data[field.name] || ''}
         handleChange={this.handleUpdatePassword}
         label={field.label}

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -16,7 +16,7 @@ import RenderGuard from 'src/components/RenderGuard';
 import Notice from 'src/components/Notice';
 
 
-type ClassNames = 'root';
+type ClassNames = 'root' | 'username';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
@@ -28,6 +28,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
       paddingBottom: 0,
     },
   },
+  username: {
+    color: 'grey',
+  },
 });
 
 interface Props {
@@ -36,6 +39,7 @@ interface Props {
   handleChange: (key: string, value: any) => void;
   udf_data: any;
   selectedLabel: string;
+  selectedUsername: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -96,7 +100,8 @@ const UserDefinedFieldsPanel: React.StatelessComponent<CombinedProps> = (props) 
         );
       })}
       <Typography variant="title">
-        {`${props.selectedLabel} Options`}
+        <span className={classes.username}>{`${props.selectedUsername} / `}</span>
+        <span>{`${props.selectedLabel} Options`}</span>
       </Typography>
       {
         userDefinedFields!.map((field: Linode.StackScript.UserDefinedField) => {

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -35,6 +35,7 @@ interface Props {
   userDefinedFields?: Linode.StackScript.UserDefinedField[];
   handleChange: (key: string, value: any) => void;
   udf_data: any;
+  selectedLabel: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -43,6 +44,8 @@ const UserDefinedFieldsPanel: React.StatelessComponent<CombinedProps> = (props) 
   const { userDefinedFields, classes, handleChange } = props;
 
   const renderField = (field: Linode.StackScript.UserDefinedField) => {
+    // if the 'default' key is returned from the API, the field is optional
+    const isOptional = field.hasOwnProperty('default');
     if (isMultiSelect(field)) {
       return <UserDefinedMultiSelect
         key={field.name}
@@ -50,6 +53,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<CombinedProps> = (props) 
         udf_data={props.udf_data}
         updateFormState={handleChange}
         updateFor={[props.udf_data[field.name]]}
+        isOptional={isOptional}
       />;
     } if (isOneSelect(field)) {
       return <UserDefinedSelect
@@ -57,6 +61,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<CombinedProps> = (props) 
         updateFormState={handleChange}
         udf_data={props.udf_data}
         updateFor={[props.udf_data[field.name]]}
+        isOptional={isOptional}
         key={field.name} />;
     } if (isPasswordField(field.name)) {
       return <UserDefinedText
@@ -66,6 +71,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<CombinedProps> = (props) 
         field={field}
         udf_data={props.udf_data}
         updateFor={[props.udf_data[field.name]]}
+        isOptional={isOptional}
       />;
     }
     return <UserDefinedText
@@ -74,6 +80,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<CombinedProps> = (props) 
       field={field}
       udf_data={props.udf_data}
       updateFor={[props.udf_data[field.name]]}
+      isOptional={isOptional}
     />;
   };
 
@@ -89,7 +96,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<CombinedProps> = (props) 
         );
       })}
       <Typography variant="title">
-        Required Fields
+        {`${props.selectedLabel} Options`}
       </Typography>
       {
         userDefinedFields!.map((field: Linode.StackScript.UserDefinedField) => {

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -18,7 +18,7 @@ import Notice from 'src/components/Notice';
 
 type ClassNames = 'root' | 'username';
 
-const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
     padding: theme.spacing.unit * 3,
     marginBottom: theme.spacing.unit * 3,
@@ -29,7 +29,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     },
   },
   username: {
-    color: 'grey',
+    color: theme.color.grey1,
   },
 });
 

--- a/src/features/linodes/LinodesCreate/PasswordPanel.tsx
+++ b/src/features/linodes/LinodesCreate/PasswordPanel.tsx
@@ -36,13 +36,14 @@ interface Props {
   heading?: string;
   label?: string;
   noPadding?: boolean;
+  required?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 class PasswordPanel extends React.Component<CombinedProps> {
   render() {
-    const { classes, handleChange, error, heading, label, noPadding } = this.props;
+    const { classes, handleChange, error, heading, label, noPadding, required } = this.props;
 
     return (
       <Paper className={classes.root}>
@@ -50,6 +51,7 @@ class PasswordPanel extends React.Component<CombinedProps> {
           { error && <Notice text={error} error /> }
           <Typography component="div" variant="title">{heading || 'Password'}</Typography>
           <PasswordInput
+            required={required}
             value={this.props.password || ''}
             label={label || 'Root Password'}
             placeholder="Enter a password."

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -89,6 +89,7 @@ interface State {
   errors?: Linode.ApiFieldError[];
   selectedStackScriptID: number | null;
   selectedStackScriptLabel: string;
+  selectedStackScriptUsername: string;
   selectedImageID: string | null;
   selectedRegionID: string | null;
   selectedTypeID: string | null;
@@ -117,6 +118,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
     udf_data: null,
     selectedStackScriptID: null,
     selectedStackScriptLabel: '',
+    selectedStackScriptUsername: '',
     selectedImageID: null,
     selectedRegionID: null,
     selectedTypeID: null,
@@ -130,8 +132,8 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
 
   mounted: boolean = false;
 
-  handleSelectStackScript = (id: number, label: string, stackScriptImages: string[],
-    userDefinedFields: Linode.StackScript.UserDefinedField[]) => {
+  handleSelectStackScript = (id: number, label: string, username: string,
+     stackScriptImages: string[], userDefinedFields: Linode.StackScript.UserDefinedField[]) => {
     const { images } = this.props;
     const filteredImages = images.filter((image) => {
       for (let i = 0; i < stackScriptImages.length; i = i + 1) {
@@ -152,6 +154,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
     // then update userDefinedFields to the fields returned
     this.setState({
       selectedStackScriptID: id,
+      selectedStackScriptUsername: username,
       selectedStackScriptLabel: label,
       compatibleImages: filteredImages,
       userDefinedFields,
@@ -295,7 +298,8 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
   render() {
     const { errors, userDefinedFields, udf_data, selectedImageID, selectedRegionID,
       selectedStackScriptID, selectedTypeID, backups, privateIP, label,
-      password, isMakingRequest, compatibleImages, selectedStackScriptLabel } = this.state;
+      password, isMakingRequest, compatibleImages, selectedStackScriptLabel,
+      selectedStackScriptUsername } = this.state;
 
     const { notice, getBackupsMonthlyPrice, regions, types, classes,
       getRegionName, getTypeInfo } = this.props;
@@ -333,6 +337,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
             <UserDefinedFieldsPanel
               errors={udfErrors}
               selectedLabel={selectedStackScriptLabel}
+              selectedUsername={selectedStackScriptUsername}
               handleChange={this.handleChangeUDF}
               userDefinedFields={userDefinedFields}
               updateFor={[userDefinedFields, udf_data, errors]}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -88,6 +88,7 @@ interface State {
   udf_data: any;
   errors?: Linode.ApiFieldError[];
   selectedStackScriptID: number | null;
+  selectedStackScriptLabel: string;
   selectedImageID: string | null;
   selectedRegionID: string | null;
   selectedTypeID: string | null;
@@ -115,6 +116,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
     userDefinedFields: [],
     udf_data: null,
     selectedStackScriptID: null,
+    selectedStackScriptLabel: '',
     selectedImageID: null,
     selectedRegionID: null,
     selectedTypeID: null,
@@ -128,7 +130,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
 
   mounted: boolean = false;
 
-  handleSelectStackScript = (id: number, stackScriptImages: string[],
+  handleSelectStackScript = (id: number, label: string, stackScriptImages: string[],
     userDefinedFields: Linode.StackScript.UserDefinedField[]) => {
     const { images } = this.props;
     const filteredImages = images.filter((image) => {
@@ -150,6 +152,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
     // then update userDefinedFields to the fields returned
     this.setState({
       selectedStackScriptID: id,
+      selectedStackScriptLabel: label,
       compatibleImages: filteredImages,
       userDefinedFields,
       udf_data: defaultUDFData,
@@ -292,7 +295,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
   render() {
     const { errors, userDefinedFields, udf_data, selectedImageID, selectedRegionID,
       selectedStackScriptID, selectedTypeID, backups, privateIP, label,
-      password, isMakingRequest, compatibleImages } = this.state;
+      password, isMakingRequest, compatibleImages, selectedStackScriptLabel } = this.state;
 
     const { notice, getBackupsMonthlyPrice, regions, types, classes,
       getRegionName, getTypeInfo } = this.props;
@@ -329,6 +332,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
           {userDefinedFields && userDefinedFields.length > 0 &&
             <UserDefinedFieldsPanel
               errors={udfErrors}
+              selectedLabel={selectedStackScriptLabel}
               handleChange={this.handleChangeUDF}
               userDefinedFields={userDefinedFields}
               updateFor={[userDefinedFields, udf_data, errors]}

--- a/src/utilities/format-date-iso8601.tsx
+++ b/src/utilities/format-date-iso8601.tsx
@@ -1,10 +1,10 @@
 import * as moment from 'moment';
 
-export const formatDate = (utcDate: string, showTime: boolean) => {
+export const formatDate = (utcDate: string, showTime?: boolean) => {
   const formattedDate = moment.utc(utcDate).toISOString();
   const startOfTimeStamp = formattedDate.indexOf('T'); // beginning of timestamp
-  if (!showTime) {
-    return formattedDate.substring(0, startOfTimeStamp);
+  if (!!showTime) {
+    return formattedDate.replace('T', ' ').replace('.000Z', '');
   }
-  return formattedDate.replace('T', ' ').replace('.000Z', '');
+  return formattedDate.substring(0, startOfTimeStamp);
 };

--- a/src/utilities/format-date-iso8601.tsx
+++ b/src/utilities/format-date-iso8601.tsx
@@ -1,0 +1,10 @@
+import * as moment from 'moment';
+
+export const formatDate = (utcDate: string, showTime: boolean) => {
+  const formattedDate = moment.utc(utcDate).toISOString();
+  const startOfTimeStamp = formattedDate.indexOf('T'); // beginning of timestamp
+  if (!showTime) {
+    return formattedDate.substring(0, startOfTimeStamp);
+  }
+  return formattedDate.replace('T', ' ').replace('.000Z', '');
+};


### PR DESCRIPTION
### Purpose

Knock out some changes that were brought up during M3 Review on June 15th, 2018

Addressed issues:
* M3-779
* M3-778
* M3-774
* M3-780

### Notes

* Last Revision date in StackScript Selection now is now in ISO-8601 format
* Header on UDF panel now reads "_StackScript Name_ Options"
* Each UDF label has an "(Optional)" text if that UDF has a default value
* Username has been added to StackScript name, similar to GitHub repo conventions (username is also greyed out)
* Changed "Active Deploy" to "Active Deploys"