### PR TITLE
M3-1237 - Skip to content link (accessibility feature)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -282,6 +282,7 @@ export class App extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
+        <a href="#main-content" className="visually-hidden">Skip to main content</a>
         <DocumentTitleSegment segment="Linode Manager" />
         {longLivedLoaded &&
           <React.Fragment>
@@ -290,9 +291,8 @@ export class App extends React.Component<CombinedProps, State> {
                 <div {...themeDataAttr()} className={classes.appFrame}>
                   <SideMenu open={menuOpen} closeMenu={this.closeMenu} toggleTheme={toggleTheme} />
                   <main className={classes.content}>
-                    <TopMenu openSideMenu={this.openMenu} />
-                   
-                    <div className={classes.wrapper}>
+                    <TopMenu openSideMenu={this.openMenu} />                  
+                    <div className={classes.wrapper} id="main-content">
                     <StickyContainer>
                       <Grid container spacing={0} className={classes.grid}>
                         <Grid item className={`${classes.switchWrapper} ${hasDoc ? 'mlMain' : ''}`}>

--- a/src/index.css
+++ b/src/index.css
@@ -48,6 +48,14 @@ a {
   cursor: pointer;
 }
 
+.visually-hidden {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+}
+
 /* 
 * do not show the ada chat app button site-wide
 */


### PR DESCRIPTION
This feature provides a link (invisible to the user) that capture the first tabIndex in order for the user navigating with a screen reader and keyboard to be able to skip to the main content area

page loads > tab > enter > tab through main area