### PR TITLE
M3-983 Volume Landing Attachment Link

### DIFF
--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -1,6 +1,7 @@
 import { compose, equals, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import 'rxjs/add/operator/filter';
 import { Subscription } from 'rxjs/Subscription';
@@ -235,7 +236,13 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                   : (
                     <TableRow key={volume.id} data-qa-volume-cell={volume.id}>
                       <TableCell data-qa-volume-cell-label>{label}</TableCell>
-                      <TableCell data-qa-volume-cell-attachment>{linodeLabel}</TableCell>
+                      <TableCell data-qa-volume-cell-attachment>
+                        {linodeLabel &&
+                          <Link to={`/linodes/${volume.linode_id}`}>
+                            {linodeLabel}
+                          </Link>
+                        }
+                      </TableCell>
                       <TableCell data-qa-volume-size>{size} GB</TableCell>
                       <TableCell data-qa-fs-path>{filesystem_path}</TableCell>
                       <TableCell data-qa-volume-region>{region}</TableCell>


### PR DESCRIPTION
### Purpose

Previously on the Volumes landing page, the Linode that the volume was attached to would appear as plain text in a table cell. Now, it's a link that navigates to the appropriate Linode.