### PR TITLE
Add Domain: fix padding for Master Nameserver IP Address field 

### DIFF
--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -143,7 +143,6 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
                   value={viewMasterIP(idx, this.state) || ''}
                   onChange={this.updateMasterIPAddress(idx)}
                   data-qa-master-ip={idx}
-                  style={{ marginBottom: 16 }}
                 />
               ))
             }


### PR DESCRIPTION
Ensure spacing is accurate in the slave section of the add new domain drawer when adding IP addresses
![screen shot 2018-07-25 at 1 33 57 pm](https://user-images.githubusercontent.com/205353/43217393-82d6d4b6-900f-11e8-9516-734c33ccbdb1.png)
