### PR TITLE
M3-632 Use user's timezone for backup windows.

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -204,14 +204,8 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
 
   initWindows(timezone: string) {
     let windows = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22].map((hour) => {
-      const start = moment.utc({ hour })
-        .add(moment.duration({ hours: 1 }))
-        .tz(timezone);
-
-      const finish = moment.utc({ hour })
-        .add(moment.duration({ hours: 3 }))
-        .tz(timezone);
-
+      const start = moment.utc({ hour }).tz(timezone);
+      const finish = moment.utc({ hour }).add(moment.duration({ hours: 2 })).tz(timezone);
       return [
         `${start.format('HH:mm')} - ${finish.format('HH:mm')}`,
         `W${evenize(+moment.utc({ hour }).format('H'))}`,

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -480,7 +480,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
             </InputLabel>
             <Select
               value={settingsForm.window}
-              onChange={e => this.setState({
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => this.setState({
                 settingsForm:
                   { ...settingsForm, window: e.target.value },
               })}
@@ -493,6 +493,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                 </MenuItem>
               ))}
             </Select>
+            <FormHelperText>Windows displayed in {this.props.timezone}</FormHelperText>
           </FormControl>
 
           <FormControl>
@@ -501,7 +502,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
             </InputLabel>
             <Select
               value={settingsForm.day}
-              onChange={e => this.setState({
+              onChange={(e: React.ChangeEvent<HTMLSelectElement>) => this.setState({
                 settingsForm:
                   { ...settingsForm, day: e.target.value },
               })}
@@ -652,7 +653,7 @@ const connected = connect((state) => ({
 
 export default compose(
   preloaded,
-  styled,
+  styled as any,
   withRouter,
   connected,
 )(LinodeBackup);


### PR DESCRIPTION
## Purpose
Previously we were using `Moment.tz.guess()`. We use guess as a default if we, for whatever reason, don't have the user's timezone.