### PR TITLE
M3-787 Volume size during creation should be limited.

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeVolumes/VolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/VolumeDrawer.tsx
@@ -126,6 +126,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       label="Size"
       onChange={this.onSizeChange}
       value={this.props.size}
+      helperText={'Maximum: 10240'}
       InputProps={{
         endAdornment: <span className={this.props.classes.suffix}>GB</span>,
       }}


### PR DESCRIPTION
## Purpose
Display error text when the user attempts to set 'size' of a volume larger than 10240 during volume creation.

## Notes
I acknowledge there is duplicate code here. This will be addressed in the future effort when switch LinodeVolumes to use the global volume creation drawer.

Additionally, I added the imperative versions of the same code for comparison. If anyone finds the usage of Ramda's when function difficult to read, we can use the imperative version.

https://github.com/linode/manager/issues/3437