### PR TITLE
M3-922 Replace trash icons with remove button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -45,6 +45,7 @@ const styles: StyleRulesCallback = (theme: Theme & Linode.Theme) => ({
       fontSize: '.9rem',
       border: 0,
       color: '#C44742',
+      padding: '14px 26px 14px',
       transition: theme.transitions.create(['color', 'border-color']),
       '&:hover, &:focus': {
         color: '#DF6560',

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -12,12 +12,13 @@ import Reload from 'src/assets/icons/reload.svg';
 type ClassNames = 'root'
   | 'loading'
   | 'destructive'
-  | 'cancel';
+  | 'cancel'
+  | 'remove';
 
 export interface Props extends ButtonProps {
   loading?: boolean;
   destructive?: boolean;
-  type?: 'primary' | 'secondary' | 'cancel';
+  type?: 'primary' | 'secondary' | 'cancel' | 'remove';
   className?: string;
   tooltipText?: string;
 }
@@ -38,6 +39,15 @@ const styles: StyleRulesCallback = (theme: Theme & Linode.Theme) => ({
       '&:hover, &:focus': {
         color: theme.palette.primary.light,
         borderColor: theme.palette.primary.light,
+      },
+    },
+    '&.remove': {
+      fontSize: '.9rem',
+      border: 0,
+      color: '#C44742',
+      transition: theme.transitions.create(['color', 'border-color']),
+      '&:hover, &:focus': {
+        color: '#DF6560',
       },
     },
   },
@@ -83,12 +93,14 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 const getVariant = cond([
   [propEq('type', 'primary'), always('raised')],
   [propEq('type', 'secondary'), always('raised')],
+  [propEq('type', 'remove'), always('raised')],
   [() => true, always(undefined)],
 ]);
 
 const getColor = cond([
   [propEq('type', 'primary'), always('primary')],
   [propEq('type', 'secondary'), always('secondary')],
+  [propEq('type', 'remove'), always('secondary')],
   [() => true, always(undefined)],
 ]);
 
@@ -125,6 +137,7 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = (props) => {
         )}
       >
         {loading ? <Reload /> : props.children}
+        {type === 'remove' && 'Remove'}
       </Button>
       {tooltipText && <HelpIcon text={tooltipText} />}
     </React.Fragment>

--- a/src/components/Button/button.stories.tsx
+++ b/src/components/Button/button.stories.tsx
@@ -21,6 +21,8 @@ storiesOf('Button', module)
       <Divider />
       <Button type="cancel" data-qa-button="cancel">Cancel</Button>
       <Divider />
+      <Button type="remove" data-qa-button="remove"/>
+      <Divider />
     </React.Fragment>
   ))
   .add('Disabled', () => (

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -9,13 +9,11 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import Delete from '@material-ui/icons/Delete';
 
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import Grid from 'src/components/Grid';
-import IconButton from 'src/components/IconButton';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import Toggle from 'src/components/Toggle';
@@ -41,7 +39,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   backendIPAction: {
     paddingLeft: theme.spacing.unit * 2,
     marginLeft: -theme.spacing.unit,
-    marginTop: theme.spacing.unit * 3,
+    marginTop: theme.spacing.unit * 2,
+    [theme.breakpoints.down('xs')]: {
+      marginLeft: -32,
+    },
   },
   suggestionsParent: {
     position: 'relative',
@@ -843,10 +844,10 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                       >
                         {idx !== 0 &&
                           <Grid item xs={12}>
-                            <Divider style={{ marginTop: 24 }} />
+                            <Divider style={{ marginTop: forEdit ? 8 : 24 }} />
                           </Grid>
                         }
-                        <Grid item xs={11} lg={forEdit ? 2 : 3}>
+                        <Grid item xs={11} sm={forEdit ? 4 : 3} xl={2} className="py0">
                           <TextField
                             label="Label"
                             value={node.label}
@@ -857,7 +858,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                             data-qa-backend-ip-label
                           />
                         </Grid>
-                        <Grid item xs={11} lg={4} xl={3}>
+                        <Grid item xs={11} sm={forEdit ? 4 : 3} xl={2} className="py0">
                           <Downshift
                             onSelect={this.handleSelectSuggestion}
                             stateReducer={this.downshiftStateReducer}
@@ -934,7 +935,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                             }
                           </Downshift>
                         </Grid>
-                        <Grid item xs={11} lg={2}>
+                        <Grid item xs={11} sm={forEdit ? 4 : 2} xl={2} className="py0">
                           <TextField
                             type="number"
                             label="Port"
@@ -944,9 +945,10 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                             errorText={hasErrorFor('port')}
                             errorGroup={forEdit ? `${configIdx}`: undefined}
                             data-qa-backend-ip-port
+                            style={{ minWidth: 'auto' }}
                           />
                         </Grid>
-                        <Grid item xs={11} lg={2}>
+                        <Grid item xs={11} sm={forEdit ? 4 : 2} xl={2} className="py0">
                           <TextField
                             type="number"
                             label="Weight"
@@ -956,10 +958,11 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                             errorText={hasErrorFor('weight')}
                             errorGroup={forEdit ? `${configIdx}`: undefined}
                             data-qa-backend-ip-weight
+                            style={{ minWidth: 'auto' }}
                           />
                         </Grid>
                         {forEdit &&
-                          <Grid item xs={12} lg={3} xl={2}>
+                          <Grid item xs={12} sm={4} xl={2} className="py0">
                             <TextField
                               label="Mode"
                               value={node.mode}
@@ -992,15 +995,12 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                         }
                         <ActionsPanel className={classes.backendIPAction}>
                           {(forEdit || idx !== 0) &&
-                            <IconButton
+                            <Button
+                              type="remove"
                               data-node-idx={idx}
                               onClick={this.removeNode}
-                              destructive
                               data-qa-remove-node
-                              style={{  width: 'auto' }}
-                            >
-                              <Delete />
-                            </IconButton>
+                            />
                           }
                         </ActionsPanel>
                       </Grid>
@@ -1013,8 +1013,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   updateFor={[]}
                   // is the Save/Delete ActionsPanel showing?
                   style={(forEdit || configIdx !== 0) ?
-                    { marginTop: 24, marginBottom: -24 } :
-                    { marginTop: 24 }
+                    { marginTop: 16, marginBottom: -24 } :
+                    { marginTop: 16 }
                   }
                 >
                   <AddNewLink

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -4,14 +4,12 @@ import * as React from 'react';
 import Divider from '@material-ui/core/Divider';
 import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import Delete from '@material-ui/icons/Delete';
 
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import Grid from 'src/components/Grid';
-import IconButton from 'src/components/IconButton';
 import LinearProgress from 'src/components/LinearProgress';
 import MenuItem from 'src/components/MenuItem';
 import Select from 'src/components/Select';
@@ -26,7 +24,9 @@ type ClassNames =
   | 'ipField'
   | 'addNewButton'
   | 'noIPsMessage'
-  | 'networkActionText';
+  | 'networkActionText'
+  | 'removeCont'
+  | 'remove';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   addNewButton: {
@@ -52,6 +52,16 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   networkActionText: {
     marginBottom: theme.spacing.unit * 2,
+  },
+  removeCont: {
+    [theme.breakpoints.down('xs')]: {
+      width: '100%',
+    },
+  },
+  remove: {
+    [theme.breakpoints.down('xs')]: {
+      margin: '-16px 0 0 -26px',
+    },
   },
 });
 
@@ -208,13 +218,12 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
             }
           </Select>
         </Grid>
-        <Grid item>
-          <IconButton
+        <Grid item className={classes.removeCont}>
+          <Button
+            type="remove"
             onClick={this.onIPDelete(idx)}
-            destructive
-          >
-            <Delete />
-          </IconButton>
+            className={classes.remove}
+          />
         </Grid>
       </Grid>
     );

--- a/src/features/profile/LishSettings/LishSettings.tsx
+++ b/src/features/profile/LishSettings/LishSettings.tsx
@@ -9,13 +9,11 @@ import InputLabel from '@material-ui/core/InputLabel';
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import Delete from '@material-ui/icons/Delete';
 
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import setDocs from 'src/components/DocsSidebar/setDocs';
-import IconButton from 'src/components/IconButton';
 import MenuItem from 'src/components/MenuItem';
 import Notice from 'src/components/Notice';
 import Select from 'src/components/Select';
@@ -30,9 +28,10 @@ type ClassNames = 'root'
   | 'intro'
   | 'modeControl'
   | 'sshWrap'
+  | 'keyTextarea'
   | 'image'
   | 'addNew'
-  | 'deleteIcon';
+  | 'remove';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
@@ -57,13 +56,21 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   },
   sshWrap: {
     margin: `${theme.spacing.unit}px 0`,
-    position: 'relative',
-    maxWidth: 415,
+    [theme.breakpoints.up('md')]: {
+      display: 'flex',
+      alignItems: 'flex-end',
+    },
   },
-  deleteIcon: {
-    position: 'absolute',
-    left: -9,
-    bottom: 14,
+  keyTextarea: {
+    [theme.breakpoints.up('md')]: {
+      minWidth: 415,
+    },
+  },
+  remove: {
+    margin: '8px 0 0 -26px',
+    [theme.breakpoints.up('md')]: {
+      margin: `0 0 ${theme.spacing.unit / 2}px 0`,
+    },
   },
 });
 
@@ -154,15 +161,13 @@ class LishSettings extends React.Component<CombinedProps, State> {
                           helperText="Place your SSH public keys here for use with Lish console access."
                           multiline
                           rows="4"
-                          // fullWidth={false}
+                          className={classes.keyTextarea}
                         />
-                        <IconButton
+                        <Button
+                          type="remove"
                           onClick={this.onPublicKeyRemove(idx)}
-                          destructive
-                          className={classes.deleteIcon}
-                        >
-                          <Delete />
-                        </IconButton>
+                          className={classes.remove}
+                        />
                       </div>
                     ))
                   }


### PR DESCRIPTION
The "remove" action is now part of the button component. this will simplify its implementation, but each instance will probably needs its own styling as it's often placed differently within forms.

to test:
- [ ] check button component story for basis implemetation
- [ ] check new instance on IP sharing panel at /linodes/[id]/networking
- [ ] check new instance on profile Lish at /profile/lish
- [ ] check new instance on Backend Node panel at /nodebalancers/[id]/configurations
- [ ] check new instance on Nodebalancer create at /nodebalancers/create