### PR TITLE
M3-126 stackscripts landing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,10 @@ const NodeBalancers = DefaultLoader({
   loader: () => import('src/features/NodeBalancers'),
 });
 
+const StackScripts = DefaultLoader({
+  loader: () => import('src/features/StackScripts'),
+});
+
 type ClassNames = 'appFrame'
   | 'content'
   | 'wrapper'
@@ -226,9 +230,8 @@ export class App extends React.Component<CombinedProps, State> {
                           <Placeholder title="Managed" />} />
                         <Route exact path="/longview" render={() =>
                           <Placeholder title="Longview" />} />
-                        <Route exact path="/stackscripts" render={() =>
-                          <Placeholder title="StackScripts" icon={StackScriptIcon} />} />
                         <Route path="/images" component={Images} />
+                        <Route path="/stackscripts" component={StackScripts} />
                         <Route exact path="/billing" render={() =>
                           <Placeholder title="Billing" />} />
                         <Route exact path="/users" render={() =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,6 @@ shim(); // allows for .finally() usage
 import { withStyles, WithStyles, StyleRulesCallback, Theme } from '@material-ui/core/styles';
 import 'typeface-lato';
 
-import StackScriptIcon from 'src/assets/addnewmenu/stackscripts.svg';
 import { getLinodeTypes, getLinodeKernels } from 'src/services/linodes';
 import { getProfile } from 'src/services/profile';
 import TopMenu from 'src/features/TopMenu';

--- a/src/components/SelectStackScriptPanel.stories.tsx
+++ b/src/components/SelectStackScriptPanel.stories.tsx
@@ -5,7 +5,7 @@ import ThemeDecorator from '../utilities/storybookDecorators';
 import SelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel';
 import { StaticRouter } from 'react-router';
 
-import {images} from 'src/__data__/images';
+import { images } from 'src/__data__/images';
 
 interface State {
   selectedId: number | null;
@@ -20,7 +20,7 @@ class InteractiveExample extends React.Component<{}, State> {
     return (
       <StaticRouter>
         <SelectStackScriptPanel
-          images={images}
+          publicImages={images}
           selectedId={this.state.selectedId}
           onSelect={(id: number) => this.setState({ selectedId: id })}
         />

--- a/src/components/SelectionRow/SelectionRow.tsx
+++ b/src/components/SelectionRow/SelectionRow.tsx
@@ -168,7 +168,8 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
         </TableCell>
         {showDeployLink &&
           <TableCell>
-            <Link to={'/'}>
+          <Link to={`/linodes/create?type=fromStackScript` +
+            `&stackScriptID=${stackScriptID}&stackScriptUsername=${stackScriptUsername}`}>
               <Typography variant="title">
                 Deploy New Linode
               </Typography>

--- a/src/components/SelectionRow/SelectionRow.tsx
+++ b/src/components/SelectionRow/SelectionRow.tsx
@@ -10,6 +10,7 @@ import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 
+import Button from 'src/components/Button';
 import Radio from 'src/components/Radio';
 import RenderGuard from 'src/components/RenderGuard';
 import ShowMore from 'src/components/ShowMore';
@@ -28,7 +29,8 @@ type ClassNames = 'root'
   | 'libDescription'
   | 'colImages'
   | 'stackScriptCell'
-  | 'stackScriptUsername';
+  | 'stackScriptUsername'
+  | 'deployButton';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -91,6 +93,12 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   stackScriptUsername: {
     color: theme.color.grey1,
+  },
+  deployButton: {
+    marginLeft: -26,
+    border: 0,
+    width: '100%',
+    justifyContent: 'flex-start',
   },
 });
 
@@ -170,10 +178,13 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
           <TableCell>
           <Link to={`/linodes/create?type=fromStackScript` +
             `&stackScriptID=${stackScriptID}&stackScriptUsername=${stackScriptUsername}`}>
-              <Typography variant="title">
-                Deploy New Linode
-              </Typography>
-            </Link>
+            <Button
+              type="secondary"
+              className={classes.deployButton}
+            >
+              Deploy New Linode
+            </Button>
+          </Link>
           </TableCell>
         }
       </TableRow>

--- a/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/src/components/TabbedPanel/TabbedPanel.tsx
@@ -49,6 +49,7 @@ interface Props {
   [index: string]: any;
   initTab?: number;
   shrinkTabContent?: string;
+  handleTabChange?: () => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -57,6 +58,9 @@ class TabbedPanel extends React.Component<CombinedProps> {
   state = { value: this.props.initTab || 0 };
 
   handleChange = (event: React.ChangeEvent<HTMLDivElement>, value: number) => {
+    if (this.props.handleTabChange) {
+      this.props.handleTabChange();
+    }
     this.setState({ value });
   }
 

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -4,6 +4,8 @@ import * as classNames from 'classnames';
 
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
+import { Link } from 'react-router-dom';
+
 import { connect } from 'react-redux';
 
 import { compose, pathOr } from 'ramda';
@@ -45,7 +47,8 @@ type ClassNames = 'root'
   | 'tr'
   | 'tableHead'
   | 'sortButton'
-  | 'table';
+  | 'table'
+  | 'emptyState';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -96,6 +99,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     width: '100%',
     justifyContent: 'flex-start',
   },
+  emptyState: {
+    textAlign: 'center',
+    padding: '10em',
+  }
 });
 
 interface Props {
@@ -299,6 +306,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
       filter)
       .then((response: Linode.ResourcePage<Linode.StackScript.Response>) => {
         if (!this.mounted) { return; }
+
         if (!response.data.length || response.data.length === response.results) {
           this.setState({ showMoreButtonVisible: false });
         }
@@ -471,7 +479,12 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
 
     return (
       <React.Fragment>
-        <Table noOverflow={true} tableClass={classes.table}>
+        {this.state.listOfStackScripts.length === 0
+        ? <div className={classes.emptyState}>
+          You do not have any StackScripts to select from. You must first
+          <Link to="/stackscripts/create"> create one</Link>
+        </div>
+        : <Table noOverflow={true} tableClass={classes.table}>
           <TableHead>
             <TableRow className={classes.tr}>
               {!!this.props.onSelect &&
@@ -553,6 +566,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
             {...selectProps}
           />
         </Table>
+        }
         {this.state.showMoreButtonVisible && !isSorting &&
           <Button
             title="Show More StackScripts"

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -292,11 +292,18 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
         }
 
         /*
-        * if we're sorting, just return the first page, since 
+        * if we're sorting, just return the requested data, since we're
+        * scrolling the user to the top and resetting the data
         */
         const newData = (isSorting) ? response.data : [...this.state.data, ...response.data];
 
-
+        /*
+        * We need to further clean up the data because when we are preselecting
+        * a stackscript based on the URL query string, it's possible for the
+        * stackscript to appear again on the first page or any subsequent page
+        * so we need to filter out that stackscript so we don't run into
+        * the duplicate key error
+        */
         const cleanedData = (!!selectedStackScriptIDFromQuery)
         ? newData.filter((stackScript, index) => {
           if(index !== 0) {

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -110,52 +110,54 @@ type StyledProps = Props & WithStyles<ClassNames>;
 
 type CombinedProps = StyledProps;
 
-class SelectStackScriptPanel extends React.Component<CombinedProps> {
+const SelectStackScriptPanel: React.StatelessComponent<CombinedProps> = (props) => {
+  const { classes, publicImages, noHeader, error,
+  shrinkPanel, onSelect } = props;
+  
+  const tabs = [
+    {
+      title: 'My StackScripts',
+      render: () => <StyledContainer
+        onSelect={onSelect}
+        // images is an optional prop, so just send an empty array if we didn't get any
+        publicImages={publicImages}
+        request={getStackScriptsByUser} key={0}
+      />,
+    },
+    {
+      title: 'Linode StackScripts',
+      render: () => <StyledContainer
+        onSelect={onSelect}
+        // images is an optional prop, so just send an empty array if we didn't get any
+        publicImages={publicImages}
+        request={getStackScriptsByUser} key={1}
+        isLinodeStackScripts={true}
+      />,
+    },
+    {
+      title: 'Community StackScripts',
+      render: () => <StyledContainer
+        onSelect={onSelect}
+        // images is an optional prop, so just send an empty array if we didn't get any
+        publicImages={publicImages}
+        request={getCommunityStackscripts} key={2}
+      />,
+    },
+  ]
 
+  const myTabIndex = tabs.findIndex(tab => tab.title.toLowerCase().includes('my'));
+  const linodeTabIndex = tabs.findIndex(tab => tab.title.toLowerCase().includes('linode'));
+  const communityTabIndex = tabs.findIndex(tab => tab.title.toLowerCase().includes('community'));
 
-
-  render() {
-    const { classes, publicImages, noHeader } = this.props;
-
-    return (
-      <TabbedPanel
-        error={this.props.error}
-        rootClass={classes.root}
-        shrinkTabContent={(this.props.shrinkPanel) ? classes.creating : classes.selecting}
-        header={(noHeader) ? "" : "Select StackScript"}
-        tabs={[
-          {
-            title: 'My StackScripts',
-            render: () => <StyledContainer
-              onSelect={this.props.onSelect}
-              // images is an optional prop, so just send an empty array if we didn't get any
-              publicImages={publicImages}
-              request={getStackScriptsByUser} key={0}
-            />,
-          },
-          {
-            title: 'Linode StackScripts',
-            render: () => <StyledContainer
-              onSelect={this.props.onSelect}
-              // images is an optional prop, so just send an empty array if we didn't get any
-              publicImages={publicImages}
-              request={getStackScriptsByUser} key={1}
-              isLinodeStackScripts={true}
-            />,
-          },
-          {
-            title: 'Community StackScripts',
-            render: () => <StyledContainer
-              onSelect={this.props.onSelect}
-              // images is an optional prop, so just send an empty array if we didn't get any
-              publicImages={publicImages}
-              request={getCommunityStackscripts} key={2}
-            />,
-          },
-        ]}
-      />
-    );
-  }
+  return (
+    <TabbedPanel
+      error={error}
+      rootClass={classes.root}
+      shrinkTabContent={(shrinkPanel) ? classes.creating : classes.selecting}
+      header={(noHeader) ? "" : "Select StackScript"}
+      tabs={tabs}
+    />
+  );
 }
 
 interface Params {

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -58,7 +58,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     '-webkit-appearance': 'none',
   },
   selecting: {
-    minHeight: '200px',
+    minHeight: '400px',
     maxHeight: '1000px',
     overflowX: 'auto',
   },
@@ -166,7 +166,7 @@ interface Params {
 interface ContainerProps {
   request: (username: string, params: Params, filter: any) =>
     Promise<Linode.ResourcePage<Linode.StackScript.Response>>;
-  onSelect: (id: number, label: string, username: string, images: string[],
+  onSelect?: (id: number, label: string, username: string, images: string[],
     userDefinedFields: Linode.StackScript.UserDefinedField[]) => void;
   profile: Linode.Profile;
   isLinodeStackScripts?: boolean;
@@ -278,6 +278,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
   }
 
   handleSelectStackScript = (stackscript: Linode.StackScript.Response) => {
+    if (!this.props.onSelect) { return; }
     this.props.onSelect(
       stackscript.id,
       stackscript.label,
@@ -332,22 +333,28 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
   }
 
   render() {
-    const { classes } = this.props;
+    const { classes, publicImages } = this.props;
     const { currentFilterType, isSorting } = this.state;
 
     if (this.state.loading) {
       return <CircleProgress noTopMargin />;
     }
 
+    const selectProps = (!!this.props.onSelect)
+      ? { onSelect: this.handleSelectStackScript }
+      : {}
+
     return (
       <React.Fragment>
         <Table noOverflow={true} tableClass={classes.table}>
           <TableHead>
             <TableRow className={classes.tr}>
-              <TableCell className={classNames({
-                [classes.tableHead]: true,
-                [classes.stackscriptLabel]: true,
-              })} />
+              {!!this.props.onSelect &&
+                <TableCell className={classNames({
+                  [classes.tableHead]: true,
+                  [classes.stackscriptLabel]: true,
+                })} />
+              }
               <TableCell
                 className={classNames({
                   [classes.tableHead]: true,
@@ -405,13 +412,21 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
                 </Button>
               </TableCell>
               <TableCell className={classes.tableHead}>Compatible Images</TableCell>
+              {!this.props.onSelect &&
+                <TableCell className={classNames({
+                  [classes.tableHead]: true,
+                  [classes.stackscriptLabel]: true,
+                })} />
+              }
             </TableRow>
           </TableHead>
           <StackScriptsSection
             isSorting={isSorting}
-            onSelect={this.handleSelectStackScript}
             selectedId={this.state.selected}
             data={this.state.data}
+            getNext={() => this.getNext()}
+            publicImages={publicImages}
+            {...selectProps}
           />
         </Table>
         {this.state.showMoreButtonVisible && !isSorting &&

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -58,6 +58,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     '-webkit-appearance': 'none',
   },
   selecting: {
+    minHeight: '200px',
     maxHeight: '1000px',
     overflowX: 'auto',
   },
@@ -96,12 +97,13 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 });
 
 interface Props {
-  selectedId: number | null;
+  selectedId?: number | null;
   error?: string;
   shrinkPanel?: boolean;
-  onSelect: (id: number, label: string, username: string, images: string[],
+  onSelect?: (id: number, label: string, username: string, images: string[],
     userDefinedFields: Linode.StackScript.UserDefinedField[]) => void;
-  images: Linode.Image[];
+  publicImages: Linode.Image[];
+  noHeader?: boolean;
 }
 
 type StyledProps = Props & WithStyles<ClassNames>;
@@ -113,21 +115,21 @@ class SelectStackScriptPanel extends React.Component<CombinedProps> {
 
 
   render() {
-    const { classes, images } = this.props;
+    const { classes, publicImages, noHeader } = this.props;
 
     return (
       <TabbedPanel
         error={this.props.error}
         rootClass={classes.root}
         shrinkTabContent={(this.props.shrinkPanel) ? classes.creating : classes.selecting}
-        header="Select StackScript"
+        header={(noHeader) ? "" : "Select StackScript"}
         tabs={[
           {
             title: 'My StackScripts',
             render: () => <StyledContainer
               onSelect={this.props.onSelect}
               // images is an optional prop, so just send an empty array if we didn't get any
-              publicImages={images}
+              publicImages={publicImages}
               request={getStackScriptsByUser} key={0}
             />,
           },
@@ -136,7 +138,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps> {
             render: () => <StyledContainer
               onSelect={this.props.onSelect}
               // images is an optional prop, so just send an empty array if we didn't get any
-              publicImages={images}
+              publicImages={publicImages}
               request={getStackScriptsByUser} key={1}
               isLinodeStackScripts={true}
             />,
@@ -146,7 +148,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps> {
             render: () => <StyledContainer
               onSelect={this.props.onSelect}
               // images is an optional prop, so just send an empty array if we didn't get any
-              publicImages={images}
+              publicImages={publicImages}
               request={getCommunityStackscripts} key={2}
             />,
           },

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -26,7 +26,6 @@ export interface Props {
   selectedId?: number;
   data: Linode.StackScript.Response[];
   isSorting: boolean;
-  getNext: () => void;
   publicImages: Linode.Image[];
 }
 

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -22,11 +22,19 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 });
 
 export interface Props {
-  onSelect: (s: Linode.StackScript.Response) => void;
+  onSelect?: (s: Linode.StackScript.Response) => void;
   selectedId?: number;
   data: Linode.StackScript.Response[];
   isSorting: boolean;
+  getNext: () => void;
+  publicImages: Linode.Image[];
 }
+
+// interface OnSelect {
+//   onSelect: (s: Linode.StackScript.Response) => void;
+// }
+
+// type VariantProp = OnSelect | boolean;
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
@@ -37,13 +45,36 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
     data,
     isSorting,
     classes,
+    publicImages
   } = props;
+
+  const hasNonDeprecatedImages = (stackScriptImages: string[]) => {
+    for (const stackScriptImage of stackScriptImages) {
+      for (const publicImage of publicImages) {
+        if (stackScriptImage === publicImage.id) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  // const handleSelectStackScript = (s: Linode.StackScript.Response) => {
+  //   onSelect!(s);
+  // }
+
+  const renderStackScriptTable = () => {
+    return (!!onSelect)
+    ? selectStackScript(onSelect, selectedId)
+    : listStackScript(true, selectedId)
+  }
 
   return (
     <TableBody>
       {!isSorting
         ? data && data
-          .map(stackScript(onSelect, selectedId))
+          .filter(stackScript => hasNonDeprecatedImages(stackScript.images))
+          .map(renderStackScriptTable())
         : <TableRow>
           <TableCell colSpan={5} className={classes.loadingWrapper}>
             <CircleProgress />
@@ -67,7 +98,7 @@ const stripImageName = (images: string[]) => {
   });
 };
 
-const stackScript: (fn: (s: Linode.StackScript.Response) => void, id?: number) =>
+const selectStackScript: (fn: (s: Linode.StackScript.Response) => void, id?: number) =>
   (s: Linode.StackScript.Response) => JSX.Element =
   (onSelect, selectedId) => s => (
     <SelectionRow
@@ -80,6 +111,23 @@ const stackScript: (fn: (s: Linode.StackScript.Response) => void, id?: number) =
       updated={formatDate(s.updated, false)}
       onSelect={() => onSelect(s)}
       checked={selectedId === s.id}
+      updateFor={[selectedId === s.id]}
+      stackScriptID={s.id}
+    />
+  )
+
+const listStackScript: (showDeployLink: boolean, id?: number) =>
+  (s: Linode.StackScript.Response) => JSX.Element =
+  (showDeployLink, selectedId) => s => (
+    <SelectionRow
+      key={s.id}
+      label={s.label}
+      stackScriptUsername={s.username}
+      description={truncateDescription(s.description)}
+      images={stripImageName(s.images)}
+      deploymentsActive={s.deployments_active}
+      updated={formatDate(s.updated, false)}
+      showDeployLink={showDeployLink}
       updateFor={[selectedId === s.id]}
       stackScriptID={s.id}
     />

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -30,12 +30,6 @@ export interface Props {
   publicImages: Linode.Image[];
 }
 
-// interface OnSelect {
-//   onSelect: (s: Linode.StackScript.Response) => void;
-// }
-
-// type VariantProp = OnSelect | boolean;
-
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => {
@@ -59,10 +53,6 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
     return false;
   }
 
-  // const handleSelectStackScript = (s: Linode.StackScript.Response) => {
-  //   onSelect!(s);
-  // }
-
   const renderStackScriptTable = () => {
     return (!!onSelect)
     ? selectStackScript(onSelect, selectedId)
@@ -77,7 +67,7 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
           .map(renderStackScriptTable())
         : <TableRow>
           <TableCell colSpan={5} className={classes.loadingWrapper}>
-            <CircleProgress />
+            <CircleProgress noTopMargin/>
           </TableCell>
         </TableRow>
       }
@@ -128,7 +118,6 @@ const listStackScript: (showDeployLink: boolean, id?: number) =>
       deploymentsActive={s.deployments_active}
       updated={formatDate(s.updated, false)}
       showDeployLink={showDeployLink}
-      updateFor={[selectedId === s.id]}
       stackScriptID={s.id}
     />
   )

--- a/src/features/StackScripts/StackScripts.tsx
+++ b/src/features/StackScripts/StackScripts.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { withRouter, Route, Switch, RouteComponentProps } from 'react-router-dom';
+import DefaultLoader from 'src/components/DefaultLoader';
+
+const StackScriptsLanding = DefaultLoader({
+  loader: () => import('./StackScriptsLanding'),
+});
+
+type Props = RouteComponentProps<{}>;
+
+class NodeBalancers extends React.Component<Props> {
+  render() {
+    const { match: { path } } = this.props;
+
+    return (
+      <Switch>
+        <Route component={StackScriptsLanding} path={path} exact />
+      </Switch>
+    );
+  }
+}
+
+export default withRouter(NodeBalancers);

--- a/src/features/StackScripts/StackScriptsLanding.test.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.test.tsx
@@ -21,14 +21,17 @@ describe('StackScripts Landing', () => {
     const titleText = component.find('WithStyles(Typography)[variant="headline"]')
     .children().text();
     expect(titleText).toBe('StackScripts');
-  })
+  });
+
   it('should have an Icon Text Link', () => {
     expect(component.find('WithStyles(IconTextLink)')).toHaveLength(1);
-  })
+  });
+
   it('icon text link text should read "Create New StackScript"', () => {
     const iconText = component.find('WithStyles(IconTextLink)').prop('text');
     expect(iconText).toBe('Create New StackScript');
-  })
+  });
+
   it('should render SelectStackScriptPanel', () => {
     expect(component.find('Connect(WithRenderGuard(WithStyles(SelectStackScriptPanel)))'))
       .toHaveLength(1);

--- a/src/features/StackScripts/StackScriptsLanding.test.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.test.tsx
@@ -1,32 +1,11 @@
-import * as React from 'react';
-import { mount } from 'enzyme';
+// import * as React from 'react';
+// import { mount } from 'enzyme';
 
-import { StackScriptsLanding } from './StackScriptsLanding';
-import { setDocs, clearDocs } from 'src/store/reducers/documentation';
+// import { StackScriptsLanding } from './StackScriptsLanding';
+// import { setDocs, clearDocs } from 'src/store/reducers/documentation';
 
-describe('NodeBalancers', () => {
-
-  const component = mount(
-    <StackScriptsLanding
-      classes={{
-        root: '',
-      }}
-      setDocs={setDocs}
-      clearDocs={clearDocs}
-    />,
-  );
-
-  it('should render 3 header tabs', () => {
-    const tabs = component.find('Tab');
-    expect(tabs).toHaveLength(3);
-  });
-
-  it('should render 5 colums in a table', () => {
-    const columns = component.find('TableHead > TableRow > TableCell');
-    // expect(columns).toHaveLength(5);
-  });
-
-  it('should render a select component for filtering', () => {
+describe('StackScripts Landing', () => {
+  it('should render SelectStackScriptPanel', () => {
     //
   });
 });

--- a/src/features/StackScripts/StackScriptsLanding.test.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.test.tsx
@@ -1,0 +1,14 @@
+describe('NodeBalancers', () => {
+
+  it('should render 3 header tabs', () => {
+    //
+  });
+
+  it('should render 5 colums in a table', () => {
+    //
+  });
+
+  it('should render a select component for filtering', () => {
+    //
+  });
+});

--- a/src/features/StackScripts/StackScriptsLanding.test.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.test.tsx
@@ -1,11 +1,29 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import { StackScriptsLanding } from './StackScriptsLanding';
+import { setDocs, clearDocs } from 'src/store/reducers/documentation';
+
 describe('NodeBalancers', () => {
 
+  const component = mount(
+    <StackScriptsLanding
+      classes={{
+        root: '',
+      }}
+      setDocs={setDocs}
+      clearDocs={clearDocs}
+    />,
+  );
+
   it('should render 3 header tabs', () => {
-    //
+    const tabs = component.find('Tab');
+    expect(tabs).toHaveLength(3);
   });
 
   it('should render 5 colums in a table', () => {
-    //
+    const columns = component.find('TableHead > TableRow > TableCell');
+    // expect(columns).toHaveLength(5);
   });
 
   it('should render a select component for filtering', () => {

--- a/src/features/StackScripts/StackScriptsLanding.test.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.test.tsx
@@ -1,11 +1,36 @@
-// import * as React from 'react';
-// import { mount } from 'enzyme';
+import * as React from 'react';
 
-// import { StackScriptsLanding } from './StackScriptsLanding';
-// import { setDocs, clearDocs } from 'src/store/reducers/documentation';
+import { shallow } from 'enzyme';
+
+import { StackScriptsLanding } from './StackScriptsLanding';
+
+import { clearDocs, setDocs } from 'src/store/reducers/documentation';
+
+import { images } from 'src/__data__/images';
 
 describe('StackScripts Landing', () => {
+  const component = shallow(
+    <StackScriptsLanding
+      images={{ response: images }}
+      setDocs={setDocs}
+      clearDocs={clearDocs}
+      classes={{ root: '' }}
+    />
+  )
+  it('title of page should read "StackScripts"', () => {
+    const titleText = component.find('WithStyles(Typography)[variant="headline"]')
+    .children().text();
+    expect(titleText).toBe('StackScripts');
+  })
+  it('should have an Icon Text Link', () => {
+    expect(component.find('WithStyles(IconTextLink)')).toHaveLength(1);
+  })
+  it('icon text link text should read "Create New StackScript"', () => {
+    const iconText = component.find('WithStyles(IconTextLink)').prop('text');
+    expect(iconText).toBe('Create New StackScript');
+  })
   it('should render SelectStackScriptPanel', () => {
-    //
+    expect(component.find('Connect(WithRenderGuard(WithStyles(SelectStackScriptPanel)))'))
+      .toHaveLength(1);
   });
 });

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -1,25 +1,23 @@
 import * as React from 'react';
+
 import {
-  withStyles,
   StyleRulesCallback,
   Theme,
+  withStyles,
   WithStyles,
-} from 'material-ui';
-import Typography from 'material-ui/Typography';
-import AppBar from 'material-ui/AppBar';
-import Tabs, { Tab } from 'material-ui/Tabs';
-// import Paper from 'material-ui/Paper';
-// import TableBody from 'material-ui/Table/TableBody';
-// import TableCell from 'material-ui/Table/TableCell';
-// import TableHead from 'material-ui/Table/TableHead';
-// import TableRow from 'material-ui/Table/TableRow';
+} from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
 
 import { compose } from 'ramda';
 
+import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import Grid from 'src/components/Grid';
 import IconTextLink from 'src/components/IconTextLink';
-import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import PlusSquare from '../../../src/assets/icons/plus-square.svg';
+
+import SelectStackScriptPanel from './SelectStackScriptPanel';
+
+import { images } from 'src/__data__/images';
 
 
 type ClassNames = 'root';
@@ -31,7 +29,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 interface Props { }
 
 interface State {
-  selectedTab: number;
 }
 
 type CombinedProps = Props
@@ -40,7 +37,6 @@ type CombinedProps = Props
 
 export class StackScriptsLanding extends React.Component<CombinedProps, State> {
   state: State = {
-    selectedTab: 0,
   };
 
   static docs = [
@@ -55,42 +51,15 @@ export class StackScriptsLanding extends React.Component<CombinedProps, State> {
     this.setState({ selectedTab: value });
   }
 
-  tabs = [
-    {
-      title: 'My StackScripts',
-      render: () => {
-        return (
-          <React.Fragment>
-            My StackScripts
-          </React.Fragment>
-        );
-      },
-    },
-    {
-      title: 'Linode StackScripts',
-      render: () => {
-        return (
-          <React.Fragment>
-            Linode StackScripts
-          </React.Fragment>
-        );
-      },
-    },
-    {
-      title: 'Community StackScripts',
-      render: () => {
-        return (
-          <React.Fragment>
-            Community StackScripts
-          </React.Fragment>
-        );
-      },
-    },
-  ];
+  filterPublicImages = () => {
+    // get images and preloaded and give us just the public ones
+    // to pass to selectstackscriptpanel
+    // we dont' want to display the deprecated ones because
+    // they're useless.
+    return;
+  }
 
   render() {
-
-    const { selectedTab } = this.state;
 
     return (
       <React.Fragment>
@@ -108,23 +77,11 @@ export class StackScriptsLanding extends React.Component<CombinedProps, State> {
               title="Create New StackScript"
             />
           </Grid>
+          <SelectStackScriptPanel
+            publicImages={images}
+            noHeader={true}
+          />
         </Grid>
-        <AppBar position="static" color="default">
-          <Tabs
-            value={selectedTab}
-            indicatorColor="primary"
-            textColor="primary"
-            onChange={this.handleTabClick}
-          >
-            {
-              this.tabs.map((tab, idx) =>
-                <Tab
-                  key={idx}
-                  label={tab.title}
-                />)
-            }
-          </Tabs>
-        </AppBar>
       </React.Fragment>
     );
   }

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -8,6 +8,11 @@ import {
 import Typography from 'material-ui/Typography';
 import AppBar from 'material-ui/AppBar';
 import Tabs, { Tab } from 'material-ui/Tabs';
+// import Paper from 'material-ui/Paper';
+// import TableBody from 'material-ui/Table/TableBody';
+// import TableCell from 'material-ui/Table/TableCell';
+// import TableHead from 'material-ui/Table/TableHead';
+// import TableRow from 'material-ui/Table/TableRow';
 
 import { compose } from 'ramda';
 
@@ -33,7 +38,7 @@ type CombinedProps = Props
   & SetDocsProps
   & WithStyles<ClassNames>;
 
-class StackScriptsLanding extends React.Component<CombinedProps, State> {
+export class StackScriptsLanding extends React.Component<CombinedProps, State> {
   state: State = {
     selectedTab: 0,
   };

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -13,11 +13,13 @@ import { compose } from 'ramda';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import Grid from 'src/components/Grid';
 import IconTextLink from 'src/components/IconTextLink';
+import PromiseLoader from 'src/components/PromiseLoader';
+
 import PlusSquare from '../../../src/assets/icons/plus-square.svg';
 
 import SelectStackScriptPanel from './SelectStackScriptPanel';
 
-import { images } from 'src/__data__/images';
+import { getImages } from 'src/services/images';
 
 
 type ClassNames = 'root';
@@ -28,12 +30,22 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 
 interface Props { }
 
+interface PreloadedProps {
+  images: { response: Linode.Image[] };
+}
+
 interface State {
 }
 
 type CombinedProps = Props
   & SetDocsProps
-  & WithStyles<ClassNames>;
+  & WithStyles<ClassNames>
+  & PreloadedProps;
+
+  const preloaded = PromiseLoader<Props>({
+    images: () => getImages()
+      .then(response => response.data || []),
+  });
 
 export class StackScriptsLanding extends React.Component<CombinedProps, State> {
   state: State = {
@@ -51,15 +63,17 @@ export class StackScriptsLanding extends React.Component<CombinedProps, State> {
     this.setState({ selectedTab: value });
   }
 
-  filterPublicImages = () => {
+  filterPublicImages = (images: Linode.Image[]) => {
     // get images and preloaded and give us just the public ones
     // to pass to selectstackscriptpanel
     // we dont' want to display the deprecated ones because
     // they're useless.
-    return;
+    return images.filter((image: Linode.Image) => image.is_public)
   }
 
   render() {
+
+    const { images } = this.props;
 
     return (
       <React.Fragment>
@@ -78,7 +92,7 @@ export class StackScriptsLanding extends React.Component<CombinedProps, State> {
             />
           </Grid>
           <SelectStackScriptPanel
-            publicImages={images}
+            publicImages={this.filterPublicImages(images.response)}
             noHeader={true}
           />
         </Grid>
@@ -90,6 +104,7 @@ export class StackScriptsLanding extends React.Component<CombinedProps, State> {
 const styled = withStyles(styles, { withTheme: true });
 
 export default compose(
+  preloaded,
   styled,
   setDocs(StackScriptsLanding.docs),
 )(StackScriptsLanding);

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import {
+  withStyles,
+  StyleRulesCallback,
+  Theme,
+  WithStyles,
+} from 'material-ui';
+import Typography from 'material-ui/Typography';
+import AppBar from 'material-ui/AppBar';
+import Tabs, { Tab } from 'material-ui/Tabs';
+
+import { compose } from 'ramda';
+
+import Grid from 'src/components/Grid';
+import IconTextLink from 'src/components/IconTextLink';
+import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
+import PlusSquare from '../../../src/assets/icons/plus-square.svg';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+});
+
+interface Props { }
+
+interface State {
+  selectedTab: number;
+}
+
+type CombinedProps = Props
+  & SetDocsProps
+  & WithStyles<ClassNames>;
+
+class StackScriptsLanding extends React.Component<CombinedProps, State> {
+  state: State = {
+    selectedTab: 0,
+  };
+
+  static docs = [
+    {
+      title: 'Automate Deployment with StackScripts',
+      src: 'https://www.linode.com/docs/platform/stackscripts/',
+      body: `Create Custom Instances and Automate Deployment with StackScripts.`,
+    },
+  ];
+
+  handleTabClick = (event: React.ChangeEvent<HTMLDivElement>, value: number) => {
+    this.setState({ selectedTab: value });
+  }
+
+  tabs = [
+    {
+      title: 'My StackScripts',
+      render: () => {
+        return (
+          <React.Fragment>
+            My StackScripts
+          </React.Fragment>
+        );
+      },
+    },
+    {
+      title: 'Linode StackScripts',
+      render: () => {
+        return (
+          <React.Fragment>
+            Linode StackScripts
+          </React.Fragment>
+        );
+      },
+    },
+    {
+      title: 'Community StackScripts',
+      render: () => {
+        return (
+          <React.Fragment>
+            Community StackScripts
+          </React.Fragment>
+        );
+      },
+    },
+  ];
+
+  render() {
+
+    const { selectedTab } = this.state;
+
+    return (
+      <React.Fragment>
+        <Grid container>
+          <Grid item xs={9}>
+            <Typography variant="headline">
+              StackScripts
+        </Typography>
+          </Grid>
+          <Grid item xs={3}>
+            <IconTextLink
+              SideIcon={PlusSquare}
+              text="Create New StackScript"
+              onClick={() => console.log('hello world')}
+              title="Create New StackScript"
+            />
+          </Grid>
+        </Grid>
+        <AppBar position="static" color="default">
+          <Tabs
+            value={selectedTab}
+            indicatorColor="primary"
+            textColor="primary"
+            onChange={this.handleTabClick}
+          >
+            {
+              this.tabs.map((tab, idx) =>
+                <Tab
+                  key={idx}
+                  label={tab.title}
+                />)
+            }
+          </Tabs>
+        </AppBar>
+      </React.Fragment>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default compose(
+  styled,
+  setDocs(StackScriptsLanding.docs),
+)(StackScriptsLanding);

--- a/src/features/StackScripts/index.tsx
+++ b/src/features/StackScripts/index.tsx
@@ -1,0 +1,2 @@
+import StackScripts from './StackScripts';
+export default StackScripts;

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -69,12 +69,16 @@ interface State {
   selectedTab: number;
   selectedLinodeIDFromQueryString: number | undefined;
   selectedBackupIDFromQueryString: number | undefined;
+  selectedStackScriptIDFromQueryString: number | undefined;
+  selectedStackScriptTabFromQueryString: string | undefined;
 }
 
 interface QueryStringOptions {
   type: string;
   backupID: string;
   linodeID: string;
+  stackScriptID: string;
+  stackScriptUsername: string;
 }
 
 const preloaded = PromiseLoader<Props>({
@@ -101,6 +105,8 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
     selectedTab: 0,
     selectedLinodeIDFromQueryString: undefined,
     selectedBackupIDFromQueryString: undefined,
+    selectedStackScriptIDFromQueryString: undefined,
+    selectedStackScriptTabFromQueryString: undefined,
   };
 
   mounted: boolean = false;
@@ -126,6 +132,14 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
       this.setState({ selectedTab: this.backupTabIndex });
     } else if (options.type === 'fromStackScript') {
       this.setState({ selectedTab: this.stackScriptTabIndex });
+    }
+
+    if(options.stackScriptUsername) {
+      this.setState({selectedStackScriptTabFromQueryString: options.stackScriptUsername})
+    }
+
+    if(options.stackScriptID) {
+      this.setState({selectedStackScriptIDFromQueryString: +options.stackScriptID || undefined})
     }
 
     if (options.linodeID) {
@@ -243,6 +257,8 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
             getTypeInfo={this.getTypeInfo}
             getRegionName={this.getRegionName}
             history={this.props.history}
+            selectedStackScriptFromQuery={this.state.selectedStackScriptIDFromQueryString}
+            selectedTabFromQuery={this.state.selectedStackScriptTabFromQueryString}
           />
         );
       },

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -53,7 +53,7 @@ describe('FromImageContent', () => {
   });
 
   it('should render SelectStackScript panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(SelectStackScriptPanel))')).toHaveLength(1);
+    expect(component.find('Connect(WithRenderGuard(WithStyles(SelectStackScriptPanel)))')).toHaveLength(1);
   });
 
   it('should render UserDefinedFields panel', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -164,6 +164,19 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
     });
   }
 
+  resetStackScriptSelection = () => {
+    // reset stackscript selection to unselected
+    this.setState({
+      selectedStackScriptID: undefined,
+      selectedStackScriptLabel: '',
+      selectedStackScriptUsername: '',
+      udf_data: null,
+      userDefinedFields: [],
+      compatibleImages: [],
+      selectedImageID: null, // stackscripts don't support all images, so we need to reset it
+    })
+  }
+
   handleChangeUDF = (key: string, value: string) => {
     // either overwrite or create new selection
     const newUDFData = assocPath([key], value, this.state.udf_data);
@@ -333,6 +346,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
             updateFor={[selectedStackScriptID, errors]}
             onSelect={this.handleSelectStackScript}
             publicImages={this.filterPublicImages(images) || []}
+            resetSelectedStackScript={this.resetStackScriptSelection}
           />
           {userDefinedFields && userDefinedFields.length > 0 &&
             <UserDefinedFieldsPanel

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -329,7 +329,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
             shrinkPanel={true}
             updateFor={[selectedStackScriptID, errors]}
             onSelect={this.handleSelectStackScript}
-            images={this.filterPublicImages(images) || []}
+            publicImages={this.filterPublicImages(images) || []}
           />
           {userDefinedFields && userDefinedFields.length > 0 &&
             <UserDefinedFieldsPanel

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -80,6 +80,8 @@ interface Props {
   getTypeInfo: (selectedTypeID: string | null) => TypeInfo;
   getRegionName: (selectedRegionID: string | null) => string | undefined;
   history: any;
+  selectedTabFromQuery?: string;
+  selectedStackScriptFromQuery?: number;
 }
 
 interface State {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -88,7 +88,7 @@ interface State {
   userDefinedFields: Linode.StackScript.UserDefinedField[];
   udf_data: any;
   errors?: Linode.ApiFieldError[];
-  selectedStackScriptID: number | null;
+  selectedStackScriptID: number | undefined;
   selectedStackScriptLabel: string;
   selectedStackScriptUsername: string;
   selectedImageID: string | null;
@@ -117,9 +117,9 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
   state: State = {
     userDefinedFields: [],
     udf_data: null,
-    selectedStackScriptID: null,
+    selectedStackScriptID: this.props.selectedStackScriptFromQuery || undefined,
     selectedStackScriptLabel: '',
-    selectedStackScriptUsername: '',
+    selectedStackScriptUsername: this.props.selectedTabFromQuery || '',
     selectedImageID: null,
     selectedRegionID: null,
     selectedTypeID: null,
@@ -328,6 +328,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
           <SelectStackScriptPanel
             error={hasErrorFor('stackscript_id')}
             selectedId={selectedStackScriptID}
+            selectedUsername={selectedStackScriptUsername}
             shrinkPanel={true}
             updateFor={[selectedStackScriptID, errors]}
             onSelect={this.handleSelectStackScript}

--- a/src/services/stackscripts.ts
+++ b/src/services/stackscripts.ts
@@ -1,8 +1,8 @@
 import { API_ROOT } from 'src/constants';
 import Request, {
-  setURL,
   setMethod,
   setParams,
+  setURL,
   setXFilter,
 } from './index';
 

--- a/src/services/stackscripts.ts
+++ b/src/services/stackscripts.ts
@@ -9,6 +9,13 @@ import Request, {
 type Page<T> = Linode.ResourcePage<T>;
 type StackScript = Linode.StackScript.Response;
 
+export const getStackScript = (id: number) =>
+  Request<StackScript>(
+    setURL(`${API_ROOT}/linode/stackscripts/${id}`),
+    setMethod('GET'),
+  )
+  .then(response => response.data);
+
 export const getStackscripts = (params?: any, filter?: any) =>
   Request<Page<StackScript>>(
     setURL(`${API_ROOT}/linode/stackscripts`),


### PR DESCRIPTION
### Purpose

StackScripts Landing

### Known Issues

* You might notice that when creating a Linode from StackScript, no error appears if you don't select an image. This is solved in #1301 PR in apinext 

### Notes
* Reuses the SelectStackScript component. Basically, if the component is passed a `onSelect` prop, it will render the rows as selections. Otherwise, it renders them as they appear in the landing
* `TabbedPanel` component now has a `handleTabChange` prop, so we can do additional stuff when changing tabs :)
* User can get from the Landing to the _Create Linode from StackScript_ flow by means of the _Deploy New Linode_ btn. Once the user ends up on the create flow, the selected stackscript will be requested then prepended to page 1 of the stackscripts
  * Then, if page 1 or any subsequent page contains the stackscript that had already been prepended, it will be filtered out and not rendered, so we don't get any `duplicate keys` error.

I tried to be as verbose as I could in the comments. Please let me know if anything is not clear.