### PR TITLE
Adding missing icon to textfield as selects

### DIFF
--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -7,6 +7,7 @@ import * as classNames from 'classnames';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
+import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 
 import HelpIcon from 'src/components/HelpIcon';
 
@@ -107,6 +108,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
             disableUnderline: true,
           }}
           SelectProps={{
+            IconComponent: KeyboardArrowDown,
             MenuProps: {
               getContentAnchorEl: undefined,
               anchorOrigin: { vertical: 'bottom', horizontal: 'left' },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -497,6 +497,7 @@ const LinodeTheme: Linode.Theme = {
       },
       icon: {
         marginTop: -2,
+        marginRight: 4,
         width: 28,
         height: 28,
         transition: 'color 225ms ease-in-out',


### PR DESCRIPTION
I recently replaced the icon for the select fields but forgot to add it for textfields with the select props.