### PR TITLE
M3-464 Display rebuilding when a Linode is rebuilding.

### DIFF
--- a/src/features/linodes/transitions.ts
+++ b/src/features/linodes/transitions.ts
@@ -6,6 +6,7 @@ export const transitionStatus = [
   'deleting',
   'migrating',
   'resizing',
+  'rebuilding',
 ];
 
 export const transitionAction = [


### PR DESCRIPTION
## Purpose
Rebuild was not being displayed in the Linode landing or power control.