### PR TITLE
Add yarn caching to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: node_js
 node_js:
   - "8.11.2"
 
+cache: yarn
+
 before_install: sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++ google-chrome-stable
 
 install:


### PR DESCRIPTION
* Adds yarn cache to builds as per documentation here: https://docs.travis-ci.com/user/caching/#yarn-cache
* Should speed some things up on subsequent builds
