### PR TITLE
Pre-Open Node Address Search Suggestions

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -81,7 +81,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 const styled = withStyles(styles, { withTheme: true });
 
 interface Props {
-  linodesWithPrivateIPs?: Linode.Linode[] | null;
+  linodesWithPrivateIPs: Linode.Linode[];
   errors?: Linode.ApiFieldError[];
   nodeMessage?: string;
   configIdx?: number;
@@ -144,6 +144,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 interface State {
   currentNodeAddressIndex: number | null;
+  hasBeenFocusedAddressInput: boolean;
 }
 
 class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
@@ -151,6 +152,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
 
   state: State = {
     currentNodeAddressIndex: null,
+    hasBeenFocusedAddressInput: false,
   }
 
   static defaultProps: Partial<Props> = {
@@ -280,12 +282,14 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
 
   handleSelectSuggestion = (selection: string) => {
     const { currentNodeAddressIndex } = this.state;
-    if (currentNodeAddressIndex) {
-      this.props.onNodeAddressChange(
-        +currentNodeAddressIndex,
-        selection,
-      );
-    }
+    this.props.onNodeAddressChange(
+      +currentNodeAddressIndex!, // converting null to number === 0
+      selection,
+    );
+  }
+
+  handleFocusInput = () => {
+    this.setState({ hasBeenFocusedAddressInput: true });
   }
 
   renderSearchSuggestion = (
@@ -319,16 +323,21 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
   }
 
   downshiftStateReducer = (state: DownshiftState, changes: StateChangeOptions) => {
+    let shouldBeOpen = true;
+    if (this.state.hasBeenFocusedAddressInput) {
+      shouldBeOpen = false;
+    }
     switch (changes.type) {
       // basically, don't clear the field value when we leave the field
       case Downshift.stateChangeTypes.blurInput:
       case Downshift.stateChangeTypes.mouseUp:
         return {
           ...changes,
+          isOpen: shouldBeOpen,
           inputValue: state.inputValue || '',
         }
-        default:
-          return changes;
+      default:
+        return changes;
     }
   }
 
@@ -864,6 +873,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                           <Downshift
                             onSelect={this.handleSelectSuggestion}
                             stateReducer={this.downshiftStateReducer}
+                            defaultIsOpen
+                            // isOpen={this.state.currentlyFocused}
                           >
                             {
                               ({
@@ -879,24 +890,33 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                       {...getInputProps({
                                         onChange: this.onNodeAddressChange,
                                         placeholder: 'Enter IP Address',
-                                        value: node.address
+                                        value: node.address,
                                       })}
                                       label="IP Address"
-                                      inputProps={{ 'data-node-idx': idx }}
+                                      inputProps={{
+                                         'data-node-idx': idx,
+                                         onFocus: this.handleFocusInput,
+                                        }}
                                       errorText={hasErrorFor('address')}
                                       errorGroup={`${configIdx}`}
                                       data-qa-backend-ip-address
                                     />
-                                    {isOpen && !!inputValue &&
+                                    {isOpen &&
                                       <Paper className={classes.suggestions}>
                                         {linodesWithPrivateIPs && linodesWithPrivateIPs
                                         // filter out the linodes that don't match what we're typing
                                         // filter by private ip and label
                                           .filter((linode: Linode.Linode) => {
-                                            const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
-                                            const privateIP = linode.ipv4.find(ipv4 => !!ipv4.match(privateIPRegex));
-                                            return linode.label.toLowerCase().includes(inputValue.toLowerCase())
-                                              || privateIP!.includes(inputValue.toLowerCase())
+                                            if (inputValue && node.address) {
+                                              const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
+                                              const privateIP = linode.ipv4.find(ipv4 => !!ipv4.match(privateIPRegex));
+                                              return linode.label.toLowerCase().includes(inputValue.toLowerCase())
+                                                || privateIP!.includes(inputValue.toLowerCase())
+                                            }
+                                            if (idx === 0 && configIdx === 0) {
+                                              return true;
+                                            }
+                                            return false;
                                           })
                                           // limit the results to 5. we don't want too
                                           // many in the suggestions

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -390,6 +390,12 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
           return linode.ipv4.some(ipv4 => !!ipv4.match(privateIPRegex)); // does it have a private IP address
         });
         this.setState({ linodesWithPrivateIPs });
+        this.setState(
+          set(lensPath(['nodeBalancerFields', 'configs', 0, 'nodes', 0, 'address']), ' '),
+          () => this.setState(
+            set(lensPath(['nodeBalancerFields', 'configs', 0, 'nodes', 0, 'address']), ''),
+          )
+        )
       })
       // we don't really need to do anything here because if the request fails
       // the user won't be presented with any suggestions when typing in the


### PR DESCRIPTION
### Purpose

Pre-open node address search suggestions when the user lands on the _create nodebalancer_ flow

### Known Issues
- [ ] Does not reopen search suggestions if the user _blurs_ and then _focuses_ back onto the node address field