### PR TITLE
Test Fixes - Stackscripts, domains, account permissions

### DIFF
--- a/e2e/pageobjects/account/permissions.page.js
+++ b/e2e/pageobjects/account/permissions.page.js
@@ -6,7 +6,7 @@ class Permissions extends Page {
     get updatePermissionsHeader() { return $('[data-qa-update-permissions-header]'); }
     get globalPermissionsHeader() { return $('[data-qa-permissions-header="Global Permissions"]'); }
     get billingAccessHeader() { return $('[data-qa-permissions-header="billing"]'); }
-    get specificGrantsHeader() { return $('[data-qa-permissions-header="Specifc Grants"]'); }
+    get specificPermissionsHeader() { return $('[data-qa-permissions-header="Specific Permissions"]'); }
     
     // Global Toggles
     get restrictAccessToggle() { return $('[data-qa-restrict-access]'); }
@@ -46,7 +46,7 @@ class Permissions extends Page {
         if (restricted) {
             expect(this.globalPermissionsHeader.isVisible()).toBe(true);
             expect(this.billingAccessHeader.isVisible()).toBe(true);
-            expect(this.specificGrantsHeader.isVisible()).toBe(true);
+            expect(this.specificPermissionsHeader.isVisible()).toBe(true);
             expect(this.globalPermissions.length).toBeGreaterThan(1);
             expect(this.billingPermissionNone.isVisible()).toBe(true);
             expect(this.billingPermissionRead.isVisible()).toBe(true);
@@ -78,17 +78,17 @@ class Permissions extends Page {
         this.waitForNotice(`Successfully updated global permissions`);
     }
 
-    setSpecificGrant(grantType, grant, accessLevel) {
+    setSpecificPermission(permType, perm, accessLevel) {
         const permission =
-            $(`[data-qa-permissions-header="${grantType}"]`).$('..')
-                .$(`[data-qa-specific-grant="${grant}"]`)
+            $(`[data-qa-permissions-header="${permType}"]`).$('..')
+                .$(`[data-qa-specific-grant="${perm}"]`)
                 .$(`[data-qa-permission="${accessLevel}"]`);
         permission.click();
         
         expect(permission.getAttribute('data-qa-radio')).toBe('true');
 
         this.specificSection.$(this.saveButton.selector).click();
-        this.waitForNotice('Successfully updated Entity-Specific Grants');
+        this.waitForNotice('Successfully updated Entity-Specific Permissions');
     }
 
     setBillingPermission(accessLevel) {

--- a/e2e/pageobjects/configure-stackscript.page.js
+++ b/e2e/pageobjects/configure-stackscript.page.js
@@ -100,7 +100,7 @@ class ConfigureStackScript extends Page {
 
         this.script.$('textarea').click();
         this.script.$('textarea').setValue(config.script);
-        this.revisionNote.$('textarea').setValue(config.revisionNote);
+        this.revisionNote.$('input').setValue(config.revisionNote);
     }
 
     create(config, update=false) {

--- a/e2e/pageobjects/list-domains.page.js
+++ b/e2e/pageobjects/list-domains.page.js
@@ -74,13 +74,19 @@ class ListDomains extends Page {
         this.createSoaEmail.$('input').setValue(email);
         this.submit.click();
 
-        if (placeholder) {
-            this.domainElem.waitForVisible(constants.wait.normal);
-        } else {
-            browser.waitUntil(function() {
-                return $$('[data-qa-domain-cell]').length > existingDomainsCount;
-            }, constants.wait.normal, 'Domain failed to be created');
-        }
+        browser.waitForVisible('[data-qa-domain-title]', constants.wait.normal);
+        
+        browser.waitUntil(function() {
+            return browser.getUrl().includes('/records');
+        }, constants.wait.normal);
+
+        // if (placeholder) {
+        //     this.domainElem.waitForVisible(constants.wait.normal);
+        // } else {
+        //     browser.waitUntil(function() {
+        //         return $$('[data-qa-domain-cell]').length > existingDomainsCount;
+        //     }, constants.wait.normal, 'Domain failed to be created');
+        // }
     }
 
     editDnsRecord(domain) {

--- a/e2e/specs/account/view-update-permissions.spec.js
+++ b/e2e/specs/account/view-update-permissions.spec.js
@@ -41,6 +41,6 @@ describe('Account - Restricted User - Permissions Suite', () => {
     });
 
     it('should update an entity-based specific grant', () => {
-        Permissions.setSpecificGrant('Linodes', linode.label, 'Read Only');
+        Permissions.setSpecificPermission('Linodes', linode.label, 'Read Only');
     });
 });

--- a/e2e/specs/domains/list-domains.spec.js
+++ b/e2e/specs/domains/list-domains.spec.js
@@ -23,16 +23,19 @@ describe('Domains - List Suite', () => {
 
     it('should fail creating the same domain', () => {
         try {
+            browser.url(constants.routes.domains);
+            ListDomains.baseElemsDisplay();
             ListDomains.create(initialDomain,'foo@bar.com');
         } catch (err) {
             ListDomains.createDomainName.$('p').waitForVisible(constants.wait.normal);
             ListDomains.cancel.click();
-            ListDomains.drawerTitle.waitForVisible(constants.wait.short, true);
+            ListDomains.drawerTitle.waitForVisible(constants.wait.normal, true);
         }
     });
 
     it('should display action menu options', () => {
-        ListDomains.domainElem.waitForVisible();
+        browser.url(constants.routes.domains);
+        ListDomains.domainElem.waitForVisible(constants.wait.normal);
         domainId = ListDomains.domains[0].getAttribute('data-qa-domain-cell');
         domainElement = `[data-qa-domain-cell="${domainId}"]`;
         
@@ -46,7 +49,7 @@ describe('Domains - List Suite', () => {
             'Zone File',
         ];
 
-        ListDomains.actionMenuItem.waitForVisible();
+        ListDomains.actionMenuItem.waitForVisible(constants.wait.normal);
         const actionMenuItems = $$(ListDomains.actionMenuItem.selector);
         actionMenuItems.forEach(i => expect(expectedMenuItems).toContain(i.getText()));
 
@@ -66,7 +69,7 @@ describe('Domains - List Suite', () => {
     it('should fail to clone with the same domain name', () => {
             ListDomains.selectActionMenuItem($(domainElement), 'Clone');
             ListDomains.clone(initialDomain);
-            ListDomains.cloneDomainName.$('p').waitForVisible();
+            ListDomains.cloneDomainName.$('p').waitForVisible(constants.wait.normal);
             ListDomains.closeDrawer();
     });
 


### PR DESCRIPTION
* Addresses UI changes that caused a few e2e tests to break.

* Update Specific Grants -> Specific Permissions
* Update stackscripts tests to target an input selector instead of a textarea
* Update create domain method to expect navigation to domain detail page after creation
* Discovered clone domains bug logged in M3-1218 while testing.


## To Test

```bash
yarn && yarn start
yarn selenium
yarn e2e --dir stackscripts # all should pass
yarn e2e --file e2e/specs/domains/list-domains.spec.js # two failures (due to M3-1218)
yarn e2e --file e2e/specs/account/view-update-permissions.spec.js # all should pass
```