### PR TITLE
M3-898 StackScript Label onClick

### DIFF
--- a/src/components/SelectionRow/SelectionRow.tsx
+++ b/src/components/SelectionRow/SelectionRow.tsx
@@ -139,6 +139,25 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
     'onSelect and showDeployLink are mutually exclusive.',
   );
 
+  const renderLabel = () => {
+    return (
+      <Typography variant="subheading">
+        {stackScriptUsername &&
+          <label
+            htmlFor={`${stackScriptID}`}
+            className={`${classes.libRadioLabel} ${classes.stackScriptUsername}`}>
+            {stackScriptUsername} /&nbsp;
+    </label>
+        }
+        <label
+          htmlFor={`${stackScriptID}`}
+          className={classes.libRadioLabel}>
+          {label}
+        </label>
+      </Typography>
+    )
+  }
+
   return (
     <React.Fragment>
       <TableRow>
@@ -148,20 +167,12 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
           </TableCell>
         }
         <TableCell className={classes.stackScriptCell}>
-          <Typography variant="subheading">
-          {stackScriptUsername &&
-                <label
-                  htmlFor={`${stackScriptID}`}
-                  className={`${classes.libRadioLabel} ${classes.stackScriptUsername}`}>
-                  {stackScriptUsername} /&nbsp;
-            </label>
-              }
-              <label
-                htmlFor={`${stackScriptID}`}
-                className={classes.libRadioLabel}>
-                 {label}
-              </label>
-          </Typography>
+          {!showDeployLink
+            ? renderLabel()
+            : <a target="_blank" href={`https://www.linode.com/stackscripts/view/${stackScriptID}`}>
+              {renderLabel()}
+            </a>
+          }
           <Typography>{description}</Typography>
         </TableCell>
         <TableCell>


### PR DESCRIPTION
### Purpose

As per the FO, user should be navigated to linode.com/stackscripts/view/${stackscriptID} upon clicking on the StackScript label in the landing

### Notes

* Page is opened in new tab
* As previously discussed, this is most likely going to get scrapped in favor of an actual StackScript detail page