### PR TITLE
Replace wrong instances of Input Adornments

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import Divider from '@material-ui/core/Divider';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
+import InputAdornment from '@material-ui/core/InputAdornment';
 import MenuItem from '@material-ui/core/MenuItem';
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
@@ -23,7 +24,6 @@ import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 type ClassNames = 'root'
   | 'inner'
   | 'divider'
-  | 'suffix'
   | 'backendIPAction'
   | 'suggestionsParent'
   | 'suggestions'
@@ -37,9 +37,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   divider: {
     marginTop: theme.spacing.unit * 2,
     marginBottom: theme.spacing.unit * 2,
-  },
-  suffix: {
-    marginRight: theme.spacing.unit * 2,
   },
   backendIPAction: {
     paddingLeft: theme.spacing.unit * 2,
@@ -632,12 +629,10 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                       label="Interval"
                       InputProps={{
                         'aria-label': 'Active Health Check Interval',
-                        endAdornment: <Typography
-                          variant="caption"
-                          component="span"
-                          className={classes.suffix}>
+                        endAdornment:
+                        <InputAdornment position="end">
                           seconds
-                        </Typography>,
+                        </InputAdornment>,
                       }}
                       value={healthCheckInterval}
                       onChange={this.onHealthCheckIntervalChange}
@@ -661,12 +656,10 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                       label="Timeout"
                       InputProps={{
                         'aria-label': 'Active Health Check Timeout',
-                        endAdornment: <Typography
-                          variant="caption"
-                          component="span"
-                          className={classes.suffix}>
+                        endAdornment: 
+                        <InputAdornment position="end">
                           seconds
-                        </Typography>,
+                        </InputAdornment>,
                       }}
                       value={healthCheckTimeout}
                       onChange={this.onHealthCheckTimeoutChange}

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -1,6 +1,7 @@
 import { clamp, compose, defaultTo } from 'ramda';
 import * as React from 'react';
 
+import InputAdornment from '@material-ui/core/InputAdornment';
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
@@ -17,7 +18,6 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 type ClassNames = 'root'
 | 'title'
-| 'adornment'
 | 'inner'
 | 'expPanelButton';
 
@@ -26,10 +26,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   title: {
     marginTop: theme.spacing.unit,
     marginBottom: theme.spacing.unit * 2,
-  },
-  adornment: {
-    fontSize: '.9rem',
-    marginRight: 10,
   },
   inner: {
     paddingBottom: theme.spacing.unit * 3,
@@ -148,8 +144,10 @@ class NodeBalancerSettings extends React.Component<CombinedProps, State> {
             <TextField
                 data-qa-connection-throttle
                 InputProps={{
-                  endAdornment: <span className={classes.adornment}>
-                  / second</span>,
+                  endAdornment:
+                  <InputAdornment position="end">
+                    seconds
+                  </InputAdornment>,
                 }}
                 errorText={hasErrorFor('client_conn_throttle')}
                 label='Client Connection Throttle'

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -146,7 +146,7 @@ class NodeBalancerSettings extends React.Component<CombinedProps, State> {
                 InputProps={{
                   endAdornment:
                   <InputAdornment position="end">
-                    seconds
+                    / second
                   </InputAdornment>,
                 }}
                 errorText={hasErrorFor('client_conn_throttle')}

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -7,6 +7,7 @@ import { Subscription } from 'rxjs/Subscription';
 
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
+import InputAdornment from '@material-ui/core/InputAdornment';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
@@ -29,15 +30,10 @@ import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 type ClassNames = 'root'
-  | 'suffix'
   | 'actionPanel';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {},
-  suffix: {
-    fontSize: '.9rem',
-    marginRight: theme.spacing.unit,
-  },
   actionPanel: {
     marginTop: theme.spacing.unit * 2,
   },
@@ -382,7 +378,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { mode, classes } = this.props;
+    const { mode } = this.props;
     const { linodes } = this.state;
     const regions = this.props.regions;
     const linodeLabel = this.props.linodeLabel || '';
@@ -466,7 +462,10 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
           errorText={sizeError}
           disabled={mode === modes.CLONING || mode === modes.EDITING}
           InputProps={{
-            endAdornment: <span className={classes.suffix}>GB</span>,
+            endAdornment: 
+              <InputAdornment position="end">
+                GB
+              </InputAdornment>,
           }}
           data-qa-size
         />

--- a/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { Divider, StyleRulesCallback, Theme, Typography, WithStyles, withStyles } from '@material-ui/core';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import InputAdornment from '@material-ui/core/InputAdornment';
 
 import Grid from 'src/components/Grid';
 import RenderGuard from 'src/components/RenderGuard';
@@ -12,7 +13,6 @@ type ClassNames = 'root'
   | 'switch'
   | 'copy'
   | 'usage'
-  | 'percentage';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   '@keyframes fadeIn': {
@@ -58,10 +58,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     marginTop: 0,
     width: 200,
   },
-  percentage: {
-    fontSize: '.9rem',
-    marginRight: 10,
-  },
 });
 
 interface Props {
@@ -94,25 +90,27 @@ class AlertSection extends React.Component<CombinedProps> {
             data-qa-alerts-panel
             >
             <Grid item className={classes.switch}>
-                <FormControlLabel
+              <FormControlLabel
                 className="toggleLabel"
                 control={<Toggle checked={this.props.state} onChange={this.props.onStateChange} />}
                 label={this.props.title}
                 data-qa-alert={this.props.title}
-                />
+              />
             </Grid>
             <Grid item className={classes.copy}>
                 <Typography>{this.props.copy}</Typography>
             </Grid>
             <Grid item>
-                <TextField
+              <TextField
                 label={this.props.textTitle}
                 type="number"
                 value={this.props.value}
                 disabled={!this.props.state}
                 InputProps={{
-                  endAdornment: <span className={classes.percentage}>
-                  {this.props.endAdornment}</span>,
+                  endAdornment: 
+                  <InputAdornment position="end">
+                    {this.props.endAdornment}
+                  </InputAdornment>,
                 }}
                 error={Boolean(this.props.error)}
                 errorText={this.props.error}
@@ -125,7 +123,7 @@ class AlertSection extends React.Component<CombinedProps> {
                 }}
                 onChange={this.props.onValueChange}
                 className={classes.usage}
-                />
+              />
             </Grid>
             </Grid>
             <Divider />

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
@@ -130,7 +130,9 @@ class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
         errorGroup="linode-disk-drawer"
         InputProps={{
           endAdornment:
-            <InputAdornment position="end"> MB </InputAdornment>,
+            <InputAdornment position="end">
+              MB
+            </InputAdornment>,
         }}
       />
       <FormHelperText style={{ marginTop: 8 }}>


### PR DESCRIPTION
We had a few instances of wrong markup for input Adornments, which I replaced with the proper component