### PR TITLE
M3-885 IP Transfer Empty State

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -25,9 +25,10 @@ type ClassNames =
   | 'containerDivider'
   | 'ipField'
   | 'addNewButton'
-  | 'noIPsMessage';
+  | 'noIPsMessage'
+  | 'networkActionText';
 
-const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   addNewButton: {
     marginTop: theme.spacing.unit * 3,
     marginBottom: -theme.spacing.unit * 2,
@@ -47,7 +48,11 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   },
   noIPsMessage: {
     marginTop: theme.spacing.unit * 2,
-  }
+    color: theme.color.grey1,
+  },
+  networkActionText: {
+    marginBottom: theme.spacing.unit * 2,
+  },
 });
 
 interface Props {
@@ -302,7 +307,7 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
       >
         <Grid container>
           <Grid item sm={12} lg={8} xl={6}>
-            <Typography>
+            <Typography className={classes.networkActionText}>
               IP Sharing allows a Linode to share an IP address assignment
               (one or more additional IPv4 addresses). This can be
               used to allow one Linode to begin serving requests should

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -424,7 +424,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<CombinedProps, Sta
               this.state.loading
                 ? <LinearProgress style={{ margin: '50px' }} /> // Loading, chill out man.
                 : this.state.linodes.length === 0
-                  ? <Typography className={classes.emptyStateText}>You have no other linodes in this Linode's datacenter with which to share IPs.</Typography>
+                  ? <Typography className={classes.emptyStateText}>You have no other linodes in this Linode's datacenter with which to transfer IPs.</Typography>
                   : Object.values(ips).map(this.ipRow)
             }
           </Grid>

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -23,10 +23,11 @@ type ClassNames =
   | 'ipField'
   | 'ipFieldLabel'
   | 'actionsLabel'
+  | 'networkActionText'
   | 'emptyStateText'
   | 'autoGridsm';
 
-const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   containerDivider: {
    marginTop: theme.spacing.unit,
   },
@@ -54,8 +55,12 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
       flexBasis: 'auto',
     },
   },
+  networkActionText: {
+    marginBottom: theme.spacing.unit * 2,
+  },
   emptyStateText: {
     marginTop: theme.spacing.unit * 2,
+    color: theme.color.grey1,
   }
 });
 
@@ -408,7 +413,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<CombinedProps, Sta
             </Grid>
           }
           <Grid item sm={12} lg={8} xl={6}>
-            <Typography>
+            <Typography className={classes.networkActionText}>
               If you have two Linodes in the same data center, you can use the IP transfer feature to
               switch their IP addresses. This could be useful in several situations. For example,
               if you’ve built a new server to replace an old one, you could swap IP addresses instead

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -1,3 +1,4 @@
+
 import { both, compose, equals, isNil, lensPath, over, path, set, uniq, view, when } from 'ramda';
 import * as React from 'react';
 
@@ -22,6 +23,7 @@ type ClassNames =
   | 'ipField'
   | 'ipFieldLabel'
   | 'actionsLabel'
+  | 'emptyStateText'
   | 'autoGridsm';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
@@ -52,6 +54,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
       flexBasis: 'auto',
     },
   },
+  emptyStateText: {
+    marginTop: theme.spacing.unit * 2,
+  }
 });
 
 interface Props {
@@ -377,10 +382,11 @@ class LinodeNetworkingIPTransferPanel extends React.Component<CombinedProps, Sta
           loading={this.state.submitting}
           onClick={this.onSubmit}
           type="primary"
+          disabled={this.state.linodes.length === 0}
         >
           Save
       </Button>
-        <Button disabled={this.state.submitting} onClick={this.onReset} type="secondary">Cancel</Button>
+        <Button disabled={this.state.submitting || this.state.linodes.length === 0} onClick={this.onReset} type="secondary">Cancel</Button>
       </ActionsPanel>)
   }
 
@@ -418,7 +424,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<CombinedProps, Sta
               this.state.loading
                 ? <LinearProgress style={{ margin: '50px' }} /> // Loading, chill out man.
                 : this.state.linodes.length === 0
-                  ? <Typography>You have no other linodes in this Linode's datacenter with which to share IPs.</Typography>
+                  ? <Typography className={classes.emptyStateText}>You have no other linodes in this Linode's datacenter with which to share IPs.</Typography>
                   : Object.values(ips).map(this.ipRow)
             }
           </Grid>

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -418,7 +418,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<CombinedProps, Sta
               this.state.loading
                 ? <LinearProgress style={{ margin: '50px' }} /> // Loading, chill out man.
                 : this.state.linodes.length === 0
-                  ? null // They don't have any other Linodes to transfer/swap with.
+                  ? <Typography>You have no other linodes in this Linode's datacenter with which to share IPs.</Typography>
                   : Object.values(ips).map(this.ipRow)
             }
           </Grid>


### PR DESCRIPTION
## Purpose
Display an empty state when a user has no eligible Linodes to move/transfer IP's to/with.

![image](https://user-images.githubusercontent.com/12218651/42449709-abecc486-834f-11e8-8057-44c7916ea134.png)
