### PR TITLE
M3-915 - Create Image Test

### DIFF
--- a/e2e/pageobjects/configure-image.page.js
+++ b/e2e/pageobjects/configure-image.page.js
@@ -1,0 +1,41 @@
+const { constants } = require('../constants');
+
+import Page from './page';
+
+
+class ConfigureImage extends Page {
+    get placeholderMsg() { return $('[data-qa-placeholder-title]'); }
+    get placeholderButton () { return $('[data-qa-placeholder-button]'); }
+    get linodeSelect() { return $('[data-qa-linode-select]'); }
+    get diskSelect() { return $('[data-qa-disk-select]'); }
+    get label() { return $('[data-qa-image-label]'); }
+    get description() { return $('[data-qa-image-description]'); }
+    get createButton() { return $('[data-qa-submit]'); }
+    get cancelButton() { return $('[data-qa-cancel]'); }
+    get linodesMenuItems() { return $$('[data-qa-linode-menu-item]'); }
+    get diskMenuItems() { return $$('[data-qa-disk-menu-item]'); }
+
+    baseElementsDisplay() {
+        this.linodeSelect.waitForVisible(constants.wait.normal);
+        expect(this.diskSelect.isVisible()).toBe(true);
+        expect(this.label.isVisible()).toBe(true);
+        expect(this.description.isVisible()).toBe(true);
+        expect(this.createButton.isVisible()).toBe(true);
+        expect(this.cancelButton.isVisible()).toBe(true);
+    }
+
+    configure(config) {
+        this.label.$('input').setValue(config.label);
+        this.description.$('textarea').setValue(config.description);
+        this.chooseSelectOption(this.linodeSelect, 1);
+        this.chooseSelectOption(this.diskSelect, 1);
+    }
+
+    create() {
+        this.createButton.click();
+        this.waitForNotice('Image scheduled for creation.');
+        this.drawerTitle.waitForVisible(constants.wait.normal, true);
+    }
+}
+
+export default new ConfigureImage();

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -274,3 +274,39 @@ exports.removeStackScript = (token, id) => {
             });
     });
 }
+
+
+exports.getImages = token => {
+    return browser.call(function() {
+        return new Promise((resolve, reject) => {
+            const endpoint = '/images?page=1';
+
+            return getAxiosInstance(token).get(endpoint, {
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'X-Filter': '{"is_public":false}'
+                }
+            })
+            .then(response => resolve(response.data))
+            .catch(error => {
+                console.error('Error', error);
+                reject(error);
+            });
+        });
+    });
+}
+
+exports.removeImage = (token, id) => {
+    return browser.call(function () {
+        return new Promise((resolve, reject) => {
+            const endpoint = `/images/${id}`;
+
+            return getAxiosInstance(token).delete(endpoint)
+                .then(response => resolve(response.data))
+                .catch(error => {
+                    console.error('Error', error);
+                    reject(error);
+                });
+        });
+    });
+}

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -276,7 +276,7 @@ exports.removeStackScript = (token, id) => {
 }
 
 
-exports.getImages = token => {
+exports.getPrivateImages = token => {
     return browser.call(function() {
         return new Promise((resolve, reject) => {
             const endpoint = '/images?page=1';
@@ -297,7 +297,7 @@ exports.getImages = token => {
 }
 
 exports.removeImage = (token, id) => {
-    return browser.call(function () {
+    return browser.call(function() {
         return new Promise((resolve, reject) => {
             const endpoint = `/images/${id}`;
 

--- a/e2e/specs/images/create.spec.js
+++ b/e2e/specs/images/create.spec.js
@@ -3,7 +3,11 @@ const { getImages } = require('../../setup/setup');
 
 import ConfigureImage from '../../pageobjects/configure-image.page';
 
-import { apiCreateLinode, apiDeleteAllLinodes } from '../../utils/common';
+import {
+    apiCreateLinode,
+    apiDeleteAllLinodes,
+    apiDeletePrivateImages,
+} from '../../utils/common';
 
 describe('Images - Create Suite', () => {
     beforeAll(() => {
@@ -13,7 +17,8 @@ describe('Images - Create Suite', () => {
 
     afterAll(() => {
         apiDeleteAllLinodes();
-    })
+        apiDeletePrivateImages(browser.readToken());
+    });
 
     it('should display create image drawer', () => {
         ConfigureImage.placeholderMsg.waitForVisible(constants.wait.normal);
@@ -32,7 +37,5 @@ describe('Images - Create Suite', () => {
 
     it('should schedule the image for creation', () => {
         ConfigureImage.create();
-        const token = browser.readToken();
-        const privateImages = getImages(token);
     });
 });

--- a/e2e/specs/images/create.spec.js
+++ b/e2e/specs/images/create.spec.js
@@ -34,6 +34,5 @@ describe('Images - Create Suite', () => {
         ConfigureImage.create();
         const token = browser.readToken();
         const privateImages = getImages(token);
-        console.log(privateImages);
     });
 });

--- a/e2e/specs/images/create.spec.js
+++ b/e2e/specs/images/create.spec.js
@@ -1,0 +1,39 @@
+const { constants } = require('../../constants');
+const { getImages } = require('../../setup/setup');
+
+import ConfigureImage from '../../pageobjects/configure-image.page';
+
+import { apiCreateLinode, apiDeleteAllLinodes } from '../../utils/common';
+
+describe('Images - Create Suite', () => {
+    beforeAll(() => {
+        apiCreateLinode();
+        browser.url(constants.routes.images);
+    });
+
+    afterAll(() => {
+        apiDeleteAllLinodes();
+    })
+
+    it('should display create image drawer', () => {
+        ConfigureImage.placeholderMsg.waitForVisible(constants.wait.normal);
+        ConfigureImage.placeholderButton.waitForVisible(constants.wait.normal);
+        ConfigureImage.placeholderButton.click();
+        ConfigureImage.baseElementsDisplay();
+    });
+
+    it('should configure the image', () => {
+        const imageConfig = {
+            label: 'my-test-image',
+            description: 'some image description!'
+        }
+        ConfigureImage.configure(imageConfig);
+    });
+
+    it('should schedule the image for creation', () => {
+        ConfigureImage.create();
+        const token = browser.readToken();
+        const privateImages = getImages(token);
+        console.log(privateImages);
+    });
+});

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -2,6 +2,7 @@ const crypto = require('crypto');
 const { argv } = require('yargs');
 const { constants } = require('../constants');
 const { readToken } = require('./config-utils');
+const { getPrivateImages, removeImage } = require('../setup/setup');
 
 import ConfigureLinode from '../pageobjects/configure-linode';
 import ListLinodes from '../pageobjects/list-linodes';
@@ -104,4 +105,9 @@ export const removeNodeBalancers = () => {
     apiDeleteAllLinodes();
     const availableNodeBalancers = browser.getNodeBalancers(token);
     availableNodeBalancers.data.forEach(nb => browser.removeNodeBalancer(token, nb.id));
+}
+
+export const apiDeletePrivateImages = token => {
+    const privateImages = getPrivateImages(token).data;
+    privateImages.forEach(i => removeImage(token, i.id));
 }

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "tslint-config-prettier": "^1.13.0",
     "typescript": "^2.7.2",
     "wdio-dot-reporter": "0.0.9",
-    "wdio-jasmine-framework": "0.3.4",
+    "wdio-jasmine-framework": "0.3.5",
     "wdio-junit-reporter": "^0.4.2",
     "wdio-selenium-standalone-service": "^0.0.10",
     "webdriverio": "4.12.0",

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -280,6 +280,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
           diskError={diskError}
           handleChange={changeDisk}
           updateFor={[disks, selectedDisk, diskError]}
+          data-qa-disk-select
         />
        }
 
@@ -292,7 +293,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               onChange={changeLabel}
               error={Boolean(labelError)}
               errorText={labelError}
-              data-qa-volume-label
+              data-qa-image-label
             />
 
             <TextField
@@ -303,7 +304,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
               onChange={changeDescription}
               error={Boolean(descriptionError)}
               errorText={descriptionError}
-              data-qa-size
+              data-qa-image-description
             />
           </React.Fragment>
         }

--- a/src/features/linodes/DiskSelect/DiskSelect.tsx
+++ b/src/features/linodes/DiskSelect/DiskSelect.tsx
@@ -48,11 +48,19 @@ const DiskSelect: React.StatelessComponent<CombinedProps> = (props) => {
           inputProps={{ name: 'linode', id: 'linode' }}
           error={Boolean(props.diskError)}
           select
+          data-qa-disk-select
         >
         <MenuItem value="none" disabled>Select a Disk</MenuItem>
         {
           props.disks && props.disks.map((disk) => {
-          return <MenuItem key={disk.id} value={disk.id}>{disk.label}</MenuItem>;
+          return (
+            <MenuItem
+              key={disk.id}
+              value={disk.id}
+              data-qa-disk-menu-item={disk.label}
+            >
+              {disk.label}
+            </MenuItem>);
           })
         }
         </TextField>

--- a/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -48,11 +48,12 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = (props) => {
             inputProps={{ name: 'linode', id: 'linode' }}
             error={Boolean(props.linodeError)}
             select
+            data-qa-linode-select
         >
         <MenuItem value="none" disabled>Select a Linode</MenuItem>
         {
             props.linodes && props.linodes.map((l) => {
-            return <MenuItem key={l[0]} value={l[0]}>{l[1]}</MenuItem>;
+            return <MenuItem key={l[0]} value={l[0]} data-qa-linode-menu-item={l[1]}>{l[1]}</MenuItem>;
             })
         }
         </TextField>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10887,9 +10887,9 @@ wdio-dot-reporter@0.0.9, wdio-dot-reporter@~0.0.8:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/wdio-dot-reporter/-/wdio-dot-reporter-0.0.9.tgz#929b2adafd49d6b0534fda068e87319b47e38fe5"
 
-wdio-jasmine-framework@0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/wdio-jasmine-framework/-/wdio-jasmine-framework-0.3.4.tgz#99fa06fc679e089c829a08088039d9574b6fdf45"
+wdio-jasmine-framework@0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/wdio-jasmine-framework/-/wdio-jasmine-framework-0.3.5.tgz#ea4729e74a4e4891e923a03d6f5b7ed3bc23bcbb"
   dependencies:
     babel-runtime "6.26.0"
     jasmine "^3.0.0"


### PR DESCRIPTION
* Created e2e test for create an image
* Created api utils to get private images and delete images.
* Added data-attributes to linode select, disk select, images drawer
* Updated `wdio-jasmine-framework` package. Prior to this version, errors thrown in test hooks (eg. `beforeAll`, `afterAll`) failed silently.

## To Test

```bash
yarn && yarn start
yarn selenium
yarn e2e --dir images
```