### PR TITLE
Ripple color for off switch on focus

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -575,6 +575,9 @@ const LinodeTheme: Linode.Theme = {
         border: '1px solid #999',
         boxSizing: 'content-box',
       },
+      switchBase: {
+        color: '#3B85D9',
+      },
     },
     MuiTab: {
       root: {


### PR DESCRIPTION
When tabbing through a form and landing on an off Switch/Toggle we would not get the ripple color.
Fixed in this pr. ex: /profile/settings  