### PR TITLE
M3-1008 Fix Image search link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -297,7 +297,7 @@ export class App extends React.Component<CombinedProps, State> {
                             <Route path="/domains" component={Domains} />
                             <Route exact path="/managed" component={Managed} />
                             <Route exact path="/longview" component={Longview} />
-                            <Route path="/images" component={Images} />
+                            <Route exact path="/images" component={Images} />
                             <Route path="/stackscripts" component={StackScripts} />
                             <Route exact path="/billing" component={Account} />
                             <Route exact path="/billing/invoices/:invoiceId" component={InvoiceDetail} />

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -320,7 +320,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
         /* TODO: Update this with the Images icon! */
         Icon: VolumeIcon,
         /* TODO: Choose a real location for this to link to */
-        path: `/images/${image.id}`,
+        path: `/images`,
       }))));
     }
 


### PR DESCRIPTION
If you click on a link for an image search result in the search bar,
the link takes you to an image detail page (which does not exist
and is not currently planned).

This PR causes all image search results to link to the `/images`
landing page, where all images can be viewed in a list. Going to the previous path (e.g. /images/private/123456) will now show a Not Found message.