### PR TITLE
M3-544 Weblish and Glish Silently Fail

### DIFF
--- a/src/features/Lish/Glish.tsx
+++ b/src/features/Lish/Glish.tsx
@@ -91,17 +91,21 @@ class Glish extends React.Component<CombinedProps, State> {
   }
 
   componentDidUpdate(prevProps: CombinedProps, prevState: State) {
+    const { linode } = this.props;
+    const region = (linode as Linode.Linode).region;
 
     /*
     * If we have a new token, refresh the console
     * and the websocket connection with the new token
     */
-    if (this.props.token !== prevProps.token) {
-      const { linode } = this.props;
-      const region = (linode as Linode.Linode).region;
-      this.refreshMonitor(region, this.props.token);
-      return;
-    }
+    // if (this.props.token !== prevProps.token) {
+    //   const { linode } = this.props;
+    //   const region = (linode as Linode.Linode).region;
+    //   this.monitor.close();
+    //   resizeViewPort(1080, 840);
+    //   this.refreshMonitor(region, this.props.token);
+    //   this.renewVncToken();
+    // }
 
     /*
     * If refreshing the console failed, and we did not surpass the max number of
@@ -111,6 +115,8 @@ class Glish extends React.Component<CombinedProps, State> {
     if (prevState.retryAttempts !== retryAttempts && isRetryingConnection) {
       setTimeout(() => {
         this.props.refreshToken();
+        this.refreshMonitor(region, this.props.token);
+        this.renewVncToken();
       }, 3000);
     }
   }

--- a/src/features/Lish/Glish.tsx
+++ b/src/features/Lish/Glish.tsx
@@ -91,22 +91,27 @@ class Glish extends React.Component<CombinedProps, State> {
   }
 
   componentDidUpdate(prevProps: CombinedProps, prevState: State) {
+
     /*
-    * If our connection failed, and we did not surpass the max number of
-    * reconnection attempts, try to reconnect
+    * If we have a new token, refresh the console
+    * and the websocket connection with the new token
+    */
+    if (this.props.token !== prevProps.token) {
+      const { linode } = this.props;
+      const region = (linode as Linode.Linode).region;
+      this.refreshMonitor(region, this.props.token);
+      return;
+    }
+
+    /*
+    * If refreshing the console failed, and we did not surpass the max number of
+    * reconnection attempts, try to get a new lish token
     */
     const { retryAttempts, isRetryingConnection } = this.state;
     if (prevState.retryAttempts !== retryAttempts && isRetryingConnection) {
       setTimeout(() => {
         this.props.refreshToken();
       }, 3000);
-    }
-
-
-    if (this.props.token !== prevProps.token) {
-      const { linode } = this.props;
-      const region = (linode as Linode.Linode).region;
-      this.refreshMonitor(region, this.props.token);
     }
   }
 

--- a/src/features/Lish/Lish.tsx
+++ b/src/features/Lish/Lish.tsx
@@ -90,7 +90,7 @@ class Lish extends React.Component<CombinedProps, State> {
       return;
     }
 
-    getLinodeLishToken(linodeId)
+    return getLinodeLishToken(linodeId)
       .then((response) => {
         const { data: { lish_token: token } } = response;
         if (!this.mounted) { return; }

--- a/src/features/Lish/Lish.tsx
+++ b/src/features/Lish/Lish.tsx
@@ -122,7 +122,7 @@ class Lish extends React.Component<CombinedProps, State> {
   renderWeblish = () => {
     const { linode, token } = this.state;
     if (linode && token) {
-      return <Weblish token={token} linode={linode} />;
+      return <Weblish token={token} linode={linode} refreshToken={this.refreshToken} />;
     }
     return null;
   }

--- a/src/features/Lish/Weblish.tsx
+++ b/src/features/Lish/Weblish.tsx
@@ -5,15 +5,27 @@ import { Terminal } from 'xterm';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
 import CircleProgress from 'src/components/CircleProgress';
+import ErrorState from 'src/components/ErrorState';
 
 import { getLishSchemeAndHostname, resizeViewPort } from '.';
 
-type ClassNames = 'progress';
+type ClassNames = 'progress' | 'message' | 'errorState';
 
-const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   progress: {
     height: 'auto',
   },
+  message: {
+    color: 'white',
+    textAlign: 'center',
+    minHeight: '30px',
+    margin: theme.spacing.unit * 2,
+  },
+  errorState: {
+    '& *': {
+      color: '#f4f4f4 !important',
+    }
+  }
 });
 
 interface Props {
@@ -23,18 +35,28 @@ interface Props {
 
 interface State {
   renderingLish: boolean;
+  retryingConnection: boolean;
+  retryAttempts: number;
+  error: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{ linodeId?: number }>;
 
+const maxRetryAttempts: number = 3;
+
 export class Weblish extends React.Component<CombinedProps, State> {
   state: State = {
     renderingLish: true,
+    retryingConnection: false,
+    retryAttempts: 0,
+    error: '',
   };
 
   mounted: boolean = false;
 
   socket: WebSocket;
+
+  terminal: Terminal;
 
   componentDidMount() {
     this.mounted = true;
@@ -46,12 +68,26 @@ export class Weblish extends React.Component<CombinedProps, State> {
     this.mounted = false;
   }
 
+  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
+    const { retryAttempts, retryingConnection } = this.state;
+    /*
+    * If our connection failed, and we did not surpass the max number of
+    * reconnection attempts, try to reconnect
+    */
+    if (prevState.retryAttempts !== retryAttempts && retryingConnection) {
+      setTimeout(() => {
+        this.connect();
+      }, 3000);
+    }
+  }
+
   connect() {
     const { linode, token } = this.props;
     const { region } = linode;
 
     this.socket = new WebSocket(
       `${getLishSchemeAndHostname(region)}:8181/${token}/weblish`);
+
     this.socket.addEventListener('open', () => {
       if (!this.mounted) { return; }
       this.setState(
@@ -63,25 +99,67 @@ export class Weblish extends React.Component<CombinedProps, State> {
 
   renderTerminal() {
     const { linode } = this.props;
+    const { retryAttempts } = this.state;
     const { group, label } = linode;
 
-    const terminal = new Terminal({
+    this.terminal = new Terminal({
       cols: 120,
       rows: 40,
       fontFamily: '"Ubuntu Mono", monospace, sans-serif',
     });
 
-    terminal.on('data', (data: string) => this.socket.send(data));
+    this.terminal.on('data', (data: string) => this.socket.send(data));
     const terminalDiv = document.getElementById('terminal');
-    terminal.open(terminalDiv as HTMLElement);
+    this.terminal.open(terminalDiv as HTMLElement);
 
-    terminal.writeln('\x1b[32mLinode Lish Console\x1b[m');
+    this.terminal.writeln('\x1b[32mLinode Lish Console\x1b[m');
 
-    this.socket.addEventListener('message', evt => terminal.write(evt.data));
+    this.socket.addEventListener('message', evt => {
+      let data;
+
+      /*
+      * data is either going to be command line strings
+      * or it's going to look like {type: 'error', reason: 'thing failed'}
+      * the latter be JSON parsed and the other cannot 
+      */
+      try {
+        data = JSON.parse(evt.data)
+      } catch{
+        data = evt.data
+      }
+
+      if (data.type
+        && data.type === 'error'
+        && data.reason.toLowerCase() === 'your session has expired.') {
+        /*
+        * We tried to reconnect 3 times
+        */
+        if (retryAttempts === maxRetryAttempts) {
+          this.setState({
+            error: 'Session could not be initialized. Please try again later'
+          });
+          return;
+        }
+        /*
+        * We've tried less than 3 reconnects
+        */
+        this.setState({
+          retryingConnection: true,
+          retryAttempts: retryAttempts + 1,
+        })
+        return;
+      }
+      this.setState({
+        retryingConnection: false,
+        retryAttempts: 0,
+      })
+      this.terminal.write(evt.data);
+    })
 
     this.socket.addEventListener('close', () => {
-      terminal.destroy();
+      this.terminal.destroy();
       if (!this.mounted) { return; }
+
       this.setState({ renderingLish: false });
     });
 
@@ -89,14 +167,46 @@ export class Weblish extends React.Component<CombinedProps, State> {
     window.document.title = `${linodeLabel} - Linode Lish Console`;
   }
 
+  renderErrorState = () => {
+    const { error } = this.state;
+    const { classes } = this.props;
+    return (
+      <div className={classes.errorState}>
+        <ErrorState errorText={error} />
+      </div>
+    )
+  }
+
+  renderRetryState = () => {
+    const { classes } = this.props;
+    const { retryAttempts } = this.state;
+
+    return (
+      <div className={classes.message}>
+        {`Connection could not be opened. Retrying in 3 seconds...
+          ${retryAttempts} / ${maxRetryAttempts}`}
+        <CircleProgress mini />
+      </div>
+    )
+  }
+
   render() {
     const { classes } = this.props;
+    const { error, retryingConnection } = this.state;
+
+    if (error) {
+      return this.renderErrorState()
+    }
+
+    if (retryingConnection) {
+      return this.renderRetryState()
+    }
 
     return (
       <React.Fragment>
         {this.socket && (this.socket.readyState === this.socket.OPEN)
           ? <div id="terminal" className="terminal" />
-          : <CircleProgress className={classes.progress} noInner/>
+          : <CircleProgress className={classes.progress} noInner />
         }
       </React.Fragment>
     );

--- a/src/features/Lish/Weblish.tsx
+++ b/src/features/Lish/Weblish.tsx
@@ -75,11 +75,11 @@ export class Weblish extends React.Component<CombinedProps, State> {
     /*
     * If we have a new token, refresh the webosocket connection
     * and console with the new token
+    * NOT WORKING
     */
-    if (this.props.token !== prevProps.token) {
-      this.connect()
-      return;
-    }
+    // if (this.props.token !== prevProps.token) {
+    //   this.socket.close();
+    // }
 
     /*
     * If our connection failed, and we did not surpass the max number of
@@ -87,7 +87,9 @@ export class Weblish extends React.Component<CombinedProps, State> {
     */
     if (prevState.retryAttempts !== retryAttempts && retryingConnection) {
       setTimeout(() => {
+        console.log('refresh token');
         this.props.refreshToken();
+        this.connect();
       }, 3000);
     }
   }
@@ -157,7 +159,7 @@ export class Weblish extends React.Component<CombinedProps, State> {
         this.setState({
           retryingConnection: true,
           retryAttempts: retryAttempts + 1,
-        })
+        });
         return;
       }
       this.setState({
@@ -194,7 +196,7 @@ export class Weblish extends React.Component<CombinedProps, State> {
 
     return (
       <div className={classes.message}>
-        {`Connection could not be opened. Retrying in 3 seconds...
+        {`Lish Token could not be validated. Retrying in 3 seconds...
           ${retryAttempts} / ${maxRetryAttempts}`}
         <CircleProgress mini />
       </div>

--- a/src/features/Lish/Weblish.tsx
+++ b/src/features/Lish/Weblish.tsx
@@ -31,6 +31,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 interface Props {
   linode: Linode.Linode;
   token: string;
+  refreshToken: () => void;
 }
 
 interface State {
@@ -70,13 +71,23 @@ export class Weblish extends React.Component<CombinedProps, State> {
 
   componentDidUpdate(prevProps: CombinedProps, prevState: State) {
     const { retryAttempts, retryingConnection } = this.state;
+
+    /*
+    * If we have a new token, refresh the webosocket connection
+    * and console with the new token
+    */
+    if (this.props.token !== prevProps.token) {
+      this.connect()
+      return;
+    }
+
     /*
     * If our connection failed, and we did not surpass the max number of
     * reconnection attempts, try to reconnect
     */
     if (prevState.retryAttempts !== retryAttempts && retryingConnection) {
       setTimeout(() => {
-        this.connect();
+        this.props.refreshToken();
       }, 3000);
     }
   }


### PR DESCRIPTION
### Purpose

Fix issue where if token expired in Glish or Weblish and couldn't reconnnect, it would silently fail.

### Problem

In a Dev environment, when trying to create a Lish session, it would immediately respond that the token is expired and the user would get no feedback pertaining to what the issue is.

### Solution

Added 3 attempts to reconnect the Lish session after the token becomes invalid. If 3 attempts go by and it doesn't reconnect, show a failure.

### To Test

Point all `.env` variables at the development environment BUT DO NOT ENTER A LISH ENV VARIABLE and enter Weblish and Glish with a powered on Linode

Then, while pointing to prod services and when on Glish, wait 5 minutes for your token to expire and then switch to Weblish...and then vice versa. The console should reconnect successfully

### Other Notes

This PR does not solve the issue where the websocket connection errors out - this simply handles retry and error states where the lish token invalidates and cannot connect with a new one. See M3-1248 for websocket connection error state. If the websocket connection fails, it will just spin infinitely