### PR TITLE
M3-1212 volume copy

### DIFF
--- a/src/features/Volumes/VolumeConfigDrawer.tsx
+++ b/src/features/Volumes/VolumeConfigDrawer.tsx
@@ -80,7 +80,7 @@ const VolumeConfigDrawer: React.StatelessComponent<CombinedProps> = (props) => {
             </Typography>
             <CopyableTextField
               className={classes.copyField}
-              value={`${props.volumePath} /mnt/${props.volumeLabel}`}
+              value={`${props.volumePath} /mnt/${props.volumeLabel} ext4 defaults,noatime 0 2`}
             />
           </div>
           <ActionsPanel>


### PR DESCRIPTION
### Purpose

Change copy instructing the user to automatically mount volume at Linode boot time from

`$device $mount-path`

to `$device  $mount-path  ext4 defaults,noatime 0 2` 