### PR TITLE
M3-727 User Permissions Management

### DIFF
--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -200,6 +200,13 @@ class UserDetail extends React.Component<CombinedProps> {
       errors={profileErrors}
     />
   }
+  
+  renderUserPermissions = () => {
+    const { username } = this.state;
+    return <UserPermissions
+      username={username}
+    />
+  }
 
   matches = (p: string) => {
     return Boolean(matchPath(p, { path: this.props.location.pathname }));
@@ -267,7 +274,7 @@ class UserDetail extends React.Component<CombinedProps> {
           <Notice success text={`User ${locationState.newUsername} created successfully`} /> 
         }
         <Switch>
-          <Route exact path={`${url}/permissions`} component={UserPermissions} />
+          <Route exact path={`${url}/permissions`} component={this.renderUserPermissions} />
           <Route path={`${url}`} render={this.renderUserProfile} />
         </Switch>
       </React.Fragment>

--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -1,4 +1,4 @@
-import { clone, equals, pathOr } from 'ramda';
+import { clone, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
 import { matchPath, Route, RouteComponentProps, Switch } from 'react-router-dom';

--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -69,7 +69,7 @@ interface State {
   profileSuccess?: boolean;
 }
 
-class Profile extends React.Component<CombinedProps> {
+class UserDetail extends React.Component<CombinedProps> {
   state: State = {
     gravatarUrl: 'not found',
     profileSaving: false,
@@ -292,4 +292,4 @@ const styled = withStyles(styles, { withTheme: true });
 
 export const connected = connect(mapStateToProps, mapDispatchToProps);
 
-export default connected(styled(reloadable(Profile)));
+export default connected(styled(reloadable(UserDetail)));

--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -124,6 +124,8 @@ class UserDetail extends React.Component<CombinedProps> {
     history.push(`${routeName}`);
   }
 
+  clearNewUser = () => { this.setState({ createdUsername: undefined }); }
+
   visitUsers = () => {
     const { history } = this.props;
     history.push('/users');
@@ -198,6 +200,7 @@ class UserDetail extends React.Component<CombinedProps> {
     const { username } = this.state;
     return <UserPermissions
       username={username}
+      clearNewUser={this.clearNewUser}
     />
   }
 

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -56,6 +56,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 
 interface Props {
   username?: string;
+  clearNewUser: () => void;
 }
 
 interface State {
@@ -155,7 +156,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   }
   
   savePermsType = (type: string) => () => {
-    const { username } = this.props;
+    const { username, clearNewUser } = this.props;
     const { grants } = this.state;
     if (!username || !(grants && grants[type])) {
       return this.setState({
@@ -163,6 +164,8 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           { reason: `Can\'t set ${type} grants at this time. Please try again later`}]
       })
     }
+
+    clearNewUser();
 
     if (type === 'global') {
       this.setState(compose(

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -313,6 +313,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         .then((user) => {
           this.setState({
             restricted: user.restricted,
+            success: { global: false, specific: false },
           })
         })
         .then(() => {

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -60,6 +60,8 @@ interface Props {
 
 interface State {
   loading: boolean;
+  /* need this separated so we can show just the restricted toggle when it's in use */
+  loadingGrants: boolean;
   grants?: Linode.Grants;
   restricted?: boolean;
   errors?: Linode.ApiFieldError[];
@@ -75,6 +77,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 class UserPermissions extends React.Component<CombinedProps, State> {
   state: State = {
+    loadingGrants: false,
     loading: true,
     setAllPerm: 'null',
   };
@@ -110,12 +113,14 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             this.setState({
               grants,
               loading: false,
+              loadingGrants: false,
               restricted: true,
             })
           } else {
             this.setState({
               grants,
               loading: false,
+              loadingGrants: false,
               restricted: false,
             })
           }
@@ -220,6 +225,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     const { username } = this.props;
     this.setState({
       errors: [],
+      loadingGrants: true,
     })
     if (username) {
       updateUser(username, { restricted: !this.state.restricted })
@@ -227,6 +233,10 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           this.setState({
             restricted: user.restricted,
           })
+        })
+        .then(() => {
+          /* unconditionally sets this.state.loadingGrants to false */
+          this.getUserGrants()
         })
         .catch((errResponse) => {
           this.setState({
@@ -556,12 +566,17 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   }
 
   renderPermissions = () => {
-    return (
-      <React.Fragment>
-        {this.renderGlobalPerms()}
-        {this.renderSpecificPerms()}
-      </React.Fragment>
-    )
+    const { loadingGrants } = this.state;
+    if (loadingGrants) {
+      return <CircleProgress />;
+    } else {
+      return (
+        <React.Fragment>
+          {this.renderGlobalPerms()}
+          {this.renderSpecificPerms()}
+        </React.Fragment>
+      )
+    }
   }
 
   renderUnrestricted = () => {

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -1,17 +1,28 @@
+import { lensPath, pathOr, set } from 'ramda';
 import * as React from 'react';
 
+import Divider from '@material-ui/core/Divider';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import Toggle from 'src/components/Toggle';
-import { getGrants, updateUser } from 'src/services/account';
+import { getGrants, updateGrants, updateUser } from 'src/services/account';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 
-type ClassNames = 'titleWrapper' | 'topGrid' | 'unrestrictedRoot'
+type ClassNames =
+  'titleWrapper'
+  | 'topGrid'
+  | 'unrestrictedRoot'
+  | 'globalSection'
+  | 'section'
+  | 'actionsPanel';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   topGrid: {
@@ -24,6 +35,16 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   unrestrictedRoot: {
     marginTop: theme.spacing.unit * 2,
     padding: theme.spacing.unit * 3,
+  },
+  globalSection: {
+    marginTop: theme.spacing.unit * 2,
+    padding: theme.spacing.unit * 3,
+  },
+  section: {
+    marginTop: theme.spacing.unit * 2,
+  },
+  actionsPanel: {
+    marginTop: theme.spacing.unit * 3,
   }
 });
 
@@ -44,6 +65,18 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   state: State = {
     loading: true,
   };
+  
+  globalBooleanPerms = [
+    'add_linodes',
+    'add_nodebalancers',
+    'add_longview',
+    'longview_subscription',
+    'add_domains',
+    'add_stackscripts',
+    'add_images',
+    'add_volumes',
+    'cancel_account'
+  ];
 
   getUserGrants = () => {
     const { username } = this.props;
@@ -105,9 +138,122 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     }
   }
 
+  globalPermOnChange = (perm: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const lp = lensPath(['grants', 'global', perm]);
+    this.setState(set(lp, e.target.checked));
+  }
+
+  renderGlobalPerm = (perm: string, checked: boolean) => {
+    const permDescriptionMap = {
+      add_linodes: 'Can add Linodes to this Account ($)',
+      add_nodebalancers: 'Can add NodeBalancers to this Account ($)',
+      add_longview: 'Can add Longview clients to this Account',
+      longview_subscription: 'Can modify this account\'s Longview subscription ($)',
+      add_domains: 'Can add Domains using the DNS Manager',
+      add_stackscripts: 'Can create StackScripts under this account',
+      add_images: 'Can create frozen Images under this account',
+      add_volumes: 'Can add Block Storage Volumes to this account ($)',
+      cancel_account: 'Can cancel the entire account',
+    }
+    return (
+      <React.Fragment key={perm}>
+        <FormControlLabel
+          style={{ marginTop: 8 }}
+          label={permDescriptionMap[perm]}
+          control={
+            <Toggle
+              checked={checked}
+              onChange={this.globalPermOnChange(perm)}
+            />
+          }
+        />
+        <Divider />
+      </React.Fragment>
+    );
+  }
+
+  savePermsType = (type: string) => () => {
+    const { username } = this.props;
+    const { grants } = this.state;
+    if (!username || !(grants && grants[type])) {
+      return this.setState({
+        errors: [
+          { reason: `Can\'t set ${type} grants at this time. Please try again later`}]
+      })
+    }
+
+    if (type === 'global') {
+      updateGrants(username, { global: grants.global } as Partial<Linode.Grants>)
+        .then((grantsResponse) => {
+          this.setState({
+            grants: grantsResponse,
+          })
+        })
+        .catch((errResponse) => {
+          this.setState({
+            errors: pathOr(
+              [{ reason: 'Error while updating global permissions for this user. Try again later'}],
+              ['response', 'data', 'errors'],
+              errResponse,
+            ),
+          })
+        });
+    }
+  }
+
+  renderActions = (
+    onConfirm: () => void,
+    onCancel: () => void,
+    loading: boolean,
+  ) => () => {
+    const { classes } = this.props;
+    return (
+      <ActionsPanel className={classes.actionsPanel}>
+        <Button
+          type="primary"
+          loading={loading}
+          onClick={onConfirm}
+        >
+          Save
+        </Button>
+        <Button
+          type="cancel"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </ActionsPanel>
+    );
+  }
+
+  renderGlobalPerms = () => {
+    const { classes } = this.props;
+    const { grants } = this.state;
+    return (
+      <Paper className={classes.globalSection}>
+        <Typography variant="title">
+          Global Permissions
+        </Typography>
+        <div className={classes.section}>
+          {grants && grants.global &&
+            this.globalBooleanPerms
+              .map((perm) => this.renderGlobalPerm(perm, grants.global[perm] as boolean))
+          }
+        </div>
+        {this.renderActions(
+          this.savePermsType('global'),
+          () => null,
+          false)()
+        }
+      </Paper>
+    )
+  }
+
   renderPermissions = () => {
     return (
-      <div>Permissions</div>
+      <React.Fragment>
+        {this.renderGlobalPerms()}
+      </React.Fragment>
     )
   }
 

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -433,7 +433,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
 
   entitySetAllTo = (entity: string, value: Linode.GrantLevel) => () => {
     const { grants } = this.state;
-    if (!(grants && grants[entity])) { return false; }
+    if (!(grants && grants[entity])) { return; }
     /* map entities to an array of state update functions */
     const updateFns = grants[entity].map((grant, idx) => {
       const lens = lensPath(['grants', entity, idx, 'permissions'])

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -1,7 +1,67 @@
 import * as React from 'react';
 
-const userPermissions = () => {
-  return <div>User Permissions</div>;
+import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+
+import Grid from 'src/components/Grid';
+
+type ClassNames = 'titleWrapper';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  titleWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+});
+
+interface Props {}
+
+interface State {
+  restricted: boolean,
 }
 
-export default userPermissions;
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class UserPermissions extends React.Component<CombinedProps, State> {
+  state: State = {
+    restricted: true,
+  };
+
+  render() {
+    const { classes } = this.props;
+    const { restricted } = this.state;
+
+    return (
+      <React.Fragment>
+        <Grid container justify="space-between">
+          <Grid item className={classes.titleWrapper}>
+            <Typography variant="title">
+              Update User Permissions
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Grid container alignItems="flex-end">
+              <Grid item>
+                <Typography variant="title">
+                  Restrict Access:
+                </Typography>
+              </Grid>
+              <Grid item>
+                <Typography variant="title">
+                  {restricted
+                    ? 'On'
+                    : 'Off'
+                  }
+                </Typography>
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </React.Fragment>
+    )
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(UserPermissions);

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -482,7 +482,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               <TableCell>
                 Label
               </TableCell>
-              <TableCell>
+              <TableCell
+                padding="checkbox"
+              >
                 None
                 <Radio
                   name={`${entity}-select-all`}
@@ -491,7 +493,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
                   onChange={this.entitySetAllTo(entity, null)}
                 />
               </TableCell>
-              <TableCell>
+              <TableCell
+                padding="checkbox"
+              >
                 Read Only
                 <Radio
                   name={`${entity}-select-all`}
@@ -500,7 +504,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
                   onChange={this.entitySetAllTo(entity, 'read_only')}
                 />
               </TableCell>
-              <TableCell>
+              <TableCell
+                padding="checkbox"
+              >
                 Read-Write
                 <Radio
                   name={`${entity}-select-all`}
@@ -518,7 +524,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
                   <TableCell>
                     {grant.label}
                   </TableCell>
-                  <TableCell>
+                  <TableCell
+                    padding="checkbox"
+                  >
                     <Radio
                       name={`${grant.id}-perms`}
                       checked={grant.permissions === null}
@@ -526,7 +534,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
                       onChange={this.setGrantTo(entity, idx, null)}
                     />
                   </TableCell>
-                  <TableCell>
+                  <TableCell
+                    padding="checkbox"
+                  >
                     <Radio
                       name={`${grant.id}-perms`}
                       checked={grant.permissions === 'read_only'}
@@ -534,7 +544,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
                       onChange={this.setGrantTo(entity, idx, 'read_only')}
                     />
                   </TableCell>
-                  <TableCell>
+                  <TableCell
+                    padding="checkbox"
+                  >
                     <Radio
                       name={`${grant.id}-perms`}
                       checked={grant.permissions === 'read_write'}

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -313,7 +313,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         .then((user) => {
           this.setState({
             restricted: user.restricted,
-            success: { global: false, specific: false },
+            success: undefined,
           })
         })
         .then(() => {

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -33,7 +33,10 @@ type ClassNames =
   | 'unrestrictedRoot'
   | 'globalSection'
   | 'globalRow'
-  | 'section';
+  | 'section'
+  | 'grantTable'
+  | 'selectAll'
+  | 'tableSubheading';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   topGrid: {
@@ -62,6 +65,19 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   section: {
     marginTop: theme.spacing.unit * 2,
     paddingBottom: 0,
+  },
+  grantTable: {
+    '& th': {
+      width: '25%',
+      minWidth: 150,
+    },
+  },
+  tableSubheading: {
+    marginTop: theme.spacing.unit * 3,
+    marginBottom: theme.spacing.unit * 2,
+  },
+  selectAll: {
+    cursor: 'pointer',
   },
 });
 
@@ -491,10 +507,10 @@ class UserPermissions extends React.Component<CombinedProps, State> {
 
     return (
       <div key={entity} className={classes.section}>
-        <Typography variant="subheading">
+        <Typography variant="subheading" className={classes.tableSubheading}>
           {entityNameMap[entity]}
         </Typography>
-        <Table>
+        <Table className={classes.grantTable}>
           <TableHead data-qa-table-head>
             <TableRow>
               <TableCell>
@@ -503,35 +519,41 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               <TableCell
                 padding="checkbox"
               >
-                None
-                <Radio
-                  name={`${entity}-select-all`}
-                  checked={this.entityIsAll(entity, null)}
-                  value="null"
-                  onChange={this.entitySetAllTo(entity, null)}
-                />
+                <label className={classes.selectAll} style={{ marginLeft: -35 }}>
+                  None
+                  <Radio
+                    name={`${entity}-select-all`}
+                    checked={this.entityIsAll(entity, null)}
+                    value="null"
+                    onChange={this.entitySetAllTo(entity, null)}
+                  />
+                </label>
               </TableCell>
               <TableCell
                 padding="checkbox"
               >
-                Read Only
-                <Radio
-                  name={`${entity}-select-all`}
-                  checked={this.entityIsAll(entity, 'read_only')}
-                  value="read_only"
-                  onChange={this.entitySetAllTo(entity, 'read_only')}
-                />
+                <label className={classes.selectAll} style={{ marginLeft: -65 }}>
+                  Read Only
+                  <Radio
+                    name={`${entity}-select-all`}
+                    checked={this.entityIsAll(entity, 'read_only')}
+                    value="read_only"
+                    onChange={this.entitySetAllTo(entity, 'read_only')}
+                  />
+                </label>
               </TableCell>
               <TableCell
                 padding="checkbox"
               >
-                Read-Write
-                <Radio
-                  name={`${entity}-select-all`}
-                  checked={this.entityIsAll(entity, 'read_write')}
-                  value="read_write"
-                  onChange={this.entitySetAllTo(entity, 'read_write')}
-                />
+                <label className={classes.selectAll} style={{ marginLeft: -73 }}>
+                  Read-Write
+                  <Radio
+                    name={`${entity}-select-all`}
+                    checked={this.entityIsAll(entity, 'read_write')}
+                    value="read_write"
+                    onChange={this.entitySetAllTo(entity, 'read_write')}
+                  />
+                </label>
               </TableCell>
             </TableRow>
           </TableHead>
@@ -602,7 +624,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             </Typography>
           </Grid>
           <Grid item>
-            <Grid container justify="flex-end">
+            <Grid container justify="flex-end" alignItems="center">
               <Grid item>
                 Set all Grants to:
               </Grid>

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -458,7 +458,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   renderEntitySection = (entity: string) => {
     const { classes } = this.props;
     const { grants } = this.state;
-    if (!(grants && grants[entity])) { return null; }
+    if (!(grants && grants[entity] && grants[entity].length)) { return null; }
     const entityGrants = grants[entity];
 
     const entityNameMap = {
@@ -472,7 +472,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     };
 
     return (
-      <div className={classes.section}>
+      <div key={entity} className={classes.section}>
         <Typography variant="subheading">
           {entityNameMap[entity]}
         </Typography>
@@ -514,7 +514,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           <TableBody>
             {entityGrants.map((grant, idx) => {
               return (
-                <TableRow key={grant.label}>
+                <TableRow key={grant.id}>
                   <TableCell>
                     {grant.label}
                   </TableCell>

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -682,7 +682,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               Update User Permissions
             </Typography>
           </Grid>
-          <Grid item className={`${classes.accessWrapper} ${'p0'}`}>
+          <Grid item className="p0">
             <Grid container alignItems="center">
               <Grid item>
                 <Typography variant="title">

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -4,10 +4,14 @@ import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/
 import Typography from '@material-ui/core/Typography';
 
 import Grid from 'src/components/Grid';
+import Toggle from 'src/components/Toggle';
 
-type ClassNames = 'titleWrapper';
+type ClassNames = 'titleWrapper' | 'topGrid';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  topGrid: {
+    marginTop: -(theme.spacing.unit * 2),
+  },
   titleWrapper: {
     display: 'flex',
     alignItems: 'center',
@@ -27,20 +31,26 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     restricted: true,
   };
 
+  onChangeRestricted = () => {
+    this.setState({
+      restricted: !this.state.restricted,
+    })
+  }
+
   render() {
     const { classes } = this.props;
     const { restricted } = this.state;
 
     return (
       <React.Fragment>
-        <Grid container justify="space-between">
+        <Grid container className={classes.topGrid} justify="space-between">
           <Grid item className={classes.titleWrapper}>
             <Typography variant="title">
               Update User Permissions
             </Typography>
           </Grid>
           <Grid item>
-            <Grid container alignItems="flex-end">
+            <Grid container alignItems="center">
               <Grid item>
                 <Typography variant="title">
                   Restrict Access:
@@ -53,6 +63,12 @@ class UserPermissions extends React.Component<CombinedProps, State> {
                     : 'Off'
                   }
                 </Typography>
+              </Grid>
+              <Grid item>
+                <Toggle
+                  checked={restricted}
+                  onChange={this.onChangeRestricted}
+                />
               </Grid>
             </Grid>
           </Grid>

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -5,6 +5,7 @@ import Typography from '@material-ui/core/Typography';
 
 import Grid from 'src/components/Grid';
 import Toggle from 'src/components/Toggle';
+import { getGrants } from 'src/services/account';
 
 type ClassNames = 'titleWrapper' | 'topGrid';
 
@@ -18,10 +19,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   },
 });
 
-interface Props {}
+interface Props {
+  username?: string;
+}
 
 interface State {
-  restricted: boolean,
+  grants?: Linode.Grants;
+  restricted: boolean;
+  errors?: Linode.ApiFieldError[];
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -30,6 +35,31 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   state: State = {
     restricted: true,
   };
+
+  getUserGrants = () => {
+    const { username } = this.props;
+    if (username) {
+      getGrants(username)
+        .then((grants) => {
+          this.setState({
+            grants,
+          })
+          console.log(grants);
+        })
+        .catch((errResponse) => {
+          this.setState({
+            errors: [{ reason: 
+              'Unknown error occured while fetching user permissions. Try again later.'}]
+          })
+        });
+    }
+  }
+
+  componentDidUpdate(prevProps: CombinedProps) {
+    if (prevProps.username !== this.props.username) {
+      this.getUserGrants();
+}
+  }
 
   onChangeRestricted = () => {
     this.setState({

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -28,18 +28,25 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 type ClassNames =
   'titleWrapper'
+  | 'toggle'
   | 'topGrid'
   | 'unrestrictedRoot'
   | 'globalSection'
+  | 'globalRow'
   | 'section';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   topGrid: {
-    marginTop: -(theme.spacing.unit * 2),
+    marginTop: theme.spacing.unit,
   },
   titleWrapper: {
+    marginTop: 0,
+    padding: 0,
     display: 'flex',
     alignItems: 'center',
+  },
+  toggle: {
+    marginRight: 3,
   },
   unrestrictedRoot: {
     marginTop: theme.spacing.unit * 2,
@@ -49,8 +56,12 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     marginTop: theme.spacing.unit * 2,
     padding: theme.spacing.unit * 3,
   },
+  globalRow: {
+    padding: `${theme.spacing.unit}px 0`,
+  },
   section: {
     marginTop: theme.spacing.unit * 2,
+    paddingBottom: 0,
   },
 });
 
@@ -304,6 +315,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
   }
 
   renderGlobalPerm = (perm: string, checked: boolean) => {
+    const { classes } = this.props;
     const permDescriptionMap = {
       add_linodes: 'Can add Linodes to this Account ($)',
       add_nodebalancers: 'Can add NodeBalancers to this Account ($)',
@@ -318,7 +330,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment key={perm}>
         <FormControlLabel
-          style={{ marginTop: 8 }}
+          className={classes.globalRow}
           label={permDescriptionMap[perm]}
           control={
             <Toggle
@@ -664,13 +676,13 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         {generalError &&
           <Notice error text={generalError} />
         }
-        <Grid container className={classes.topGrid} justify="space-between">
+        <Grid container className={`${classes.topGrid} ${'py0'}`} justify="space-between" alignItems="center">
           <Grid item className={classes.titleWrapper}>
             <Typography variant="title">
               Update User Permissions
             </Typography>
           </Grid>
-          <Grid item>
+          <Grid item className={`${classes.accessWrapper} ${'p0'}`}>
             <Grid container alignItems="center">
               <Grid item>
                 <Typography variant="title">
@@ -689,6 +701,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
                 <Toggle
                   checked={restricted}
                   onChange={this.onChangeRestricted}
+                  className={classes.toggle}
                 />
               </Grid>
             </Grid>

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -240,7 +240,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         })
         updateFns = flatten(updateFns);
         /* apply all of them at once */
-        this.setState((compose as any)(...updateFns));
+        if (updateFns.length) {
+          this.setState((compose as any)(...updateFns));
+        }
         this.setState(compose(
           set(lensPath(['success', 'specific']),
             'Successfully updated Entity-Specific Grants'),
@@ -277,7 +279,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
         return set(lens, originalGrants[entity]);
       })
       /* apply all of them at once */
-      this.setState((compose as any)(...updateFns));
+      if (updateFns.length) {
+        this.setState((compose as any)(...updateFns));
+      }
       return;
     }
   }
@@ -455,7 +459,9 @@ class UserPermissions extends React.Component<CombinedProps, State> {
       return set(lens, value);
     });
     /* compose all of the update functions and setState */
-    this.setState((compose as any)(...updateFns));
+    if (updateFns.length) {
+      this.setState((compose as any)(...updateFns));
+    }
   }
 
   setGrantTo = (entity: string, idx: number, value: Linode.GrantLevel) => () => {

--- a/src/features/Users/UserProfile.tsx
+++ b/src/features/Users/UserProfile.tsx
@@ -123,21 +123,21 @@ class UserProfile extends React.Component<CombinedProps> {
             value={email}
           />
           <ActionsPanel style={{ marginTop: 16 }}>
-          <Button
-            type="primary"
-            loading={saving}
-            onClick={save}
-            data-qa-submit
-          >
-            Save
-          </Button>
-          <Button
-            type="cancel"
-            onClick={reset}
-            data-qa-cancel
-          >
-            Cancel
-          </Button>
+            <Button
+              type="primary"
+              loading={saving}
+              onClick={save}
+              data-qa-submit
+            >
+              Save
+            </Button>
+            <Button
+              type="cancel"
+              onClick={reset}
+              data-qa-cancel
+            >
+              Cancel
+            </Button>
           </ActionsPanel>
         </div>
       </Paper>

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -118,6 +118,13 @@ export const getUser = (username: string) =>
   )
     .then(response => response.data);
 
+export const getGrants = (username: string) =>
+  Request<Linode.Grants>(
+    setURL(`${API_ROOT}/account/users/${username}/grants`),
+    setMethod('GET'),
+  )
+    .then(response => response.data);
+
 export const updateUser = (username: string, data: Partial<Linode.User>) =>
   Request<Linode.User>(
     setURL(`${API_ROOT}/account/users/${username}`),

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -125,6 +125,14 @@ export const getGrants = (username: string) =>
   )
     .then(response => response.data);
 
+export const updateGrants = (username: string, data: Partial<Linode.Grants>) =>
+  Request<Linode.Grants>(
+    setURL(`${API_ROOT}/account/users/${username}/grants`),
+    setMethod('PUT'),
+    setData(data),
+  )
+    .then(response => response.data);
+
 export const updateUser = (username: string, data: Partial<Linode.User>) =>
   Request<Linode.User>(
     setURL(`${API_ROOT}/account/users/${username}`),

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -40,15 +40,17 @@ namespace Linode {
     usd: string | number;
   }
 
+  export type GrantLevel = null | 'read_only' | 'read_write';
+
   export interface Grant {
     id: number;
-    permissions: null | 'read_only' | 'read_write';
+    permissions: GrantLevel;
     label: string;
   }
 
   export interface GlobalGrants {
     global: {
-      [key: string]: boolean | null | 'read_only' | 'read_write'
+      [key: string]: boolean | GrantLevel,
     };
   }
 

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -41,12 +41,18 @@ namespace Linode {
   }
 
   export interface Grant {
-
+    id: number;
+    permissions: null | 'read_only' | 'read_write';
+    label: string;
   }
 
-  export interface Grants {
+  export interface GlobalGrants {
     global: {
-      [key: string]: bool,
+      [key: string]: boolean | null | 'read_only' | 'read_write'
     };
+  }
+
+  export type Grants = GlobalGrants & {
+    [key: string]: Grant[];
   }
 }

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -40,4 +40,13 @@ namespace Linode {
     usd: string | number;
   }
 
+  export interface Grant {
+
+  }
+
+  export interface Grants {
+    global: {
+      [key: string]: bool,
+    };
+  }
 }


### PR DESCRIPTION
Implements user permissions management

A toggle on the page allows one to immediately switch a user from restricted to unrestricted. Unrestricted users show no permissions fields with a message (perhaps we should show all fields disabled?)

Restricted users show two permissions edit sections. 

The first section allows one to modify global permissions. All of these are booleans, and so use toggles, except for billing access, which has three states and therefore shows selection cards. Per the PO, global permissions were combined into one section to simplify the implementation.

The second section allows one to modify entity-specific permissions. Tables are shown for each entity owned by the account (Linode, NodeBalancer, etc.). Each entity can be set to a permission level of "None", "Read Only", or "Read-Write" with radio buttons. There are Radio buttons in the header that allow setting all of a specific entity type to a specific permission level. There is a select field above all the tables that allows setting ALL entities to a specific permission level. Per the PO, expansion panels were not used for each entity, and all entity-specific grants are handled with a single save button. 
