### PR TITLE
M3-920 Domain deletion confirmation shows 'undefined' on submission.

### DIFF
--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -238,8 +238,9 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
   }
 
   closeRemoveDialog = () => {
+    const { removeDialog } = this.state;
     this.setState({
-      removeDialog: { open: false },
+      removeDialog: { ...removeDialog, open: false },
     });
   }
 


### PR DESCRIPTION
## Purpose
It was found that confirming the request to delete a Domain would result in "undefined" flashing in place of the domains title in the confirmation dialog. This was a result of clearing the state when closing the dialog, which was unnecessary.