### PR TITLE
M3-439 backups from landing

### DIFF
--- a/src/components/Placeholder/Placeholder.tsx
+++ b/src/components/Placeholder/Placeholder.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
-import Button, { ButtonProps } from '@material-ui/core/Button';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
+import Button, { ButtonProps } from 'src/components/Button';
 import Grid from 'src/components/Grid';
 
 type ClassNames = 'root'
@@ -105,7 +105,7 @@ const Placeholder: React.StatelessComponent<CombinedProps> = (props) => {
         <Grid item xs={12} lg={10} className={classes.copy}>
           <Button
             variant="raised"
-            color="primary"
+            type="primary"
             className={classes.button}
             {...buttonProps}
             data-qa-placeholder-button

--- a/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
@@ -1,0 +1,62 @@
+import * as moment from 'moment-timezone';
+import * as React from 'react';
+
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
+
+import { formatBackupDate } from './LinodeBackup';
+import LinodeBackupActionMenu from './LinodeBackupActionMenu';
+
+interface Props {
+  backup: Linode.LinodeBackup;
+  handleRestore: (backup:Linode.LinodeBackup) => void;
+  handleDeploy: (backup:Linode.LinodeBackup) => void;
+}
+
+const typeMap = {
+  auto: 'Automatic',
+  snapshot: 'Manual',
+};
+
+const BackupTableRow:React.StatelessComponent<Props> = (props) => {
+  const onDeploy = () => {
+    props.handleDeploy(props.backup);
+  }
+  const { backup, handleRestore } = props;
+  return (
+    <TableRow key={backup.id} data-qa-backup>
+      <TableCell>
+        {formatBackupDate(backup.created)}
+      </TableCell>
+      <TableCell data-qa-backup-name>
+        {backup.label || typeMap[backup.type]}
+      </TableCell>
+      <TableCell>
+        {moment.duration(
+          moment(backup.finished).diff(moment(backup.created)),
+        ).humanize()}
+      </TableCell>
+      <TableCell data-qa-backup-disks>
+        {backup.disks.map((disk, idx) => (
+          <div key={idx}>
+            {disk.label} ({disk.filesystem}) - {disk.size}MB
+          </div>
+        ))}
+      </TableCell>
+      <TableCell data-qa-space-required>
+        {backup.disks.reduce((acc, disk) => (
+          acc + disk.size
+        ), 0)}MB
+      </TableCell>
+      <TableCell>
+        <LinodeBackupActionMenu
+          backup={backup}
+          onRestore={handleRestore}
+          onDeploy={onDeploy}
+        />
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export default BackupTableRow;

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -193,7 +193,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
           });
       });
     const { enableOnLoad } = pathOr(false, ['location','state'], this.props);
-    if (enableOnLoad) { this.enableBackups(); }
+    if (enableOnLoad && !this.props.backupsEnabled) { this.enableBackups(); }
   }
 
   componentWillUnmount() {

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -139,7 +139,7 @@ const typeMap = {
 };
 
 const evenize = (n: number): number => {
-  if (n === 0) return n;
+  if (n === 0) { return n; }
   return (n % 2 === 0) ? n : n - 1;
 };
 
@@ -150,7 +150,7 @@ export const aggregateBackups = (backups: Linode.LinodeBackupsResponse): Linode.
   return backups && [...backups.automatic!, manualSnapshot!].filter(b => Boolean(b));
 };
 
-export function formatBackupDate(backupDate: string) {
+export const formatBackupDate = (backupDate: string) => {
   return moment.utc(backupDate).local().fromNow();
 }
 
@@ -197,6 +197,8 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
             /* @todo: how do we want to display this error? */
           });
       });
+    const { enableOnLoad } = pathOr(false, ['location','state'], this.props);
+    if (enableOnLoad) { this.enableBackups(); }
   }
 
   componentWillUnmount() {
@@ -239,7 +241,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
     ];
   }
 
-  enableBackups() {
+  enableBackups = () => {
     const { linodeID } = this.props;
     enableBackups(linodeID)
       .then(() => {
@@ -337,6 +339,11 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
     this.setState({ cancelBackupsAlertOpen: true });
   }
 
+  handleRestoreSubmit = () => {
+    this.closeRestoreDrawer();
+    sendToast('Backup restore started');
+  }
+
   Placeholder = (): JSX.Element | null => {
     const backupsMonthlyPrice = path<number>(
       ['type', 'response', 'addons', 'backups', 'price'],
@@ -376,7 +383,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                 <TableCell>Duration</TableCell>
                 <TableCell>Disks</TableCell>
                 <TableCell>Space Required</TableCell>
-                <TableCell></TableCell>
+                <TableCell />
               </TableRow>
             </TableHead>
             <TableBody>
@@ -604,10 +611,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
           backupID={this.state.restoreDrawer.backupID}
           backupCreated={this.state.restoreDrawer.backupCreated}
           onClose={this.closeRestoreDrawer}
-          onSubmit={() => {
-            this.closeRestoreDrawer();
-            sendToast('Backup restore started');
-          }}
+          onSubmit={this.handleRestoreSubmit}
         />
         <ConfirmationDialog
           title="Confirm Cancellation"

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
@@ -4,7 +4,8 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
-  onRestore: () => void;
+  backup: Linode.LinodeBackup;
+  onRestore: (backup:Linode.LinodeBackup) => void;
   onDeploy: () => void;
 }
 
@@ -13,16 +14,17 @@ type CombinedProps = Props & RouteComponentProps<{}>;
 class LinodeBackupActionMenu extends React.Component<CombinedProps> {
   createActions = () => {
     const {
+      backup,
       onRestore,
       onDeploy,
     } = this.props;
 
-    return function (closeMenu: Function): Action[] {
+    return (closeMenu: Function): Action[] => {
       const actions = [
         {
           title: 'Restore to Existing Linode',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            onRestore();
+            onRestore(backup);
             closeMenu();
             e.preventDefault();
           },

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
@@ -6,7 +6,7 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 interface Props {
   backup: Linode.LinodeBackup;
   onRestore: (backup:Linode.LinodeBackup) => void;
-  onDeploy: () => void;
+  onDeploy: (backup:Linode.LinodeBackup) => void;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}>;
@@ -32,7 +32,7 @@ class LinodeBackupActionMenu extends React.Component<CombinedProps> {
         {
           title: 'Deploy New Linode',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            onDeploy();
+            onDeploy(backup);
             closeMenu();
             e.preventDefault();
           },

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -8,6 +8,7 @@ import { powerOnLinode } from './powerActions';
 interface Props {
   linodeId: number;
   linodeLabel: string;
+  linodeBackups: Linode.LinodeBackups;
   linodeStatus: string;
   openConfigDrawer: (configs: Linode.Config[], fn: (id: number) => void) => void;
   toggleConfirmation: (bootOption: Linode.BootAction,
@@ -18,9 +19,8 @@ type CombinedProps = Props & RouteComponentProps<{}>;
 
 class LinodeActionMenu extends React.Component<CombinedProps> {
   createLinodeActions = () => {
-    const { linodeId, linodeLabel, linodeStatus,
+    const { linodeId, linodeLabel, linodeBackups, linodeStatus,
        openConfigDrawer, toggleConfirmation, history: { push } } = this.props;
-
     return (closeMenu: Function): Action[] => {
       const actions = [
         {
@@ -88,6 +88,19 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
             },
           }
         );
+      }
+
+      if (!linodeBackups.enabled) {
+        actions.splice(-2, 1, {
+          title: 'Enable Backups',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            push({
+              pathname: `/linodes/${linodeId}/backup`,
+              state: { enableOnLoad: true }
+            });
+            e.preventDefault();
+          },
+        })
       }
 
       return actions;

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -178,6 +178,7 @@ interface Props {
   linodeType: null | string;
   linodeNotification?: string;
   linodeLabel: string;
+  linodeBackups: Linode.LinodeBackups;
   linodeRecentEvent?: Linode.Event;
   linodeSpecDisk: number;
   linodeSpecMemory: number;
@@ -308,7 +309,7 @@ class LinodeCard extends React.Component<CombinedProps> {
 
   render() {
     const { classes, openConfigDrawer, linodeId, linodeLabel, linodeRecentEvent,
-      linodeStatus, toggleConfirmation } = this.props;
+      linodeStatus, linodeBackups, toggleConfirmation } = this.props;
     const loading = linodeInTransition(linodeStatus, linodeRecentEvent)
 
     return (
@@ -326,6 +327,7 @@ class LinodeCard extends React.Component<CombinedProps> {
                   linodeId={linodeId}
                   linodeLabel={linodeLabel}
                   linodeStatus={linodeStatus}
+                  linodeBackups={linodeBackups}
                   openConfigDrawer={openConfigDrawer}
                   toggleConfirmation={toggleConfirmation}
                 />

--- a/src/features/linodes/LinodesLanding/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow.tsx
@@ -106,6 +106,7 @@ interface Props {
   linodeType: null | string;
   linodeNotification?: string;
   linodeLabel: string;
+  linodeBackups: Linode.LinodeBackups;
   linodeRecentEvent?: Linode.Event;
   openConfigDrawer: (configs: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
   toggleConfirmation: (bootOption: Linode.BootAction,
@@ -192,6 +193,7 @@ class LinodeRow extends React.Component<CombinedProps> {
       linodeRegion,
       linodeNotification,
       linodeLabel,
+      linodeBackups,
       classes,
       openConfigDrawer,
       toggleConfirmation,
@@ -216,6 +218,7 @@ class LinodeRow extends React.Component<CombinedProps> {
               linodeId={linodeId}
               linodeLabel={linodeLabel}
               linodeStatus={linodeStatus}
+              linodeBackups={linodeBackups}
               openConfigDrawer={openConfigDrawer}
               toggleConfirmation={toggleConfirmation}
             />

--- a/src/features/linodes/LinodesLanding/LinodesGridView.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesGridView.tsx
@@ -23,7 +23,6 @@ const safeGetImageLabel = (images: Linode.Image[], slug: string | null): string 
 
 const LinodesGridView: React.StatelessComponent<Props> = (props) => {
   const { linodes, images, openConfigDrawer, toggleConfirmation } = props;
-
   return (
     <Grid container>
       {linodes.map(linode =>
@@ -37,6 +36,7 @@ const LinodesGridView: React.StatelessComponent<Props> = (props) => {
           linodeType={linode.type}
           linodeNotification={linode.notification}
           linodeLabel={linode.label}
+          linodeBackups={linode.backups}
           linodeRecentEvent={linode.recentEvent}
           imageLabel={safeGetImageLabel(images, linode.image)}
           openConfigDrawer={openConfigDrawer}

--- a/src/features/linodes/LinodesLanding/LinodesListView.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesListView.tsx
@@ -48,6 +48,7 @@ const LinodesListView: React.StatelessComponent<Props> = (props) => {
                   linodeRegion={linode.region}
                   linodeNotification={linode.notification}
                   linodeLabel={linode.label}
+                  linodeBackups={linode.backups}
                   linodeRecentEvent={linode.recentEvent}
                   openConfigDrawer={openConfigDrawer}
                   toggleConfirmation={toggleConfirmation}


### PR DESCRIPTION
## Notes

* On Linodes landing page (both list and grid view), if a Linode
has backups enabled, "View Backups" is displayed as an option in
the action (meatball) menu. (This was the original behavior).
* If backups are not enabled, "View Backups" is replaced by
"Enable Backups." Choosing this option will redirect to the
Backups tab of that Linode's detail view. The cDM handler
will then run the `enableBackups` method.