### PR TITLE
Make sure DT switch sticks to the bottom of primary nav

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -69,6 +69,9 @@ const styles = (theme: Theme & Linode.Theme): StyleRules => ({
   },
   fadeContainer: {
     width: '100%',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
   },
   logoItem: {
     padding: '10px 0 8px 26px',


### PR DESCRIPTION
regression was introduced after we merged the managed link PR and the fade in container on the primary nav. 