### PR TITLE
M3-1079 revoked personal tokens

### DIFF
--- a/e2e/specs/profile/tokens.spec.js
+++ b/e2e/specs/profile/tokens.spec.js
@@ -136,7 +136,6 @@ describe('View - Personal Access Tokens', () => {
 
             it('should revoke on remove', () => {
                 browser.click(dialogConfirm);
-                browser.refresh();
                 profile.tokenBaseElems();
                 browser.waitForVisible(updatedSelector, constants.wait.long, true);
             });

--- a/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -132,6 +132,14 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
     });
   }
 
+  handleLabelChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.props.onChange('label', e.target.value);
+  }
+
+  handleExpiryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    this.props.onChange('expiry', e.target.value);
+  }
+
   // return whether all scopes selected in the create token flow are the same
   allScopesIdentical = () => {
     const { scopes, selectAllSelectedScope } = this.state;
@@ -283,7 +291,7 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
             errorText={errorFor('label')}
             value={label || ''}
             label="Label"
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange('label', e.target.value)}
+            onChange={this.handleLabelChange}
             data-qa-add-label
           />
         }
@@ -294,7 +302,7 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
             </InputLabel>
             <Select
               value={expiry || expiryTups[0][1]}
-              onChange={e => onChange('expiry', e.target.value)}
+              onChange={this.handleExpiryChange}
               inputProps={{ name: 'expiry', id: 'expiry' }}
             >
               {expiryTups.map((expiryTup: Expiry) => (
@@ -322,7 +330,7 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
             <Button
               variant="raised"
               color="primary"
-              onClick={() => closeDrawer()}
+              onClick={closeDrawer}
               data-qa-close-drawer
             >
               Done
@@ -347,7 +355,7 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
                 color="secondary"
                 className="cancel"
                 key="cancel"
-                onClick={() => closeDrawer()} data-qa-cancel
+                onClick={closeDrawer} data-qa-cancel
               >
                 Cancel
               </Button>,

--- a/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -267,7 +267,6 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
       open,
       mode,
       closeDrawer,
-      onChange,
       onCreate,
       onEdit,
     } = this.props;

--- a/src/features/Profile/APITokens/APITokenMenu.tsx
+++ b/src/features/Profile/APITokens/APITokenMenu.tsx
@@ -3,39 +3,41 @@ import * as React from 'react';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
+  token: Linode.Token;
+  type: string;
   isAppTokenMenu: boolean;
-  openViewDrawer: () => void;
-  openEditDrawer: () => void;
-  openRevokeDialog: () => void;
+  openViewDrawer: (token:Linode.Token) => void;
+  openEditDrawer: (token:Linode.Token) => void;
+  openRevokeDialog: (token:Linode.Token, type:string) => void;
 }
 
 type CombinedProps = Props;
 
 class APITokenMenu extends React.Component<CombinedProps> {
   createActions = () => {
-    const { isAppTokenMenu, openViewDrawer, openEditDrawer, openRevokeDialog } = this.props;
+    const { isAppTokenMenu, openViewDrawer, openEditDrawer, openRevokeDialog, token, type } = this.props;
 
-    return function (closeMenu: Function): Action[] {
+    return (closeMenu: Function): Action[] => {
       const actions = (!isAppTokenMenu)
         ? [
           {
             title: 'View Token Scopes',
             onClick: (e: React.MouseEvent<HTMLElement>) => {
-              openViewDrawer();
+              openViewDrawer(token);
               closeMenu();
             },
           },
           {
             title: 'Edit',
             onClick: (e: React.MouseEvent<HTMLElement>) => {
-              openEditDrawer();
+              openEditDrawer(token);
               closeMenu();
             },
           },
           {
             title: 'Revoke',
             onClick: (e: React.MouseEvent<HTMLElement>) => {
-              openRevokeDialog();
+              openRevokeDialog(token,type);
               closeMenu();
             },
           },
@@ -44,14 +46,14 @@ class APITokenMenu extends React.Component<CombinedProps> {
           {
             title: 'View Token Scopes',
             onClick: (e: React.MouseEvent<HTMLElement>) => {
-              openViewDrawer();
+              openViewDrawer(token);
               closeMenu();
             },
           },
           {
             title: 'Revoke',
             onClick: (e: React.MouseEvent<HTMLElement>) => {
-              openRevokeDialog();
+              openRevokeDialog(token,type);
               closeMenu();
             },
           },


### PR DESCRIPTION
## Purpose

When revoking personal access tokens, a race condition occasionally caused
the expiry date of the token to be set slightly ahead of the
current time as reported by the `render()` function, so the token
would still appear in the list of rendered tokens (with a listed
expiration time of "In a few seconds").

Adding ten seconds to 'now' as computed by the render method
should avoid this condition. Since precise times are not important
for tokens, this will only cause discrepancies in the unlikely event
that a user loads the page 5 seconds before their token
is due to expire.

## Notes

Also refactored Lambda methods
