### PR TITLE
Consistency fixes

### DIFF
--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -13,6 +13,7 @@ type ClassNames = 'root' | 'destructive';
 
 interface Props {
   destructive?: boolean;
+  style?: any;
   onClick?: (e: React.SyntheticEvent<HTMLElement>) => void;
 }
 
@@ -35,7 +36,7 @@ const styles: StyleRulesCallback = (theme: Theme & Linode.Theme) => ({
 type CombinedProps = IconButtonProps & Props & WithStyles<ClassNames>;
 
 const IconButtonWrapper: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, destructive, ...rest } = props;
+  const { classes, destructive, style, ...rest } = props;
 
   return (
     <IconButton
@@ -43,6 +44,7 @@ const IconButtonWrapper: React.StatelessComponent<CombinedProps> = (props) => {
         [classes.root]: true,
         [classes.destructive]: destructive,
       })}
+      style={style}
       {...rest}
     >
       {props.children}

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -947,7 +947,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                           />
                         </Grid>
                         {forEdit &&
-                          <Grid item xs={11} lg={3}>
+                          <Grid item xs={12} lg={3} xl={2}>
                             <TextField
                               label="Mode"
                               value={node.mode}

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -852,7 +852,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                             <Divider style={{ marginTop: 24 }} />
                           </Grid>
                         }
-                        <Grid item xs={11} lg={4} xl={2}>
+                        <Grid item xs={11} lg={forEdit ? 2 : 3}>
                           <TextField
                             label="Label"
                             value={node.label}
@@ -922,7 +922,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                             }
                           </Downshift>
                         </Grid>
-                        <Grid item xs={11} lg={4} xl={2}>
+                        <Grid item xs={11} lg={2}>
                           <TextField
                             type="number"
                             label="Port"
@@ -934,7 +934,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                             data-qa-backend-ip-port
                           />
                         </Grid>
-                        <Grid item xs={11} lg={4} xl={2}>
+                        <Grid item xs={11} lg={2}>
                           <TextField
                             type="number"
                             label="Weight"
@@ -947,7 +947,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                           />
                         </Grid>
                         {forEdit &&
-                          <Grid item xs={11} lg={4} xl={2}>
+                          <Grid item xs={11} lg={3}>
                             <TextField
                               label="Mode"
                               value={node.mode}
@@ -985,6 +985,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                               onClick={this.removeNode}
                               destructive
                               data-qa-remove-node
+                              style={{  width: 'auto' }}
                             >
                               <Delete />
                             </IconButton>

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -25,12 +25,21 @@ import VolumeAttachmentDrawer from './VolumeAttachmentDrawer';
 import VolumeConfigDrawer from './VolumeConfigDrawer';
 import VolumesActionMenu from './VolumesActionMenu';
 
-type ClassNames = 'root' | 'title';
+type ClassNames = 'root'
+  | 'title'
+  | 'label'
+  | 'attachment';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {},
   title: {
     marginBottom: theme.spacing.unit * 2,
+  },
+  label: {
+    width: '15%',
+  },
+  attachment: {
+    width: '15%',
   },
 });
 
@@ -213,8 +222,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell>Label</TableCell>
-                <TableCell>Attachment</TableCell>
+                <TableCell className={classes.label}>Label</TableCell>
+                <TableCell className={classes.attachment}>Attachment</TableCell>
                 <TableCell>Size</TableCell>
                 <TableCell>File System Path</TableCell>
                 <TableCell>Region</TableCell>

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -173,7 +173,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   currentPlanContainer: {
     '& .selectionCard': {
-      padding: 0,
+      padding: `0 ${theme.spacing.unit}px 0 0`,
       cursor: 'not-allowed',
       '& > div, &:focus > div': {
         backgroundColor: theme.bg.main,

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -95,12 +95,12 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
                 disabled={submitting}
               />
             </Grid>
-            <Grid item xs={12} md={10}>
+            <Grid item xs={12} md={10} lg={8} xl={6}>
               <Typography>
                 Shutdown Watchdog, also known as Lassie, is a Linode Manager feature capable of
-              automatically rebooting your Linode if it powers off unexpectedly. <br />Lassie is not
-              technically an availability monitoring tool, but it can help get your Linode back
-              online fast if it’s accidentally powered off.
+                automatically rebooting your Linode if it powers off unexpectedly. Lassie is not
+                technically an availability monitoring tool, but it can help get your Linode back
+                online fast if it’s accidentally powered off.
               </Typography>
             </Grid>
           </Grid>

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -18,10 +18,13 @@ import Grid from 'src/components/Grid';
 import PanelErrorBoundary from 'src/components/PanelErrorBoundary';
 import Notice from 'src/components/Notice';
 
-type ClassNames = 'root';
+type ClassNames = 'root' | 'shutDownWatchdog';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {},
+  shutDownWatchdog: {
+    margin: `${theme.spacing.unit * 2}px 0`,
+  },
 });
 
 interface Props {
@@ -67,11 +70,12 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
 
   render() {
     const { currentStatus, submitting, success, errors } = this.state;
+    const { classes } = this.props;
 
     return (
       <React.Fragment>
         <ExpansionPanel defaultExpanded heading="Shutdown Watchdog">
-          <Grid container>
+          <Grid container alignItems="center" className={classes.shutDownWatchdog}>
             {
               (success || errors) &&
               <Grid item xs={12}>
@@ -94,7 +98,7 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
             <Grid item xs={12} md={10}>
               <Typography>
                 Shutdown Watchdog, also known as Lassie, is a Linode Manager feature capable of
-              automatically rebooting your Linode if it powers off unexpectedly. Lassie is not
+              automatically rebooting your Linode if it powers off unexpectedly. <br />Lassie is not
               technically an availability monitoring tool, but it can help get your Linode back
               online fast if it’s accidentally powered off.
               </Typography>

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -43,7 +43,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Linode.Theme) => {
     leftLegend: {
       position: 'absolute',
       left: -8,
-      bottom: 36,
+      bottom: 39,
       transform: 'rotate(-90deg)',
       color: '#777',
       fontSize: 14,
@@ -418,7 +418,7 @@ class LinodeSummary extends React.Component<CombinedProps, State> {
             >
               <React.Fragment>
                 <div className={classes.chart}>
-                  <div className={classes.leftLegend}>
+                  <div className={classes.leftLegend} style={{ left: -18, bottom: 48 }}>
                     blocks/sec
                     </div>
                   <LineGraph


### PR DESCRIPTION
- [x] Linode resize current plan card width (/linodes/[id]/resize)
- [x] Shutdown watchdog pane spacing (/linodes/[id]/settings)
- [x] charts left legend adjustments (/linodes/[id]/summary)
- [x] NodeBalancers backend nodes grid rework (/nodebalancers/[id]/configurations)
- [x] VolumeLanding table columns default width (page  load, avoid style jump => /volumes)