### PR TITLE
Action Menu - Single Menu Item Story and Test

### DIFF
--- a/src/components/ActionMenu/ActionMenu.spec.js
+++ b/src/components/ActionMenu/ActionMenu.spec.js
@@ -2,21 +2,23 @@ const { navigateToStory, executeInAllStories } = require('../../../e2e/utils/sto
 
 describe('Action Menu Suite', () => {
     const component = 'Action Menu';
-    const childStories = [
+    const menuStories = [
         'Action Menu',
         'Action Menu with disabled menu item %26 tooltip',
     ];
+    const singleItemStory = 'Action Menu with one menu item';
     const actionMenu = '[data-qa-action-menu]';
     const actionMenuItem = '[data-qa-action-menu-item]';
+    const actionMenuSingleItem = '[data-qa-action-menu-link]';
 
     it('should display action menu element', () => {
-        executeInAllStories(component, childStories, () => {
+        navigateToStory(component, menuStories, () => {
             browser.waitForVisible(actionMenu);
         });
     });
 
     it('should display action menu items', () => {
-        executeInAllStories(component, childStories, () => {
+        executeInAllStories(component, menuStories, () => {
             browser.click(actionMenu);
             browser.waitForVisible(actionMenuItem);
             expect($$(actionMenuItem).length).toBeGreaterThan(1);
@@ -25,7 +27,7 @@ describe('Action Menu Suite', () => {
     });
 
     it('should hide the menu items on select of an item', () => {
-        navigateToStory(component, childStories[0]);
+        navigateToStory(component, menuStories[0]);
         browser.click(actionMenu);
         browser.waitForVisible(actionMenuItem);
         browser.click(actionMenuItem);
@@ -33,7 +35,7 @@ describe('Action Menu Suite', () => {
     });
 
     it('should display tooltip menu item', () => {
-        navigateToStory(component, childStories[1]);
+        navigateToStory(component, menuStories[1]);
 
         const disabledMenuItem = '[data-qa-action-menu-item="Disabled Action"]';
         const tooltipIcon = '[data-qa-tooltip-icon]';
@@ -50,5 +52,16 @@ describe('Action Menu Suite', () => {
 
         expect($(tooltipIcon).getTagName()).toBe('button');
         expect($(tooltip).getText()).toBe('An explanation as to why this item is disabled');
+    });
+
+    it('should display menu item as a link when only one menu item', () => {
+        navigateToStory(component, singleItemStory);
+        browser.waitForVisible(actionMenuSingleItem);
+
+        const tagType = browser.getTagName(actionMenuSingleItem);
+        const linkUrl = browser.getAttribute(actionMenuSingleItem, 'href');
+
+        expect(linkUrl).toContain('iframe.html?selectedKind=Action%20Menu&selectedStory=Action%20Menu%20with%20one%20menu%20item#');
+        expect(tagType).toBe('a');
     });
 });

--- a/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -87,7 +87,7 @@ class StoryActionMenuWithOneAction extends React.Component<CombinedProps> {
   createActions = () => (closeMenu: Function): Action[] => {
     return [
       {
-        title: 'First Action',
+        title: 'Single Action',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
         },
@@ -111,7 +111,7 @@ storiesOf('Action Menu', module)
       <StoryActionMenuWithTooltip />
     </div>
   ))
-  .add('Action Menu with one action', () => (
+  .add('Action Menu with one menu item', () => (
       <div style={{ float: 'left' }}>
         <StoryActionMenuWithOneAction />
       </div>

--- a/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -83,6 +83,22 @@ class StoryActionMenuWithTooltip extends React.Component<CombinedProps> {
   }
 }
 
+class StoryActionMenuWithOneAction extends React.Component<CombinedProps> {
+  createActions = () => (closeMenu: Function): Action[] => {
+    return [
+      {
+        title: 'First Action',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+        },
+      }
+    ];
+  }
+  render() {
+    return (<ActionMenu createActions={this.createActions()} />);
+  }
+}
+
 storiesOf('Action Menu', module)
   .addDecorator(ThemeDecorator)
   .add('Action Menu', () => (
@@ -94,5 +110,10 @@ storiesOf('Action Menu', module)
     <div style={{ float: 'left' }}>
       <StoryActionMenuWithTooltip />
     </div>
+  ))
+  .add('Action Menu with one action', () => (
+      <div style={{ float: 'left' }}>
+        <StoryActionMenuWithOneAction />
+      </div>
   ))
 ;

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -111,7 +111,8 @@ class ActionMenu extends React.Component<CombinedProps, State> {
           href="#"
           key={idx}
           onClick={e => a.onClick(e)}
-          className={classes.actionSingleLink}>
+          className={classes.actionSingleLink}
+          data-qa-action-menu-link>
             {a.title}
         </a>)
       : (<div className={classes.root}>


### PR DESCRIPTION
* Adds a storybook story for action menus containing a single menu item (they render as a link)
* Adds a UI test in `ActionMenu.spec.js`
* I am aware a similar unit test exists for this state, but seeing as storybook is our visual reference for how the site looks, i figured this would be a good story to have.