### PR TITLE
M3-992 Removed Managed from Nav

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -36,6 +36,7 @@ const primaryLinks: PrimaryLink[] = [
 
 type ClassNames =
   'menuGrid'
+  | 'fadeContainer'
   | 'logoItem'
   | 'listItem'
   | 'collapsible'
@@ -65,6 +66,9 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
     [theme.breakpoints.up('md')]: {
       minHeight: 80,
     },
+  },
+  fadeContainer: {
+    width: '100%',
   },
   logoItem: {
     padding: '10px 0 8px 26px',
@@ -268,10 +272,6 @@ class PrimaryNav extends React.Component<Props, State> {
     const { expandedMenus, userHasManaged } = this.state;
     const themeName = (this.props.theme as any).name;
 
-    if (userHasManaged === undefined) {
-      return null;
-    }
-
     return (
       <React.Fragment>
         <Grid
@@ -292,118 +292,128 @@ class PrimaryNav extends React.Component<Props, State> {
             </Link>
             </div>
           </Grid>
-          
-          {primaryLinks.map(primaryLink => this.renderPrimaryLink(primaryLink))}
 
-          <ListItem
-            data-menu-name="account"
-            focusRipple={true}
-            button
-            component="li"
-            role="menuitem"
-            onClick={this.expandMenutItem}
-            className={classNames({
-              [classes.listItem]: true,
-              [classes.collapsible]: true,
-            })}
-          >
-            <ListItemText
-              disableTypography={true}
+          {userHasManaged !== undefined &&
+          <div className={classNames(
+            'fade-in-table',
+            {
+              [classes.fadeContainer]: true,
+            }
+          )}>
+
+            {primaryLinks.map(primaryLink => this.renderPrimaryLink(primaryLink))}
+
+            <ListItem
+              data-menu-name="account"
+              focusRipple={true}
+              button
+              component="li"
+              role="menuitem"
+              onClick={this.expandMenutItem}
               className={classNames({
-                [classes.linkItem]: true,
-                [classes.activeLink]:
-                  expandedMenus.account
-                  || this.linkIsActive('/billing') === true
-                  || this.linkIsActive('/users') === true,
+                [classes.listItem]: true,
+                [classes.collapsible]: true,
               })}
             >
-              <KeyboardArrowRight className={classes.arrow} />
-              Account
-            </ListItemText>
-          </ListItem>
-          <Collapse
-            in={expandedMenus.account
-                || (this.linkIsActive('/billing') === true)
-                || (this.linkIsActive('/users') === true)}
-            timeout="auto"
-            component="ul"
-            unmountOnExit
-            className={classes.sublinkPanel}
-          >
-            <li role="menuitem">
-              <Link
-                to="/billing"
+              <ListItemText
+                disableTypography={true}
                 className={classNames({
-                  [classes.sublink]: true,
-                  [classes.sublinkActive]: this.linkIsActive('/billing') === true,
+                  [classes.linkItem]: true,
+                  [classes.activeLink]:
+                    expandedMenus.account
+                    || this.linkIsActive('/billing') === true
+                    || this.linkIsActive('/users') === true,
                 })}
               >
-                Account &amp; Billing
-              </Link>
-            </li>
-            <li role="menuitem">
-              <Link
-                to="/users"
-                className={classNames({
-                  [classes.sublink]: true,
-                  [classes.sublinkActive]: this.linkIsActive('/users') === true,
-                })}
-              >
-                Users
-              </Link>
-            </li>
-          </Collapse>
-
-          <ListItem
-            button
-            focusRipple={true}
-            onClick={this.goToHelp}
-            className={classNames({
-              [classes.listItem]: true,
-              [classes.collapsible]: true,
-              [classes.active]: this.linkIsActive('/support') === true,
-            })}
-          >
-            <ListItemText
-              disableTypography={true}
+                <KeyboardArrowRight className={classes.arrow} />
+                Account
+              </ListItemText>
+            </ListItem>
+            <Collapse
+              in={expandedMenus.account
+                  || (this.linkIsActive('/billing') === true)
+                  || (this.linkIsActive('/users') === true)}
+              timeout="auto"
+              component="ul"
+              unmountOnExit
+              className={classes.sublinkPanel}
+            >
+              <li role="menuitem">
+                <Link
+                  to="/billing"
+                  className={classNames({
+                    [classes.sublink]: true,
+                    [classes.sublinkActive]: this.linkIsActive('/billing') === true,
+                  })}
+                >
+                  Account &amp; Billing
+                </Link>
+              </li>
+              <li role="menuitem">
+                <Link
+                  to="/users"
+                  className={classNames({
+                    [classes.sublink]: true,
+                    [classes.sublinkActive]: this.linkIsActive('/users') === true,
+                  })}
+                >
+                  Users
+                </Link>
+              </li>
+            </Collapse>
+  
+            <ListItem
+              button
+              focusRipple={true}
+              onClick={this.goToHelp}
               className={classNames({
-                [classes.linkItem]: true,
-                [classes.activeLink]:
-                  expandedMenus.support
-                  || this.linkIsActive('/support') === true,
+                [classes.listItem]: true,
+                [classes.collapsible]: true,
+                [classes.active]: this.linkIsActive('/support') === true,
               })}
             >
-              Get Help
-            </ListItemText>
-          </ListItem>
-
-          <div className={classes.spacer} />
-
-          <div className={classes.switchWrapper}>
-            <span className={`
-              ${classes.switchText}
-              ${themeName === 'lightTheme' ? 'active' : ''}
-            `}>
-              Light
-            </span>
-            <Toggle
-              onChange={() => toggleTheme()}
-              checked={themeName !== 'lightTheme'}
-              className={`
-                ${classes.toggle}
-                ${themeName}
-              `}
-            />
-            <span
-              className={`
+              <ListItemText
+                disableTypography={true}
+                className={classNames({
+                  [classes.linkItem]: true,
+                  [classes.activeLink]:
+                    expandedMenus.support
+                    || this.linkIsActive('/support') === true,
+                })}
+              >
+                Get Help
+              </ListItemText>
+            </ListItem>
+  
+            <div className={classes.spacer} />
+  
+            <div className={classes.switchWrapper}>
+              <span className={`
                 ${classes.switchText}
-                ${themeName === 'darkTheme' ? 'active' : ''}
-              `}
-              style={{ marginLeft: 4 }}
-            >
-              Dark
-            </span>
+                ${themeName === 'lightTheme' ? 'active' : ''}
+              `}>
+                Light
+              </span>
+              <Toggle
+                onChange={() => toggleTheme()}
+                checked={themeName !== 'lightTheme'}
+                className={`
+                  ${classes.toggle}
+                  ${themeName}
+                `}
+              />
+              <span
+                className={`
+                  ${classes.switchText}
+                  ${themeName === 'darkTheme' ? 'active' : ''}
+                `}
+                style={{ marginLeft: 4 }}
+              >
+                Dark
+              </span>
+            </div>
           </div>
+          }
         </Grid>
       </React.Fragment>
     );

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -12,9 +12,12 @@ import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 import Logo from 'src/assets/logo/logo-text.svg';
 import Grid from 'src/components/Grid';
 import Toggle from 'src/components/Toggle';
+
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
 
-type PrimaryLink = {
+import { getAccountSettings } from 'src/services/account';
+
+interface PrimaryLink {
   display: string,
   href: string,
 };
@@ -175,6 +178,7 @@ interface State {
   expandedMenus: {
     [key: string]: boolean;
   };
+  userHasManaged: boolean;
 }
 
 class PrimaryNav extends React.Component<Props, State> {
@@ -184,11 +188,24 @@ class PrimaryNav extends React.Component<Props, State> {
       account: false,
       support: false,
     },
+    userHasManaged: false,
   };
 
   constructor(props: Props) {
     super(props);
   }
+  
+  componentDidMount() {
+    getAccountSettings()
+      .then(data => this.setState({ userHasManaged: data.managed }))
+      /*
+      * Don't really need to do any error handling here since 
+      * the fallback is the Managed navigation tab not rendering 
+      */
+      .catch(e => e);
+  }
+
+  
 
   navigate(href: string) {
     const { history , closeMenu } = this.props;
@@ -202,7 +219,7 @@ class PrimaryNav extends React.Component<Props, State> {
 
   expandMenutItem = (e: React.MouseEvent<HTMLElement>) => {
     const menuName = e.currentTarget.getAttribute('data-menu-name');
-    if (!menuName) return;
+    if (!menuName) { return };
     this.setState({
       expandedMenus: {
         ...this.state.expandedMenus,
@@ -215,29 +232,31 @@ class PrimaryNav extends React.Component<Props, State> {
     this.navigate('/support');
   }
 
-  renderPrimaryLink(PrimaryLink: PrimaryLink) {
+  renderPrimaryLink(primaryLink: PrimaryLink) {
     const { classes } = this.props;
+
+    if (primaryLink.display === 'Managed' && !this.state.userHasManaged) { return; }
 
     return (
       <ListItem
-        key={PrimaryLink.display}
+        key={primaryLink.display}
         button
         divider
         component="li"
         role="menuitem"
         focusRipple={true}
-        onClick={() => this.navigate(PrimaryLink.href)}
+        onClick={() => this.navigate(primaryLink.href)}
         className={`
           ${classes.listItem}
-          ${this.linkIsActive(PrimaryLink.href) && classes.active}
+          ${this.linkIsActive(primaryLink.href) && classes.active}
         `}
       >
         <ListItemText
-          primary={PrimaryLink.display}
+          primary={primaryLink.display}
           disableTypography={true}
           className={`
             ${classes.linkItem}
-            ${this.linkIsActive(PrimaryLink.href) && classes.activeLink}
+            ${this.linkIsActive(primaryLink.href) && classes.activeLink}
           `}
         />
       </ListItem>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -178,7 +178,7 @@ interface State {
   expandedMenus: {
     [key: string]: boolean;
   };
-  userHasManaged: boolean;
+  userHasManaged?: boolean;
 }
 
 class PrimaryNav extends React.Component<Props, State> {
@@ -188,7 +188,7 @@ class PrimaryNav extends React.Component<Props, State> {
       account: false,
       support: false,
     },
-    userHasManaged: false,
+    userHasManaged: undefined,
   };
 
   constructor(props: Props) {
@@ -265,8 +265,12 @@ class PrimaryNav extends React.Component<Props, State> {
 
   render() {
     const { classes, toggleTheme } = this.props;
-    const { expandedMenus } = this.state;
+    const { expandedMenus, userHasManaged } = this.state;
     const themeName = (this.props.theme as any).name;
+
+    if (userHasManaged === undefined) {
+      return null;
+    }
 
     return (
       <React.Fragment>

--- a/src/features/Managed/ManagedLanding.tsx
+++ b/src/features/Managed/ManagedLanding.tsx
@@ -39,10 +39,10 @@ export class ManagedLanding extends React.Component<CombinedProps, State> {
     return (
       <Placeholder
         title="Managed Services"
-        copy="Let us worry about your infrastructure, so you can get back to worrying about your business."
+        copy={`Linode Managed is only available in the Classic Manager`}
         buttonProps={{
           onClick: () => window.open('https://manager.linode.com/account#managed', '_blank'),
-          children: 'Upgrade to Linode Managed',
+          children: 'Navigate to Classic Manager',
         }}
       />
     );

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -217,7 +217,8 @@ export const stagePaypalPayment = (data: Paypal) =>
     setURL(`${API_ROOT}/account/payments/paypal`),
     setMethod('POST'),
     setData(data),
-  ).then(response => response.data);
+  )
+    .then(response => response.data);
 
 interface ExecutePayload {
   payer_id: string;
@@ -229,4 +230,12 @@ export const executePaypalPayment = (data: ExecutePayload) =>
     setURL(`${API_ROOT}/account/payments/paypal/execute`),
     setMethod('POST'),
     setData(data),
-  ).then(response => response.data);
+  )
+    .then(response => response.data);
+
+export const getAccountSettings = () =>
+  Request<Linode.AccountSettings>(
+    setURL(`${API_ROOT}/account/settings`),
+    setMethod('GET')
+  )
+    .then(response => response.data);

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -22,6 +22,12 @@ namespace Linode {
     phone: string;
     company: string;
   }
+
+  export interface AccountSettings {
+    managed: boolean;
+    longview_subscription: string | null;
+    network_helper: boolean;
+  }
   interface CreditCard {
     expiry: string;
     last_four: string;
@@ -74,3 +80,5 @@ namespace Linode {
    quota: number;
   }
 }
+
+


### PR DESCRIPTION
### Purpose

If the user does not have Managed Services, do not render the _Managed_ tab in the navigation bar

### Notes
* Makes API call to `/account/settings` on mount.
* Cannot rely on events because CF Manager does not create any related events when signing up for Managed Services