### PR TITLE
M3-127 Display List of User Images

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,10 @@ const Domains = DefaultLoader({
   loader: () => import('src/features/Domains'),
 });
 
+const Images = DefaultLoader({
+  loader: () => import('src/features/Images'),
+})
+
 const Profile = DefaultLoader({
   loader: () => import('src/features/profile'),
 });
@@ -224,8 +228,7 @@ export class App extends React.Component<CombinedProps, State> {
                           <Placeholder title="Longview" />} />
                         <Route exact path="/stackscripts" render={() =>
                           <Placeholder title="StackScripts" icon={StackScriptIcon} />} />
-                        <Route exact path="/images" render={() =>
-                          <Placeholder title="Images" />} />
+                        <Route path="/images" component={Images} />
                         <Route exact path="/billing" render={() =>
                           <Placeholder title="Billing" />} />
                         <Route exact path="/users" render={() =>

--- a/src/features/Images/ImagesActionMenu.tsx
+++ b/src/features/Images/ImagesActionMenu.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+
+import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+
+interface Props {
+  onRestore: () => void;
+  onDeploy: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+type CombinedProps = Props & RouteComponentProps<{}>;
+
+class ImagesActionMenu extends React.Component<CombinedProps> {
+  createActions = () => {
+    const {
+      onRestore,
+      onDeploy,
+      onEdit,
+      onDelete,
+    } = this.props;
+
+    return (closeMenu: Function): Action[] => {
+      const actions = [
+        {
+          title: 'Restore to Existing Linode',
+          disabled: true,
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onRestore();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+        {
+          title: 'Deploy New Linode',
+          disabled: true,
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onDeploy();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+        {
+          title: 'Edit',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onEdit();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+        {
+          title: 'Delete',
+          disabled: true,
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            onDelete();
+            closeMenu();
+            e.preventDefault();
+          },
+        },
+      ];
+
+      return actions;
+    };
+  }
+
+  render() {
+    return (
+      <ActionMenu createActions={this.createActions()} />
+    );
+  }
+}
+
+export default withRouter(ImagesActionMenu);

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -1,0 +1,204 @@
+import * as React from 'react';
+
+import { compose, path } from 'ramda';
+
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+
+import Button from '@material-ui/core/Button';
+
+import { updateImage } from 'src/services/images';
+
+import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+
+import ActionsPanel from 'src/components/ActionsPanel';
+import Drawer from 'src/components/Drawer';
+import Notice from 'src/components/Notice';
+import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
+import TextField from 'src/components/TextField';
+
+type ClassNames = 'root'
+|  'suffix'
+|  'actionPanel';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+  suffix: {
+    fontSize: '.9rem',
+    marginRight: theme.spacing.unit,
+  },
+  actionPanel: {
+    marginTop: theme.spacing.unit * 2,
+  },
+});
+
+export interface Props {
+  label: string;
+  description: string;
+  imageID: string;
+  mode: string;
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  setLabel: (e:React.ChangeEvent<HTMLInputElement>) => void;
+  setDescription: (e:React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+interface State {
+  errors?: Linode.ApiFieldError[];
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export const modes = {
+  CLOSED: 'closed',
+  CREATING: 'creating',
+  RESTORING: 'resizing',
+  DEPLOYING: 'cloning',
+  EDITING: 'edit',
+};
+
+const titleMap = {
+  [modes.CLOSED]: '',
+  [modes.CREATING]: 'Create an Image',
+  [modes.RESTORING]: 'Restore from an Image',
+  [modes.DEPLOYING]: 'Deploy a New Linode',
+  [modes.EDITING]: 'Edit an Image',
+};
+
+class ImageDrawer extends React.Component<CombinedProps, State> {
+  mounted: boolean = false;
+  state = { errors: undefined };
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
+  close = () => {
+    this.setState({ errors: undefined });
+    this.props.onClose();
+  }
+
+  onSubmit = () => {
+    const { mode, onSuccess, label, description, imageID } = this.props;
+
+    switch (mode) {
+      case modes.EDITING:
+        if (!imageID) {
+          return;
+        }
+
+        if (!label) {
+            this.setState({
+              errors: [{ field: 'label', reason: 'Label cannot be blank.' }],
+            }, () => {
+              scrollErrorIntoView();
+            });
+            return;
+        }
+
+        updateImage(imageID, label, description)
+          .then(() => {
+            this.close();
+            onSuccess();
+          })
+          .catch((errorResponse) => {
+            if (this.mounted) {
+              this.setState({
+                errors: path(['response', 'data', 'errors'], errorResponse),
+              }, () => {
+                scrollErrorIntoView();
+              });
+            }
+          });
+        return;
+      default:
+        return;
+    }
+  }
+
+  render() {
+    const { mode, label, description, setLabel, setDescription } = this.props;
+
+    const { errors } = this.state;
+
+    const hasErrorFor = getAPIErrorFor({
+      linode_id: 'Linode',
+      config_id: 'Config',
+      region: 'Region',
+      size: 'Size',
+      label: 'Label',
+    }, errors);
+    const labelError = hasErrorFor('label');
+    const descriptionError = hasErrorFor('description');
+    const generalError = hasErrorFor('none');
+
+    return (
+      <Drawer
+        open={this.props.open}
+        onClose={this.props.onClose}
+        title={titleMap[mode]}
+      >
+        {generalError &&
+          <Notice
+            error
+            text={generalError}
+            data-qa-notice
+          />
+        }
+
+        <TextField
+          label="Label"
+          required
+          value={label}
+          onChange={setLabel}
+          error={Boolean(labelError)}
+          errorText={labelError}
+          data-qa-volume-label
+        />
+
+        <TextField
+          label="Description"
+          required
+          multiline
+          value={description}
+          onChange={setDescription}
+          error={Boolean(descriptionError)}
+          errorText={descriptionError}
+          data-qa-size
+        />
+
+        <ActionsPanel style={{ marginTop: 16 }}>
+          <Button
+            onClick={this.onSubmit}
+            variant="raised"
+            color="primary"
+            data-qa-submit
+          >
+            Submit
+          </Button>
+          <Button
+            onClick={this.close}
+            variant="raised"
+            color="secondary"
+            className="cancel"
+            data-qa-cancel
+          >
+            Cancel
+          </Button>
+        </ActionsPanel>
+      </Drawer>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default compose<any, any, any>(
+  styled,
+  SectionErrorBoundary,
+)(ImageDrawer);

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -1,0 +1,297 @@
+import * as React from 'react';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+
+import { compose, pathOr } from 'ramda';
+
+import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
+
+import Button from '@material-ui/core/Button';
+import Paper from '@material-ui/core/Paper';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import Typography from '@material-ui/core/Typography';
+
+import ActionsPanel from 'src/components/ActionsPanel';
+import AddNewLink from 'src/components/AddNewLink';
+// import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import setDocs from 'src/components/DocsSidebar/setDocs';
+import ErrorState from 'src/components/ErrorState';
+import Grid from 'src/components/Grid';
+import Placeholder from 'src/components/Placeholder';
+import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader';
+import Table from 'src/components/Table';
+
+import { getUserImages } from 'src/services/images';
+
+import { formatDate } from 'src/utilities/format-date-iso8601';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+
+import ActionMenu from './ImagesActionMenu';
+import ImagesDrawer from './ImagesDrawer';
+
+type ClassNames = 'root' | 'title';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+  title: {
+    marginBottom: theme.spacing.unit * 2,
+  },
+});
+
+interface Props { }
+
+interface PromiseLoaderProps {
+  images: PromiseLoaderResponse<Linode.Image>;
+}
+
+interface State {
+  images: Linode.Image[];
+  error?: Error;
+  imageDrawer: {
+    open: boolean,
+    mode: 'edit' | 'create' | 'delete' | 'deploy',
+    description?: string,
+    imageID?: string,
+    label?: string,
+  };
+  // removeDialog: {
+  //   open: boolean,
+  //   image?: string,
+  //   imageID?: number,
+  // };
+}
+
+type CombinedProps = Props & PromiseLoaderProps & WithStyles<ClassNames> & RouteComponentProps<{}>;
+
+class ImagesLanding extends React.Component<CombinedProps, State> {
+  state: State = {
+    images: pathOr([], ['response', 'data'], this.props.images),
+    error: pathOr(undefined, ['error'], this.props.images),
+    imageDrawer: {
+      open: false,
+      mode: 'edit',
+      label: '',
+      description: '',
+    },
+    // removeDialog: {
+    //   open: false,
+    // },
+  };
+
+  static docs: Linode.Doc[] = [
+    {
+      title: 'Linode Images',
+      src: 'https://linode.com/docs/platform/linode-images/',
+      body: `Linode Images allows you to take snapshots of your disks, 
+      and then deploy them to any Linode under your account. 
+      This can be useful for bootstrapping a master image for a large deployment, 
+      or retaining a disk for a configuration that you may not need running, 
+      but wish to return to in the future.`,
+    },
+    {
+      title: 'Deploy an Image to a Linode',
+      src: 'https://linode.com/docs/quick-answers/linode-platform/deploy-an-image-to-a-linode/',
+      body: `This QuickAnswer will show you how to deploy a Linux distribution to your Linode.`
+    }
+  ];
+
+  refreshImages = () => {
+     getUserImages()
+       .then((response) => {
+        this.setState({ images: response.data });
+       });
+  }
+
+  componentDidCatch(error: Error) {
+    this.setState({ error }, () => { scrollErrorIntoView(); });
+  }
+
+  openCreateDrawer = () => {
+    this.setState({
+      imageDrawer: { open: true, mode: 'edit' },
+    });
+  }
+
+  getActions = () => {
+    return (
+      <ActionsPanel>
+        <Button
+          variant="raised"
+          color="secondary"
+          className="destructive"
+          // onClick={this.removeImage}
+          onClick={() => null}
+          data-qa-submit
+        >
+          Confirm
+        </Button>
+        <Button
+          // onClick={this.closeRemoveDialog}
+          variant="raised"
+          color="secondary"
+          className="cancel"
+          data-qa-cancel
+        >
+          Cancel
+        </Button>
+      </ActionsPanel>
+    )
+  }
+
+  // openRemoveDialog = (image: string, imageID: number) => {
+  //   this.setState({
+  //     removeDialog: { open: true, image, imageID },
+  //   });
+  // }
+
+  // closeRemoveDialog = () => {
+  //   this.setState({
+  //     removeDialog: { open: false, image: undefined, imageID: undefined },
+  //   });
+  // }
+
+  openForEdit = (label: string, description: string, imageID: string) => {
+    this.setState({
+      imageDrawer: {
+        open: true,
+        mode: 'edit',
+        description,
+        imageID,
+        label,
+      }
+    })
+  }
+
+  setLabel = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { imageDrawer } = this.state;
+    this.setState({ imageDrawer: {...imageDrawer, label: e.target.value }});
+  }
+
+  setDescription = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { imageDrawer } = this.state;
+    this.setState({ imageDrawer: {...imageDrawer, description: e.target.value }});
+  }
+
+  closeImageDrawer = () => {
+    this.setState({ imageDrawer: { open: false, mode: 'create', label: '', description: '' }});
+  }
+
+  render() {
+    const { classes } = this.props;
+    const { error, images } = this.state;
+
+    /** Error State */
+    if (error) {
+      return <ErrorState
+        errorText="There was an error retrieving your images. Please reload and try again."
+      />;
+    }
+
+    /** Empty State */
+    if (images.length === 0) {
+      return (
+        <React.Fragment>
+          <Placeholder
+            title="Add an Image"
+            copy="Adding a new image is easy. Click below to add an image."
+            buttonProps={{
+              onClick: () => this.openCreateDrawer(),
+              children: 'Add an Image',
+            }}
+          />
+          {/* <this.ImageCreateDrawer /> */}
+        </React.Fragment>
+      );
+    }
+
+    return (
+      <React.Fragment>
+        <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }} >
+          <Grid item>
+            <Typography variant="headline" data-qa-title className={classes.title}>
+              Images
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container alignItems="flex-end">
+              <Grid item>
+                <AddNewLink
+                  onClick={() => null}
+                  label="Add an Image"
+                  disabled={true}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+        <Paper>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell data-qa-image-name-header>Label</TableCell>
+                <TableCell data-qa-image-date-header>Date Created</TableCell>
+                <TableCell data-qa-image-size-header>Size</TableCell>
+                <TableCell />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {images.map(image =>
+                <TableRow key={image.id} data-qa-image-cell={image.id}>
+                  <TableCell data-qa-image-label>
+                    <Link to={`/images/${image.id}`}>
+                      {image.label}
+                    </Link>
+                  </TableCell>
+                  <TableCell data-qa-image-date>{formatDate(image.created)}</TableCell>
+                  <TableCell data-qa-image-size>{image.size} GiB</TableCell>
+                  <TableCell>
+                    <ActionMenu
+                      onRestore={() => { null; }}
+                      onDeploy={() => { null; }}
+                      onEdit={() => this.openForEdit(image.label, image.description ? image.description : ' ', image.id)}
+                      onDelete={() => { null; }}
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </Paper>
+        <ImagesDrawer
+          open={this.state.imageDrawer.open}
+          label={this.state.imageDrawer.label}
+          imageID={this.state.imageDrawer.imageID}
+          mode={this.state.imageDrawer.mode}
+          description={this.state.imageDrawer.description}
+          onClose={this.closeImageDrawer}
+          onSuccess={this.refreshImages}
+          setLabel={this.setLabel}
+          setDescription={this.setDescription}
+        />
+        {/* <ConfirmationDialog
+          open={this.state.removeDialog.open}
+          title={`Remove ${this.state.removeDialog.image}`}
+          onClose={this.closeRemoveDialog}
+          actions={this.getActions}
+        >
+          <Typography>Are you sure you want to remove this image?</Typography>
+        </ConfirmationDialog> */}
+      </React.Fragment>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+const loaded = PromiseLoader<Props>({
+  images: props => getUserImages(),
+});
+
+export default compose(
+  setDocs(ImagesLanding.docs),
+  withRouter,
+  loaded,
+  styled,
+)(ImagesLanding);

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -222,7 +222,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
                     </Link>
                   </TableCell>
                   <TableCell data-qa-image-date>{formatDate(image.created)}</TableCell>
-                  <TableCell data-qa-image-size>{image.size} GiB</TableCell>
+                  <TableCell data-qa-image-size>{image.size} MB</TableCell>
                   <TableCell>
                     <ActionMenu
                       onRestore={() => { null; }}

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -56,11 +56,6 @@ interface State {
     imageID?: string,
     label?: string,
   };
-  // removeDialog: {
-  //   open: boolean,
-  //   image?: string,
-  //   imageID?: number,
-  // };
 }
 
 type CombinedProps = Props & PromiseLoaderProps & WithStyles<ClassNames> & RouteComponentProps<{}>;
@@ -75,9 +70,6 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
       label: '',
       description: '',
     },
-    // removeDialog: {
-    //   open: false,
-    // },
   };
 
   static docs: Linode.Doc[] = [
@@ -121,14 +113,12 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
           variant="raised"
           color="secondary"
           className="destructive"
-          // onClick={this.removeImage}
           onClick={() => null}
           data-qa-submit
         >
           Confirm
         </Button>
         <Button
-          // onClick={this.closeRemoveDialog}
           variant="raised"
           color="secondary"
           className="cancel"
@@ -139,18 +129,6 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
       </ActionsPanel>
     )
   }
-
-  // openRemoveDialog = (image: string, imageID: number) => {
-  //   this.setState({
-  //     removeDialog: { open: true, image, imageID },
-  //   });
-  // }
-
-  // closeRemoveDialog = () => {
-  //   this.setState({
-  //     removeDialog: { open: false, image: undefined, imageID: undefined },
-  //   });
-  // }
 
   openForEdit = (label: string, description: string, imageID: string) => {
     this.setState({
@@ -201,7 +179,6 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
               children: 'Add an Image',
             }}
           />
-          {/* <this.ImageCreateDrawer /> */}
         </React.Fragment>
       );
     }
@@ -270,14 +247,6 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
           setLabel={this.setLabel}
           setDescription={this.setDescription}
         />
-        {/* <ConfirmationDialog
-          open={this.state.removeDialog.open}
-          title={`Remove ${this.state.removeDialog.image}`}
-          onClose={this.closeRemoveDialog}
-          actions={this.getActions}
-        >
-          <Typography>Are you sure you want to remove this image?</Typography>
-        </ConfirmationDialog> */}
       </React.Fragment>
     );
   }

--- a/src/features/Images/index.tsx
+++ b/src/features/Images/index.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import {
+    Route,
+    RouteComponentProps,
+    Switch,
+    withRouter,
+} from 'react-router-dom';
+import DefaultLoader from 'src/components/DefaultLoader';
+
+const ImagesLanding = DefaultLoader({
+  loader: () => import('./ImagesLanding'),
+});
+
+type Props = RouteComponentProps<{}>;
+
+class ImagesRoutes extends React.Component<Props> {
+  render() {
+    const { match: { path } } = this.props;
+
+    return (
+      <Switch>
+        <Route component={ImagesLanding} path={path} exact />
+      </Switch>
+    );
+  }
+}
+
+export default withRouter(ImagesRoutes);

--- a/src/services/images.ts
+++ b/src/services/images.ts
@@ -26,8 +26,13 @@ export const getImage = (imageId: string) =>
   )
     .then(response => response.data);
 
-export const updateImage = (imageId: string, label: string, description: string) => Request<{}>(
-  setURL(`${API_ROOT}/images/${imageId}`),
-  setMethod('PUT'),
-  setData({ label, description }),
-);
+export const updateImage = (imageId: string, label: string, description: string) => { 
+  // Blank descriptions are represented as ' ' in the API; 
+  // API will return an error if passed the empty string.
+  if (description=== '') { description = ' '; }
+  return Request<{}>(
+    setURL(`${API_ROOT}/images/${imageId}`),
+    setMethod('PUT'),
+    setData({ label, description }),
+  );
+}

--- a/src/services/images.ts
+++ b/src/services/images.ts
@@ -29,10 +29,10 @@ export const getImage = (imageId: string) =>
 export const updateImage = (imageId: string, label: string, description: string) => { 
   // Blank descriptions are represented as ' ' in the API; 
   // API will return an error if passed the empty string.
-  if (description=== '') { description = ' '; }
+  const safeDescription = description === '' ? ' ' : description;
   return Request<{}>(
     setURL(`${API_ROOT}/images/${imageId}`),
     setMethod('PUT'),
-    setData({ label, description }),
+    setData({ label, description: safeDescription }),
   );
 }

--- a/src/services/images.ts
+++ b/src/services/images.ts
@@ -1,19 +1,23 @@
 import { API_ROOT } from 'src/constants';
-import Request, { setURL, setMethod, setParams } from 'src/services';
+import Request, { setData, setMethod, setParams, setURL, setXFilter } from 'src/services';
 
 type Page<T> = Linode.ResourcePage<T>;
 type Image = Linode.Image;
 
-export const getImagesPage = (page: number) =>
+export const getImagesPage = (page: number, userOnly: boolean = false) =>
   Request<Page<Image>>(
-    setURL(`${API_ROOT}/images/?page=${page}`),
+    setURL(`${API_ROOT}/images`),
     setMethod('GET'),
     setParams({ page }),
+    setXFilter({...(userOnly && {'is_public': false })}),
   )
     .then(response => response.data);
 
 export const getImages = () =>
   getImagesPage(1);
+
+export const getUserImages = () =>
+  getImagesPage(1, true);
 
 export const getImage = (imageId: string) =>
   Request<Image>(
@@ -21,3 +25,9 @@ export const getImage = (imageId: string) =>
     setMethod('GET'),
   )
     .then(response => response.data);
+
+export const updateImage = (imageId: string, label: string, description: string) => Request<{}>(
+  setURL(`${API_ROOT}/images/${imageId}`),
+  setMethod('PUT'),
+  setData({ label, description }),
+);


### PR DESCRIPTION
**Purpose**

Complete the Images landing page, where a list of the user's
images will be displayed.

This issue includes adding the action menu (kebab) and editing
functionality; creation, delete, restore, and deploy are
addressed in separate issues.

**Note**

User images are filtered using the `is_public` field, which
the API team says is a sufficiently stable solution.

When editing an image, if a description is left completely blank,
the API will return an error, despite the fact that the
description field is technically optional. The API adds a whitespace
description during creation if the description is blank.