### PR TITLE
M3-733 Lazy Load StackScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-router-dom": "^4.2.2",
     "react-sticky": "^6.0.1",
     "react-text-mask": "^5.4.3",
+    "react-waypoint": "^8.0.3",
     "redux": "^3.7.2",
     "rxjs": "^5.5.6",
     "source-map-loader": "^0.2.1",

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
+import Waypoint from 'react-waypoint';
+
 import {
   StyleRulesCallback,
   Theme,
@@ -681,18 +683,23 @@ class SelectStackScriptPanelContent extends React.Component<CombinedProps, State
         * so don't show the "show more stackscripts" button
         */}
         {this.state.showMoreButtonVisible && !isSorting &&
-          <Button
-            title="Show More StackScripts"
-            onClick={this.getNext}
-            type="secondary"
-            disabled={this.state.gettingMoreStackScripts}
-            style={{ marginTop: 32 }}
-          >
-            {!this.state.gettingMoreStackScripts
-              ? 'Show More StackScripts'
-              : 'Loading...'
-            }
-          </Button>
+          <React.Fragment>
+            <Waypoint
+              onEnter={() => console.log('hello world')}
+            />
+            <Button
+              title="Show More StackScripts"
+              onClick={this.getNext}
+              type="secondary"
+              disabled={this.state.gettingMoreStackScripts}
+              style={{ marginTop: 32 }}
+            >
+              {!this.state.gettingMoreStackScripts
+                ? 'Show More StackScripts'
+                : 'Loading...'
+              }
+            </Button>
+          </React.Fragment>
         }
         {this.renderDeleteStackScriptDialog()}
         {this.renderMakePublicDialog()}

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -169,8 +169,6 @@ class SelectStackScriptPanelContent extends React.Component<CombinedProps, State
       .then((response: Linode.ResourcePage<Linode.StackScript.Response>) => {
         if (!this.mounted) { return; }
 
-        if (page > 1) { throw new Error('noooooo') }
-
         /*
         * if we have no results at all or if we've loaded all available results
         */
@@ -526,7 +524,9 @@ class SelectStackScriptPanelContent extends React.Component<CombinedProps, State
         actions={this.renderConfirmDeleteActions}
         onClose={this.handleCloseDialog}
       >
-        <Typography>Are you sure you want to delete this StackScript?</Typography>
+        <Typography>
+          Are you sure you want to delete this StackScript?
+        </Typography>
       </ConfirmationDialog>
     )
   }
@@ -555,6 +555,9 @@ class SelectStackScriptPanelContent extends React.Component<CombinedProps, State
     const { currentFilter } = this.state;
     const filteredUser = (isLinodeStackScripts) ? 'linode' : currentUser;
 
+    /*
+    * Search by label or description of the StackScript
+    */
     const filter = {
       ["+or"]: [
         {
@@ -702,7 +705,8 @@ class SelectStackScriptPanelContent extends React.Component<CombinedProps, State
         {!isSorting && !allStackScriptsLoaded && !gettingMoreStackScripts &&
           <div style={{ textAlign: 'center' }}>
             {/* 
-            * If the lazy-load failed, show the "Show more StackScripts button
+            * If the lazy-load failed (marked by the catch in getNext), 
+            * show the "Show more StackScripts button
             * Otherwise, try to lazy load some more dang stackscripts
             */}
             {(!getMoreStackScriptsFailed)

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -692,7 +692,7 @@ class SelectStackScriptPanelContent extends React.Component<CombinedProps, State
             * show loading indicator if we're getting more stackscripts
             * and if we're not showing the "get more stackscripts" button
             */}
-            {gettingMoreStackScripts &&
+            {gettingMoreStackScripts && !isSorting &&
               <div style={{ margin: '32px 0 32px 0', textAlign: 'center' }}><CircleProgress mini /></div>
             }
           </React.Fragment>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3343,6 +3343,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
+"consolidated-events@^1.1.0 || ^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/consolidated-events/-/consolidated-events-2.0.2.tgz#da8d8f8c2b232831413d9e190dc11669c79f4a91"
+
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
@@ -8609,7 +8613,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -9096,6 +9100,13 @@ react-treebeard@^2.1.0:
     radium "^0.19.0"
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
+
+react-waypoint@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/react-waypoint/-/react-waypoint-8.0.3.tgz#860db860d3301c6f449800f7a330856028730af5"
+  dependencies:
+    consolidated-events "^1.1.0 || ^2.0.0"
+    prop-types "^15.0.0"
 
 react@^16.4.1:
   version "16.4.1"


### PR DESCRIPTION
### Purpose

Lazy load some more stackscripts when a user reaches the bottom of the list

### Notes
* Implements react-waypoint, which takes a function to run when it enters the viewport
* If a lazy-load fails, the "Show More StackScripts" button will appear and give the user another try to load more StackScripts
   * Test by throwing an error in the `then` of `getDataAtPage`
* `<Waypoint />` will only render if a request isn't currently running to prevent from firing multiple requests when a user scrolls up and down over and over and over

#### References
[react-waypoint](https://github.com/brigade/react-waypoint)
