### PR TITLE
M3-421 Toasts accessibility: Add missing aria tag for screen readers

### DIFF
--- a/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/src/features/ToastNotifications/ToastNotifications.tsx
@@ -194,6 +194,7 @@ class Notifier extends React.Component<CombinedProps, State> {
           autoHideDuration={6000}
           onClose={this.onClose}
           onExited={this.onExited}
+          aria-live="assertive"
           ContentProps={{
             className:
               classNames({


### PR DESCRIPTION
We were missing an aria tag to tell a screen reader when a toast message is happening. 

to test: 
CMD F5 (enable voice over)
Navigate to an action that will trigger a toast. 
Confirm toast message gets prioritized