### PR TITLE
M3-1128 Linode IP Refresh Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linode-manager",
   "author": "Linode",
   "description": "The Linode Manager website",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "private": true,
   "engines": {
     "node": ">= 8.11.2"

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -1,4 +1,4 @@
-import { compose, head, path, pathOr } from 'ramda';
+import { compose, equals, head, path, pathOr } from 'ramda';
 import * as React from 'react';
 
 import Paper from '@material-ui/core/Paper';
@@ -148,6 +148,18 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     },
   };
 
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    const maybeNewLinodeIPs =
+      path<Linode.LinodeIPsResponse>(['linodeIPs', 'response'], this.props);
+    const oldLinodeIPs =
+      path<Linode.LinodeIPsResponse>(['linodeIPs', 'response'], prevProps); 
+    if (!equals(maybeNewLinodeIPs, oldLinodeIPs)) {
+      this.setState({
+        linodeIPs: maybeNewLinodeIPs,
+      });
+    }
+  }
+
   refreshIPs = () => {
     return getLinodeIPs(this.props.linodeID)
       .then(ips => this.setState({ linodeIPs: ips }))
@@ -227,7 +239,8 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
 
   closeViewIPDrawer = () => this.setState({ viewIPDrawer: { open: false, ip: undefined }, })
 
-  closeViewRangeDrawer = () => this.setState({ viewRangeDrawer: { open: false, range: undefined }, })
+  closeViewRangeDrawer = () => this.setState(
+    { viewRangeDrawer: { open: false, range: undefined }, })
 
   closeEditRDNSDrawer = () => {
     this.setState({ editRDNSDrawer: { open: false, address: undefined, rnds: undefined }, });
@@ -243,14 +256,16 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
 
   openCreateIPv6Drawer = () => this.setState({ createIPv6Drawer: { open: true } })
 
-  openCreatePublicIPv4Drawer = () => this.setState({ createIPv4Drawer: { ...this.state.createIPv4Drawer, open: true, forPublic: true } })
+  openCreatePublicIPv4Drawer = () => this.setState(
+    { createIPv4Drawer: { ...this.state.createIPv4Drawer, open: true, forPublic: true } })
 
-  openCreatePrivateIPv4Drawer = () => this.setState({ createIPv4Drawer: { ...this.state.createIPv4Drawer, open: true, forPublic: false } })
+  openCreatePrivateIPv4Drawer = () => this.setState(
+    { createIPv4Drawer: { ...this.state.createIPv4Drawer, open: true, forPublic: false } })
 
   hasPrivateIPAddress() {
     const { linodeIPs } = this.state;
     const privateIPs = pathOr([], ['ipv4', 'private'], linodeIPs);
-    return privateIPs > 0;
+    return privateIPs.length > 0;
   }
 
   render() {
@@ -310,7 +325,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
 
   renderIPv4 = () => {
     const { classes } = this.props;
-    const ipv4 = path<Linode.LinodeIPsResponseIPV4>(['linodeIPs', 'response', 'ipv4'], this.props);
+    const ipv4 = path<Linode.LinodeIPsResponseIPV4>(['linodeIPs', 'ipv4'], this.state);
 
     if (!ipv4) { return null; }
 
@@ -374,7 +389,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
 
   renderIPv6 = () => {
     const { classes } = this.props;
-    const ipv6 = path<Linode.LinodeIPsResponseIPV6>(['linodeIPs', 'response', 'ipv6'], this.props);
+    const ipv6 = path<Linode.LinodeIPsResponseIPV6>(['linodeIPs', 'ipv6'], this.state);
 
     if (!ipv6) { return null; }
 


### PR DESCRIPTION
A recent refactor that turned state into props caused multiple regressions related to the Linode > Networking > IP Addres Tables not refreshing upon modification.

This addresses those issues. 