### PR TITLE
M3-1090 Request domains on successful creation.

### DIFF
--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -29,7 +29,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 
 interface Props {
   open: boolean;
-  onClose: (domain?: Partial<Linode.Domain>) => void;
+  onClose: () => void;
+  onSuccess: () => void;
   mode: 'clone' | 'create';
   cloneID?: number;
   domain?: string;
@@ -197,7 +198,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
   reset = () => this.setState({ ...this.defaultState });
 
   create = () => {
-    const { onClose } = this.props;
+    const { onClose, onSuccess } = this.props;
     const { domain, type, soaEmail, master_ips } = this.state;
 
     const finalMasterIPs = master_ips.filter(v => v !== '');
@@ -223,7 +224,8 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
     createDomain(data)
       .then((res) => {
         this.reset();
-        onClose(res.data);
+        onSuccess();
+        onClose();
       })
       .catch((err) => {
         this.setState({
@@ -249,7 +251,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
     cloneDomain(cloneID, cloneName)
       .then((res) => {
         this.reset();
-        onClose(res.data);
+        onClose();
       })
       .catch((err) => {
         this.setState({

--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -238,7 +238,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
   }
 
   clone = () => {
-    const { onClose, cloneID } = this.props;
+    const { onClose, onSuccess, cloneID } = this.props;
     const { cloneName } = this.state;
 
     if (!cloneID) {
@@ -251,6 +251,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
     cloneDomain(cloneID, cloneName)
       .then((res) => {
         this.reset();
+        onSuccess()
         onClose();
       })
       .catch((err) => {

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -1,7 +1,3 @@
-import { compose, pathOr } from 'ramda';
-import * as React from 'react';
-import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
-
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
 import TableBody from '@material-ui/core/TableBody';
@@ -9,7 +5,9 @@ import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
-
+import { compose, pathOr } from 'ramda';
+import * as React from 'react';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import DomainIcon from 'src/assets/addnewmenu/domain.svg';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
@@ -25,7 +23,6 @@ import TableRowLoading from 'src/components/TableRowLoading';
 import { sendToast } from 'src/features/ToastNotifications/toasts';
 import { deleteDomain, getDomains } from 'src/services/domains';
 import scrollToTop from 'src/utilities/scrollToTop';
-
 import ActionMenu from './DomainActionMenu';
 import DomainCreateDrawer from './DomainCreateDrawer';
 import DomainZoneImportDrawer from './DomainZoneImportDrawer';
@@ -171,21 +168,16 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
     });
   }
 
-  openCloneDrawer(domain: string, id: number) {
+  openCloneDrawer = (domain: string, id: number) => {
     this.setState({
       createDrawer: { open: true, mode: 'clone', domain, cloneID: id },
     });
   }
 
-  closeCreateDrawer(domain?: Partial<Linode.Domain>) {
+  closeCreateDrawer = () => {
     this.setState({
       createDrawer: { open: false, mode: 'create' },
     });
-    if (domain) {
-      this.setState({
-        domains: [...this.state.domains, domain as Linode.Domain],
-      });
-    }
   }
 
   getActions = () => {
@@ -232,10 +224,11 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
     return (
       <DomainCreateDrawer
         open={this.state.createDrawer.open}
-        onClose={(domain: Partial<Linode.Domain>) => this.closeCreateDrawer(domain)}
+        onClose={this.closeCreateDrawer}
         mode={this.state.createDrawer.mode}
         domain={this.state.createDrawer.domain}
         cloneID={this.state.createDrawer.cloneID}
+        onSuccess={this.getDomains}
       />
     );
   }


### PR DESCRIPTION
## Purpose
Recent pagination changes cause a bug when going from an empty state to stateful view. TL;DR the "count" is not updated when pushing a new volume onto the array. Rather than just pushing the newly created domain on the state, I'm re-sending the current paginated request.