### PR TITLE
StackScript InitTab Fix

### DIFF
--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -217,8 +217,6 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
   getInitTab = () => {
     const { profile, onSelect, selectedUsername } = this.props;
 
-    if (!this.mounted) { return; }
-
     if (profile.username === selectedUsername) {
       return this.myTabIndex;
     }

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -155,6 +155,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
 
   resetStackScriptSelection = () => {
     // reset stackscript selection to unselected
+    if (!this.mounted) { return; }
     this.setState({
       selectedStackScriptID: undefined,
       selectedStackScriptLabel: '',


### PR DESCRIPTION
### Purpose

Upon clicking _deploy new linode_ on a stackscript, the `getInitTab()` wasn't properly returning the correct tab that corresponded with the query string

### To Test
1. Navigate to StackScripts landing
2. Go to _Linode Stackscripts_ tab
3. Click Deploy New Linode
4. You should be navigated to _Linode StackScripts_ tab on the create flow