### PR TITLE
M3-635 - Nodebalancer Configuration - Add HTTPS Tests

### DIFF
--- a/e2e/pageobjects/nodebalancers.page.js
+++ b/e2e/pageobjects/nodebalancers.page.js
@@ -26,6 +26,9 @@ class NodeBalancers extends Page {
     get algorithmHeader() { return $('[data-qa-algorithm-header]'); }
     get algorithmSelect() { return $('[data-qa-algorithm-select]'); }
 
+    get certTextField() { return $('[data-qa-cert-field]'); }
+    get privateKeyTextField() { return $('[data-qa-private-key-field]'); }
+
     get sessionStickinessHeader() { return $('[data-qa-session-stickiness-header]'); }
     get sessionStickiness() { return $('[data-qa-session-stickiness-select]'); }
     

--- a/e2e/specs/nodebalancers/configurations.spec.js
+++ b/e2e/specs/nodebalancers/configurations.spec.js
@@ -33,6 +33,24 @@ describe('NodeBalancer - Configurations Suite', () => {
         NodeBalancers.configSave();
     });
 
+    it('should display certificate and private key fields on set protocol to https', () => {
+        NodeBalancers.selectMenuOption(NodeBalancers.protocolSelect, 'https');
+        NodeBalancers.certTextField.waitForVisible();
+        NodeBalancers.privateKeyTextField.waitForVisible();
+    });
+
+    it('should display error on save configuration without a cert and private key', () => {
+        NodeBalancers.saveButton.click();
+
+        expect(NodeBalancers.certTextField.$('p').getText()).toBe('"SSL certificate" is required');
+        expect(NodeBalancers.privateKeyTextField.$('p').getText()).toBe('"SSL private key" is required');
+
+        // Revert choice to HTTP
+        NodeBalancers.selectMenuOption(NodeBalancers.protocolSelect, 'http');
+        NodeBalancers.certTextField.waitForVisible(constants.wait.short, true);
+        NodeBalancers.privateKeyTextField.waitForVisible(constants.wait.short, true);
+    });
+
     it('should display attached node', () => {
         const attachedNodes = NodeBalancers.nodes
             .filter(n => n.$('[data-qa-backend-ip-label] input').getValue() !== '');

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -469,6 +469,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                     required={protocol === 'https'}
                     errorText={hasErrorFor('ssl_cert')}
                     errorGroup={forEdit ? `${configIdx}`: undefined}
+                    data-qa-cert-field
                   />
                 </Grid>
                 <Grid item xs={12} md={6}>
@@ -481,6 +482,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                     required={protocol === 'https'}
                     errorText={hasErrorFor('ssl_key')}
                     errorGroup={forEdit ? `${configIdx}`: undefined}
+                    data-qa-private-key-field
                   />
                 </Grid>
               </Grid>


### PR DESCRIPTION
* Adds tests for selecting HTTPS as a protocol, attempting to use https without providing credentials then revert protocol back to HTTP.
* I did not configure a linode with HTTPS because i did not want to commit fake certs to the repo, but if we have faked credentials i can/should use and we think it's a valuable test case, then I will happily add a test for it.

## To Test

```
yarn && yarn start
yarn selenium
yarn e2e --file e2e/specs/nodebalancers/configurations.spec.js
```