### PR TITLE
M3-715 Update User Timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@material-ui/core": "^1.2.2",
     "@material-ui/icons": "^1.1.0",
+    "@types/react-virtualized-select": "^3.0.5",
     "@types/throttle-debounce": "^1.0.0",
     "autoprefixer": "7.1.6",
     "axios": "^0.18.0",
@@ -66,6 +67,7 @@
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "react-sticky": "^6.0.1",
+    "react-virtualized-select": "^3.1.3",
     "redux": "^3.7.2",
     "rxjs": "^5.5.6",
     "serve": "6.4.8",

--- a/src/assets/timezones/timezones.ts
+++ b/src/assets/timezones/timezones.ts
@@ -1,0 +1,1293 @@
+/* Timezones are borrowed from Google Calendar */
+/* This file borrowed from https://github.com/vahnag/react-timezone */
+
+// eslint-disable-next-line max-len
+// [...$0.children].map(el => ({ label: (el.getAttribute('aria-label')|| '').replace(/\(.*?\)(.+)/, '$1').trim(), name: el.getAttribute('data-value'), offset: +(el.getAttribute('aria-label')|| '').replace(/\(.*?(-?[0-9]{2}):([0-9]{2})\).*/, (all, one, two) => +one + (two / 60) * (one > 0 ? 1 : -1)) }))
+
+export default [
+    {
+      label: 'Niue',
+      name: 'Pacific/Niue',
+      offset: -11,
+    },
+    {
+      label: 'Pago Pago',
+      name: 'Pacific/Pago_Pago',
+      offset: -11,
+    },
+    {
+      label: 'Hawaii Time',
+      name: 'Pacific/Honolulu',
+      offset: -10,
+    },
+    {
+      label: 'Rarotonga',
+      name: 'Pacific/Rarotonga',
+      offset: -10,
+    },
+    {
+      label: 'Tahiti',
+      name: 'Pacific/Tahiti',
+      offset: -10,
+    },
+    {
+      label: 'Marquesas',
+      name: 'Pacific/Marquesas',
+      offset: -9.5,
+    },
+    {
+      label: 'Gambier',
+      name: 'Pacific/Gambier',
+      offset: -9,
+    },
+    {
+      label: 'Alaska Time',
+      name: 'America/Anchorage',
+      offset: -8,
+    },
+    {
+      label: 'Pitcairn',
+      name: 'Pacific/Pitcairn',
+      offset: -8,
+    },
+    {
+      label: 'Dawson',
+      name: 'America/Dawson',
+      offset: -7,
+    },
+    {
+      label: 'Mountain Time - Arizona',
+      name: 'America/Phoenix',
+      offset: -7,
+    },
+    {
+      label: 'Mountain Time - Dawson Creek',
+      name: 'America/Dawson_Creek',
+      offset: -7,
+    },
+    {
+      label: 'Mountain Time - Hermosillo',
+      name: 'America/Hermosillo',
+      offset: -7,
+    },
+    {
+      label: 'Pacific Time',
+      name: 'America/Los_Angeles',
+      offset: -7,
+    },
+    {
+      label: 'Pacific Time - Tijuana',
+      name: 'America/Tijuana',
+      offset: -7,
+    },
+    {
+      label: 'Pacific Time - Vancouver',
+      name: 'America/Vancouver',
+      offset: -7,
+    },
+    {
+      label: 'Pacific Time - Whitehorse',
+      name: 'America/Whitehorse',
+      offset: -7,
+    },
+    {
+      label: 'Belize',
+      name: 'America/Belize',
+      offset: -6,
+    },
+    {
+      label: 'Boise',
+      name: 'America/Boise',
+      offset: -6,
+    },
+    {
+      label: 'Central Time - Regina',
+      name: 'America/Regina',
+      offset: -6,
+    },
+    {
+      label: 'Central Time - Tegucigalpa',
+      name: 'America/Tegucigalpa',
+      offset: -6,
+    },
+    {
+      label: 'Costa Rica',
+      name: 'America/Costa_Rica',
+      offset: -6,
+    },
+    {
+      label: 'Easter Island',
+      name: 'Pacific/Easter',
+      offset: -6,
+    },
+    {
+      label: 'El Salvador',
+      name: 'America/El_Salvador',
+      offset: -6,
+    },
+    {
+      label: 'Galapagos',
+      name: 'Pacific/Galapagos',
+      offset: -6,
+    },
+    {
+      label: 'Guatemala',
+      name: 'America/Guatemala',
+      offset: -6,
+    },
+    {
+      label: 'Managua',
+      name: 'America/Managua',
+      offset: -6,
+    },
+    {
+      label: 'Mountain Time',
+      name: 'America/Denver',
+      offset: -6,
+    },
+    {
+      label: 'Mountain Time - Chihuahua, Mazatlan',
+      name: 'America/Mazatlan',
+      offset: -6,
+    },
+    {
+      label: 'Mountain Time - Edmonton',
+      name: 'America/Edmonton',
+      offset: -6,
+    },
+    {
+      label: 'Mountain Time - Yellowknife',
+      name: 'America/Yellowknife',
+      offset: -6,
+    },
+    {
+      label: 'America Cancun',
+      name: 'America/Cancun',
+      offset: -5,
+    },
+    {
+      label: 'Bogota',
+      name: 'America/Bogota',
+      offset: -5,
+    },
+    {
+      label: 'Central Time',
+      name: 'America/Chicago',
+      offset: -5,
+    },
+    {
+      label: 'Central Time - Mexico City',
+      name: 'America/Mexico_City',
+      offset: -5,
+    },
+    {
+      label: 'Central Time - Winnipeg',
+      name: 'America/Winnipeg',
+      offset: -5,
+    },
+    {
+      label: 'Guayaquil',
+      name: 'America/Guayaquil',
+      offset: -5,
+    },
+    {
+      label: 'Jamaica',
+      name: 'America/Jamaica',
+      offset: -5,
+    },
+    {
+      label: 'Lima',
+      name: 'America/Lima',
+      offset: -5,
+    },
+    {
+      label: 'Panama',
+      name: 'America/Panama',
+      offset: -5,
+    },
+    {
+      label: 'Rio Branco',
+      name: 'America/Rio_Branco',
+      offset: -5,
+    },
+    {
+      label: 'Asuncion',
+      name: 'America/Asuncion',
+      offset: -4,
+    },
+    {
+      label: 'Barbados',
+      name: 'America/Barbados',
+      offset: -4,
+    },
+    {
+      label: 'Boa Vista',
+      name: 'America/Boa_Vista',
+      offset: -4,
+    },
+    {
+      label: 'Campo Grande',
+      name: 'America/Campo_Grande',
+      offset: -4,
+    },
+    {
+      label: 'Caracas',
+      name: 'America/Caracas',
+      offset: -4,
+    },
+    {
+      label: 'Cuiaba',
+      name: 'America/Cuiaba',
+      offset: -4,
+    },
+    {
+      label: 'Curacao',
+      name: 'America/Curacao',
+      offset: -4,
+    },
+    {
+      label: 'Detroit',
+      name: 'America/Detroit',
+      offset: -4,
+    },
+    {
+      label: 'Eastern Time',
+      name: 'America/New_York',
+      offset: -4,
+    },
+    {
+      label: 'Eastern Time - Iqaluit',
+      name: 'America/Iqaluit',
+      offset: -4,
+    },
+    {
+      label: 'Eastern Time - Toronto',
+      name: 'America/Toronto',
+      offset: -4,
+    },
+    {
+      label: 'Grand Turk',
+      name: 'America/Grand_Turk',
+      offset: -4,
+    },
+    {
+      label: 'Guyana',
+      name: 'America/Guyana',
+      offset: -4,
+    },
+    {
+      label: 'Havana',
+      name: 'America/Havana',
+      offset: -4,
+    },
+    {
+      label: 'La Paz',
+      name: 'America/La_Paz',
+      offset: -4,
+    },
+    {
+      label: 'Manaus',
+      name: 'America/Manaus',
+      offset: -4,
+    },
+    {
+      label: 'Martinique',
+      name: 'America/Martinique',
+      offset: -4,
+    },
+    {
+      label: 'Nassau',
+      name: 'America/Nassau',
+      offset: -4,
+    },
+    {
+      label: 'Port of Spain',
+      name: 'America/Port_of_Spain',
+      offset: -4,
+    },
+    {
+      label: 'Port-au-Prince',
+      name: 'America/Port-au-Prince',
+      offset: -4,
+    },
+    {
+      label: 'Porto Velho',
+      name: 'America/Porto_Velho',
+      offset: -4,
+    },
+    {
+      label: 'Puerto Rico',
+      name: 'America/Puerto_Rico',
+      offset: -4,
+    },
+    {
+      label: 'Santiago',
+      name: 'America/Santiago',
+      offset: -4,
+    },
+    {
+      label: 'Santo Domingo',
+      name: 'America/Santo_Domingo',
+      offset: -4,
+    },
+    {
+      label: 'Araguaina',
+      name: 'America/Araguaina',
+      offset: -3,
+    },
+    {
+      label: 'Atlantic Time - Halifax',
+      name: 'America/Halifax',
+      offset: -3,
+    },
+    {
+      label: 'Belem',
+      name: 'America/Belem',
+      offset: -3,
+    },
+    {
+      label: 'Bermuda',
+      name: 'Atlantic/Bermuda',
+      offset: -3,
+    },
+    {
+      label: 'Buenos Aires',
+      name: 'America/Argentina/Buenos_Aires',
+      offset: -3,
+    },
+    {
+      label: 'Cayenne',
+      name: 'America/Cayenne',
+      offset: -3,
+    },
+    {
+      label: 'Cordoba',
+      name: 'America/Argentina/Cordoba',
+      offset: -3,
+    },
+    {
+      label: 'Fortaleza',
+      name: 'America/Fortaleza',
+      offset: -3,
+    },
+    {
+      label: 'Maceio',
+      name: 'America/Maceio',
+      offset: -3,
+    },
+    {
+      label: 'Montevideo',
+      name: 'America/Montevideo',
+      offset: -3,
+    },
+    {
+      label: 'Palmer',
+      name: 'Antarctica/Palmer',
+      offset: -3,
+    },
+    {
+      label: 'Paramaribo',
+      name: 'America/Paramaribo',
+      offset: -3,
+    },
+    {
+      label: 'Punta Arenas',
+      name: 'America/Punta_Arenas',
+      offset: -3,
+    },
+    {
+      label: 'Recife',
+      name: 'America/Recife',
+      offset: -3,
+    },
+    {
+      label: 'Rothera',
+      name: 'Antarctica/Rothera',
+      offset: -3,
+    },
+    {
+      label: 'Salvador',
+      name: 'America/Bahia',
+      offset: -3,
+    },
+    {
+      label: 'Sao Paulo',
+      name: 'America/Sao_Paulo',
+      offset: -3,
+    },
+    {
+      label: 'Stanley',
+      name: 'Atlantic/Stanley',
+      offset: -3,
+    },
+    {
+      label: 'Thule',
+      name: 'America/Thule',
+      offset: -3,
+    },
+    {
+      label: 'Newfoundland Time - St. Johns',
+      name: 'America/St_Johns',
+      offset: -2.5,
+    },
+    {
+      label: 'Godthab',
+      name: 'America/Godthab',
+      offset: -2,
+    },
+    {
+      label: 'Miquelon',
+      name: 'America/Miquelon',
+      offset: -2,
+    },
+    {
+      label: 'Noronha',
+      name: 'America/Noronha',
+      offset: -2,
+    },
+    {
+      label: 'South Georgia',
+      name: 'Atlantic/South_Georgia',
+      offset: -2,
+    },
+    {
+      label: 'Cape Verde',
+      name: 'Atlantic/Cape_Verde',
+      offset: -1,
+    },
+    {
+      label: 'Abidjan',
+      name: 'Africa/Abidjan',
+      offset: 0,
+    },
+    {
+      label: 'Accra',
+      name: 'Africa/Accra',
+      offset: 0,
+    },
+    {
+      label: 'Azores',
+      name: 'Atlantic/Azores',
+      offset: 0,
+    },
+    {
+      label: 'Bissau',
+      name: 'Africa/Bissau',
+      offset: 0,
+    },
+    {
+      label: 'Casablanca',
+      name: 'Africa/Casablanca',
+      offset: 0,
+    },
+    {
+      label: 'Danmarkshavn',
+      name: 'America/Danmarkshavn',
+      offset: 0,
+    },
+    {
+      label: 'El Aaiun',
+      name: 'Africa/El_Aaiun',
+      offset: 0,
+    },
+    {
+      label: 'GMT (no daylight saving)',
+      name: 'Etc/GMT',
+      offset: 0,
+    },
+    {
+      label: 'Monrovia',
+      name: 'Africa/Monrovia',
+      offset: 0,
+    },
+    {
+      label: 'Reykjavik',
+      name: 'Atlantic/Reykjavik',
+      offset: 0,
+    },
+    {
+      label: 'Scoresbysund',
+      name: 'America/Scoresbysund',
+      offset: 0,
+    },
+    {
+      label: 'UTC',
+      name: 'UTC',
+      offset: null,
+    },
+    {
+      label: 'Algiers',
+      name: 'Africa/Algiers',
+      offset: 1,
+    },
+    {
+      label: 'Canary Islands',
+      name: 'Atlantic/Canary',
+      offset: 1,
+    },
+    {
+      label: 'Dublin',
+      name: 'Europe/Dublin',
+      offset: 1,
+    },
+    {
+      label: 'Faeroe',
+      name: 'Atlantic/Faroe',
+      offset: 1,
+    },
+    {
+      label: 'Lagos',
+      name: 'Africa/Lagos',
+      offset: 1,
+    },
+    {
+      label: 'Lisbon',
+      name: 'Europe/Lisbon',
+      offset: 1,
+    },
+    {
+      label: 'London',
+      name: 'Europe/London',
+      offset: 1,
+    },
+    {
+      label: 'Ndjamena',
+      name: 'Africa/Ndjamena',
+      offset: 1,
+    },
+    {
+      label: 'Sao Tome',
+      name: 'Africa/Sao_Tome',
+      offset: 1,
+    },
+    {
+      label: 'Tunis',
+      name: 'Africa/Tunis',
+      offset: 1,
+    },
+    {
+      label: 'Amsterdam',
+      name: 'Europe/Amsterdam',
+      offset: 2,
+    },
+    {
+      label: 'Andorra',
+      name: 'Europe/Andorra',
+      offset: 2,
+    },
+    {
+      label: 'Berlin',
+      name: 'Europe/Berlin',
+      offset: 2,
+    },
+    {
+      label: 'Brussels',
+      name: 'Europe/Brussels',
+      offset: 2,
+    },
+    {
+      label: 'Budapest',
+      name: 'Europe/Budapest',
+      offset: 2,
+    },
+    {
+      label: 'Cairo',
+      name: 'Africa/Cairo',
+      offset: 2,
+    },
+    {
+      label: 'Central European Time - Belgrade',
+      name: 'Europe/Belgrade',
+      offset: 2,
+    },
+    {
+      label: 'Central European Time - Prague',
+      name: 'Europe/Prague',
+      offset: 2,
+    },
+    {
+      label: 'Ceuta',
+      name: 'Africa/Ceuta',
+      offset: 2,
+    },
+    {
+      label: 'Copenhagen',
+      name: 'Europe/Copenhagen',
+      offset: 2,
+    },
+    {
+      label: 'Gibraltar',
+      name: 'Europe/Gibraltar',
+      offset: 2,
+    },
+    {
+      label: 'Johannesburg',
+      name: 'Africa/Johannesburg',
+      offset: 2,
+    },
+    {
+      label: 'Khartoum',
+      name: 'Africa/Khartoum',
+      offset: 2,
+    },
+    {
+      label: 'Luxembourg',
+      name: 'Europe/Luxembourg',
+      offset: 2,
+    },
+    {
+      label: 'Madrid',
+      name: 'Europe/Madrid',
+      offset: 2,
+    },
+    {
+      label: 'Malta',
+      name: 'Europe/Malta',
+      offset: 2,
+    },
+    {
+      label: 'Maputo',
+      name: 'Africa/Maputo',
+      offset: 2,
+    },
+    {
+      label: 'Monaco',
+      name: 'Europe/Monaco',
+      offset: 2,
+    },
+    {
+      label: 'Moscow-01 - Kaliningrad',
+      name: 'Europe/Kaliningrad',
+      offset: 2,
+    },
+    {
+      label: 'Oslo',
+      name: 'Europe/Oslo',
+      offset: 2,
+    },
+    {
+      label: 'Paris',
+      name: 'Europe/Paris',
+      offset: 2,
+    },
+    {
+      label: 'Rome',
+      name: 'Europe/Rome',
+      offset: 2,
+    },
+    {
+      label: 'Stockholm',
+      name: 'Europe/Stockholm',
+      offset: 2,
+    },
+    {
+      label: 'Tirane',
+      name: 'Europe/Tirane',
+      offset: 2,
+    },
+    {
+      label: 'Tripoli',
+      name: 'Africa/Tripoli',
+      offset: 2,
+    },
+    {
+      label: 'Vienna',
+      name: 'Europe/Vienna',
+      offset: 2,
+    },
+    {
+      label: 'Warsaw',
+      name: 'Europe/Warsaw',
+      offset: 2,
+    },
+    {
+      label: 'Windhoek',
+      name: 'Africa/Windhoek',
+      offset: 2,
+    },
+    {
+      label: 'Zurich',
+      name: 'Europe/Zurich',
+      offset: 2,
+    },
+    {
+      label: 'Amman',
+      name: 'Asia/Amman',
+      offset: 3,
+    },
+    {
+      label: 'Athens',
+      name: 'Europe/Athens',
+      offset: 3,
+    },
+    {
+      label: 'Baghdad',
+      name: 'Asia/Baghdad',
+      offset: 3,
+    },
+    {
+      label: 'Beirut',
+      name: 'Asia/Beirut',
+      offset: 3,
+    },
+    {
+      label: 'Bucharest',
+      name: 'Europe/Bucharest',
+      offset: 3,
+    },
+    {
+      label: 'Chisinau',
+      name: 'Europe/Chisinau',
+      offset: 3,
+    },
+    {
+      label: 'Damascus',
+      name: 'Asia/Damascus',
+      offset: 3,
+    },
+    {
+      label: 'Gaza',
+      name: 'Asia/Gaza',
+      offset: 3,
+    },
+    {
+      label: 'Helsinki',
+      name: 'Europe/Helsinki',
+      offset: 3,
+    },
+    {
+      label: 'Istanbul',
+      name: 'Europe/Istanbul',
+      offset: 3,
+    },
+    {
+      label: 'Jerusalem',
+      name: 'Asia/Jerusalem',
+      offset: 3,
+    },
+    {
+      label: 'Kiev',
+      name: 'Europe/Kiev',
+      offset: 3,
+    },
+    {
+      label: 'Minsk',
+      name: 'Europe/Minsk',
+      offset: 3,
+    },
+    {
+      label: 'Moscow+00 - Moscow',
+      name: 'Europe/Moscow',
+      offset: 3,
+    },
+    {
+      label: 'Nairobi',
+      name: 'Africa/Nairobi',
+      offset: 3,
+    },
+    {
+      label: 'Nicosia',
+      name: 'Asia/Nicosia',
+      offset: 3,
+    },
+    {
+      label: 'Qatar',
+      name: 'Asia/Qatar',
+      offset: 3,
+    },
+    {
+      label: 'Riga',
+      name: 'Europe/Riga',
+      offset: 3,
+    },
+    {
+      label: 'Riyadh',
+      name: 'Asia/Riyadh',
+      offset: 3,
+    },
+    {
+      label: 'Sofia',
+      name: 'Europe/Sofia',
+      offset: 3,
+    },
+    {
+      label: 'Syowa',
+      name: 'Antarctica/Syowa',
+      offset: 3,
+    },
+    {
+      label: 'Tallinn',
+      name: 'Europe/Tallinn',
+      offset: 3,
+    },
+    {
+      label: 'Vilnius',
+      name: 'Europe/Vilnius',
+      offset: 3,
+    },
+    {
+      label: 'Baku',
+      name: 'Asia/Baku',
+      offset: 4,
+    },
+    {
+      label: 'Dubai',
+      name: 'Asia/Dubai',
+      offset: 4,
+    },
+    {
+      label: 'Mahe',
+      name: 'Indian/Mahe',
+      offset: 4,
+    },
+    {
+      label: 'Mauritius',
+      name: 'Indian/Mauritius',
+      offset: 4,
+    },
+    {
+      label: 'Moscow+01 - Samara',
+      name: 'Europe/Samara',
+      offset: 4,
+    },
+    {
+      label: 'Reunion',
+      name: 'Indian/Reunion',
+      offset: 4,
+    },
+    {
+      label: 'Tbilisi',
+      name: 'Asia/Tbilisi',
+      offset: 4,
+    },
+    {
+      label: 'Yerevan',
+      name: 'Asia/Yerevan',
+      offset: 4,
+    },
+    {
+      label: 'Kabul',
+      name: 'Asia/Kabul',
+      offset: 4.5,
+    },
+    {
+      label: 'Tehran',
+      name: 'Asia/Tehran',
+      offset: 4.5,
+    },
+    {
+      label: 'Aqtau',
+      name: 'Asia/Aqtau',
+      offset: 5,
+    },
+    {
+      label: 'Aqtobe',
+      name: 'Asia/Aqtobe',
+      offset: 5,
+    },
+    {
+      label: 'Ashgabat',
+      name: 'Asia/Ashgabat',
+      offset: 5,
+    },
+    {
+      label: 'Dushanbe',
+      name: 'Asia/Dushanbe',
+      offset: 5,
+    },
+    {
+      label: 'Karachi',
+      name: 'Asia/Karachi',
+      offset: 5,
+    },
+    {
+      label: 'Kerguelen',
+      name: 'Indian/Kerguelen',
+      offset: 5,
+    },
+    {
+      label: 'Maldives',
+      name: 'Indian/Maldives',
+      offset: 5,
+    },
+    {
+      label: 'Mawson',
+      name: 'Antarctica/Mawson',
+      offset: 5,
+    },
+    {
+      label: 'Moscow+02 - Yekaterinburg',
+      name: 'Asia/Yekaterinburg',
+      offset: 5,
+    },
+    {
+      label: 'Tashkent',
+      name: 'Asia/Tashkent',
+      offset: 5,
+    },
+    {
+      label: 'Colombo',
+      name: 'Asia/Colombo',
+      offset: 5.5,
+    },
+    {
+      label: 'India Standard Time',
+      name: 'Asia/Calcutta',
+      offset: 5.5,
+    },
+    {
+      label: 'Katmandu',
+      name: 'Asia/Katmandu',
+      offset: 5.75,
+    },
+    {
+      label: 'Almaty',
+      name: 'Asia/Almaty',
+      offset: 6,
+    },
+    {
+      label: 'Bishkek',
+      name: 'Asia/Bishkek',
+      offset: 6,
+    },
+    {
+      label: 'Chagos',
+      name: 'Indian/Chagos',
+      offset: 6,
+    },
+    {
+      label: 'Dhaka',
+      name: 'Asia/Dhaka',
+      offset: 6,
+    },
+    {
+      label: 'Moscow+03 - Omsk',
+      name: 'Asia/Omsk',
+      offset: 6,
+    },
+    {
+      label: 'Thimphu',
+      name: 'Asia/Thimphu',
+      offset: 6,
+    },
+    {
+      label: 'Vostok',
+      name: 'Antarctica/Vostok',
+      offset: 6,
+    },
+    {
+      label: 'Cocos',
+      name: 'Indian/Cocos',
+      offset: 6.5,
+    },
+    {
+      label: 'Rangoon',
+      name: 'Asia/Yangon',
+      offset: 6.5,
+    },
+    {
+      label: 'Bangkok',
+      name: 'Asia/Bangkok',
+      offset: 7,
+    },
+    {
+      label: 'Christmas',
+      name: 'Indian/Christmas',
+      offset: 7,
+    },
+    {
+      label: 'Davis',
+      name: 'Antarctica/Davis',
+      offset: 7,
+    },
+    {
+      label: 'Hanoi',
+      name: 'Asia/Saigon',
+      offset: 7,
+    },
+    {
+      label: 'Hovd',
+      name: 'Asia/Hovd',
+      offset: 7,
+    },
+    {
+      label: 'Jakarta',
+      name: 'Asia/Jakarta',
+      offset: 7,
+    },
+    {
+      label: 'Moscow+04 - Krasnoyarsk',
+      name: 'Asia/Krasnoyarsk',
+      offset: 7,
+    },
+    {
+      label: 'Brunei',
+      name: 'Asia/Brunei',
+      offset: 8,
+    },
+    {
+      label: 'Casey',
+      name: 'Antarctica/Casey',
+      offset: 8,
+    },
+    {
+      label: 'China Time - Beijing',
+      name: 'Asia/Shanghai',
+      offset: 8,
+    },
+    {
+      label: 'Choibalsan',
+      name: 'Asia/Choibalsan',
+      offset: 8,
+    },
+    {
+      label: 'Hong Kong',
+      name: 'Asia/Hong_Kong',
+      offset: 8,
+    },
+    {
+      label: 'Kuala Lumpur',
+      name: 'Asia/Kuala_Lumpur',
+      offset: 8,
+    },
+    {
+      label: 'Macau',
+      name: 'Asia/Macau',
+      offset: 8,
+    },
+    {
+      label: 'Makassar',
+      name: 'Asia/Makassar',
+      offset: 8,
+    },
+    {
+      label: 'Manila',
+      name: 'Asia/Manila',
+      offset: 8,
+    },
+    {
+      label: 'Moscow+05 - Irkutsk',
+      name: 'Asia/Irkutsk',
+      offset: 8,
+    },
+    {
+      label: 'Singapore',
+      name: 'Asia/Singapore',
+      offset: 8,
+    },
+    {
+      label: 'Taipei',
+      name: 'Asia/Taipei',
+      offset: 8,
+    },
+    {
+      label: 'Ulaanbaatar',
+      name: 'Asia/Ulaanbaatar',
+      offset: 8,
+    },
+    {
+      label: 'Western Time - Perth',
+      name: 'Australia/Perth',
+      offset: 8,
+    },
+    {
+      label: 'Dili',
+      name: 'Asia/Dili',
+      offset: 9,
+    },
+    {
+      label: 'Jayapura',
+      name: 'Asia/Jayapura',
+      offset: 9,
+    },
+    {
+      label: 'Moscow+06 - Yakutsk',
+      name: 'Asia/Yakutsk',
+      offset: 9,
+    },
+    {
+      label: 'Palau',
+      name: 'Pacific/Palau',
+      offset: 9,
+    },
+    {
+      label: 'Pyongyang',
+      name: 'Asia/Pyongyang',
+      offset: 9,
+    },
+    {
+      label: 'Seoul',
+      name: 'Asia/Seoul',
+      offset: 9,
+    },
+    {
+      label: 'Tokyo',
+      name: 'Asia/Tokyo',
+      offset: 9,
+    },
+    {
+      label: 'Central Time - Adelaide',
+      name: 'Australia/Adelaide',
+      offset: 9.5,
+    },
+    {
+      label: 'Central Time - Darwin',
+      name: 'Australia/Darwin',
+      offset: 9.5,
+    },
+    {
+      label: "Dumont D'Urville",
+      name: 'Antarctica/DumontDUrville',
+      offset: 10,
+    },
+    {
+      label: 'Eastern Time - Brisbane',
+      name: 'Australia/Brisbane',
+      offset: 10,
+    },
+    {
+      label: 'Eastern Time - Hobart',
+      name: 'Australia/Hobart',
+      offset: 10,
+    },
+    {
+      label: 'Eastern Time - Melbourne',
+      name: 'Australia/Melbourne',
+      offset: 10,
+    },
+    {
+      label: 'Eastern Time - Melbourne, Sydney',
+      name: 'Australia/Sydney',
+      offset: 10,
+    },
+    {
+      label: 'Guam',
+      name: 'Pacific/Guam',
+      offset: 10,
+    },
+    {
+      label: 'Moscow+07 - Vladivostok',
+      name: 'Asia/Vladivostok',
+      offset: 10,
+    },
+    {
+      label: 'Port Moresby',
+      name: 'Pacific/Port_Moresby',
+      offset: 10,
+    },
+    {
+      label: 'Truk',
+      name: 'Pacific/Chuuk',
+      offset: 10,
+    },
+    {
+      label: 'Efate',
+      name: 'Pacific/Efate',
+      offset: 11,
+    },
+    {
+      label: 'Guadalcanal',
+      name: 'Pacific/Guadalcanal',
+      offset: 11,
+    },
+    {
+      label: 'Kosrae',
+      name: 'Pacific/Kosrae',
+      offset: 11,
+    },
+    {
+      label: 'Moscow+08 - Magadan',
+      name: 'Asia/Magadan',
+      offset: 11,
+    },
+    {
+      label: 'Norfolk',
+      name: 'Pacific/Norfolk',
+      offset: 11,
+    },
+    {
+      label: 'Noumea',
+      name: 'Pacific/Noumea',
+      offset: 11,
+    },
+    {
+      label: 'Ponape',
+      name: 'Pacific/Pohnpei',
+      offset: 11,
+    },
+    {
+      label: 'Auckland',
+      name: 'Pacific/Auckland',
+      offset: 12,
+    },
+    {
+      label: 'Fiji',
+      name: 'Pacific/Fiji',
+      offset: 12,
+    },
+    {
+      label: 'Funafuti',
+      name: 'Pacific/Funafuti',
+      offset: 12,
+    },
+    {
+      label: 'Kwajalein',
+      name: 'Pacific/Kwajalein',
+      offset: 12,
+    },
+    {
+      label: 'Majuro',
+      name: 'Pacific/Majuro',
+      offset: 12,
+    },
+    {
+      label: 'Moscow+09 - Petropavlovsk-Kamchatskiy',
+      name: 'Asia/Kamchatka',
+      offset: 12,
+    },
+    {
+      label: 'Nauru',
+      name: 'Pacific/Nauru',
+      offset: 12,
+    },
+    {
+      label: 'Tarawa',
+      name: 'Pacific/Tarawa',
+      offset: 12,
+    },
+    {
+      label: 'Wake',
+      name: 'Pacific/Wake',
+      offset: 12,
+    },
+    {
+      label: 'Wallis',
+      name: 'Pacific/Wallis',
+      offset: 12,
+    },
+    {
+      label: 'Apia',
+      name: 'Pacific/Apia',
+      offset: 13,
+    },
+    {
+      label: 'Enderbury',
+      name: 'Pacific/Enderbury',
+      offset: 13,
+    },
+    {
+      label: 'Fakaofo',
+      name: 'Pacific/Fakaofo',
+      offset: 13,
+    },
+    {
+      label: 'Tongatapu',
+      name: 'Pacific/Tongatapu',
+      offset: 13,
+    },
+    {
+      label: 'Kiritimati',
+      name: 'Pacific/Kiritimati',
+      offset: 14,
+    },
+  ];

--- a/src/features/profile/DisplaySettings/DisplaySettings.test.tsx
+++ b/src/features/profile/DisplaySettings/DisplaySettings.test.tsx
@@ -10,7 +10,8 @@ describe('Email change form', () => {
     <DisplaySettings 
       loading={false} 
       username="exampleuser" 
-      email="me@this.com" 
+      email="me@this.com"
+      timezone='Europe/San_Marino'
       updateProfile={update}
       classes={{
         root: '',

--- a/src/features/profile/DisplaySettings/DisplaySettings.tsx
+++ b/src/features/profile/DisplaySettings/DisplaySettings.tsx
@@ -10,6 +10,7 @@ import setDocs from 'src/components/DocsSidebar/setDocs';
 import { response } from 'src/store/reducers/resources';
 
 import EmailChangeForm from './EmailChangeForm';
+import TimezoneForm from './TimezoneForm';
 
 type ClassNames = 'root' | 'title';
 
@@ -17,6 +18,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
     padding: theme.spacing.unit * 3,
     paddingBottom: theme.spacing.unit * 3,
+    marginBottom: theme.spacing.unit * 3,
   },
   title: {
     marginBottom: theme.spacing.unit * 2,
@@ -29,11 +31,11 @@ interface ConnectedProps {
   loading: boolean;
   username: string;
   email: string;
+  timezone: string;
   updateProfile: (v: Linode.Profile) => void;
 }
 
 interface State {
-
 }
 
 type CombinedProps = Props & ConnectedProps & WithStyles<ClassNames>;
@@ -42,22 +44,30 @@ export class DisplaySettings extends React.Component<CombinedProps, State> {
   state: State = {
     submitting: false,
     updatedEmail: this.props.email || '',
+    updatedTimezone: this.props.timezone || '',
     errors: undefined,
     success: undefined,
   }
 
   render() {
-    const { email, loading, updateProfile, username } = this.props;
+    const { email, loading, timezone, updateProfile, username } = this.props;
 
     return (
       <React.Fragment>
         {!loading &&
-        <EmailChangeForm
-          email={email} 
-          username={username}
-          updateProfile={updateProfile}
-          data-qa-email-change
-        />}
+          <React.Fragment>
+            <EmailChangeForm
+              email={email} 
+              username={username}
+              updateProfile={updateProfile}
+              data-qa-email-change
+            />
+            <TimezoneForm
+              timezone={timezone}
+              updateProfile={updateProfile}
+            />
+          </React.Fragment>
+        }
       </React.Fragment>
     );
   }
@@ -83,6 +93,7 @@ const mapStateToProps = (state: Linode.AppState) => {
     loading: false,
     username: data.username,
     email: data.email,
+    timezone: data.timezone,
   };
 };
 

--- a/src/features/profile/DisplaySettings/EmailChangeForm.tsx
+++ b/src/features/profile/DisplaySettings/EmailChangeForm.tsx
@@ -24,6 +24,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     root: {
       padding: theme.spacing.unit * 3,
       paddingBottom: theme.spacing.unit * 3,
+      marginBottom: theme.spacing.unit * 3,
     },
     title: {
       marginBottom: theme.spacing.unit * 2,

--- a/src/features/profile/DisplaySettings/TimezoneForm.test.tsx
+++ b/src/features/profile/DisplaySettings/TimezoneForm.test.tsx
@@ -1,0 +1,32 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { TimezoneForm } from './TimezoneForm';
+
+describe('Email change form', () => {
+  const updateProfile = jest.fn();
+  
+  const component = shallow(
+      <TimezoneForm
+        classes={{
+          root: '',
+          select: '',
+          title: '',
+        }}
+        timezone={'Europe/San_Marino'}
+        updateProfile={updateProfile}
+      />,
+  );
+
+  it('should render .', () => {
+    expect(component).toHaveLength(1);
+  });
+
+  it('should include text with the user\'s current time zone', () => {
+    expect(component.find('[data-qa-copy]').html()).toContain('Europe/San_Marino');
+  });
+
+  it('should have a select with the user\'s current timezone selected', () => {
+    expect(component.find('[data-qa-tz-select]').props().value).toBe('Europe/San_Marino');
+  });
+});

--- a/src/features/profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/profile/DisplaySettings/TimezoneForm.tsx
@@ -1,0 +1,189 @@
+import * as moment from 'moment-timezone';
+import { lensPath, pathOr, set } from 'ramda';
+import * as React from 'react';
+import VirtualizedSelect from 'react-virtualized-select'
+
+import 'react-select/dist/react-select.css'
+import 'react-virtualized-select/styles.css'
+
+import {
+    StyleRulesCallback,
+    Theme,
+    WithStyles,
+    withStyles,
+  } from '@material-ui/core/styles';
+
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+
+import timezones from 'src/assets/timezones/timezones';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Notice from 'src/components/Notice';
+import { updateProfile } from 'src/services/profile';
+import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+
+type ClassNames = 'root' | 'select' | 'title';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+    root: {
+      padding: theme.spacing.unit * 3,
+      paddingBottom: theme.spacing.unit * 3,
+      marginBottom: theme.spacing.unit * 3,
+    },
+    select: {
+      maxWidth: '30%',  
+    },
+    title: {
+      marginBottom: theme.spacing.unit * 2,
+    },
+  });
+
+interface Props {
+  timezone: string;
+  updateProfile: (v: Linode.Profile) => void;
+}
+
+interface State {
+    updatedTimezone: string;
+    errors?: Linode.ApiFieldError[];
+    submitting: boolean;
+    success?: string;
+}
+
+interface Timezone {
+    label: string;
+    offset: number;
+    name: string;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const renderTimezoneOffset = (tz:Timezone) => {
+    const offset = moment.tz(tz.name).format("Z");
+    return `\(GMT${offset}\) ${tz.label}`;
+}
+
+const renderTimeZonesList = () => {
+    return timezones.map((tz:Timezone) => {
+        const label = renderTimezoneOffset(tz);
+        return { label, value: tz.name}
+    });
+}
+
+const timezoneList = renderTimeZonesList();
+
+export class TimezoneForm extends React.Component<CombinedProps, State> {
+    state: State = {
+        updatedTimezone: this.props.timezone || '',
+        errors: undefined,
+        submitting: false,
+        success: undefined,
+    }
+
+    handleTimezoneChange = (timezone: any) => {
+        if (timezone) { this.setState(set(lensPath(['updatedTimezone']), timezone.value)); }
+    }
+
+    onCancel = () => {
+        this.setState({
+          submitting: false,
+          errors: undefined,
+          success: undefined,
+          updatedTimezone: this.props.timezone || '',
+        })
+      }
+
+    onSubmit = () => {
+        const { updatedTimezone } = this.state;
+        this.setState({ errors: undefined, submitting: true });
+    
+        updateProfile({ timezone: updatedTimezone, })
+          .then((response) => {
+            this.props.updateProfile(response);
+            this.setState({
+              submitting: false,
+              success: 'Account timezone updated.',
+            })
+          })
+          .catch((error) => {
+            const fallbackError = [{ reason: 'An unexpected error has occured.' }];
+            this.setState({
+              submitting: false,
+              errors: pathOr(fallbackError, ['response', 'data', 'errors'], error),
+              success: undefined,
+            }, () => {
+              scrollErrorIntoView();
+            })
+          });
+      };
+
+    render() {
+        const { classes, timezone } = this.props;
+        const { errors, submitting, success, updatedTimezone } = this.state;
+
+        const hasErrorFor = getAPIErrorFor({
+            timezone: 'timezone',
+          }, errors);
+          const generalError = hasErrorFor('none');
+          // const timezoneError = hasErrorFor('timezone');
+
+        return (
+            <React.Fragment>
+                <Paper className={classes.root}>
+                    {success && <Notice success text={success} />}
+                    {generalError && <Notice error text={generalError} />}
+                    <Typography
+                        variant="body1"
+                        data-qa-copy
+                    >
+                        {`This setting converts the dates and times displayed in the Linode Manager
+                        to a timezone of your choice. Your current timezone is: ${timezone}.`}
+                    </Typography>
+                    <React.Fragment>
+                        {/* <TextField
+                            select
+                            label="Timezone"
+                            value={updatedTimezone}
+                            onChange={this.handleTimezoneChange}
+                            errorText={timezoneError}
+                            errorGroup="display-settings-email"
+                            data-qa-timezone
+                        >
+                            {timezoneList}
+                        </TextField> */}
+                        <VirtualizedSelect
+                            className={classes.select} 
+                            options={timezoneList}
+                            value={updatedTimezone}
+                            onChange={this.handleTimezoneChange}
+                            searchable
+                            data-qa-tz-select
+                        />
+                        <ActionsPanel>
+                        <Button
+                            type="primary"
+                            onClick={this.onSubmit}
+                            loading={submitting}
+                            data-qa-tz-submit
+                        >
+                            Save
+                        </Button>
+                        <Button
+                            type="cancel"
+                            onClick={this.onCancel}
+                            data-qa-tz-cancel
+                        >
+                            Cancel
+                        </Button>
+                        </ActionsPanel>
+                    </React.Fragment>
+                </Paper>
+            </React.Fragment>)
+        }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(TimezoneForm);

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,6 +899,10 @@
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/promise.prototype.finally/-/promise.prototype.finally-2.0.2.tgz#68fefb8f0e23f21893a33740c931c79f44be3499"
 
+"@types/prop-types@*":
+  version "15.5.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.3.tgz#bef071852dca2a2dbb65fecdb7bfb30cedae2de2"
+
 "@types/ramda@^0.25.18":
   version "0.25.33"
   resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.33.tgz#a134fde6da3be303a1bdefd9155d8365bb7b14ec"
@@ -939,6 +943,12 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-select@*":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-1.2.10.tgz#3f261c819fd82850a020de4ed0e823306820e0fa"
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-sticky@^5.0.6":
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-sticky/-/react-sticky-5.0.6.tgz#eb65a40a0f3f46cd02ea21983c9816e99d84e754"
@@ -949,6 +959,21 @@
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.11.tgz#feb274676a39383fffaa0dff710958d2251abefb"
   dependencies:
+    "@types/react" "*"
+
+"@types/react-virtualized-select@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized-select/-/react-virtualized-select-3.0.5.tgz#d0313eb6e84a4e982b29b2a529094e7f2905b415"
+  dependencies:
+    "@types/react" "*"
+    "@types/react-select" "*"
+    "@types/react-virtualized" "*"
+
+"@types/react-virtualized@*":
+  version "9.18.4"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.18.4.tgz#467907cc6fd7a94fc2eeded3e8c67903a5d19643"
+  dependencies:
+    "@types/prop-types" "*"
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.4.0":
@@ -3016,7 +3041,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.3, classnames@^2.2.4, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
 
@@ -3933,7 +3958,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.1, dom-helpers@^3.3.1:
+"dom-helpers@^2.4.0 || ^3.0.0", dom-helpers@^3.2.1, dom-helpers@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -6391,6 +6416,10 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.4.3, js-yaml@^3.6.1, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
@@ -6888,6 +6917,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -8669,6 +8704,12 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
+react-input-autosize@^2.1.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
+  dependencies:
+    prop-types "^15.5.8"
+
 react-inspector@^2.2.2:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.3.0.tgz#fc9c1d38ab687fc0d190dcaf133ae40158968fc8"
@@ -8690,7 +8731,7 @@ react-jss@^8.1.0:
     prop-types "^15.6.0"
     theming "^1.3.0"
 
-react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2:
+react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
@@ -8763,6 +8804,14 @@ react-router@^4.2.0, react-router@^4.3.1:
     prop-types "^15.6.1"
     warning "^4.0.1"
 
+react-select@^1.0.0-rc.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.2.1.tgz#a2fe58a569eb14dcaa6543816260b97e538120d1"
+  dependencies:
+    classnames "^2.2.4"
+    prop-types "^15.5.8"
+    react-input-autosize "^2.1.2"
+
 react-split-pane@^0.1.77:
   version "0.1.77"
   resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.77.tgz#f0c8cd18d076bbac900248dcf6dbcec02d5340db"
@@ -8811,6 +8860,26 @@ react-treebeard@^2.1.0:
     radium "^0.19.0"
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
+
+react-virtualized-select@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-virtualized-select/-/react-virtualized-select-3.1.3.tgz#e5c1fed5e493e3e5a628e53100e83d27cfd8c0ac"
+  dependencies:
+    babel-runtime "^6.11.6"
+    prop-types "^15.5.8"
+    react-select "^1.0.0-rc.2"
+    react-virtualized "^9.0.0"
+
+react-virtualized@^9.0.0:
+  version "9.20.1"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.20.1.tgz#02dc08fe9070386b8c48e2ac56bce7af0208d22d"
+  dependencies:
+    babel-runtime "^6.26.0"
+    classnames "^2.2.3"
+    dom-helpers "^2.4.0 || ^3.0.0"
+    loose-envify "^1.3.0"
+    prop-types "^15.6.0"
+    react-lifecycles-compat "^3.0.4"
 
 react@^16.4.1:
   version "16.4.1"


### PR DESCRIPTION
## Purpose

Users should be able to update their account timezones when viewing their profile. Instead of the full list of >500 moment.tz time zones, used the Google Calendar list (from https://github.com/vahnag/react-timezone/blob/master/src/timezones.js) instead.

* Add TimezoneForm component
* Add tests for TimezoneForm
* Bring in virtualized-select package
* Add list of timezones (pilfered from Github/Google Calendar)
* Formatted timezone labels to include offset (again matches Google Calendar format)

## To Test

* yarn && yarn start
* Navigate to /profile/display
* Update your timezone using the dropdown

## Notes

* New VirtualizedSelect needs review and approval (cf https://github.com/bvaughn/react-virtualized-select)
* Included because MUI selects were unacceptably slow.
* Styling doesn't match yet and there is no label/error handling. This can be added (:sheep: @alioso) if the component is approved.