### PR TITLE
Fix Volume Drawer Crashing

### DIFF
--- a/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -53,11 +53,11 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
 
   state: State = this.defaultState;
 
-  reset() {
+  reset = () => {
     this.setState({ ...this.defaultState });
   }
 
-  updateLinodes(linodeRegion: string) {
+  updateLinodes = (linodeRegion: string) => {
     /*
      * @todo: We're only getting page 1 here, what if the account has over 100
      * Linodes?
@@ -113,7 +113,7 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
     this.setState({ configs: [] });
   }
 
-  attachToLinode() {
+  attachToLinode = () => {
     const { volumeID, onClose } = this.props;
     const { selectedLinode } = this.state;
     if (!selectedLinode || selectedLinode === 'none') {


### PR DESCRIPTION
### Purpose

Volume drawer was crashing due to `this` being undefined

### Notes
* Changed multiple methods to arrow functions so that `this` would refer to the class