### PR TITLE
Fix error display bug and post-ticket bug

### DIFF
--- a/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -223,7 +223,7 @@ class SupportTicketDrawer extends React.Component<CombinedProps, State> {
   onSubmit = () => {
     const { description, entity_type, entity_id, summary } = this.state.ticket;
     const { onSuccess } = this.props;
-    if (entity_type && !entity_id) {
+    if (entity_type !== 'none' && !entity_id) {
       this.setState({ 
         errors: [{ field: 'input', reason: `Please select a ${entityIdtoNameMap[entity_type]}.`}]
       });

--- a/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -223,7 +223,7 @@ class SupportTicketDrawer extends React.Component<CombinedProps, State> {
   onSubmit = () => {
     const { description, entity_type, entity_id, summary } = this.state.ticket;
     const { onSuccess } = this.props;
-    if (entity_type !== 'none' && !entity_id) {
+    if (!['none','general'].includes(entity_type) && !entity_id) {
       this.setState({ 
         errors: [{ field: 'input', reason: `Please select a ${entityIdtoNameMap[entity_type]}.`}]
       });

--- a/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -67,6 +67,7 @@ const L = {
   entity_id: lensPath(['ticket','entity_id']),
   inputValue: lensPath(['inputValue']),
   data: lensPath(['data']),
+  errors: lensPath(['errors']),
 };
 
 const entityMap = {
@@ -189,7 +190,8 @@ class SupportTicketDrawer extends React.Component<CombinedProps, State> {
       set(L.entity_type, e.target.value),
       set(L.entity_id, undefined),
       set(L.inputValue, ''),
-      set(L.data, [])
+      set(L.data, []),
+      set(L.errors, undefined),
     ]);
   }
 
@@ -222,7 +224,9 @@ class SupportTicketDrawer extends React.Component<CombinedProps, State> {
     const { description, entity_type, entity_id, summary } = this.state.ticket;
     const { onSuccess } = this.props;
     if (entity_type && !entity_id) {
-      this.setState({ errors: [{ reason: `Please select a ${entityIdtoNameMap[entity_type]}.`}] });
+      this.setState({ 
+        errors: [{ field: 'input', reason: `Please select a ${entityIdtoNameMap[entity_type]}.`}]
+      });
       return;
     }
     this.setState({ errors: undefined });
@@ -266,6 +270,7 @@ class SupportTicketDrawer extends React.Component<CombinedProps, State> {
     const summaryError = hasErrorFor('summary');
     const descriptionError = hasErrorFor('description');
     const generalError = hasErrorFor('none');
+    const inputError = hasErrorFor('input');
 
     const hasNoEntitiesMessage = this.getHasNoEntitiesMessage();
 
@@ -310,6 +315,7 @@ class SupportTicketDrawer extends React.Component<CombinedProps, State> {
             value={ticket.entity_id}
             handleSelect={this.handleEntityIDChange}
             disabled={data.length === 0}
+            errorText={inputError}
             helperText={hasNoEntitiesMessage}
             placeholder={`Select a ${entityIdtoNameMap[ticket.entity_type]}`}
             label={entityIdtoNameMap[ticket.entity_type]}

--- a/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -77,7 +77,7 @@ export class SupportTicketsLanding extends React.Component<CombinedProps, State>
 
   render() {
     const { classes } = this.props;
-    const { notice, value } = this.state;
+    const { notice, newTicket, value } = this.state;
 
 
     return (
@@ -114,7 +114,7 @@ export class SupportTicketsLanding extends React.Component<CombinedProps, State>
           </Tabs>
         </AppBar>
         {/* NB: 0 is the index of the open tickets tab, which evaluates to false */}
-        <TicketList filterStatus={value ? 'closed' : 'open'} />
+        <TicketList newTicket={newTicket} filterStatus={value ? 'closed' : 'open'} />
         {this.renderTicketDrawer()}
       </React.Fragment>
     );


### PR DESCRIPTION
* Client side error checking now uses errorText in the input field
rather than a Notice when a user attempts to create a ticket
with a Product but no entity
* The newTicket prop was not being passed to the TicketList due
to a regression. Readding it allows the list of tickets to be updated
when a new ticket is added.