### PR TITLE
Consolidate tooltips helper text

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,6 +5,8 @@ import * as React from 'react';
 import Button, { ButtonProps } from '@material-ui/core/Button';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
+import HelpIcon from 'src/components/HelpIcon';
+
 import Reload from 'src/assets/icons/reload.svg';
 
 type ClassNames = 'root'
@@ -17,6 +19,7 @@ interface Props extends ButtonProps {
   destructive?: boolean;
   type?: 'primary' | 'secondary' | 'cancel';
   className?: string;
+  tooltipText?: string;
 }
 
 const styles: StyleRulesCallback = (theme: Theme & Linode.Theme) => ({
@@ -92,37 +95,42 @@ const getColor = cond([
 // Add invariant warning if loading destructive cancel
 // Add invariant warning if destructive cancel
 
-const WrappedButton: React.StatelessComponent<CombinedProps> = (props) => {
+const wrappedButton: React.StatelessComponent<CombinedProps> = (props) => {
   const {
     theme,
     classes,
     loading,
     destructive,
+    tooltipText,
     type,
     className,
     ...rest
   } = props;
 
-  return React.createElement(
-    Button,
-    {
-      ...rest,
-      variant: getVariant(props),
-      disabled: props.disabled || loading,
-      color: getColor(props),
-      className: classNames(
-        type,
-        {
-          [classes.root]: true,
-          [classes.loading]: loading,
-          [classes.destructive]: destructive,
-        },
-        className,
-      ),
-    },
-    loading ? <Reload /> : props.children);
+  return (
+    <React.Fragment>
+      <Button
+        {...rest}
+        variant={getVariant(props)}
+        disabled={props.disabled || loading}
+        color={getColor(props)}
+        className={classNames(
+          type,
+          {
+            [classes.root]: true,
+            [classes.loading]: loading,
+            [classes.destructive]: destructive,
+          },
+          className,
+        )}
+      >
+        {loading ? <Reload /> : props.children}
+      </Button>
+      {tooltipText && <HelpIcon text={tooltipText} />}
+    </React.Fragment>
+  );
 };
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled<Props>(WrappedButton);
+export default styled<Props>(wrappedButton);

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -43,7 +43,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     alignItems: 'flex-end',
   },
   helpWrapperSelectField: {
-    width: 380,
+    width: 415,
     [theme.breakpoints.down('xs')]: {
       width: 240,
     },
@@ -51,7 +51,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 });
 
 interface Props extends SelectProps {
-  helpText?: string;
+  tooltipText?: string;
   success?: boolean;
   open?: boolean;
   errorText?: string;
@@ -65,7 +65,7 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
   classes,
   success,
   error,
-  helpText,
+  tooltipText,
   errorText,
   errorGroup,
   ...props
@@ -94,13 +94,13 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
     [classes.inputSucess]: success === true,
     [classes.inputError]: error === true,
     [errorScrollClassName]: !!errorScrollClassName,
-    [classes.helpWrapperSelectField]: Boolean(helpText),
+    [classes.helpWrapperSelectField]: Boolean(tooltipText),
   });
 
   return (
     <React.Fragment>
       <div className={classNames({
-        [classes.helpWrapper]: Boolean(helpText),
+        [classes.helpWrapper]: Boolean(tooltipText),
       })}>
         <Select
           open={props.open}
@@ -112,7 +112,7 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
         >
           {children}
         </Select>
-        {helpText && <HelpIcon text={helpText} />}
+        {tooltipText && <HelpIcon text={tooltipText} />}
       </div>
       {errorText && <FormHelperText className={classes.textError}>{errorText}</FormHelperText>}
     </React.Fragment>

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -21,7 +21,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     alignItems: 'flex-end',
   },
   helpWrapperTextField: {
-    width: 380,
+    width: 415,
     [theme.breakpoints.down('xs')]: {
       width: 240,
     },

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -208,7 +208,7 @@ export class StackScriptForm extends React.Component<CombinedProps> {
                   value='none'
                   onChange={selectImages.onChange}
                   inputProps={{ name: 'image', id: 'image' }}
-                  helpText='Select which images are compatible with this StackScript'
+                  tooltipText='Select which images are compatible with this StackScript'
                   error={Boolean(hasErrorFor('images'))}
                   errorText={hasErrorFor('images')}
                 >

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -171,7 +171,7 @@ class LinodeRebuild extends React.Component<CombinedProps, State> {
             </InputLabel>
             <div>
               <Select
-                helpText="Choosing a 64-bit distro is recommended."
+                tooltipText="Choosing a 64-bit distro is recommended."
                 error={Boolean(imageError)}
                 value={selected || 'select'}
                 onChange={e => this.onImageChange(e.target.value)}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -9,7 +9,6 @@ import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ExpansionPanel from 'src/components/ExpansionPanel';
-import HelpIcon from 'src/components/HelpIcon';
 import MenuItem from 'src/components/MenuItem';
 import Notice from 'src/components/Notice';
 import PanelErrorBoundary from 'src/components/PanelErrorBoundary';
@@ -109,14 +108,15 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
                 loading={submitting}
                 disabled={linodeStatus !== 'offline' || submitting}
                 data-qa-password-save
+                tooltipText={
+                  linodeStatus !== 'offline'
+                  ?
+                    'Your Linode must be fully powered down in order to change your root password'
+                  : ''
+                }
               >
                 Save
               </Button>
-              {linodeStatus !== 'offline' &&
-              <HelpIcon
-                text="Your Linode must be fully powered down
-                in order to change your root password"
-              />}
             </ActionsPanel>
   }
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -147,12 +147,13 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
           </InputLabel>
           <div>
             <Select
-            value={this.state.diskId}
-            disabled={singleDisk}
-            onChange={this.handleDiskChange}
-            inputProps={{ name: 'disk', id: 'disk' }}
-            error={Boolean(diskIdError)}
-            data-qa-select-disk={singleDisk}
+              value={this.state.diskId}
+              disabled={singleDisk}
+              onChange={this.handleDiskChange}
+              inputProps={{ name: 'disk', id: 'disk' }}
+              error={Boolean(diskIdError)}
+              data-qa-select-disk={singleDisk}
+              tooltipText={singleDisk ? 'This option is available for Linodes with multiple disks.' : ''}
             >
               {
                 this.state.linodeDisks.map(disk =>
@@ -165,9 +166,6 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
                   </MenuItem>)
               }
             </Select>
-            {singleDisk && <HelpIcon
-                text="This option is available for Linodes with multiple disks."
-            />}
           </div>
           {
             diskIdError &&


### PR DESCRIPTION
- [ ] add tooltipText Prop to buttons to follow same concepts (applied on /linodes/[id]/settings
- [ ] consolidate props (prop name should be same for selects, textfields and buttons)
- [ ] ensure styling is consistent and proper at all breakpoints