### PR TITLE
Remove lint requirement from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_script:
 
 script:
       - yarn build
-      - yarn run lint
       - yarn test --coverage --maxWorkers=2
       - yarn storybook:e2e
       - "pkill -f selenium-standalone || :"


### PR DESCRIPTION
## Purpose
Linting is run during the build process and thus not necessary to run a second time.