### PR TITLE
M3-1164 Fix ticket routing bugs

### DIFF
--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -120,6 +120,13 @@ export class SupportTicketDetail extends React.Component<CombinedProps,State> {
     this.loadTicketAndReplies();
   }
 
+  componentDidUpdate(prevProps:CombinedProps, prevState:State) {
+    if (prevProps.match.params.ticketId !== this.props.match.params.ticketId) {
+      this.setState({ loading: true });
+      this.loadTicketAndReplies();
+    }
+  }
+
   loadTicket = () : any => {
     const ticketId = this.props.match.params.ticketId;
     if (!ticketId) { return null; }

--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -154,7 +154,11 @@ export class SupportTicketDetail extends React.Component<CombinedProps,State> {
   };
 
   loadTicketAndReplies = () => {
-    Bluebird.join(this.loadTicket(), this.loadReplies(), this.handleJoinedPromise);
+    Bluebird.join(this.loadTicket(), this.loadReplies(), this.handleJoinedPromise)
+      .catch((err) => {
+        const error = [{ "reason": "Ticket not found." }]
+        this.setState({ loading: false, errors: pathOr(error, ['response', 'data', 'errors'], err)});
+      });
   }
 
   onBackButtonClick = () => {

--- a/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -90,7 +90,7 @@ const createClickHandlerForNotification = (
       return (e: React.MouseEvent<HTMLElement>) => onClick(`/linodes/${id}`);
 
     case 'ticket':
-      return (e: React.MouseEvent<HTMLElement>) => onClick(`/support/ticket/${id}`);
+      return (e: React.MouseEvent<HTMLElement>) => onClick(`/support/tickets/${id}`);
 
     case 'domain':
       return (e: React.MouseEvent<HTMLElement>) => onClick(`/domains/${id}`);


### PR DESCRIPTION
* The target generator in `userEventList` was routing ticket events
to support/ticket instead of support/tickets.

* On 404 error when loading tickets, the `loading` state was not
being cleared, resulting in an infinite spinner. Events from the
joined promise were also not being caught.