### PR TITLE
M3-126 Add Sorting to Select StackScript Panel

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -19,6 +19,7 @@ interface Props extends ButtonProps {
   loading?: boolean;
   destructive?: boolean;
   type?: 'primary' | 'secondary' | 'cancel';
+  className?: string;
 }
 
 const styles: StyleRulesCallback = (theme: Theme & Linode.Theme) => ({
@@ -101,6 +102,7 @@ const WrappedButton: React.StatelessComponent<CombinedProps> = (props) => {
     loading,
     destructive,
     type,
+    className,
     ...rest,
   } = props;
 
@@ -117,7 +119,9 @@ const WrappedButton: React.StatelessComponent<CombinedProps> = (props) => {
           [classes.root]: true,
           [classes.loading]: loading,
           [classes.destructive]: destructive,
-        }),
+        },
+        className,
+      ),
     },
     loading ? <Reload /> : props.children);
 };

--- a/src/components/SelectionRow/SelectionRow.tsx
+++ b/src/components/SelectionRow/SelectionRow.tsx
@@ -3,9 +3,11 @@ import { compose, map, unless, isEmpty, over, lensIndex, splitAt } from 'ramda';
 import { Link } from 'react-router-dom';
 import * as invariant from 'invariant';
 import { withStyles, StyleRulesCallback, Theme, WithStyles } from 'material-ui';
+import TableCell from 'material-ui/Table/TableCell';
+import TableRow from 'material-ui/Table/TableRow';
 
 import Typography from 'material-ui/Typography';
-import Grid from 'src/components/Grid';
+// import Grid from 'src/components/Grid';
 import Radio from 'src/components/Radio';
 import Tag from 'src/components/Tag';
 import ShowMore from 'src/components/ShowMore';
@@ -20,7 +22,8 @@ type ClassNames = 'root'
   | 'libTitle'
   | 'libTitleLink'
   | 'libDescription'
-  | 'colImages';
+  | 'colImages'
+  | 'stackScriptCell';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -78,6 +81,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     marginRight: theme.spacing.unit,
     marginBottom: theme.spacing.unit,
   },
+  stackScriptCell: {
+    maxWidth: '200px',
+  },
 });
 
 export interface Props {
@@ -115,58 +121,95 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
   );
 
   return (
-    <Grid container className={classes.root}>
-      <Grid item xs={12} lg={onSelect ? 6 : 5} className={classes.libTitleContainer}>
+    <React.Fragment>
+      <TableRow>
         {onSelect &&
-          <Grid item className={classes.libRadio}>
-            <div>
-              <Radio checked={checked} onChange={onSelect} id={`${stackScriptID}`} />
-            </div>
-          </Grid>
+          <TableCell>
+            <Radio checked={checked} onChange={onSelect} id={`${stackScriptID}`} />
+          </TableCell>
         }
-        <Grid container alignItems="center">
-          <Grid item className={classes.libTitle}>
-            <Typography variant="subheading">
-              <label htmlFor={`${stackScriptID}`} className={classes.libRadioLabel}>{label}</label>
-            </Typography>
-            <Link to={'/'} target="_blank" className={classes.libTitleLink}>
-              More Info
-            </Link>
-          </Grid>
-          <Grid item xs={12} className={classes.libDescription}>
-            <Typography>{description}</Typography>
-          </Grid>
-        </Grid>
-      </Grid>
-
-      <Grid item xs={12} lg={1} className={classes.respPadding}>
-        <Typography variant="subheading">{deploymentsActive}</Typography>
-      </Grid>
-
-      <Grid item xs={12} lg={2} className={classes.respPadding}>
-        <Typography variant="subheading">{updated}</Typography>
-      </Grid>
-
-      <Grid item xs={12} lg={3} className={`${classes.colImages} ${classes.respPadding}`}>
-        {
-          displayTagsAndShowMore(images)
-        }
-      </Grid>
-
-      {showDeployLink &&
-        <Grid item xs={2}>
-          <Grid container alignItems="center">
-            <Grid item xs={12}>
-              <Link to={'/'}>
-                <Typography variant="title">
-                  Deploy New Linode
+        <TableCell className={classes.stackScriptCell}>
+          <Typography variant="subheading">
+            <label htmlFor={`${stackScriptID}`} className={classes.libRadioLabel}>{label}
+            </label>
+          </Typography>
+          <Typography>{description}</Typography>
+        </TableCell>
+        <TableCell>
+          <Typography variant="subheading">{deploymentsActive}</Typography>
+        </TableCell>
+        <TableCell>
+          <Typography variant="subheading">{updated}</Typography>
+        </TableCell>
+        <TableCell className={classes.stackScriptCell}>
+          {
+            displayTagsAndShowMore(images)
+          }
+        </TableCell>
+        {showDeployLink &&
+          <TableCell>
+            <Link to={'/'}>
+              <Typography variant="title">
+                Deploy New Linode
               </Typography>
-              </Link>
+            </Link>
+          </TableCell>
+        }
+      </TableRow>
+      {/* <Grid container className={classes.root}>
+        <Grid item xs={12} lg={onSelect ? 6 : 5} className={classes.libTitleContainer}>
+          {onSelect &&
+            <Grid item className={classes.libRadio}>
+              <div>
+                <Radio checked={checked} onChange={onSelect} id={`${stackScriptID}`} />
+              </div>
+            </Grid>
+          }
+          <Grid container alignItems="center">
+            <Grid item className={classes.libTitle}>
+              <Typography variant="subheading">
+                <label htmlFor={`${stackScriptID}`} className={classes.libRadioLabel}>{label}
+                </label>
+              </Typography>
+              <Link to={'/'} target="_blank" className={classes.libTitleLink}>
+                More Info
+            </Link>
+            </Grid>
+            <Grid item xs={12} className={classes.libDescription}>
+              <Typography>{description}</Typography>
             </Grid>
           </Grid>
         </Grid>
-      }
-    </Grid>
+
+        <Grid item xs={12} lg={1} className={classes.respPadding}>
+          <Typography variant="subheading">{deploymentsActive}</Typography>
+        </Grid>
+
+        <Grid item xs={12} lg={2} className={classes.respPadding}>
+          <Typography variant="subheading">{updated}</Typography>
+        </Grid>
+
+        <Grid item xs={12} lg={3} className={`${classes.colImages} ${classes.respPadding}`}>
+          {
+            displayTagsAndShowMore(images)
+          }
+        </Grid>
+
+        {showDeployLink &&
+          <Grid item xs={2}>
+            <Grid container alignItems="center">
+              <Grid item xs={12}>
+                <Link to={'/'}>
+                  <Typography variant="title">
+                    Deploy New Linode
+              </Typography>
+                </Link>
+              </Grid>
+            </Grid>
+          </Grid>
+        }
+      </Grid> */}
+    </React.Fragment>
   );
 };
 

--- a/src/components/SelectionRow/SelectionRow.tsx
+++ b/src/components/SelectionRow/SelectionRow.tsx
@@ -7,7 +7,6 @@ import TableCell from 'material-ui/Table/TableCell';
 import TableRow from 'material-ui/Table/TableRow';
 
 import Typography from 'material-ui/Typography';
-// import Grid from 'src/components/Grid';
 import Radio from 'src/components/Radio';
 import Tag from 'src/components/Tag';
 import ShowMore from 'src/components/ShowMore';
@@ -156,59 +155,6 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
           </TableCell>
         }
       </TableRow>
-      {/* <Grid container className={classes.root}>
-        <Grid item xs={12} lg={onSelect ? 6 : 5} className={classes.libTitleContainer}>
-          {onSelect &&
-            <Grid item className={classes.libRadio}>
-              <div>
-                <Radio checked={checked} onChange={onSelect} id={`${stackScriptID}`} />
-              </div>
-            </Grid>
-          }
-          <Grid container alignItems="center">
-            <Grid item className={classes.libTitle}>
-              <Typography variant="subheading">
-                <label htmlFor={`${stackScriptID}`} className={classes.libRadioLabel}>{label}
-                </label>
-              </Typography>
-              <Link to={'/'} target="_blank" className={classes.libTitleLink}>
-                More Info
-            </Link>
-            </Grid>
-            <Grid item xs={12} className={classes.libDescription}>
-              <Typography>{description}</Typography>
-            </Grid>
-          </Grid>
-        </Grid>
-
-        <Grid item xs={12} lg={1} className={classes.respPadding}>
-          <Typography variant="subheading">{deploymentsActive}</Typography>
-        </Grid>
-
-        <Grid item xs={12} lg={2} className={classes.respPadding}>
-          <Typography variant="subheading">{updated}</Typography>
-        </Grid>
-
-        <Grid item xs={12} lg={3} className={`${classes.colImages} ${classes.respPadding}`}>
-          {
-            displayTagsAndShowMore(images)
-          }
-        </Grid>
-
-        {showDeployLink &&
-          <Grid item xs={2}>
-            <Grid container alignItems="center">
-              <Grid item xs={12}>
-                <Link to={'/'}>
-                  <Typography variant="title">
-                    Deploy New Linode
-              </Typography>
-                </Link>
-              </Grid>
-            </Grid>
-          </Grid>
-        }
-      </Grid> */}
     </React.Fragment>
   );
 };

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -18,6 +18,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 
 interface Props {
   className?: string;
+  noOverflow?: boolean;
+  tableClass?: string;
 }
 
 type CombinedProps = Props & TableProps & WithStyles<ClassNames>;
@@ -25,11 +27,13 @@ type CombinedProps = Props & TableProps & WithStyles<ClassNames>;
 class WrappedTable extends React.Component<CombinedProps> {
 
   render() {
-    const { classes, className, ...rest } = this.props;
+    const { classes, className, tableClass, noOverflow, ...rest } = this.props;
+
+    const tableWrapperClasses = (noOverflow) ? className : `${classes.root} ${className}`;
 
     return (
-      <div className={`${classes.root} ${className}`}>
-        <Table {...rest}>{this.props.children}</Table>
+      <div className={tableWrapperClasses}>
+        <Table className={tableClass} {...rest}>{this.props.children}</Table>
       </div>
     );
   }

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -28,6 +28,8 @@ type ClassNames = 'root'
   | 'creating'
   | 'selecting'
   | 'stackscriptLabel'
+  | 'deploys'
+  | 'revisions'
   | 'tr'
   | 'tableHead'
   | 'sortable'
@@ -55,6 +57,12 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   stackscriptLabel: {
     width: 50,
+  },
+  deploys: {
+    width: '15%',
+  },
+  revisions: {
+    width: '15%',
   },
   tr: {
     height: 48,
@@ -303,6 +311,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
                 className={classNames({
                   [classes.tableHead]: true,
                   [classes.sortable]: true,
+                  [classes.deploys]: true,
                 })}
               >
                 <Button
@@ -320,6 +329,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
                 className={classNames({
                   [classes.tableHead]: true,
                   [classes.sortable]: true,
+                  [classes.revisions]: true,
                 })}
               >
                 <Button

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -1,16 +1,20 @@
 import * as React from 'react';
 import { withStyles, StyleRulesCallback, Theme, WithStyles } from 'material-ui';
-
+// import TableBody from 'material-ui/Table/TableBody';
+import TableCell from 'material-ui/Table/TableCell';
+import TableHead from 'material-ui/Table/TableHead';
+import TableRow from 'material-ui/Table/TableRow';
 
 import { getStackscripts, getMyStackscripts, getLinodeStackscripts }
   from 'src/services/stackscripts';
 
 import Button from 'src/components/Button';
-import Grid from 'src/components/Grid';
+// import Grid from 'src/components/Grid';
 import TabbedPanel from 'src/components/TabbedPanel';
 import StackScriptsSection from './StackScriptsSection';
 import CircleProgress from 'src/components/CircleProgress';
 import RenderGuard from 'src/components/RenderGuard';
+import Table from 'src/components/Table';
 
 export interface ExtendedLinode extends Linode.Linode {
   heading: string;
@@ -22,7 +26,9 @@ type ClassNames = 'root'
   | 'selecting'
   | 'container'
   | 'labelCell'
-  | 'stackscriptLabel';
+  | 'stackscriptLabel'
+  | 'tableHead'
+  | 'table';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -31,14 +37,17 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   creating: {
     minHeight: '200px',
     maxHeight: '400px',
-    overflowX: 'hidden',
+    overflowX: 'auto',
   },
   selecting: {
     maxHeight: '1000px',
-    overflowX: 'hidden',
+    overflowX: 'auto',
   },
   container: {
     padding: theme.spacing.unit * 2,
+  },
+  table: {
+    overflow: 'scroll',
   },
   labelCell: {
     background: theme.bg.offWhite,
@@ -51,6 +60,12 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     [theme.breakpoints.up('lg')]: {
       paddingLeft: '78px !important',
     },
+  },
+  tableHead: {
+    position: 'sticky',
+    top: 0,
+    backgroundColor: theme.bg.offWhite,
+    zIndex: 10,
   },
 });
 
@@ -186,7 +201,17 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
 
     return (
       <React.Fragment>
-        <Grid container className={classes.container}>
+        <Table noOverflow={true} tableClass={classes.table} className={classes.container}>
+          <TableHead>
+            <TableRow>
+              <TableCell className={classes.tableHead}></TableCell>
+              <TableCell className={classes.tableHead}>StackScripts</TableCell>
+              <TableCell className={classes.tableHead}>Active Deploys</TableCell>
+              <TableCell className={classes.tableHead}>Last Revision</TableCell>
+              <TableCell className={classes.tableHead}>Compatible Images</TableCell>
+            </TableRow>
+          </TableHead>
+          {/* <Grid container className={classes.container}>
           <Grid
             item xs={12}
             lg={6}
@@ -215,13 +240,14 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
           >
             <label>Compatible Images</label>
           </Grid>
-        </Grid>
-        <StackScriptsSection
-          onSelect={this.handleSelectStackScript}
-          selectedId={this.state.selected}
-          data={this.state.data}
-          getNext={() => this.getNext()}
-        />
+        </Grid> */}
+          <StackScriptsSection
+            onSelect={this.handleSelectStackScript}
+            selectedId={this.state.selected}
+            data={this.state.data}
+            getNext={() => this.getNext()}
+          />
+        </Table>
         {this.state.showMoreButtonVisible &&
           <Button
             title="Show More StackScripts"

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -29,6 +29,7 @@ type ClassNames = 'root'
   | 'creating'
   | 'selecting'
   | 'stackscriptLabel'
+  | 'tr'
   | 'tableHead'
   | 'sortable'
   | 'sortButton'
@@ -55,6 +56,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   stackscriptLabel: {
     width: 50,
+  },
+  tr: {
+    height: 48,
   },
   tableHead: {
     position: 'sticky',
@@ -263,7 +267,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
       <React.Fragment>
         <Table noOverflow={true} tableClass={classes.table}>
           <TableHead>
-            <TableRow>
+            <TableRow className={classes.tr}>
               <TableCell className={classNames({
                 [classes.tableHead]: true,
                 [classes.stackscriptLabel]: true,

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as moment from 'moment';
 import * as classNames from 'classnames';
 import { withStyles, StyleRulesCallback, Theme, WithStyles } from 'material-ui';
 import TableCell from 'material-ui/Table/TableCell';
@@ -8,10 +7,10 @@ import TableRow from 'material-ui/Table/TableRow';
 import KeyboardArrowDown from 'material-ui-icons/KeyboardArrowDown';
 import KeyboardArrowUp from 'material-ui-icons/KeyboardArrowUp';
 
-import { sort } from 'ramda';
-
 import { getStackscripts, getMyStackscripts, getLinodeStackscripts }
   from 'src/services/stackscripts';
+
+import { sortByString, sortByNumber, sortByUTFDate } from 'src/utilities/sort-by';
 
 import Button from 'src/components/Button';
 import TabbedPanel from 'src/components/TabbedPanel';
@@ -24,6 +23,8 @@ export interface ExtendedLinode extends Linode.Linode {
   heading: string;
   subHeadings: string[];
 }
+
+type SortOrder = 'asc' | 'desc';
 
 type ClassNames = 'root'
   | 'creating'
@@ -219,7 +220,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     const { sortOrder } = this.state;
     const nextSortOrder = (sortOrder === 'asc') ? 'desc' : 'asc';
     this.setState({
-      data: sortByName(sortOrder)(this.state.data),
+      data: sortByString(sortOrder, 'label')(this.state.data),
       sortOrder: nextSortOrder,
       currentFilter: 'label',
     });
@@ -229,7 +230,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     const { sortOrder } = this.state;
     const nextSortOrder = (sortOrder === 'asc') ? 'desc' : 'asc';
     this.setState({
-      data: sortByDeploys(sortOrder)(this.state.data),
+      data: sortByNumber(sortOrder, 'deployments_active')(this.state.data),
       sortOrder: nextSortOrder,
       currentFilter: 'deploys',
     });
@@ -239,7 +240,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     const { sortOrder } = this.state;
     const nextSortOrder = (sortOrder === 'asc') ? 'desc' : 'asc';
     this.setState({
-      data: sortByRevision(sortOrder)(this.state.data),
+      data: sortByUTFDate(sortOrder, 'updated')(this.state.data),
       sortOrder: nextSortOrder,
       currentFilter: 'revision',
     });
@@ -351,41 +352,6 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     );
   }
 }
-
-type SortOrder = 'asc' | 'desc';
-
-const sortByName = (order: SortOrder) =>
-  sort((a: Linode.StackScript.Response, b: Linode.StackScript.Response) => {
-    let result = 1; // by default a > b
-    if (a.label.toLowerCase() < b.label.toLowerCase()) {
-      result = -1; // otherwise result is -1
-    }
-    if (order === 'desc') {
-      return result; // descending order
-    }
-    return -result; // ascending order
-  });
-
-const sortByRevision = (order: SortOrder) =>
-  sort((a: Linode.StackScript.Response, b: Linode.StackScript.Response) => {
-    const result = moment.utc(b.updated).diff(moment.utc(a.updated));
-    if (order === 'desc') {
-      return -result; // descending order
-    }
-    return result; // ascending order
-  });
-
-const sortByDeploys = (order: SortOrder) =>
-  sort((a: Linode.StackScript.Response, b: Linode.StackScript.Response) => {
-    let result = 1; // by default a > b
-    if (a.deployments_active < b.deployments_active) {
-      result = -1; // otherwise result is -1
-    }
-    if (order === 'desc') {
-      return result; // descending order
-    }
-    return -result; // ascending order
-  });
 
 const styled = withStyles(styles, { withTheme: true });
 

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -1,9 +1,12 @@
 import * as React from 'react';
 import * as moment from 'moment';
+import * as classNames from 'classnames';
 import { withStyles, StyleRulesCallback, Theme, WithStyles } from 'material-ui';
 import TableCell from 'material-ui/Table/TableCell';
 import TableHead from 'material-ui/Table/TableHead';
 import TableRow from 'material-ui/Table/TableRow';
+import KeyboardArrowDown from 'material-ui-icons/KeyboardArrowDown';
+import KeyboardArrowUp from 'material-ui-icons/KeyboardArrowUp';
 
 import { sort } from 'ramda';
 
@@ -25,10 +28,11 @@ export interface ExtendedLinode extends Linode.Linode {
 type ClassNames = 'root'
   | 'creating'
   | 'selecting'
-  | 'container'
-  | 'labelCell'
   | 'stackscriptLabel'
   | 'tableHead'
+  | 'sortable'
+  | 'sortButton'
+  | 'sortIcon'
   | 'table';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
@@ -39,34 +43,42 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     minHeight: '200px',
     maxHeight: '400px',
     overflowX: 'auto',
+    paddingTop: 0,
+    marginTop: theme.spacing.unit * 2,
   },
   selecting: {
     maxHeight: '1000px',
     overflowX: 'auto',
   },
-  container: {
-    padding: theme.spacing.unit * 2,
-  },
   table: {
     overflow: 'scroll',
   },
-  labelCell: {
-    background: theme.bg.offWhite,
-    fontSize: '.9rem',
-    fontWeight: 700,
-    paddingTop: '16px !important',
-    paddingBottom: '16px !important',
-  },
   stackscriptLabel: {
-    [theme.breakpoints.up('lg')]: {
-      paddingLeft: '78px !important',
-    },
+    width: 50,
   },
   tableHead: {
     position: 'sticky',
     top: 0,
     backgroundColor: theme.bg.offWhite,
     zIndex: 10,
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+  sortable: {
+    color: theme.palette.primary.main,
+    fontWeight: 700,
+    cursor: 'pointer',
+  },
+  sortButton: {
+    marginLeft: -26,
+    border: 0,
+    width: '100%',
+    justifyContent: 'flex-start',
+  },
+  sortIcon: {
+    position: 'relative',
+    top: 2,
+    left: 10,
   },
 });
 
@@ -231,10 +243,11 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
 
   renderIcon = () => {
     const { sortOrder } = this.state;
+    const { classes } = this.props;
     return (
       sortOrder === 'asc'
-        ? <div>asc</div>
-        : <div>desc</div>
+        ? <KeyboardArrowUp className={classes.sortIcon} />
+        : <KeyboardArrowDown className={classes.sortIcon} />
     );
   }
 
@@ -248,33 +261,63 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
 
     return (
       <React.Fragment>
-        <Table noOverflow={true} tableClass={classes.table} className={classes.container}>
+        <Table noOverflow={true} tableClass={classes.table}>
           <TableHead>
             <TableRow>
-              <TableCell className={classes.tableHead}></TableCell>
+              <TableCell className={classNames({
+                [classes.tableHead]: true,
+                [classes.stackscriptLabel]: true,
+              })} />
               <TableCell
-                className={classes.tableHead}
-                onClick={this.handleClickStackScriptsTableHeader}
+                className={classNames({
+                  [classes.tableHead]: true,
+                  [classes.sortable]: true,
+                })}
               >
-                StackScripts
-                {currentFilter === 'label' &&
-                  this.renderIcon()}
+                <Button
+                  type="secondary"
+                  className={classes.sortButton}
+                  onClick={this.handleClickStackScriptsTableHeader}
+                >
+                  StackScripts
+                  {currentFilter === 'label' &&
+                    this.renderIcon()
+                  }
+                </Button>
               </TableCell>
               <TableCell
-                className={classes.tableHead}
-                onClick={this.handleClickDeploymentsTableHeader}
+                className={classNames({
+                  [classes.tableHead]: true,
+                  [classes.sortable]: true,
+                })}
               >
-                Active Deploys
-                {currentFilter === 'deploys' &&
-                  this.renderIcon()}
+                <Button
+                  type="secondary"
+                  className={classes.sortButton}
+                  onClick={this.handleClickDeploymentsTableHeader}
+                >
+                  Active Deploys
+                  {currentFilter === 'deploys' &&
+                    this.renderIcon()
+                  }
+                </Button>
               </TableCell>
               <TableCell
-                className={classes.tableHead}
-                onClick={this.handleClickRevisionsTableHeader}
+                className={classNames({
+                  [classes.tableHead]: true,
+                  [classes.sortable]: true,
+                })}
               >
-                Last Revision
-                {currentFilter === 'revision' &&
-                  this.renderIcon()}
+                <Button
+                  type="secondary"
+                  className={classes.sortButton}
+                  onClick={this.handleClickRevisionsTableHeader}
+                >
+                  Last Revision
+                  {currentFilter === 'revision' &&
+                    this.renderIcon()
+                  }
+                </Button>
               </TableCell>
               <TableCell className={classes.tableHead}>Compatible Images</TableCell>
             </TableRow>

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -28,6 +28,7 @@ type ClassNames = 'root'
   | 'creating'
   | 'selecting'
   | 'stackscriptLabel'
+  | 'stackscriptTitles'
   | 'deploys'
   | 'revisions'
   | 'tr'
@@ -42,11 +43,11 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     marginBottom: theme.spacing.unit * 3,
   },
   creating: {
-    minHeight: '200px',
-    maxHeight: '400px',
+    height: 400,
     overflowX: 'auto',
     paddingTop: 0,
     marginTop: theme.spacing.unit * 2,
+    overflowY: 'scroll',
   },
   selecting: {
     maxHeight: '1000px',
@@ -56,7 +57,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     overflow: 'scroll',
   },
   stackscriptLabel: {
-    width: 50,
+    width: 84,
+  },
+  stackscriptTitles: {
+    width: '30%',
   },
   deploys: {
     width: '15%',
@@ -294,6 +298,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
                 className={classNames({
                   [classes.tableHead]: true,
                   [classes.sortable]: true,
+                  [classes.stackscriptTitles]: true,
                 })}
               >
                 <Button

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 import { withStyles, StyleRulesCallback, Theme, WithStyles } from 'material-ui';
 import TableBody from 'material-ui/Table/TableBody';
+import TableRow from 'material-ui/Table/TableRow';
+import TableCell from 'material-ui/Table/TableCell';
 
 import SelectionRow from 'src/components/SelectionRow';
+import CircleProgress from 'src/components/CircleProgress';
 
 type ClassNames = 'root';
 
@@ -15,6 +18,7 @@ export interface Props {
   selectedId?: number;
   data: Linode.StackScript.Response[];
   getNext: () => void;
+  isSorting: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -24,12 +28,14 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
     onSelect,
     selectedId,
     data,
+    isSorting,
   } = props;
 
   return (
     <TableBody>
-      {
-        data && data.map(stackScript(onSelect, selectedId))
+      {!isSorting
+        ? data && data.map(stackScript(onSelect, selectedId))
+        : <TableRow><TableCell><CircleProgress/></TableCell></TableRow>
       }
     </TableBody>
   );

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -7,10 +7,14 @@ import TableCell from 'material-ui/Table/TableCell';
 import SelectionRow from 'src/components/SelectionRow';
 import CircleProgress from 'src/components/CircleProgress';
 
-type ClassNames = 'root';
+type ClassNames = 'root' | 'loadingWrapper';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {},
+  loadingWrapper: {
+    border: 0,
+    paddingTop: 100,
+  },
 });
 
 export interface Props {
@@ -29,13 +33,18 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
     selectedId,
     data,
     isSorting,
+    classes,
   } = props;
 
   return (
     <TableBody>
       {!isSorting
         ? data && data.map(stackScript(onSelect, selectedId))
-        : <TableRow><TableCell><CircleProgress/></TableCell></TableRow>
+        : <TableRow>
+            <TableCell colSpan={5} className={classes.loadingWrapper}>
+              <CircleProgress />
+            </TableCell>
+          </TableRow>
       }
     </TableBody>
   );

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { withStyles, StyleRulesCallback, Theme, WithStyles } from 'material-ui';
+import TableBody from 'material-ui/Table/TableBody';
+
 import SelectionRow from 'src/components/SelectionRow';
 
 type ClassNames = 'root';
@@ -25,11 +27,11 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
   } = props;
 
   return (
-    <div>
+    <TableBody>
       {
         data && data.map(stackScript(onSelect, selectedId))
       }
-    </div>
+    </TableBody>
   );
 };
 

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -35,9 +35,6 @@ import { resetEventsPolling } from 'src/events';
 import SelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel';
 import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
 
-// import { UserDefinedFields as mockUserDefinedFields } from 'src/__data__/UserDefinedFields';
-
-
 type ClassNames = 'root'
   | 'main'
   | 'sidebar'

--- a/src/services/stackscripts.ts
+++ b/src/services/stackscripts.ts
@@ -20,8 +20,8 @@ export const getStackscripts = (params?: any, filter?: any) =>
   )
     .then(response => response.data);
 
-export const getMyStackscripts = (params?: any) =>
-  getStackscripts(params, { mine: true });
+export const getMyStackscripts = (params?: any, filter?: any) =>
+  getStackscripts(params, { mine: true, ...filter });
 
 export const getLinodeStackscripts = (params?: any, filter?: any) =>
   getStackscripts(params, filter)

--- a/src/utilities/sort-by.tsx
+++ b/src/utilities/sort-by.tsx
@@ -1,0 +1,39 @@
+import * as moment from 'moment';
+import { sort } from 'ramda';
+
+type SortOrder = 'asc' | 'desc';
+
+type PropertyToCompare = 'label' | 'updated' | 'deployments_active';
+
+export const sortByString = (order: SortOrder, propertyToCompare: PropertyToCompare) =>
+  sort((a, b) => {
+    let result = 1; // by default a > b
+    if (a[propertyToCompare].toLowerCase() < b[propertyToCompare].toLowerCase()) {
+      result = -1; // otherwise result is -1
+    }
+    if (order === 'desc') {
+      return result; // descending order
+    }
+    return -result; // ascending order
+  });
+
+export const sortByUTFDate = (order: SortOrder, propertyToCompare: PropertyToCompare) =>
+  sort((a, b) => {
+    const result = moment.utc(b[propertyToCompare]).diff(moment.utc(a[propertyToCompare]));
+    if (order === 'desc') {
+      return -result; // descending order
+    }
+    return result; // ascending order
+  });
+
+export const sortByNumber = (order: SortOrder, propertyToCompare: PropertyToCompare) =>
+  sort((a, b) => {
+    let result = 1; // by default a > b
+    if (a[propertyToCompare] < b[propertyToCompare]) {
+      result = -1; // otherwise result is -1
+    }
+    if (order === 'desc') {
+      return result; // descending order
+    }
+    return -result; // ascending order
+  });


### PR DESCRIPTION
### Purpose

Add sorting to SelectStackScript panel

### Notes
* Table Headers are now sticky and scroll with the table rows
* user can now sort the following in ascending or descending order:
  * StackScript name
  * Active deployments
  * updated date
* added new sort-by library so we can now use sorted tables elsewhere