### PR TITLE
Fix stray toast messages when the Events menu is used

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,5 +1,5 @@
 import * as moment from 'moment';
-import { assoc, compose, ifElse, isEmpty, isNil, lensPath, map, not, over, path, view, when } from 'ramda';
+import { assoc, compose, either, ifElse, isEmpty, isNil, lensPath, map, not, over, path, view, when } from 'ramda';
 import { Subject } from 'rxjs/Subject';
 
 import { getEvents } from 'src/services/account';
@@ -69,7 +69,7 @@ export const setInitialEvents = when(
             () => false,
             compose(not, isPasttheBeginningOfTime),
           ),
-          path(['created', '+gt']),
+          either(path(['created', '+gt']) as any, path(['+or', 0, 'created', '+gt']) as any),
           when(compose(not, isEmpty), v => JSON.parse(v)),
           path(['config', 'headers', 'X-Filter']),
         ),


### PR DESCRIPTION
When the events menu is used, it calls `init()` on the events stream. If there is an entity currently being polled-for then the `setInitialEvents` function was looking at the wrong path for the timestamp, which it uses to decide if `_initial` should be placed on the re-initialized events (this is done to update the appearance of the read/unread status in the menu). Without `_initial` being properly set, "old" toasts would re-appear, because we have a global event listener that only ignores events that do not have the `_initial` flag.