### PR TITLE
M3-465  Refactor collapsible menu items (Primary Nav)

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -40,6 +40,7 @@ type ClassNames =
   'headerGrid'
   | 'logoItem'
   | 'listItem'
+  | 'collapsible'
   | 'lastItem'
   | 'linkItem'
   | 'active'
@@ -79,6 +80,15 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
         color: 'white',
       },
     },
+    '&:focus, &:active': {
+      '& $linkItem': {
+        color: 'white',
+        zIndex: 2,
+      },
+    },
+  },
+  collapsible: {
+    fontSize: '.9rem',
   },
   linkItem: {
     transition: theme.transitions.create(['color']),
@@ -251,10 +261,12 @@ class PrimaryNav extends React.Component<Props, State> {
 
         <ListItem 
           data-menu-name="account"
+          focusRipple={true}
           button
           onClick={this.expandMenutItem}
           className={classNames({
             [classes.listItem]: true,
+            [classes.collapsible]: true,
           })}
         >
           <ListItemText
@@ -273,8 +285,8 @@ class PrimaryNav extends React.Component<Props, State> {
         </ListItem>
         <Collapse 
           in={expandedMenus.account
-              || this.linkIsActive('/billing') === true
-              || this.linkIsActive('/users') === true}
+              || (this.linkIsActive('/billing') === true)
+              || (this.linkIsActive('/users') === true)}
           timeout="auto" 
           unmountOnExit
           className={classes.sublinkPanel}
@@ -304,8 +316,12 @@ class PrimaryNav extends React.Component<Props, State> {
         <ListItem
           data-menu-name="support"
           button
+          focusRipple={true}
           onClick={this.expandMenutItem}
-          className={classes.listItem}
+          className={classNames({
+            [classes.listItem]: true,
+            [classes.collapsible]: true,
+          })}
         >
           <ListItemText
             disableTypography={true}

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -2,16 +2,19 @@ import * as React from 'react';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
+import * as classNames from 'classnames';
+
 import { StyleRules, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
+import Collapse from '@material-ui/core/Collapse';
 import Divider from '@material-ui/core/Divider';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
 
 import Grid from 'src/components/Grid';
-import ShowMoreExpansion from 'src/components/ShowMoreExpansion';
 import Toggle from 'src/components/Toggle';
 
 import Logo from 'src/assets/logo/logo-text.svg';
@@ -32,6 +35,22 @@ const primaryLinks: PrimaryLink[] = [
   { display: 'StackScripts', href: '/stackscripts' },
   { display: 'Images', href: '/images' },
 ];
+
+type ClassNames =
+  'headerGrid'
+  | 'logoItem'
+  | 'listItem'
+  | 'lastItem'
+  | 'linkItem'
+  | 'active'
+  | 'activeLink'
+  | 'sublink'
+  | 'sublinkActive'
+  | 'arrow'
+  | 'sublinkPanel'
+  | 'switchWrapper'
+  | 'toggle'
+  | 'switchText';
 
 const styles = (theme: Theme & Linode.Theme): StyleRules => ({
   headerGrid: {
@@ -78,36 +97,10 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
     flex: 1,
     backgroundColor: 'transparent',
   },
-  activeLink: {
-    color: 'white',
-  },
   sublinkPanel: {
-    paddingLeft: theme.spacing.unit * 4,
-    paddingRight: theme.spacing.unit * 4,
+    paddingLeft: theme.spacing.unit * 6,
+    paddingRight: theme.spacing.unit * 2,
     fontSize: '.9rem',
-    transition: theme.transitions.create(['color', 'background-color']),
-    '&:hover, &:focus': {
-      backgroundColor: 'rgba(0, 0, 0, 0.1)',
-    },
-    '& span': {
-      color: '#C9CACB',
-      transition: theme.transitions.create(['color']),
-    },
-    '& svg': {
-      color: '#C9CACB',
-      fontSize: '20px',
-      margin: '5px 2px 4px 0',
-      transition: theme.transitions.create(['color']),
-    },
-    '&:hover, &:focus, & .hOpen': {
-      color: 'white',
-      '& span, & svg': {
-        color: 'white !important',
-      },
-    },
-    '& .pOpen': {
-      margin: '5px 0 0 14px',
-    },
   },
   sublink: {
     padding: '4px 0 4px 8px',
@@ -118,6 +111,22 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
       textDecoration: 'underline',
       outline: 0,
     },
+  },
+  activeLink: {
+    color: 'white',
+    '& $arrow': {
+      transform: 'rotate(90deg)',
+    },
+  },
+  sublinkActive: {
+    textDecoration: 'underline',
+  },
+  arrow: {
+    position: 'relative',
+    top: 4,
+    fontSize: '1.2rem',
+    margin: '0 4px 0 -7px',
+    transition: theme.transitions.create(['transform']),
   },
   switchWrapper: {
     padding: '16px 40px 16px 34px',
@@ -146,28 +155,25 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
   },
 });
 
-type ClassNames =
-  'headerGrid'
-  | 'logoItem'
-  | 'listItem'
-  | 'lastItem'
-  | 'linkItem'
-  | 'active'
-  | 'activeLink'
-  | 'sublink'
-  | 'sublinkPanel'
-  | 'switchWrapper'
-  | 'toggle'
-  | 'switchText';
-
 interface Props extends WithStyles<ClassNames>, RouteComponentProps<{}> {
   toggleMenu: () => void;
   toggleTheme: () => void;
 }
 
-class PrimaryNav extends React.Component<Props> {
-  state = {
+interface State {
+  drawerOpen: boolean;
+  expandedMenus: {
+    [key: string]: boolean;
+  };
+}
+
+class PrimaryNav extends React.Component<Props, State> {
+  state: State = {
     drawerOpen: false,
+    expandedMenus: {
+      account: false,
+      support: false,
+    },
   };
 
   constructor(props: Props) {
@@ -183,6 +189,17 @@ class PrimaryNav extends React.Component<Props> {
   linkIsActive(href: string) {
     return isPathOneOf([href], this.props.location.pathname);
   }
+
+  expandMenutItem = (e: React.MouseEvent<HTMLElement>) => {
+    const menuName = e.currentTarget.getAttribute('data-menu-name');
+    if (!menuName) return;
+    this.setState({
+      expandedMenus: {
+        ...this.state.expandedMenus,
+        [menuName]: !this.state.expandedMenus[menuName],
+      }
+    });
+  };
 
   renderPrimaryLink(PrimaryLink: PrimaryLink) {
     const { classes } = this.props;
@@ -213,6 +230,7 @@ class PrimaryNav extends React.Component<Props> {
 
   render() {
     const { classes, toggleTheme } = this.props;
+    const { expandedMenus } = this.state;
     const themeName = (this.props.theme as any).name;
 
     return (
@@ -230,25 +248,84 @@ class PrimaryNav extends React.Component<Props> {
           </Grid>
         </Grid>
         {primaryLinks.map(primaryLink => this.renderPrimaryLink(primaryLink))}
-        <ShowMoreExpansion classes={{ root: classes.sublinkPanel }} name="Account">
+
+        <ListItem 
+          data-menu-name="account"
+          button
+          onClick={this.expandMenutItem}
+          className={classNames({
+            [classes.listItem]: true,
+          })}
+        >
+          <ListItemText
+            disableTypography={true}
+            className={classNames({
+              [classes.linkItem]: true,
+              [classes.activeLink]: 
+                expandedMenus.account
+                || this.linkIsActive('/billing') === true
+                || this.linkIsActive('/users') === true,
+            })}
+          >
+            <KeyboardArrowRight className={classes.arrow} />
+            Account
+          </ListItemText>
+        </ListItem>
+        <Collapse 
+          in={expandedMenus.account
+              || this.linkIsActive('/billing') === true
+              || this.linkIsActive('/users') === true}
+          timeout="auto" 
+          unmountOnExit
+          className={classes.sublinkPanel}
+        >
           <Link
-            className={classes.sublink}
             to="/billing"
             role="menuitem"
+            className={classNames({
+              [classes.sublink]: true,
+              [classes.sublinkActive]: this.linkIsActive('/billing') === true,
+            })}
           >
             Account &amp; Billing
           </Link>
           <Link
-            className={classes.sublink}
             to="/users"
             role="menuitem"
+            className={classNames({
+              [classes.sublink]: true,
+              [classes.sublinkActive]: this.linkIsActive('/users') === true,
+            })}
           >
             Users
           </Link>
-        </ShowMoreExpansion>
-        <ShowMoreExpansion
-          classes={{ root: classes.sublinkPanel }}
-          name="Support"
+        </Collapse>
+
+        <ListItem
+          data-menu-name="support"
+          button
+          onClick={this.expandMenutItem}
+          className={classes.listItem}
+        >
+          <ListItemText
+            disableTypography={true}
+            className={classNames({
+              [classes.linkItem]: true,
+              [classes.activeLink]:
+                expandedMenus.support
+                || this.linkIsActive('/support') === true,
+            })}
+          >
+            <KeyboardArrowRight className={classes.arrow} />
+            Support
+          </ListItemText>
+        </ListItem>
+        <Collapse 
+          in={expandedMenus.support 
+              || this.linkIsActive('/support') === true}
+          timeout="auto" 
+          unmountOnExit
+          className={classes.sublinkPanel}
         >
           <a
             className={classes.sublink}
@@ -267,13 +344,17 @@ class PrimaryNav extends React.Component<Props> {
             Community Forum
           </a>
           <Link
-            className={classes.sublink}
             to="/support"
             role="menuitem"
+            className={classNames({
+              [classes.sublink]: true,
+              [classes.sublinkActive]: this.linkIsActive('/support') === true,
+            })}
           >
             Support Tickets
           </Link>
-        </ShowMoreExpansion>
+        </Collapse>
+
         <Divider className={classes.lastItem} />
         <div className={classes.switchWrapper}>
           <span className={`

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -1,17 +1,20 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
-import { withStyles, WithStyles, StyleRules, Theme } from '@material-ui/core/styles';
+import { StyleRules, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+
 import Divider from '@material-ui/core/Divider';
-import Grid from 'src/components/Grid';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
-import Logo from 'src/assets/logo/logo-text.svg';
+
+import Grid from 'src/components/Grid';
 import ShowMoreExpansion from 'src/components/ShowMoreExpansion';
 import Toggle from 'src/components/Toggle';
+
+import Logo from 'src/assets/logo/logo-text.svg';
 
 type PrimaryLink = {
   display: string,

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -7,7 +7,6 @@ import * as classNames from 'classnames';
 import { StyleRules, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
 import Collapse from '@material-ui/core/Collapse';
-import Divider from '@material-ui/core/Divider';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
@@ -37,11 +36,10 @@ const primaryLinks: PrimaryLink[] = [
 ];
 
 type ClassNames =
-  'headerGrid'
+  'menuGrid'
   | 'logoItem'
   | 'listItem'
   | 'collapsible'
-  | 'lastItem'
   | 'linkItem'
   | 'active'
   | 'activeLink'
@@ -51,14 +49,16 @@ type ClassNames =
   | 'sublinkPanel'
   | 'switchWrapper'
   | 'toggle'
-  | 'switchText';
+  | 'switchText'
+  | 'spacer';
 
 const styles = (theme: Theme & Linode.Theme): StyleRules => ({
-  headerGrid: {
-    borderBottom: '1px solid rgba(0, 0, 0, 0.12)',
+  menuGrid: {
     minHeight: 64,
     width: '100%',
+    height: '100%',
     margin: 0,
+    paddingBottom: theme.spacing.unit * 3,
     [theme.breakpoints.up('sm')]: {
       minHeight: 72,
     },
@@ -74,6 +74,7 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
     borderBottomColor: 'rgba(0, 0, 0, 0.12)',
     borderLeft: '6px solid transparent',
     transition: theme.transitions.create(['background-color', 'border-left-color']),
+    flexShrink: 0,
     '&:hover': {
       borderLeftColor: 'rgba(0, 0, 0, 0.1)',
       '& $linkItem': {
@@ -103,14 +104,11 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
       borderLeftColor: theme.color.green,
     },
   },
-  lastItem: {
-    flex: 1,
-    backgroundColor: 'transparent',
-  },
   sublinkPanel: {
     paddingLeft: theme.spacing.unit * 6,
     paddingRight: theme.spacing.unit * 2,
     fontSize: '.9rem',
+    flexShrink: 0,
   },
   sublink: {
     padding: '4px 0 4px 8px',
@@ -141,6 +139,7 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
   switchWrapper: {
     padding: '16px 40px 16px 34px',
     alignItems: 'center',
+    marginTop: 'auto',
     // hidding for now - replace with flex
     display: 'none',
   },
@@ -162,6 +161,9 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
       transition: theme.transitions.create(['color']),
       color: '#C9CACB',
     },
+  },
+  spacer: {
+    padding: 25,
   },
 });
 
@@ -246,9 +248,12 @@ class PrimaryNav extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <Grid
-          className={classes.headerGrid}
+          className={classes.menuGrid}
           container
-          alignItems="center"
+          alignItems="flex-start"
+          justify="flex-start"
+          direction="column"
+          wrap="nowrap"
           spacing={0}
         >
           <Grid item>
@@ -256,147 +261,149 @@ class PrimaryNav extends React.Component<Props, State> {
               <Logo width={115} height={43} />
             </div>
           </Grid>
-        </Grid>
-        {primaryLinks.map(primaryLink => this.renderPrimaryLink(primaryLink))}
 
-        <ListItem 
-          data-menu-name="account"
-          focusRipple={true}
-          button
-          onClick={this.expandMenutItem}
-          className={classNames({
-            [classes.listItem]: true,
-            [classes.collapsible]: true,
-          })}
-        >
-          <ListItemText
-            disableTypography={true}
-            className={classNames({
-              [classes.linkItem]: true,
-              [classes.activeLink]: 
-                expandedMenus.account
-                || this.linkIsActive('/billing') === true
-                || this.linkIsActive('/users') === true,
-            })}
-          >
-            <KeyboardArrowRight className={classes.arrow} />
-            Account
-          </ListItemText>
-        </ListItem>
-        <Collapse 
-          in={expandedMenus.account
-              || (this.linkIsActive('/billing') === true)
-              || (this.linkIsActive('/users') === true)}
-          timeout="auto" 
-          unmountOnExit
-          className={classes.sublinkPanel}
-        >
-          <Link
-            to="/billing"
-            role="menuitem"
-            className={classNames({
-              [classes.sublink]: true,
-              [classes.sublinkActive]: this.linkIsActive('/billing') === true,
-            })}
-          >
-            Account &amp; Billing
-          </Link>
-          <Link
-            to="/users"
-            role="menuitem"
-            className={classNames({
-              [classes.sublink]: true,
-              [classes.sublinkActive]: this.linkIsActive('/users') === true,
-            })}
-          >
-            Users
-          </Link>
-        </Collapse>
+          {primaryLinks.map(primaryLink => this.renderPrimaryLink(primaryLink))}
 
-        <ListItem
-          data-menu-name="support"
-          button
-          focusRipple={true}
-          onClick={this.expandMenutItem}
-          className={classNames({
-            [classes.listItem]: true,
-            [classes.collapsible]: true,
-          })}
-        >
-          <ListItemText
-            disableTypography={true}
+          <ListItem 
+            data-menu-name="account"
+            focusRipple={true}
+            button
+            onClick={this.expandMenutItem}
             className={classNames({
-              [classes.linkItem]: true,
-              [classes.activeLink]:
-                expandedMenus.support
-                || this.linkIsActive('/support') === true,
+              [classes.listItem]: true,
+              [classes.collapsible]: true,
             })}
           >
-            <KeyboardArrowRight className={classes.arrow} />
-            Support
-          </ListItemText>
-        </ListItem>
-        <Collapse 
-          in={expandedMenus.support 
-              || this.linkIsActive('/support') === true}
-          timeout="auto" 
-          unmountOnExit
-          className={classes.sublinkPanel}
-        >
-          <a
-            className={classes.sublink}
-            href="https://www.linode.com/docs"
-            target="_blank"
-            role="menuitem"
+            <ListItemText
+              disableTypography={true}
+              className={classNames({
+                [classes.linkItem]: true,
+                [classes.activeLink]: 
+                  expandedMenus.account
+                  || this.linkIsActive('/billing') === true
+                  || this.linkIsActive('/users') === true,
+              })}
+            >
+              <KeyboardArrowRight className={classes.arrow} />
+              Account
+            </ListItemText>
+          </ListItem>
+          <Collapse 
+            in={expandedMenus.account
+                || (this.linkIsActive('/billing') === true)
+                || (this.linkIsActive('/users') === true)}
+            timeout="auto" 
+            unmountOnExit
+            className={classes.sublinkPanel}
           >
-            Documentation
-          </a>
-          <a
-            className={classes.sublink}
-            href="//www.linode.com/community/questions"
-            target="_blank"
-            role="menuitem"
-          >
-            Community Forum
-          </a>
-          <Link
-            to="/support"
-            role="menuitem"
-            className={classNames({
-              [classes.sublink]: true,
-              [classes.sublinkActive]: this.linkIsActive('/support') === true,
-            })}
-          >
-            Support Tickets
-          </Link>
-        </Collapse>
+            <Link
+              to="/billing"
+              role="menuitem"
+              className={classNames({
+                [classes.sublink]: true,
+                [classes.sublinkActive]: this.linkIsActive('/billing') === true,
+              })}
+            >
+              Account &amp; Billing
+            </Link>
+            <Link
+              to="/users"
+              role="menuitem"
+              className={classNames({
+                [classes.sublink]: true,
+                [classes.sublinkActive]: this.linkIsActive('/users') === true,
+              })}
+            >
+              Users
+            </Link>
+          </Collapse>
 
-        <Divider className={classes.lastItem} />
-        <div className={classes.switchWrapper}>
-          <span className={`
-            ${classes.switchText}
-            ${themeName === 'lightTheme' ? 'active' : ''}
-          `}>
-            Light
-          </span>
-          <Toggle
-            onChange={() => toggleTheme()}
-            checked={themeName !== 'lightTheme'}
-            className={`
-              ${classes.toggle}
-              ${themeName}
-            `}
-          />
-          <span
-            className={`
+          <ListItem
+            data-menu-name="support"
+            button
+            focusRipple={true}
+            onClick={this.expandMenutItem}
+            className={classNames({
+              [classes.listItem]: true,
+              [classes.collapsible]: true,
+            })}
+          >
+            <ListItemText
+              disableTypography={true}
+              className={classNames({
+                [classes.linkItem]: true,
+                [classes.activeLink]:
+                  expandedMenus.support
+                  || this.linkIsActive('/support') === true,
+              })}
+            >
+              <KeyboardArrowRight className={classes.arrow} />
+              Support
+            </ListItemText>
+          </ListItem>
+          <Collapse 
+            in={expandedMenus.support 
+                || this.linkIsActive('/support') === true}
+            timeout="auto" 
+            unmountOnExit
+            className={classes.sublinkPanel}
+          >
+            <a
+              className={classes.sublink}
+              href="https://www.linode.com/docs"
+              target="_blank"
+              role="menuitem"
+            >
+              Documentation
+            </a>
+            <a
+              className={classes.sublink}
+              href="//www.linode.com/community/questions"
+              target="_blank"
+              role="menuitem"
+            >
+              Community Forum
+            </a>
+            <Link
+              to="/support"
+              role="menuitem"
+              className={classNames({
+                [classes.sublink]: true,
+                [classes.sublinkActive]: this.linkIsActive('/support') === true,
+              })}
+            >
+              Support Tickets
+            </Link>
+          </Collapse>
+
+          <div className={classes.switchWrapper}>
+            <span className={`
               ${classes.switchText}
-              ${themeName === 'darkTheme' ? 'active' : ''}
-            `}
-            style={{ marginLeft: 4 }}
-          >
-            Dark
-          </span>
-        </div>
+              ${themeName === 'lightTheme' ? 'active' : ''}
+            `}>
+              Light
+            </span>
+            <Toggle
+              onChange={() => toggleTheme()}
+              checked={themeName !== 'lightTheme'}
+              className={`
+                ${classes.toggle}
+                ${themeName}
+              `}
+            />
+            <span
+              className={`
+                ${classes.switchText}
+                ${themeName === 'darkTheme' ? 'active' : ''}
+              `}
+              style={{ marginLeft: 4 }}
+            >
+              Dark
+            </span>
+          </div>
+
+          <div className={classes.spacer} />
+        </Grid>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
This PR replaces the showMoreExpansion component for the new Collapse component as well as implementing missing functionality (submenu item container open if active on navigate and page reload) and add missing accessibility features (tab navigation all the way through submenu items)

steps to test: any page, primary navigation in left sidebar, play with "Account" and "Support" link containers 