### PR TITLE
E2E & Storybook Testing docker-compose improvements

### DIFF
--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -27,7 +27,7 @@ if (argv.log) {
 
 exports.config = {
     // Selenium Host/Port
-    host: process.env.DOCKER ? 'selenium-hub' : 'localhost',
+    host: process.env.DOCKER ? 'selenium-standalone' : 'localhost',
     port: 4444,
     //
     // ==================
@@ -201,6 +201,15 @@ exports.config = {
         require('babel-register');
 
         browserCommands();
+
+        // if (argv.record) {
+        //     // POST RECORD PROXY
+        // }
+
+        // if (argv.replay) {
+        //     // POST REPLAY
+        // }
+
         browser.timeouts('page load', 20000);
         login(username, password);
     },
@@ -268,8 +277,14 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      * @param {Array.<String>} specs List of spec file paths that ran
      */
-    // after: function (result, capabilities, specs) {
-    // },
+    after: function (result, capabilities, specs) {
+        // if (mbTest) {
+        //     // DELETE IMPOSTERS
+        //     if (argv.record) { 
+        //         // SAVE
+        //     }
+        // }
+    },
     /**
      * Gets executed right after terminating the webdriver session.
      * @param {Object} config wdio configuration object

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -202,14 +202,6 @@ exports.config = {
 
         browserCommands();
 
-        // if (argv.record) {
-        //     // POST RECORD PROXY
-        // }
-
-        // if (argv.replay) {
-        //     // POST REPLAY
-        // }
-
         browser.timeouts('page load', 20000);
         login(username, password);
     },
@@ -278,12 +270,6 @@ exports.config = {
      * @param {Array.<String>} specs List of spec file paths that ran
      */
     after: function (result, capabilities, specs) {
-        // if (mbTest) {
-        //     // DELETE IMPOSTERS
-        //     if (argv.record) { 
-        //         // SAVE
-        //     }
-        // }
     },
     /**
      * Gets executed right after terminating the webdriver session.

--- a/integration-test.yml
+++ b/integration-test.yml
@@ -20,6 +20,10 @@ services:
     volumes:
       - ./src:/src/src
     entrypoint: ["/src/scripts/start_manager.sh"]
+    depends_on:
+      - selenium-standalone
+    networks:
+      - backend
   manager-e2e:
     container_name: manager_e2e
     environment:
@@ -36,3 +40,7 @@ services:
     entrypoint: ["./scripts/wait-for-it.sh", "-t", "250", "-s", "manager-local:3000", "--", "yarn","e2e", "--log"]
     depends_on:
       - manager-local
+    networks:
+      - backend
+networks:
+  backend:

--- a/integration-test.yml
+++ b/integration-test.yml
@@ -1,22 +1,13 @@
 version: '3.1'
 services: 
-  selenium-hub:
-    image: selenium/hub:3.4.0-francium
-    ports:
-      - "4444:4444"
-  chrome:
-    image: selenium/node-chrome:3.4.0-francium
-    depends_on:
-      - selenium-hub
+  selenium-standalone:
+    image: selenium/standalone-chrome:3.4.0-francium
     volumes:
       - /dev/shm:/dev/shm #Mitigates the Chromium issue described at https://code.google.com/p/chromium/issues/detail?id=519952
-    environment:
-      - HUB_PORT_4444_TCP_ADDR=selenium-hub
-      - HUB_PORT_4444_TCP_PORT=4444
+    networks:
+      - backend
   manager-local:
     container_name: manager_local
-    ports:
-      - "3000:3000"
     environment:
       - HTTPS=true
       - REACT_APP_APP_ROOT=https://manager-local:3000
@@ -44,4 +35,4 @@ services:
       - ./e2e:/src/e2e
     entrypoint: ["./scripts/wait-for-it.sh", "-t", "250", "-s", "manager-local:3000", "--", "yarn","e2e", "--log"]
     depends_on:
-      - chrome
+      - manager-local

--- a/storybook-test.yml
+++ b/storybook-test.yml
@@ -1,22 +1,13 @@
 version: '3.1'
 services: 
-  selenium-hub:
-    image: selenium/hub:3.11.0-bismuth
-    ports:
-      - "4444:4444"
-  chrome:
-    image: selenium/node-chrome:3.11.0-bismuth
-    depends_on:
-      - selenium-hub
+  selenium-standalone:
+    image: selenium/standalone-chrome:3.4.0-francium
     volumes:
       - /dev/shm:/dev/shm #Mitigates the Chromium issue described at https://code.google.com/p/chromium/issues/detail?id=519952
-    environment:
-      - HUB_PORT_4444_TCP_ADDR=selenium-hub
-      - HUB_PORT_4444_TCP_PORT=4444
+    networks:
+      - backend
   manager-storybook:
     container_name: manager_storybook
-    ports:
-      - "6006:6006"
     build:
       context: .
       dockerfile: Dockerfile
@@ -24,7 +15,9 @@ services:
       - ./src:/src/src
     entrypoint: yarn storybook
     depends_on:
-      - chrome
+      - selenium-standalone
+    networks:
+      - backend
   storybook-test:
     container_name: storybook_test
     environment:
@@ -41,3 +34,7 @@ services:
     entrypoint: ["./scripts/storybook_entrypoint.sh"]
     depends_on:
       - manager-storybook
+    networks:
+      - backend
+networks:
+  backend:


### PR DESCRIPTION
* Replaced the selenium-hub image in favor of `selenium-standalone` which matches what we use for local testing more closely. Also locked in the version of the standalone image at `3.4.0` which also matches what we used locally.
* Using standalone also has the benefit of reducing the number of containers needed to run the tests.
* Used docker networking to ensure all containers are on the same "backend" network.
* Removed exposed ports, as the containers only need to access each other via their backend network and not the outside world. This will also prevent port collision when running other selenium jobs on Jenkins or other CI's.

# To Test:

* Storybook docker test:
```bash
# ensure you are not running storybook locally, docker will start it for you
yarn docker:storybook:test
```

* E2E Tests:
These have been tested internally via jenkins, PM me for a log. 