### PR TITLE
Extend objects, set others, in resource state management.

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigs.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigs.tsx
@@ -436,9 +436,13 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles, { withTheme: true });
 
-const mapStateToProps = (state: Linode.AppState) => ({
-  kernels: state.resources.kernels && state.resources.kernels.data || [],
-});
+const mapStateToProps = (state: Linode.AppState) => {
+  const kernels = state.resources.kernels && state.resources.kernels.data || [];
+  console.log(kernels);
+  return {
+    kernels,
+  };
+};
 
 const connected = connect<ConnectedProps>(mapStateToProps);
 


### PR DESCRIPTION
## Purpose
A recent fix to resource state management assumed the response values to be objects, causing arrays to be converted into objects and exploding all the things.

https://gph.is/1aEPqjq