### PR TITLE
M3-967 M3-1032 Linodes without IPv6

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -265,6 +265,86 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
           linodeRegion={ZONES[linodeRegion]}
         />
 
+        {this.renderIPv4()}
+
+        {this.renderIPv6()}
+
+        <Grid container>
+          <Grid item xs={12}>
+            <Typography
+              variant="title"
+              className={classes.netActionsTitle}
+              data-qa-network-actions-title
+            >
+              Networking Actions
+            </Typography>
+            <IPTransferPanel
+              linodeID={linodeID}
+              linodeRegion={linodeRegion}
+              refreshIPs={this.refreshIPs}
+              ipAddresses={[
+                ...linodeIPs.ipv4.public.map(i => i.address),
+                ...linodeIPs.ipv4.private.map(i => i.address),
+              ]}
+            />
+            <IPSharingPanel
+              linodeID={linodeID}
+              linodeIPs={[
+                ...linodeIPs.ipv4.public.map(i => i.address),
+              ]}
+              linodeSharedIPs={[
+                ...linodeIPs.ipv4.shared.map(i => i.address),
+              ]}
+              linodeRegion={linodeRegion}
+              refreshIPs={this.refreshIPs}
+            />
+          </Grid>
+        </Grid>
+
+        <ViewIPDrawer
+          open={this.state.viewIPDrawer.open}
+          onClose={this.closeViewIPDrawer}
+          ip={this.state.viewIPDrawer.ip}
+        />
+
+        <ViewRangeDrawer
+          open={this.state.viewRangeDrawer.open}
+          onClose={this.closeViewRangeDrawer}
+          range={this.state.viewRangeDrawer.range}
+        />
+
+        <EditRDNSDrawer
+          open={this.state.editRDNSDrawer.open}
+          onClose={this.closeEditRDNSDrawer}
+          address={this.state.editRDNSDrawer.address}
+          rdns={this.state.editRDNSDrawer.rdns}
+        />
+
+        <CreateIPv6Drawer
+          open={this.state.createIPv6Drawer.open}
+          onClose={this.closeCreateIPv6Drawer}
+        />
+
+        <CreateIPv4Drawer
+          forPublic={this.state.createIPv4Drawer.forPublic}
+          open={this.state.createIPv4Drawer.open}
+          onClose={this.closeCreateIPv4Drawer}
+          linodeID={linodeID}
+        />
+      </React.Fragment>
+    );
+  }
+
+  renderIPv4 = () => {
+    const { classes } = this.props;
+    const ipv4 = path<Linode.LinodeIPsResponseIPV4>(['linodeIPs', 'response', 'ipv4'], this.props);
+
+    if (!ipv4) { return null; }
+
+    const { private: privateIPs, public: publicIPs, shared: sharedIPs } = ipv4;
+
+    return (
+      <React.Fragment>
         <Grid container justify="space-between" alignItems="flex-end">
           <Grid item className={classes.ipv4TitleContainer}>
             <Typography
@@ -308,17 +388,31 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
               </TableRow>
             </TableHead>
             <TableBody>
-              {linodeIPs.ipv4.public.map((ip: Linode.IPAddress) => this.renderIPRow(ip, 'Public'))}
-              {linodeIPs.ipv4.private.map((ip: Linode.IPAddress) => this.renderIPRow(ip, 'Private'))}
-              {linodeIPs.ipv4.shared.map((ip: Linode.IPAddress) => this.renderIPRow(ip, 'Shared'))}
+              {publicIPs.map((ip: Linode.IPAddress) => this.renderIPRow(ip, 'Public'))}
+              {privateIPs.map((ip: Linode.IPAddress) => this.renderIPRow(ip, 'Private'))}
+              {sharedIPs.map((ip: Linode.IPAddress) => this.renderIPRow(ip, 'Shared'))}
             </TableBody>
           </Table>
         </Paper>
+      </React.Fragment>
+    );
+  };
 
+  renderIPv6 = () => {
+    const { classes } = this.props;
+    const ipv6 = path<Linode.LinodeIPsResponseIPV6>(['linodeIPs', 'response', 'ipv6'], this.props);
+
+    if (!ipv6) { return null; }
+
+    const { slaac, link_local, global: globalRange } = ipv6;
+
+    return (
+      <React.Fragment>
         <Grid
           container
           justify="space-between"
-          alignItems="flex-end">
+          alignItems="flex-end"
+        >
           <Grid item>
             <Typography
               variant="title"
@@ -347,77 +441,14 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
               </TableRow>
             </TableHead>
             <TableBody>
-              {[linodeIPs.ipv6.slaac].map((ip: Linode.IPAddress) => this.renderIPRow(ip, 'SLAAC'))}
-              {[linodeIPs.ipv6.link_local].map((ip: Linode.IPAddress) => this.renderIPRow(ip, 'Link Local'))}
-              {linodeIPs.ipv6.global.map((range: Linode.IPRange) => this.renderRangeRow(range, 'Range'))}
+              {slaac && this.renderIPRow(slaac, 'SLAAC')}
+              {link_local && this.renderIPRow(link_local, 'Link Local')}
+              {globalRange && globalRange.map((range: Linode.IPRange) => this.renderRangeRow(range, 'Range'))}
             </TableBody>
           </Table>
         </Paper>
-
-        <Grid container>
-          <Grid item xs={12}>
-            <Typography
-              variant="title"
-              className={classes.netActionsTitle}
-              data-qa-network-actions-title
-            >
-              Networking Actions
-            </Typography>
-              <IPTransferPanel
-                linodeID={linodeID}
-                linodeRegion={linodeRegion}
-                refreshIPs={this.refreshIPs}
-                ipAddresses={[
-                  ...linodeIPs.ipv4.public.map(i => i.address),
-                  ...linodeIPs.ipv4.private.map(i => i.address),
-                ]}
-              />
-              <IPSharingPanel
-                linodeID={linodeID}
-                linodeIPs={[
-                  ...linodeIPs.ipv4.public.map(i => i.address),
-                ]}
-                linodeSharedIPs={[
-                  ...linodeIPs.ipv4.shared.map(i => i.address),
-                ]}
-                linodeRegion={linodeRegion}
-                refreshIPs={this.refreshIPs}
-              />
-          </Grid>
-        </Grid>
-
-        <ViewIPDrawer
-          open={this.state.viewIPDrawer.open}
-          onClose={this.closeViewIPDrawer}
-          ip={this.state.viewIPDrawer.ip}
-        />
-
-        <ViewRangeDrawer
-          open={this.state.viewRangeDrawer.open}
-          onClose={this.closeViewRangeDrawer}
-          range={this.state.viewRangeDrawer.range}
-        />
-
-        <EditRDNSDrawer
-          open={this.state.editRDNSDrawer.open}
-          onClose={this.closeEditRDNSDrawer}
-          address={this.state.editRDNSDrawer.address}
-          rdns={this.state.editRDNSDrawer.rdns}
-        />
-
-        <CreateIPv6Drawer
-          open={this.state.createIPv6Drawer.open}
-          onClose={this.closeCreateIPv6Drawer}
-        />
-
-        <CreateIPv4Drawer
-          forPublic={this.state.createIPv4Drawer.forPublic}
-          open={this.state.createIPv4Drawer.open}
-          onClose={this.closeCreateIPv4Drawer}
-          linodeID={linodeID}
-        />
       </React.Fragment>
-    );
+    )
   }
 }
 

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -98,9 +98,12 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = (props) => {
           <Typography className={classes.section} variant="caption">
             <IPAddress ips={linode.ipv4} copyRight />
           </Typography>
-          <Typography className={classes.section} variant="caption">
-            <IPAddress ips={[linode.ipv6]} copyRight />
-          </Typography>
+          {
+            linode.ipv6 &&
+            <Typography className={classes.section} variant="caption">
+              <IPAddress ips={[linode.ipv6]} copyRight />
+            </Typography>
+          }
         </Grid>
         <Grid item xs={12} sm={6} lg={4} className={classes.region}>
           <Typography className={`${classes.section}`} variant="caption">

--- a/src/types/Linode.ts
+++ b/src/types/Linode.ts
@@ -108,16 +108,20 @@ namespace Linode {
   }
 
   export interface LinodeIPsResponse {
-    ipv4: {
-      public: IPAddress[];
-      private: IPAddress[];
-      shared: IPAddress[];
-    };
-    ipv6: {
-      link_local: IPAddress;
-      slaac: IPAddress;
-      global: IPRange[];
-    };
+    ipv4: LinodeIPsResponseIPV4;
+    ipv6?: LinodeIPsResponseIPV6;
+  }
+
+  export interface LinodeIPsResponseIPV4 {
+    public: IPAddress[];
+    private: IPAddress[];
+    shared: IPAddress[];
+  }
+
+  export interface LinodeIPsResponseIPV6 {
+    link_local: IPAddress;
+    slaac: IPAddress;
+    global: IPRange[];
   }
 
   export type LinodeStatus =


### PR DESCRIPTION
## Purpose
Very old Linodes may not have IPv6. Use safe object access to prevent unnecessary error displays.