### PR TITLE
Storybook Testing - Add --story flag to run a single test

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -111,6 +111,18 @@ live in `src/components/ComponentName/ComponentName.spec.js`. The WDIO config li
 
      yarn storybook:e2e  # Executes specs matching src/components/**/*.spec.js
 
+#### Run a Single Test
+
+    yarn storybook:e2e --story StoryName # Executes spec matching src/components/StoryName/StoryName.spec.js
+
+#### Run a Test in Non-Headless Chrome
+
+    yarn selenium
+
+    ## New Shell
+
+    yarn storybook:e2e --debug --story StoryName # The --debug flag spawns a visible chrome session
+
 #### Run Suite in Docker Environment
 
 ##### Dependencies

--- a/e2e/config/wdio.storybook.conf.js
+++ b/e2e/config/wdio.storybook.conf.js
@@ -15,7 +15,7 @@ const selectedBrowser = () => {
 }
 
 const seleniumSettings = require('./selenium-config');
-const specsToRun = argv.file ? [ argv.file ] : ['./src/components/**/*.spec.js'];
+const specsToRun = argv.story ? [ `./src/components/${argv.story}/${argv.story}.spec.js` ] : ['./src/components/**/*.spec.js'];
 const servicesToStart = process.env.DOCKER || argv.debug ? [] : ['selenium-standalone'];
 
 exports.config = merge(wdioMaster.config, {


### PR DESCRIPTION
* Replaces `--file path/to/story.spec.js` with `--story StoryName` as the way to run
* Added documentation on running individual storybook tests and debugging flag