### PR TITLE
M3-525

### DIFF
--- a/e2e/specs/create/create-volume.spec.js
+++ b/e2e/specs/create/create-volume.spec.js
@@ -24,7 +24,7 @@ describe('Create - Volume Suite', () => {
 
     it('should display create volumes option in global create menu', () => {
         ListLinodes.globalCreate.click();
-        ListLinodes.addVolumeMenu.waitForVisible();
+        ListLinodes.addVolumeMenu.waitForVisible(constants.wait.normal);
     });
 
     it('should display global volume create drawer', () => {
@@ -36,14 +36,14 @@ describe('Create - Volume Suite', () => {
 
     it('should display form error on create without a label', () => {
         VolumeDetail.createVolume(testVolume, true);
-        VolumeDetail.label.$('p').waitForText();
+        VolumeDetail.label.$('p').waitForText(constants.wait.normal);
         VolumeDetail.closeVolumeDrawer();
     });
 
     it('should display a error notice on create without region', () => {
         testVolume['label'] = `ASD${new Date().getTime()}`;
         VolumeDetail.createVolume(testVolume, true);
-        VolumeDetail.notice.waitForVisible();
+        VolumeDetail.notice.waitForVisible(constants.wait.normal);
         VolumeDetail.closeVolumeDrawer();
     });
 
@@ -58,7 +58,7 @@ describe('Create - Volume Suite', () => {
             return VolumeDetail.getVolumeId(testVolume.label).length > 0;
         }, 10000);
 
-        VolumeDetail.volumeCellElem.waitForVisible();
+        VolumeDetail.volumeCellElem.waitForVisible(constants.wait.normal);
         VolumeDetail.removeAllVolumes();
     });
 
@@ -68,12 +68,17 @@ describe('Create - Volume Suite', () => {
 
         VolumeDetail.createVolume(testVolume, true);
 
-        VolumeDetail.volumeCellElem.waitForVisible();
+        VolumeDetail.volumeCellElem.waitForVisible(constants.wait.normal);
         VolumeDetail.removeAllVolumes();
     });
 
     afterAll(() => {
         apiDeleteAllLinodes();
-        apiDeleteAllVolumes();
+        try {
+            // attempt to remove all volumes, in case the ui failed
+            apiDeleteAllVolumes();
+        } catch (err) {
+            // do nothing
+        }
     });
 });

--- a/e2e/specs/linodes/detail/edit-clone-resize-volumes.spec.js
+++ b/e2e/specs/linodes/detail/edit-clone-resize-volumes.spec.js
@@ -54,7 +54,12 @@ describe('Edit - Clone - Resize Volumes Suite', () => {
         VolumeDetail.removeAllVolumes();
 
         apiDeleteAllLinodes();
-        apiDeleteAllVolumes();
+        try {
+            // API remove all volumes, in case the UI fails to
+            apiDeleteAllVolumes();
+        } catch (err) {
+            // do nothing
+        }
     });
 
     it('should edit the volume label', () => {

--- a/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/src/features/ToastNotifications/ToastNotifications.tsx
@@ -171,6 +171,11 @@ class Notifier extends React.Component<CombinedProps, State> {
     this.subscription.unsubscribe();
   }
 
+  onExited = () => this.setState(
+    { toasts: removeFirstToast(this.state.toasts) },
+    () => this.setState(({ toasts: openFirstToast(this.state.toasts) })),
+  );
+
   render() {
     const { classes } = this.props;
     const { toasts } = this.state;
@@ -187,13 +192,7 @@ class Notifier extends React.Component<CombinedProps, State> {
           open={Boolean(toast.open)}
           autoHideDuration={6000}
           onClose={this.onClose}
-          onExited={() => {
-            this.setState({ toasts: removeFirstToast(this.state.toasts) },
-              () => {
-                this.setState(({ toasts: openFirstToast(this.state.toasts) }));
-              },
-            );
-          }}
+          onExited={this.onExited}
           ContentProps={{
             className:
               classNames({

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -619,7 +619,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
           </Button>
           <Button
             onClick={this.onClose}
-            type="secondary"
+            type="cancel"
             data-qa-cancel
           >
             Cancel

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -125,12 +125,15 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
         !event._initial
         && [
           'volume_detach',
+          'volume_create',
         ].includes(event.action)
       ))
       .subscribe((event) => {
-        if (event.action === 'volume_detach'
-            && event.status === 'finished') {
+        if (event.status === 'finished') {
           sendToast(`Volume ${event.entity && event.entity.label} finished detaching`);
+        }
+        if (event.action === ('volume_create' as Linode.EventAction) && event.status === 'notification') {
+          sendToast(`Volume ${event.entity && event.entity.label} created successfully.`);
         }
       });
   }

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -133,7 +133,8 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
   };
 
   handleAPIErrorResponse = (errorResponse: any) => this.composeState([
-    set(L.errors, path(['response', 'data', 'errors'], errorResponse))
+    set(L.errors, path(['response', 'data', 'errors'], errorResponse)),
+    set(L.submitting, false)
   ], () => scrollErrorIntoView());
 
   composeState = (fns: ((s: State) => State)[], callback?: () => void) =>
@@ -223,7 +224,18 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       });
   }
 
+  reset = () => this.composeState([
+    set(L.cloneLabel, ''),
+    set(L.errors, undefined),
+    set(L.label, ''),
+    set(L.linodeId, 0),
+    set(L.region, 'none'),
+    set(L.submitting, false),
+    set(L.success, undefined),
+  ]);
+
   onClose = () => {
+    this.reset();
     this.props.close();
   }
 
@@ -266,7 +278,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
 
         if (!label) {
           this.composeState([
-            set(L.errors, [{ filed: 'label', reason: 'Label cannot be blank.' }])
+            set(L.errors, [{ field: 'label', reason: 'Label cannot be blank.' }])
           ], () => scrollErrorIntoView());
 
           return;
@@ -344,7 +356,11 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
 
   setSelectedLinode = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (this.mounted) { this.setState({ linodeId: +(e.target.value) }); }
-    if (e.target.value) {
+    /**
+     * linodeId of 0 indicates user has selected the "Select a Linode" option, and we
+     * dont need to get configs for it.
+     */
+    if (e.target.value && +e.target.value !== 0) {
       this.updateConfigs(+e.target.value);
     }
   }

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -15,7 +15,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
 
-
+import AddNewLink from 'src/components/AddNewLink';
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import Grid from 'src/components/Grid';
 import Table from 'src/components/Table';
@@ -27,7 +27,7 @@ import { getLinodes } from 'src/services/linodes';
 import { _delete, detach,  } from 'src/services/volumes';
 
 import { generateInFilter, resetEventsPolling } from 'src/events';
-import { openForClone, openForEdit, openForResize,  } from 'src/store/reducers/volumeDrawer';
+import { openForClone, openForCreating, openForEdit, openForResize,  } from 'src/store/reducers/volumeDrawer';
 
 import DestructiveVolumeDialog from './DestructiveVolumeDialog';
 import VolumeAttachmentDrawer from './VolumeAttachmentDrawer';
@@ -48,6 +48,7 @@ interface Props {
   openForEdit: typeof openForEdit;
   openForResize: typeof openForResize;
   openForClone: typeof openForClone;
+  openForCreating: typeof openForCreating;
 }
 
 interface State {
@@ -146,6 +147,11 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     });
   }
 
+  openCreateVolumeDrawer = (e: any) => {
+    this.props.openForCreating();
+    e.preventDefault();
+}
+
   detachVolume = () => {
     const { destructiveDialog: { volumeID } } = this.state;
     if (!volumeID) { return; }
@@ -187,11 +193,21 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     const { linodeLabels, linodeStatuses } = this.state;
     return (
       <React.Fragment>
-        <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }} >
+        <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }}>
           <Grid item>
-            <Typography variant="headline" data-qa-title className={classes.title}>
+            <Typography variant="headline" className={classes.title} data-qa-title >
               Volumes
             </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container alignItems="flex-end">
+              <Grid item>
+                <AddNewLink
+                  onClick={this.openCreateVolumeDrawer}
+                  label="Create a Volume"
+                />
+              </Grid>
+            </Grid>
           </Grid>
         </Grid>
         <Paper>
@@ -203,7 +219,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                 <TableCell>Size</TableCell>
                 <TableCell>File System Path</TableCell>
                 <TableCell>Region</TableCell>
-                <TableCell></TableCell>
+                <TableCell/>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -322,7 +338,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) => bindActionCreators(
-  { openForEdit, openForResize, openForClone },
+  { openForEdit, openForResize, openForClone, openForCreating },
   dispatch,
 );
 

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -1,35 +1,38 @@
 import * as React from 'react';
-import { compose, pathOr, equals } from 'ramda';
-import {
-  withStyles,
-  StyleRulesCallback,
-  Theme,
-  WithStyles,
-} from '@material-ui/core/styles';
-import { bindActionCreators } from 'redux';
-import { connect, Dispatch } from 'react-redux';
 
-import Typography from '@material-ui/core/Typography';
+import { compose, equals, pathOr } from 'ramda';
+
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+
+import { connect, Dispatch } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+
 import Paper from '@material-ui/core/Paper';
-import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
-import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+
 
 import setDocs from 'src/components/DocsSidebar/setDocs';
-import Table from 'src/components/Table';
 import Grid from 'src/components/Grid';
-import { getLinodes } from 'src/services/linodes';
-import { dcDisplayNames } from 'src/constants';
-import { sendToast } from 'src/features/ToastNotifications/toasts';
-import { generateInFilter, resetEventsPolling } from 'src/events';
-import { openForEdit, openForResize, openForClone } from 'src/store/reducers/volumeDrawer';
-import { detach, _delete } from 'src/services/volumes';
+import Table from 'src/components/Table';
 
-import VolumesActionMenu from './VolumesActionMenu';
-import VolumeConfigDrawer from './VolumeConfigDrawer';
-import VolumeAttachmentDrawer from './VolumeAttachmentDrawer';
+import { sendToast } from 'src/features/ToastNotifications/toasts';
+
+import { dcDisplayNames } from 'src/constants';
+import { getLinodes } from 'src/services/linodes';
+import { _delete, detach,  } from 'src/services/volumes';
+
+import { generateInFilter, resetEventsPolling } from 'src/events';
+import { openForClone, openForEdit, openForResize,  } from 'src/store/reducers/volumeDrawer';
+
 import DestructiveVolumeDialog from './DestructiveVolumeDialog';
+import VolumeAttachmentDrawer from './VolumeAttachmentDrawer';
+import VolumeConfigDrawer from './VolumeConfigDrawer';
+import VolumesActionMenu from './VolumesActionMenu';
 
 type ClassNames = 'root' | 'title';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,6 +121,8 @@ namespace Linode {
     'stackscript_publicize' |
     'stackscript_revise' |
     'stackscript_delete' |
+    'volume_create' |
+    'volume_delete' |
     'volume_detach';
 
   export type EventStatus =

--- a/tslint.json
+++ b/tslint.json
@@ -29,7 +29,7 @@
     "no-shadowed-variable": { "severity": "warning"},
     "no-string-literal": { "severity": "warning" },
     "no-unused-expression": { "severity": "warning" },
-    "object-literal-sort-keys": { "severity": "warning" },
+    "object-literal-sort-keys": false,
     "only-arrow-functions": { "severity": "warning" },
     "ordered-imports": { "severity": "warning" },
     "prefer-for-of": {"severity": "warning"},


### PR DESCRIPTION
## Purpose
Volume creation is asynchronous and we needed a pattern for acknowledging the request was successful, and then notifying the user that the creation was successful.

We now display a message within the drawer that the volume was queued for creation. The drawer will then close automatically (after 4 seconds). When the volume has been created (and optionally attached) a toast notification displays alerting the user.

## Gold Plating
- Updated usage of Button to our abstraction.
- Added submitting state.
- Added composeState instance method.
- Added lenses for state composition.
- Added generic API request catch handler.