### PR TITLE
missing line break between address1 and address2

### DIFF
--- a/src/features/Account/AccountPanels/SummaryPanel/SummaryPanel.tsx
+++ b/src/features/Account/AccountPanels/SummaryPanel/SummaryPanel.tsx
@@ -135,7 +135,7 @@ export class SummaryPanel extends React.Component<CombinedProps, State> {
                 <strong>Address: </strong>
                 {!(address_1 || address_2 || city || state || zip) && 'None'}
                 <span>{address_1}</span>
-                <span>{address_2}</span>
+                <div className={classes.address2}>{address_2}</div>
                 <div className={classes.address2}>
                   {`${city} ${city && state && ', '} ${state} ${zip}`}
                 </div>


### PR DESCRIPTION
Currently looks like:

![screen shot 2018-08-08 at 4 13 19 pm](https://user-images.githubusercontent.com/6052180/43861865-23d5fc7c-9b26-11e8-8262-352246c8b4f3.png)

Being unfamiliar with React and convention, I don't know if this is the correct way to fix it, but works locally.