### PR TITLE
M3-978 Always Use Kebab

### DIFF
--- a/src/components/ActionMenu/ActionMenu.spec.js
+++ b/src/components/ActionMenu/ActionMenu.spec.js
@@ -54,14 +54,14 @@ describe('Action Menu Suite', () => {
         expect($(tooltip).getText()).toBe('An explanation as to why this item is disabled');
     });
 
-    it('should display menu item as a link when only one menu item', () => {
-        navigateToStory(component, singleItemStory);
-        browser.waitForVisible(actionMenuSingleItem);
+    // it('should display menu item as a link when only one menu item', () => {
+    //     navigateToStory(component, singleItemStory);
+    //     browser.waitForVisible(actionMenuSingleItem);
 
-        const tagType = browser.getTagName(actionMenuSingleItem);
-        const linkUrl = browser.getAttribute(actionMenuSingleItem, 'href');
+    //     const tagType = browser.getTagName(actionMenuSingleItem);
+    //     const linkUrl = browser.getAttribute(actionMenuSingleItem, 'href');
 
-        expect(linkUrl).toContain('iframe.html?selectedKind=Action%20Menu&selectedStory=Action%20Menu%20with%20one%20menu%20item#');
-        expect(tagType).toBe('a');
-    });
+    //     expect(linkUrl).toContain('iframe.html?selectedKind=Action%20Menu&selectedStory=Action%20Menu%20with%20one%20menu%20item#');
+    //     expect(tagType).toBe('a');
+    // });
 });

--- a/src/components/ActionMenu/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/ActionMenu.test.tsx
@@ -6,23 +6,23 @@ import ActionMenu from './ActionMenu';
 
 describe('ActionMenu', () => {
   const action = { title: 'whatever', onClick: () => undefined };
-  const createActionsOne = (closeMenu: Function) => {
-    return [action];
-  };
+  // const createActionsOne = (closeMenu: Function) => {
+  //   return [action];
+  // };
   const createActionsMany = (closeMenu: Function) => {
     return [action, action, action];
   };
 
-  it('should render a link when provided one action.', () => {
-    const result = mount(
-      <StaticRouter context={{}}>
-        <ActionMenu createActions={createActionsOne} />
-      </StaticRouter>,
-    );
-    expect(result.find('a')).toHaveLength(1);
-  });
+  // it('should render a link when provided one action.', () => {
+  //   const result = mount(
+  //     <StaticRouter context={{}}>
+  //       <ActionMenu createActions={createActionsOne} />
+  //     </StaticRouter>,
+  //   );
+  //   expect(result.find('a')).toHaveLength(1);
+  // });
 
-  it('should render a menu when provided many actions.', () => {
+  it('should render a menu when provided many or one action(s).', () => {
     const result = mount(
       <StaticRouter context={{}}>
         <ActionMenu createActions={createActionsMany}/>

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -108,17 +108,8 @@ class ActionMenu extends React.Component<CombinedProps, State> {
 
     if (typeof actions === 'undefined') { return null; }
 
-    return actions.length === 1
-      ? (actions as Action[]).map((a, idx) =>
-        <a
-          href="#"
-          key={idx}
-          onClick={e => a.onClick(e)}
-          className={classes.actionSingleLink}
-          data-qa-action-menu-link>
-            {a.title}
-        </a>)
-      : (<div className={classes.root}>
+    return (
+      <div className={classes.root}>
         <IconButton
           aria-owns={anchorEl ? 'action-menu' : undefined}
           aria-expanded={anchorEl ? true : undefined}
@@ -152,7 +143,8 @@ class ActionMenu extends React.Component<CombinedProps, State> {
             </MenuItem>,
           )}
         </Menu>
-      </div >);
+      </div >
+    );
   }
 }
 


### PR DESCRIPTION
### Purpose

Previously, the _Linode_ and _Community StackScripts_ were only rendering a _Deploy New Linode_ Link, which inconsistent with _My StackScripts_ because they were rendering a kebab menu

Now, StackScripts rows will render a Kebab, regardless of the amount of action items.

### Notes

* This is a site-wide change, so any component using an Action Menu that has one action item will always render a Kebab
* Commented out tests, just in case