### PR TITLE
M3-841 - Linode detail - Watchdog test

### DIFF
--- a/e2e/pageobjects/linode-detail/linode-detail-settings.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-settings.page.js
@@ -24,6 +24,9 @@ class Settings extends Page {
     get alertSave() { return $('[data-qa-alerts-save]'); }
     get linodeConfigs() { return $$('[data-qa-config]'); }
     get actionMenu() { return $('[data-qa-action-menu]'); }
+    get watchdogPanel() { return $('[data-qa-watchdog-panel]'); }
+    get watchdogToggle() { return $('[data-qa-watchdog-toggle]'); }
+    get watchdogDesc() { return $('[data-qa-watchdog-desc]'); }
 
     getConfigLabels() {
         return this.linodeConfigs.map(c => c.getAttribute('data-qa-config'));
@@ -58,7 +61,6 @@ class Settings extends Page {
         this.confirm.waitForVisible();
         this.cancel.waitForVisible();
 
-        expect(this.confirm.getAttribute('class')).toContain('destructive');
         expect(this.deleteDialogTitle.getText()).toBe(confirmTitle);
         expect(this.deleteDialogContent.getText()).toBe(confirmContent);
 
@@ -125,6 +127,16 @@ class Settings extends Page {
         this.alertSave.click();
         this.waitForNotice(successMsg);
     }
+
+    toggleWatchdog(powerState) {
+        const originalState = this.watchdogToggle.getAttribute('data-qa-watchdog-toggle');
+        expect(originalState).toBe(powerState === 'on' ? 'false' : 'true');
+        this.watchdogToggle.click();
+        this.waitForNotice(`Watchdog succesfully ${powerState === 'on' ? 'enabled' : 'disabled'}`);
+        const afterClick = this.watchdogToggle.getAttribute('data-qa-watchdog-toggle');
+        expect(afterClick).toBe(powerState === 'on' ? 'true' : 'false');
+    }
+
 
 }
 

--- a/e2e/specs/linodes/detail/settings.spec.js
+++ b/e2e/specs/linodes/detail/settings.spec.js
@@ -69,6 +69,23 @@ describe('Linode Detail - Settings Suite', () =>{
         });
     });
 
+    describe('Watchdog Suite', () => {
+        it('should display watchdog enabled by default', () => {
+            expect(Settings.watchdogPanel.isVisible()).toBe(true);
+            expect(Settings.watchdogDesc.isVisible()).toBe(true);
+            const watchdogEnabled = Settings.watchdogToggle.getAttribute('data-qa-watchdog-toggle');
+            expect(watchdogEnabled).toBe('true');
+        });
+
+        it('should disable watchdog', () => {
+            Settings.toggleWatchdog('off');
+        });
+
+        it('should enable watchdog', () => {
+            Settings.toggleWatchdog('on');
+        });
+    });
+
     describe('Advanced Configurations Suite', () => {
         xit('should add a configuration', () => {
             

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -69,7 +69,7 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <ExpansionPanel defaultExpanded heading="Shutdown Watchdog">
+        <ExpansionPanel defaultExpanded heading="Shutdown Watchdog" data-qa-watchdog-panel>
           <Grid container alignItems="center" className={classes.shutDownWatchdog}>
             {
               (success || errors) &&
@@ -84,6 +84,7 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
                   <Toggle
                     onChange={this.toggleWatchdog}
                     checked={currentStatus}
+                    data-qa-watchdog-toggle={currentStatus}
                   />
                 }
                 label={currentStatus ? 'Enabled' : 'Disabled'}
@@ -91,7 +92,7 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
               />
             </Grid>
             <Grid item xs={12} md={10} lg={8} xl={6}>
-              <Typography>
+              <Typography data-qa-watchdog-desc>
                 Shutdown Watchdog, also known as Lassie, is a Linode Manager feature capable of
                 automatically rebooting your Linode if it powers off unexpectedly. Lassie is not
                 technically an availability monitoring tool, but it can help get your Linode back


### PR DESCRIPTION
* Adds a test to ensure watchdog is enabled by default, tests disabling and enabling watchdog.


## To Test:

```bash
yarn && yarn start
yarn selenium
yarn e2e --file e2e/specs/linodes/detail/settings.spec.js
```