### PR TITLE
Fix volumes landing action.

### DIFF
--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -349,21 +349,21 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                     },
                   });
                 }}
-                onEdit={() => openForEdit(
+                onEdit={() => this.props.openForEdit(
                   volume.id,
                   label,
                   size,
                   regionID,
                   linodeLabel,
                 )}
-                onResize={() => openForResize(
+                onResize={() => this.props.openForResize(
                   volume.id,
                   label,
                   size,
                   regionID,
                   linodeLabel,
                 )}
-                onClone={() => openForClone(
+                onClone={() => this.props.openForClone(
                   volume.id,
                   label,
                   size,
@@ -540,7 +540,7 @@ const styled = withStyles(styles, { withTheme: true });
 const documented = setDocs(VolumesLanding.docs);
 
 export default compose<Linode.TodoAny, Linode.TodoAny, Linode.TodoAny, Linode.TodoAny>(
-  documented,
   connected,
+  documented,
   styled,
 )(VolumesLanding);


### PR DESCRIPTION
## Purpose
Found a regression that caused the rename, resize, and clone actions, located on the Volumes Landing action menu, to not open the volume drawer as expected.

Found that shadowed names of the bound action creators caused the regression during the recent pagination PR.