### PR TITLE
M3-657 search backend ips

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -893,7 +893,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                           .filter((linode: Linode.Linode) => {
                                             const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/; 
                                             const privateIP = linode.ipv4.find(ipv4 => !!ipv4.match(privateIPRegex));
-                                            return linode.label.includes(inputValue.toLowerCase())
+                                            return linode.label.toLowerCase().includes(inputValue.toLowerCase())
                                               || privateIP!.includes(inputValue.toLowerCase())
                                           })
                                           // limit the results to 5. we don't want too

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -1,22 +1,27 @@
 import * as React from 'react';
-import { withStyles, StyleRulesCallback, WithStyles, Theme } from '@material-ui/core/styles';
-import { Delete } from '@material-ui/icons';
+
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+
+
 import Divider from '@material-ui/core/Divider';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
+import MenuItem from '@material-ui/core/MenuItem';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
+
+import { Delete } from '@material-ui/icons';
 
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
-import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import Grid from 'src/components/Grid';
 import IconButton from 'src/components/IconButton';
-import MenuItem from 'src/components/MenuItem';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import Toggle from 'src/components/Toggle';
+
+import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 
 import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
 
@@ -24,7 +29,11 @@ type ClassNames = 'root'
   | 'inner'
   | 'divider'
   | 'suffix'
-  | 'backendIPAction';
+  | 'backendIPAction'
+  | 'suggestionsParent'
+  | 'suggestions'
+  | 'suggestionItem'
+  | 'selectedSuggestionItem';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -41,6 +50,35 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     paddingLeft: theme.spacing.unit * 2,
     marginLeft: -theme.spacing.unit,
     marginTop: theme.spacing.unit * 3,
+  },
+  suggestionsParent: {
+    position: 'relative',
+  },
+  suggestions: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 80,
+    padding: 0,
+    boxShadow: `0 0 5px ${theme.color.boxShadow}`,
+    maxHeight: 150,
+    overflowY: 'auto',
+    width: '100%',
+    maxWidth: 415,
+    zIndex: 2,
+  },
+  suggestionItem: {
+    color: `${theme.palette.primary.main} !important`,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    '&:hover, &:focus': {
+      backgroundColor: `${theme.bg.offWhite} !important`,
+    },
+    '&:last-item': {
+      border: 0,
+    },
+  },
+  selectedSuggestionItem: {
+    backgroundColor: `${theme.bg.offWhite} !important`,
   },
 });
 
@@ -261,6 +299,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     itemProps: any,
   ) => {
     const isHighlighted = highlightedIndex === index;
+    const { classes } = this.props;
 
     const privateIP = linode.ipv4.find(ipv4 => ipv4.includes('192.168'));
     return (
@@ -270,8 +309,14 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
         key={index}
         component="div"
         selected={isHighlighted}
+        className={classes.suggestionItem}
+        classes={{ selected: classes.selectedSuggestionItem }}
       >
-        {`${linode.label} ${privateIP}`}
+        {
+          <React.Fragment>
+            <strong>{linode.label}</strong> {privateIP}
+          </React.Fragment>
+        }
       </MenuItem>
     )
   }
@@ -825,7 +870,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                 highlightedIndex,
                               }) => {
                                 return (
-                                  <div>
+                                  <div className={classes.suggestionsParent}>
                                     <TextField
                                       label="IP Address"
                                       inputProps={{ 'data-node-idx': idx }}
@@ -841,7 +886,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                       data-qa-backend-ip-address
                                     />
                                     {isOpen && !!inputValue &&
-                                      <Paper>
+                                      <Paper className={classes.suggestions}>
                                         {linodesWithPrivateIPs && linodesWithPrivateIPs
                                         // filter out the linodes that don't match what we're typing
                                         // filter by private ip and label

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -302,7 +302,13 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     const isHighlighted = highlightedIndex === index;
     const { classes } = this.props;
 
-    const privateIP = linode.ipv4.find(ipv4 => ipv4.includes('192.168'));
+    const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/; 
+    const privateIP = linode.ipv4.find(ipv4 => {
+      if(ipv4.match(privateIPRegex)){
+        return true;
+      }
+      return false;
+    });
     return (
       <MenuItem
         // when the suggested is selected, put the private IP in the field
@@ -890,7 +896,13 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                         // filter out the linodes that don't match what we're typing
                                         // filter by private ip and label
                                           .filter((linode: Linode.Linode) => {
-                                            const privateIP = linode.ipv4.find(ipv4 => ipv4.includes('192.168'));
+                                            const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/; 
+                                            const privateIP = linode.ipv4.find(ipv4 => {
+                                              if(ipv4.match(privateIPRegex)){
+                                                return true;
+                                              }
+                                              return false;
+                                            });
                                             return linode.label.includes(inputValue.toLowerCase())
                                               || privateIP!.includes(inputValue.toLowerCase())
                                           })

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -315,7 +315,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
       >
         {
           <React.Fragment>
-            <strong>{linode.label}</strong> {privateIP}
+            <strong>{linode.label}</strong>&nbsp;{privateIP}
           </React.Fragment>
         }
       </MenuItem>

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -68,17 +68,18 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     zIndex: 2,
   },
   suggestionItem: {
-    color: `${theme.palette.primary.main} !important`,
     borderBottom: `1px solid ${theme.palette.divider}`,
     '&:hover, &:focus': {
-      backgroundColor: `${theme.bg.offWhite} !important`,
+      backgroundColor: `${theme.palette.primary.main} !important`,
+      color: `${theme.color.white} !important`,
     },
     '&:last-item': {
       border: 0,
     },
   },
   selectedSuggestionItem: {
-    backgroundColor: `${theme.bg.offWhite} !important`,
+    backgroundColor: `${theme.palette.primary.main} !important`,
+    color: `${theme.color.white} !important`,
   },
 });
 

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -303,12 +303,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     const { classes } = this.props;
 
     const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/; 
-    const privateIP = linode.ipv4.find(ipv4 => {
-      if(ipv4.match(privateIPRegex)){
-        return true;
-      }
-      return false;
-    });
+    const privateIP = linode.ipv4.find(ipv4 => !!ipv4.match(privateIPRegex));
     return (
       <MenuItem
         // when the suggested is selected, put the private IP in the field
@@ -897,12 +892,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                         // filter by private ip and label
                                           .filter((linode: Linode.Linode) => {
                                             const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/; 
-                                            const privateIP = linode.ipv4.find(ipv4 => {
-                                              if(ipv4.match(privateIPRegex)){
-                                                return true;
-                                              }
-                                              return false;
-                                            });
+                                            const privateIP = linode.ipv4.find(ipv4 => !!ipv4.match(privateIPRegex));
                                             return linode.label.includes(inputValue.toLowerCase())
                                               || privateIP!.includes(inputValue.toLowerCase())
                                           })

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -873,15 +873,13 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                 return (
                                   <div className={classes.suggestionsParent}>
                                     <TextField
+                                      {...getInputProps({
+                                        onChange: this.onNodeAddressChange,
+                                        placeholder: 'Enter IP Address',
+                                        value: node.address
+                                      })}
                                       label="IP Address"
                                       inputProps={{ 'data-node-idx': idx }}
-                                      InputProps={{
-                                        ...getInputProps({
-                                          onChange: this.onNodeAddressChange,
-                                          placeholder: 'Enter IP Address',
-                                          value: node.address
-                                        })
-                                      }}
                                       errorText={hasErrorFor('address')}
                                       errorGroup={`${configIdx}`}
                                       data-qa-backend-ip-address

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -18,6 +18,8 @@ import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import Toggle from 'src/components/Toggle';
 
+import Downshift, { DownshiftState, StateChangeOptions } from 'downshift';
+
 type ClassNames = 'root'
   | 'inner'
   | 'divider'
@@ -45,6 +47,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 const styled = withStyles(styles, { withTheme: true });
 
 interface Props {
+  linodesWithPrivateIPs?: Linode.Linode[] | null;
   errors?: Linode.ApiFieldError[];
   nodeMessage?: string;
   configIdx?: number;
@@ -174,6 +177,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
   }
 
   onNodeAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { linodesWithPrivateIPs } = this.props;
+    console.log(linodesWithPrivateIPs);
     const nodeIdx = e.currentTarget.getAttribute('data-node-idx');
     if (nodeIdx) {
       this.props.onNodeAddressChange(
@@ -243,6 +248,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
       healthCheckInterval,
       healthCheckTimeout,
       healthCheckType,
+      linodesWithPrivateIPs,
       nodes,
       nodeMessage,
       port,
@@ -750,6 +756,46 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                           />
                         </Grid>
                         <Grid item xs={11} lg={4} xl={3}>
+                          <Downshift
+                            onSelect={() => console.log('hello world')}
+                          >
+                            {
+                              ({
+                                getInputProps,
+                                getItemProps,
+                                isOpen,
+                                inputValue,
+                                highlightedIndex
+                              }) => {
+                                return (
+                                  <div>
+                                    <TextField
+                                      label="IP Address"
+                                      value={node.address}
+                                      inputProps={{ 'data-node-idx': idx }}
+                                      InputProps={{
+                                        ...getInputProps({
+                                          onChange: this.onNodeAddressChange,
+                                          placeholder: 'Enter IP Address',
+                                        })
+                                      }}
+                                      errorText={hasErrorFor('address')}
+                                      errorGroup={`${configIdx}`}
+                                      data-qa-backend-ip-address
+                                    />
+                                    {isOpen &&
+                                      <Paper>
+                                        {linodesWithPrivateIPs && linodesWithPrivateIPs
+                                          .map((linode) => {
+                                            return <div key={linode.label}>{linode.label}</div>
+                                          })}
+                                      </Paper>
+                                    }
+                                  </div>
+                                )
+                              }
+                            }
+                          </Downshift>
                           <TextField
                             label="IP Address"
                             value={node.address}

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -836,12 +836,12 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                   <div>
                                     <TextField
                                       label="IP Address"
-                                      value={node.address}
                                       inputProps={{ 'data-node-idx': idx }}
                                       InputProps={{
                                         ...getInputProps({
                                           onChange: this.onNodeAddressChange,
                                           placeholder: 'Enter IP Address',
+                                          value: node.address
                                         })
                                       }}
                                       errorText={hasErrorFor('address')}

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -255,7 +255,6 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
   }
 
   renderSearchSuggestion = (
-    inputValue: string,
     linode: Linode.Linode,
     index: number,
     highlightedIndex: number | null,
@@ -264,23 +263,17 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     const isHighlighted = highlightedIndex === index;
 
     const privateIP = linode.ipv4.find(ipv4 => ipv4.includes('192.168'));
-    // only show suggestions if you're typing an existing linode's label
-    // or a Linode's private IP
-    if (linode.label.includes(inputValue.toLowerCase()) ||
-      privateIP!.includes(inputValue.toLowerCase())) {
-      return (
-        <MenuItem
-          // when the suggested is selected, put the private IP in the field
-          {...itemProps({ item: privateIP })}
-          key={index}
-          component="div"
-          selected={isHighlighted}
-        >
-          {`${linode.label} ${privateIP}`}
-        </MenuItem>
-      )
-    }
-    return;
+    return (
+      <MenuItem
+        // when the suggested is selected, put the private IP in the field
+        {...itemProps({ item: privateIP })}
+        key={index}
+        component="div"
+        selected={isHighlighted}
+      >
+        {`${linode.label} ${privateIP}`}
+      </MenuItem>
+    )
   }
 
   downshiftStateReducer = (state: DownshiftState, changes: StateChangeOptions) => {
@@ -831,7 +824,6 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                 inputValue,
                                 highlightedIndex,
                               }) => {
-                                console.log(node.address);
                                 return (
                                   <div>
                                     <TextField
@@ -851,9 +843,19 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                     {isOpen && !!inputValue &&
                                       <Paper>
                                         {linodesWithPrivateIPs && linodesWithPrivateIPs
+                                        // filter out the linodes that don't match what we're typing
+                                        // filter by private ip and label
+                                          .filter((linode: Linode.Linode) => {
+                                            const privateIP = linode.ipv4.find(ipv4 => ipv4.includes('192.168'));
+                                            return linode.label.includes(inputValue.toLowerCase())
+                                              || privateIP!.includes(inputValue.toLowerCase())
+                                          })
+                                          // limit the results to 5. we don't want too
+                                          // many in the suggestions
+                                          .splice(0, 10)
+                                          // finally map over the results and render the suggestion
                                           .map((linode, index) => {
                                             return this.renderSearchSuggestion(
-                                              inputValue,
                                               linode,
                                               index,
                                               highlightedIndex,

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -405,6 +405,10 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
         });
         this.setState({ linodesWithPrivateIPs });
       })
+      // we don't really need to do anything here because if the request fails
+      // the user won't be presented with any suggestions when typing in the
+      // node address field, which isn't the end of the world.
+      .catch(err => err);
   }
 
   render() {

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -163,8 +163,9 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
   onNodeLabelChange = (configIdx: number, nodeIdx: number, value: string) =>
     this.setNodeValue(configIdx, nodeIdx, 'label', value)
 
-  onNodeAddressChange = (configIdx: number, nodeIdx: number, value: string) =>
-    this.setNodeValue(configIdx, nodeIdx, 'address', value)
+  onNodeAddressChange = (configIdx: number, nodeIdx: number, value: string) => {
+    this.setNodeValue(configIdx, nodeIdx, 'address', value);
+  }
 
   onNodePortChange = (configIdx: number, nodeIdx: number, value: string) =>
     this.setNodeValue(configIdx, nodeIdx, 'port', value)
@@ -402,7 +403,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
         const linodesWithPrivateIPs = result.data.filter((linode) => {
           return linode.ipv4.some(ipv4 => ipv4.includes('192.168')); // does it have a private IP address
         });
-        this.setState({linodesWithPrivateIPs});
+        this.setState({ linodesWithPrivateIPs });
       })
   }
 

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -48,6 +48,8 @@ import {
 } from './utils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
+import { getLinodes } from 'src/services/linodes';
+
 type Styles =
   'root'
   | 'main'
@@ -88,6 +90,7 @@ interface NodeBalancerFieldsState {
 }
 
 interface State {
+  linodesWithPrivateIPs: Linode.Linode[];
   submitting: boolean;
   nodeBalancerFields: NodeBalancerFieldsState;
   errors?: Linode.ApiFieldError[];
@@ -120,6 +123,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
   };
 
   state: State = {
+    linodesWithPrivateIPs: [],
     submitting: false,
     nodeBalancerFields: NodeBalancerCreate.defaultFieldsStates,
     deleteConfigConfirmDialog:
@@ -391,6 +395,16 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     </Button>
     </ActionsPanel>
   )
+
+  componentDidMount() {
+    getLinodes()
+      .then(result => {
+        const linodesWithPrivateIPs = result.data.filter((linode) => {
+          return linode.ipv4.some(ipv4 => ipv4.includes('192.168')); // does it have a private IP address
+        });
+        this.setState({linodesWithPrivateIPs});
+      })
+  }
 
   render() {
     const { classes, regions } = this.props;

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -400,8 +400,9 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
   componentDidMount() {
     getLinodes()
       .then(result => {
+        const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
         const linodesWithPrivateIPs = result.data.filter((linode) => {
-          return linode.ipv4.some(ipv4 => ipv4.includes('192.168')); // does it have a private IP address
+          return linode.ipv4.some(ipv4 => !!ipv4.match(privateIPRegex)); // does it have a private IP address
         });
         this.setState({ linodesWithPrivateIPs });
       })

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -408,7 +408,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
 
   render() {
     const { classes, regions } = this.props;
-    const { nodeBalancerFields } = this.state;
+    const { nodeBalancerFields, linodesWithPrivateIPs } = this.state;
     const hasErrorFor = getAPIErrorFor(errorResources, this.state.errors);
     const generalError = hasErrorFor('none');
 
@@ -472,6 +472,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
                   return <Paper key={idx} style={{ padding: 24, margin: 8, width: '100%' }}>
                     <NodeBalancerConfigPanel
                       errors={nodeBalancerConfig.errors}
+                      linodesWithPrivateIPs={linodesWithPrivateIPs}
                       configIdx={idx}
 
                       algorithm={view(algorithmLens, this.state)}

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -874,8 +874,9 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
   componentDidMount() {
     getLinodes()
       .then(result => {
+        const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
         const linodesWithPrivateIPs = result.data.filter((linode) => {
-          return linode.ipv4.some(ipv4 => ipv4.includes('192.168')); // does it have a private IP address
+          return linode.ipv4.some(ipv4 => !!ipv4.match(privateIPRegex)); // does it have a private IP address
         });
         this.setState({ linodesWithPrivateIPs });
       })

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -24,6 +24,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import Typography from '@material-ui/core/Typography';
 
+import { getLinodes } from 'src/services/linodes';
 import {
   getNodeBalancerConfigs,
   updateNodeBalancerConfig,
@@ -77,6 +78,7 @@ interface PreloadedProps {
 }
 
 interface State {
+  linodesWithPrivateIPs: Linode.Linode[],
   configs: NodeBalancerConfigFields[];
   configErrors: Linode.ApiFieldError[][];
   configSubmitting: boolean[];
@@ -133,6 +135,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
   };
 
   state: State = {
+    linodesWithPrivateIPs: [],
     configs: pathOr([], ['response'], this.props.configs),
     configErrors: [],
     configSubmitting: [],
@@ -768,6 +771,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
         heading={`Port ${config.port !== undefined ? config.port : ''}`}
       >
         <NodeBalancerConfigPanel
+          linodesWithPrivateIPs={this.state.linodesWithPrivateIPs}
           forEdit
           configIdx={idx}
           onSave={this.onSaveConfig(idx)}
@@ -866,6 +870,16 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
     </Button>
     </ActionsPanel>
   )
+
+  componentDidMount() {
+    getLinodes()
+      .then(result => {
+        const linodesWithPrivateIPs = result.data.filter((linode) => {
+          return linode.ipv4.some(ipv4 => ipv4.includes('192.168')); // does it have a private IP address
+        });
+        this.setState({ linodesWithPrivateIPs });
+      })
+  }
 
   render() {
     const { classes } = this.props;

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -879,6 +879,10 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
         });
         this.setState({ linodesWithPrivateIPs });
       })
+      // we don't really need to do anything here because if the request fails
+      // the user won't be presented with any suggestions when typing in the
+      // node address field, which isn't the end of the world.
+      .catch(err => err);
   }
 
   render() {

--- a/src/services/networking.ts
+++ b/src/services/networking.ts
@@ -7,11 +7,19 @@ export const updateIP = (address: string, payload: any) =>
     setData(payload),
     setMethod('PUT'),
   )
-  .then(response => response.data);
+    .then(response => response.data);
 
-  export const assignAddresses = (data: any) =>
-    Request(
-      setURL(`${API_ROOT}/networking/ipv4/assign`),
-      setMethod('POST'),
-      setData(data),
-    );
+export const assignAddresses = (data: any) =>
+  Request(
+    setURL(`${API_ROOT}/networking/ipv4/assign`),
+    setMethod('POST'),
+    setData(data),
+  );
+
+export const getIPs = () => {
+  return Request<Linode.ResourcePage<Linode.IPAddress>>(
+    setURL(`${API_ROOT}/networking/ips`),
+    setMethod('GET'),
+  )
+    .then(response => response.data);
+}

--- a/src/types/Linode.ts
+++ b/src/types/Linode.ts
@@ -40,8 +40,8 @@ namespace Linode {
   }
 
   export interface LinodeBackupSchedule {
-    window: string;
-    day: string;
+    window: string | null;
+    day: string | null;
   }
 
   export interface LinodeBackupsResponse {


### PR DESCRIPTION
### Purpose
 
AutoComplete suggestion dropdown for NodeBalancer node addresses

### To Test

1. Either go to the Create or Edit flow for a NodeBalancer
2. Scroll down to your nodes and begin either typing a Linode's label or a private IP address
3. Watch the suggestions appear 💯 

### Notes

* You're only going to get suggestion for Linodes that have private IPs.
* Only 10 suggestions will show at a time. We can raise that or lower that, and I'm ready to debate about it
* The user doesn't have to select a dropdown suggestion. If they choose, they can certainly just type in the IP address themselves

### Misc
* We can assume that any ipv4 from the API that begins with `192.168` is a private one

### References

[Downshift](https://github.com/paypal/downshift)