### PR TITLE
M3-773 Filter StackScripts with Deprecated Images

### DIFF
--- a/src/components/SelectStackScriptPanel.stories.tsx
+++ b/src/components/SelectStackScriptPanel.stories.tsx
@@ -5,6 +5,8 @@ import ThemeDecorator from '../utilities/storybookDecorators';
 import SelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel';
 import { StaticRouter } from 'react-router';
 
+import {images} from 'src/__data__/images';
+
 interface State {
   selectedId: number | null;
 }
@@ -18,6 +20,7 @@ class InteractiveExample extends React.Component<{}, State> {
     return (
       <StaticRouter>
         <SelectStackScriptPanel
+          images={images}
           selectedId={this.state.selectedId}
           onSelect={(id: number) => this.setState({ selectedId: id })}
         />

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -121,9 +121,7 @@ type CombinedProps = StyledProps;
 
 class SelectStackScriptPanel extends React.Component<CombinedProps> {
 
-  filterPublicImages = (images: Linode.Image[]) => {
-    return images.filter((image: Linode.Image) => image.is_public)
-  }
+
 
   render() {
     const { classes, images } = this.props;
@@ -140,7 +138,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps> {
             render: () => <StyledContainer
               onSelect={this.props.onSelect}
               // images is an optional prop, so just send an empty array if we didn't get any
-              publicImages={(images) ? this.filterPublicImages(images) : []}
+              publicImages={images}
               request={getStackScriptsByUser} key={0}
             />,
           },
@@ -149,7 +147,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps> {
             render: () => <StyledContainer
               onSelect={this.props.onSelect}
               // images is an optional prop, so just send an empty array if we didn't get any
-              publicImages={(images) ? this.filterPublicImages(images) : []}
+              publicImages={images}
               request={getStackScriptsByUser} key={1}
               isLinodeStackScripts={true}
             />,
@@ -159,7 +157,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps> {
             render: () => <StyledContainer
               onSelect={this.props.onSelect}
               // images is an optional prop, so just send an empty array if we didn't get any
-              publicImages={(images) ? this.filterPublicImages(images) : []}
+              publicImages={images}
               request={getCommunityStackscripts} key={2}
             />,
           },

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -112,7 +112,7 @@ interface Props {
   shrinkPanel?: boolean;
   onSelect: (id: number, label: string, username: string, images: string[],
     userDefinedFields: Linode.StackScript.UserDefinedField[]) => void;
-  images?: Linode.Image[];
+  images: Linode.Image[];
 }
 
 type StyledProps = Props & WithStyles<ClassNames>;
@@ -181,7 +181,7 @@ interface ContainerProps {
     userDefinedFields: Linode.StackScript.UserDefinedField[]) => void;
   profile: Linode.Profile;
   isLinodeStackScripts?: boolean;
-  publicImages?: Linode.Image[];
+  publicImages: Linode.Image[];
 }
 
 type CurrentFilter = 'label' | 'deploys' | 'revision';
@@ -319,7 +319,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
   }
 
   render() {
-    const { classes } = this.props;
+    const { classes, publicImages } = this.props;
     const { currentFilterType, isSorting } = this.state;
 
     if (this.state.loading) {
@@ -398,6 +398,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
             selectedId={this.state.selected}
             data={this.state.data}
             getNext={() => this.getNext()}
+            publicImages={publicImages}
           />
         </Table>
         {this.state.showMoreButtonVisible && !isSorting &&

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -27,6 +27,7 @@ export interface Props {
   data: Linode.StackScript.Response[];
   getNext: () => void;
   isSorting: boolean;
+  publicImages: Linode.Image[];
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -38,17 +39,31 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
     data,
     isSorting,
     classes,
+    publicImages,
   } = props;
+
+  const hasNonDeprecatedImages = (stackScriptImages: string[]) => {
+    for (const stackScriptImage of stackScriptImages) {
+      for (const publicImage of publicImages) {
+        if (stackScriptImage === publicImage.id) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 
   return (
     <TableBody>
       {!isSorting
-        ? data && data.map(stackScript(onSelect, selectedId))
+        ? data && data
+          .filter(stackScript => hasNonDeprecatedImages(stackScript.images))
+          .map(stackScript(onSelect, selectedId))
         : <TableRow>
-            <TableCell colSpan={5} className={classes.loadingWrapper}>
-              <CircleProgress />
-            </TableCell>
-          </TableRow>
+          <TableCell colSpan={5} className={classes.loadingWrapper}>
+            <CircleProgress />
+          </TableCell>
+        </TableRow>
       }
     </TableBody>
   );
@@ -83,7 +98,7 @@ const stackScript: (fn: (s: Linode.StackScript.Response) => void, id?: number) =
       updateFor={[selectedId === s.id]}
       stackScriptID={s.id}
     />
-  );
+  )
 
 const styled = withStyles(styles, { withTheme: true });
 

--- a/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
@@ -16,11 +16,28 @@ import {
   values,
 } from 'ramda';
 
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+// import Paper from '@material-ui/core/Paper';
+// import Typography from '@material-ui/core/Typography';
+
 import Grid from 'src/components/Grid';
 import RenderGuard from 'src/components/RenderGuard';
 import SelectionCard from 'src/components/SelectionCard';
 import ShowMoreExpansion from 'src/components/ShowMoreExpansion';
 import TabbedPanel from 'src/components/TabbedPanel';
+
+type ClassNames = 'root' | 'flatImagePanel' | 'flatImagePanelSelections';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  flatImagePanel: {
+    padding: theme.spacing.unit * 3,
+  },
+  flatImagePanelSelections: {
+    marginTop: theme.spacing.unit,
+    padding: `${theme.spacing.unit}px 0`,
+  },
+  root: {},
+});
 
 const distroIcons = {
   Arch: 'archlinux',
@@ -39,6 +56,7 @@ interface Props {
   error?: string;
   selectedImageID: string | null;
   handleSelection: (id: string) => void;
+  hideMyImages?: boolean;
 }
 
 const sortByVendor = sortBy(prop('vendor'));
@@ -77,24 +95,38 @@ export const getMyImages = compose<any, any, any>(
   filter(propSatisfies(startsWith('private'), 'id')),
 );
 
-const CreateFromImage: React.StatelessComponent<Props> = (props) => {
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const CreateFromImage: React.StatelessComponent<CombinedProps> = (props) => {
   const { images, error, handleSelection } = props;
   const publicImages = getPublicImages(images);
   const olderPublicImages = getOlderPublicImages(images);
   const myImages = getMyImages(images);
 
-  return (
-    <TabbedPanel
-      error={error}
-      header="Select Image Type"
-      tabs={[
-        {
-          title: 'Public Images',
-          render: () => (
-            <React.Fragment>
-              <Grid container spacing={16}>
-                {publicImages.length
-                && publicImages.map((image: Linode.Image, idx: number) => (
+  const tabs = [
+    {
+      title: 'Public Images',
+      render: () => (
+        <React.Fragment>
+          <Grid container spacing={16}>
+            {publicImages.length
+              && publicImages.map((image: Linode.Image, idx: number) => (
+                <SelectionCard
+                  key={idx}
+                  checked={image.id === String(props.selectedImageID)}
+                  onClick={() => handleSelection(image.id)}
+                  renderIcon={() => {
+                    return <span className={`fl-${distroIcons[(image.vendor as string)]}`} />;
+                  }}
+                  heading={(image.vendor as string)}
+                  subheadings={[image.label]}
+                />
+              ))}
+          </Grid>
+          <ShowMoreExpansion name="Show Older Images">
+            <Grid container spacing={8} style={{ marginTop: 16 }}>
+              {olderPublicImages.length
+                && olderPublicImages.map((image: Linode.Image, idx: number) => (
                   <SelectionCard
                     key={idx}
                     checked={image.id === String(props.selectedImageID)}
@@ -106,48 +138,66 @@ const CreateFromImage: React.StatelessComponent<Props> = (props) => {
                     subheadings={[image.label]}
                   />
                 ))}
-              </Grid>
-              <ShowMoreExpansion name="Show Older Images">
-                <Grid container spacing={8} style={{ marginTop: 16 }}>
-                  {olderPublicImages.length
-                  && olderPublicImages.map((image: Linode.Image, idx: number) => (
-                    <SelectionCard
-                      key={idx}
-                      checked={image.id === String(props.selectedImageID)}
-                      onClick={() => handleSelection(image.id)}
-                      renderIcon={() => {
-                        return <span className={`fl-${distroIcons[(image.vendor as string)]}`} />;
-                      }}
-                      heading={(image.vendor as string)}
-                      subheadings={[image.label]}
-                    />
-                  ))}
-                </Grid>
-              </ShowMoreExpansion>
-            </React.Fragment>
-          ),
-        },
-        {
-          title: 'My Images',
-          render: () => (
-            <Grid container>
-              { myImages && myImages.map((image: Linode.Image, idx: number) => (
-                <SelectionCard
-                  key={idx}
-                  checked={image.id === String(props.selectedImageID)}
-                  onClick={() => handleSelection(image.id)}
-                  renderIcon={() => <span className="fl-tux" /> }
-                  heading={(image.label as string)}
-                  subheadings={[(image.description as string)]}
-                />
-              )) }
             </Grid>
-          ),
-        },
-      ]}
-    >
-    </TabbedPanel>
+          </ShowMoreExpansion>
+        </React.Fragment>
+      ),
+    },
+    {
+      title: 'My Images',
+      render: () => (
+        <Grid container>
+          {myImages && myImages.map((image: Linode.Image, idx: number) => (
+            <SelectionCard
+              key={idx}
+              checked={image.id === String(props.selectedImageID)}
+              onClick={() => handleSelection(image.id)}
+              renderIcon={() => <span className="fl-tux" />}
+              heading={(image.label as string)}
+              subheadings={[(image.description as string)]}
+            />
+          ))}
+        </Grid>
+      ),
+    },
+  ];
+  
+  const renderTabs = () => {
+    const { hideMyImages } = props;
+    if (hideMyImages) {
+      return tabs.filter(tab => tab.title !== 'My Images')
+    }
+    return tabs;
+  }
+
+  return (
+    <TabbedPanel
+      error={error}
+      header="Select Image Type"
+      tabs={renderTabs()}
+    />
+    // <Paper className={props.classes.flatImagePanel}>
+    //   <Typography variant="title">
+    //     Select Image
+    //   </Typography>
+    //   <Grid className={props.classes.flatImagePanelSelections} container>
+    //     {publicImages && publicImages.map((image: Linode.Image, idx: number) => (
+    //       <SelectionCard
+    //         key={idx}
+    //         checked={image.id === String(props.selectedImageID)}
+    //         onClick={() => handleSelection(image.id)}
+    //         renderIcon={() => {
+    //           return <span className={`fl-${distroIcons[(image.vendor as string)]}`} />;
+    //         }}
+    //         heading={(image.vendor as string)}
+    //         subheadings={[image.label]}
+    //       />
+    //     ))}
+    //   </Grid>
+    // </Paper>
   );
 };
 
-export default RenderGuard<Props>(CreateFromImage);
+const styled = withStyles(styles, { withTheme: true });
+
+export default RenderGuard<Props>(styled(CreateFromImage));

--- a/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
@@ -17,8 +17,8 @@ import {
 } from 'ramda';
 
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
-// import Paper from '@material-ui/core/Paper';
-// import Typography from '@material-ui/core/Typography';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
 
 import Grid from 'src/components/Grid';
 import RenderGuard from 'src/components/RenderGuard';
@@ -33,7 +33,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     padding: theme.spacing.unit * 3,
   },
   flatImagePanelSelections: {
-    marginTop: theme.spacing.unit,
+    marginTop: theme.spacing.unit * 2,
     padding: `${theme.spacing.unit}px 0`,
   },
   root: {},
@@ -103,41 +103,49 @@ const CreateFromImage: React.StatelessComponent<CombinedProps> = (props) => {
   const olderPublicImages = getOlderPublicImages(images);
   const myImages = getMyImages(images);
 
+  const renderPublicImages = () => (
+    publicImages.length
+    && publicImages.map((image: Linode.Image, idx: number) => (
+      <SelectionCard
+        key={idx}
+        checked={image.id === String(props.selectedImageID)}
+        onClick={() => handleSelection(image.id)}
+        renderIcon={() => {
+          return <span className={`fl-${distroIcons[(image.vendor as string)]}`} />;
+        }}
+        heading={(image.vendor as string)}
+        subheadings={[image.label]}
+      />
+    ))
+  );
+
+  const renderOlderPublicImages = () => (
+    olderPublicImages.length
+    && olderPublicImages.map((image: Linode.Image, idx: number) => (
+      <SelectionCard
+        key={idx}
+        checked={image.id === String(props.selectedImageID)}
+        onClick={() => handleSelection(image.id)}
+        renderIcon={() => {
+          return <span className={`fl-${distroIcons[(image.vendor as string)]}`} />;
+        }}
+        heading={(image.vendor as string)}
+        subheadings={[image.label]}
+      />
+    ))
+  );
+
   const tabs = [
     {
       title: 'Public Images',
       render: () => (
         <React.Fragment>
           <Grid container spacing={16}>
-            {publicImages.length
-              && publicImages.map((image: Linode.Image, idx: number) => (
-                <SelectionCard
-                  key={idx}
-                  checked={image.id === String(props.selectedImageID)}
-                  onClick={() => handleSelection(image.id)}
-                  renderIcon={() => {
-                    return <span className={`fl-${distroIcons[(image.vendor as string)]}`} />;
-                  }}
-                  heading={(image.vendor as string)}
-                  subheadings={[image.label]}
-                />
-              ))}
+            {renderPublicImages()}
           </Grid>
           <ShowMoreExpansion name="Show Older Images">
             <Grid container spacing={8} style={{ marginTop: 16 }}>
-              {olderPublicImages.length
-                && olderPublicImages.map((image: Linode.Image, idx: number) => (
-                  <SelectionCard
-                    key={idx}
-                    checked={image.id === String(props.selectedImageID)}
-                    onClick={() => handleSelection(image.id)}
-                    renderIcon={() => {
-                      return <span className={`fl-${distroIcons[(image.vendor as string)]}`} />;
-                    }}
-                    heading={(image.vendor as string)}
-                    subheadings={[image.label]}
-                  />
-                ))}
+              {renderOlderPublicImages()}
             </Grid>
           </ShowMoreExpansion>
         </React.Fragment>
@@ -165,36 +173,36 @@ const CreateFromImage: React.StatelessComponent<CombinedProps> = (props) => {
   const renderTabs = () => {
     const { hideMyImages } = props;
     if (hideMyImages) {
-      return tabs.filter(tab => tab.title !== 'My Images')
+      return tabs;
     }
     return tabs;
   }
 
   return (
-    <TabbedPanel
-      error={error}
-      header="Select Image Type"
-      tabs={renderTabs()}
-    />
-    // <Paper className={props.classes.flatImagePanel}>
-    //   <Typography variant="title">
-    //     Select Image
-    //   </Typography>
-    //   <Grid className={props.classes.flatImagePanelSelections} container>
-    //     {publicImages && publicImages.map((image: Linode.Image, idx: number) => (
-    //       <SelectionCard
-    //         key={idx}
-    //         checked={image.id === String(props.selectedImageID)}
-    //         onClick={() => handleSelection(image.id)}
-    //         renderIcon={() => {
-    //           return <span className={`fl-${distroIcons[(image.vendor as string)]}`} />;
-    //         }}
-    //         heading={(image.vendor as string)}
-    //         subheadings={[image.label]}
-    //       />
-    //     ))}
-    //   </Grid>
-    // </Paper>
+    <React.Fragment>
+      {(props.hideMyImages !== true) // if we have no olderPublicImage, hide the dropdown
+        ? <TabbedPanel
+          error={error}
+          header="Select Image"
+          tabs={renderTabs()}
+        />
+        : <Paper className={props.classes.flatImagePanel}>
+          <Typography variant="title">
+            Select Image
+</Typography>
+          <Grid className={props.classes.flatImagePanelSelections} container>
+            {renderPublicImages()}
+          </Grid>
+          {olderPublicImages.length > 0 &&
+            <ShowMoreExpansion name="Show Older Images">
+              <Grid container spacing={8} style={{ marginTop: 16 }}>
+                {renderOlderPublicImages()}
+              </Grid>
+            </ShowMoreExpansion>
+          }
+        </Paper>
+      }
+    </React.Fragment>
   );
 };
 

--- a/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
@@ -144,7 +144,7 @@ const CreateFromImage: React.StatelessComponent<CombinedProps> = (props) => {
             {renderPublicImages()}
           </Grid>
           <ShowMoreExpansion name="Show Older Images">
-            <Grid container spacing={8} style={{ marginTop: 16 }}>
+            <Grid container spacing={16} style={{ marginTop: 16 }}>
               {renderOlderPublicImages()}
             </Grid>
           </ShowMoreExpansion>
@@ -195,7 +195,7 @@ const CreateFromImage: React.StatelessComponent<CombinedProps> = (props) => {
           </Grid>
           {olderPublicImages.length > 0 &&
             <ShowMoreExpansion name="Show Older Images">
-              <Grid container spacing={8} style={{ marginTop: 16 }}>
+              <Grid container spacing={16} style={{ marginTop: 16 }}>
                 {renderOlderPublicImages()}
               </Grid>
             </ShowMoreExpansion>

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
@@ -40,7 +40,7 @@ describe('FromImageContent', () => {
   });
 
   it('should render SelectImage panel', () => {
-    expect(component.find('WithRenderGuard(CreateFromImage)')).toHaveLength(1);
+    expect(component.find('WithRenderGuard(WithStyles(CreateFromImage))')).toHaveLength(1);
   });
 
   it('should render SelectRegion panel', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -67,12 +67,12 @@ describe('FromImageContent', () => {
   });
 
   it('should render SelectImage panel if no compatibleImages', () => {
-    expect(component.find('WithRenderGuard(CreateFromImage)')).toHaveLength(0);
+    expect(component.find('WithRenderGuard(WithStyles(CreateFromImage))')).toHaveLength(0);
   });
 
   it('should render SelectImage panel if no compatibleImages', () => {
-    component.setState({ compatibleImages: ['linode/centos7'] });
-    expect(component.find('WithRenderGuard(CreateFromImage)')).toHaveLength(1);
+    component.setState({ compatibleImages: [{label: 'linode/centos7', is_public: true}] });
+    expect(component.find('WithRenderGuard(WithStyles(CreateFromImage))')).toHaveLength(1);
   });
 
   it('should render SelectRegion panel', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -294,7 +294,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
       selectedStackScriptUsername } = this.state;
 
     const { notice, getBackupsMonthlyPrice, regions, types, classes,
-      getRegionName, getTypeInfo } = this.props;
+      getRegionName, getTypeInfo, images } = this.props;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
@@ -302,7 +302,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
 
     const regionName = getRegionName(selectedRegionID);
     const typeInfo = getTypeInfo(selectedTypeID);
-    const imageInfo = this.getImageInfo(this.props.images.find(
+    const imageInfo = this.getImageInfo(images.find(
       image => image.id === selectedImageID));
 
     return (
@@ -324,6 +324,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
             shrinkPanel={true}
             updateFor={[selectedStackScriptID, errors]}
             onSelect={this.handleSelectStackScript}
+            images={images}
           />
           {userDefinedFields && userDefinedFields.length > 0 &&
             <UserDefinedFieldsPanel
@@ -343,6 +344,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
               updateFor={[selectedImageID, compatibleImages, errors]}
               selectedImageID={selectedImageID}
               error={hasErrorFor('image')}
+              hideMyImages={true}
             />
             : <Paper
               className={classes.emptyImagePanel}>

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -287,6 +287,10 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
     this.mounted = false;
   }
 
+  filterPublicImages = (images: Linode.Image[]) => {
+    return images.filter((image: Linode.Image) => image.is_public)
+  }
+
   render() {
     const { errors, userDefinedFields, udf_data, selectedImageID, selectedRegionID,
       selectedStackScriptID, selectedTypeID, backups, privateIP, label,
@@ -324,7 +328,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
             shrinkPanel={true}
             updateFor={[selectedStackScriptID, errors]}
             onSelect={this.handleSelectStackScript}
-            images={images}
+            images={this.filterPublicImages(images) || []}
           />
           {userDefinedFields && userDefinedFields.length > 0 &&
             <UserDefinedFieldsPanel

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -138,6 +138,11 @@ const LinodeTheme: Linode.Theme = {
         strokeLinecap: 'inherit',
       },
     },
+    MuiCollapse: {
+      container: {
+        width: '100%',
+      },
+    },
     MuiDialog: {
       paper: {
         boxShadow: '0 0 5px #bbb',


### PR DESCRIPTION
### Purpose

In the `SelectStackScriptsPanel`, only show StackScripts that are compatible with an image that is currently being offered.

### Notes
* Also changed the `SelectImage` component, so the _Show Older Images_ dropdown will only appear if there are actually older images in the list.
* The _My Images_ tab no longer appears in the StackScript images selection