### PR TITLE
M3-829 - StackScripts - Edit Existing Test

### DIFF
--- a/e2e/pageobjects/configure-stackscript.page.js
+++ b/e2e/pageobjects/configure-stackscript.page.js
@@ -117,6 +117,16 @@ class ConfigureStackScript extends Page {
         expect(myStackscript[0].$(ListStackScripts.stackScriptActionMenu.selector).isVisible()).toBe(true);
         ListStackScripts.waitForNotice(`${config.label} successfully ${update ? 'updated' : 'created'}`);
     }
+
+    removeImage(imageName) {
+        this.imageTags
+            .filter(i => i.getText().includes(imageName))
+            .forEach(i => {
+                i.$('svg').click();
+                i.waitForVisible(constants.wait.normal, true);
+            });
+
+    }
 }
     
 export default new ConfigureStackScript();

--- a/e2e/pageobjects/configure-stackscript.page.js
+++ b/e2e/pageobjects/configure-stackscript.page.js
@@ -82,7 +82,7 @@ class ConfigureStackScript extends Page {
                 const imageElement = $(`[data-value="linode/${i}"]`);
                 const imageName = imageElement.getAttribute('data-value');
                 
-                imageElement.click();
+                browser.jsClick(`[data-value="linode/${i}"]`);
                 browser.waitForVisible(`[data-value="linode/${imageName}"]`, constants.wait.normal, true);
             });
         } else {

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -249,7 +249,6 @@ exports.removeDomain = (token, domainId) => {
 exports.getMyStackScripts = token => {
     return new Promise((resolve, reject) => {
         const endpoint = '/linode/stackscripts';
-
         getAxiosInstance(token).get(endpoint, {
             headers: {
                 'Authorization': `Bearer ${token}`,
@@ -267,7 +266,6 @@ exports.getMyStackScripts = token => {
 exports.removeStackScript = (token, id) => {
     return new Promise((resolve, reject) => {
         const endpoint = `/linode/stackscripts/${id}`;
-
         getAxiosInstance(token).delete(endpoint)
             .then(response => resolve(response.data))
             .catch(error => {

--- a/e2e/specs/stackscripts/edit-existing-stackscript.spec.js
+++ b/e2e/specs/stackscripts/edit-existing-stackscript.spec.js
@@ -1,0 +1,47 @@
+const { constants } = require('../../constants');
+
+import { apiDeleteMyStackScripts } from '../../utils/common';
+
+import ConfigureStackScripts from '../../pageobjects/configure-stackscript.page';
+import ListStackScripts from '../../pageobjects/list-stackscripts.page';
+
+describe('StackScript - Edit Existing', () => {
+    const stackConfig = {
+        label: `${new Date().getTime()}-MyStackScript`,
+        description: 'test stackscript example',
+        revisionNote: new Date().getTime(),
+        script: '#!/bin/bash',
+    }
+
+    beforeAll(() => {
+        browser.url(constants.routes.stackscripts);
+        ListStackScripts.baseElementsDisplay();
+        ListStackScripts.create.click();
+        ConfigureStackScript.createHeader.waitForVisible(constants.wait.normal);
+        ConfigureStackScripts.configure(stackConfig);
+        ConfigureStackScripts.create(stackConfig);
+    });
+
+    it('should display edit action menu option', () => {
+        ListStackScripts.stackScriptRows[0].$('[data-qa-action-menu]').click();
+        browser.waitForVisible('[data-qa-action-menu-item="Edit"]', constants.wait.normal);
+    });
+
+    it('should display edit stackscript page', () => {
+        browser.click('[data-qa-action-menu-item="Edit"]');
+        // assert "Edit StackScript"
+        // assert ConfigureStackScript.baseElemsDisplay()
+    });
+
+    it('should update the config fields of the stackscript with new configuration', () => {
+        
+    });
+
+    it('should clear the changes on cancel', () => {
+        
+    });
+
+    it('should successfully update the name of the stackscript', () => {
+        
+    });
+});

--- a/e2e/specs/stackscripts/edit-existing-stackscript.spec.js
+++ b/e2e/specs/stackscripts/edit-existing-stackscript.spec.js
@@ -63,6 +63,10 @@ describe('StackScript - Edit Existing', () => {
         assertOriginalDisplays();
     });
 
+    it('should remove all compatible images', () => {
+        ConfigureStackScripts.removeImage(stackConfig.images[0]);
+    });
+
     it('should update the config fields of the stackscript with new configuration', () => {
         ConfigureStackScripts.configure(newConfig);
     });

--- a/e2e/specs/stackscripts/edit-existing-stackscript.spec.js
+++ b/e2e/specs/stackscripts/edit-existing-stackscript.spec.js
@@ -12,7 +12,7 @@ describe('StackScript - Edit Existing', () => {
         description: 'test stackscript example',
         revisionNote: new Date().getTime(),
         script: '#!/bin/bash',
-        images: ['arch'],
+        images: ['debian9'],
     }
 
     const newConfig = {
@@ -37,7 +37,7 @@ describe('StackScript - Edit Existing', () => {
     }
 
 
-    beforeAll(() => {
+    it('should setup spec', () => {
         browser.url(constants.routes.stackscripts);
         ListStackScripts.baseElementsDisplay();
         ListStackScripts.create.click();

--- a/e2e/specs/stackscripts/edit-existing-stackscript.spec.js
+++ b/e2e/specs/stackscripts/edit-existing-stackscript.spec.js
@@ -6,42 +6,74 @@ import ConfigureStackScripts from '../../pageobjects/configure-stackscript.page'
 import ListStackScripts from '../../pageobjects/list-stackscripts.page';
 
 describe('StackScript - Edit Existing', () => {
+
     const stackConfig = {
         label: `${new Date().getTime()}-MyStackScript`,
         description: 'test stackscript example',
         revisionNote: new Date().getTime(),
         script: '#!/bin/bash',
+        images: ['arch'],
     }
+
+    const newConfig = {
+        label: `someNewLabel`,
+        description: 'new description!',
+        revisionNote: 'new revision',
+        script: '#!/bin/bash \n echo fooooo',
+    }
+
+    function assertOriginalDisplays() {
+        const compatibleImages =
+            ConfigureStackScripts.imageTags
+                .filter(t => t.getText().includes(stackConfig.images[0]));
+        const description = ConfigureStackScripts.description.$('textarea').getValue();
+        const script = ConfigureStackScripts.script.$('textarea').getText();
+        const label = ConfigureStackScripts.label.$('input').getValue();
+
+        expect(description).toBe(stackConfig.description);
+        expect(compatibleImages.length).toBe(1);
+        expect(script).toBe(stackConfig.script);
+        expect(label).toBe(stackConfig.label);
+    }
+
 
     beforeAll(() => {
         browser.url(constants.routes.stackscripts);
         ListStackScripts.baseElementsDisplay();
         ListStackScripts.create.click();
-        ConfigureStackScript.createHeader.waitForVisible(constants.wait.normal);
+        ConfigureStackScripts.createHeader.waitForVisible(constants.wait.normal);
         ConfigureStackScripts.configure(stackConfig);
         ConfigureStackScripts.create(stackConfig);
     });
 
+    afterAll(() => {
+        apiDeleteMyStackScripts();
+    });
+
     it('should display edit action menu option', () => {
+        ListStackScripts.stackScriptRow.waitForVisible(constants.wait.normal);
         ListStackScripts.stackScriptRows[0].$('[data-qa-action-menu]').click();
         browser.waitForVisible('[data-qa-action-menu-item="Edit"]', constants.wait.normal);
     });
 
     it('should display edit stackscript page', () => {
         browser.click('[data-qa-action-menu-item="Edit"]');
-        // assert "Edit StackScript"
-        // assert ConfigureStackScript.baseElemsDisplay()
+        ConfigureStackScripts.editElementsDisplay();
+            
+        assertOriginalDisplays();
     });
 
     it('should update the config fields of the stackscript with new configuration', () => {
-        
+        ConfigureStackScripts.configure(newConfig);
     });
 
     it('should clear the changes on cancel', () => {
-        
+        ConfigureStackScripts.cancel();
+        assertOriginalDisplays();
     });
 
     it('should successfully update the name of the stackscript', () => {
-        
+        ConfigureStackScripts.configure(newConfig);
+        ConfigureStackScripts.create(newConfig, true);
     });
 });

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -287,12 +287,15 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
           <Button
             type="secondary"
             destructive
-            onClick={this.resetAllFields}>
+            onClick={this.resetAllFields}
+            data-qa-confirm-cancel
+            >
             Yes
           </Button>
           <Button
             type="cancel"
             onClick={this.handleCloseDialog}
+            data-qa-cancel-cancel
           >
             No
           </Button>
@@ -342,7 +345,11 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
                 <KeyboardArrowLeft />
               </IconButton>
             </Link>
-            <Typography className={classes.createTitle} variant="headline">
+            <Typography
+              className={classes.createTitle}
+              variant="headline"
+              data-qa-edit-header
+              >
               Edit StackScript
             </Typography>
           </Grid>


### PR DESCRIPTION
* Adds tests for editing an existing stackscript
* Adds data attributes to the edit stackscript page for above test
* Adds some edit specific utilities to Configure Stackscript page object
* Also disabled a test due to a tiny bug: documented in M3-950

## To test:
```bash
yarn && yarn start
yarn selenium
yarn e2e --file e2e/specs/stackscripts/edit-existing-stackscript.spec.js
```
