### PR TITLE
M3-559 add domain to dropdown

### DIFF
--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -95,6 +95,11 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
         open={open}
         onClose={this.closeDrawer}
       >
+        {generalError &&
+          <Notice error spacingTop={8}>
+            {generalError}
+          </Notice>
+        }
         <RadioGroup
           aria-label="type"
           name="type"
@@ -154,11 +159,6 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
               left
             />
           </React.Fragment>
-        }
-        {generalError &&
-          <Notice error>
-            generalError
-          </Notice>
         }
         <ActionsPanel>
           {!submitting

--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -30,7 +30,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 interface Props {
   open: boolean;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess: (domain?:Linode.Domain) => void;
   mode: 'clone' | 'create';
   cloneID?: number;
   domain?: string;
@@ -224,7 +224,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
     createDomain(data)
       .then((res) => {
         this.reset();
-        onSuccess();
+        onSuccess(res.data);
         onClose();
       })
       .catch((err) => {

--- a/src/features/Domains/DomainZoneImportDrawer.tsx
+++ b/src/features/Domains/DomainZoneImportDrawer.tsx
@@ -20,7 +20,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 interface Props {
   open: boolean;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess: (domain:Linode.Domain) => void;
 }
 
 interface State {
@@ -92,9 +92,9 @@ class DomainZoneImportDrawer extends React.Component<CombinedProps, State> {
     importZone(domain, remote_nameserver)
       .then((response) => {
         this.onClose();
-        this.props.onSuccess();
+        this.props.onSuccess(response.data);
       })
-      .catch((error) => {
+      .catch((error:Linode.ApiFieldError) => {
         const err: Linode.ApiFieldError[] = [{ field: 'none', reason: 'An unexpected error has ocurred.' }];
 
         this.setState({

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -186,8 +186,13 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
     });
   }
 
-  handleSuccess = () => {
-    this.getDomains();
+  handleSuccess = (domain:Linode.Domain) => {
+    if (domain.id) {
+      this.props.history.push(`/domains/${domain.id}`);
+    }
+    else {
+      this.getDomains();
+    }
   }
 
   getActions = () => {
@@ -305,7 +310,7 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
         <DomainZoneImportDrawer
           open={this.state.importDrawer.open}
           onClose={this.closeImportZoneDrawer}
-          onSuccess={this.getDomains}
+          onSuccess={this.handleSuccess}
         />
         <ConfirmationDialog
           open={this.state.removeDialog.open}

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -186,6 +186,10 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
     });
   }
 
+  handleSuccess = () => {
+    this.getDomains();
+  }
+
   getActions = () => {
     return (
       <ActionsPanel>
@@ -234,7 +238,7 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
         mode={this.state.createDrawer.mode}
         domain={this.state.createDrawer.domain}
         cloneID={this.state.createDrawer.cloneID}
-        onSuccess={this.getDomains}
+        onSuccess={this.handleSuccess}
       />
     );
   }

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -124,7 +124,8 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
   }
 
   onDomainSuccess = (domain:Linode.Domain) => {
-    this.props.history.push(`/domains/${domain.id}`);
+    const id = domain.id ? domain.id : '';
+    this.props.history.push(`/domains/${id}`);
   }
 
   render() {

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -9,10 +9,12 @@ import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/
 import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUp from '@material-ui/icons/KeyboardArrowUp';
 
+import DomainIcon from 'src/assets/addnewmenu/domain.svg';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import NodebalancerIcon from 'src/assets/addnewmenu/nodebalancer.svg';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 
+import DomainCreateDrawer from 'src/features/Domains/DomainCreateDrawer';
 import { openForCreating } from 'src/store/reducers/volumeDrawer';
 import AddNewMenuItem, { MenuItem } from './AddNewMenuItem';
 
@@ -49,6 +51,7 @@ interface Props {
 
 interface State {
   anchorEl?: HTMLElement;
+  domainDrawerOpen: boolean;
 }
 
 type CombinedProps = Props & WithStyles<CSSClasses> & RouteComponentProps<{}>;
@@ -58,6 +61,7 @@ const styled = withStyles(styles, { withTheme: true });
 class AddNewMenu extends React.Component<CombinedProps, State> {
   state = {
     anchorEl: undefined,
+    domainDrawerOpen: false,
   };
 
   items: MenuItem[] = [
@@ -91,6 +95,16 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
       body: `Ensure your valuable applications and services are highly-available`,
       ItemIcon: NodebalancerIcon,
     },
+    {
+      title: 'Domain',
+      onClick: (e) => {
+        this.openDomainDrawer();
+        this.handleClose();
+        e.preventDefault();
+      },
+      body: `Ensure your valuable applications and services are highly-available`,
+      ItemIcon: DomainIcon,
+    },
   ];
 
   handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -101,8 +115,22 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
     this.setState({ anchorEl: undefined });
   }
 
+  openDomainDrawer = () => {
+    this.setState({ domainDrawerOpen: true });
+  }
+
+  closeDomainDrawer = () => {
+    this.setState({ domainDrawerOpen: false });
+  }
+
+  onDomainSuccess = (domain:Linode.Domain) => {
+    const id = domain.id;
+    if (!id) { console.log(`There was an error featuring ${domain}.`)}
+    this.props.history.push(`/domains/${id}`); 
+  }
+
   render() {
-    const { anchorEl } = this.state;
+    const { anchorEl, domainDrawerOpen } = this.state;
     const { classes } = this.props;
     const itemsLen = this.items.length;
 
@@ -143,6 +171,12 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
               {...i}
             />)}
         </Menu>
+        <DomainCreateDrawer
+          open={domainDrawerOpen}
+          onClose={this.closeDomainDrawer}
+          onSuccess={this.onDomainSuccess}
+          mode="create"
+        />
       </div>
 
     );

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -102,7 +102,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
         this.handleClose();
         e.preventDefault();
       },
-      body: `Manage your DNS records and direct web traffic to your Linodes`,
+      body: `Manage your DNS records using Linode’s high-availability name servers`,
       ItemIcon: DomainIcon,
     },
   ];

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -102,7 +102,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
         this.handleClose();
         e.preventDefault();
       },
-      body: `Ensure your valuable applications and services are highly-available`,
+      body: `Manage your DNS records and direct web traffic to your Linodes`,
       ItemIcon: DomainIcon,
     },
   ];
@@ -124,9 +124,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
   }
 
   onDomainSuccess = (domain:Linode.Domain) => {
-    const id = domain.id;
-    if (!id) { console.log(`There was an error featuring ${domain}.`)}
-    this.props.history.push(`/domains/${id}`); 
+    this.props.history.push(`/domains/${domain.id}`);
   }
 
   render() {

--- a/src/services/domains.ts
+++ b/src/services/domains.ts
@@ -89,7 +89,7 @@ const importZoneSchema = Joi.object({
 });
 
 export const importZone = (domain?: string, remote_nameserver?: string) =>
-  Request(
+  Request<Domain>(
     validateRequestData({ domain, remote_nameserver }, importZoneSchema),
     setData({ domain, remote_nameserver }),
     setURL(`${API_ROOT}/domains/import`),


### PR DESCRIPTION
## Purpose

Users should be able to create a Domain from anywhere in the app by using the Create dropdown menu.

## Notes

* Added `DomainCreateDrawer` to the `AddNewMenu` component with associated handlers. This is a little messy (there will be two domain drawers when users visit `/domains`).
* Changed the signature of the `onSuccess` method to allow an optional `domain` parameter, necessary for redirecting to the domain detail page after the domain has been created.
* *Question*: currently when creating a domain from `/domains`, the list of domains is refreshed but the user is not redirected to the detail page for the new domain. Should we change this as well? I'd suggest doing it conditionally: a new domain can redirect, a cloned domain can show the updated list.
* Fixed error handling in `DomainCreateDrawer` and moved the general error Notice to the top of the drawer to match similar drawers elsewhere in the app.