### PR TITLE
M3-1020 - User Detail Page Tests

### DIFF
--- a/e2e/pageobjects/account/user-detail.page.js
+++ b/e2e/pageobjects/account/user-detail.page.js
@@ -1,0 +1,54 @@
+const { constants } = require('../../constants');
+
+import Page from '../page';
+
+class UserDetail extends Page {
+    get userDetailHeader() { return $('[data-qa-user-detail-header]'); }
+    get subHeader() { return $('[data-qa-profile-header]'); }
+    get deleteSubHeader() { return $('[data-qa-delete-user-header]'); }
+    get deleteButton() { return $('[data-qa-confirm-delete]'); }
+    get deleteHelpButton() { return $('[data-qa-help-button]'); }
+    get usernameField() { return $('[data-qa-username]'); }
+    get emailField() { return $('[data-qa-email]'); }
+    get saveButton() { return $('[data-qa-submit]'); }
+    get cancelButton() { return $('[data-qa-cancel]'); }
+
+    baseElementsDisplay(owner) {
+        this.userDetailHeader.waitForVisible(constants.wait.normal);
+        this.subHeader.waitForVisible(constants.wait.normal);
+
+        if (owner) {
+            expect(this.deleteHelpButton.isExisting()).toBe(true);
+        }
+
+        expect(this.deleteSubHeader.isVisible()).toBe(true);
+        expect(this.deleteButton.isExisting()).toBe(true);
+        expect(this.usernameField.isVisible()).toBe(true);
+        expect(this.emailField.isVisible()).toBe(true);
+        expect(this.saveButton.isVisible()).toBe(true);
+        expect(this.cancelButton.isVisible()).toBe(true);
+    }
+
+
+    updateUsername(username) {
+        this.usernameField.$('input').setValue(username);
+        this.saveButton.click();
+        this.waitForNotice('User Profile updated successfully', constants.wait.normal);
+    }
+
+    deleteUser() {
+        this.deleteButton.click();
+        this.dialogTitle.waitForText(constants.wait.normal);
+
+        expect(this.dialogTitle.getText()).toBe('Confirm Deletion');
+        expect(this.dialogContent.getText()).toContain('will be permanently deleted');
+        expect(this.dialogConfirmCancel.isVisible()).toBe(true);
+        expect(this.dialogConfirmDelete.isVisible()).toBe(true);
+
+        this.dialogTitle.$('..').$(this.dialogConfirmDelete.selector).click();
+        this.waitForNotice('deleted successfully', constants.wait.normal);
+        expect(browser.getUrl()).toMatch(/\/users$/);
+    }
+}
+
+export default new UserDetail();

--- a/e2e/specs/account/user-detail-spec.js
+++ b/e2e/specs/account/user-detail-spec.js
@@ -1,0 +1,82 @@
+const { constants } = require('../../constants');
+
+import UserDetail from '../../pageobjects/account/user-detail.page';
+import Users from '../../pageobjects/account/users.page';
+
+describe('Account - User Detail - Username Suite', () => {
+    const userConfig = {
+        username: `test-user${new Date().getTime()}`,
+        email: `pthiel@linode.com`,
+    }
+
+    beforeAll(() => {
+        browser.url(constants.routes.account.users);
+        Users.baseElementsDisplay();
+        Users.add(userConfig);
+        const userRow = Users.userRow(userConfig.username);
+        userRow.$(Users.username.selector).click();
+    });
+
+    describe('User Detail - Update Username Suite', () => {
+        it('should display user detail page base elements', () => {
+            UserDetail.baseElementsDisplay();
+        });
+
+        it('should clear username changes on cancel', () => {
+            const originalUsername = browser.getText(`${UserDetail.usernameField.selector} input`);
+            browser.setValue(`${UserDetail.usernameField.selector} input`, `someTest${new Date().getTime()}`);
+            UserDetail.cancelButton.click();
+            const updatedUsername = browser.getText(`${UserDetail.usernameField.selector} input`);
+
+            expect(updatedUsername).toBe(originalUsername);
+        });
+
+        it('should fail to update username on empty string', () => {
+            UserDetail.usernameField.$('input').setValue(' ');
+            UserDetail.saveButton.click();
+            UserDetail.usernameField.$('p').waitForVisible(constants.wait.normal);
+            expect(UserDetail.usernameField.$('p').getText()).toContain('Username may only contain');
+            UserDetail.cancelButton.click();
+        });
+
+        it('should fail validation on bad username value', () => {
+            const badUsername = '$%#5364é-';
+            UserDetail.usernameField.$('input').setValue(badUsername);
+            UserDetail.saveButton.click();
+            UserDetail.usernameField.$('p').waitForVisible(constants.wait.normal);
+            expect(UserDetail.usernameField.$('p').getText()).toContain('Username must only use ASCII characters');
+            UserDetail.cancelButton.click();
+        });
+
+        it('should fail to update when submitting an existing username', () => {
+            UserDetail.usernameField.$('input').setValue(process.env.MANAGER_USER);
+            UserDetail.saveButton.click();
+            UserDetail.usernameField.$('p').waitForVisible(constants.wait.normal);
+            expect(UserDetail.usernameField.$('p').getText()).toContain('Username taken');
+            UserDetail.cancelButton.click();
+
+        });
+
+        it('should succeed updating with a legitimate username', () => {
+            UserDetail.updateUsername(`Test${new Date().getTime()}`);
+        });
+    });
+
+    describe('User Detail - Remove User Suite', () => {
+       it('should display the remove dialog', () => {
+            UserDetail.deleteButton.click();
+            UserDetail.dialogTitle.waitForVisible(constants.wait.normal);
+            UserDetail.dialogConfirmDelete.waitForVisible(constants.wait.normal);
+            UserDetail.dialogConfirmCancel.waitForVisible(constants.wait.normal);
+        });
+
+        it('should dismiss the dialog on cancel', () => {
+            UserDetail.dialogConfirmCancel.click();
+            UserDetail.dialogTitle.waitForExist(constants.wait.normal, true);
+        }); 
+
+        it('should remove the user', () => {
+            UserDetail.deleteUser();
+        });
+    });
+});

--- a/src/features/Users/UserProfile.tsx
+++ b/src/features/Users/UserProfile.tsx
@@ -106,7 +106,7 @@ class UserProfile extends React.Component<CombinedProps> {
           {generalError &&
             <Notice error>Error when updating user profile</Notice>
           }
-          <Typography role="header" variant="title">
+          <Typography variant="title" data-qa-profile-header>
             User Profile
           </Typography>
           <TextField
@@ -115,12 +115,14 @@ class UserProfile extends React.Component<CombinedProps> {
             value={username}
             onChange={changeUsername}
             errorText={hasErrorFor('username')}
+            data-qa-username
           />
           <TextField
             disabled /* API doesn't allow changing user email address */
             className={classes.field}
             label="Email Address"
             value={email}
+            data-qa-email
           />
           <ActionsPanel style={{ marginTop: 16 }}>
             <Button
@@ -180,7 +182,7 @@ class UserProfile extends React.Component<CombinedProps> {
     return (
       <Paper className={classes.deleteRoot}>
         <div className={classes.inner}>
-          <Typography role="header" variant="title">
+          <Typography variant="title" data-qa-delete-user-header>
             Delete User
           </Typography>
           {userDeleteError &&


### PR DESCRIPTION
* This PR has been based off the 08-10 test maintenance PR, once that is merged i will rebase off dev.
* Adds `Account - User Detail - Username Suite` for creating/updating/removing usernames. 

## To Test:

```bash
yarn && yarn start
yarn selenium
yarn e2e --file e2e/specs/account/user-detail-spec.js
```
