### PR TITLE
M3-1220 Fix console tabs background colors (DT)

### DIFF
--- a/src/features/Lish/Lish.tsx
+++ b/src/features/Lish/Lish.tsx
@@ -14,9 +14,9 @@ import Weblish from './Weblish';
 
 type ClassNames = 'tabs' | 'tabRoot' | 'progress' | 'notFound';
 
-const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   tabs: {
-    backgroundColor: '#f4f4f4',
+    backgroundColor: theme.bg.offWhite,
     margin: 0,
   },
   tabRoot: {


### PR DESCRIPTION
the dark theme was displaying the wrong bg colors for the console tabs. 