### PR TITLE
M3-385

### DIFF
--- a/src/features/Domains/DomainZoneImportDrawer.tsx
+++ b/src/features/Domains/DomainZoneImportDrawer.tsx
@@ -59,7 +59,7 @@ class DomainZoneImportDrawer extends React.Component<CombinedProps, State> {
         <LinodeTextField label="Remote Nameserver" onChange={this.updateRemoteNameserver} errorText={remoteNameserverError} />
         <ActionsPanel>
           <Button type="primary" loading={submitting} onClick={this.onSubmit}>Save</Button>
-          <Button type="secondary" onClick={this.onClose}>Cancel</Button>
+          <Button type="cancel" onClick={this.onClose}>Cancel</Button>
         </ActionsPanel>
       </Drawer>
     );

--- a/src/features/Domains/DomainZoneImportDrawer.tsx
+++ b/src/features/Domains/DomainZoneImportDrawer.tsx
@@ -1,0 +1,106 @@
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { pathOr } from 'ramda';
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Drawer from 'src/components/Drawer';
+import Notice from 'src/components/Notice';
+import LinodeTextField from 'src/components/TextField';
+import { importZone } from 'src/services/domains';
+import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface State {
+  submitting: boolean;
+  errors?: Linode.ApiFieldError[];
+  domain?: string
+  remote_nameserver?: string
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class DomainZoneImportDrawer extends React.Component<CombinedProps, State> {
+  state: State = {
+    submitting: false,
+  };
+
+  static errorResources = {
+    domain: 'domain',
+    remote_nameserver: 'remote nameserver',
+  };
+
+  render() {
+    const { open } = this.props;
+    const { submitting, errors } = this.state;
+    const hasErrorFor = getAPIErrorsFor(DomainZoneImportDrawer.errorResources, errors);
+    const generalError = hasErrorFor('none');
+    const domainError = hasErrorFor('domain');
+    const remoteNameserverError = hasErrorFor('remote_nameserver');
+
+    return (
+      <Drawer
+        open={open}
+        onClose={this.onClose}
+        title="Import a Zone"
+      >
+        {generalError && <Notice error text={generalError} />}
+        <LinodeTextField label="Domain" onChange={this.updateDomain} errorText={domainError} />
+        <LinodeTextField label="Remote Nameserver" onChange={this.updateRemoteNameserver} errorText={remoteNameserverError} />
+        <ActionsPanel>
+          <Button type="primary" loading={submitting} onClick={this.onSubmit}>Save</Button>
+          <Button type="secondary" onClick={this.onClose}>Cancel</Button>
+        </ActionsPanel>
+      </Drawer>
+    );
+  }
+
+  updateRemoteNameserver = (e: React.ChangeEvent<HTMLInputElement>) => this.setState({ remote_nameserver: e.target.value });
+
+  updateDomain = (e: React.ChangeEvent<HTMLInputElement>) => this.setState({ domain: e.target.value });
+
+  reset = () => this.setState({
+    submitting: false,
+    errors: undefined,
+    domain: undefined,
+    remote_nameserver: undefined,
+  });
+
+  onClose = () => {
+    const { onClose } = this.props;
+    this.reset();
+    onClose();
+  };
+
+  onSubmit = () => {
+    const { domain, remote_nameserver } = this.state;
+
+    this.setState({ submitting: true });
+
+    importZone(domain, remote_nameserver)
+      .then((response) => {
+        this.onClose();
+      })
+      .catch((error) => {
+        const err: Linode.ApiFieldError[] = [{ field: 'none', reason: 'An unexpected error has ocurred.' }];
+
+        this.setState({
+          submitting: false,
+          errors: pathOr(err, ['response', 'data', 'errors'], error),
+        })
+      });
+  };
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(DomainZoneImportDrawer);

--- a/src/features/Domains/DomainZoneImportDrawer.tsx
+++ b/src/features/Domains/DomainZoneImportDrawer.tsx
@@ -18,6 +18,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 interface Props {
   open: boolean;
   onClose: () => void;
+  onSuccess: () => void;
 }
 
 interface State {
@@ -89,6 +90,7 @@ class DomainZoneImportDrawer extends React.Component<CombinedProps, State> {
     importZone(domain, remote_nameserver)
       .then((response) => {
         this.onClose();
+        this.props.onSuccess();
       })
       .catch((error) => {
         const err: Linode.ApiFieldError[] = [{ field: 'none', reason: 'An unexpected error has ocurred.' }];

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -95,7 +95,7 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
     },
   ];
 
-  refreshDomains() {
+  refreshDomains = () => {
     getDomains()
       .then((response) => {
         this.setState({ domains: response.data });
@@ -274,6 +274,7 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
         <DomainZoneImportDrawer
           open={this.state.importDrawer.open}
           onClose={this.closeImportZoneDrawer}
+          onSuccess={this.refreshDomains}
         />
         <ConfirmationDialog
           open={this.state.removeDialog.open}

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -26,6 +26,7 @@ import ActionMenu from './DomainActionMenu';
 import DomainCreateDrawer from './DomainCreateDrawer';
 import AddNewLink from 'src/components/AddNewLink';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import DomainZoneImportDrawer from './DomainZoneImportDrawer';
 
 type ClassNames = 'root' | 'title';
 
@@ -45,6 +46,13 @@ interface PromiseLoaderProps {
 interface State {
   domains: Linode.Domain[];
   error?: Error;
+  importDrawer: {
+    open: boolean,
+    submitting: boolean,
+    errors?: Linode.ApiFieldError[];
+    domain?: string;
+    remote_nameserver?: string;
+  },
   createDrawer: {
     open: boolean,
     mode: 'clone' | 'create',
@@ -64,6 +72,10 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
   state: State = {
     domains: pathOr([], ['response', 'data'], this.props.domains),
     error: pathOr(undefined, ['error'], this.props.domains),
+    importDrawer: {
+      open: false,
+      submitting: false,
+    },
     createDrawer: {
       open: false,
       mode: 'create',
@@ -96,6 +108,16 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
   componentDidCatch(error: Error) {
     this.setState({ error }, () => { scrollErrorIntoView(); });
   }
+
+  openImportZoneDrawer = () => this.setState({ importDrawer: { ...this.state.importDrawer, open: true }});
+
+  closeImportZoneDrawer = () => this.setState({ importDrawer: {
+    open: false,
+    submitting: false,
+    remote_nameserver: undefined,
+    domain: undefined,
+    errors: undefined,
+  }});
 
   openCreateDrawer() {
     this.setState({
@@ -200,6 +222,12 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
             <Grid container alignItems="flex-end">
               <Grid item>
                 <AddNewLink
+                  onClick={this.openImportZoneDrawer}
+                  label="Import a Zone"
+                />
+              </Grid>
+              <Grid item>
+                <AddNewLink
                   onClick={() => this.openCreateDrawer()}
                   label="Add a Domain"
                 />
@@ -246,6 +274,10 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
           </Table>
         </Paper>
         <this.DomainCreateDrawer />
+        <DomainZoneImportDrawer
+          open={this.state.importDrawer.open}
+          onClose={this.closeImportZoneDrawer}
+        />
         <ConfirmationDialog
           open={this.state.removeDialog.open}
           title={`Remove ${this.state.removeDialog.domain}`}

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -1,31 +1,28 @@
-import * as React from 'react';
-import { compose, pathOr } from 'ramda';
-import { Link, withRouter, RouteComponentProps } from 'react-router-dom';
-
-import { withStyles, StyleRulesCallback, Theme, WithStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
-
-import { getDomains, deleteDomain } from 'src/services/domains';
-import { sendToast } from 'src/features/ToastNotifications/toasts';
-import Placeholder from 'src/components/Placeholder';
-import Table from 'src/components/Table';
-import Grid from 'src/components/Grid';
-import ErrorState from 'src/components/ErrorState';
-import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import { compose, pathOr } from 'ramda';
+import * as React from 'react';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
-import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader';
+import AddNewLink from 'src/components/AddNewLink';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import setDocs from 'src/components/DocsSidebar/setDocs';
-
+import ErrorState from 'src/components/ErrorState';
+import Grid from 'src/components/Grid';
+import Placeholder from 'src/components/Placeholder';
+import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader';
+import Table from 'src/components/Table';
+import { sendToast } from 'src/features/ToastNotifications/toasts';
+import { deleteDomain, getDomains } from 'src/services/domains';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import ActionMenu from './DomainActionMenu';
 import DomainCreateDrawer from './DomainCreateDrawer';
-import AddNewLink from 'src/components/AddNewLink';
-import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import DomainZoneImportDrawer from './DomainZoneImportDrawer';
 
 type ClassNames = 'root' | 'title';

--- a/src/services/domains.ts
+++ b/src/services/domains.ts
@@ -1,5 +1,6 @@
 import { API_ROOT } from 'src/constants';
-import Request, { setURL, setMethod, setParams, setData } from './index';
+import Request, { setURL, setMethod, setParams, setData, validateRequestData } from './index';
+import * as Joi from 'joi';
 
 type Page<T> = Linode.ResourcePage<T>;
 type Domain = Linode.Domain;
@@ -79,3 +80,16 @@ export const cloneDomain = (domainID: number, cloneName: string) =>
   setURL(`${API_ROOT}/domains/${domainID}/clone`),
   setMethod('POST'),
 );
+
+const importZoneSchema = Joi.object({
+  domain: Joi.string().required(),
+  remote_nameserver: Joi.string().required(),
+});
+
+export const importZone = (domain?: string, remote_nameserver?: string) =>
+  Request(
+    validateRequestData({ domain, remote_nameserver }, importZoneSchema),
+    setData({ domain, remote_nameserver }),
+    setURL(`${API_ROOT}/domains/import`),
+    setMethod('POST'),
+  );


### PR DESCRIPTION
## Purpose
Users need a means by which they can import a domain zone.

DM me for a zone to import for testing purposes.

## Solution
Following existing patterns provide a drawer with fields for domain and remote_nameserver. I did not use the scroll to error function as there's no scrolling on the drawer.