### PR TITLE
Fix bug for undefined timezone

### DIFF
--- a/src/components/EnhancedSelect/EnhancedSelect.tsx
+++ b/src/components/EnhancedSelect/EnhancedSelect.tsx
@@ -30,6 +30,7 @@ const styles: StyleRulesCallback = (theme: Theme & Linode.Theme) => ({
     width: '100%',
     maxWidth: 415,
     zIndex: 2,
+    marginTop: -2,
   },
 })
 

--- a/src/features/profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/profile/DisplaySettings/TimezoneForm.tsx
@@ -125,8 +125,7 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
   render() {
     const { classes, timezone } = this.props;
     const { errors, submitting, success, updatedTimezone } = this.state;
-    const tz = this.getTimezone(timezone);
-    const timezoneLabel = (tz && tz.label) ? tz.label : 'not set';
+    const timezoneDisplay = pathOr(timezone, ['label'], this.getTimezone(timezone));
 
     const hasErrorFor = getAPIErrorFor({
         timezone: 'timezone',
@@ -145,7 +144,7 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
           >
             This setting converts the dates and times displayed in the Linode Manager
             to a timezone of your choice.
-            Your current timezone is: <strong>{timezoneLabel}</strong>.
+            Your current timezone is: <strong>{timezoneDisplay}</strong>.
           </Typography>
           <React.Fragment>
             <EnhancedSelect

--- a/src/features/profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/profile/DisplaySettings/TimezoneForm.tsx
@@ -125,7 +125,8 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
   render() {
     const { classes, timezone } = this.props;
     const { errors, submitting, success, updatedTimezone } = this.state;
-    const timezoneLabel = this.getTimezone(timezone).label;
+    const tz = this.getTimezone(timezone);
+    const timezoneLabel = (tz && tz.label) ? tz.label : 'not set';
 
     const hasErrorFor = getAPIErrorFor({
         timezone: 'timezone',


### PR DESCRIPTION
By default, API sets timezone to GMT, which isn't in timezones.ts.
This could cause the app to crash (since tz.label is accessed on
an undefined entity). This fix includes a check before looking for the
label, with 'not set' as a fallback value. This value may need to be
updated based on feedback from the API team.