### PR TITLE
M3-1193 Table Rows as links

### DIFF
--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -1,0 +1,50 @@
+import * as classNames from 'classnames';
+import { compose } from 'ramda';
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import TableRow, { TableRowProps } from '@material-ui/core/TableRow';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
+  root: {},
+});
+
+interface Props {
+  goTo?: string;
+}
+
+type CombinedProps = Props & TableRowProps & RouteComponentProps<{}> & WithStyles<ClassNames>;
+
+class WrappedTableRow extends React.Component<CombinedProps> {
+
+  goTo = (path: string) =>  {
+    this.props.history.push(path);
+  }
+
+  render() {
+    const { classes, className, ...rest } = this.props;
+
+    return (
+        <TableRow
+          className={classNames(
+          className,
+            {
+              [classes.root]: true,
+            })}
+          {...rest
+        }>
+          {this.props.children}
+        </TableRow>
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default compose(
+  styled,
+  withRouter
+)(WrappedTableRow);

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -8,28 +8,36 @@ import TableRow, { TableRowProps } from '@material-ui/core/TableRow';
 type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
-  root: {},
+  root: {
+    transition: theme.transitions.create('background-color'),
+  },
 });
 
 interface Props {
-  goToLink?: string;
+  rowLink?: string;
   className?: string;
+  staticContext?: boolean;
 }
 
 type CombinedProps = Props & TableRowProps & RouteComponentProps<{}> & WithStyles<ClassNames>;
 
 class WrappedTableRow extends React.Component<CombinedProps> {
 
-  goTo = (path: string) =>  {
-    this.props.history.push(path);
+  goTo = (e: any, path: string) =>  {
+    if (e.target.tagName === 'TD') {
+      e.stopPropagation();
+      this.props.history.push(path);
+    }
   }
 
   render() {
-    const { classes, className, goToLink, ...rest } = this.props;
+    const { classes, className, rowLink, staticContext, ...rest } = this.props;
 
     return (
         <TableRow
-          onClick={() => goToLink && this.goTo(goToLink)}
+          onClick={(e) => rowLink && this.goTo(e, rowLink)}
+          hover={rowLink !== undefined}
+          role={rowLink && 'link'}
           className={classNames(
           className,
             {
@@ -46,5 +54,6 @@ class WrappedTableRow extends React.Component<CombinedProps> {
 const styled = withStyles<ClassNames>(styles, { withTheme: true });
 const styledTableRow = styled<CombinedProps>(WrappedTableRow);
 const routedStyledTableRow = withRouter(styledTableRow);
+
 
 export default routedStyledTableRow;

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -1,5 +1,4 @@
 import * as classNames from 'classnames';
-import { compose } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
@@ -13,7 +12,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 });
 
 interface Props {
-  goTo?: string;
+  goToLink?: string;
+  className?: string;
 }
 
 type CombinedProps = Props & TableRowProps & RouteComponentProps<{}> & WithStyles<ClassNames>;
@@ -25,26 +25,26 @@ class WrappedTableRow extends React.Component<CombinedProps> {
   }
 
   render() {
-    const { classes, className, ...rest } = this.props;
+    const { classes, className, goToLink, ...rest } = this.props;
 
     return (
         <TableRow
+          onClick={() => goToLink && this.goTo(goToLink)}
           className={classNames(
           className,
             {
               [classes.root]: true,
             })}
-          {...rest
-        }>
+          {...rest}
+        >
           {this.props.children}
         </TableRow>
     );
   }
 }
 
-const styled = withStyles(styles, { withTheme: true });
+const styled = withStyles<ClassNames>(styles, { withTheme: true });
+const styledTableRow = styled<CombinedProps>(WrappedTableRow);
+const routedStyledTableRow = withRouter(styledTableRow);
 
-export default compose(
-  styled,
-  withRouter
-)(WrappedTableRow);
+export default routedStyledTableRow;

--- a/src/components/TableRow/index.ts
+++ b/src/components/TableRow/index.ts
@@ -1,0 +1,2 @@
+import TableRow from './TableRow';
+export default TableRow;

--- a/src/darkTheme.ts
+++ b/src/darkTheme.ts
@@ -9,6 +9,7 @@ const primaryColors = {
   text: '#ffffff',
   headline: '#f4f4f4',
   divider: '#222222',
+  offBlack: '#fff',
 }
 
 const LinodeTheme: Linode.Theme = {
@@ -787,14 +788,14 @@ const LinodeTheme: Linode.Theme = {
         zIndex: 1,
         '&:hover': {
           '&$hover': {
-            backgroundColor: 'rgba(0, 0, 0, 0.1)',
+            backgroundColor: '#fbfbfb',
           },
         },
       },
       hover: {
         cursor: 'pointer',
         '& a': {
-          color: primaryColors.text,
+          color: primaryColors.offBlack,
           fontWeight: 700,
         },
       },

--- a/src/darkTheme.ts
+++ b/src/darkTheme.ts
@@ -788,7 +788,7 @@ const LinodeTheme: Linode.Theme = {
         zIndex: 1,
         '&:hover': {
           '&$hover': {
-            backgroundColor: '#fbfbfb',
+            color: primaryColors.offBlack,
           },
         },
       },

--- a/src/darkTheme.ts
+++ b/src/darkTheme.ts
@@ -781,6 +781,24 @@ const LinodeTheme: Linode.Theme = {
         backgroundColor: '#32363C',
       },
     },
+    MuiTableRow: {
+      root: {
+        position: 'relative',
+        zIndex: 1,
+        '&:hover': {
+          '&$hover': {
+            backgroundColor: 'rgba(0, 0, 0, 0.1)',
+          },
+        },
+      },
+      hover: {
+        cursor: 'pointer',
+        '& a': {
+          color: primaryColors.text,
+          fontWeight: 700,
+        },
+      },
+    },
     MuiTabs: {
       root: {
         margin: '16px 0',

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -3,7 +3,6 @@ import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
 import { compose, pathOr } from 'ramda';
 import * as React from 'react';
@@ -20,6 +19,7 @@ import Grid from 'src/components/Grid';
 import PaginationFooter, { PaginationProps } from 'src/components/PaginationFooter';
 import Placeholder from 'src/components/Placeholder';
 import Table from 'src/components/Table';
+import TableRow from 'src/components/TableRow';
 import { sendToast } from 'src/features/ToastNotifications/toasts';
 import { deleteDomain, getDomains } from 'src/services/domains';
 import scrollToTop from 'src/utilities/scrollToTop';

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -7,7 +7,6 @@ import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import TableBody from '@material-ui/core/TableBody';
 import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
 import Typography from '@material-ui/core/Typography';
 
 import NodeBalancer from 'src/assets/addnewmenu/nodebalancer.svg';
@@ -23,6 +22,7 @@ import Placeholder from 'src/components/Placeholder';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
 import TableRowError from 'src/components/TableRowError';
 import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
@@ -382,7 +382,13 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
 
     return nodeBalancers.map((nodeBalancer) => {
       return (
-        <TableRow key={nodeBalancer.id} data-qa-nodebalancer-cell className="fade-in-table">
+        <TableRow
+          key={nodeBalancer.id}
+          data-qa-nodebalancer-cell
+          rowLink={`/nodebalancers/${nodeBalancer.id}`}
+          className="fade-in-table"
+          arial-label={nodeBalancer.label}
+        >
           <TableCell data-qa-nodebalancer-label>
             <Link to={`/nodebalancers/${nodeBalancer.id}`}>
               {nodeBalancer.label}

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -29,9 +29,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => 
     },
   },
   root: {
-    alignItems: 'center',
     marginBottom: theme.spacing.unit / 2,
-    width: '100%',
     '&:last-child': {
       marginBottom: 0,
     },

--- a/src/features/linodes/LinodesLanding/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow.tsx
@@ -2,16 +2,15 @@ import { compose } from 'ramda';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
-import Button from '@material-ui/core/Button';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import TableCell from '@material-ui/core/TableCell';
-import TableRow from '@material-ui/core/TableRow';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 
 import Flag from 'src/assets/icons/flag.svg';
 import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
+import TableRow from 'src/components/TableRow';
 import { withTypes } from 'src/context/types';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 import { displayType } from 'src/features/linodes/presentation';
@@ -147,21 +146,17 @@ class LinodeRow extends React.Component<CombinedProps> {
 
     return (
       <TableCell className={classes.linodeCell}>
-        <Link to={`/linodes/${linodeId}`} className={classes.link} tabIndex={-1}>
-          <Button className={classes.linkButton}>
-            <Grid container wrap="nowrap" alignItems="center">
-              <Grid item className="py0">
-                <LinodeStatusIndicator status={linodeStatus} />
-              </Grid>
-              <Grid item className="py0">
-                <Typography role="header" variant="subheading" data-qa-label>
-                  {linodeLabel}
-                </Typography>
-                {!typesLoading && <Typography> {displayType(linodeType, typesData || [])} </Typography>}
-              </Grid>
-            </Grid>
-          </Button>
-        </Link>
+        <Grid container wrap="nowrap" alignItems="center">
+          <Grid item className="py0">
+            <LinodeStatusIndicator status={linodeStatus} />
+          </Grid>
+          <Grid item className="py0">
+            <Typography role="header" variant="subheading" data-qa-label>
+              <Link to={`/linodes/${linodeId}`} className={classes.link}>{linodeLabel}</Link>
+            </Typography>
+            {!typesLoading && <Typography> {displayType(linodeType, typesData || [])} </Typography>}
+          </Grid>
+        </Grid>
       </TableCell>
     );
   }
@@ -200,7 +195,13 @@ class LinodeRow extends React.Component<CombinedProps> {
     } = this.props;
 
     return (
-      <TableRow key={linodeId} data-qa-linode={linodeLabel}>
+      <TableRow
+        key={linodeId}
+        className={`${classes.bodyRow} 'fade-in-table'`}
+        data-qa-loading
+        rowLink={`/linodes/${linodeId}`}
+        arial-label={linodeLabel}
+      >
         {this.headCell()}
         <TableCell className={classes.ipCell} data-qa-ips>
           <IPAddress ips={linodeIpv4} copyRight />

--- a/src/features/linodes/LinodesLanding/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow.tsx
@@ -26,6 +26,7 @@ type ClassNames = 'bodyRow'
   | 'linodeCell'
   | 'tagsCell'
   | 'ipCell'
+  | 'ipCellWrapper'
   | 'regionCell'
   | 'actionCell'
   | 'actionInner'
@@ -50,6 +51,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => {
     },
     ipCell: {
       width: '30%',
+    },
+    ipCellWrapper: {
+      display: 'inline-flex',
+      flexDirection: 'column',
     },
     regionCell: {
       width: '15%',
@@ -146,17 +151,19 @@ class LinodeRow extends React.Component<CombinedProps> {
 
     return (
       <TableCell className={classes.linodeCell}>
-        <Grid container wrap="nowrap" alignItems="center">
-          <Grid item className="py0">
-            <LinodeStatusIndicator status={linodeStatus} />
+        <Link to={`/linodes/${linodeId}`} className={classes.link}>
+          <Grid container wrap="nowrap" alignItems="center">
+            <Grid item className="py0">
+              <LinodeStatusIndicator status={linodeStatus} />
+            </Grid>
+            <Grid item className="py0">
+              <Typography role="header" variant="subheading" data-qa-label>
+                {linodeLabel}
+              </Typography>
+              {!typesLoading && <Typography variant="caption">{displayType(linodeType, typesData || [])} </Typography>}
+            </Grid>
           </Grid>
-          <Grid item className="py0">
-            <Typography role="header" variant="subheading" data-qa-label>
-              <Link to={`/linodes/${linodeId}`} className={classes.link}>{linodeLabel}</Link>
-            </Typography>
-            {!typesLoading && <Typography> {displayType(linodeType, typesData || [])} </Typography>}
-          </Grid>
-        </Grid>
+          </Link>
       </TableCell>
     );
   }
@@ -204,8 +211,10 @@ class LinodeRow extends React.Component<CombinedProps> {
       >
         {this.headCell()}
         <TableCell className={classes.ipCell} data-qa-ips>
-          <IPAddress ips={linodeIpv4} copyRight />
-          <IPAddress ips={[linodeIpv6]} copyRight />
+          <div className={classes.ipCellWrapper}>
+            <IPAddress ips={linodeIpv4} copyRight />
+            <IPAddress ips={[linodeIpv6]} copyRight />
+          </div>
         </TableCell>
         <TableCell className={classes.regionCell} data-qa-region>
           <RegionIndicator region={linodeRegion} />

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -9,6 +9,7 @@ const primaryColors = {
   text: '#606469',
   headline: '#32363C',
   divider: '#f4f4f4',
+  offBlack: '#444',
 }
 
 const LinodeTheme: Linode.Theme = {
@@ -785,7 +786,7 @@ const LinodeTheme: Linode.Theme = {
       hover: {
         cursor: 'pointer',
         '& a': {
-          color: primaryColors.text,
+          color: primaryColors.offBlack,
           fontWeight: 700,
         },
       },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -772,6 +772,24 @@ const LinodeTheme: Linode.Theme = {
         overflowX: 'auto',
       },
     },
+    MuiTableRow: {
+      root: {
+        position: 'relative',
+        zIndex: 1,
+        '&:hover': {
+          '&$hover': {
+            backgroundColor: '#fbfbfb',
+          },
+        },
+      },
+      hover: {
+        cursor: 'pointer',
+        '& a': {
+          color: primaryColors.text,
+          fontWeight: 700,
+        },
+      },
+    },
     MuiTooltip: {
       tooltip: {
         borderRadius: 0,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -240,7 +240,6 @@ const LinodeTheme: Linode.Theme = {
         paddingRight: 4,
         fontSize: '.9rem',
         position: 'relative',
-        top: -1,
       },
       deleteIcon: {
         color: '#aaa',


### PR DESCRIPTION
This is the one of two PRs for M3-1193.

https://github.com/linode/manager/pull/3741 targets grid tiles

This PR addresses clicking table rows to get to primary destination. The idea is to be able to click on the whole row but also make sure we can click on component within the row with bubbling up. I wanted to avoid having to go to change components and add stopPropagation everywhere so instead I check the markup of target element of the clickHandler and make sure we are on a TableCell (most parent) to trigger the click event.

**Note:** We can safely replace the new TableRow site-wide without risking regressions. Only if a rowLink prop is added will the component behave as a clickable row.

In order to test this component, it was added to:

/nodebalancers
/linodes (list view)