### PR TITLE
Sortable table headers

### DIFF
--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -15,13 +15,19 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     whiteSpace: 'nowrap',
   },
   sortable: {
-    color: theme.palette.text.primary,
+    color: theme.color.headline,
     fontWeight: 'normal',
     cursor: 'pointer',
     '& button': {
-      color: theme.palette.text.primary,
+      color: theme.color.headline,
       fontWeight: 'normal',
       fontSize: '.9rem',
+    },
+    '& .sortIcon': {
+      position: 'relative',
+      top: 2,
+      left: 10,
+      color: theme.palette.primary.main,
     },
   },
 });

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -18,7 +18,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     color: theme.color.headline,
     fontWeight: 'normal',
     cursor: 'pointer',
-    '& button': {
+    '& button, & button:focus': {
       color: theme.color.headline,
       fontWeight: 'normal',
       fontSize: '.9rem',

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+import * as classNames from 'classnames';
+
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import TableCell, { TableCellProps } from '@material-ui/core/TableCell';
+
+type ClassNames = 'root'
+  | 'noWrap'
+  | 'sortable';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  root: {},
+  noWrap: {
+    whiteSpace: 'nowrap',
+  },
+  sortable: {
+    color: theme.palette.text.primary,
+    fontWeight: 'normal',
+    cursor: 'pointer',
+    '& button': {
+      color: theme.palette.text.primary,
+      fontWeight: 'normal',
+      fontSize: '.9rem',
+    },
+  },
+});
+
+interface Props {
+  noWrap?: boolean;
+  sortable?: boolean;
+  className?: string;
+}
+
+type CombinedProps = Props & TableCellProps & WithStyles<ClassNames>;
+
+class WrappedTableCell extends React.Component<CombinedProps> {
+
+  render() {
+    const { classes, className, noWrap, sortable, ...rest } = this.props;
+
+    return (
+        <TableCell
+          className={classNames(
+          className,
+            {
+              [classes.root]: true,
+              [classes.noWrap]: noWrap,
+              [classes.sortable]: sortable,
+            })} 
+          {...rest
+        }>
+          {this.props.children}
+        </TableCell>
+    );
+  }
+}
+
+export default withStyles(styles, { withTheme: true })(WrappedTableCell);

--- a/src/components/TableCell/index.ts
+++ b/src/components/TableCell/index.ts
@@ -1,0 +1,2 @@
+import TableCell from './TableCell';
+export default TableCell;

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -5,12 +5,11 @@ import * as classNames from 'classnames';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
 import { connect } from 'react-redux';
-import { pathOr, compose } from 'ramda';
 
-import { getStackScriptsByUser, getCommunityStackscripts }
-  from 'src/services/stackscripts';
+import { compose, pathOr } from 'ramda';
 
-import TableCell from '@material-ui/core/TableCell';
+import { getCommunityStackscripts, getStackScriptsByUser } from 'src/services/stackscripts';
+
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 
@@ -21,6 +20,7 @@ import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
 import RenderGuard from 'src/components/RenderGuard';
 import TabbedPanel from 'src/components/TabbedPanel';
+import TableCell from 'src/components/TableCell';
 
 import StackScriptsSection from './StackScriptsSection';
 
@@ -42,7 +42,6 @@ type ClassNames = 'root'
   | 'revisions'
   | 'tr'
   | 'tableHead'
-  | 'sortable'
   | 'sortButton'
   | 'sortIcon'
   | 'table';
@@ -57,6 +56,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     paddingTop: 0,
     marginTop: theme.spacing.unit * 2,
     overflowY: 'scroll',
+    '-webkit-appearance': 'none',
   },
   selecting: {
     maxHeight: '1000px',
@@ -87,11 +87,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     zIndex: 10,
     paddingTop: 0,
     paddingBottom: 0,
-  },
-  sortable: {
-    color: theme.palette.primary.main,
-    fontWeight: 700,
-    cursor: 'pointer',
   },
   sortButton: {
     marginLeft: -26,
@@ -336,9 +331,9 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
               <TableCell
                 className={classNames({
                   [classes.tableHead]: true,
-                  [classes.sortable]: true,
                   [classes.stackscriptTitles]: true,
                 })}
+                sortable
               >
                 <Button
                   type="secondary"
@@ -354,9 +349,10 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
               <TableCell
                 className={classNames({
                   [classes.tableHead]: true,
-                  [classes.sortable]: true,
                   [classes.deploys]: true,
                 })}
+                noWrap
+                sortable
               >
                 <Button
                   type="secondary"
@@ -372,9 +368,10 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
               <TableCell
                 className={classNames({
                   [classes.tableHead]: true,
-                  [classes.sortable]: true,
                   [classes.revisions]: true,
                 })}
+                noWrap
+                sortable
               >
                 <Button
                   type="secondary"

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -360,7 +360,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
                   onClick={this.handleClickDeploymentsTableHeader}
                 >
                   Active Deploys
-                  {currentFilterType === 'deploys' &&
+                  {currentFilterType !== 'label' && currentFilterType !== 'revision' &&
                     this.renderIcon()
                   }
                 </Button>

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -43,7 +43,6 @@ type ClassNames = 'root'
   | 'tr'
   | 'tableHead'
   | 'sortButton'
-  | 'sortIcon'
   | 'table';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
@@ -72,10 +71,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     width: '30%',
   },
   deploys: {
-    width: '15%',
+    width: '20%',
   },
   revisions: {
-    width: '15%',
+    width: '20%',
   },
   tr: {
     height: 48,
@@ -93,11 +92,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     border: 0,
     width: '100%',
     justifyContent: 'flex-start',
-  },
-  sortIcon: {
-    position: 'relative',
-    top: 2,
-    left: 10,
   },
 });
 
@@ -303,11 +297,11 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
 
   renderIcon = () => {
     const { sortOrder } = this.state;
-    const { classes } = this.props;
+
     return (
       sortOrder === 'desc'
-        ? <KeyboardArrowUp className={classes.sortIcon} />
-        : <KeyboardArrowDown className={classes.sortIcon} />
+        ? <KeyboardArrowUp className="sortIcon" />
+        : <KeyboardArrowDown className="sortIcon" />
     );
   }
 

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -25,9 +25,7 @@ export interface Props {
   onSelect: (s: Linode.StackScript.Response) => void;
   selectedId?: number;
   data: Linode.StackScript.Response[];
-  getNext: () => void;
   isSorting: boolean;
-  publicImages: Linode.Image[];
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -39,25 +37,12 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
     data,
     isSorting,
     classes,
-    publicImages,
   } = props;
-
-  const hasNonDeprecatedImages = (stackScriptImages: string[]) => {
-    for (const stackScriptImage of stackScriptImages) {
-      for (const publicImage of publicImages) {
-        if (stackScriptImage === publicImage.id) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
 
   return (
     <TableBody>
       {!isSorting
         ? data && data
-          .filter(stackScript => hasNonDeprecatedImages(stackScript.images))
           .map(stackScript(onSelect, selectedId))
         : <TableRow>
           <TableCell colSpan={5} className={classes.loadingWrapper}>


### PR DESCRIPTION
This PR adjusts the style of the sortable table headers in order to match the comps. 
I also included a default sorting icon for the active deploys column since it is sorted by that column on initial load