### PR TITLE
M3-835 Linode Detail - Volumes - View Linode Config button Redirect

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -241,7 +241,7 @@ class PrimaryNav extends React.Component<Props, State> {
   }
 
   render() {
-    const { classes, toggleTheme, toggleMenu } = this.props;
+    const { classes, toggleTheme } = this.props;
     const { expandedMenus } = this.state;
     const themeName = (this.props.theme as any).name;
 
@@ -299,7 +299,6 @@ class PrimaryNav extends React.Component<Props, State> {
             <Link
               to="/billing"
               role="menuitem"
-              onClick={toggleMenu}
               className={classNames({
                 [classes.sublink]: true,
                 [classes.sublinkActive]: this.linkIsActive('/billing') === true,
@@ -310,7 +309,6 @@ class PrimaryNav extends React.Component<Props, State> {
             <Link
               to="/users"
               role="menuitem"
-              onClick={toggleMenu}
               className={classNames({
                 [classes.sublink]: true,
                 [classes.sublinkActive]: this.linkIsActive('/users') === true,
@@ -369,7 +367,6 @@ class PrimaryNav extends React.Component<Props, State> {
             <Link
               to="/support"
               role="menuitem"
-              onClick={toggleMenu}
               className={classNames({
                 [classes.sublink]: true,
                 [classes.sublinkActive]: this.linkIsActive('/support') === true,

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
@@ -243,6 +243,13 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
     });
   }
 
+  componentDidMount() {
+    if (window.location.hash) {
+      const hashWithoutSymbol = window.location.hash.replace('#', '');
+      document.getElementById(hashWithoutSymbol)!.scrollIntoView();
+    }
+  }
+
   calculateDiskFree = (): number => {
     return this.props.linodeTotalDisk -
       this.state.devices.disks.reduce((acc: number, disk: ExtendedDisk) => {
@@ -260,6 +267,7 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
             defaultExpanded
             heading="Advanced Configurations"
             success={this.state.success}
+            id="configs"
           >
             <Grid
               container

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigsPanel.tsx
@@ -246,7 +246,8 @@ class LinodeConfigsPanel extends React.Component<CombinedProps, State> {
   componentDidMount() {
     if (window.location.hash) {
       const hashWithoutSymbol = window.location.hash.replace('#', '');
-      document.getElementById(hashWithoutSymbol)!.scrollIntoView();
+      const elementToScrollTo = document.getElementById(hashWithoutSymbol);
+      if (elementToScrollTo) { elementToScrollTo.scrollIntoView() };
     }
   }
 

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.test.tsx
@@ -12,6 +12,13 @@ describe('Linode Volumes', () => {
   const linodeConfigsAsPromiseResponse = createPromiseLoaderResponse(linodeConfigs);
   const volumesAsPromiseResponse = createPromiseLoaderResponse(volumes);
 
+  const mockLocation = {
+    pathname: 'localhost',
+    search: 'search',
+    state: 'hello',
+    hash: 'hash',
+  }
+
   const component = shallow(
     <LinodeVolumes
       classes={{ title: '' }}
@@ -21,6 +28,27 @@ describe('Linode Volumes', () => {
       linodeLabel="test"
       linodeRegion="us-east"
       linodeID={100}
+      history={{
+        length: 2,
+        action: 'PUSH',
+        location: mockLocation,
+        push: jest.fn(),
+        replace: jest.fn(),
+        go: jest.fn(),
+        goBack: jest.fn(),
+        goForward: jest.fn(),
+        block: jest.fn(),
+        listen: jest.fn(),
+        createHref: jest.fn(),
+      }}
+      location={mockLocation}
+      match={{
+        params: 'test',
+        isExact: false,
+        path: 'localhost',
+        url: 'localhost'
+      }}
+      staticContext={undefined}
     />
   )
   it('should render Update Volume Drawer', () => {

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -1,47 +1,53 @@
 import * as React from 'react';
-import { pathOr, compose } from 'ramda';
+
+import { Redirect } from 'react-router';
+
+import { compose, pathOr } from 'ramda';
+
 import { Subscription } from 'rxjs/Rx';
 
-import {
-  withStyles,
-  StyleRulesCallback,
-  Theme,
-  WithStyles,
-} from '@material-ui/core/styles';
+import { StyleRulesCallback, Theme, withStyles,  WithStyles } from '@material-ui/core/styles';
+
 import Paper from '@material-ui/core/Paper';
-import Typography from '@material-ui/core/Typography';
-import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
-import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
 
 import {
-  getVolumes,
-  attach as attachtoLinode,
-  detach as detachVolume,
   _delete as deleteVolume,
+  attach as attachtoLinode,
   clone as cloneVolume,
   create as createVolume,
-  update as updateVolume,
+  detach as detachVolume,
+  getVolumes,
   resize as resizeVolume,
+  update as updateVolume,
 } from 'src/services/volumes';
+
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import Table from 'src/components/Table';
 import Grid from 'src/components/Grid';
-import Placeholder, { PlaceholderProps } from 'src/components/Placeholder';
-import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
-import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader';
+import Table from 'src/components/Table';
+
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
-import { getLinodeConfigs, getLinodeVolumes } from 'src/services/linodes';
-import ErrorState from 'src/components/ErrorState';
+
+import AddNewLink, { Props as AddNewLinkProps } from 'src/components/AddNewLink';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import ErrorState from 'src/components/ErrorState';
+import Placeholder, { PlaceholderProps } from 'src/components/Placeholder';
+import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader';
+import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
+
+import { events$, resetEventsPolling } from 'src/events';
+import { getLinodeConfigs, getLinodeVolumes } from 'src/services/linodes';
+
 
 import AttachVolumeDrawer from './AttachVolumeDrawer';
-import UpdateVolumeDrawer, { Props as UpdateVolumeDrawerProps } from './UpdateVolumeDrawer';
 import ActionMenu from './LinodeVolumesActionMenu';
-import { events$, resetEventsPolling } from 'src/events';
-import AddNewLink, { Props as AddNewLinkProps } from 'src/components/AddNewLink';
+import UpdateVolumeDrawer, { Props as UpdateVolumeDrawerProps } from './UpdateVolumeDrawer';
+
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { withLinode, withVolumes } from '../context';
 
@@ -90,6 +96,7 @@ interface State {
   attachVolumeDrawer: AttachVolumeDrawerState;
   updateDialog: UpdateDialogState;
   updateVolumeDrawer: UpdateVolumeDrawerState;
+  redirect: boolean;
 }
 
 type CombinedProps = Props & ContextProps & WithStyles<ClassNames>;
@@ -132,6 +139,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
       attachVolumeDrawer: LinodeVolumes.attachVolumeDrawerDefaultState,
       updateDialog: LinodeVolumes.updateDialogDefaultState,
       updateVolumeDrawer: LinodeVolumes.updateVolumeDrawerDefaultState,
+      redirect: false,
     };
   }
 
@@ -185,6 +193,10 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
           attachableVolumes,
         });
       });
+  }
+
+  goToSettings = () => {
+    this.setState({redirect: true});
   }
 
   /** Attachment */
@@ -709,7 +721,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     if (configs.length === 0) {
       props = {
         buttonProps: {
-          onClick: this.openAttachmentDrawer,
+          onClick: this.goToSettings,
           children: 'View Linode Config',
         },
         icon: VolumeIcon,
@@ -849,6 +861,11 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     } = this.props;
 
     const { updateVolumeDrawer } = this.state;
+
+    if (this.state.redirect) {
+      return <Redirect push to="settings" />;
+    }
+  
 
     if (volumesError || linodeConfigsError) {
       return <ErrorState errorText="An error has occured." />;

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -724,7 +724,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
       props = {
         buttonProps: {
           onClick: this.goToSettings,
-          children: 'View Linode Config',
+          children: 'View Linode Configurations',
         },
         icon: VolumeIcon,
         title: 'No configs available',

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -863,7 +863,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     const { updateVolumeDrawer } = this.state;
 
     if (this.state.redirect) {
-      return <Redirect push to="settings" />;
+      return <Redirect push to="settings#configs" />;
     }
   
 

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Redirect } from 'react-router';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import { compose, pathOr } from 'ramda';
 
@@ -96,10 +96,12 @@ interface State {
   attachVolumeDrawer: AttachVolumeDrawerState;
   updateDialog: UpdateDialogState;
   updateVolumeDrawer: UpdateVolumeDrawerState;
-  redirect: boolean;
 }
 
-type CombinedProps = Props & ContextProps & WithStyles<ClassNames>;
+type CombinedProps = Props
+& WithStyles<ClassNames>
+& ContextProps
+& RouteComponentProps<{}>;
 
 export class LinodeVolumes extends React.Component<CombinedProps, State> {
   static defaultProps = {
@@ -139,7 +141,6 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
       attachVolumeDrawer: LinodeVolumes.attachVolumeDrawerDefaultState,
       updateDialog: LinodeVolumes.updateDialogDefaultState,
       updateVolumeDrawer: LinodeVolumes.updateVolumeDrawerDefaultState,
-      redirect: false,
     };
   }
 
@@ -196,7 +197,8 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
   }
 
   goToSettings = () => {
-    this.setState({redirect: true});
+    const { history, linodeID } = this.props;
+    history.push(`/linodes/${linodeID}/settings#configs`);
   }
 
   /** Attachment */
@@ -861,10 +863,6 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     } = this.props;
 
     const { updateVolumeDrawer } = this.state;
-
-    if (this.state.redirect) {
-      return <Redirect push to="settings#configs" />;
-    }
   
 
     if (volumesError || linodeConfigsError) {
@@ -903,10 +901,11 @@ const volumesContext = withVolumes((context) => ({
   linodeVolumes: context.data,
 }));
 
-export default compose<any, any, any, any, any, any>(
+export default compose<any, any, any, any, any, any, any>(
   linodeContext,
   volumesContext,
   styled,
+  withRouter,
   SectionErrorBoundary,
   preloaded,
 )(LinodeVolumes);

--- a/src/features/linodes/LinodesLanding/LinodeStatusIndicator.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeStatusIndicator.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react';
 
-import {
-  withStyles,
-  StyleRulesCallback,
-  WithStyles,
-} from '@material-ui/core/styles';
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import { Cached } from '@material-ui/icons';
 
 import { linodeInTransition } from 'src/features/linodes/transitions';
@@ -16,13 +12,24 @@ interface Props {
 
 type CSSClasses = 'dot' | 'green' | 'red' | 'transition';
 
-const styles: StyleRulesCallback<CSSClasses> = theme => ({
+const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => ({
+  '@keyframes rotate': {
+    from: {
+      transform: 'rotate(0deg)',
+    },
+    to: {
+      transform: 'rotate(360deg)',
+    },
+  },
   dot: {
     fontSize: '1.5rem',
     userSelect: 'none',
   },
   transition: {
     marginLeft: -1,
+    '& svg': {
+      animation: 'rotate 2s linear infinite',
+    },
   },
   green: {
     color: '#01b159',


### PR DESCRIPTION
**Bug Description**
After creating a linode without a configuration (not selecting an image), the Volumes section displays a "no configs available" message, with a "View Linode Config" placeholder button. The placeholder button opens the "attach volume" drawer, instead of taking you to the linode config.

**Steps to test fix**

- Navigate to create a linode
- Select a region and a plan
- Deploy Linode
- Navigate to Linode detail from List Linodes
- Click the Volumes Tab
- Observe "No Config" placeholder message.
- Click View Linode Config
- Should be redirected to settings