### PR TITLE
M3-169 search stackscripts panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@material-ui/core": "^1.2.2",
     "@material-ui/icons": "^1.1.0",
+    "@types/throttle-debounce": "^1.0.0",
     "autoprefixer": "7.1.6",
     "axios": "^0.18.0",
     "bluebird": "^3.5.1",
@@ -71,6 +72,7 @@
     "source-map-loader": "^0.2.1",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
+    "throttle-debounce": "^2.0.0",
     "ts-jest": "^22.0.4",
     "ts-loader": "^3.5.0",
     "tsconfig-paths-webpack-plugin": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "source-map-loader": "^0.2.1",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
+    "throttle-debounce": "^2.0.0",
     "ts-jest": "^22.0.4",
     "ts-loader": "^3.5.0",
     "tsconfig-paths-webpack-plugin": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "source-map-loader": "^0.2.1",
     "style-loader": "0.19.0",
     "sw-precache-webpack-plugin": "0.11.4",
-    "throttle-debounce": "^2.0.0",
     "ts-jest": "^22.0.4",
     "ts-loader": "^3.5.0",
     "tsconfig-paths-webpack-plugin": "^2.0.0",

--- a/src/components/CircleProgress/CircleProgress.tsx
+++ b/src/components/CircleProgress/CircleProgress.tsx
@@ -105,7 +105,10 @@ const circleProgressComponent = (props: Props & WithStyles<CSSClasses>) => {
           data-qa-circle-progress
         />
       </div>
-      : <CircularProgress className={classes.mini} />
+      : <CircularProgress 
+          className={classes.mini}
+          data-qa-circle-progress
+        />
   );
 };
 

--- a/src/components/CircleProgress/CircleProgress.tsx
+++ b/src/components/CircleProgress/CircleProgress.tsx
@@ -8,7 +8,8 @@ type CSSClasses = 'root'
 | 'top'
 | 'progress'
 | 'topWrapper'
-| 'noTopMargin';
+| 'noTopMargin'
+| 'mini';
 
 const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -54,6 +55,9 @@ const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => 
       top: 0,
     },
   },
+  mini: {
+    padding: theme.spacing.unit * 1.3,
+  }
 });
 
 interface Props {
@@ -61,9 +65,10 @@ interface Props {
   noTopMargin?: boolean;
   className?: string;
   noInner?: boolean;
+  mini?: boolean; 
 }
 
-const CircleProgressComponent = (props: Props & WithStyles<CSSClasses>) => {
+const circleProgressComponent = (props: Props & WithStyles<CSSClasses>) => {
   const variant = typeof props.value === 'number' ? 'static' : 'indeterminate';
   const value = typeof props.value === 'number' ? props.value : 0;
   const { classes, noTopMargin } = props;
@@ -78,24 +83,32 @@ const CircleProgressComponent = (props: Props & WithStyles<CSSClasses>) => {
   }
 
   return (
-    <div className={classNames(outerClasses)}>
-      {(props.noInner !== true) &&
-        <div className={classes.topWrapper}>
-          <div className={classes.top} />
-        </div>
-      }
-      <CircularProgress
-        className={classes.progress}
-        size={124}
-        value={value}
-        variant={variant}
-        thickness={2}
-        data-qa-circle-progress
-      />
-    </div>
+    (!props.mini)
+      ? <div className={classNames({
+        [classes.root]: true,
+        [classes.noTopMargin]: noTopMargin,
+      },
+        outerClasses,
+      )}
+      >
+        {(props.noInner !== true) &&
+          <div className={classes.topWrapper}>
+            <div className={classes.top} />
+          </div>
+        }
+        <CircularProgress
+          className={classes.progress}
+          size={124}
+          value={value}
+          variant={variant}
+          thickness={2}
+          data-qa-circle-progress
+        />
+      </div>
+      : <CircularProgress className={classes.mini} />
   );
 };
 
 const decorate = withStyles(styles, { withTheme: true });
 
-export default decorate<Props>(CircleProgressComponent);
+export default decorate<Props>(circleProgressComponent);

--- a/src/components/DebouncedSearch/DebouncedSearch.tsx
+++ b/src/components/DebouncedSearch/DebouncedSearch.tsx
@@ -7,7 +7,7 @@ import {
   WithStyles,
 } from '@material-ui/core/styles';
 
-import { debounce } from 'throttle-debounce';
+// import { debounce } from 'throttle-debounce';
 
 import TextField from 'src/components/TextField';
 
@@ -24,7 +24,7 @@ interface Props {
 
 interface State {
   query: string;
-  debouncedSearch: Function;
+  // debouncedSearch: Function;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -33,14 +33,13 @@ class DebouncedSearch extends React.Component<CombinedProps, State> {
 
   public state: State = {
     query: '',
-    debouncedSearch: debounce(400, false, this.props.onSearch)
+    // debouncedSearch: debounce(400, false, this.props.onSearch)
   };
 
   handleChangeQuery = (e: any) => {
-    // const { onSearch } = this.props;
-    const { debouncedSearch } = this.state;
+    // const { debouncedSearch } = this.state;
     this.setState({ query: e.target.value });
-    debouncedSearch(e.target.value);
+    // debouncedSearch(e.target.value);
   }
 
   render() {

--- a/src/components/DebouncedSearch/DebouncedSearch.tsx
+++ b/src/components/DebouncedSearch/DebouncedSearch.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+
+import {
+  StyleRulesCallback,
+  Theme,
+  withStyles,
+  WithStyles,
+} from '@material-ui/core/styles';
+
+import { debounce } from 'throttle-debounce';
+
+import TextField from 'src/components/TextField';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {
+  onSearch: (value: string) => void;
+}
+
+interface State {
+  query: string;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class DebouncedSearch extends React.Component<CombinedProps, State> {
+  state: State = {
+    query: ''
+  };
+
+  handleChangeQuery = (e: any) => {
+    // const { onSearch } = this.props;
+    this.setState({ query: e.target.value });
+    debounce(200, false, () => console.log('hello world'));
+  }
+
+  render() {
+    const { query } = this.state;
+    return (
+      <React.Fragment>
+        <TextField
+          fullWidth
+          // autoFocus={}
+          InputProps={{
+            placeholder: 'search for something',
+            value: query,
+            onChange: this.handleChangeQuery,
+          }}
+        />
+      </React.Fragment>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(DebouncedSearch);

--- a/src/components/DebouncedSearch/DebouncedSearch.tsx
+++ b/src/components/DebouncedSearch/DebouncedSearch.tsx
@@ -19,24 +19,28 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 });
 
 interface Props {
-  onSearch: (value: string) => void;
+  onSearch: any;
 }
 
 interface State {
   query: string;
+  debouncedSearch: Function;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 class DebouncedSearch extends React.Component<CombinedProps, State> {
-  state: State = {
-    query: ''
+
+  public state: State = {
+    query: '',
+    debouncedSearch: debounce(400, false, this.props.onSearch)
   };
 
   handleChangeQuery = (e: any) => {
     // const { onSearch } = this.props;
+    const { debouncedSearch } = this.state;
     this.setState({ query: e.target.value });
-    debounce(200, false, () => console.log('hello world'));
+    debouncedSearch(e.target.value);
   }
 
   render() {
@@ -45,9 +49,8 @@ class DebouncedSearch extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <TextField
           fullWidth
-          // autoFocus={}
           InputProps={{
-            placeholder: 'search for something',
+            placeholder: 'Search for StackScript by Label or Description',
             value: query,
             onChange: this.handleChangeQuery,
           }}

--- a/src/components/DebouncedSearch/DebouncedSearch.tsx
+++ b/src/components/DebouncedSearch/DebouncedSearch.tsx
@@ -7,7 +7,7 @@ import {
   WithStyles,
 } from '@material-ui/core/styles';
 
-// import { debounce } from 'throttle-debounce';
+import { debounce } from 'throttle-debounce';
 
 import TextField from 'src/components/TextField';
 
@@ -24,7 +24,7 @@ interface Props {
 
 interface State {
   query: string;
-  // debouncedSearch: Function;
+  debouncedSearch: Function;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -33,13 +33,13 @@ class DebouncedSearch extends React.Component<CombinedProps, State> {
 
   public state: State = {
     query: '',
-    // debouncedSearch: debounce(400, false, this.props.onSearch)
+    debouncedSearch: debounce(400, false, this.props.onSearch)
   };
 
   handleChangeQuery = (e: any) => {
-    // const { debouncedSearch } = this.state;
+    const { debouncedSearch } = this.state;
     this.setState({ query: e.target.value });
-    // debouncedSearch(e.target.value);
+    debouncedSearch(e.target.value);
   }
 
   render() {

--- a/src/components/DebouncedSearch/DebouncedSearch.tsx
+++ b/src/components/DebouncedSearch/DebouncedSearch.tsx
@@ -1,25 +1,29 @@
 import * as React from 'react';
 
-import {
-  StyleRulesCallback,
-  Theme,
-  withStyles,
-  WithStyles,
-} from '@material-ui/core/styles';
+import * as ClassNames from 'classnames';
+
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+
+import InputAdornment from '@material-ui/core/InputAdornment';
+import Search from '@material-ui/icons/Search';
 
 import { debounce } from 'throttle-debounce';
 
 import TextField from 'src/components/TextField';
 
 
-type ClassNames = 'root';
+type ClassNames = 'root' | 'searchIcon';
 
-const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {},
+  searchIcon: {
+    color: `${theme.color.grey1} !important`,
+  },
 });
 
 interface Props {
   onSearch: any;
+  className?: string;
 }
 
 interface State {
@@ -44,6 +48,8 @@ class DebouncedSearch extends React.Component<CombinedProps, State> {
 
   render() {
     const { query } = this.state;
+    const { classes, className } = this.props;
+
     return (
       <React.Fragment>
         <TextField
@@ -52,7 +58,14 @@ class DebouncedSearch extends React.Component<CombinedProps, State> {
             placeholder: 'Search for StackScript by Label or Description',
             value: query,
             onChange: this.handleChangeQuery,
+            startAdornment:
+              <InputAdornment position="end">
+                <Search className={classes.searchIcon} />
+              </InputAdornment>
           }}
+          className={ClassNames(
+            className,
+          )}
         />
       </React.Fragment>
     );

--- a/src/components/DebouncedSearch/DebouncedSearch.tsx
+++ b/src/components/DebouncedSearch/DebouncedSearch.tsx
@@ -9,6 +9,7 @@ import Search from '@material-ui/icons/Search';
 
 import { debounce } from 'throttle-debounce';
 
+import CircleProgress from 'src/components/CircleProgress';
 import TextField from 'src/components/TextField';
 
 
@@ -24,6 +25,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 interface Props {
   onSearch: any;
   className?: string;
+  actionBeingPerfomed?: boolean;
 }
 
 interface State {
@@ -48,7 +50,7 @@ class DebouncedSearch extends React.Component<CombinedProps, State> {
 
   render() {
     const { query } = this.state;
-    const { classes, className } = this.props;
+    const { classes, className, actionBeingPerfomed } = this.props;
 
     return (
       <React.Fragment>
@@ -61,7 +63,13 @@ class DebouncedSearch extends React.Component<CombinedProps, State> {
             startAdornment:
               <InputAdornment position="end">
                 <Search className={classes.searchIcon} />
-              </InputAdornment>
+              </InputAdornment>,
+            endAdornment:
+              actionBeingPerfomed
+                ? <InputAdornment position="end">
+                  <CircleProgress mini={true} />
+                </InputAdornment>
+                : <React.Fragment />
           }}
           className={ClassNames(
             className,

--- a/src/components/DebouncedSearch/index.tsx
+++ b/src/components/DebouncedSearch/index.tsx
@@ -1,0 +1,2 @@
+import DebouncedSearch from './DebouncedSearch';
+export default DebouncedSearch;

--- a/src/components/PromiseLoader/PromiseLoader.test.tsx
+++ b/src/components/PromiseLoader/PromiseLoader.test.tsx
@@ -21,7 +21,7 @@ describe('PromiseLoaderSpec', () => {
     });
 
     it('should display loading component.', async () => {
-      expect(wrapper.find('WithStyles(CircleProgressComponent)').exists()).toBeTruthy();
+      expect(wrapper.find('[data-qa-circle-progress]').exists()).toBeTruthy();
     });
   });
 

--- a/src/components/PromiseLoader/PromiseLoader.tsx
+++ b/src/components/PromiseLoader/PromiseLoader.tsx
@@ -69,7 +69,7 @@ export default function preload<P>(requests: RequestMap<P>) {
       render() {
         const { loading, ...responses } = this.state;
         if (loading) {
-          return <CircleProgress />;
+          return <CircleProgress data-qa-circle-progress />;
         }
 
         return <Component {...this.props} {...responses} />;

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -25,6 +25,8 @@ import { deleteStackScript, getCommunityStackscripts, getStackScript, getStackSc
 
 import StackScriptsSection from './StackScriptsSection';
 
+import DebouncedSearch from 'src/components/DebouncedSearch';
+
 export interface ExtendedLinode extends Linode.Linode {
   heading: string;
   subHeadings: string[];
@@ -573,6 +575,10 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     )
   }
 
+  handleSearch = (value: string) => {
+    console.log(`making request with ${value}`);
+  }
+
   renderIcon = () => {
     const { sortOrder } = this.state;
 
@@ -611,98 +617,101 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
             You do not have any StackScripts to select from. You must first
           <Link to="/stackscripts/create"> create one</Link>
           </div>
-          : <Table noOverflow={true} tableClass={classes.table}>
-            <TableHead>
-              <TableRow className={classes.tr}>
-                {!!this.props.onSelect &&
-                  <TableCell className={classNames({
-                    [classes.tableHead]: true,
-                    [classes.stackscriptLabel]: true,
-                  })} />
-                }
-                <TableCell
-                  className={classNames({
-                    [classes.tableHead]: true,
-                    [classes.stackscriptTitles]: true,
-                  })}
-                  sortable
-                >
-                  <Button
-                    type="secondary"
-                    className={classes.sortButton}
-                    onClick={this.handleClickStackScriptsTableHeader}
-                    data-qa-stackscript-table-header
+          : <React.Fragment>
+            <DebouncedSearch onSearch={this.handleSearch} />
+            <Table noOverflow={true} tableClass={classes.table}>
+              <TableHead>
+                <TableRow className={classes.tr}>
+                  {!!this.props.onSelect &&
+                    <TableCell className={classNames({
+                      [classes.tableHead]: true,
+                      [classes.stackscriptLabel]: true,
+                    })} />
+                  }
+                  <TableCell
+                    className={classNames({
+                      [classes.tableHead]: true,
+                      [classes.stackscriptTitles]: true,
+                    })}
+                    sortable
                   >
-                    StackScripts
+                    <Button
+                      type="secondary"
+                      className={classes.sortButton}
+                      onClick={this.handleClickStackScriptsTableHeader}
+                      data-qa-stackscript-table-header
+                    >
+                      StackScripts
                   {currentFilterType === 'label' &&
-                      this.renderIcon()
-                    }
-                  </Button>
-                </TableCell>
-                <TableCell
-                  className={classNames({
-                    [classes.tableHead]: true,
-                    [classes.deploys]: true,
-                  })}
-                  noWrap
-                  sortable
-                >
-                  <Button
-                    type="secondary"
-                    className={classes.sortButton}
-                    onClick={this.handleClickDeploymentsTableHeader}
-                    data-qa-stackscript-active-deploy-header
+                        this.renderIcon()
+                      }
+                    </Button>
+                  </TableCell>
+                  <TableCell
+                    className={classNames({
+                      [classes.tableHead]: true,
+                      [classes.deploys]: true,
+                    })}
+                    noWrap
+                    sortable
                   >
-                    Active Deploys
+                    <Button
+                      type="secondary"
+                      className={classes.sortButton}
+                      onClick={this.handleClickDeploymentsTableHeader}
+                      data-qa-stackscript-active-deploy-header
+                    >
+                      Active Deploys
                   {currentFilterType !== 'label' && currentFilterType !== 'revision' &&
-                      this.renderIcon()
-                    }
-                  </Button>
-                </TableCell>
-                <TableCell
-                  className={classNames({
-                    [classes.tableHead]: true,
-                    [classes.revisions]: true,
-                  })}
-                  noWrap
-                  sortable
-                >
-                  <Button
-                    type="secondary"
-                    className={classes.sortButton}
-                    onClick={this.handleClickRevisionsTableHeader}
-                    data-qa-stackscript-revision-header
+                        this.renderIcon()
+                      }
+                    </Button>
+                  </TableCell>
+                  <TableCell
+                    className={classNames({
+                      [classes.tableHead]: true,
+                      [classes.revisions]: true,
+                    })}
+                    noWrap
+                    sortable
                   >
-                    Last Revision
+                    <Button
+                      type="secondary"
+                      className={classes.sortButton}
+                      onClick={this.handleClickRevisionsTableHeader}
+                      data-qa-stackscript-revision-header
+                    >
+                      Last Revision
                   {currentFilterType === 'revision' &&
-                      this.renderIcon()
-                    }
-                  </Button>
-                </TableCell>
-                <TableCell
-                  className={classes.tableHead}
-                  data-qa-stackscript-compatible-images
-                >
-                  Compatible Images
+                        this.renderIcon()
+                      }
+                    </Button>
+                  </TableCell>
+                  <TableCell
+                    className={classes.tableHead}
+                    data-qa-stackscript-compatible-images
+                  >
+                    Compatible Images
               </TableCell>
-                {!this.props.onSelect &&
-                  <TableCell className={classNames({
-                    [classes.tableHead]: true,
-                    [classes.stackscriptLabel]: true,
-                  })} />
-                }
-              </TableRow>
-            </TableHead>
-            <StackScriptsSection
-              isSorting={isSorting}
-              selectedId={this.state.selected}
-              data={this.state.listOfStackScripts}
-              publicImages={publicImages}
-              triggerDelete={this.handleOpenDialog}
-              currentUser={currentUser}
-              {...selectProps}
-            />
-          </Table>
+                  {!this.props.onSelect &&
+                    <TableCell className={classNames({
+                      [classes.tableHead]: true,
+                      [classes.stackscriptLabel]: true,
+                    })} />
+                  }
+                </TableRow>
+              </TableHead>
+              <StackScriptsSection
+                isSorting={isSorting}
+                selectedId={this.state.selected}
+                data={this.state.listOfStackScripts}
+                publicImages={publicImages}
+                triggerDelete={this.handleOpenDialog}
+                currentUser={currentUser}
+                {...selectProps}
+              />
+            </Table>
+          </React.Fragment>
         }
         {this.state.showMoreButtonVisible && !isSorting &&
           <Button

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -650,10 +650,14 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     const { currentFilterType, isSorting, error, fieldError,
       isSearching, listOfStackScripts, didSearch } = this.state;
 
-    if (error) {
-      return <ErrorState
-        errorText="There was an error loading your StackScripts. Please try again later."
-      />
+    if(error) {
+      return (
+        <div style={{ overflow: 'hidden' }}>
+          <ErrorState 
+            errorText="There was an error loading your StackScripts. Please try again later."
+          />
+        </div>
+      )
     }
 
     if (this.state.loading) {

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -44,8 +44,11 @@ type ClassNames = 'root'
   | 'tr'
   | 'tableHead'
   | 'sortButton'
+  | 'emptyState'
+  | 'sortIcon'
   | 'table'
-  | 'emptyState';
+  | 'searchWrapper'
+  | 'searchBar';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -86,7 +89,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   tableHead: {
     position: 'sticky',
-    top: 0,
+    top: 72,
     backgroundColor: theme.bg.offWhite,
     zIndex: 10,
     paddingTop: 0,
@@ -101,7 +104,23 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   emptyState: {
     textAlign: 'center',
     padding: '10em',
-  }
+  },
+  sortIcon: {
+    position: 'relative',
+    top: 2,
+    left: 10,
+  },
+  searchWrapper: {
+    position: 'sticky', 
+    width: '100%',
+    top: 0,
+    zIndex: 11,
+  },
+  searchBar: {
+    marginTop: 0,
+    paddingBottom: theme.spacing.unit * 3,
+    backgroundColor: theme.color.white,
+  },
 });
 
 interface Props {
@@ -647,16 +666,19 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
           <Link to="/stackscripts/create"> create one</Link>
           </div>
           : <React.Fragment>
-            <DebouncedSearch onSearch={this.handleSearch} />
+            <div className={classes.searchWrapper}>
+              <DebouncedSearch
+                onSearch={this.handleSearch}
+                className={classes.searchBar}
+              />
+            </div>
             <Table noOverflow={true} tableClass={classes.table}>
               <TableHead>
                 <TableRow className={classes.tr}>
-                  {!!this.props.onSelect &&
-                    <TableCell className={classNames({
-                      [classes.tableHead]: true,
-                      [classes.stackscriptLabel]: true,
-                    })} />
-                  }
+                  <TableCell className={classNames({
+                    [classes.tableHead]: true,
+                    [classes.stackscriptLabel]: true,
+                  })} />
                   <TableCell
                     className={classNames({
                       [classes.tableHead]: true,

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -576,33 +576,35 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
   }
 
   handleSearch = (value: string) => {
-    const { request } = this.props;
-    const filter = {
-      ["+or"]: [
-        {
-          "label": {
-            ["+contains"]: "security"
-          }
-        },
-        {
-          "description": {
-            ["+contains"]: "security"
-          }
-        },
-        {
-          ["+and"]: [
-            {
-              "username": "linode"
-            }
-          ]
-        }
-      ]
-    }
-    request({ page: 1, page_size: 50 }, filter)
-      .then((response) => {
-        console.log(response);
-      })
-      .catch(e => console.log(e))
+    // const { request, profile, isLinodeStackScripts } = this.props;
+    // const filteredUser = (isLinodeStackScripts) ? 'linode' : profile.username;
+
+    // const filter = {
+    //   ["+or"]: [
+    //     {
+    //       "label": {
+    //         ["+contains"]: "security"
+    //       }
+    //     },
+    //     {
+    //       "description": {
+    //         ["+contains"]: "security"
+    //       }
+    //     },
+    //     {
+    //       ["+and"]: [
+    //         {
+    //           "username": "linode"
+    //         }
+    //       ]
+    //     }
+    //   ]
+    // }
+    // request(filteredUser, { page: 1, page_size: 50 }, filter)
+    //   .then((response) => {
+    //     console.log(response);
+    //   })
+    //   .catch(e => console.log(e));
     console.log(`making request with ${value}`);
   }
 

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -576,6 +576,33 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
   }
 
   handleSearch = (value: string) => {
+    const { request } = this.props;
+    const filter = {
+      ["+or"]: [
+        {
+          "label": {
+            ["+contains"]: "security"
+          }
+        },
+        {
+          "description": {
+            ["+contains"]: "security"
+          }
+        },
+        {
+          ["+and"]: [
+            {
+              "username": "linode"
+            }
+          ]
+        }
+      ]
+    }
+    request({ page: 1, page_size: 50 }, filter)
+      .then((response) => {
+        console.log(response);
+      })
+      .catch(e => console.log(e))
     console.log(`making request with ${value}`);
   }
 

--- a/src/services/stackscripts.ts
+++ b/src/services/stackscripts.ts
@@ -35,25 +35,13 @@ export const getStackScriptsByUser = (username: string, params?: any, filter?: a
     ...filter,
   });
 
-// API does not currently support this
-// export const getCommunityStackscripts = (currentUser: string, params?: any, filter?: any) =>
-//   getStackscripts(params, {
-//     '+and': [
-//       { username: { '+not': 'linode' } },
-//       { username: { '+not': currentUser } },
-//       ...filter,
-//     ],
-//   });
-
 export const getCommunityStackscripts = (currentUser: string, params?: any, filter?: any) =>
-  getStackscripts(params, filter).then((response) => {
-    const withoutOwnAndLinode = response.data.filter((stackScript) => {
-      return stackScript.username !== 'linode' && stackScript.username !== currentUser;
-    });
-    return {
-      ...response,
-      data: withoutOwnAndLinode,
-    };
+  getStackscripts(params, {
+    '+and': [
+      { username: { '+neq': 'linode' } },
+      { username: { '+neq': currentUser } },
+    ],
+    ...filter
   });
 
 export const deleteStackScript = (id: number) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,6 +972,10 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.2.tgz#e13182e1b69871a422d7863e11a4a6f5b814a4bd"
 
+"@types/throttle-debounce@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/throttle-debounce/-/throttle-debounce-1.0.0.tgz#4a871d80fed83496916c8598abb361a2d2277d6f"
+
 "@types/uglify-js@*":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.2.tgz#f30c75458d18e8ee885c792c04adcb78a13bc286"
@@ -10221,6 +10225,10 @@ thenify-all@^1.0.0:
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
+
+throttle-debounce@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.0.0.tgz#2d8d24bd8cf3cb0cc7bd1a2dbeb624b4081a1ed4"
 
 through2@^2.0.0:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10222,6 +10222,10 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
+throttle-debounce@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.0.0.tgz#2d8d24bd8cf3cb0cc7bd1a2dbeb624b4081a1ed4"
+
 through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10222,10 +10222,6 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
-throttle-debounce@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.0.0.tgz#2d8d24bd8cf3cb0cc7bd1a2dbeb624b4081a1ed4"
-
 through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"


### PR DESCRIPTION
### Purpose

Allow user to search the list of stackscripts by label and description

### To Test
* change `.env` file to use development login and API environments
* run `yarn && yarn start` to install new `thottle-debounce` package
* Navigate to _create from stackscript flow_
* search for a stackscript by typing in the search bar

### Notes
* Searching is on a by-username basis. In other words, if you're in the _My StackScripts_ tab, you can't search for Linode or Community StackScripts
* Introduces new `DebouncedSearch` component
  * search is debounced by 400ms by default

### Considerations
- [x] Empty State after searching:
<img width="823" alt="screen shot 2018-07-09 at 12 41 08 pm" src="https://user-images.githubusercontent.com/7387001/42463855-63272504-8375-11e8-8b99-c4102f21784e.png">

- [x] Error State after searching:
<img width="819" alt="screen shot 2018-07-09 at 12 42 50 pm" src="https://user-images.githubusercontent.com/7387001/42463949-a62d696c-8375-11e8-9cd2-e0577d83ec69.png">

- [x] `isMounted` checks

### Is Blocked By
~~Pending the ability to filter by username and other filters, this will be completed. Right now, the API only supports getting a list of stackscripts by username. That filter does not work with the `+and`, `+or`, etc operators yet...~~