### PR TITLE
Tooltip messages on mobile

### DIFF
--- a/src/components/HelpIcon/HelpIcon.tsx
+++ b/src/components/HelpIcon/HelpIcon.tsx
@@ -60,6 +60,8 @@ class HelpIcon extends React.Component<CombinedProps, State> {
         <Tooltip 
           title={text}
           data-qa-help-tootlip
+          enterTouchDelay={0}
+          leaveTouchDelay={5000}
         > 
           <IconButton data-qa-help-button>
             <HelpOutline />

--- a/src/components/HelpIcon/HelpIcon.tsx
+++ b/src/components/HelpIcon/HelpIcon.tsx
@@ -59,7 +59,7 @@ class HelpIcon extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <Tooltip 
           title={text}
-          data-qa-help-tootlip
+          data-qa-help-tooltip
           enterTouchDelay={0}
           leaveTouchDelay={5000}
         > 


### PR DESCRIPTION
MUI tooltips have an enterTouchDelay prop that makes the tooltip appear too late on touch. I set it to 0 and make the tooltip fade away at 5s if no other touch event happens.