### PR TITLE
M3-730 Create StackScript

### DIFF
--- a/e2e/config/selenium-config.js
+++ b/e2e/config/selenium-config.js
@@ -9,7 +9,7 @@ module.exports = {
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },
     ie: {
-      version: '3.8.1',
+      version: '3.8.0',
       arch: process.arch,
       baseURL: 'https://selenium-release.storage.googleapis.com'
     },

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -192,7 +192,7 @@ class EditableText extends React.Component<FinalProps, State> {
                   className={classes.textField}
                   type="text"
                   onChange={this.onChange}
-                  onKeyDown={(e) => {
+                  onKeyDown={(e: any) => {
                     if (e.key === 'Enter') { this.finishEditing(text); }
                     if (e.key === 'Escape' || e.key === 'Esc') { this.cancelEditing(); }
                   }}

--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -86,7 +86,7 @@ const Notice: React.StatelessComponent<CombinedProps> = (props) => {
       <Typography {...typeProps} dangerouslySetInnerHTML={{ __html: html }} />
     )
     : (
-      <Typography {...typeProps}>
+      <Typography {...typeProps} component="div">
         {text && text}
         {children && children}
       </Typography>

--- a/src/components/Select/Select.spec.js
+++ b/src/components/Select/Select.spec.js
@@ -20,8 +20,8 @@ describe('Select Suite', () => {
         selectBoxes = $$(select);
         selectBoxes.forEach(s => {
             expect(s.isVisible()).toBe(true);
-            expect(s.$('..').$('label').isVisible()).toBe(true);
-            expect(s.$('..').$('p').isVisible()).toBe(true);
+            expect(s.$('..').$('..').$('label').isVisible()).toBe(true);
+            expect(s.$('..').$('..').$('p').isVisible()).toBe(true);
             expect(s.$('svg').isVisible()).toBe(true);
         });
     });
@@ -42,7 +42,7 @@ describe('Select Suite', () => {
     });
 
     it('should display options on click', () => {
-        const selectTitle = enabledSelects[0].$('..').$('label').getText().toLowerCase();
+        const selectTitle = enabledSelects[0].$('..').$('..').$('label').getText().toLowerCase();
         enabledSelects[0].click();
         
         selectOptions = $(`#menu-${selectTitle}`).$$('li');

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -32,6 +32,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 interface Props extends SelectProps {
   helpText?: string;
   success?: boolean;
+  open?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -68,6 +69,7 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
   return (
     <React.Fragment>
       <Select
+        open={props.open}
         className={c}
         MenuProps={menuProps}
         input={<Input {...inputProps} />}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -10,7 +10,9 @@ import HelpIcon from 'src/components/HelpIcon';
 
 type ClassNames = 'inputSucess'
   | 'inputError'
-  | 'textError';
+  | 'textError'
+  | 'helpWrapper'
+  | 'helpWrapperSelectField';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   inputError: {
@@ -33,6 +35,17 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     },
     '& + p': {
       color: theme.color.green,
+    },
+  },
+  helpWrapper: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'flex-end',
+  },
+  helpWrapperSelectField: {
+    width: 380,
+    [theme.breakpoints.down('xs')]: {
+      width: 240,
     },
   },
 });
@@ -81,10 +94,13 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
     [classes.inputSucess]: success === true,
     [classes.inputError]: error === true,
     [errorScrollClassName]: !!errorScrollClassName,
+    [classes.helpWrapperSelectField]: Boolean(helpText),
   });
 
   return (
-    <React.Fragment>
+    <div className={classNames({
+      [classes.helpWrapper]: Boolean(helpText),
+    })}>
       <Select
         open={props.open}
         className={c}
@@ -97,7 +113,7 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
       </Select>
       {errorText && <p className={classes.textError}>{errorText}</p>}
       {helpText && <HelpIcon text={helpText} />}
-    </React.Fragment>
+    </div>
   );
 };
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,6 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 
+import FormHelperText from '@material-ui/core/FormHelperText';
 import Input, { InputProps } from '@material-ui/core/Input';
 import { MenuProps } from '@material-ui/core/Menu';
 import Select, { SelectProps } from '@material-ui/core/Select';
@@ -111,7 +112,7 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
       >
         {children}
       </Select>
-      {errorText && <p className={classes.textError}>{errorText}</p>}
+      {errorText && <FormHelperText className={classes.textError}>{errorText}</FormHelperText>}
       {helpText && <HelpIcon text={helpText} />}
     </div>
   );

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -9,7 +9,8 @@ import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/
 import HelpIcon from 'src/components/HelpIcon';
 
 type ClassNames = 'inputSucess'
-  | 'inputError';
+  | 'inputError'
+  | 'textError';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   inputError: {
@@ -17,6 +18,13 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     '&[class*="focused"]': {
       borderColor: theme.color.red,
     },
+  },
+  textError: {
+    marginTop: theme.spacing.unit,
+    color: theme.color.red,
+    fontSize: '0.8571428571428571rem',
+    minHeight: '1em',
+    lineHeight: '1em',
   },
   inputSucess: {
     borderColor: theme.color.green,
@@ -33,6 +41,8 @@ interface Props extends SelectProps {
   helpText?: string;
   success?: boolean;
   open?: boolean;
+  errorText?: string;
+  errorGroup?: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -43,8 +53,14 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
   success,
   error,
   helpText,
+  errorText,
+  errorGroup,
   ...props
 }) => {
+
+  const errorScrollClassName = errorGroup
+    ? `error-for-scroll-${errorGroup}`
+    : `error-for-scroll`;
 
   const menuProps: Partial<MenuProps> = {
     getContentAnchorEl: undefined,
@@ -64,6 +80,7 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
   const c = classNames({
     [classes.inputSucess]: success === true,
     [classes.inputError]: error === true,
+    [errorScrollClassName]: !!errorScrollClassName,
   });
 
   return (
@@ -78,6 +95,7 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
       >
         {children}
       </Select>
+      {errorText && <p className={classes.textError}>{errorText}</p>}
       {helpText && <HelpIcon text={helpText} />}
     </React.Fragment>
   );

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -40,7 +40,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   helpWrapper: {
     display: 'flex',
-    flexWrap: 'wrap',
     alignItems: 'flex-end',
   },
   helpWrapperSelectField: {
@@ -99,22 +98,24 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
   });
 
   return (
-    <div className={classNames({
-      [classes.helpWrapper]: Boolean(helpText),
-    })}>
-      <Select
-        open={props.open}
-        className={c}
-        MenuProps={menuProps}
-        input={<Input {...inputProps} />}
-        {...props}
-        data-qa-select
-      >
-        {children}
-      </Select>
+    <React.Fragment>
+      <div className={classNames({
+        [classes.helpWrapper]: Boolean(helpText),
+      })}>
+        <Select
+          open={props.open}
+          className={c}
+          MenuProps={menuProps}
+          input={<Input {...inputProps} />}
+          {...props}
+          data-qa-select
+        >
+          {children}
+        </Select>
+        {helpText && <HelpIcon text={helpText} />}
+      </div>
       {errorText && <FormHelperText className={classes.textError}>{errorText}</FormHelperText>}
-      {helpText && <HelpIcon text={helpText} />}
-    </div>
+    </React.Fragment>
   );
 };
 

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -59,7 +59,6 @@ const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => 
 interface Props extends ChipProps {
   label: string;
   variant?: Variants;
-  onDelete?: () => void;
 }
 
 type PropsWithStyles = Props & WithStyles<CSSClasses>;

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -1,16 +1,46 @@
-import { equals } from 'ramda';
 import * as React from 'react';
 
+import { equals } from 'ramda';
+
+import * as classNames from 'classnames';
+
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
+
+import HelpIcon from 'src/components/HelpIcon';
+
+type ClassNames = 'root'
+  | 'helpWrapper'
+  | 'helpWrapperTextField';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  root: {},
+  helpWrapper: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'flex-end',
+  },
+  helpWrapperTextField: {
+    width: 380,
+    [theme.breakpoints.down('xs')]: {
+      width: 240,
+    },
+  },
+});
 
 export interface Props extends TextFieldProps {
   errorText?: string;
   errorGroup?: string;
   affirmative?: Boolean;
+  tooltipText?: string;
+  className?: any;
   [index: string]: any;
 }
 
-class LinodeTextField extends React.Component<Props> {
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class LinodeTextField extends React.Component<CombinedProps> {
   shouldComponentUpdate(nextProps: Props) {
     return nextProps.value !== this.props.value
       || nextProps.error !== this.props.error
@@ -28,8 +58,12 @@ class LinodeTextField extends React.Component<Props> {
       errorText,
       errorGroup,
       affirmative,
+      classes,
       fullWidth,
       children,
+      tooltipText,
+      theme,
+      className,
       ...textFieldProps
     } = this.props;
 
@@ -57,30 +91,43 @@ class LinodeTextField extends React.Component<Props> {
       : true;
 
     return (
-      <TextField
-        {...finalProps}
-        InputLabelProps={{
-          ...finalProps.InputLabelProps,
-          shrink: true,
-        }}
-        InputProps={{
-          ...finalProps.InputProps,
-          disableUnderline: true,
-        }}
-        SelectProps={{
-          MenuProps: {
-            getContentAnchorEl: undefined,
-            anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
-            transformOrigin: { vertical: 'top', horizontal: 'left' },
-            MenuListProps: { className: 'selectMenuList' },
-            PaperProps: { className: 'selectMenuDropdown' },
-          },
-        }}
+      <div className={classNames({
+        [classes.helpWrapper]: Boolean(tooltipText),
+      })}
       >
-        {this.props.children}
-      </TextField>
+        <TextField
+          {...finalProps}
+          InputLabelProps={{
+            ...finalProps.InputLabelProps,
+            shrink: true,
+          }}
+          InputProps={{
+            ...finalProps.InputProps,
+            disableUnderline: true,
+          }}
+          SelectProps={{
+            MenuProps: {
+              getContentAnchorEl: undefined,
+              anchorOrigin: { vertical: 'bottom', horizontal: 'left' },
+              transformOrigin: { vertical: 'top', horizontal: 'left' },
+              MenuListProps: { className: 'selectMenuList' },
+              PaperProps: { className: 'selectMenuDropdown' },
+            },
+          }}
+          className={classNames({
+            [classes.helpWrapperTextField]: Boolean(tooltipText),
+          },
+          className,
+          )}
+        >
+          {this.props.children}
+        </TextField>
+        {tooltipText && <HelpIcon text={tooltipText} />}
+      </div>
     );
   }
 }
 
-export default LinodeTextField;
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled<CombinedProps>(LinodeTextField);

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -77,6 +77,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
         : `error-for-scroll`;
       finalProps.InputProps = {
         className: errorScrollClassName,
+        ...finalProps.InputProps
       };
     }
 

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -18,7 +18,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   root: {},
   helpWrapper: {
     display: 'flex',
-    flexWrap: 'wrap',
     alignItems: 'flex-end',
   },
   helpWrapperTextField: {

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -336,7 +336,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
         const newDataWithoutDeprecatedDistros =
           newData.filter(stackScript => this.hasNonDeprecatedImages(stackScript.images));
 
-        if (newDataWithoutDeprecatedDistros.length === 0) {
+        if (isSorting && newDataWithoutDeprecatedDistros.length === 0) {
           this.getNext();
           return;
         }

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -129,6 +129,16 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
     shouldPreSelectStackScript: true,
   }
 
+  mounted: boolean = false;
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
+
   tabs = [
     {
       title: 'My StackScripts',
@@ -185,6 +195,8 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
   */
   getInitTab = () => {
     const { profile, onSelect, selectedUsername } = this.props;
+
+    if (!this.mounted) { return; }
 
     if (profile.username === selectedUsername) {
       return this.myTabIndex;
@@ -352,13 +364,13 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
         * the duplicate key error
         */
         const cleanedData = (!!selectedStackScriptIDFromQuery)
-        ? newDataWithoutDeprecatedDistros.filter((stackScript, index) => {
-          if(index !== 0) {
-            return stackScript.id !== selectedStackScriptIDFromQuery;
-          }
-          return stackScript;
-        })
-        : newDataWithoutDeprecatedDistros;
+          ? newDataWithoutDeprecatedDistros.filter((stackScript, index) => {
+            if (index !== 0) {
+              return stackScript.id !== selectedStackScriptIDFromQuery;
+            }
+            return stackScript;
+          })
+          : newDataWithoutDeprecatedDistros;
         this.setState({
           listOfStackScripts: cleanedData,
           gettingMoreStackScripts: false,
@@ -375,7 +387,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
 
   componentDidMount() {
     const { selectedStackScriptIDFromQuery, shouldPreSelectStackScript,
-    onSelect } = this.props;
+      onSelect } = this.props;
     this.mounted = true;
     /*
     * if the user is coming to the StackScripts panel from a query string
@@ -401,7 +413,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
         .catch(e => {
           if (!this.mounted) { return; }
           this.props.resetStackScriptSelection();
-          this.setState({error: e.response});
+          this.setState({ error: e.response });
         });
     }
     return this.getDataAtPage(0);
@@ -575,7 +587,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     const { classes, publicImages, currentUser } = this.props;
     const { currentFilterType, isSorting, fieldError, error } = this.state;
 
-    if(error) {
+    if (error) {
       return <ErrorState
         errorText="There was an error loading your StackScripts. Please try again later."
       />
@@ -595,102 +607,102 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
           <Notice text={fieldError.reason} error />
         }
         {this.state.listOfStackScripts.length === 0
-        ? <div className={classes.emptyState} data-qa-stackscript-empty-msg>
-          You do not have any StackScripts to select from. You must first
+          ? <div className={classes.emptyState} data-qa-stackscript-empty-msg>
+            You do not have any StackScripts to select from. You must first
           <Link to="/stackscripts/create"> create one</Link>
-        </div>
-        : <Table noOverflow={true} tableClass={classes.table}>
-          <TableHead>
-            <TableRow className={classes.tr}>
-              {!!this.props.onSelect &&
-                <TableCell className={classNames({
-                  [classes.tableHead]: true,
-                  [classes.stackscriptLabel]: true,
-                })} />
-              }
-              <TableCell
-                className={classNames({
-                  [classes.tableHead]: true,
-                  [classes.stackscriptTitles]: true,
-                })}
-                sortable
-              >
-                <Button
-                  type="secondary"
-                  className={classes.sortButton}
-                  onClick={this.handleClickStackScriptsTableHeader}
-                  data-qa-stackscript-table-header
+          </div>
+          : <Table noOverflow={true} tableClass={classes.table}>
+            <TableHead>
+              <TableRow className={classes.tr}>
+                {!!this.props.onSelect &&
+                  <TableCell className={classNames({
+                    [classes.tableHead]: true,
+                    [classes.stackscriptLabel]: true,
+                  })} />
+                }
+                <TableCell
+                  className={classNames({
+                    [classes.tableHead]: true,
+                    [classes.stackscriptTitles]: true,
+                  })}
+                  sortable
                 >
-                  StackScripts
+                  <Button
+                    type="secondary"
+                    className={classes.sortButton}
+                    onClick={this.handleClickStackScriptsTableHeader}
+                    data-qa-stackscript-table-header
+                  >
+                    StackScripts
                   {currentFilterType === 'label' &&
-                    this.renderIcon()
-                  }
-                </Button>
-              </TableCell>
-              <TableCell
-                className={classNames({
-                  [classes.tableHead]: true,
-                  [classes.deploys]: true,
-                })}
-                noWrap
-                sortable
-              >
-                <Button
-                  type="secondary"
-                  className={classes.sortButton}
-                  onClick={this.handleClickDeploymentsTableHeader}
-                  data-qa-stackscript-active-deploy-header
+                      this.renderIcon()
+                    }
+                  </Button>
+                </TableCell>
+                <TableCell
+                  className={classNames({
+                    [classes.tableHead]: true,
+                    [classes.deploys]: true,
+                  })}
+                  noWrap
+                  sortable
                 >
-                  Active Deploys
+                  <Button
+                    type="secondary"
+                    className={classes.sortButton}
+                    onClick={this.handleClickDeploymentsTableHeader}
+                    data-qa-stackscript-active-deploy-header
+                  >
+                    Active Deploys
                   {currentFilterType !== 'label' && currentFilterType !== 'revision' &&
-                    this.renderIcon()
-                  }
-                </Button>
-              </TableCell>
-              <TableCell
-                className={classNames({
-                  [classes.tableHead]: true,
-                  [classes.revisions]: true,
-                })}
-                noWrap
-                sortable
-              >
-                <Button
-                  type="secondary"
-                  className={classes.sortButton}
-                  onClick={this.handleClickRevisionsTableHeader}
-                  data-qa-stackscript-revision-header
+                      this.renderIcon()
+                    }
+                  </Button>
+                </TableCell>
+                <TableCell
+                  className={classNames({
+                    [classes.tableHead]: true,
+                    [classes.revisions]: true,
+                  })}
+                  noWrap
+                  sortable
                 >
-                  Last Revision
+                  <Button
+                    type="secondary"
+                    className={classes.sortButton}
+                    onClick={this.handleClickRevisionsTableHeader}
+                    data-qa-stackscript-revision-header
+                  >
+                    Last Revision
                   {currentFilterType === 'revision' &&
-                    this.renderIcon()
-                  }
-                </Button>
+                      this.renderIcon()
+                    }
+                  </Button>
+                </TableCell>
+                <TableCell
+                  className={classes.tableHead}
+                  data-qa-stackscript-compatible-images
+                >
+                  Compatible Images
               </TableCell>
-              <TableCell
-                className={classes.tableHead}
-                data-qa-stackscript-compatible-images
-              >
-                Compatible Images
-              </TableCell>
-              {!this.props.onSelect &&
-                <TableCell className={classNames({
-                  [classes.tableHead]: true,
-                  [classes.stackscriptLabel]: true,
-                })} />
-              }
-            </TableRow>
-          </TableHead>
-          <StackScriptsSection
-            isSorting={isSorting}
-            selectedId={this.state.selected}
-            data={this.state.listOfStackScripts}
-            publicImages={publicImages}
-            triggerDelete={this.handleOpenDialog}
-            currentUser={currentUser}
-            {...selectProps}
-          />
-        </Table>
+                {!this.props.onSelect &&
+                  <TableCell className={classNames({
+                    [classes.tableHead]: true,
+                    [classes.stackscriptLabel]: true,
+                  })} />
+                }
+              </TableRow>
+            </TableHead>
+            <StackScriptsSection
+              isSorting={isSorting}
+              selectedId={this.state.selected}
+              data={this.state.listOfStackScripts}
+              publicImages={publicImages}
+              triggerDelete={this.handleOpenDialog}
+              currentUser={currentUser}
+              {...selectProps}
+            />
+          </Table>
         }
         {this.state.showMoreButtonVisible && !isSorting &&
           <Button

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -43,17 +43,6 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
     currentUser,
   } = props;
 
-  const hasNonDeprecatedImages = (stackScriptImages: string[]) => {
-    for (const stackScriptImage of stackScriptImages) {
-      for (const publicImage of publicImages) {
-        if (stackScriptImage === publicImage.id) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
   const renderStackScriptTable = () => {
     return (!!onSelect)
     ? selectStackScript(onSelect, selectedId)
@@ -116,7 +105,6 @@ const listStackScript: (
     <TableBody>
       {!isSorting
         ? data && data
-          .filter(stackScript => hasNonDeprecatedImages(stackScript.images))
           .map(renderStackScriptTable())
         : <TableRow>
           <TableCell colSpan={5} className={classes.loadingWrapper}>

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -38,7 +38,6 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
     data,
     isSorting,
     classes,
-    publicImages,
     triggerDelete,
     currentUser,
   } = props;

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -115,13 +115,21 @@ const listStackScript: (
   );
 };
 
+/*
+* Truncate description of stackscript on the select panel
+* only if the description exceeds 140 characters (s/o Twitter)
+*/
 const truncateDescription = (desc: string) => {
-  if (desc.length > 200) { // 200 characters
-    return `${desc.split(' ').splice(0, 30).join(' ')} [...]`; // truncate to 30 words
+  if (desc.length > 140) {
+    return `${desc.split(' ').splice(0, 10).join(' ')} [...]`;
   }
   return desc;
 };
 
+/*
+* @TODO Deprecate once we have a reliable way of mapping
+* the slug to the display name
+*/
 const stripImageName = (images: string[]) => {
   return images.map((image: string) => {
     return image.replace('linode/', '');

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
@@ -22,19 +22,29 @@ describe('StackScriptCreate', () => {
     />
   )
   it('should render a title that reads "Create New StackScript', () => {
-    const titleText = component.find('WithStyles(Typography)').children().text();
+    const titleText = component.find('WithStyles(Typography)').first().children().text();
     expect(titleText).toBe('Create New StackScript');
   });
 
   it('should render three text fields', () => {
     expect(component.find('LinodeTextField')).toHaveLength(4);
   });
-  
+
   it('should render a select field', () => {
     expect(component.find('WithStyles(SSelect)')).toHaveLength(1);
   });
 
   it('should render a code text field', () => {
-    // render code text
+    // not done yet!!
   });
+
+  it('should render a checkbox', () => {
+    expect(component.find('WithStyles(LinodeCheckBox)')).toHaveLength(1);
+  });
+
+  it(`should render a confirmation dialog with the
+  title "Clear StackScript Configuration?"`, () => {
+      const modalTitle = component.find('WithStyles(ConfirmationDialog)').prop('title');
+      expect(modalTitle).toBe('Clear StackScript Configuration?');
+    });
 });

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
@@ -26,8 +26,8 @@ describe('StackScriptCreate', () => {
     expect(titleText).toBe('Create New StackScript');
   });
 
-  it('should render two text fields', () => {
-    expect(component.find('LinodeTextField')).toHaveLength(2);
+  it('should render three text fields', () => {
+    expect(component.find('LinodeTextField')).toHaveLength(4);
   });
   
   it('should render a select field', () => {

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { StackScriptCreate } from './StackScriptCreate';
+
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
+
+describe('StackScriptCreate', () => {
+  const component = shallow(
+    <StackScriptCreate
+      {...reactRouterProps}
+      classes={{
+        titleWrapper: '',
+        root: '',
+        backButton: '',
+        createTitle: '',
+      }}
+      profile={[]}
+    />
+  )
+  it('should render a title that reads "Create New StackScript', () => {
+    const titleText = component.find('WithStyles(Typography)').children().text();
+    expect(titleText).toBe('Create New StackScript');
+  });
+
+  it('should render two text fields', () => {
+    expect(component.find('LinodeTextField')).toHaveLength(2);
+  });
+  
+  it('should render a select field', () => {
+    expect(component.find('WithStyles(SSelect)')).toHaveLength(1);
+  });
+
+  it('should render a code text field', () => {
+    // render code text
+  });
+});

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
@@ -26,9 +26,9 @@ describe('StackScriptCreate', () => {
     expect(titleText).toBe('Create New StackScript');
   });
 
-  // it('should render three text fields', () => {
-  //   expect(component.find('LinodeTextField')).toHaveLength(4);
-  // });
+  it('should render three text fields', () => {
+    expect(component.find('WithStyles(LinodeTextField)')).toHaveLength(4);
+  });
 
   it('should render a select field', () => {
     expect(component.find('WithStyles(SSelect)')).toHaveLength(1);
@@ -38,9 +38,9 @@ describe('StackScriptCreate', () => {
     // not done yet!!
   });
 
-  // it('should render a checkbox', () => {
-  //   expect(component.find('WithStyles(LinodeCheckBox)')).toHaveLength(1);
-  // });
+  it('should render a checkbox', () => {
+    expect(component.find('WithStyles(FormControlLabel)')).toHaveLength(1);
+  });
 
   it(`should render a confirmation dialog with the
   title "Clear StackScript Configuration?"`, () => {

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
@@ -5,6 +5,8 @@ import { StackScriptCreate } from './StackScriptCreate';
 
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 
+import { images } from 'src/__data__/images';
+
 describe('StackScriptCreate', () => {
   const component = shallow(
     <StackScriptCreate
@@ -16,6 +18,7 @@ describe('StackScriptCreate', () => {
         createTitle: '',
       }}
       profile={[]}
+      images={{ response: images }}
     />
   )
   it('should render a title that reads "Create New StackScript', () => {

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
@@ -38,9 +38,9 @@ describe('StackScriptCreate', () => {
     // not done yet!!
   });
 
-  it('should render a checkbox', () => {
-    expect(component.find('WithStyles(LinodeCheckBox)')).toHaveLength(1);
-  });
+  // it('should render a checkbox', () => {
+  //   expect(component.find('WithStyles(LinodeCheckBox)')).toHaveLength(1);
+  // });
 
   it(`should render a confirmation dialog with the
   title "Clear StackScript Configuration?"`, () => {

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
@@ -26,9 +26,9 @@ describe('StackScriptCreate', () => {
     expect(titleText).toBe('Create New StackScript');
   });
 
-  it('should render three text fields', () => {
-    expect(component.find('LinodeTextField')).toHaveLength(4);
-  });
+  // it('should render three text fields', () => {
+  //   expect(component.find('LinodeTextField')).toHaveLength(4);
+  // });
 
   it('should render a select field', () => {
     expect(component.find('WithStyles(SSelect)')).toHaveLength(1);

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -24,10 +24,10 @@ import Grid from 'src/components/Grid';
 import HelpIcon from 'src/components/HelpIcon';
 import PromiseLoader from 'src/components/PromiseLoader';
 import Select from 'src/components/Select';
+import Tag from 'src/components/Tag';
 import TextField from 'src/components/TextField';
 
 import { getLinodeImages } from 'src/services/images';
-
 
 type ClassNames = 'root'
   | 'backButton'
@@ -111,14 +111,27 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     this.setState({ imageSelectOpen: false });
   }
 
+  handleRemoveImage = (indexToRemove: any) => {
+    const selectedImagesCopy = this.state.selectedImages;
+    selectedImagesCopy.splice(indexToRemove, 1);
+    this.setState({ selectedImages: selectedImagesCopy });
+  }
+
   handleChooseImage = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    console.log(this.state.selectedImages);
-    this.setState({ selectedImages: [...this.state.selectedImages, e.target.value] })
+    const { availableImages } = this.state;
+    const filteredAvailableImages = availableImages.filter((image) => {
+      return image.label !== e.target.value;
+    })
+    this.setState({
+      selectedImages: [...this.state.selectedImages, e.target.value],
+      availableImages: filteredAvailableImages,
+    })
     this.setState({ imageSelectOpen: true });
   }
 
   render() {
-    const { classes, profile, images } = this.props;
+    const { classes, profile } = this.props;
+    const { availableImages, selectedImages } = this.state;
     return (
       <React.Fragment>
         <Grid
@@ -180,7 +193,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             // error={Boolean(regionError)}
             >
               <MenuItem disabled key="none" value="none">Select Compatible Images</MenuItem>,
-            {images && images.response.map(image =>
+            {availableImages && availableImages.map(image =>
                 <MenuItem
                   key={image.id}
                   value={image.label}
@@ -196,6 +209,16 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
           } */}
           </FormControl>
           <HelpIcon text="Select Multiple Images" />
+          {selectedImages && selectedImages.map((selectedImage, index) => {
+            return (
+              <Tag
+                key={selectedImage}
+                label={selectedImage}
+                variant='lightBlue'
+                onDelete={() => this.handleRemoveImage(index)}
+              />
+            )
+          })}
         </Paper>
       </React.Fragment>
     );

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -83,8 +83,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   tips: {
     marginLeft: theme.spacing.unit * 4,
     marginTop: theme.spacing.unit * 4,
-    paddingLeft: theme.spacing.unit * 4,
-    borderLeft: `5px solid ${theme.palette.divider}`,
+    padding: theme.spacing.unit * 4,
+    backgroundColor: theme.palette.divider,
     [theme.breakpoints.down('lg')]: {
       marginLeft: 0,
     },

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -13,6 +13,7 @@ import {
 
 import FormControl from '@material-ui/core/FormControl';
 import IconButton from '@material-ui/core/IconButton';
+import InputAdornment from '@material-ui/core/InputAdornment';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import Paper from '@material-ui/core/Paper';
@@ -24,7 +25,6 @@ import Button from 'src/components/Button';
 import Checkbox from 'src/components/CheckBox';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Grid from 'src/components/Grid';
-import HelpIcon from 'src/components/HelpIcon';
 import Notice from 'src/components/Notice';
 import PromiseLoader from 'src/components/PromiseLoader';
 import Select from 'src/components/Select';
@@ -43,7 +43,7 @@ type ClassNames = 'root'
   | 'backButton'
   | 'titleWrapper'
   | 'createTitle'
-  | 'adornment'
+  | 'labelField'
   | 'tips';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
@@ -60,14 +60,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   createTitle: {
     lineHeight: '2.25em'
   },
+  labelField: {
+    '& input': {
+      paddingLeft: 0,
+    },
+  },
   titleWrapper: {
     display: 'flex',
     marginTop: 5,
-  },
-  adornment: {
-    fontSize: '.9rem',
-    marginLeft: 5,
-    color: theme.color.grey1
   },
   tips: {
     backgroundColor: theme.bg.main,
@@ -349,8 +349,10 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
         <Paper className={classes.root}>
           <TextField
             InputProps={{
-              startAdornment: <span className={classes.adornment}>
-                {profile.username} /</span>,
+              startAdornment: 
+                <InputAdornment position="end">
+                  {profile.username} /
+                </InputAdornment>,
             }}
             label='StackScript Label'
             required
@@ -358,8 +360,9 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             placeholder='Enter a label'
             value={labelText}
             errorText={hasErrorFor('label')}
+            tooltipText="Select a StackScript Label"
+            className={classes.labelField}
           />
-          <HelpIcon text="Select a StackScript Label" />
           <TextField
             multiline
             rows={1}
@@ -367,8 +370,8 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             placeholder="Enter a description"
             onChange={this.handleDescriptionChange}
             value={descriptionText}
+            tooltipText="Give your StackScript a description"
           />
-          <HelpIcon text="Give your StackScript a description" />
           <FormControl fullWidth>
             <InputLabel
               htmlFor="image"

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -103,7 +103,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
 });
 
-interface Props { 
+interface Props {
   profile: Linode.Profile;
 }
 
@@ -123,7 +123,7 @@ interface State {
   isSubmitting: boolean;
   errors?: Linode.ApiFieldError[];
   dialogOpen: boolean;
- }
+}
 
 type CombinedProps = Props
   & SetDocsProps
@@ -164,7 +164,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
       body: `Create Custom Instances and Automate Deployment with StackScripts.`,
     },
   ];
-  
+
   mounted: boolean = false;
 
   componentDidMount() {
@@ -174,7 +174,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
   componentWillUnmount() {
     this.mounted = false;
   }
-  
+
   /*
   * Gets images by two types: deprecated and non-deprecated
   */
@@ -183,7 +183,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
   }
 
   handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({labelText: e.target.value});
+    this.setState({ labelText: e.target.value });
   }
 
   handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -199,9 +199,24 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
   }
 
   handleRemoveImage = (indexToRemove: any) => {
+    /*
+    * remove selected image from the selected list
+    */
     const selectedImagesCopy = this.state.selectedImages;
-    selectedImagesCopy.splice(indexToRemove, 1);
-    this.setState({ selectedImages: selectedImagesCopy });
+    const removedImage = selectedImagesCopy.splice(indexToRemove, 1);
+
+    /*
+    * add the remvoed image back to the selection list
+    */
+    const availableImagesCopy = this.state.availableImages;
+    const imageToBeReAdded = this.props.images.response.find(image =>
+      image.id === removedImage[0]);
+    availableImagesCopy.unshift(imageToBeReAdded!);
+
+    this.setState({
+      selectedImages: selectedImagesCopy,
+      availableImages: availableImagesCopy,
+    });
   }
 
   handleChooseImage = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -323,7 +338,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
   render() {
     const { classes, profile } = this.props;
     const { selectedImages, script,
-    labelText, descriptionText, revisionNote, errors } = this.state;
+      labelText, descriptionText, revisionNote, errors } = this.state;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
@@ -355,7 +370,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             <Grid item className={classes.gridWithTips}>
               <TextField
                 InputProps={{
-                  startAdornment: 
+                  startAdornment:
                     <InputAdornment position="end">
                       {profile.username} /
                     </InputAdornment>,
@@ -433,11 +448,11 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
               </div>
             </Grid>
             <Grid item className={classes.gridWithTips}>
-              <Notice 
+              <Notice
                 className={classes.tips}
                 component="div"
               >
-              <Typography variant="title">Tips</Typography>
+                <Typography variant="title">Tips</Typography>
                 <Typography>There are four default environment variables provided to you:</Typography>
                 <ul>
                   <li>LINODE_ID</li>
@@ -455,6 +470,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             placeholder={`#!/bin/bash \n\n# Your script goes here`}
             onChange={this.handleChangeScript}
             value={script}
+            errorText={hasErrorFor('script')}
             required
           />
           <TextField
@@ -468,13 +484,13 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
           <Notice
             component="div"
             warning
-            flag 
+            flag
             className={classes.warning}
           >
             <Typography variant="title">Woah, just a word of caution...</Typography>
             <Typography>
-                Making this StackScript public cannot be undone. Once made public, your StackScript will
-                be available to all Linode users and can be used to provision new Linodes.
+              Making this StackScript public cannot be undone. Once made public, your StackScript will
+              be available to all Linode users and can be used to provision new Linodes.
             </Typography>
           </Notice>
           <FormControlLabel
@@ -486,8 +502,8 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
                 checked={this.state.is_public}
               />
             }
-              label="Publish this StackScript to the Public Library"
-            />
+            label="Publish this StackScript to the Public Library"
+          />
           <ActionsPanel style={{ paddingBottom: 0 }}>
             <Button
               data-qa-confirm-cancel

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -26,7 +26,7 @@ import PromiseLoader from 'src/components/PromiseLoader';
 import Select from 'src/components/Select';
 import TextField from 'src/components/TextField';
 
-import { getImages } from 'src/services/images';
+import { getLinodeImages } from 'src/services/images';
 
 
 type ClassNames = 'root'
@@ -72,6 +72,8 @@ interface State {
   labelText: string;
   descriptionText: string;
   imageSelectOpen: boolean;
+  selectedImages: string[];
+  availableImages: Linode.Image[];
  }
 
 type CombinedProps = Props
@@ -79,7 +81,7 @@ type CombinedProps = Props
   & PreloadedProps;
 
 const preloaded = PromiseLoader<Props>({
-  images: () => getImages()
+  images: () => getLinodeImages()
     .then(response => response.data || [])
 })
 
@@ -88,9 +90,12 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     labelText: '',
     descriptionText: '',
     imageSelectOpen: false,
+    selectedImages: [],
+    /* available images to select from in the dropdown */
+    availableImages: this.props.images.response,
   };
 
-  handleLabelChagne = (e: React.ChangeEvent<HTMLInputElement>) => {
+  handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({labelText: e.target.value});
   }
 
@@ -107,7 +112,8 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
   }
 
   handleChooseImage = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    console.log(e.target.value);
+    console.log(this.state.selectedImages);
+    this.setState({ selectedImages: [...this.state.selectedImages, e.target.value] })
     this.setState({ imageSelectOpen: true });
   }
 
@@ -141,7 +147,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             // errorText={hasErrorFor('client_conn_throttle')}
             label='StackScript Label'
             required
-            onChange={this.handleLabelChagne}
+            onChange={this.handleLabelChange}
             placeholder='Enter a label'
           />
           <HelpIcon text="Select a StackScript Label" />

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -31,6 +31,8 @@ import Select from 'src/components/Select';
 import Tag from 'src/components/Tag';
 import TextField from 'src/components/TextField';
 
+import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
+
 import { getLinodeImages } from 'src/services/images';
 import { createStackScript } from 'src/services/stackscripts';
 
@@ -95,6 +97,7 @@ interface State {
  }
 
 type CombinedProps = Props
+  & SetDocsProps
   & WithStyles<ClassNames>
   & PreloadedProps
   & RouteComponentProps<{}>;
@@ -124,6 +127,14 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     isSubmitting: false,
     dialogOpen: false,
   };
+
+  static docs = [
+    {
+      title: 'Automate Deployment with StackScripts',
+      src: 'https://www.linode.com/docs/platform/stackscripts/',
+      body: `Create Custom Instances and Automate Deployment with StackScripts.`,
+    },
+  ];
   
   mounted: boolean = false;
 
@@ -456,8 +467,9 @@ const mapStateToProps = (state: Linode.AppState) => ({
 const styled = withStyles(styles, { withTheme: true });
 
 export default compose(
+  setDocs(StackScriptCreate.docs),
   styled,
   withRouter,
   connect(mapStateToProps),
-  preloaded
+  preloaded,
 )(StackScriptCreate)

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -289,16 +289,13 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <ActionsPanel>
           <Button
-            variant="raised"
-            color="secondary"
-            className="destructive"
+            type="secondary"
+            destructive
             onClick={this.resetAllFields}>
             Yes
           </Button>
           <Button
-            variant="raised"
-            color="secondary"
-            className="cancel"
+            type="cancel"
             onClick={this.handleCloseDialog}
           >
             No

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -44,7 +44,8 @@ type ClassNames = 'root'
   | 'titleWrapper'
   | 'createTitle'
   | 'labelField'
-  | 'tips';
+  | 'tips'
+  | 'warning';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -70,7 +71,19 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     marginTop: 5,
   },
   tips: {
-    backgroundColor: theme.bg.main,
+    marginLeft: theme.spacing.unit * 4,
+    marginTop: theme.spacing.unit * 4,
+    paddingLeft: theme.spacing.unit * 4,
+    borderLeft: `5px solid ${theme.palette.divider}`,
+    [theme.breakpoints.down('lg')]: {
+      marginLeft: 0,
+    },
+    [theme.breakpoints.down('md')]: {
+      paddingLeft: theme.spacing.unit * 2,
+    },
+  },
+  warning: {
+    marginTop: theme.spacing.unit * 2,
   }
 });
 
@@ -255,28 +268,6 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     this.setState({ dialogOpen: false })
   }
 
-  renderNoticeHTML = () => {
-    return (
-      `<h3>Woah, just a word of caution...</h3>
-        <p>Making this StackScript public cannot be undone. Once made public, your StackScript will
-          be available to all Linode users and can be used to provision new Linodes.
-      </p>`
-    )
-  }
-
-  renderTipsHTML = () => {
-    return (
-      `<h3>Tips</h3>
-      <p>There are four default environment variables provided to you:</p>
-      <ul>
-        <li>LINODE_ID</li>
-        <li>LINODE_LISTUSERNAME</li>
-        <li>LINODE_RAM</li>
-        <li>LINODE_DATACENTERID</li>
-      </ul>`
-    )
-  }
-
   renderDialogActions = () => {
     return (
       <React.Fragment>
@@ -343,86 +334,104 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             </Link>
             <Typography className={classes.createTitle} variant="headline">
               Create New StackScript
-      </Typography>
+            </Typography>
           </Grid>
         </Grid>
         <Paper className={classes.root}>
-          <TextField
-            InputProps={{
-              startAdornment: 
-                <InputAdornment position="end">
-                  {profile.username} /
-                </InputAdornment>,
-            }}
-            label='StackScript Label'
-            required
-            onChange={this.handleLabelChange}
-            placeholder='Enter a label'
-            value={labelText}
-            errorText={hasErrorFor('label')}
-            tooltipText="Select a StackScript Label"
-            className={classes.labelField}
-          />
-          <TextField
-            multiline
-            rows={1}
-            label="Description"
-            placeholder="Enter a description"
-            onChange={this.handleDescriptionChange}
-            value={descriptionText}
-            tooltipText="Give your StackScript a description"
-          />
-          <FormControl fullWidth>
-            <InputLabel
-              htmlFor="image"
-              disableAnimation
-              shrink={true}
-              required
-            >
-              Target Images
-          </InputLabel>
-            <Select
-              open={this.state.imageSelectOpen}
-              onOpen={this.handleOpenSelect}
-              onClose={this.handleCloseSelect}
-              value='none'
-              onChange={this.handleChooseImage}
-              inputProps={{ name: 'image', id: 'image' }}
-              helpText='Select which images are compatible with this StackScript'
-              error={Boolean(hasErrorFor('images'))}
-              errorText={hasErrorFor('images')}
-            >
-              <MenuItem disabled key="none" value="none">Select Compatible Images</MenuItem>,
-            {this.getImagesByDeprecationStatus(false).map(image =>
-                <MenuItem
-                  key={image.id}
-                  value={image.id}
-                >
-                  {image.label}
-                </MenuItem>,
-              )}
-              <MenuItem disabled key="deprecated" value="deprecated">Older Images</MenuItem>,
-            {this.getImagesByDeprecationStatus(true).map(image =>
-                <MenuItem
-                  key={image.id}
-                  value={image.id}
-                >
-                  {image.label}
-                </MenuItem>,
-              )}
-            </Select>
-          </FormControl>
-          {selectedImages && selectedImages.map((selectedImage, index) => {
-            return (
-              <Tag
-                key={selectedImage}
-                label={selectedImage}
-                variant='lightBlue'
-                onDelete={() => this.handleRemoveImage(index)}
+          <Grid container>
+            <Grid item>
+              <TextField
+                InputProps={{
+                  startAdornment: 
+                    <InputAdornment position="end">
+                      {profile.username} /
+                    </InputAdornment>,
+                }}
+                label='StackScript Label'
+                required
+                onChange={this.handleLabelChange}
+                placeholder='Enter a label'
+                value={labelText}
+                errorText={hasErrorFor('label')}
+                tooltipText="Select a StackScript Label"
+                className={classes.labelField}
               />
-            )
-          })}
-          <Notice className={classes.tips} html={this.renderTipsHTML()} />
+              <TextField
+                multiline
+                rows={1}
+                label="Description"
+                placeholder="Enter a description"
+                onChange={this.handleDescriptionChange}
+                value={descriptionText}
+                tooltipText="Give your StackScript a description"
+              />
+              <FormControl fullWidth>
+                <InputLabel
+                  htmlFor="image"
+                  disableAnimation
+                  shrink={true}
+                  required
+                >
+                  Target Images
+              </InputLabel>
+                <Select
+                  open={this.state.imageSelectOpen}
+                  onOpen={this.handleOpenSelect}
+                  onClose={this.handleCloseSelect}
+                  value='none'
+                  onChange={this.handleChooseImage}
+                  inputProps={{ name: 'image', id: 'image' }}
+                  helpText='Select which images are compatible with this StackScript'
+                  error={Boolean(hasErrorFor('images'))}
+                  errorText={hasErrorFor('images')}
+                >
+                  <MenuItem disabled key="none" value="none">Select Compatible Images</MenuItem>,
+                {this.getImagesByDeprecationStatus(false).map(image =>
+                    <MenuItem
+                      key={image.id}
+                      value={image.id}
+                    >
+                      {image.label}
+                    </MenuItem>,
+                  )}
+                  <MenuItem disabled key="deprecated" value="deprecated">Older Images</MenuItem>,
+                {this.getImagesByDeprecationStatus(true).map(image =>
+                    <MenuItem
+                      key={image.id}
+                      value={image.id}
+                    >
+                      {image.label}
+                    </MenuItem>,
+                  )}
+                </Select>
+              </FormControl>
+              {selectedImages && selectedImages.map((selectedImage, index) => {
+                return (
+                  <Tag
+                    key={selectedImage}
+                    label={selectedImage}
+                    variant='lightBlue'
+                    onDelete={() => this.handleRemoveImage(index)}
+                  />
+                )
+              })}
+            </Grid>
+            <Grid item>
+              <Notice 
+                className={classes.tips}
+                component="div"
+              >
+              <Typography variant="title">Tips</Typography>
+                <Typography>There are four default environment variables provided to you:</Typography>
+                <ul>
+                  <li>LINODE_ID</li>
+                  <li>LINODE_LISTUSERNAME</li>
+                  <li>LINODE_RAM</li>
+                  <li>LINODE_DATACENTERID</li>
+                </ul>
+              </Notice>
+            </Grid>
+          </Grid>
           <TextField
             multiline
             rows={1}
@@ -440,7 +449,18 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             onChange={this.handleChangeRevisionNote}
             value={revisionNote}
           />
-          <Notice warning flag html={this.renderNoticeHTML()} />
+          <Notice
+            component="div"
+            warning
+            flag 
+            className={classes.warning}
+          >
+            <Typography variant="title">Woah, just a word of caution...</Typography>
+            <Typography>
+                Making this StackScript public cannot be undone. Once made public, your StackScript will
+                be available to all Linode users and can be used to provision new Linodes.
+            </Typography>
+          </Notice>
           <InputLabel
             htmlFor="make_public"
             disableAnimation

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -44,6 +44,7 @@ type ClassNames = 'root'
   | 'titleWrapper'
   | 'createTitle'
   | 'labelField'
+  | 'gridWithTips'
   | 'tips'
   | 'warning';
 
@@ -69,6 +70,12 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   titleWrapper: {
     display: 'flex',
     marginTop: 5,
+  },
+  gridWithTips: {
+    maxWidth: '50%',
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: '100%',
+    },
   },
   tips: {
     marginLeft: theme.spacing.unit * 4,
@@ -339,7 +346,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
         </Grid>
         <Paper className={classes.root}>
           <Grid container>
-            <Grid item>
+            <Grid item className={classes.gridWithTips}>
               <TextField
                 InputProps={{
                   startAdornment: 
@@ -416,7 +423,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
                 )
               })}
             </Grid>
-            <Grid item>
+            <Grid item className={classes.gridWithTips}>
               <Notice 
                 className={classes.tips}
                 component="div"

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -1,0 +1,209 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+import { compose, pathOr } from 'ramda';
+
+import {
+  StyleRulesCallback,
+  Theme,
+  withStyles,
+  WithStyles,
+} from '@material-ui/core/styles';
+
+import FormControl from '@material-ui/core/FormControl';
+// import FormHelperText from '@material-ui/core/FormHelperText';
+import IconButton from '@material-ui/core/IconButton';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import { KeyboardArrowLeft } from '@material-ui/icons';
+
+import Grid from 'src/components/Grid';
+import HelpIcon from 'src/components/HelpIcon';
+import PromiseLoader from 'src/components/PromiseLoader';
+import Select from 'src/components/Select';
+import TextField from 'src/components/TextField';
+
+import { getImages } from 'src/services/images';
+
+
+type ClassNames = 'root'
+  | 'backButton'
+  | 'titleWrapper'
+  | 'createTitle'
+  | 'adornment';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  root: {
+    padding: theme.spacing.unit * 2,
+  },
+  backButton: {
+    margin: '5px 0 0 -16px',
+    '& svg': {
+      width: 34,
+      height: 34,
+    },
+  },
+  createTitle: {
+    lineHeight: '2.25em'
+  },
+  titleWrapper: {
+    display: 'flex',
+    marginTop: 5,
+  },
+  adornment: {
+    fontSize: '.9rem',
+    marginLeft: 5,
+    color: theme.color.grey1
+  },
+});
+
+interface Props { 
+  profile: Linode.Profile;
+}
+
+interface PreloadedProps {
+  images: { response: Linode.Image[] }
+}
+
+interface State {
+  labelText: string;
+  descriptionText: string;
+  imageSelectOpen: boolean;
+ }
+
+type CombinedProps = Props
+  & WithStyles<ClassNames>
+  & PreloadedProps;
+
+const preloaded = PromiseLoader<Props>({
+  images: () => getImages()
+    .then(response => response.data || [])
+})
+
+export class StackScriptCreate extends React.Component<CombinedProps, State> {
+  state: State = {
+    labelText: '',
+    descriptionText: '',
+    imageSelectOpen: false,
+  };
+
+  handleLabelChagne = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({labelText: e.target.value});
+  }
+
+  handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ descriptionText: e.target.value });
+  }
+
+  handleOpenSelect = () => {
+    this.setState({ imageSelectOpen: true });
+  }
+
+  handleCloseSelect = () => {
+    this.setState({ imageSelectOpen: false });
+  }
+
+  handleChooseImage = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    console.log(e.target.value);
+    this.setState({ imageSelectOpen: true });
+  }
+
+  render() {
+    const { classes, profile, images } = this.props;
+    return (
+      <React.Fragment>
+        <Grid
+          container
+          justify="space-between"
+        >
+          <Grid item className={classes.titleWrapper}>
+            <Link to={`/stackscripts`}>
+              <IconButton
+                className={classes.backButton}
+              >
+                <KeyboardArrowLeft />
+              </IconButton>
+            </Link>
+            <Typography className={classes.createTitle} variant="headline">
+              Create New StackScript
+      </Typography>
+          </Grid>
+        </Grid>
+        <Paper className={classes.root}>
+          <TextField
+            InputProps={{
+              startAdornment: <span className={classes.adornment}>
+                {profile.username} /</span>,
+            }}
+            // errorText={hasErrorFor('client_conn_throttle')}
+            label='StackScript Label'
+            required
+            onChange={this.handleLabelChagne}
+            placeholder='Enter a label'
+          />
+          <HelpIcon text="Select a StackScript Label" />
+          <TextField
+            multiline
+            rows={1}
+            label="Description"
+            placeholder="Enter a description"
+            onChange={this.handleDescriptionChange}
+          // errorText={hasErrorFor('ssl_cert')}
+          // errorGroup={forEdit ? `${configIdx}`: undefined}
+          />
+          <HelpIcon text="Give your StackScript a description" />
+          <FormControl fullWidth>
+            <InputLabel
+              htmlFor="image"
+              disableAnimation
+              shrink={true}
+            // error={Boolean(regionError)}
+            >
+              Target Images
+          </InputLabel>
+            <Select
+              open={this.state.imageSelectOpen}
+              onOpen={this.handleOpenSelect}
+              onClose={this.handleCloseSelect}
+              value='none'
+              onChange={this.handleChooseImage}
+              inputProps={{ name: 'image', id: 'image' }}
+            // error={Boolean(regionError)}
+            >
+              <MenuItem disabled key="none" value="none">Select Compatible Images</MenuItem>,
+            {images && images.response.map(image =>
+                <MenuItem
+                  key={image.id}
+                  value={image.label}
+                >
+                  {image.label}
+              </MenuItem>,
+              )}
+            </Select>
+            {/* {regionError &&
+            <FormHelperText error={Boolean(regionError)}>
+              {regionError}
+            </FormHelperText>
+          } */}
+          </FormControl>
+          <HelpIcon text="Select Multiple Images" />
+        </Paper>
+      </React.Fragment>
+    );
+  }
+}
+
+const mapStateToProps = (state: Linode.AppState) => ({
+  profile: pathOr({}, ['resources', 'profile', 'data'], state),
+});
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default compose(
+  styled,
+  connect(mapStateToProps),
+  preloaded
+)(StackScriptCreate)

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -145,6 +145,13 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
   componentWillUnmount() {
     this.mounted = false;
   }
+  
+  /*
+  * Gets images by two types: deprecated and non-deprecated
+  */
+  getImagesByDeprecationStatus = (deprecated: boolean) => {
+    return this.state.availableImages.filter(image => image.deprecated === deprecated);
+  }
 
   handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({labelText: e.target.value});
@@ -311,7 +318,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
 
   render() {
     const { classes, profile } = this.props;
-    const { availableImages, selectedImages, script,
+    const { selectedImages, script,
     labelText, descriptionText, revisionNote, errors } = this.state;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
@@ -383,13 +390,22 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
               errorText={hasErrorFor('images')}
             >
               <MenuItem disabled key="none" value="none">Select Compatible Images</MenuItem>,
-            {availableImages && availableImages.map(image =>
+            {this.getImagesByDeprecationStatus(false).map(image =>
                 <MenuItem
                   key={image.id}
                   value={image.id}
                 >
                   {image.label}
-              </MenuItem>,
+                </MenuItem>,
+              )}
+              <MenuItem disabled key="deprecated" value="deprecated">Older Images</MenuItem>,
+            {this.getImagesByDeprecationStatus(true).map(image =>
+                <MenuItem
+                  key={image.id}
+                  value={image.id}
+                >
+                  {image.label}
+                </MenuItem>,
               )}
             </Select>
           </FormControl>

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -200,6 +200,14 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     return this.state.availableImages.filter(image => image.deprecated === deprecated);
   }
 
+  /*
+  * @TODO Deprecate once we have a reliable way of mapping
+  * the slug to the display name
+  */
+  stripImageName = (image: string) => {
+    return image.replace('linode/', '');
+  };
+
   handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({ labelText: e.target.value });
   }
@@ -456,7 +464,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
                   return (
                     <Tag
                       key={selectedImage}
-                      label={selectedImage}
+                      label={this.stripImageName(selectedImage)}
                       variant='lightBlue'
                       onDelete={() => this.handleRemoveImage(index)}
                       className={classes.targetTag}

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -20,8 +20,12 @@ import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import { KeyboardArrowLeft } from '@material-ui/icons';
 
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Checkbox from 'src/components/CheckBox';
 import Grid from 'src/components/Grid';
 import HelpIcon from 'src/components/HelpIcon';
+import Notice from 'src/components/Notice';
 import PromiseLoader from 'src/components/PromiseLoader';
 import Select from 'src/components/Select';
 import Tag from 'src/components/Tag';
@@ -74,6 +78,9 @@ interface State {
   imageSelectOpen: boolean;
   selectedImages: string[];
   availableImages: Linode.Image[];
+  script: string;
+  revisionNote: string;
+  is_public: boolean;
  }
 
 type CombinedProps = Props
@@ -93,6 +100,9 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     selectedImages: [],
     /* available images to select from in the dropdown */
     availableImages: this.props.images.response,
+    script: '',
+    revisionNote: '',
+    is_public: false,
   };
 
   handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -129,9 +139,54 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     this.setState({ imageSelectOpen: true });
   }
 
+  handleChangeScript = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ script: e.target.value });
+  }
+
+  handleChangeRevisionNote = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ revisionNote: e.target.value });
+  }
+
+  handleToggleIsPublic = () => {
+    this.setState({ is_public: !this.state.is_public });
+  }
+
+  resetAllFields = () => {
+    this.setState({
+      script: '',
+      labelText: '',
+      selectedImages: [],
+      descriptionText: '',
+      is_public: false,
+      revisionNote: '',
+    })
+  }
+
+  renderNoticeHTML = () => {
+    return (
+      `<h3>Woah, just a word of caution...</h3>
+        <p>Making this StackScript public cannot be undone. Once made public, your StackScript will
+          be available to all Linode users and can be used to provision new Linodes.
+      </p>`
+    )
+  }
+
   render() {
     const { classes, profile } = this.props;
-    const { availableImages, selectedImages } = this.state;
+    const { availableImages, selectedImages, script,
+    labelText, descriptionText, revisionNote } = this.state;
+
+    const payload = {
+      script: this.state.script,
+      label: this.state.labelText,
+      images: this.state.selectedImages,
+      description: this.state.descriptionText,
+      is_public: this.state.is_public,
+      rev_note: this.state.revisionNote,
+    }
+
+    console.log(payload);
+
     return (
       <React.Fragment>
         <Grid
@@ -162,6 +217,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             required
             onChange={this.handleLabelChange}
             placeholder='Enter a label'
+            value={labelText}
           />
           <HelpIcon text="Select a StackScript Label" />
           <TextField
@@ -170,6 +226,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             label="Description"
             placeholder="Enter a description"
             onChange={this.handleDescriptionChange}
+            value={descriptionText}
           // errorText={hasErrorFor('ssl_cert')}
           // errorGroup={forEdit ? `${configIdx}`: undefined}
           />
@@ -179,6 +236,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
               htmlFor="image"
               disableAnimation
               shrink={true}
+              required
             // error={Boolean(regionError)}
             >
               Target Images
@@ -202,11 +260,6 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
               </MenuItem>,
               )}
             </Select>
-            {/* {regionError &&
-            <FormHelperText error={Boolean(regionError)}>
-              {regionError}
-            </FormHelperText>
-          } */}
           </FormControl>
           <HelpIcon text="Select Multiple Images" />
           {selectedImages && selectedImages.map((selectedImage, index) => {
@@ -219,6 +272,60 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
               />
             )
           })}
+          <TextField
+            multiline
+            rows={1}
+            label="Script"
+            placeholder={`#!/bin/bash \n\n# Your script goes here`}
+            onChange={this.handleChangeScript}
+            value={script}
+            required
+          // errorText={hasErrorFor('ssl_cert')}
+          // errorGroup={forEdit ? `${configIdx}`: undefined}
+          />
+          <TextField
+            multiline
+            rows={1}
+            label="Revision Note"
+            placeholder='Enter a revision note'
+            onChange={this.handleChangeRevisionNote}
+            value={revisionNote}
+          // errorText={hasErrorFor('ssl_cert')}
+          // errorGroup={forEdit ? `${configIdx}`: undefined}
+          />
+          <Notice warning flag html={this.renderNoticeHTML()} />
+          <InputLabel
+            htmlFor="make_public"
+            disableAnimation
+            shrink={true}
+          // error={Boolean(regionError)}
+          >
+            <Checkbox
+              name='make_public'
+              variant='warning'
+              onChange={this.handleToggleIsPublic}
+              checked={this.state.is_public}
+            />
+            Publish this StackScript to the Public Library
+          </InputLabel>
+          <ActionsPanel style={{ padding: 0 }}>
+            <Button
+              data-qa-confirm-cancel
+              onClick={() => console.log('saved')}
+              type="primary"
+              loading={false}
+            >
+              Save
+            </Button>
+            <Button
+              onClick={this.resetAllFields}
+              type="secondary"
+              className="cancel"
+              data-qa-cancel-cancel
+            >
+              Cancel
+            </Button>
+          </ActionsPanel>
         </Paper>
       </React.Fragment>
     );

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -12,6 +12,7 @@ import {
 } from '@material-ui/core/styles';
 
 import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import InputLabel from '@material-ui/core/InputLabel';
@@ -46,7 +47,9 @@ type ClassNames = 'root'
   | 'labelField'
   | 'gridWithTips'
   | 'tips'
-  | 'warning';
+  | 'chipsContainer'
+  | 'warning'
+  | 'targetTag';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -89,9 +92,15 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
       paddingLeft: theme.spacing.unit * 2,
     },
   },
+  chipsContainer: {
+    maxWidth: 415,
+  },
   warning: {
     marginTop: theme.spacing.unit * 2,
-  }
+  },
+  targetTag: {
+    margin: `${theme.spacing.unit}px ${theme.spacing.unit}px 0 0`,
+  },
 });
 
 interface Props { 
@@ -412,16 +421,19 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
                   )}
                 </Select>
               </FormControl>
-              {selectedImages && selectedImages.map((selectedImage, index) => {
-                return (
-                  <Tag
-                    key={selectedImage}
-                    label={selectedImage}
-                    variant='lightBlue'
-                    onDelete={() => this.handleRemoveImage(index)}
-                  />
-                )
-              })}
+              <div className={classes.chipsContainer}>
+                {selectedImages && selectedImages.map((selectedImage, index) => {
+                  return (
+                    <Tag
+                      key={selectedImage}
+                      label={selectedImage}
+                      variant='lightBlue'
+                      onDelete={() => this.handleRemoveImage(index)}
+                      className={classes.targetTag}
+                    />
+                  )
+                })}
+              </div>
             </Grid>
             <Grid item className={classes.gridWithTips}>
               <Notice 
@@ -468,20 +480,18 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
                 be available to all Linode users and can be used to provision new Linodes.
             </Typography>
           </Notice>
-          <InputLabel
-            htmlFor="make_public"
-            disableAnimation
-            shrink={true}
-          >
-            <Checkbox
-              name='make_public'
-              variant='warning'
-              onChange={this.handleToggleIsPublic}
-              checked={this.state.is_public}
+          <FormControlLabel
+            control={
+              <Checkbox
+                name='make_public'
+                variant='warning'
+                onChange={this.handleToggleIsPublic}
+                checked={this.state.is_public}
+              />
+            }
+              label="Publish this StackScript to the Public Library"
             />
-            Publish this StackScript to the Public Library
-          </InputLabel>
-          <ActionsPanel style={{ padding: 0 }}>
+          <ActionsPanel style={{ paddingBottom: 0 }}>
             <Button
               data-qa-confirm-cancel
               onClick={this.handleCreateStackScript}

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -39,15 +39,19 @@ import { createStackScript } from 'src/services/stackscripts';
 
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { Divider } from '../../../../node_modules/@material-ui/core';
 
 type ClassNames = 'root'
   | 'backButton'
   | 'titleWrapper'
   | 'createTitle'
   | 'labelField'
+  | 'divider'
   | 'gridWithTips'
   | 'tips'
   | 'chipsContainer'
+  | 'scriptTextarea'
+  | 'revisionTextarea'
   | 'warning'
   | 'targetTag';
 
@@ -64,6 +68,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   createTitle: {
     lineHeight: '2.25em'
+  },
+  divider: {
+    margin: `0 0 ${theme.spacing.unit * 2}px 0`,
+    height: 0,
   },
   labelField: {
     '& input': {
@@ -96,10 +104,20 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     maxWidth: 415,
   },
   warning: {
-    marginTop: theme.spacing.unit * 2,
+    marginTop: theme.spacing.unit * 4,
   },
   targetTag: {
     margin: `${theme.spacing.unit}px ${theme.spacing.unit}px 0 0`,
+  },
+  scriptTextarea: {
+    maxWidth: '100%',
+    height: 400,
+    '& textarea': {
+      height: '100%',
+    }
+  },
+  revisionTextarea: {
+    maxWidth: '100%',
   },
 });
 
@@ -463,6 +481,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
               </Notice>
             </Grid>
           </Grid>
+          <Divider className={classes.divider} />
           <TextField
             multiline
             rows={1}
@@ -472,6 +491,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             value={script}
             errorText={hasErrorFor('script')}
             required
+            InputProps={{ className: classes.scriptTextarea }}
           />
           <TextField
             multiline
@@ -480,6 +500,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             placeholder='Enter a revision note'
             onChange={this.handleChangeRevisionNote}
             value={revisionNote}
+            InputProps={{ className: classes.revisionTextarea }}
           />
           <Notice
             component="div"

--- a/src/features/StackScripts/StackScriptCreate/index.tsx
+++ b/src/features/StackScripts/StackScriptCreate/index.tsx
@@ -1,0 +1,2 @@
+import StackScriptCreate from './StackScriptCreate';
+export default StackScriptCreate;

--- a/src/features/StackScripts/StackScripts.tsx
+++ b/src/features/StackScripts/StackScripts.tsx
@@ -7,6 +7,10 @@ const StackScriptsLanding = DefaultLoader({
   loader: () => import('./StackScriptsLanding'),
 });
 
+const StackScriptCreate = DefaultLoader({
+  loader: () => import('./StackScriptCreate'),
+});
+
 type Props = RouteComponentProps<{}>;
 
 class NodeBalancers extends React.Component<Props> {
@@ -16,6 +20,7 @@ class NodeBalancers extends React.Component<Props> {
     return (
       <Switch>
         <Route component={StackScriptsLanding} path={path} exact />
+        <Route component={StackScriptCreate} path={`${path}/create`} exact />
       </Switch>
     );
   }

--- a/src/features/StackScripts/StackScriptsLanding.test.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.test.tsx
@@ -1,10 +1,11 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
-import { images } from 'src/__data__/images';
 import { clearDocs, setDocs } from 'src/store/reducers/documentation';
 
 import { StackScriptsLanding } from './StackScriptsLanding';
+
+import { images } from 'src/__data__/images';
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
 
 describe('StackScripts Landing', () => {
   const component = shallow(
@@ -13,6 +14,7 @@ describe('StackScripts Landing', () => {
       setDocs={setDocs}
       clearDocs={clearDocs}
       classes={{ root: '', title: '' }}
+      {...reactRouterProps}
     />
   )
 

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -1,12 +1,13 @@
 import { compose } from 'ramda';
 import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+
+import { compose } from 'ramda';
 
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
 import AddNewLink from 'src/components/AddNewLink';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
-
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import Grid from 'src/components/Grid';
 import PromiseLoader from 'src/components/PromiseLoader';

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -1,4 +1,3 @@
-import { compose } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -5,6 +5,8 @@ import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/
 import Typography from '@material-ui/core/Typography';
 
 import AddNewLink from 'src/components/AddNewLink';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import Grid from 'src/components/Grid';
 import PromiseLoader from 'src/components/PromiseLoader';
@@ -33,7 +35,8 @@ interface State {
 type CombinedProps = Props
   & SetDocsProps
   & WithStyles<ClassNames>
-  & PreloadedProps;
+  & PreloadedProps
+  & RouteComponentProps<{}>;
 
   const preloaded = PromiseLoader<Props>({
     images: () => getImages()
@@ -60,6 +63,11 @@ export class StackScriptsLanding extends React.Component<CombinedProps, State> {
     return images.filter((image: Linode.Image) => image.is_public)
   }
 
+  goToCreateStackScript = () => {
+    const { history } = this.props;
+    history.push('/stackscripts/create');
+  }
+
   render() {
 
     const { images, classes } = this.props;
@@ -76,9 +84,8 @@ export class StackScriptsLanding extends React.Component<CombinedProps, State> {
             <Grid container alignItems="flex-end">
               <Grid item>
                 <AddNewLink
-                  onClick={() => console.log('Feature Not currently available')}
+                  onClick={this.goToCreateStackScript}
                   label="Create New StackScript"
-                  disabled
                   data-qa-create-new-stackscript
                 />
               </Grid>
@@ -101,5 +108,6 @@ const styled = withStyles(styles, { withTheme: true });
 export default compose(
   preloaded,
   styled,
+  withRouter,
   setDocs(StackScriptsLanding.docs),
 )(StackScriptsLanding);

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -10,7 +10,7 @@ import AddNewLink from 'src/components/AddNewLink';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import Grid from 'src/components/Grid';
 import PromiseLoader from 'src/components/PromiseLoader';
-import { getImages } from 'src/services/images';
+import { getLinodeImages } from 'src/services/images';
 
 import SelectStackScriptPanel from './SelectStackScriptPanel';
 
@@ -39,7 +39,7 @@ type CombinedProps = Props
   & RouteComponentProps<{}>;
 
   const preloaded = PromiseLoader<Props>({
-    images: () => getImages()
+    images: () => getLinodeImages()
       .then(response => response.data || []),
   });
 
@@ -54,14 +54,6 @@ export class StackScriptsLanding extends React.Component<CombinedProps, State> {
       body: `Create Custom Instances and Automate Deployment with StackScripts.`,
     },
   ];
-
-  filterPublicImages = (images: Linode.Image[]) => {
-    // get images and preloaded and give us just the public ones
-    // to pass to selectstackscriptpanel
-    // we dont' want to display the deprecated ones because
-    // they're useless.
-    return images.filter((image: Linode.Image) => image.is_public)
-  }
 
   goToCreateStackScript = () => {
     const { history } = this.props;
@@ -94,7 +86,7 @@ export class StackScriptsLanding extends React.Component<CombinedProps, State> {
         </Grid>
         <Grid container>
           <SelectStackScriptPanel
-            publicImages={this.filterPublicImages(images.response)}
+            publicImages={images.response}
             noHeader={true}
           />
         </Grid>

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
@@ -85,7 +85,7 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
             placeholder="Enter a domain name"
             value={rdns || ''}
             errorText={hasErrorFor('rdns')}
-            onChange={e => this.setState({ rdns: e.target.value })}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => this.setState({ rdns: e.target.value })}
             data-qa-domain-name
           />
           <Typography variant="caption">

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -125,7 +125,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               label="Label"
               required
               value={label}
-              onChange={e => onChange('label', e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange('label', e.target.value)}
               errorText={errorFor('label')}
               errorGroup="linode-config-drawer"
             />
@@ -133,7 +133,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             <TextField
               label="Comments"
               value={comments}
-              onChange={e => onChange('comments', e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange('comments', e.target.value)}
               multiline={true}
               rows={3}
               errorText={errorFor('comments')}
@@ -172,7 +172,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               label="Kernel"
               select={true}
               value={kernel}
-              onChange={e => onChange('kernel', e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange('kernel', e.target.value)}
               errorText={errorFor('kernel')}
               errorGroup="linode-config-drawer"
             >
@@ -213,7 +213,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               type="number"
               label="Memory Limit"
               value={memory_limit}
-              onChange={e => onChange('memory_limit', clamp(0, maxMemory, +e.target.value))}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange('memory_limit', clamp(0, maxMemory, +e.target.value))}
               helperText={`Max: ${maxMemory}`}
             />
           </Grid>
@@ -244,7 +244,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               <TextField
                 label={`${useCustomRoot ? 'Custom ' : ''}Root Device`}
                 value={root_device}
-                onChange={e => onChange('root_device', e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange('root_device', e.target.value)}
                 inputProps={{ name: 'root_device', id: 'root_device' }}
                 select={!useCustomRoot}
                 fullWidth

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
@@ -96,7 +96,7 @@ class LinodeSettingsLabelPanel extends React.Component<CombinedProps, State> {
         <TextField
           label="Label"
           value={this.state.updatedValue}
-          onChange={e =>
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             this.setState(set(lensPath(['updatedValue']), e.target.value))}
           errorText={labelError}
           errorGroup="linode-settings-label"

--- a/src/features/profile/APITokens/APITokenDrawer.tsx
+++ b/src/features/profile/APITokens/APITokenDrawer.tsx
@@ -284,7 +284,7 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
             errorText={errorFor('label')}
             value={label || ''}
             label="Label"
-            onChange={e => onChange('label', e.target.value)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange('label', e.target.value)}
             data-qa-add-label
           />
         }

--- a/src/features/profile/OAuthClients/OAuthFormDrawer.tsx
+++ b/src/features/profile/OAuthClients/OAuthFormDrawer.tsx
@@ -57,14 +57,14 @@ const OAuthCreationDrawer: React.StatelessComponent<CombinedProps> = (props) => 
         value={label || ''}
         errorText={hasErrorFor('label')}
         label="Label"
-        onChange={e => onChange('label', e.target.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange('label', e.target.value)}
         data-qa-add-label
       />
       <TextField
         value={redirect_uri || ''}
         label="Callback URL"
         errorText={hasErrorFor('redirect_uri')}
-        onChange={e => onChange('redirect_uri', e.target.value)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange('redirect_uri', e.target.value)}
         data-qa-callback
       />
       <FormControl>

--- a/src/services/images.ts
+++ b/src/services/images.ts
@@ -17,7 +17,10 @@ export const getImages = () =>
   getImagesPage(1);
 
 export const getUserImages = () =>
-  getImagesPage(1, { 'is_public': false });
+  getImagesPage(1, { "is_public": false });
+
+export const getLinodeImages = () =>
+  getImagesPage(1, { "is_public": true });
 
 export const getImage = (imageId: string) =>
   Request<Image>(

--- a/src/services/stackscripts.ts
+++ b/src/services/stackscripts.ts
@@ -1,3 +1,5 @@
+import * as Joi from 'joi';
+
 import { API_ROOT } from 'src/constants';
 import Request, {
   setData,
@@ -5,6 +7,7 @@ import Request, {
   setParams,
   setURL,
   setXFilter,
+  validateRequestData,
 } from './index';
 
 type Page<T> = Linode.ResourcePage<T>;
@@ -15,7 +18,7 @@ export const getStackScript = (id: number) =>
     setURL(`${API_ROOT}/linode/stackscripts/${id}`),
     setMethod('GET'),
   )
-  .then(response => response.data);
+    .then(response => response.data);
 
 export const getStackscripts = (params?: any, filter?: any) =>
   Request<Page<StackScript>>(
@@ -59,17 +62,27 @@ export const deleteStackScript = (id: number) =>
     setMethod('DELETE'),
   )
     .then(response => response.data);
-  interface CreatePayload {
-    script: string;
-    label: string;
-    images: string[];
-    description?: string;
-    is_public?: boolean;
-    rev_note?: string;
-  }
+interface CreatePayload {
+  script: string;
+  label: string;
+  images: string[];
+  description?: string;
+  is_public?: boolean;
+  rev_note?: string;
+}
+
+const createStackScriptSchema = Joi.object({
+  script: Joi.string().required(),
+  label: Joi.string().required(),
+  images: Joi.array().items(Joi.string()).required(),
+  description: Joi.string(),
+  is_public: Joi.boolean(),
+  rev_note: Joi.string(),
+});
 
 export const createStackScript = (payload: CreatePayload) =>
   Request(
+    validateRequestData(payload, createStackScriptSchema),
     setURL(`${API_ROOT}/linode/stackscripts`),
     setMethod('POST'),
     setData(payload)

--- a/src/services/stackscripts.ts
+++ b/src/services/stackscripts.ts
@@ -1,6 +1,11 @@
 import { API_ROOT } from 'src/constants';
-
-import Request, { setMethod, setParams, setURL, setXFilter } from './index';
+import Request, {
+  setData,
+  setMethod,
+  setParams,
+  setURL,
+  setXFilter,
+} from './index';
 
 type Page<T> = Linode.ResourcePage<T>;
 type StackScript = Linode.StackScript.Response;
@@ -54,3 +59,18 @@ export const deleteStackScript = (id: number) =>
     setMethod('DELETE'),
   )
     .then(response => response.data);
+  interface CreatePayload {
+    script: string;
+    label: string;
+    images: string[];
+    description?: string;
+    is_public?: boolean;
+    rev_note?: string;
+  }
+
+export const createStackScript = (payload: CreatePayload) =>
+  Request(
+    setURL(`${API_ROOT}/linode/stackscripts`),
+    setMethod('POST'),
+    setData(payload)
+  )

--- a/src/services/stackscripts.ts
+++ b/src/services/stackscripts.ts
@@ -75,9 +75,9 @@ const createStackScriptSchema = Joi.object({
   script: Joi.string().required(),
   label: Joi.string().required(),
   images: Joi.array().items(Joi.string()).required(),
-  description: Joi.string(),
+  description: Joi.string().allow(""),
   is_public: Joi.boolean(),
-  rev_note: Joi.string(),
+  rev_note: Joi.string().allow(""),
 });
 
 export const createStackScript = (payload: CreatePayload) =>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -330,6 +330,7 @@ const LinodeTheme: Linode.Theme = {
       inputMultiline: {
         minHeight: 125,
         padding: '5px 12px',
+        lineHeight: 1.4,
       },
       focused: {
         borderColor: '#999',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -650,6 +650,7 @@ const LinodeTheme: Linode.Theme = {
         backgroundColor: 'white',
         boxShadow: '0 0 5px #bbb',
         color: '#666',
+        visibility: 'hidden',
         textAlign: 'left',
         [breakpoints.up('sm')]: {
           padding: '12px  16px',
@@ -657,6 +658,7 @@ const LinodeTheme: Linode.Theme = {
         },
         '&$open': {
           opacity: 1,
+          visibility: 'visible',
         },
       },
     },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -357,6 +357,9 @@ const LinodeTheme: Linode.Theme = {
     },
     MuiInputAdornment: {
       root: {
+        fontSize: '.9rem',
+        color: '#666',
+        whiteSpace: 'nowrap',
         '& p': {
           fontSize: '.9rem',
         },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -126,6 +126,7 @@ const LinodeTheme: Linode.Theme = {
       label: {
         paddingLeft: 4,
         paddingRight: 4,
+        fontSize: '.9rem',
       },
       deleteIcon: {
         color: '#aaa',

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -652,11 +652,15 @@ const LinodeTheme: Linode.Theme = {
         color: '#666',
         visibility: 'hidden',
         textAlign: 'left',
+        width: 0,
+        height: 0,
         [breakpoints.up('sm')]: {
           padding: '12px  16px',
           fontSize: '.9rem',
         },
         '&$open': {
+          width: 'auto',
+          height: 'auto',
           opacity: 1,
           visibility: 'visible',
         },


### PR DESCRIPTION
### Purpose

Create a StackScript

### Known Issues
- [x] no docs
- [x] memory leak upon creating a StackScript
- [x] Confirmation Modal action buttons miscolored
- [x] Clicking on the left side of the image select does not open the dropdown
- [ ] StackScript script error not appearing next to the field (to be solved in the next API release)
- [ ] Code field is a basic text field, rather than a text editor-like field (for the sake of release, this will not be completed in this PR)
- [x] Target Images dropdown doesn't make clear which images are older

### Features
* Creates a new StackScript assuming label, script, and target images fields are selected.
* User can clear their selections with the cancel button
  * user will receive a confirmation before doing so