### PR TITLE
Small refactor user notification & event menus

### DIFF
--- a/src/features/TopMenu/UserEventsMenu/UserEventsListItem.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsListItem.tsx
@@ -3,6 +3,9 @@ import * as React from 'react';
 
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
+import ListItem from '@material-ui/core/ListItem';
+import Typography from '@material-ui/core/Typography';
+
 type ClassNames = 'root'
   | 'title'
   | 'content'
@@ -18,14 +21,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
       borderLeft: '5px solid transparent',
       padding: `${theme.spacing.unit * 2}px ${theme.spacing.unit * 3}px`,
       borderBottom: `1px solid ${theme.palette.divider}`,
-      opacity: .7,
+      display: 'block',
       transition: theme.transitions.create(['border-color', 'opacity']),
-      '&:hover': {
-        backgroundColor: 'white',
+      outline: 0,
+      '&:hover, &:focus': {
+        backgroundColor: theme.bg.main,
       },
     },
     title: {
-      ...theme.typography.subheading,
       marginBottom: theme.spacing.unit / 2,
     },
     content: {
@@ -42,12 +45,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
       borderLeftColor: status.successDark,
     },
     pointer: {
-      cursor: 'pointer',
-      border: 'none',
-      outline: 0,
-      '&:hover, &:focus': {
-        backgroundColor: theme.bg.main,
-        opacity: 1,
+      '& > h3': {
+        lineHeight: '1.2',
+        textDecoration: 'underline',
       },
     },
   };
@@ -67,17 +67,19 @@ type CombinedProps = UserEventsListItemProps & WithStyles<ClassNames>;
 const userEventsListItem: React.StatelessComponent<CombinedProps> = (props) => {
   const { classes, title, content, warning, success, error, onClick } = props;
   return (
-    <div className={classNames({
-      [classes.root]: true,
-      [classes.unread]: error || warning || success,
-      [classes.pointer]: Boolean(onClick),
-    })}
-      onClick={onClick}
+    <ListItem className={classNames({
+        [classes.root]: true,
+        [classes.unread]: error || warning || success,
+        [classes.pointer]: Boolean(onClick),
+      })}
+      component="li"
       tabIndex={1}
+      onClick={onClick}
+      button={Boolean(onClick)}
     >
-      <div className={classes.title}>{title}</div>
+      <Typography variant="subheading" className={classes.title}>{title}</Typography>
       {content && <div className={classes.content}>{content}</div>}
-    </div>
+    </ListItem>
   );
 };
 

--- a/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
@@ -12,8 +12,8 @@ import 'rxjs/add/operator/withLatestFrom';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
 
+import ListItem from '@material-ui/core/ListItem';
 import Menu from '@material-ui/core/Menu';
-import MenuItem from '@material-ui/core/MenuItem';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
 import { events$, init } from 'src/events';
@@ -133,8 +133,6 @@ class UserEventsMenu extends React.Component<CombinedProps, State> {
     this.buttonRef = element;
   }
 
-  closeMenu = () => this.setState({ anchorEl: undefined });
-
   render() {
     const { anchorEl, events, unseenCount } = this.state;
     const { classes } = this.props;
@@ -142,7 +140,7 @@ class UserEventsMenu extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <UserEventsButton
-          onClick={e => this.setState({ anchorEl: e.currentTarget })}
+          onClick={this.openMenu}
           getRef={this.setRef}
           count={unseenCount}
           disabled={events.length === 0}
@@ -158,7 +156,7 @@ class UserEventsMenu extends React.Component<CombinedProps, State> {
           className={classes.root}
           PaperProps={{ className: classes.dropDown }}
         >
-          <MenuItem key="placeholder" className={classes.hidden} />
+          <ListItem key="placeholder" className={classes.hidden} tabIndex={1} />
           <UserEventsList
             events={events}
             closeMenu={this.closeMenu}
@@ -167,6 +165,12 @@ class UserEventsMenu extends React.Component<CombinedProps, State> {
       </React.Fragment>
     );
   }
+
+  openMenu = (e: React.MouseEvent<HTMLElement>) =>
+    this.setState({ anchorEl: e.currentTarget });
+
+  closeMenu = (e: React.MouseEvent<HTMLElement>) =>
+    this.setState({ anchorEl: undefined })
 }
 
 const styled = withStyles(styles, { withTheme: true });

--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationListItem.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationListItem.tsx
@@ -1,15 +1,16 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 
+import ListItem from '@material-ui/core/ListItem';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-
-import Grid, { GridProps } from 'src/components/Grid';
 
 type ClassNames =
   | 'critical'
   | 'flag'
   | 'inner'
+  | 'innerLink'
+  | 'innerTitle'
   | 'major'
   | 'minor'
   | 'noticeText'
@@ -28,19 +29,33 @@ const styles: StyleRulesCallback = (theme: Theme & Linode.Theme) => {
       justifyContent: 'center',
       padding: `${theme.spacing.unit * 2}px ${theme.spacing.unit * 3}px`,
       borderBottom: `1px solid ${theme.palette.divider}`,
+      transition: theme.transitions.create('background-color'),
       '& p': {
         color: '#333',
       },
       '& + .notice': {
         marginTop: '0 !important',
       },
-      // marginBottom: the1`me.spacing.unit,
+      '&:hover, &:focus': {
+        backgroundColor: theme.bg.main,
+      },
       maxWidth: '100%',
       display: 'flex',
       alignItems: 'center',
+      outline: 0,
     },
     inner: {
       width: '100%',
+      display: 'block',
+    },
+    innerLink: {
+      '& > h3': {
+        lineHeight: '1.2',
+        textDecoration: 'underline',
+      },
+    },
+    innerTitle: {
+      marginBottom: theme.spacing.unit / 2,
     },
     noticeText: {
       color: theme.palette.text.primary,
@@ -61,7 +76,7 @@ const styles: StyleRulesCallback = (theme: Theme & Linode.Theme) => {
   };
 };
 
-interface Props extends GridProps {
+interface Props {
   label: string;
   message: string;
   severity: Linode.NotificationSeverity;
@@ -70,7 +85,7 @@ interface Props extends GridProps {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const UserNotificationListItem: React.StatelessComponent<CombinedProps> = (props) => {
+const userNotificationListItem: React.StatelessComponent<CombinedProps> = (props) => {
   const {
     classes,
     label,
@@ -80,8 +95,7 @@ const UserNotificationListItem: React.StatelessComponent<CombinedProps> = (props
   } = props;
 
   return (
-    <Grid
-      item
+    <ListItem
       className={classNames({
         [classes.root]: true,
         [classes[severity]]: true,
@@ -89,15 +103,24 @@ const UserNotificationListItem: React.StatelessComponent<CombinedProps> = (props
         notice: true,
       })}
       data-qa-notice
+      component="li"
+      tabIndex={1}
+      onClick={onClick}
+      button={Boolean(onClick)}
     >
-      <div className={classes.inner} onClick={onClick}>
-        <Typography>{label}</Typography>
+      <div className={classNames(
+        {
+          [classes.inner]: true,
+          [classes.innerLink]: Boolean(onClick),
+        }
+      )}>
+        <Typography variant="subheading" className={classes.innerTitle}>{label}</Typography>
         <Typography variant="caption">{message}</Typography>
       </div>
-    </Grid>
+    </ListItem>
   );
 };
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled<Props>(UserNotificationListItem);
+export default styled<Props>(userNotificationListItem);

--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationsMenu.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationsMenu.tsx
@@ -6,13 +6,16 @@ import { Subscription } from 'rxjs/Subscription';
 import Menu from '@material-ui/core/Menu';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
+import MenuItem from 'src/components/MenuItem';
 import GDPRNotification from 'src/GDPRNotification';
 import notifications$ from 'src/notifications';
 
 import UserNotificationButton from './UserNotificationsButton';
 import UserNotificationsList from './UserNotificationsList';
 
-type ClassNames = 'root' | 'dropDown';
+type ClassNames = 'root'
+  | 'dropDown'
+  | 'hidden';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -38,6 +41,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
         ...theme.typography.subheading,
       },
     },
+  },
+  hidden: {
+    height: 0,
+    padding: 0,
   },
 });
 
@@ -137,6 +144,7 @@ class UserNotificationsMenu extends React.Component<CombinedProps, State> {
           className={classes.root}
           PaperProps={{ className: classes.dropDown }}
         >
+          <MenuItem key="placeholder" className={classes.hidden} tabIndex={1} />
           <UserNotificationsList notifications={notifications} closeMenu={this.closeMenu} />
         </Menu>
         <GDPRNotification open={this.state.privacyPolicyModalOpen} onClose={this.closePrivacyPolicyModal} />


### PR DESCRIPTION
This PR provides better accessibility and consistency for both the event and user notification menus:

1. placeholder list item when menu open to have invisible focus
2. if link exists, the list item will receive a button role and the title will be underline for better visual recognition
3. the menus are now tab indexed and keyboard clickable
4. both menu use similar markup and styles
5. consistent hover style 