### PR TITLE
M3-1172 Correct balance display on MakeAPayment

### DIFF
--- a/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -118,7 +118,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
     }, errors);
 
     const generalError = hasErrorFor('none');
-    const balanceDisplay = !accountLoading && balance !== false ? `$${balance.toFixed(2)}` : '';
+    const balanceDisplay = !accountLoading && balance !== false ? `$${Math.abs(balance).toFixed(2)}` : '';
     return (
       <ExpansionPanel heading="Make a Payment" actions={this.renderActions}>
         <Grid container>
@@ -134,8 +134,8 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
                   component={'span'}
                   variant="title"
                   className={classNames({
-                    [classes.positive]: balance >= 0,
-                    [classes.negative]: balance < 0,
+                    [classes.negative]: balance > 0,
+                    [classes.positive]: balance <= 0,
                   })}
                 >
                   {balanceDisplay}

--- a/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Account/AccountPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -139,6 +139,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
                   })}
                 >
                   {balanceDisplay}
+                  { balance < 0 && ` (credit)` }
                 </Typography>
               </Grid>
             </Grid>


### PR DESCRIPTION
## Purpose
It was found that balance display was swapped, showing credits with a negative symbol and in the color red while showing owned balance as a positive value in green.
