### PR TITLE
Nodebalancers - Update E2E Tests for Fast Track

### DIFF
--- a/e2e/pageobjects/list-linodes.js
+++ b/e2e/pageobjects/list-linodes.js
@@ -126,7 +126,7 @@ export class ListLinodes extends Page {
     powerOff(linode) {
         linode.$(this.linodeActionMenu.selector).click();
         this.powerOffMenu.click();
-        this.acceptDialog('Powering Down');
+        this.acceptDialog('Powering Off');
         
         browser.waitUntil(function() {
             return browser.isVisible('[data-qa-status="offline"]');

--- a/e2e/pageobjects/list-nodebalancers.page.js
+++ b/e2e/pageobjects/list-nodebalancers.page.js
@@ -23,7 +23,7 @@ class ListNodeBalancers extends Page {
 
         this.nodeBalancers.forEach(nb => {
             expect(nb.$(this.label.selector).isVisible()).toBe(true);
-            expect(nb.$(this.nodeStatus.selector).getText()).toMatch(/\d* up, \d* down$/m);
+            expect(nb.$(this.nodeStatus.selector).getText()).toMatch(/\d* up\s\d down/gm);
             expect(nb.$(this.transferred.selector).getText()).toMatch(/\d* bytes/ig);
             expect(nb.$(this.ports.selector).getText()).toMatch(/\d/);
             expect(nb.$(this.ips.selector).getText()).toMatch(/\b((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}\b/g);

--- a/e2e/pageobjects/nodebalancer-detail/configurations.page.js
+++ b/e2e/pageobjects/nodebalancer-detail/configurations.page.js
@@ -1,0 +1,24 @@
+const { constants } = require('../../constants');
+
+import Page from '../page';
+
+class NodeBalancerConfigurations extends Page {
+    get panels() { return $$('[data-qa-panel]'); }
+    get tabPanels() { return $$('[data-qa-panel-summary]'); }   
+    get gridItems() { return $$('[data-qa-grid-item]'); }
+    get panelSubheadings() { return $$('[data-qa-panel-subheading="true"]'); }
+    get save() { return $('[data-qa-label-save]'); }
+    get portConfigHeader() { return $('[data-qa-port-config-header]'); }
+
+    baseElemsDisplay() {
+        expect(this.tabPanels.length).toBe(1);
+        expect(this.panelSubheadings.length).toBe(1);
+    }
+
+    expandConfiguration(configPanel) {
+        configPanel.click();
+        this.portConfigHeader.waitForText();
+    }
+}
+
+export default new NodeBalancerConfigurations();

--- a/e2e/pageobjects/nodebalancer-detail/settings.page.js
+++ b/e2e/pageobjects/nodebalancer-detail/settings.page.js
@@ -3,32 +3,29 @@ const { constants } = require('../../constants');
 import Page from '../page';
 
 class NodeBalancerSettings extends Page {
-    get tabPanels() { return $$('[data-qa-panel-summary]'); }
-    get gridItems() { return $$('[data-qa-grid-item]'); }
-    get panelSubheadings() { return $$('[data-qa-panel-subheading="true"]'); }
     get label() { return $('[data-qa-label-panel] input'); }
     get save() { return $('[data-qa-label-save]'); }
     get connectionThrottle() { return $('[data-qa-connection-throttle] input'); }
 
     baseElemsDisplay() {
-        expect(this.tabPanels.length).toBe(2);
-        expect(this.panelSubheadings.length).toBe(2);
+        expect(this.label.isVisible()).toBe(true);
         expect(this.connectionThrottle.isVisible()).toBe(true);
         expect(this.connectionThrottle.getValue()).toBe('0');
-        expect($$('[data-qa-label-save]').length).toBe(2);   
+        expect(this.save.getTagName()).toBe('button');
+        expect(this.save.isVisible()).toBe(true);
     }
 
     changeLabel(label) {
         this.label.setValue(label);
-        this.gridItems[0].$(this.save.selector).click();
-        this.waitForNotice('Label updated successfully');
+        this.save.click();
+        this.waitForNotice('NodeBalancer settings updated successfully');
         expect(this.label.getValue()).toBe(label);
     }
 
     setConnectionThrottle(connections) {
         this.connectionThrottle.setValue(connections);
-        this.gridItems[1].$(this.save.selector).click();
-        this.waitForNotice('Client Connection Throttle updated successfully');
+        this.save.click();
+        this.waitForNotice('NodeBalancer settings updated successfully');
         expect(this.connectionThrottle.getValue()).toBe(String(connections));
     }
 }

--- a/e2e/pageobjects/nodebalancers.page.js
+++ b/e2e/pageobjects/nodebalancers.page.js
@@ -42,6 +42,7 @@ class NodeBalancers extends Page {
     get backendIps() { return $$('[data-qa-backend-ip]'); }
     get backendIpLabel() { return $('[data-qa-backend-ip-label] input'); }
     get backendIpAddress() { return $('[data-qa-backend-ip-address] input'); }
+    get backendIpPort() { return $('[data-qa-backend-ip-port] input'); }
     get backendIpWeight() { return $('[data-qa-backend-ip-weight] input'); }
     get backendIpMode() { return $('[data-qa-backend-ip-mode]'); }
 
@@ -63,21 +64,16 @@ class NodeBalancers extends Page {
             expect(this.regionTabs.length).toBeGreaterThan(0);
             expect(this.regionCards.length).toBeGreaterThan(0);
 
-            expect(this.connectionThrottleSection.isVisible()).toBe(true);
-            expect(this.connectionThrottle.isVisible()).toBe(true);
+            // expect(this.connectionThrottleSection.isVisible()).toBe(true);
+            // expect(this.connectionThrottle.isVisible()).toBe(true);
             expect(this.settingsSection.isVisible()).toBe(true);
             expect(this.port.isVisible()).toBe(true);
             expect(this.protocolSelect.isVisible()).toBe(true);
-            expect(this.algorithmHeader.waitForText()).toBe(true);
             expect(this.algorithmSelect.getText()).toContain('Round Robin');
-            expect(this.sessionStickinessHeader.waitForText()).toBe(true);
             expect(this.sessionStickiness.getText()).toContain('Table');
             
             expect(this.activeChecksHeader.isVisible()).toBe(true);
-            expect(this.activeCheckAttempts.getValue()).toBe('2');
-            expect(this.activeCheckTimeout.getValue()).toBe('3');
             expect(this.activeCheckType.isVisible()).toBe(true);
-            expect(this.activeCheckInterval.getValue()).toBe('5');
 
             expect(this.passiveChecksHeader.waitForText()).toBe(true);
             expect(this.passiveChecksToggle.isVisible()).toBe(true);
@@ -85,8 +81,8 @@ class NodeBalancers extends Page {
             expect(this.backendIpsHeader.waitForText()).toBe(true);
             expect(this.backendIpLabel.isVisible()).toBe(true);
             expect(this.backendIpAddress.isVisible()).toBe(true);
+            expect(this.backendIpPort.isVisible()).toBe(true);
             expect(this.backendIpWeight.getValue()).toBe('100');
-            expect(this.backendIpMode.getText()).toContain('Accept');
         }
     }
 
@@ -114,6 +110,7 @@ class NodeBalancers extends Page {
         expect(this.backendIpsHeader.waitForText()).toBe(true);
         expect(this.backendIpLabel.isVisible()).toBe(true);
         expect(this.backendIpAddress.isVisible()).toBe(true);
+        expect(this.backendIpPort.isVisible()).toBe(true);
         expect(this.backendIpWeight.getValue()).toBe('100');
         expect(this.backendIpMode.getText()).toContain('Accept');
     }
@@ -199,7 +196,8 @@ class NodeBalancers extends Page {
         this.selectMenuOption(this.algorithmSelect, nodeBalancerConfig.algorithm);
         this.selectMenuOption(this.sessionStickiness, nodeBalancerConfig.sessionStickiness);
         this.backendIpLabel.setValue(linodeConfig.label);
-        this.backendIpAddress.setValue(`${linodeConfig.privateIp}:${nodeBalancerConfig.port}`);
+        this.backendIpAddress.setValue(linodeConfig.privateIp);
+        this.backendIpPort.setValue(linodeConfig.port);
         browser.jsClick('[data-qa-deploy-linode]');
     }
 

--- a/e2e/pageobjects/nodebalancers.page.js
+++ b/e2e/pageobjects/nodebalancers.page.js
@@ -50,7 +50,7 @@ class NodeBalancers extends Page {
     get deleteButton() { return $('[data-qa-delete-config]'); }
     get nodes() { return $$('[data-qa-node]'); }
     get removeNode() { return $('[data-qa-remove-node]'); }
-    get addNode() { return $('[data-qa-add-node]'); }
+    get addNode() { return $('[data-qa-icon-text-link="Add a Node"]'); }
     get addConfiguration() { return $('[data-qa-add-config]'); }
 
     baseElemsDisplay(initial) {
@@ -93,19 +93,17 @@ class NodeBalancers extends Page {
 
         expect(this.port.isVisible()).toBe(true);
         expect(this.protocolSelect.isVisible()).toBe(true);
-        expect(this.algorithmHeader.waitForText()).toBe(true);
         expect(this.algorithmSelect.getText()).toContain('Round Robin');
-        expect(this.sessionStickinessHeader.waitForText()).toBe(true);
+        // expect(this.sessionStickinessHeader.waitForText()).toBe(true);
         expect(this.sessionStickiness.getText()).toContain('Table');
 
         expect(this.activeChecksHeader.isVisible()).toBe(true);
-        expect(this.activeCheckAttempts.getValue()).toBe('2');
-        expect(this.activeCheckTimeout.getValue()).toBe('3');
-        expect(this.activeCheckType.isVisible()).toBe(true);
-        expect(this.activeCheckInterval.getValue()).toBe('5');
+        // expect(this.activeCheckTimeout.getValue()).toBe('3');
+        expect(this.activeCheckType.getText()).toContain('None');
+        // expect(this.activeCheckInterval.getValue()).toBe('5');
 
         expect(this.passiveChecksHeader.waitForText()).toBe(true);
-        expect(this.passiveChecksToggle.isVisible()).toBe(true);
+        expect(this.passiveChecksToggle.getAttribute('data-qa-passive-checks-toggle')).toBe('true');
 
         expect(this.backendIpsHeader.waitForText()).toBe(true);
         expect(this.backendIpLabel.isVisible()).toBe(true);
@@ -113,6 +111,11 @@ class NodeBalancers extends Page {
         expect(this.backendIpPort.isVisible()).toBe(true);
         expect(this.backendIpWeight.getValue()).toBe('100');
         expect(this.backendIpMode.getText()).toContain('Accept');
+        expect(this.addNode.isVisible()).toBe(true);
+        expect(this.addNode.getTagName()).toBe('button');
+        expect(this.addConfiguration.getTagName()).toBe('button');
+        expect(this.addConfiguration.getText()).toBe('Add another Configuration');
+        expect(this.removeNode.isVisible()).toBe(true)
     }
 
     configDelete() {
@@ -136,6 +139,7 @@ class NodeBalancers extends Page {
 
 
     configAddNode(nodeConfig) {
+        this.addNode.click();
         const labels = $$('[data-qa-backend-ip-label] input')
             .filter(label => label.getValue() === '');
         const ips = $$('[data-qa-backend-ip-address] input')
@@ -159,7 +163,7 @@ class NodeBalancers extends Page {
     }
 
     configSave() {
-        const successMsg = 'NodeBalancer config updated successfully'; 
+        const successMsg = 'NodeBalancer Configuration updated successfully'; 
         this.saveButton.click();
         this.waitForNotice(successMsg);
     }
@@ -178,7 +182,7 @@ class NodeBalancers extends Page {
         label: `NB-${new Date().getTime()}`,
         regionIndex: 0,
         connectionThrottle: 0,
-        port: 80,
+        port: '80',
         protocol: 'http',
         algorithm: 'roundrobin',
         sessionStickiness: 'table',
@@ -197,7 +201,7 @@ class NodeBalancers extends Page {
         this.selectMenuOption(this.sessionStickiness, nodeBalancerConfig.sessionStickiness);
         this.backendIpLabel.setValue(linodeConfig.label);
         this.backendIpAddress.setValue(linodeConfig.privateIp);
-        this.backendIpPort.setValue(linodeConfig.port);
+        this.backendIpPort.setValue(80);
         browser.jsClick('[data-qa-deploy-linode]');
     }
 

--- a/e2e/specs/nodebalancers/configurations.spec.js
+++ b/e2e/specs/nodebalancers/configurations.spec.js
@@ -1,4 +1,6 @@
+const { constants } = require('../../constants');
 import NodeBalancers from '../../pageobjects/nodebalancers.page';
+import NodeBalancerConfigurations from '../../pageobjects/nodebalancer-detail/configurations.page';
 import {
     createNodeBalancer,
     removeNodeBalancers,
@@ -8,13 +10,18 @@ describe('NodeBalancer - Configurations Suite', () => {
     let nodeLabel,
         nodeIp;
 
-    beforeAll(() => {
-        createNodeBalancer();
-        NodeBalancers.changeTab('Configurations');
-    });
-
     afterAll(() => {
         removeNodeBalancers();
+    });
+
+    it('should configure the nodebalancer', () => {
+        createNodeBalancer();
+        NodeBalancers.changeTab('Configurations');
+        browser.waitForVisible('[data-qa-panel]', constants.wait.normal);
+        
+        const configPanel = NodeBalancerConfigurations.panels[0];
+        
+        NodeBalancerConfigurations.expandConfiguration(configPanel);
     });
 
     it('should display default configuration', () => {

--- a/e2e/specs/nodebalancers/create.spec.js
+++ b/e2e/specs/nodebalancers/create.spec.js
@@ -39,8 +39,8 @@ describe('Nodebalancer - Create Suite', () => {
     });
 
     it('should fail to create without choosing a backend ip', () => {
-        const labelError = '"label" length must be at least 3 characters long';
-        const addressError = '"address" with value "" fails to match the required pattern';
+        const labelError = 'Label must be at least 3 characters';
+        const addressError = 'IP Address must be a Linode private address';
 
         NodeBalancers.regionCards[0].click();
         browser.jsClick('[data-qa-deploy-linode]');
@@ -53,8 +53,9 @@ describe('Nodebalancer - Create Suite', () => {
     });
 
     it('should create a nodebalancer with a valid backend ip', () => {
-        NodeBalancers.backendIpLabel.setValue(linode.label);
-        NodeBalancers.backendIpAddress.setValue(`${linode.privateIp}:80`);
+        NodeBalancers.backendIpLabel.addValue(linode.label);
+        NodeBalancers.backendIpAddress.addValue(linode.privateIp);
+        NodeBalancers.backendIpPort.setValue('80');
         browser.jsClick('[data-qa-deploy-linode]');
         
         NodeBalancerDetail.baseElemsDisplay();

--- a/e2e/specs/nodebalancers/error-handling.spec.js
+++ b/e2e/specs/nodebalancers/error-handling.spec.js
@@ -1,4 +1,5 @@
 const { constants } = require('../../constants');
+const { merge } = require('ramda');
 
 import NodeBalancers from '../../pageobjects/nodebalancers.page';
 import {
@@ -7,9 +8,11 @@ import {
 } from '../../utils/common';
 
 describe('NodeBalancer - Negative Tests Suite', () => {
+    let linode;
+
     beforeAll(() => {
         const token = browser.readToken();
-        const linode = apiCreateLinode();
+        linode = apiCreateLinode();
         linode['privateIp'] = browser.allocatePrivateIp(token, linode.id).address;
         browser.url(constants.routes.nodeBalancers);
         NodeBalancers.baseElemsDisplay(true);
@@ -20,16 +23,14 @@ describe('NodeBalancer - Negative Tests Suite', () => {
         removeNodeBalancers();
     });
 
-    it('should display a service error msg on create with an invalid node', () => {
-        const badLinode = {
+    it('should display a service error msg on create with an invalid node name', () => {
+        const invalidLabel = {
             label: 'Something-NotLegit',
-            privateIp: '192.168.1.1',
-            port: '80',
         }
-        const noticeMsg = `Unable to create node ${badLinode.label}.`;
-        const serviceError = 'This address is not allowed.';
+        const invalidConfig = merge(linode, invalidLabel);
+        const serviceError = 'label must not contain any special characters. Only a-z0-9.-_ allowed';
 
-        NodeBalancers.configure(badLinode, {
+        NodeBalancers.configure(invalidConfig, {
             label: `NB-${new Date().getTime()}`,
             regionIndex: 0,
             connectionThrottle: 0,
@@ -44,7 +45,33 @@ describe('NodeBalancer - Negative Tests Suite', () => {
             passiveChecksToggle: true,
         });
 
-        NodeBalancers.waitForNotice(noticeMsg);
-        NodeBalancers.waitForNotice(serviceError);
+        browser.waitForVisible('[data-qa-backend-ip-label] p');
+        const errorMsg = $('[data-qa-backend-ip-label] p').getText();
+        expect(errorMsg).toBe(serviceError);
+    });
+
+    it('should fail to create a configuration with an invalid. ip', () => {
+        const invalidIp = { privateIp:'192.168.1.1'};
+        const invalidConfig = merge(linode, invalidIp);
+        const serviceError = 'This address is not allowed.';
+
+        NodeBalancers.configure(invalidConfig,  {
+            label: `NB-${new Date().getTime()}`,
+            regionIndex: 0,
+            connectionThrottle: 0,
+            port: 80,
+            protocol: 'http',
+            algorithm: 'roundrobin',
+            sessionStickiness: 'table',
+            activeCheckType: 'TCP Connection',
+            healthCheckInterval: 5,
+            healthCheckTimeout: 3,
+            healthCheckAttempts: 2,
+            passiveChecksToggle: true,
+        });
+
+        browser.waitForVisible('[data-qa-backend-ip-address] p');
+        const errorMsg = $('[data-qa-backend-ip-address] p').getText();
+        expect(errorMsg).toBe(serviceError);
     });
 });

--- a/e2e/specs/nodebalancers/error-handling.spec.js
+++ b/e2e/specs/nodebalancers/error-handling.spec.js
@@ -24,6 +24,7 @@ describe('NodeBalancer - Negative Tests Suite', () => {
         const badLinode = {
             label: 'Something-NotLegit',
             privateIp: '192.168.1.1',
+            port: '80',
         }
         const noticeMsg = `Unable to create node ${badLinode.label}.`;
         const serviceError = 'This address is not allowed.';

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -286,7 +286,12 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
               container
             >
               <Grid item xs={12}>
-                <Typography variant="title">Port Configuration</Typography>
+                <Typography
+                  variant="title"
+                  data-qa-port-config-header
+                >
+                  Port Configuration
+                </Typography>
               </Grid>
               <Grid item xs={12} md={4}>
                 <TextField
@@ -662,7 +667,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                     <Toggle
                       checked={checkPassive}
                       onChange={this.onCheckPassiveChange}
-                      data-qa-passive-checks-toggle
+                      data-qa-passive-checks-toggle={checkPassive}
                     />
                   }
                   label="Passive Checks"

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -412,6 +412,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
             {generalError && <Notice error>{generalError}</Notice>}
 
             <LabelAndTagsPanel
+              data-qa-label-input
               labelFieldProps={{
                 errorText: hasErrorFor('label'),
                 label: 'NodeBalancer Label',


### PR DESCRIPTION
* Updated nodebalancers tests to handle the changes introduced in the nodebalancer fast track work
* Updated list linodes powerOff action's assertion to "Powering off" (Although 'Powering Down' sounds more like regular english to be honest).

## To Test

```
yarn && yarn start
yarn selenium
yarn e2e -d nodebalancers
```

Tests take a while, because they create new linodes and a new nodebalancer per test spec. This will be much quicker when running on mocks.

```
22 passing (289.20s)
```