### PR TITLE
Fix Extra Table Header Rendering

### DIFF
--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -692,10 +692,12 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
             <Table noOverflow={true} tableClass={classes.table}>
               <TableHead>
                 <TableRow className={classes.tr}>
-                  <TableCell className={classNames({
-                    [classes.tableHead]: true,
-                    [classes.stackscriptLabel]: true,
-                  })} />
+                  {!!this.props.onSelect &&
+                    <TableCell className={classNames({
+                      [classes.tableHead]: true,
+                      [classes.stackscriptLabel]: true,
+                    })} />
+                  }
                   <TableCell
                     className={classNames({
                       [classes.tableHead]: true,


### PR DESCRIPTION
### Purpose

Too many table headers appearing on StackScripts landing throwing all the subsequent rows out of position