### PR TITLE
Hotfix/fix support link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -287,10 +287,6 @@ export class App extends React.Component<CombinedProps, State> {
     window.localStorage.setItem('BetaNotification', 'closed');
   }
 
-  Dashboard = () => <Placeholder title="Dashboard" />;
-
-  Support = () => <Placeholder title="Support" />;
-
   render() {
     const { menuOpen } = this.state;
     const { classes, longLivedLoaded, documentation, toggleTheme } = this.props;
@@ -321,7 +317,6 @@ export class App extends React.Component<CombinedProps, State> {
                             <Route exact path="/billing" component={Account} />
                             <Route exact path="/billing/invoices/:invoiceId" component={InvoiceDetail} />
                             <Route path="/users" component={Users} />
-                            <Route exact path="/support" render={this.Support} />
                             <Route exact path="/support/tickets" component={SupportTickets} />
                             <Route path="/support/tickets/:ticketId" component={SupportTicketDetail} />
                             <Route path="/profile" component={Profile} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,6 @@ import DefaultLoader from 'src/components/DefaultLoader';
 import DocsSidebar from 'src/components/DocsSidebar';
 import Grid from 'src/components/Grid';
 import NotFound from 'src/components/NotFound';
-import Placeholder from 'src/components/Placeholder';
 import SideMenu from 'src/components/SideMenu';
 import { RegionsProvider, WithRegionsContext } from 'src/context/regions';
 import { TypesProvider, WithTypesContext } from 'src/context/types';

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -336,7 +336,7 @@ class PrimaryNav extends React.Component<Props, State> {
                 [classes.linkItem]: true,
                 [classes.activeLink]:
                   expandedMenus.support
-                  || this.linkIsActive('/support') === true,
+                  || this.linkIsActive('/support/tickets') === true,
               })}
             >
               <KeyboardArrowRight className={classes.arrow} />
@@ -345,7 +345,7 @@ class PrimaryNav extends React.Component<Props, State> {
           </ListItem>
           <Collapse
             in={expandedMenus.support
-                || this.linkIsActive('/support') === true}
+                || this.linkIsActive('/support/tickets') === true}
             timeout="auto"
             unmountOnExit
             className={classes.sublinkPanel}
@@ -367,11 +367,11 @@ class PrimaryNav extends React.Component<Props, State> {
               Community Forum
             </a>
             <Link
-              to="/support"
+              to="/support/tickets"
               role="menuitem"
               className={classNames({
                 [classes.sublink]: true,
-                [classes.sublinkActive]: this.linkIsActive('/support') === true,
+                [classes.sublinkActive]: this.linkIsActive('/support/tickets') === true,
               })}
             >
               Support Tickets


### PR DESCRIPTION
Now that Support is active, we don't want to render a placeholder saying that the feature is in development (at `/support`). 

Changed `PrimaryNav` links so that "support tickets" goes to `/support/tickets`.