### PR TITLE
M3-878

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -209,7 +209,8 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     */
     const nodePathErrors = fieldErrorsToNodePathErrors(errors);
 
-    if (nodePathErrors.length === 0) { return; }
+    /** We still need to set the errors */
+    if (nodePathErrors.length === 0) { return this.setState({ errors }); }
 
     const setFns = nodePathErrors.map((nodePathError: any) => {
       return compose(

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -673,8 +673,7 @@ export const fieldErrorsToNodePathErrors = (errors: Linode.ApiFieldError[]) => {
   */
   return errors.reduce(
     (acc: any, error: Linode.ApiFieldError) => {
-      const { field, path } = getPathAnFieldFromFieldString(error.field!
-      );
+      const { field, path } = getPathAnFieldFromFieldString(error.field!);
 
       if (!path.length) { return acc; }
 

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -84,7 +84,7 @@ type CombinedProps = Props
 interface NodeBalancerFieldsState {
   label?: string;
   region?: string;
-  configs: (NodeBalancerConfigFields & { errors?: any }) [];
+  configs: (NodeBalancerConfigFields & { errors?: any })[];
 }
 
 interface State {
@@ -281,9 +281,9 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
         if (errors) {
           this.setNodeErrors(errors.map((e) => ({
             ...e,
-            field: e.field.replace(/(\[|\]\.)/g, '_')
+            ...(e.field && { field: e.field.replace(/(\[|\]\.)/g, '_') })
           })));
-          return this.setState( { submitting: false }, () => scrollErrorIntoView());
+          return this.setState({ submitting: false }, () => scrollErrorIntoView());
         }
 
         return this.setState({
@@ -671,20 +671,20 @@ export const fieldErrorsToNodePathErrors = (errors: Linode.ApiFieldError[]) => {
   */
   return errors.reduce(
     (acc: any, error: Linode.ApiFieldError) => {
-        const { field, path } = getPathAnFieldFromFieldString(error.field);
+      const { field, path } = getPathAnFieldFromFieldString(error.field);
 
-        if(!path.length){ return acc; }
+      if (!path.length) { return acc; }
 
-        return [
-          ...acc,
-          {
-            error: {
-              field,
-              reason: error.reason,
-            },
-            path: [...path, 'errors'],
+      return [
+        ...acc,
+        {
+          error: {
+            field,
+            reason: error.reason,
           },
-        ];
+          path: [...path, 'errors'],
+        },
+      ];
       return acc;
     },
     [],

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -284,7 +284,8 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
             ...e,
             ...(e.field && { field: e.field.replace(/(\[|\]\.)/g, '_') })
           })));
-          return this.setState({ submitting: false }, () => scrollErrorIntoView());
+
+          return this.setState({ errors, submitting: false }, () => scrollErrorIntoView());
         }
 
         return this.setState({
@@ -672,7 +673,8 @@ export const fieldErrorsToNodePathErrors = (errors: Linode.ApiFieldError[]) => {
   */
   return errors.reduce(
     (acc: any, error: Linode.ApiFieldError) => {
-      const { field, path } = getPathAnFieldFromFieldString(error.field!);
+      const { field, path } = getPathAnFieldFromFieldString(error.field!
+      );
 
       if (!path.length) { return acc; }
 

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -289,7 +289,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
 
         return this.setState({
           errors: [
-            { field: 'none', reason: `An unexpected error has occured..` }],
+            { reason: `An unexpected error has occured..` }],
         }, () => {
           scrollErrorIntoView();
         });
@@ -333,7 +333,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
       this.setState({
         errors: this.state.errors!.filter((error: Linode.ApiFieldError) => {
           const t = new RegExp(`configs_${idxToDelete}_`);
-          return !t.test(error.field);
+          return error.field && !t.test(error.field);
         }),
       });
     }
@@ -672,7 +672,7 @@ export const fieldErrorsToNodePathErrors = (errors: Linode.ApiFieldError[]) => {
   */
   return errors.reduce(
     (acc: any, error: Linode.ApiFieldError) => {
-      const { field, path } = getPathAnFieldFromFieldString(error.field);
+      const { field, path } = getPathAnFieldFromFieldString(error.field!);
 
       if (!path.length) { return acc; }
 

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -180,7 +180,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
     */
     const nodePathErrors = errors.reduce(
       (acc: any, error: Linode.ApiFieldError) => {
-        const match = /^nodes_(\d+)_(\w+)$/.exec(error.field);
+        const match = /^nodes_(\d+)_(\w+)$/.exec(error.field!);
         if (match && match[1] && match[2]) {
           return [
             ...acc,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -109,11 +109,13 @@ export const mockAPIError = (
   status: number = 400,
   statusText: string = 'Internal Server Error',
   data: any = {},
-): Promise<Axios.AxiosError> => Promise.reject(
-  createError(
-    `Request failed with a status of ${status}`,
-    { data, status, statusText, headers: {}, config: {} },
-  ));
+): Promise<Axios.AxiosError> =>
+  new Promise((resolve, reject) => setTimeout(() => reject(
+    createError(
+      `Request failed with a status of ${status}`,
+      { data, status, statusText, headers: {}, config: {} },
+    )
+  ), process.env.NODE_ENV === 'test' ? 0 : 250));
 
 const createError = (message: string, response: Axios.AxiosResponse) => {
   const error = new Error(message) as any;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -146,7 +146,7 @@ namespace Linode {
   }
 
   export interface ApiFieldError {
-    field: string;
+    field?: string;
     reason: string;
   }
 }

--- a/src/utilities/getAPIErrorFor.ts
+++ b/src/utilities/getAPIErrorFor.ts
@@ -14,5 +14,5 @@ export default (
     return;
   }
 
-  return err.reason.replace(err.field, errorMap[err.field]);
+  return err.field ? err.reason.replace(err.field, errorMap[err.field]) : err.reason;
 };


### PR DESCRIPTION
## Purpose
It was found that when a "general" API error was encountered during node balancer creation we encountered a syntax error. After resolving the syntax error it was found that general API errors were not being communicated to the user.

## Gold Plating
Added a 250ms delay to the mockAPIError to prevent state updates in the subsequent catch handler from being batched and potentially run out of order.

## Solution
- Check for the existence of the error field before running a regex replace on it.
- In the event there are no nodeErrors, set the errors to state as is, and return early.

## How to Verify!
Replace createNodeBalancer in `services/nodebalancer.ts` with the new fancy mockAPIError helper and a data object of { errors: [{ reason: 'cheeky shenanigans' }]`