### PR TITLE
M3-368 Add 'Unknown Image' to Linode Card

### DIFF
--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -172,7 +172,7 @@ interface Props {
   linodeSpecMemory: number;
   linodeSpecVcpus: number;
   linodeSpecTransfer: number;
-  image?: Linode.Image;
+  imageLabel: string;
   openConfigDrawer: (configs: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
   toggleConfirmation: (bootOption: Linode.BootAction,
     linodeId: number, linodeLabel: string) => void;
@@ -240,7 +240,7 @@ class LinodeCard extends React.Component<CombinedProps> {
   loadedState = () => {
     const {
       classes,
-      image,
+      imageLabel,
       linodeIpv4,
       linodeIpv6,
       linodeRegion,
@@ -265,7 +265,7 @@ class LinodeCard extends React.Component<CombinedProps> {
             <IPAddress ips={[linodeIpv6]} copyRight />
           </div>
           <div className={classes.cardSection} data-qa-image>
-            {image ? image.label : "Unknown Image" }
+            {imageLabel}
           </div>
         </div>
       </CardContent>

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+
 import { compose, pathOr } from 'ramda';
 
-import { withStyles, Theme, WithStyles, StyleRulesCallback } from '@material-ui/core/styles';
+import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
+
 import Button from '@material-ui/core/Button';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
@@ -14,18 +16,19 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 
 import Flag from 'src/assets/icons/flag.svg';
-import haveAnyBeenModified from 'src/utilities/haveAnyBeenModified';
+import CircleProgress from 'src/components/CircleProgress';
+import Grid from 'src/components/Grid';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 import { weblishLaunch } from 'src/features/Weblish';
-import Grid from 'src/components/Grid';
-import CircleProgress from 'src/components/CircleProgress';
+import haveAnyBeenModified from 'src/utilities/haveAnyBeenModified';
 
-import RegionIndicator from './RegionIndicator';
+import transitionStatus from '../linodeTransitionStatus';
+import { displayType, typeLabelDetails } from '../presentation';
+
 import IPAddress from './IPAddress';
 import LinodeActionMenu from './LinodeActionMenu';
-import { typeLabelDetails, displayType } from '../presentation';
-import transitionStatus from '../linodeTransitionStatus';
 import LinodeStatusIndicator from './LinodeStatusIndicator';
+import RegionIndicator from './RegionIndicator';
 
 type CSSClasses =
   'customeMQ'
@@ -204,6 +207,16 @@ class LinodeCard extends React.Component<CombinedProps> {
     );
   }
 
+  handleConsoleButtonClick = () => {
+    const { linodeId } = this.props;
+    weblishLaunch(`${linodeId}`);
+  }
+
+  handleRebootButtonClick = () => {
+    const { linodeId, linodeLabel, toggleConfirmation} = this.props;
+    toggleConfirmation('reboot', linodeId, linodeLabel);
+  }
+
   loadingState = () => {
     const { classes, linodeRecentEvent, linodeStatus } = this.props;
     const value = (linodeRecentEvent && linodeRecentEvent.percent_complete) || 1;
@@ -251,11 +264,9 @@ class LinodeCard extends React.Component<CombinedProps> {
             <IPAddress ips={linodeIpv4} copyRight />
             <IPAddress ips={[linodeIpv6]} copyRight />
           </div>
-          {image &&
-            <div className={classes.cardSection} data-qa-image>
-              {image.label}
-            </div>
-          }
+          <div className={classes.cardSection} data-qa-image>
+            {image ? image.label : "Unknown Image" }
+          </div>
         </div>
       </CardContent>
     );
@@ -302,14 +313,14 @@ class LinodeCard extends React.Component<CombinedProps> {
                 />
               </div>
             }
-            className={`${classes.customeMQ}} ${'title'}`}
+            className={`${classes.customeMQ} ${'title'}`}
           />
           <Divider />
           {loading ? this.loadingState() : this.loadedState()}
           <CardActions className={classes.cardActions}>
             <Button
               className={`${classes.button} ${classes.consoleButton}`}
-              onClick={() => weblishLaunch(`${linodeId}`)}
+              onClick={this.handleConsoleButtonClick}
               data-qa-console
             >
               Launch Console
@@ -317,7 +328,7 @@ class LinodeCard extends React.Component<CombinedProps> {
             <Button
               className={`${classes.button}
               ${classes.rebootButton}`}
-              onClick={() => toggleConfirmation('reboot', linodeId, linodeLabel)}
+              onClick={this.handleRebootButtonClick}
               data-qa-reboot
             >
               Reboot

--- a/src/features/linodes/LinodesLanding/LinodesGridView.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesGridView.tsx
@@ -14,6 +14,14 @@ interface Props {
      linodeId: number, linodeLabel: string) => void;
 }
 
+const safeGetImageLabel = (images: Linode.Image[], slug: string | null): string => {
+  if (!slug) {
+    return 'No Image'
+  }
+  const iv = images.find((i) => i.id === slug);
+  return iv ? iv.label : 'Unknown Image';
+};
+
 const LinodesGridView: React.StatelessComponent<Props> = (props) => {
   const { linodes, images, openConfigDrawer, toggleConfirmation } = props;
 
@@ -31,7 +39,7 @@ const LinodesGridView: React.StatelessComponent<Props> = (props) => {
           linodeNotification={linode.notification}
           linodeLabel={linode.label}
           linodeRecentEvent={linode.recentEvent}
-          image={images.find(image => linode.image === image.id)}
+          imageLabel={safeGetImageLabel(images, linode.image)}
           openConfigDrawer={openConfigDrawer}
           linodeSpecDisk={linode.specs.disk}
           linodeSpecMemory={linode.specs.memory}

--- a/src/features/linodes/LinodesLanding/LinodesGridView.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesGridView.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import Grid from 'src/components/Grid';
 
 import LinodeCard from './LinodeCard';
+
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 
 interface Props {


### PR DESCRIPTION
**Purpose**

Add an "Unknown Image" label to Linode Card
when a Linode's image name is unavailable
(images no longer supported by the API)

* Add label
* Refactor Lambda methods in render()
* Fix linter warnings