### PR TITLE
M3-720 Pay with Paypal

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "ramda": "^0.25.0",
     "raven-js": "^3.22.3",
     "react": "^16.4.1",
+    "react-async-script-loader": "^0.3.0",
     "react-chartjs-2": "^2.7.0",
     "react-dev-utils": "4.2.1",
     "react-dom": "^16.4.1",

--- a/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/src/components/ActionsPanel/ActionsPanel.tsx
@@ -12,7 +12,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
     paddingTop: 16,
     paddingBottom: 16,
-    '& > :not(:first-child)': {
+    '& > :not(:first-child, [data-qa-paypal-button])': {
       marginLeft: 8,
     },
   },

--- a/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/src/components/ActionsPanel/ActionsPanel.tsx
@@ -12,7 +12,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
     paddingTop: 16,
     paddingBottom: 16,
-    '& > :not(:first-child, [data-qa-paypal-button])': {
+    '& > :not(:first-child):not([data-qa-paypal-button])': {
       marginLeft: 8,
     },
   },

--- a/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -28,7 +28,10 @@ import scriptLoader from 'react-async-script-loader';
 type ClassNames = 'root'
   | 'positive'
   | 'negative'
-  | 'actionPanel';
+  | 'actionPanel'
+  | 'paypalMask'
+  | 'paypalButtonWrapper'
+  | 'PaypalHidden';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {},
@@ -42,6 +45,23 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     display: 'flex',
     alignItems: 'center',
     flexWrap: 'wrap',
+    position: 'relative',
+  },
+  paypalMask: {
+    width: 175,
+    height: 45,
+    position: 'absolute',
+    zIndex: 2,
+    left: theme.spacing.unit * 2,
+    top: theme.spacing.unit * 2,
+  },
+  paypalButtonWrapper: {
+    position: 'relative',
+    zIndex: 1,
+    transition: [theme.transitions.create('opacity')],
+  },
+  PaypalHidden: {
+    opacity: .3,
   },
 });
 
@@ -439,25 +459,29 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
 
   renderActions = () => {
     const { classes } = this.props;
+    const { paypalSubmitEnabled } = this.state;
     return (
       <ActionsPanel className={classes.actionPanel}>
         {this.state.type === 'PAYPAL' && this.state.showPaypal
-          // @Alban: I ran into issues when wrapping the Paypal
-          // button in a MUI Button component
-          // what should happen is when you click the paypal button
-          // it should open up paypal.com in a new tab
-          // further, the user should only be able to click this button
-          // if this.state.paypalSubmitEnabled is true
-          ? <div>
-            <PaypalButton
-              env={env}
-              payment={this.payment}
-              onAuthorize={this.onAuthorize}
-              client={client}
-              commit={false}
-              onCancel={this.onCancel}
-            />
-          </div>
+          ? 
+          <React.Fragment>
+            {!paypalSubmitEnabled && <div className={classes.paypalMask} />}
+            <div className={classNames(
+              {
+                [classes.paypalButtonWrapper]: true,
+                [classes.PaypalHidden]: !paypalSubmitEnabled,
+              }
+            )}>
+              <PaypalButton
+                env={env}
+                payment={this.payment}
+                onAuthorize={this.onAuthorize}
+                client={client}
+                commit={false}
+                onCancel={this.onCancel}
+              />
+            </div>
+          </React.Fragment>
           : <Button
             type="primary"
             loading={this.state.submitting}

--- a/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -79,7 +79,7 @@ let PaypalButton: any = undefined; // needs to be a JSX.Element with some props
 */
 const client = {
   sandbox: 'YbjxBCou-0Aum1f2K1xqSgrJqhNCHOEbdmvi1pPQhk-bj_dLrJ41Cssm_ektzlNxZJc9A-dx6UkYu2n',
-  production: 'YbjxBCou-0Aum1f2K1xqSgrJqhNCHOEbdmvi1pPQhk-bj_dLrJ41Cssm_ektzlNxZJc9A-dx6UkYu2n'
+  production: 'AWdnFJ_Yx5X9uqKZQdbdkLfCnEJwtauQJ2tyesKf3S0IxSrkRLmB2ZN2ACSwy37gxY_AZoTagHWlZCOA'
 }
 
 const env = (process.env.NODE_ENV === 'development')

--- a/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -57,7 +57,7 @@ interface State {
 
 interface PaypalScript {
   isScriptLoadSucceed?: boolean;
-  isScriptLoaded: boolean;
+  isScriptLoaded?: boolean;
   onScriptLoaded?: () => void;
 } 
 
@@ -334,7 +334,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
     const balanceDisplay = !accountLoading && balance !== false ? `$${Math.abs(balance).toFixed(2)}` : '';
     return (
       <React.Fragment>
-      <ExpansionPanel defaultExpanded={true} heading="Make a Payment" actions={this.renderActions}>
+      <ExpansionPanel heading="Make a Payment" actions={this.renderActions}>
         <Grid container>
           {/* Current Balance */}
           <Grid item xs={12}>

--- a/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -52,7 +52,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     width: 175,
     height: 45,
     position: 'absolute',
-    zIndex: 2,
+    zIndex: 10,
     left: theme.spacing.unit * 2,
     top: theme.spacing.unit * 2,
   },
@@ -66,8 +66,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
 });
 
-interface Props {
- }
+interface Props { }
 
 interface State {
   type: 'CREDIT_CARD' | 'PAYPAL',
@@ -146,7 +145,11 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
   }
 
   handleTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ type: e.target.value as 'CREDIT_CARD' | 'PAYPAL' });
+    this.setState({
+      success: false,
+      successMessage: '', 
+      type: e.target.value as 'CREDIT_CARD' | 'PAYPAL' 
+    });
   }
 
   handleUSDChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -223,9 +226,11 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
 
   closeDialog = () => {
     this.setState({ 
+      errors: undefined,
       dialogOpen: false,
       success: true,
-      successMessage: 'Payment Cancelled' });
+      successMessage: 'Payment Cancelled' 
+    });
   }
 
   confirmPaypalPayment = () => {
@@ -292,7 +297,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
 
     this.setState({
       submitting: true,
-      errors: [],
+      errors: undefined,
     });
 
     return stagePaypalPayment({

--- a/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -2,8 +2,8 @@ import * as classNames from 'classnames';
 import { compose, pathOr } from 'ramda';
 import * as React from 'react';
 
-// import FormControlLabel from '@material-ui/core/FormControlLabel';
-// import RadioGroup from '@material-ui/core/RadioGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import RadioGroup from '@material-ui/core/RadioGroup';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
@@ -13,11 +13,14 @@ import ErrorState from 'src/components/ErrorState';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
-// import Radio from 'src/components/Radio';
+import Radio from 'src/components/Radio';
 import TextField from 'src/components/TextField';
 import { withAccount } from 'src/features/Account/context';
-import { makePayment } from 'src/services/account';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+
+import { makePayment } from 'src/services/account';
+
+import scriptLoader from 'react-async-script-loader';
 
 type ClassNames = 'root' | 'positive' | 'negative';
 
@@ -59,7 +62,17 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
     ccv: '',
   };
 
-  handleTypeChange = () => null;
+  componentDidMount() {
+    console.log(this.props);
+  }
+
+  componentDidUpdate() {
+    console.log(this.props);
+  }
+
+  handleTypeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ type: e.target.value as 'CREDIT_CARD' | 'PAYPAL' });
+  }
 
   handleUSDChange = (e: React.ChangeEvent<HTMLInputElement>) => this.setState({ usd: e.target.value || '' });
 
@@ -161,16 +174,16 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
           <Grid item xs={12}>
             {generalError && <Notice error text={generalError} />}
             {success && <Notice success text={`Payment successfully submitted.`} />}
-            {/* <RadioGroup // Hide this choice until PayPal component is completed.
+            <RadioGroup
               aria-label="payment type"
               name="type"
               value={this.state.type}
               onChange={this.handleTypeChange}
               row
             >
-              <FormControlLabel value="CREDIT_CARD" label="Credit Card" control={<Radio disabled />} />
-              <FormControlLabel value="PAYPAL" label="Paypal" control={<Radio disabled />} />
-            </RadioGroup> */}
+              <FormControlLabel value="CREDIT_CARD" label="Credit Card" control={<Radio />} />
+              <FormControlLabel value="PAYPAL" label="Paypal" control={<Radio />} />
+            </RadioGroup>
             <TextField
               errorText={hasErrorFor('usd')}
               label="Amount to Charge"
@@ -180,15 +193,17 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
               type="number"
               placeholder={`1.00`}
             />
-            <TextField
-              errorText={hasErrorFor('ccv')}
-              label="CCV"
-              onChange={this.handleCCVChange}
-              value={this.state.ccv}
-              required
-              type="number"
-              placeholder={`000`}
-            />
+            {this.state.type === 'CREDIT_CARD' &&
+              <TextField
+                errorText={hasErrorFor('ccv')}
+                label="CCV"
+                onChange={this.handleCCVChange}
+                value={this.state.ccv}
+                required
+                type="number"
+                placeholder={`000`}
+              />
+            }
           </Grid>
         </Grid>
       </ExpansionPanel>
@@ -208,9 +223,12 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
         <Button
           type="primary"
           loading={this.state.submitting}
-          onClick={this.submitForm}
+          onClick={() => console.log('payment submitted!')}
         >
-          Confirm Payment
+          {this.state.type === 'PAYPAL'
+            ? 'Proceed to Paypal'
+            : 'Confrm Payment'
+          }
         </Button>
         <Button
           type="cancel"
@@ -232,4 +250,6 @@ const accountContext = withAccount((context) => ({
 
 const enhanced = compose(styled, accountContext);
 
-export default enhanced(MakeAPaymentPanel);
+export default
+  scriptLoader('https://www.paypalobjects.com/api/checkout.js')
+    (enhanced(MakeAPaymentPanel));

--- a/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -6,6 +6,7 @@ import * as ReactDOM from 'react-dom';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -58,7 +59,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   paypalButtonWrapper: {
     position: 'relative',
     zIndex: 1,
-    transition: [theme.transitions.create('opacity')],
+    transition: theme.transitions.create(['opacity']),
   },
   PaypalHidden: {
     opacity: .3,
@@ -465,22 +466,33 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
         {this.state.type === 'PAYPAL' && this.state.showPaypal
           ? 
           <React.Fragment>
-            {!paypalSubmitEnabled && <div className={classes.paypalMask} />}
-            <div className={classNames(
-              {
-                [classes.paypalButtonWrapper]: true,
-                [classes.PaypalHidden]: !paypalSubmitEnabled,
-              }
-            )}>
-              <PaypalButton
-                env={env}
-                payment={this.payment}
-                onAuthorize={this.onAuthorize}
-                client={client}
-                commit={false}
-                onCancel={this.onCancel}
-              />
-            </div>
+            {!paypalSubmitEnabled && 
+              <Tooltip
+                title={'You need a minimum amount of $5.00 to enable the payment.'}
+                data-qa-help-tooltip
+                enterTouchDelay={0}
+                leaveTouchDelay={5000}
+              >
+                <div className={classes.paypalMask} />
+              </Tooltip>
+            }
+            
+              <div className={classNames(
+                {
+                  [classes.paypalButtonWrapper]: true,
+                  [classes.PaypalHidden]: !paypalSubmitEnabled,
+                }
+              )}>
+                <PaypalButton
+                  env={env}
+                  payment={this.payment}
+                  onAuthorize={this.onAuthorize}
+                  client={client}
+                  commit={false}
+                  onCancel={this.onCancel}
+                />
+              </div>
+            
           </React.Fragment>
           : <Button
             type="primary"

--- a/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -25,7 +25,10 @@ import { executePaypalPayment, makePayment, stagePaypalPayment }
 
 import scriptLoader from 'react-async-script-loader';
 
-type ClassNames = 'root' | 'positive' | 'negative';
+type ClassNames = 'root'
+  | 'positive'
+  | 'negative'
+  | 'actionPanel';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {},
@@ -34,6 +37,11 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   negative: {
     color: theme.color.red,
+  },
+  actionPanel: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
   },
 });
 
@@ -430,8 +438,9 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
   }
 
   renderActions = () => {
+    const { classes } = this.props;
     return (
-      <ActionsPanel>
+      <ActionsPanel className={classes.actionPanel}>
         {this.state.type === 'PAYPAL' && this.state.showPaypal
           // @Alban: I ran into issues when wrapping the Paypal
           // button in a MUI Button component

--- a/src/features/Account/AccountPanels/MakeAPaymentPanel/react-async-script-loader.d.ts
+++ b/src/features/Account/AccountPanels/MakeAPaymentPanel/react-async-script-loader.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-async-script-loader';

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -201,3 +201,28 @@ export const getNetworkUtilization = () =>
     setMethod('GET'),
   )
   .then(response => response.data);
+
+interface Paypal {
+  cancel_url: string;
+  redirect_url: string;
+  usd: string;
+}
+
+export const stagePaypalPayment = (data: Paypal) =>
+  Request<any>(
+    setURL(`${API_ROOT}/account/payments/paypal`),
+    setMethod('POST'),
+    setData(data),
+  ).then(response => response.data);
+
+interface Execute {
+  payer_id: string;
+  payment_id: string;
+}
+
+export const executePaypalPayment = (data: Execute) =>
+  Request<any>(
+    setURL(`${API_ROOT}/account/payments/paypal/execute`),
+    setMethod('POST'),
+    setData(data),
+  ).then(response => response.data);

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -208,19 +208,23 @@ interface Paypal {
   usd: string;
 }
 
+interface PaymentID {
+  payment_id: string;
+}
+
 export const stagePaypalPayment = (data: Paypal) =>
-  Request<any>(
+  Request<PaymentID>(
     setURL(`${API_ROOT}/account/payments/paypal`),
     setMethod('POST'),
     setData(data),
   ).then(response => response.data);
 
-interface Execute {
+interface ExecutePayload {
   payer_id: string;
   payment_id: string;
 }
 
-export const executePaypalPayment = (data: Execute) =>
+export const executePaypalPayment = (data: ExecutePayload) =>
   Request<any>(
     setURL(`${API_ROOT}/account/payments/paypal/execute`),
     setMethod('POST'),

--- a/src/types/Paypal.ts
+++ b/src/types/Paypal.ts
@@ -1,0 +1,26 @@
+namespace Paypal {
+  export interface AuthData {
+    intent: string;
+    orderID: string;
+    payerID: string;
+    paymentID: string;
+    returnUrl: string
+  }
+
+  interface Client {
+    sandbox: string;
+    production: string;
+  }
+
+  /*
+  * Please note. The is not the full list of available props
+  * but for our purposes, these are the ones we require
+  */
+  export interface PayButtonProps {
+    client: Client,
+    onAuthorize: () => void;
+    onCancel: () => void;
+    onClick: () => void;
+    payment: () => string;
+  }
+}

--- a/src/types/Paypal.ts
+++ b/src/types/Paypal.ts
@@ -12,11 +12,14 @@ namespace Paypal {
     production: string;
   }
 
+  type Env = 'sandbox' | 'production';
+
   /*
   * Please note. The is not the full list of available props
   * but for our purposes, these are the ones we require
   */
   export interface PayButtonProps {
+    env: Env;
     client: Client,
     onAuthorize: () => void;
     onCancel: () => void;

--- a/src/types/Paypal.ts
+++ b/src/types/Paypal.ts
@@ -21,9 +21,11 @@ namespace Paypal {
   export interface PayButtonProps {
     env: Env;
     client: Client,
-    onAuthorize: () => void;
+    onAuthorize: (data: AuthData) => void;
     onCancel: () => void;
-    onClick: () => void;
-    payment: () => string;
+    onClick?: () => void;
+    payment: (data?: any, actions?: any) => Promise<any>;
+    commit?: boolean;
+    style?: any;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5465,7 +5465,7 @@ hoek@5.x.x:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.3.tgz#b71d40d943d0a95da01956b547f83c4a5b4a34ac"
 
-hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
+hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
@@ -8846,6 +8846,12 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-async-script-loader@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/react-async-script-loader/-/react-async-script-loader-0.3.0.tgz#c742b3ca25e08ba61ab7eb64371f814027692b86"
+  dependencies:
+    hoist-non-react-statics "^1.0.3"
 
 react-chartjs-2@^2.7.0:
   version "2.7.2"


### PR DESCRIPTION
### Purpose

Pay with Paypal!

### To Test

If you want to place a test transaction, please reach out to get our sandbox credentials or create your own Paypal sandbox account

Also requires you `.env` file is pointing at development API endpoints

### Notes
* Utilizes react-async-script-loader, so we're only loading the Paypal checkout script when the component mounts
* There is no way to validate the form before the user gets sent to paypal.com, so the current plan is to just disable the submit button until the user enters a correct USD value (which is anything above $5 USD)
* If the Paypal script cannot load, the Paypal radio will not render and the user will not be able to choose the option to pay with Paypal.

### Other Comments

A lot of this is seemingly magic and may be hard to wrap your head around the functionality. I recommend reading the docs listed below if something isn't making sense. PayPal's documentation is not super reliable, so even then it may be confusing

### References
[react-async-script-loader](https://www.npmjs.com/package/react-async-script-loader)
[Github Issue: Early return on payment callback](https://github.com/paypal/paypal-checkout/issues/794)
[Tutorial: How to integrate Paypal Checkout with React](https://www.robinwieruch.de/react-paypal-payment/)

Paypal docs:
[Paypal Checkout](https://github.com/paypal/paypal-checkout)
[Using Paypal Checkout with React](https://github.com/paypal/paypal-checkout/blob/master/docs/frameworks.md)
[Advanced JavaScript Integration](https://github.com/paypal/paypal-checkout/blob/master/docs/button.md#advanced-integration)
[Customize Checkout Button](https://developer.paypal.com/docs/checkout/how-to/customize-button/#)