### PR TITLE
M3-1097 - Browserstack Integration

### DIFF
--- a/e2e/config/browser-config.js
+++ b/e2e/config/browser-config.js
@@ -10,7 +10,21 @@ exports.browserConf = {
             '--disable-dev-shm-usage',
             '--window-size=1600,1080',
             ]
-        }
+        },
+        'os': 'Windows',
+        'os_version': '10',
+        'browser': 'Chrome',
+        'browser_version': '68.0',
+        'resolution': '1440x900',
+    },
+    edge: {
+        'browserName': 'edge',
+        'acceptSslCerts': true,
+        'os': 'Windows',
+        'os_version': '10',
+        'browser': 'Edge',
+        'browser_version': '17.0',
+        'resolution': '1440x900'
     },
     headlessChrome: {
         browserName: 'chrome',
@@ -57,7 +71,12 @@ exports.browserConf = {
             acceptInsecureCerts: true
         },
         maxInstances: 1,
-        acceptInsecureCerts: true
+        acceptInsecureCerts: true,
+        'os': 'OS X',
+        'os_version': 'High Sierra',
+        'browser': 'Safari',
+        'browser_version': '11.0',
+        'resolution': '1600x1200'
     },
     safariPreview: {
         browserName: 'safari',

--- a/e2e/config/browserstack.conf.js
+++ b/e2e/config/browserstack.conf.js
@@ -1,0 +1,34 @@
+require('dotenv').config();
+
+const { merge } = require('ramda');
+const { argv } = require('yargs');
+const { constants } = require('../constants');
+const { browserConf } = require('./browser-config');
+
+const wdioMaster = require('./wdio.conf.js');
+const selectedBrowser = argv.browser ? browserConf[argv.browser] : browserConf['chrome'];
+const seleniumSettings = require('./selenium-config');
+
+const username = process.env.MANAGER_USER;
+const password = process.env.MANAGER_PASS;
+
+exports.config = merge(wdioMaster.config, {
+    host: 'hub.browserstack.com',
+    services: ['browserstack'],
+    capabilities: [{
+        browserName: 'chrome',
+        'browserstack.local': true,
+        acceptSslCerts: true,
+        acceptInsecureCerts: true,
+        chromeOptions: {
+            args: [
+            '--no-sandbox',
+            '--disable-dev-shm-usage',
+            '--window-size=1600,1080',
+            ]
+        }
+    }],
+    user: process.env.BROWSERSTACK_USERNAME,
+    key: process.env.BROWSERSTACK_ACCESS_KEY,
+    browserstackLocal: true,
+});

--- a/e2e/config/browserstack.conf.js
+++ b/e2e/config/browserstack.conf.js
@@ -2,17 +2,26 @@ require('dotenv').config();
 
 const { merge } = require('ramda');
 const { argv } = require('yargs');
-const { constants } = require('../constants');
 const { browserConf } = require('./browser-config');
+const { constants } = require('../constants');
 
 const wdioMaster = require('./wdio.conf.js');
 const selectedBrowser = argv.browser ? browserConf[argv.browser] : browserConf['chrome'];
-const seleniumSettings = require('./selenium-config');
+// Enable When browserstack support Selenium 3.13.0
+// const seleniumSettings = require('./selenium-config');
 
 const username = process.env.MANAGER_USER;
 const password = process.env.MANAGER_PASS;
 
-selectedBrowser['browserstack.local'] = true;
+if (argv.local) {
+    selectedBrowser['browserstack.local'] = true;
+} else {
+    selectedBrowser['browserstack.local'] = false;
+}
+
+// Enable When browserstack support Selenium 3.13.0
+//selectedBrowser['browserstack.selenium_version'] = seleniumSettings.version;
+selectedBrowser['browserstack.selenium_version'] = '3.11.0';
 
 exports.config = merge(wdioMaster.config, {
     host: 'hub.browserstack.com',
@@ -20,5 +29,7 @@ exports.config = merge(wdioMaster.config, {
     capabilities: [selectedBrowser],
     user: process.env.BROWSERSTACK_USERNAME,
     key: process.env.BROWSERSTACK_ACCESS_KEY,
-    browserstackLocal: true,
+    browserstackLocal: argv.local ? true : false,
+    browserstackLocalForcedStop: true,
+    waitforTimeout: 25000,
 });

--- a/e2e/config/browserstack.conf.js
+++ b/e2e/config/browserstack.conf.js
@@ -12,22 +12,12 @@ const seleniumSettings = require('./selenium-config');
 const username = process.env.MANAGER_USER;
 const password = process.env.MANAGER_PASS;
 
+selectedBrowser['browserstack.local'] = true;
+
 exports.config = merge(wdioMaster.config, {
     host: 'hub.browserstack.com',
     services: ['browserstack'],
-    capabilities: [{
-        browserName: 'chrome',
-        'browserstack.local': true,
-        acceptSslCerts: true,
-        acceptInsecureCerts: true,
-        chromeOptions: {
-            args: [
-            '--no-sandbox',
-            '--disable-dev-shm-usage',
-            '--window-size=1600,1080',
-            ]
-        }
-    }],
+    capabilities: [selectedBrowser],
     user: process.env.BROWSERSTACK_USERNAME,
     key: process.env.BROWSERSTACK_ACCESS_KEY,
     browserstackLocal: true,

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -226,8 +226,13 @@ exports.config = {
             browser.loadImposter(imposter);
         }
 
+
         if (browser.options.desiredCapabilities.browserName.includes('chrome')) {
             browser.timeouts('page load', process.env.DOCKER ? 30000 : 20000);
+        }
+
+        if (browser.options.desiredCapabilities.browserName.includes('edge')) {
+            browser.windowHandleMaximize();
         }
 
         login(username, password);

--- a/e2e/config/wdio.storybook.conf.js
+++ b/e2e/config/wdio.storybook.conf.js
@@ -5,8 +5,8 @@ const wdioMaster = require('./wdio.conf.js');
 const { constants } = require('../constants');
 const { browserConf } = require('./browser-config');
 const selectedBrowser = () => {
-    if (argv.b) {
-        return browserConf[argv.b];
+    if (argv.browser) {
+        return browserConf[argv.browser];
     }
     if (process.env.DOCKER || argv.debug) {
      return browserConf['chrome'];

--- a/e2e/constants.js
+++ b/e2e/constants.js
@@ -3,10 +3,10 @@ exports.constants = {
 
 	},
 	wait: {
-		short: process.env.DOCKER ? 10000 : 5000,
-		normal: process.env.DOCKER ? 20000 : 12000,
-		long: process.env.DOCKER ?  40000 : 30000,
-		minute: process.env.DOCKER ? 75000 : 60000,
+		short: process.env.DOCKER || process.env.BROWSERSTACK_USERNAME ? 10000 : 5000,
+		normal: process.env.DOCKER || process.env.BROWSERSTACK_USERNAME ? 20000 : 12000,
+		long: process.env.DOCKER || process.env.BROWSERSTACK_USERNAME ?  40000 : 30000,
+		minute: process.env.DOCKER || process.env.BROWSERSTACK_USERNAME ? 75000 : 60000,
 		custom: (milliseconds) => milliseconds,
 	},
 	routes: {

--- a/e2e/specs/profile/clients.spec.js
+++ b/e2e/specs/profile/clients.spec.js
@@ -88,10 +88,10 @@ describe('Profile - OAuth Clients Suite', () => {
 
         it('should update table on edit submit', () => {
             createDrawer.updateLabel(editedClient.label);
-            createDrawer.callbackUrl.setValue(editedClient.callback);
+            browser.trySetValue(createDrawer.callbackUrl.selector, editedClient.callback);
             createDrawer.submit.click();
 
-            browser.waitForVisible(editedRow);
+            browser.waitForVisible(editedRow, constants.wait.normal);
             const displayedLabel = $(editedRow).$(profile.oauthLabel.selector).getText();
             const displayedAccess = $(editedRow).$(profile.oauthAccess.selector).getText();
             const displayedCallback = $(editedRow).$(profile.oauthCallback.selector).getText();
@@ -106,7 +106,7 @@ describe('Profile - OAuth Clients Suite', () => {
         it('should display reset in action panel', () => {
             browser.click(`${editedRow} [data-qa-action-menu]`);
 
-            browser.waitForVisible('[data-qa-action-menu-item]');
+            browser.waitForVisible('[data-qa-action-menu-item]', constants.wait.normal);
 
             const actionMenuItems = $$('[data-qa-action-menu-item]')
                 .map(item => item.getAttribute('data-qa-action-menu-item'));
@@ -149,7 +149,7 @@ describe('Profile - OAuth Clients Suite', () => {
 
         beforeAll(() => {
             browser.refresh()
-            profile.oauthLabel.waitForVisible();
+            profile.oauthLabel.waitForVisible(constants.wait.normal);
         });
 
         it('should display delete dialog', () => {

--- a/package.json
+++ b/package.json
@@ -113,9 +113,10 @@
     "storyshots:test": "npx jest --config ./.storybook/storyshots.jest.config.js src/components/Storyshots.test.tsx --env=jsdom",
     "build-storybook": "build-storybook",
     "serve": "node testServer.js",
-    "selenium": "./node_modules/.bin/selenium-standalone install --config=./e2e/config/selenium-config.js && ./node_modules/.bin/selenium-standalone start --config=./e2e/config/selenium-config.js",
-    "e2e": "./node_modules/.bin/wdio ./e2e/config/wdio.conf.js",
-    "e2e:all": "./node_modules/.bin/wdio ./e2e/config/wdio.conf.js; ./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js",
+    "selenium": "npx selenium-standalone install --config=./e2e/config/selenium-config.js && ./node_modules/.bin/selenium-standalone start --config=./e2e/config/selenium-config.js",
+    "e2e": "npx wdio ./e2e/config/wdio.conf.js",
+    "e2e:all": "npx wdio ./e2e/config/wdio.conf.js; ./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js",
+    "e2e:browserstack": "npx wdio ./e2e/config/browserstack.conf.js",
     "mb": "npx mb"
   },
   "pre-commit": [
@@ -165,6 +166,7 @@
     "tslint-config-airbnb": "^5.6.0",
     "tslint-config-prettier": "^1.13.0",
     "typescript": "^2.7.2",
+    "wdio-browserstack-service": "^0.1.16",
     "wdio-dot-reporter": "0.0.9",
     "wdio-jasmine-framework": "0.3.5",
     "wdio-junit-reporter": "^0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,6 +1556,10 @@ aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
+
 axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
@@ -2592,7 +2596,7 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
-bluebird@^3.4.7, bluebird@^3.5.1:
+bluebird@^3.4.7, bluebird@^3.5.0, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -2801,6 +2805,15 @@ browserslist@^3.0.0, browserslist@^3.2.6:
   dependencies:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
+
+browserstack-local@^1.2.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/browserstack-local/-/browserstack-local-1.3.3.tgz#7500d630f24651e89a8fe9b3f5c166d3b67259af"
+  dependencies:
+    https-proxy-agent "^2.2.1"
+    is-running "^2.0.0"
+    sinon "^1.17.6"
+    temp-fs "^0.9.9"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -3265,7 +3278,7 @@ colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
-combined-stream@1.0.6, combined-stream@~1.0.5:
+combined-stream@1.0.6, combined-stream@~1.0.5, combined-stream@~1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
@@ -4660,6 +4673,10 @@ extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
 external-editor@^2.0.4:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
@@ -4949,13 +4966,19 @@ fork-ts-checker-webpack-plugin@^0.2.8:
     lodash.startswith "^4.2.1"
     minimatch "^3.0.4"
 
-form-data@~2.3.1:
+form-data@~2.3.1, form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
     mime-types "^2.1.12"
+
+formatio@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  dependencies:
+    samsam "~1.1"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -5343,6 +5366,13 @@ har-validator@~5.0.3:
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
   dependencies:
     ajv "^5.1.0"
+    har-schema "^2.0.0"
+
+har-validator@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
+  dependencies:
+    ajv "^5.3.0"
     har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
@@ -6109,6 +6139,10 @@ is-retry-allowed@^1.0.0:
 is-root@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-1.0.0.tgz#07b6c233bc394cd9d02ba15c966bd6660d6342d5"
+
+is-running@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-running/-/is-running-2.1.0.tgz#30a73ff5cc3854e4fc25490809e9f5abf8de09e0"
 
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
@@ -7129,6 +7163,10 @@ loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
+lolex@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -7331,7 +7369,7 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-mime-db@1.x.x:
+mime-db@1.x.x, mime-db@~1.35.0:
   version "1.35.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
 
@@ -7348,6 +7386,12 @@ mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18:
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime-types@~2.1.19:
+  version "2.1.19"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
+  dependencies:
+    mime-db "~1.35.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -7780,6 +7824,10 @@ nwsapi@^2.0.0:
 oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
 object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -8729,7 +8777,7 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@^6.5.1, qs@~6.5.1:
+qs@^6.5.1, qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -9454,6 +9502,15 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
+request-promise@^4.2.1:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.2.tgz#d1ea46d654a6ee4f8ee6a4fea1018c22911904b4"
+  dependencies:
+    bluebird "^3.5.0"
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
+
 request@2.87.0, request@^2.79.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
@@ -9478,6 +9535,31 @@ request@2.87.0, request@^2.79.0, request@^2.83.0:
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
+
+request@^2.81.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 request@~2.83.0:
   version "2.83.0"
@@ -9599,6 +9681,12 @@ rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   dependencies:
     glob "^7.0.5"
 
+rimraf@~2.5.2:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
+  dependencies:
+    glob "^7.0.5"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -9662,6 +9750,14 @@ safe-regex@^1.1.0:
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
+samsam@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+
+samsam@~1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
 
 sane@^2.0.0:
   version "2.5.2"
@@ -9895,6 +9991,15 @@ simplesmtp@~0.3.16:
   dependencies:
     rai "~0.1.11"
     xoauth2 "~0.1.8"
+
+sinon@^1.17.6:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  dependencies:
+    formatio "1.1.1"
+    lolex "1.3.2"
+    samsam "1.1.2"
+    util ">=0.10.3 <1"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -10487,6 +10592,12 @@ teamwork@3.x.x:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/teamwork/-/teamwork-3.0.1.tgz#ff38c7161f41f8070b7813716eb6154036ece196"
 
+temp-fs@^0.9.9:
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/temp-fs/-/temp-fs-0.9.9.tgz#8071730437870720e9431532fe2814364f8803d7"
+  dependencies:
+    rimraf "~2.5.2"
+
 term-size@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
@@ -10638,6 +10749,13 @@ tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
+    punycode "^1.4.1"
+
+tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  dependencies:
+    psl "^1.1.24"
     punycode "^1.4.1"
 
 tr46@^1.0.1:
@@ -11048,6 +11166,12 @@ util@0.10.3:
   dependencies:
     inherits "2.0.1"
 
+"util@>=0.10.3 <1":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.11.0.tgz#c5f391beb244103d799b21077a926fef8769e1fb"
+  dependencies:
+    inherits "2.0.3"
+
 util@^0.10.3:
   version "0.10.4"
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
@@ -11080,6 +11204,10 @@ uuid@^2.0.2:
 uuid@^3.1.0, uuid@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
@@ -11177,6 +11305,14 @@ wbuf@^1.1.0, wbuf@^1.7.2:
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
   dependencies:
     minimalistic-assert "^1.0.0"
+
+wdio-browserstack-service@^0.1.16:
+  version "0.1.16"
+  resolved "https://registry.yarnpkg.com/wdio-browserstack-service/-/wdio-browserstack-service-0.1.16.tgz#2a5d216d1af7d95e752095aba3c11eff68b92d64"
+  dependencies:
+    browserstack-local "^1.2.0"
+    request "^2.81.0"
+    request-promise "^4.2.1"
 
 wdio-dot-reporter@0.0.9, wdio-dot-reporter@~0.0.8:
   version "0.0.9"


### PR DESCRIPTION
* Added support for running e2e tests via browserstack automate services
* Added browser configs with browserstack-specific capabilities
* Added `browserstack.conf.js` wdio test runner config file for inheriting base `wdio.conf.js` and overriding specific configurations.
* Updated yarn scripts to use `npx` instead of using relative paths to the npm binaries.

# To Test

* Add the following env variables to your `.env` file:

`BROWSERSTACK_USERNAME='YOUR_USERNAME_HERE'`
`BROWSERSTACK_ACCESS_KEY='YOUR_ACCESS_KEY_HERE'`

```bash
yarn && yarn start
yarn e2e:browserstack --local --dir profile # testing this folder so you do not have to run the whole suite
```

* Message me for further instructions