### PR TITLE
M3-737 Edit StackScript

### DIFF
--- a/src/__data__/reactRouterProps.ts
+++ b/src/__data__/reactRouterProps.ts
@@ -1,7 +1,7 @@
 const mockLocation = {
   pathname: '/',
   search: '',
-  state: undefined,
+  state: {},
   hash: '',
 }
 

--- a/src/components/SelectionRow/SelectionRow.stories.tsx
+++ b/src/components/SelectionRow/SelectionRow.stories.tsx
@@ -34,6 +34,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptID: 1000,
       stackScriptUsername: 'mmckenna',
       canDelete: false,
+      canEdit: false,
     },
     {
       checked: this.state.selected === 1,
@@ -52,6 +53,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptID: 1001,
       stackScriptUsername: 'mmckenna',
       canDelete: false,
+      canEdit: false,
     },
     {
       checked: this.state.selected === 2,
@@ -70,6 +72,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptID: 1002,
       stackScriptUsername: 'mmckenna',
       canDelete: false,
+      canEdit: false,
     },
     {
       label: 'Livin\' on a Prayer',
@@ -85,6 +88,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptID: 1003,
       stackScriptUsername: 'mmckenna',
       canDelete: false,
+      canEdit: false,
     },
     {
       label: 'Sweet Child O\' Mine',
@@ -103,6 +107,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptID: 1004,
       stackScriptUsername: 'mmckenna',
       canDelete: false,
+      canEdit: false,
     },
     {
       label: 'Africa',
@@ -120,6 +125,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptID: 1005,
       stackScriptUsername: 'mmckenna',
       canDelete: false,
+      canEdit: false,
     },
   ]
 

--- a/src/components/SelectionRow/SelectionRow.stories.tsx
+++ b/src/components/SelectionRow/SelectionRow.stories.tsx
@@ -35,6 +35,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptUsername: 'mmckenna',
       canDelete: false,
       canEdit: false,
+      isPublic: false,
     },
     {
       checked: this.state.selected === 1,
@@ -54,6 +55,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptUsername: 'mmckenna',
       canDelete: false,
       canEdit: false,
+      isPublic: false,
     },
     {
       checked: this.state.selected === 2,
@@ -73,6 +75,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptUsername: 'mmckenna',
       canDelete: false,
       canEdit: false,
+      isPublic: false,
     },
     {
       label: 'Livin\' on a Prayer',
@@ -89,6 +92,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptUsername: 'mmckenna',
       canDelete: false,
       canEdit: false,
+      isPublic: false,
     },
     {
       label: 'Sweet Child O\' Mine',
@@ -108,6 +112,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptUsername: 'mmckenna',
       canDelete: false,
       canEdit: false,
+      isPublic: false,
     },
     {
       label: 'Africa',
@@ -126,6 +131,7 @@ class InteractiveExample extends React.Component<{}, State> {
       stackScriptUsername: 'mmckenna',
       canDelete: false,
       canEdit: false,
+      isPublic: false,
     },
   ]
 

--- a/src/components/SelectionRow/SelectionRow.tsx
+++ b/src/components/SelectionRow/SelectionRow.tsx
@@ -111,8 +111,10 @@ export interface Props {
   stackScriptID: number;
   stackScriptUsername: string;
   triggerDelete?: (id: number, label: string) => void;
+  triggerMakePublic?: (id: number, label: string) => void;
   canDelete: boolean;
   canEdit: boolean;
+  isPublic: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -131,8 +133,10 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
     stackScriptID,
     stackScriptUsername,
     triggerDelete,
+    triggerMakePublic,
     canDelete,
-    canEdit
+    canEdit,
+    isPublic,
   } = props;
 
   /** onSelect and showDeployLink should not be used simultaneously */
@@ -200,8 +204,10 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
             stackScriptUsername={stackScriptUsername}
             stackScriptLabel={label}
             triggerDelete={triggerDelete!}
+            triggerMakePublic={triggerMakePublic!}
             canDelete={canDelete}
             canEdit={canEdit}
+            isPublic={isPublic}
           />
           </TableCell>
         }

--- a/src/components/SelectionRow/SelectionRow.tsx
+++ b/src/components/SelectionRow/SelectionRow.tsx
@@ -112,6 +112,7 @@ export interface Props {
   stackScriptUsername: string;
   triggerDelete?: (id: number, label: string) => void;
   canDelete: boolean;
+  canEdit: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -131,6 +132,7 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
     stackScriptUsername,
     triggerDelete,
     canDelete,
+    canEdit
   } = props;
 
   /** onSelect and showDeployLink should not be used simultaneously */
@@ -199,6 +201,7 @@ const SelectionRow: React.StatelessComponent<CombinedProps> = (props) => {
             stackScriptLabel={label}
             triggerDelete={triggerDelete!}
             canDelete={canDelete}
+            canEdit={canEdit}
           />
           </TableCell>
         }

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -15,17 +15,23 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import DebouncedSearch from 'src/components/DebouncedSearch';
 import ErrorState from 'src/components/ErrorState';
 import Notice from 'src/components/Notice';
 import RenderGuard from 'src/components/RenderGuard';
 import TabbedPanel from 'src/components/TabbedPanel';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
-import { deleteStackScript, getCommunityStackscripts, getStackScript, getStackScriptsByUser } from 'src/services/stackscripts';
+
+import {
+  deleteStackScript,
+  getCommunityStackscripts,
+  getStackScript,
+  getStackScriptsByUser,
+  makeStackScriptPublic
+} from 'src/services/stackscripts';
 
 import StackScriptsSection from './StackScriptsSection';
-
-import DebouncedSearch from 'src/components/DebouncedSearch';
 
 export interface ExtendedLinode extends Linode.Linode {
   heading: string;
@@ -287,8 +293,12 @@ interface ContainerProps {
 
 type CurrentFilter = 'label' | 'deploys' | 'revision';
 
-interface Dialog {
+interface DialogVariantProps {
   open: boolean;
+}
+interface Dialog {
+  makePublic: DialogVariantProps,
+  delete: DialogVariantProps,
   stackScriptID: number | undefined;
   stackScriptLabel: string;
 }
@@ -309,6 +319,7 @@ interface ContainerState {
   dialog: Dialog;
   isSearching: boolean;
   didSearch: boolean;
+  successMessage: string;
 }
 
 type ContainerCombinedProps = ContainerProps & WithStyles<ClassNames>;
@@ -328,12 +339,18 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     error: undefined,
     fieldError: undefined,
     dialog: {
-      open: false,
+      makePublic: {
+        open: false,
+      },
+      delete: {
+        open: false,
+      },
       stackScriptID: undefined,
       stackScriptLabel: '',
     },
     isSearching: false,
     didSearch: false,
+    successMessage: '',
   };
 
   mounted: boolean = false;
@@ -371,7 +388,11 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
         const newDataWithoutDeprecatedDistros =
           newData.filter(stackScript => this.hasNonDeprecatedImages(stackScript.images));
 
-        if (isSorting && newDataWithoutDeprecatedDistros.length === 0) {
+        // we have to make sure both the original data set
+        // AND the filtered data set is 0 before we request the next page automatically
+        if (isSorting
+          && (newData.length !== 0
+            && newDataWithoutDeprecatedDistros.length === 0)) {
           this.getNext();
           return;
         }
@@ -404,7 +425,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
       })
       .catch((e: any) => {
         if (!this.mounted) { return; }
-        this.setState({ error: e.response });
+        this.setState({ error: e.response, loading: false, });
       });
   }
 
@@ -511,10 +532,30 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     });
   }
 
-  handleOpenDialog = (id: number, label: string) => {
+  handleOpenDeleteDialog = (id: number, label: string) => {
     this.setState({
       dialog: {
-        open: true,
+        delete: {
+          open: true,
+        },
+        makePublic: {
+          open: false,
+        },
+        stackScriptID: id,
+        stackScriptLabel: label,
+      }
+    })
+  }
+
+  handleOpenMakePublicDialog = (id: number, label: string) => {
+    this.setState({
+      dialog: {
+        delete: {
+          open: false,
+        },
+        makePublic: {
+          open: true,
+        },
         stackScriptID: id,
         stackScriptLabel: label,
       }
@@ -524,7 +565,12 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
   handleCloseDialog = () => {
     this.setState({
       dialog: {
-        open: false,
+        delete: {
+          open: false,
+        },
+        makePublic: {
+          open: false,
+        },
         stackScriptID: undefined,
         stackScriptLabel: '',
       }
@@ -536,7 +582,12 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
       .then(response => {
         this.setState({
           dialog: {
-            open: false,
+            delete: {
+              open: false,
+            },
+            makePublic: {
+              open: false,
+            },
             stackScriptID: undefined,
             stackScriptLabel: '',
           }
@@ -546,7 +597,12 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
       .catch(e => {
         this.setState({
           dialog: {
-            open: false,
+            delete: {
+              open: false,
+            },
+            makePublic: {
+              open: false,
+            },
             stackScriptID: undefined,
             stackScriptLabel: '',
           },
@@ -557,7 +613,52 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
       });
   }
 
+  handleMakePublic = () => {
+    const { dialog, currentFilter } = this.state;
+    
+    makeStackScriptPublic(dialog.stackScriptID!)
+      .then(response => {
+        if (!this.mounted) { return; }
+        this.setState({
+          successMessage: `${dialog.stackScriptLabel} successfully published to the public library`,
+          dialog: {
+            delete: {
+              open: false,
+            },
+            makePublic: {
+              open: false,
+            },
+            stackScriptID: undefined,
+            stackScriptLabel: '',
+          }
+        });
+        this.getDataAtPage(1, currentFilter, true);
+      })
+      .catch(e => {
+        this.setState({
+          dialog: {
+            delete: {
+              open: false,
+            },
+            makePublic: {
+              open: false,
+            },
+            stackScriptID: undefined,
+            stackScriptLabel: '',
+          },
+          fieldError: {
+            reason: 'Unable to complete your request at this time'
+          }
+        })
+      });
+  }
+
+  
   renderDialogActions = () => {
+    const onClick = (this.state.dialog.delete.open)
+      ? this.handleDeleteStackScript
+      : this.handleMakePublic;
+
     return (
       <React.Fragment>
         <ActionsPanel>
@@ -565,7 +666,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
             variant="raised"
             type="secondary"
             destructive
-            onClick={this.handleDeleteStackScript}>
+            onClick={onClick}>
             Yes
           </Button>
           <Button
@@ -587,11 +688,28 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
     return (
       <ConfirmationDialog
         title={`Delete ${dialog.stackScriptLabel}?`}
-        open={dialog.open}
+        open={dialog.delete.open}
         actions={this.renderDialogActions}
         onClose={this.handleCloseDialog}
       >
         <Typography>Are you sure you want to delete this StackScript?</Typography>
+      </ConfirmationDialog>
+    )
+  }
+
+  renderMakePublicDialog = () => {
+    const { dialog } = this.state;
+
+    return (
+      <ConfirmationDialog
+        title={`Woah, just a word of caution...`}
+        open={dialog.makePublic.open}
+        actions={this.renderDialogActions}
+        onClose={this.handleCloseDialog}
+      >
+        <Typography>Are you sure you want to make {dialog.stackScriptLabel} public?
+        This action cannot be undone, nor will you be able to delete the StackScript once
+        made available to the public.</Typography>
       </ConfirmationDialog>
     )
   }
@@ -645,8 +763,16 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
 
   render() {
     const { classes, publicImages, currentUser } = this.props;
-    const { currentFilterType, isSorting, error, fieldError,
-      isSearching, listOfStackScripts, didSearch } = this.state;
+    const {
+      currentFilterType,
+      isSorting,
+      error,
+      fieldError,
+      isSearching,
+      listOfStackScripts,
+      didSearch,
+      successMessage,
+    } = this.state;
 
     if(error) {
       return (
@@ -670,6 +796,9 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
       <React.Fragment>
         {fieldError && fieldError.reason &&
           <Notice text={fieldError.reason} error />
+        }
+        {successMessage &&
+          <Notice text={successMessage} success />
         }
         {/*
         * We only want to show this empty state on the initial GET StackScripts request
@@ -776,7 +905,8 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
                 selectedId={this.state.selected}
                 data={this.state.listOfStackScripts}
                 publicImages={publicImages}
-                triggerDelete={this.handleOpenDialog}
+                triggerDelete={this.handleOpenDeleteDialog}
+                triggerMakePublic={this.handleOpenMakePublicDialog}
                 currentUser={currentUser}
                 {...selectProps}
               />
@@ -798,6 +928,7 @@ class Container extends React.Component<ContainerCombinedProps, ContainerState> 
           </Button>
         }
         {this.renderDeleteStackScriptDialog()}
+        {this.renderMakePublicDialog()}
       </React.Fragment>
     );
   }

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptActionMenu.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptActionMenu.tsx
@@ -8,15 +8,26 @@ interface Props {
   stackScriptUsername: string;
   stackScriptLabel: string;
   triggerDelete: (id: number, label: string) => void;
+  triggerMakePublic: (id: number, label: string) => void;
   canDelete: boolean;
   canEdit: boolean;
+  isPublic: boolean;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}>;
 
 const StackScriptActionMenu: React.StatelessComponent<CombinedProps> = (props) => {
-  const { stackScriptID, stackScriptUsername,
-     history, triggerDelete, stackScriptLabel, canDelete, canEdit } = props;
+  const {
+    stackScriptID,
+    stackScriptUsername,
+    history,
+    triggerDelete,
+    triggerMakePublic,
+    stackScriptLabel,
+    canDelete,
+    canEdit,
+    isPublic,
+  } = props;
 
   const createActions = () => {
     return (closeMenu: Function): Action[] => {
@@ -52,12 +63,17 @@ const StackScriptActionMenu: React.StatelessComponent<CombinedProps> = (props) =
               e.preventDefault();
             },
           },
+        );
+      }
+
+      if (canEdit && !isPublic) {
+        actions.push(
           {
             title: 'Make StackScript Public',
             onClick: (e: React.MouseEvent<HTMLElement>) => {
               // open a modal here as well
               closeMenu();
-              e.preventDefault();
+              triggerMakePublic(stackScriptID, stackScriptLabel)
             },
           }
         );

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptActionMenu.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptActionMenu.tsx
@@ -28,25 +28,25 @@ const StackScriptActionMenu: React.StatelessComponent<CombinedProps> = (props) =
             e.preventDefault();
           },
         },
+        {
+          title: 'Edit',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            history.push(`/stackscripts/${stackScriptID}/edit`);
+            e.preventDefault();
+          },
+        }
       ];
 
-      if (false) {
-        actions.push({
-          title: 'Edit',
-          onClick: (e) => {
-            console.log('edit');
-          },
-        });
-      }
-
       if (canDelete) {
-        actions.push({
-          title: 'Delete',
-          onClick: (e) => {
-            closeMenu();
-            triggerDelete(stackScriptID, stackScriptLabel);
+        actions.push(
+          {
+            title: 'Delete',
+            onClick: (e) => {
+              closeMenu();
+              triggerDelete(stackScriptID, stackScriptLabel);
+            },
           },
-        });
+        );
       }
 
       return actions;

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptActionMenu.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptActionMenu.tsx
@@ -9,13 +9,14 @@ interface Props {
   stackScriptLabel: string;
   triggerDelete: (id: number, label: string) => void;
   canDelete: boolean;
+  canEdit: boolean;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}>;
 
 const StackScriptActionMenu: React.StatelessComponent<CombinedProps> = (props) => {
   const { stackScriptID, stackScriptUsername,
-     history, triggerDelete, stackScriptLabel, canDelete } = props;
+     history, triggerDelete, stackScriptLabel, canDelete, canEdit } = props;
 
   const createActions = () => {
     return (closeMenu: Function): Action[] => {
@@ -28,13 +29,6 @@ const StackScriptActionMenu: React.StatelessComponent<CombinedProps> = (props) =
             e.preventDefault();
           },
         },
-        {
-          title: 'Edit',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            history.push(`/stackscripts/${stackScriptID}/edit`);
-            e.preventDefault();
-          },
-        }
       ];
 
       if (canDelete) {
@@ -46,6 +40,18 @@ const StackScriptActionMenu: React.StatelessComponent<CombinedProps> = (props) =
               triggerDelete(stackScriptID, stackScriptLabel);
             },
           },
+        );
+      }
+
+      if (canEdit) {
+        actions.push(
+          {
+            title: 'Edit',
+            onClick: (e: React.MouseEvent<HTMLElement>) => {
+              history.push(`/stackscripts/${stackScriptID}/edit`);
+              e.preventDefault();
+            },
+          }
         );
       }
 

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptActionMenu.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptActionMenu.tsx
@@ -51,6 +51,14 @@ const StackScriptActionMenu: React.StatelessComponent<CombinedProps> = (props) =
               history.push(`/stackscripts/${stackScriptID}/edit`);
               e.preventDefault();
             },
+          },
+          {
+            title: 'Make StackScript Public',
+            onClick: (e: React.MouseEvent<HTMLElement>) => {
+              // open a modal here as well
+              closeMenu();
+              e.preventDefault();
+            },
           }
         );
       }

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -26,6 +26,7 @@ export interface Props {
   isSorting: boolean;
   publicImages: Linode.Image[];
   triggerDelete: (id: number, label: string) => void;
+  triggerMakePublic: (id: number, label: string) => void;
   currentUser: string;
 }
 
@@ -40,6 +41,7 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
     classes,
     triggerDelete,
     currentUser,
+    triggerMakePublic
   } = props;
 
   const renderStackScriptTable = () => {
@@ -56,6 +58,7 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
       label={s.label}
       stackScriptUsername={s.username}
       description={truncateDescription(s.description)}
+      isPublic={s.is_public}
       images={stripImageName(s.images)}
       deploymentsActive={s.deployments_active}
       updated={formatDate(s.updated, false)}
@@ -80,12 +83,14 @@ const listStackScript: (
       label={s.label}
       stackScriptUsername={s.username}
       description={truncateDescription(s.description)}
+      isPublic={s.is_public}
       images={stripImageName(s.images)}
       deploymentsActive={s.deployments_active}
       updated={formatDate(s.updated, false)}
       showDeployLink={showDeployLink}
       stackScriptID={s.id}
       triggerDelete={triggerDelete}
+      triggerMakePublic={triggerMakePublic}
       canDelete={canDelete(s.username, s.is_public)}
       canEdit={canEdit(s.username)}
     />

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -108,8 +108,8 @@ const listStackScript: (
   }
 
   /*
-  * We can only delete a stackscript if it's ours
-  * and it's not publicly available
+  * We can only edit a stackscript if it's ours
+  * it doesn't matter if it's public or not
   */
   const canEdit = (stackScriptUser: string) => {
     if (stackScriptUser === currentUser) {

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -64,6 +64,7 @@ const StackScriptsSection: React.StatelessComponent<CombinedProps> = (props) => 
       updateFor={[selectedId === s.id]}
       stackScriptID={s.id}
       canDelete={false}
+      canEdit={false}
     />
   )
 
@@ -86,6 +87,7 @@ const listStackScript: (
       stackScriptID={s.id}
       triggerDelete={triggerDelete}
       canDelete={canDelete(s.username, s.is_public)}
+      canEdit={canEdit(s.username)}
     />
   )
 
@@ -95,6 +97,17 @@ const listStackScript: (
   */
   const canDelete = (stackScriptUser: string, stackScriptIsPublic: boolean) => {
     if (stackScriptUser === currentUser && !stackScriptIsPublic) {
+      return true;
+    }
+    return false;
+  }
+
+  /*
+  * We can only delete a stackscript if it's ours
+  * and it's not publicly available
+  */
+  const canEdit = (stackScriptUser: string) => {
+    if (stackScriptUser === currentUser) {
       return true;
     }
     return false;

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
@@ -31,4 +31,22 @@ describe('StackScriptCreate', () => {
       const modalTitle = component.find('WithStyles(ConfirmationDialog)').prop('title');
       expect(modalTitle).toBe('Clear StackScript Configuration?');
     });
+
+    it('should render StackScript Form',() => {
+      expect(component.find('WithStyles(StackScriptForm)')).toHaveLength(1);
+    });
+
+    describe('Back Arrow Icon Button', () => {
+
+      it('should render back array icon button', () => {
+        const backIcon = component.find('WithStyles(IconButton)').first();
+        expect(backIcon.find('pure(KeyboardArrowLeft)')).toHaveLength(1);
+      });
+
+      it('back arrow icon should link back to stackscripts landing', () => {
+        const backIcon = component.find('WithStyles(IconButton)').first();
+        const parentLink = backIcon.closest('Link');
+        expect(parentLink.prop('to')).toBe('/stackscripts');
+      });
+    });
 });

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
@@ -26,22 +26,6 @@ describe('StackScriptCreate', () => {
     expect(titleText).toBe('Create New StackScript');
   });
 
-  it('should render three text fields', () => {
-    expect(component.find('WithStyles(LinodeTextField)')).toHaveLength(4);
-  });
-
-  it('should render a select field', () => {
-    expect(component.find('WithStyles(SSelect)')).toHaveLength(1);
-  });
-
-  it('should render a code text field', () => {
-    // not done yet!!
-  });
-
-  it('should render a checkbox', () => {
-    expect(component.find('WithStyles(FormControlLabel)')).toHaveLength(1);
-  });
-
   it(`should render a confirmation dialog with the
   title "Clear StackScript Configuration?"`, () => {
       const modalTitle = component.find('WithStyles(ConfirmationDialog)').prop('title');

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -184,10 +184,6 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     this.setState({ revisionNote: e.target.value });
   }
 
-  handleToggleIsPublic = () => {
-    this.setState({ is_public: !this.state.is_public });
-  }
-
   resetAllFields = () => {
     this.handleCloseDialog();
     this.setState({
@@ -283,7 +279,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
   render() {
     const { classes, profile } = this.props;
     const { availableImages, selectedImages, script,
-      labelText, descriptionText, revisionNote, errors, is_public,
+      labelText, descriptionText, revisionNote, errors,
     isSubmitting } = this.state;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
@@ -339,10 +335,6 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             onOpen: this.handleOpenSelect,
             onClose: this.handleCloseSelect,
             onChange: this.handleChooseImage
-          }}
-          isPublic={{
-            checked: is_public,
-            handler: this.handleToggleIsPublic
           }}
           errors={errors}
           onSubmit={this.handleCreateStackScript}

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -71,7 +71,6 @@ interface State {
   availableImages: Linode.Image[];
   script: string;
   revisionNote: string;
-  is_public: boolean;
   isSubmitting: boolean;
   errors?: Linode.ApiFieldError[];
   dialogOpen: boolean;
@@ -104,7 +103,6 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     availableImages: this.props.images.response,
     script: '',
     revisionNote: '',
-    is_public: false,
     isSubmitting: false,
     dialogOpen: false,
   };
@@ -191,14 +189,12 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
       labelText: '',
       selectedImages: [],
       descriptionText: '',
-      is_public: false,
       revisionNote: '',
     })
   }
 
   handleCreateStackScript = () => {
-    const { script, labelText, selectedImages, descriptionText,
-      is_public, revisionNote } = this.state;
+    const { script, labelText, selectedImages, descriptionText, revisionNote } = this.state;
 
     const { history } = this.props;
 
@@ -207,7 +203,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
       label: labelText,
       images: selectedImages,
       description: descriptionText,
-      is_public,
+      is_public: false,
       rev_note: revisionNote,
     }
 
@@ -340,7 +336,6 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
           onSubmit={this.handleCreateStackScript}
           onCancel={this.handleOpenDialog}
           isSubmitting={isSubmitting}
-          shouldShowMakePublicToggle={true}
         />
         {this.renderCancelStackScriptDialog()}
       </React.Fragment>

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -211,10 +211,13 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     this.setState({ isSubmitting: true });
 
     createStackScript(payload)
-      .then(stackScript => {
+      .then((stackScript: Linode.StackScript.Response) => {
         if (!this.mounted) { return; }
         this.setState({ isSubmitting: false });
-        history.push('/stackscripts');
+        history.push(
+          '/stackscripts',
+          { successMessage: `${stackScript.label} successfully created` }
+        );
       })
       .catch(error => {
         if (!this.mounted) { return; }

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.test.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.test.tsx
@@ -55,7 +55,6 @@ describe('StackScriptCreate', () => {
       onSubmit={jest.fn()}
       onCancel={jest.fn()}
       isSubmitting={false}
-      shouldShowMakePublicToggle={true}
     />
   );
 

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.test.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.test.tsx
@@ -1,0 +1,81 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { StackScriptForm } from './StackScriptForm';
+
+import { images } from 'src/__data__/images';
+
+describe('StackScriptCreate', () => {
+  const component = shallow(
+    <StackScriptForm
+      classes={{
+        titleWrapper: '',
+        root: '',
+        backButton: '',
+        createTitle: '',
+        labelField: '',
+        divider: '',
+        gridWithTips: '',
+        tips: '',
+        chipsContainer: '',
+        scriptTextarea: '',
+        revisionTextarea: '',
+        warning: '',
+        targetTag: ''
+      }}
+      images={{
+        available: images,
+        selected: [],
+        handleRemove: jest.fn(),
+      }}
+      currentUser='mmckenna'
+      label={{
+        value: '',
+        handler: jest.fn()
+      }}
+      description={{
+        value: '',
+        handler: jest.fn()
+      }}
+      revision={{
+        value: '',
+        handler: jest.fn()
+      }}
+      script={{
+        value: '',
+        handler: jest.fn()
+      }}
+      selectImages={{
+        open: false,
+        onOpen: jest.fn(),
+        onClose: jest.fn(),
+        onChange: jest.fn()
+      }}
+      isPublic={{
+        checked: false,
+        handler: jest.fn()
+      }}
+      errors={[]}
+      onSubmit={jest.fn()}
+      onCancel={jest.fn()}
+      isSubmitting={false}
+      shouldShowMakePublicToggle={true}
+    />
+  );
+
+  it('should render three text fields', () => {
+    expect(component.find('WithStyles(LinodeTextField)')).toHaveLength(4);
+  });
+
+  it('should render a select field', () => {
+    expect(component.find('WithStyles(SSelect)')).toHaveLength(1);
+  });
+
+  it('should render a code text field', () => {
+    // not done yet!!
+  });
+
+  it('should render a checkbox', () => {
+    expect(component.find('WithStyles(FormControlLabel)')).toHaveLength(1);
+  });
+});

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.test.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.test.tsx
@@ -51,10 +51,6 @@ describe('StackScriptCreate', () => {
         onClose: jest.fn(),
         onChange: jest.fn()
       }}
-      isPublic={{
-        checked: false,
-        handler: jest.fn()
-      }}
       errors={[]}
       onSubmit={jest.fn()}
       onCancel={jest.fn()}
@@ -73,9 +69,5 @@ describe('StackScriptCreate', () => {
 
   it('should render a code text field', () => {
     // not done yet!!
-  });
-
-  it('should render a checkbox', () => {
-    expect(component.find('WithStyles(FormControlLabel)')).toHaveLength(1);
   });
 });

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -283,33 +283,6 @@ export class StackScriptForm extends React.Component<CombinedProps> {
             value={revision.value}
             InputProps={{ className: classes.revisionTextarea }}
           />
-          {/* {this.props.shouldShowMakePublicToggle &&
-            <React.Fragment>
-              <Notice
-                component="div"
-                warning
-                flag
-                className={classes.warning}
-              >
-                <Typography variant="title">Woah, just a word of caution...</Typography>
-                <Typography>
-                  Making this StackScript public cannot be undone. Once made public, your StackScript will
-                  be available to all Linode users and can be used to provision new Linodes.
-            </Typography>
-              </Notice>
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    name='make_public'
-                    variant='warning'
-                    onChange={isPublic.handler}
-                    checked={isPublic.checked}
-                  />
-                }
-                label="Publish this StackScript to the Public Library"
-              />
-            </React.Fragment>
-          } */}
           <ActionsPanel style={{ paddingBottom: 0 }}>
             <Button
               data-qa-confirm-cancel

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -1,0 +1,353 @@
+import * as React from 'react';
+
+import {
+  StyleRulesCallback,
+  Theme,
+  withStyles,
+  WithStyles,
+} from '@material-ui/core/styles';
+
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Checkbox from 'src/components/CheckBox';
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
+import Select from 'src/components/Select';
+import Tag from 'src/components/Tag';
+import TextField from 'src/components/TextField';
+
+import { Divider } from '../../../../node_modules/@material-ui/core';
+
+import filterImagesByDeprecationStatus from 'src/utilities/filterImagesByDeprecationStatus';
+import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+
+
+type ClassNames = 'root'
+  | 'backButton'
+  | 'titleWrapper'
+  | 'createTitle'
+  | 'labelField'
+  | 'divider'
+  | 'gridWithTips'
+  | 'tips'
+  | 'chipsContainer'
+  | 'scriptTextarea'
+  | 'revisionTextarea'
+  | 'warning'
+  | 'targetTag';
+
+  const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+    root: {
+      padding: theme.spacing.unit * 2,
+    },
+    backButton: {
+      margin: '5px 0 0 -16px',
+      '& svg': {
+        width: 34,
+        height: 34,
+      },
+    },
+    createTitle: {
+      lineHeight: '2.25em'
+    },
+    divider: {
+      margin: `0 0 ${theme.spacing.unit * 2}px 0`,
+      height: 0,
+    },
+    labelField: {
+      '& input': {
+        paddingLeft: 0,
+      },
+    },
+    titleWrapper: {
+      display: 'flex',
+      marginTop: 5,
+    },
+    gridWithTips: {
+      maxWidth: '50%',
+      [theme.breakpoints.down('sm')]: {
+        maxWidth: '100%',
+      },
+    },
+    tips: {
+      marginLeft: theme.spacing.unit * 4,
+      marginTop: theme.spacing.unit * 4,
+      padding: theme.spacing.unit * 4,
+      backgroundColor: theme.palette.divider,
+      [theme.breakpoints.down('lg')]: {
+        marginLeft: 0,
+      },
+      [theme.breakpoints.down('md')]: {
+        paddingLeft: theme.spacing.unit * 2,
+      },
+    },
+    chipsContainer: {
+      maxWidth: 415,
+    },
+    warning: {
+      marginTop: theme.spacing.unit * 4,
+    },
+    targetTag: {
+      margin: `${theme.spacing.unit}px ${theme.spacing.unit}px 0 0`,
+    },
+    scriptTextarea: {
+      maxWidth: '100%',
+      height: 400,
+      '& textarea': {
+        height: '100%',
+      }
+    },
+    revisionTextarea: {
+      maxWidth: '100%',
+    },
+  });
+
+interface TextFieldHandler {
+  value: string;
+  handler: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+interface ToggleFieldHandler {
+  checked: boolean;
+  handler: () => void;
+}
+
+interface SelectFieldHandler {
+  open: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+interface Images {
+  // available to select in the dropdown
+  available: Linode.Image[];
+  // image ids that are already selected
+  selected: string[];
+  handleRemove: (index: number) => void;
+}
+
+interface Props {
+  currentUser: string;
+  images: Images;
+  label: TextFieldHandler;
+  revision: TextFieldHandler;
+  description: TextFieldHandler;
+  script: TextFieldHandler;
+  selectImages: SelectFieldHandler;
+  isPublic: ToggleFieldHandler;
+  errors?: Linode.ApiFieldError[];
+  onSubmit: () => void;
+  onCancel: () => void;
+  isSubmitting: boolean;
+  shouldShowMakePublicToggle: boolean;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const errorResources = {
+  label: 'A label',
+  images: 'Images',
+  script: 'A script'
+};
+
+export const StackScriptForm: React.StatelessComponent<CombinedProps> = (props) => {
+
+  const { currentUser, classes, label, revision, description,
+    script, selectImages, isPublic, errors, onSubmit, onCancel,
+    isSubmitting, images } = props;
+
+  const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+
+  return (
+    <React.Fragment>
+      <Paper className={classes.root}>
+        <Grid container>
+          <Grid item className={classes.gridWithTips}>
+            <TextField
+              InputProps={{
+                startAdornment:
+                  <InputAdornment position="end">
+                    {currentUser} /
+                    </InputAdornment>,
+              }}
+              label='StackScript Label'
+              required
+              onChange={label.handler}
+              placeholder='Enter a label'
+              value={label.value}
+              errorText={hasErrorFor('label')}
+              tooltipText="Select a StackScript Label"
+              className={classes.labelField}
+            />
+            <TextField
+              multiline
+              rows={1}
+              label="Description"
+              placeholder="Enter a description"
+              onChange={description.handler}
+              value={description.value}
+              tooltipText="Give your StackScript a description"
+            />
+            <FormControl fullWidth>
+              <InputLabel
+                htmlFor="image"
+                disableAnimation
+                shrink={true}
+                required
+              >
+                Target Images
+              </InputLabel>
+              <Select
+                // open={this.state.image}
+                open={selectImages.open}
+                onOpen={selectImages.onOpen}
+                onClose={selectImages.onClose}
+                value='none'
+                onChange={selectImages.onChange}
+                inputProps={{ name: 'image', id: 'image' }}
+                helpText='Select which images are compatible with this StackScript'
+                error={Boolean(hasErrorFor('images'))}
+                errorText={hasErrorFor('images')}
+              >
+                <MenuItem disabled key="none" value="none">Select Compatible Images</MenuItem>,
+                {filterImagesByDeprecationStatus(images.available, false).map(image =>
+                  <MenuItem
+                    key={image.id}
+                    value={image.id}
+                  >
+                    {image.label}
+                  </MenuItem>,
+                )}
+                <MenuItem disabled key="deprecated" value="deprecated">Older Images</MenuItem>,
+                {filterImagesByDeprecationStatus(images.available, true).map(image =>
+                  <MenuItem
+                    key={image.id}
+                    value={image.id}
+                  >
+                    {image.label}
+                  </MenuItem>,
+                )}
+              </Select>
+            </FormControl>
+            <div className={classes.chipsContainer}>
+              {images.selected && images.selected.map((selectedImage, index) => {
+                return (
+                  <Tag
+                    key={selectedImage}
+                    label={stripImageName(selectedImage)}
+                    variant='lightBlue'
+                    onDelete={() => images.handleRemove(index)}
+                    className={classes.targetTag}
+                  />
+                )
+              })}
+            </div>
+          </Grid>
+          <Grid item className={classes.gridWithTips}>
+            <Notice
+              className={classes.tips}
+              component="div"
+            >
+              <Typography variant="title">Tips</Typography>
+              <Typography>There are four default environment variables provided to you:</Typography>
+              <ul>
+                <li>LINODE_ID</li>
+                <li>LINODE_LISTUSERNAME</li>
+                <li>LINODE_RAM</li>
+                <li>LINODE_DATACENTERID</li>
+              </ul>
+            </Notice>
+          </Grid>
+        </Grid>
+        <Divider className={classes.divider} />
+        <TextField
+          multiline
+          rows={1}
+          label="Script"
+          placeholder={`#!/bin/bash \n\n# Your script goes here`}
+          onChange={script.handler}
+          value={script.value}
+          errorText={hasErrorFor('script')}
+          required
+          InputProps={{ className: classes.scriptTextarea }}
+        />
+        <TextField
+          multiline
+          rows={1}
+          label="Revision Note"
+          placeholder='Enter a revision note'
+          onChange={revision.handler}
+          value={revision.value}
+          InputProps={{ className: classes.revisionTextarea }}
+        />
+        {props.shouldShowMakePublicToggle &&
+          <React.Fragment>
+            <Notice
+              component="div"
+              warning
+              flag
+              className={classes.warning}
+            >
+              <Typography variant="title">Woah, just a word of caution...</Typography>
+              <Typography>
+                Making this StackScript public cannot be undone. Once made public, your StackScript will
+                be available to all Linode users and can be used to provision new Linodes.
+            </Typography>
+            </Notice>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name='make_public'
+                  variant='warning'
+                  onChange={isPublic.handler}
+                  checked={isPublic.checked}
+                />
+              }
+              label="Publish this StackScript to the Public Library"
+            />
+          </React.Fragment>
+        }
+        <ActionsPanel style={{ paddingBottom: 0 }}>
+          <Button
+            data-qa-confirm-cancel
+            onClick={onSubmit}
+            type="primary"
+            loading={isSubmitting}
+          >
+            Save
+            </Button>
+          <Button
+            onClick={onCancel}
+            type="secondary"
+            className="cancel"
+            data-qa-cancel-cancel
+          >
+            Cancel
+            </Button>
+        </ActionsPanel>
+      </Paper>
+    </React.Fragment>
+  );
+}
+
+/*
+* @TODO Deprecate once we have a reliable way of mapping
+* the slug to the display name
+*/
+const stripImageName = (image: string) => {
+  return image.replace('linode/', '');
+};
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled<Props>(StackScriptForm);
+

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -159,184 +159,188 @@ const errorResources = {
   script: 'A script'
 };
 
-export const StackScriptForm: React.StatelessComponent<CombinedProps> = (props) => {
+// exported as a class component, otherwise no display name
+// appears in tests
+export class StackScriptForm extends React.Component<CombinedProps> {
 
-  const { currentUser, classes, label, revision, description,
-    script, selectImages, isPublic, errors, onSubmit, onCancel,
-    isSubmitting, images } = props;
+  render() {
 
-  const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+    const { currentUser, classes, label, revision, description,
+      script, selectImages, isPublic, errors, onSubmit, onCancel,
+      isSubmitting, images } = this.props;
 
-  return (
-    <React.Fragment>
-      <Paper className={classes.root}>
-        <Grid container>
-          <Grid item className={classes.gridWithTips}>
-            <TextField
-              InputProps={{
-                startAdornment:
-                  <InputAdornment position="end">
-                    {currentUser} /
+    const hasErrorFor = getAPIErrorsFor(errorResources, errors);
+
+    return (
+      <React.Fragment>
+        <Paper className={classes.root}>
+          <Grid container>
+            <Grid item className={classes.gridWithTips}>
+              <TextField
+                InputProps={{
+                  startAdornment:
+                    <InputAdornment position="end">
+                      {currentUser} /
                     </InputAdornment>,
-              }}
-              label='StackScript Label'
-              required
-              onChange={label.handler}
-              placeholder='Enter a label'
-              value={label.value}
-              errorText={hasErrorFor('label')}
-              tooltipText="Select a StackScript Label"
-              className={classes.labelField}
-            />
-            <TextField
-              multiline
-              rows={1}
-              label="Description"
-              placeholder="Enter a description"
-              onChange={description.handler}
-              value={description.value}
-              tooltipText="Give your StackScript a description"
-            />
-            <FormControl fullWidth>
-              <InputLabel
-                htmlFor="image"
-                disableAnimation
-                shrink={true}
+                }}
+                label='StackScript Label'
                 required
-              >
-                Target Images
+                onChange={label.handler}
+                placeholder='Enter a label'
+                value={label.value}
+                errorText={hasErrorFor('label')}
+                tooltipText="Select a StackScript Label"
+                className={classes.labelField}
+              />
+              <TextField
+                multiline
+                rows={1}
+                label="Description"
+                placeholder="Enter a description"
+                onChange={description.handler}
+                value={description.value}
+                tooltipText="Give your StackScript a description"
+              />
+              <FormControl fullWidth>
+                <InputLabel
+                  htmlFor="image"
+                  disableAnimation
+                  shrink={true}
+                  required
+                >
+                  Target Images
               </InputLabel>
-              <Select
-                // open={this.state.image}
-                open={selectImages.open}
-                onOpen={selectImages.onOpen}
-                onClose={selectImages.onClose}
-                value='none'
-                onChange={selectImages.onChange}
-                inputProps={{ name: 'image', id: 'image' }}
-                helpText='Select which images are compatible with this StackScript'
-                error={Boolean(hasErrorFor('images'))}
-                errorText={hasErrorFor('images')}
-              >
-                <MenuItem disabled key="none" value="none">Select Compatible Images</MenuItem>,
+                <Select
+                  open={selectImages.open}
+                  onOpen={selectImages.onOpen}
+                  onClose={selectImages.onClose}
+                  value='none'
+                  onChange={selectImages.onChange}
+                  inputProps={{ name: 'image', id: 'image' }}
+                  helpText='Select which images are compatible with this StackScript'
+                  error={Boolean(hasErrorFor('images'))}
+                  errorText={hasErrorFor('images')}
+                >
+                  <MenuItem disabled key="none" value="none">Select Compatible Images</MenuItem>,
                 {filterImagesByDeprecationStatus(images.available, false).map(image =>
-                  <MenuItem
-                    key={image.id}
-                    value={image.id}
-                  >
-                    {image.label}
-                  </MenuItem>,
-                )}
-                <MenuItem disabled key="deprecated" value="deprecated">Older Images</MenuItem>,
+                    <MenuItem
+                      key={image.id}
+                      value={image.id}
+                    >
+                      {image.label}
+                    </MenuItem>,
+                  )}
+                  <MenuItem disabled key="deprecated" value="deprecated">Older Images</MenuItem>,
                 {filterImagesByDeprecationStatus(images.available, true).map(image =>
-                  <MenuItem
-                    key={image.id}
-                    value={image.id}
-                  >
-                    {image.label}
-                  </MenuItem>,
-                )}
-              </Select>
-            </FormControl>
-            <div className={classes.chipsContainer}>
-              {images.selected && images.selected.map((selectedImage, index) => {
-                return (
-                  <Tag
-                    key={selectedImage}
-                    label={stripImageName(selectedImage)}
-                    variant='lightBlue'
-                    onDelete={() => images.handleRemove(index)}
-                    className={classes.targetTag}
-                  />
-                )
-              })}
-            </div>
+                    <MenuItem
+                      key={image.id}
+                      value={image.id}
+                    >
+                      {image.label}
+                    </MenuItem>,
+                  )}
+                </Select>
+              </FormControl>
+              <div className={classes.chipsContainer}>
+                {images.selected && images.selected.map((selectedImage, index) => {
+                  return (
+                    <Tag
+                      key={selectedImage}
+                      label={stripImageName(selectedImage)}
+                      variant='lightBlue'
+                      onDelete={() => images.handleRemove(index)}
+                      className={classes.targetTag}
+                    />
+                  )
+                })}
+              </div>
+            </Grid>
+            <Grid item className={classes.gridWithTips}>
+              <Notice
+                className={classes.tips}
+                component="div"
+              >
+                <Typography variant="title">Tips</Typography>
+                <Typography>There are four default environment variables provided to you:</Typography>
+                <ul>
+                  <li>LINODE_ID</li>
+                  <li>LINODE_LISTUSERNAME</li>
+                  <li>LINODE_RAM</li>
+                  <li>LINODE_DATACENTERID</li>
+                </ul>
+              </Notice>
+            </Grid>
           </Grid>
-          <Grid item className={classes.gridWithTips}>
-            <Notice
-              className={classes.tips}
-              component="div"
-            >
-              <Typography variant="title">Tips</Typography>
-              <Typography>There are four default environment variables provided to you:</Typography>
-              <ul>
-                <li>LINODE_ID</li>
-                <li>LINODE_LISTUSERNAME</li>
-                <li>LINODE_RAM</li>
-                <li>LINODE_DATACENTERID</li>
-              </ul>
-            </Notice>
-          </Grid>
-        </Grid>
-        <Divider className={classes.divider} />
-        <TextField
-          multiline
-          rows={1}
-          label="Script"
-          placeholder={`#!/bin/bash \n\n# Your script goes here`}
-          onChange={script.handler}
-          value={script.value}
-          errorText={hasErrorFor('script')}
-          required
-          InputProps={{ className: classes.scriptTextarea }}
-        />
-        <TextField
-          multiline
-          rows={1}
-          label="Revision Note"
-          placeholder='Enter a revision note'
-          onChange={revision.handler}
-          value={revision.value}
-          InputProps={{ className: classes.revisionTextarea }}
-        />
-        {props.shouldShowMakePublicToggle &&
-          <React.Fragment>
-            <Notice
-              component="div"
-              warning
-              flag
-              className={classes.warning}
-            >
-              <Typography variant="title">Woah, just a word of caution...</Typography>
-              <Typography>
-                Making this StackScript public cannot be undone. Once made public, your StackScript will
-                be available to all Linode users and can be used to provision new Linodes.
+          <Divider className={classes.divider} />
+          <TextField
+            multiline
+            rows={1}
+            label="Script"
+            placeholder={`#!/bin/bash \n\n# Your script goes here`}
+            onChange={script.handler}
+            value={script.value}
+            errorText={hasErrorFor('script')}
+            required
+            InputProps={{ className: classes.scriptTextarea }}
+          />
+          <TextField
+            multiline
+            rows={1}
+            label="Revision Note"
+            placeholder='Enter a revision note'
+            onChange={revision.handler}
+            value={revision.value}
+            InputProps={{ className: classes.revisionTextarea }}
+          />
+          {this.props.shouldShowMakePublicToggle &&
+            <React.Fragment>
+              <Notice
+                component="div"
+                warning
+                flag
+                className={classes.warning}
+              >
+                <Typography variant="title">Woah, just a word of caution...</Typography>
+                <Typography>
+                  Making this StackScript public cannot be undone. Once made public, your StackScript will
+                  be available to all Linode users and can be used to provision new Linodes.
             </Typography>
-            </Notice>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  name='make_public'
-                  variant='warning'
-                  onChange={isPublic.handler}
-                  checked={isPublic.checked}
-                />
-              }
-              label="Publish this StackScript to the Public Library"
-            />
-          </React.Fragment>
-        }
-        <ActionsPanel style={{ paddingBottom: 0 }}>
-          <Button
-            data-qa-confirm-cancel
-            onClick={onSubmit}
-            type="primary"
-            loading={isSubmitting}
-          >
-            Save
+              </Notice>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    name='make_public'
+                    variant='warning'
+                    onChange={isPublic.handler}
+                    checked={isPublic.checked}
+                  />
+                }
+                label="Publish this StackScript to the Public Library"
+              />
+            </React.Fragment>
+          }
+          <ActionsPanel style={{ paddingBottom: 0 }}>
+            <Button
+              data-qa-confirm-cancel
+              onClick={onSubmit}
+              type="primary"
+              loading={isSubmitting}
+            >
+              Save
             </Button>
-          <Button
-            onClick={onCancel}
-            type="secondary"
-            className="cancel"
-            data-qa-cancel-cancel
-          >
-            Cancel
+            <Button
+              onClick={onCancel}
+              type="secondary"
+              className="cancel"
+              data-qa-cancel-cancel
+            >
+              Cancel
             </Button>
-        </ActionsPanel>
-      </Paper>
-    </React.Fragment>
-  );
+          </ActionsPanel>
+        </Paper>
+      </React.Fragment>
+    );
+  }
 }
 
 /*
@@ -349,5 +353,5 @@ const stripImageName = (image: string) => {
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled<Props>(StackScriptForm);
+export default styled<CombinedProps>(StackScriptForm);
 

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -8,7 +8,6 @@ import {
 } from '@material-ui/core/styles';
 
 import FormControl from '@material-ui/core/FormControl';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -17,7 +16,6 @@ import Typography from '@material-ui/core/Typography';
 
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import Checkbox from 'src/components/CheckBox';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import Select from 'src/components/Select';
@@ -115,11 +113,6 @@ interface TextFieldHandler {
   handler: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-interface ToggleFieldHandler {
-  checked: boolean;
-  handler: () => void;
-}
-
 interface SelectFieldHandler {
   open: boolean;
   onOpen: () => void;
@@ -143,7 +136,6 @@ interface Props {
   description: TextFieldHandler;
   script: TextFieldHandler;
   selectImages: SelectFieldHandler;
-  isPublic: ToggleFieldHandler;
   errors?: Linode.ApiFieldError[];
   onSubmit: () => void;
   onCancel: () => void;
@@ -166,7 +158,7 @@ export class StackScriptForm extends React.Component<CombinedProps> {
   render() {
 
     const { currentUser, classes, label, revision, description,
-      script, selectImages, isPublic, errors, onSubmit, onCancel,
+      script, selectImages, errors, onSubmit, onCancel,
       isSubmitting, images } = this.props;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
@@ -292,7 +284,7 @@ export class StackScriptForm extends React.Component<CombinedProps> {
             value={revision.value}
             InputProps={{ className: classes.revisionTextarea }}
           />
-          {this.props.shouldShowMakePublicToggle &&
+          {/* {this.props.shouldShowMakePublicToggle &&
             <React.Fragment>
               <Notice
                 component="div"
@@ -318,7 +310,7 @@ export class StackScriptForm extends React.Component<CombinedProps> {
                 label="Publish this StackScript to the Public Library"
               />
             </React.Fragment>
-          }
+          } */}
           <ActionsPanel style={{ paddingBottom: 0 }}>
             <Button
               data-qa-confirm-cancel

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -140,7 +140,6 @@ interface Props {
   onSubmit: () => void;
   onCancel: () => void;
   isSubmitting: boolean;
-  shouldShowMakePublicToggle: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;

--- a/src/features/StackScripts/StackScriptForm/index.tsx
+++ b/src/features/StackScripts/StackScriptForm/index.tsx
@@ -1,0 +1,2 @@
+import ScriptForm from './StackScriptForm';
+export default ScriptForm;

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.test.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.test.tsx
@@ -1,0 +1,28 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { StackScriptUpdate } from './StackScriptUpdate';
+
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
+
+import { images } from 'src/__data__/images';
+
+describe('StackScriptUpdate', () => {
+  // const component = shallow(
+  //   <StackScriptUpdate
+  //     {...reactRouterProps}
+  //     classes={{
+  //       titleWrapper: '',
+  //       root: '',
+  //       backButton: '',
+  //       createTitle: '',
+  //     }}
+  //     profile={[]}
+  //     images={{ response: images }}
+  //   />
+  // )
+
+  it('should do the thing', () => {
+    // do the thing
+  });
+});

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.test.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.test.tsx
@@ -1,28 +1,54 @@
-// import { shallow } from 'enzyme';
-// import * as React from 'react';
+import { shallow } from 'enzyme';
+import * as React from 'react';
 
-// import { StackScriptUpdate } from './StackScriptUpdate';
+import { StackScriptUpdate } from './StackScriptUpdate';
 
-// import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
 
-// import { images } from 'src/__data__/images';
+import { images } from 'src/__data__/images';
 
 describe('StackScriptUpdate', () => {
-  // const component = shallow(
-  //   <StackScriptUpdate
-  //     {...reactRouterProps}
-  //     classes={{
-  //       titleWrapper: '',
-  //       root: '',
-  //       backButton: '',
-  //       createTitle: '',
-  //     }}
-  //     profile={[]}
-  //     images={{ response: images }}
-  //   />
-  // )
+  
+  const component = shallow(
+    <StackScriptUpdate
+      {...reactRouterProps}
+      classes={{
+        titleWrapper: '',
+        root: '',
+        backButton: '',
+        createTitle: '',
+      }}
+      profile={[]}
+      images={{ response: images }}
+    />
+  )
 
-  it('should do the thing', () => {
-    // do the thing
+  it('should render a title that reads "Edit StackScript', () => {
+    const titleText = component.find('WithStyles(Typography)').first().children().text();
+    expect(titleText).toBe('Edit StackScript');
   });
+
+  it(`should render a confirmation dialog with the
+  title "Clear StackScript Configuration?"`, () => {
+      const modalTitle = component.find('WithStyles(ConfirmationDialog)').prop('title');
+      expect(modalTitle).toBe('Clear StackScript Configuration?');
+    });
+
+    it('should render StackScript Form',() => {
+      expect(component.find('WithStyles(StackScriptForm)')).toHaveLength(1);
+    });
+
+    describe('Back Arrow Icon Button', () => {
+
+      it('should render back array icon button', () => {
+        const backIcon = component.find('WithStyles(IconButton)').first();
+        expect(backIcon.find('pure(KeyboardArrowLeft)')).toHaveLength(1);
+      });
+
+      it('back arrow icon should link back to stackscripts landing', () => {
+        const backIcon = component.find('WithStyles(IconButton)').first();
+        const parentLink = backIcon.closest('Link');
+        expect(parentLink.prop('to')).toBe('/stackscripts');
+      });
+    });
 });

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.test.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.test.tsx
@@ -1,11 +1,11 @@
-import { shallow } from 'enzyme';
-import * as React from 'react';
+// import { shallow } from 'enzyme';
+// import * as React from 'react';
 
-import { StackScriptUpdate } from './StackScriptUpdate';
+// import { StackScriptUpdate } from './StackScriptUpdate';
 
-import { reactRouterProps } from 'src/__data__/reactRouterProps';
+// import { reactRouterProps } from 'src/__data__/reactRouterProps';
 
-import { images } from 'src/__data__/images';
+// import { images } from 'src/__data__/images';
 
 describe('StackScriptUpdate', () => {
   // const component = shallow(

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -249,12 +249,15 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
     this.setState({ isSubmitting: true });
 
     updateStackScript(stackScript.response.id, payload)
-      .then(stackScript => {
+      .then((stackScript: Linode.StackScript.Response) => {
         if (!this.mounted) { return; }
         this.setState({ isSubmitting: false });
-        history.push('/stackscripts');
+        history.push(
+          '/stackscripts',
+          { successMessage: `${stackScript.label} successfully updated` }
+        );
       })
-      .catch(error => {
+      .catch((error: Linode.TodoAny) => {
         if (!this.mounted) { return; }
 
         this.setState(() => ({

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -124,9 +124,11 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
     * Filter out already selected images in the available images dropdown
     */
     const availableImages = this.props.images.response.filter(image => {
-      for (const compatibleImage of this.defaultStackScriptValues.selectedImages) {
-        if (compatibleImage === image.id) {
-          return false;
+      if (this.defaultStackScriptValues.selectedImages) {
+        for (const compatibleImage of this.defaultStackScriptValues.selectedImages) {
+          if (compatibleImage === image.id) {
+            return false;
+          }
         }
       }
       return true;

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -242,7 +242,6 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
       label: labelText,
       images: selectedImages,
       description: descriptionText,
-      is_public: false,
       rev_note: revisionNote,
     }
 

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 
 import { compose, pathOr } from 'ramda';
 
@@ -25,12 +25,14 @@ import PromiseLoader from 'src/components/PromiseLoader';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 
 import { getLinodeImages } from 'src/services/images';
-import { createStackScript } from 'src/services/stackscripts';
+import { getStackScript, updateStackScript } from 'src/services/stackscripts';
 
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 import ScriptForm from 'src/features/StackScripts/StackScriptForm';
+
+import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 
 type ClassNames = 'root'
   | 'backButton'
@@ -61,9 +63,12 @@ interface Props {
 
 interface PreloadedProps {
   images: { response: Linode.Image[] }
+  stackScript: { response: Linode.StackScript.Response }
 }
 
 interface State {
+  stackScript: Linode.StackScript.Response;
+  retrievalError?: Error; // error retrieving the stackscript
   labelText: string;
   descriptionText: string;
   imageSelectOpen: boolean;
@@ -81,11 +86,18 @@ type CombinedProps = Props
   & SetDocsProps
   & WithStyles<ClassNames>
   & PreloadedProps
-  & RouteComponentProps<{}>;
+  & RouteComponentProps<{ stackScriptID?: number }>;
 
-const preloaded = PromiseLoader<Props>({
+const preloaded = PromiseLoader<CombinedProps>({
   images: () => getLinodeImages()
-    .then(response => response.data || [])
+    .then(response => response.data || []),
+  stackScript: ({ match: { params: { stackScriptID } } }) => {
+    if (!stackScriptID) {
+      return Promise.reject(new Error('stackScriptID param not set.'));
+    }
+    return getStackScript(stackScriptID)
+      .then(response => response || [])
+  }
 })
 
 const errorResources = {
@@ -94,20 +106,48 @@ const errorResources = {
   script: 'A script'
 };
 
-export class StackScriptCreate extends React.Component<CombinedProps, State> {
-  state: State = {
-    labelText: '',
-    descriptionText: '',
-    imageSelectOpen: false,
-    selectedImages: [],
-    /* available images to select from in the dropdown */
-    availableImages: this.props.images.response,
-    script: '',
-    revisionNote: '',
-    is_public: false,
-    isSubmitting: false,
-    dialogOpen: false,
-  };
+export class StackScriptUpdate extends React.Component<CombinedProps, State> {
+
+  defaultStackScriptValues = {
+    labelText: pathOr(undefined, ['response', 'label'], this.props.stackScript),
+    descriptionText: pathOr(undefined, ['response', 'description'], this.props.stackScript),
+    selectedImages: pathOr(undefined, ['response', 'images'], this.props.stackScript),
+    script: pathOr(undefined, ['response', 'script'], this.props.stackScript),
+    revisionNote: pathOr(undefined, ['response', 'rev_note'], this.props.stackScript),
+    is_public: pathOr(undefined, ['response', 'is_public'], this.props.stackScript),
+  }
+
+  constructor(props: CombinedProps) {
+    super(props);
+
+    /*
+    * Filter out already selected images in the available images dropdown
+    */
+    const availableImages = this.props.images.response.filter(image => {
+      for (const compatibleImage of this.defaultStackScriptValues.selectedImages) {
+        if (compatibleImage === image.id) {
+          return false;
+        }
+      }
+      return true;
+    })
+
+    this.state = {
+      stackScript: pathOr(undefined, ['response'], this.props.stackScript),
+      retrievalError: pathOr(undefined, ['error'], this.props.stackScript),
+      labelText: this.defaultStackScriptValues.labelText,
+      descriptionText: this.defaultStackScriptValues.descriptionText,
+      imageSelectOpen: false,
+      selectedImages: this.defaultStackScriptValues.selectedImages,
+      /* available images to select from in the dropdown */
+      availableImages,
+      script: this.defaultStackScriptValues.script,
+      revisionNote: this.defaultStackScriptValues.revisionNote,
+      is_public: this.defaultStackScriptValues.is_public,
+      isSubmitting: false,
+      dialogOpen: false,
+    }
+  }
 
   static docs = [
     {
@@ -191,18 +231,15 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
   resetAllFields = () => {
     this.handleCloseDialog();
     this.setState({
-      script: '',
-      labelText: '',
-      selectedImages: [],
-      descriptionText: '',
-      is_public: false,
-      revisionNote: '',
+      ...this.defaultStackScriptValues
     })
   }
 
-  handleCreateStackScript = () => {
+  handleUpdateStackScript = () => {
     const { script, labelText, selectedImages, descriptionText,
       is_public, revisionNote } = this.state;
+
+    const { stackScript } = this.props;
 
     const { history } = this.props;
 
@@ -218,7 +255,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     if (!this.mounted) { return; }
     this.setState({ isSubmitting: true });
 
-    createStackScript(payload)
+    updateStackScript(stackScript.response.id, payload)
       .then(stackScript => {
         if (!this.mounted) { return; }
         this.setState({ isSubmitting: false });
@@ -284,7 +321,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     const { classes, profile } = this.props;
     const { availableImages, selectedImages, script,
       labelText, descriptionText, revisionNote, errors, is_public,
-    isSubmitting } = this.state;
+      isSubmitting } = this.state;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
@@ -307,7 +344,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
               </IconButton>
             </Link>
             <Typography className={classes.createTitle} variant="headline">
-              Create New StackScript
+              Edit StackScript
             </Typography>
           </Grid>
         </Grid>
@@ -345,10 +382,13 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
             handler: this.handleToggleIsPublic
           }}
           errors={errors}
-          onSubmit={this.handleCreateStackScript}
+          onSubmit={this.handleUpdateStackScript}
           onCancel={this.handleOpenDialog}
           isSubmitting={isSubmitting}
-          shouldShowMakePublicToggle={true}
+          // if the stackscript is public by already, don't give the user
+          // the option to make this selection beacuse you can't
+          // make a stackscript private when it's already been made public
+          shouldShowMakePublicToggle={!this.defaultStackScriptValues.is_public}
         />
         {this.renderCancelStackScriptDialog()}
       </React.Fragment>
@@ -362,10 +402,16 @@ const mapStateToProps = (state: Linode.AppState) => ({
 
 const styled = withStyles(styles, { withTheme: true });
 
+const reloaded = reloadableWithRouter<PreloadedProps, { stackScriptID?: number }>(
+  (routePropsOld, routePropsNew) => {
+    return routePropsOld.match.params.stackScriptID !== routePropsNew.match.params.stackScriptID;
+  },
+);
+
 export default compose(
-  setDocs(StackScriptCreate.docs),
+  setDocs(StackScriptUpdate.docs),
   styled,
-  withRouter,
+  reloaded,
   connect(mapStateToProps),
   preloaded,
-)(StackScriptCreate)
+)(StackScriptUpdate)

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -76,7 +76,6 @@ interface State {
   availableImages: Linode.Image[];
   script: string;
   revisionNote: string;
-  is_public: boolean;
   isSubmitting: boolean;
   errors?: Linode.ApiFieldError[];
   dialogOpen: boolean;
@@ -114,7 +113,6 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
     selectedImages: pathOr(undefined, ['response', 'images'], this.props.stackScript),
     script: pathOr(undefined, ['response', 'script'], this.props.stackScript),
     revisionNote: pathOr(undefined, ['response', 'rev_note'], this.props.stackScript),
-    is_public: pathOr(undefined, ['response', 'is_public'], this.props.stackScript),
   }
 
   constructor(props: CombinedProps) {
@@ -145,7 +143,6 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
       availableImages,
       script: this.defaultStackScriptValues.script,
       revisionNote: this.defaultStackScriptValues.revisionNote,
-      is_public: this.defaultStackScriptValues.is_public,
       isSubmitting: false,
       dialogOpen: false,
     }
@@ -234,8 +231,7 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
   }
 
   handleUpdateStackScript = () => {
-    const { script, labelText, selectedImages, descriptionText,
-      is_public, revisionNote } = this.state;
+    const { script, labelText, selectedImages, descriptionText, revisionNote } = this.state;
 
     const { stackScript } = this.props;
 
@@ -246,7 +242,7 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
       label: labelText,
       images: selectedImages,
       description: descriptionText,
-      is_public,
+      is_public: false,
       rev_note: revisionNote,
     }
 
@@ -379,10 +375,6 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
           onSubmit={this.handleUpdateStackScript}
           onCancel={this.handleOpenDialog}
           isSubmitting={isSubmitting}
-          // if the stackscript is public by already, don't give the user
-          // the option to make this selection beacuse you can't
-          // make a stackscript private when it's already been made public
-          shouldShowMakePublicToggle={!this.defaultStackScriptValues.is_public}
         />
         {this.renderCancelStackScriptDialog()}
       </React.Fragment>

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -226,10 +226,6 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
     this.setState({ revisionNote: e.target.value });
   }
 
-  handleToggleIsPublic = () => {
-    this.setState({ is_public: !this.state.is_public });
-  }
-
   resetAllFields = () => {
     this.handleCloseDialog();
     this.setState({
@@ -322,7 +318,7 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
   render() {
     const { classes, profile } = this.props;
     const { availableImages, selectedImages, script,
-      labelText, descriptionText, revisionNote, errors, is_public,
+      labelText, descriptionText, revisionNote, errors,
       isSubmitting } = this.state;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
@@ -378,10 +374,6 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
             onOpen: this.handleOpenSelect,
             onClose: this.handleCloseSelect,
             onChange: this.handleChooseImage
-          }}
-          isPublic={{
-            checked: is_public,
-            handler: this.handleToggleIsPublic
           }}
           errors={errors}
           onSubmit={this.handleUpdateStackScript}

--- a/src/features/StackScripts/StackScriptUpdate/index.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/index.tsx
@@ -1,0 +1,2 @@
+import StackScriptUpdate from './StackScriptUpdate';
+export default StackScriptUpdate;

--- a/src/features/StackScripts/StackScripts.tsx
+++ b/src/features/StackScripts/StackScripts.tsx
@@ -11,6 +11,10 @@ const StackScriptCreate = DefaultLoader({
   loader: () => import('./StackScriptCreate'),
 });
 
+const StackScriptUpdate = DefaultLoader({
+  loader: () => import('./StackScriptUpdate'),
+});
+
 type Props = RouteComponentProps<{}>;
 
 class NodeBalancers extends React.Component<Props> {
@@ -21,6 +25,7 @@ class NodeBalancers extends React.Component<Props> {
       <Switch>
         <Route component={StackScriptsLanding} path={path} exact />
         <Route component={StackScriptCreate} path={`${path}/create`} exact />
+        <Route component={StackScriptUpdate} path={`${path}/:stackScriptID/edit`} exact />
       </Switch>
     );
   }

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -9,6 +9,7 @@ import Typography from '@material-ui/core/Typography';
 import AddNewLink from 'src/components/AddNewLink';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
 import PromiseLoader from 'src/components/PromiseLoader';
 import { getLinodeImages } from 'src/services/images';
 
@@ -62,10 +63,13 @@ export class StackScriptsLanding extends React.Component<CombinedProps, State> {
 
   render() {
 
-    const { images, classes } = this.props;
+    const { images, classes, history } = this.props;
 
     return (
       <React.Fragment>
+        {!!history.location.state.successMessage &&
+          <Notice success text={history.location.state.successMessage} />
+        }
         <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }}>
           <Grid item>
             <Typography variant="headline" className={classes.title} data-qa-title >

--- a/src/services/stackscripts.ts
+++ b/src/services/stackscripts.ts
@@ -50,7 +50,7 @@ export const deleteStackScript = (id: number) =>
     setMethod('DELETE'),
   )
     .then(response => response.data);
-interface CreatePayload {
+interface StackScriptPayload {
   script: string;
   label: string;
   images: string[];
@@ -59,7 +59,7 @@ interface CreatePayload {
   rev_note?: string;
 }
 
-const createStackScriptSchema = Joi.object({
+const stackScriptSchema = Joi.object({
   script: Joi.string().required(),
   label: Joi.string().required(),
   images: Joi.array().items(Joi.string()).required(),
@@ -68,10 +68,18 @@ const createStackScriptSchema = Joi.object({
   rev_note: Joi.string().allow(""),
 });
 
-export const createStackScript = (payload: CreatePayload) =>
+export const createStackScript = (payload: StackScriptPayload) =>
   Request(
-    validateRequestData(payload, createStackScriptSchema),
+    validateRequestData(payload, stackScriptSchema),
     setURL(`${API_ROOT}/linode/stackscripts`),
     setMethod('POST'),
+    setData(payload)
+  )
+
+export const updateStackScript = (id: number, payload: StackScriptPayload) =>
+  Request(
+    validateRequestData(payload, stackScriptSchema),
+    setURL(`${API_ROOT}/linode/stackscripts/${id}`),
+    setMethod('PUT'),
     setData(payload)
   )

--- a/src/services/stackscripts.ts
+++ b/src/services/stackscripts.ts
@@ -83,3 +83,12 @@ export const updateStackScript = (id: number, payload: StackScriptPayload) =>
     setMethod('PUT'),
     setData(payload)
   )
+
+export const makeStackScriptPublic = (id: number) =>
+  Request(
+    setURL(`${API_ROOT}/linode/stackscripts/${id}`),
+    setMethod('PUT'),
+    setData({
+      is_public: true,
+    })
+  )

--- a/src/services/stackscripts.ts
+++ b/src/services/stackscripts.ts
@@ -75,6 +75,7 @@ export const createStackScript = (payload: StackScriptPayload) =>
     setMethod('POST'),
     setData(payload)
   )
+  .then(response => response.data);
 
 export const updateStackScript = (id: number, payload: StackScriptPayload) =>
   Request(
@@ -83,6 +84,7 @@ export const updateStackScript = (id: number, payload: StackScriptPayload) =>
     setMethod('PUT'),
     setData(payload)
   )
+  .then(response => response.data);
 
 export const makeStackScriptPublic = (id: number) =>
   Request(

--- a/src/utilities/filterImagesByDeprecationStatus.tsx
+++ b/src/utilities/filterImagesByDeprecationStatus.tsx
@@ -1,0 +1,8 @@
+/*
+* Gets images by two types: deprecated and non-deprecated
+*/
+const getImagesByDeprecationStatus = (images: Linode.Image[], deprecated: boolean) => {
+  return images.filter(image => image.deprecated === deprecated);
+}
+
+export default getImagesByDeprecationStatus;


### PR DESCRIPTION
### Purpose

Allow user to edit personal StackScripts

### Notes
* Abstracted the _StackScript Form_ out of `StackScriptCreate.tsx` so that it could be re-used in `StackScriptUpdate`
* Removed `is_public` toggle from the `StackScriptCreate.tsx` form, as per review feedback. Now, the only way to make your StackScript public is by selecting the option on the landing page in the Kebab menu (with a Dialog box to confirm the choice)
* Fixed issue where if you would delete your last stackscript, the list would load indefinitely.

### Known Issues
* _still_ can't filter stackscripts by image in our API request, so this will remain a front-end task for now
* Kebab menu is not showing at all times. If there is only one selection, the Kebab is removed in favor of just one link (to be fixed in another PR)
* Clicking the stackscript label in the landing still takes you to linode.com, rather than `StackScriptUpdate.tsx` - reason being, you can't edit non-personal stackscripts, so we're most likely going to need _StackScript Detail_ page

### Other Considerations
* Upon _make stackscript public_ failing
<img width="849" alt="screen shot 2018-07-16 at 11 35 47 am" src="https://user-images.githubusercontent.com/7387001/42768033-72b6ff22-88ec-11e8-91f9-332fed01dbd2.png">

* Successful _make stackscript public_
<img width="847" alt="screen shot 2018-07-16 at 11 36 51 am" src="https://user-images.githubusercontent.com/7387001/42768077-90261fe8-88ec-11e8-9a41-85bef18a30f7.png">

