### PR TITLE
M3-1009 volume delete button while powered on

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.test.tsx
@@ -30,6 +30,7 @@ describe('Linode Volumes', () => {
       linodeVolumes={volumes}
       linodeLabel="test"
       linodeRegion="us-east"
+      linodeStatus="running"
       linodeID={100}
       history={{
         length: 2,
@@ -71,6 +72,7 @@ describe('Linode Volumes', () => {
             linodeVolumes={[]}
             linodeLabel="test"
             linodeRegion="us-east"
+            linodeStatus="running"
             linodeID={100}
             {...reactRouterProps}
           />
@@ -93,6 +95,7 @@ describe('Linode Volumes', () => {
             linodeConfigs={linodeConfigsAsPromiseResponse}
             linodeVolumes={[]}
             linodeLabel="test"
+            linodeStatus="running"
             linodeRegion="us-east"
             linodeID={100}
             {...reactRouterProps}
@@ -120,6 +123,7 @@ describe('Linode Volumes', () => {
               linodeVolumes={volumes}
               linodeLabel="test"
               linodeRegion="us-east"
+              linodeStatus="running"
               linodeID={100}
               {...reactRouterProps}
             />

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -59,6 +59,7 @@ interface LinodeContextProps {
   linodeLabel: string;
   linodeRegion: string;
   linodeID: number;
+  linodeStatus: string;
 }
 
 interface UpdateDialogState {
@@ -741,7 +742,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
    * - Else show rows of volumes.
    */
   table = renderGuard((): null | JSX.Element => {
-    const { classes } = this.props;
+    const { classes, linodeStatus } = this.props;
     const { attachedVolumes } = this.state;
 
     if (attachedVolumes.length === 0) {
@@ -792,7 +793,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
                     <TableCell data-qa-fs-path>{filesysPath}</TableCell>
                     <TableCell>
                       <ActionMenu
-                        volume={volume}
+                        poweredOff={['offline'].includes(linodeStatus)}
                         onDetach={this.openUpdateDialog('detach', volume.id)}
                         onDelete={this.openUpdateDialog('delete', volume.id)}
                         onClone={this.openUpdatingDrawer(
@@ -854,7 +855,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <DocumentTitleSegment segment={`${linodeLabel} - Volumes`} />
         <this.placeholder />
-        <this.table updateFor={[this.props.linodeVolumes]} />
+        <this.table updateFor={[this.props.linodeVolumes, this.props.linodeStatus]} />
         <VolumeDrawer {...volumeDrawer} />
         <this.updateDialog />
       </React.Fragment>
@@ -877,6 +878,7 @@ const linodeContext = withLinode((context) => ({
   linodeID: context.data!.id,
   linodeLabel: context.data!.label,
   linodeRegion: context.data!.region,
+  linodeStatus: context.data!.status
 }));
 
 const volumesContext = withVolumes((context) => ({

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -792,7 +792,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
                     <TableCell data-qa-fs-path>{filesysPath}</TableCell>
                     <TableCell>
                       <ActionMenu
-                        volumeId={volume.id}
+                        volume={volume}
                         onDetach={this.openUpdateDialog('detach', volume.id)}
                         onDelete={this.openUpdateDialog('delete', volume.id)}
                         onClone={this.openUpdatingDrawer(

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -793,6 +793,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
                     <TableCell data-qa-fs-path>{filesysPath}</TableCell>
                     <TableCell>
                       <ActionMenu
+                        data-qa-linode-volume-actions
                         poweredOff={['offline'].includes(linodeStatus)}
                         onDetach={this.openUpdateDialog('detach', volume.id)}
                         onDelete={this.openUpdateDialog('delete', volume.id)}

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumesActionMenu.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumesActionMenu.test.tsx
@@ -1,0 +1,36 @@
+import { LinodeVolumeActionMenu } from './LinodeVolumesActionMenu';
+
+const poweredOnMenu = new LinodeVolumeActionMenu({
+  onEdit: () => null,
+  onDelete: () => null,
+  onDetach: () => null,
+  onClone: () => null,
+  onResize: () => null,
+  poweredOff: false,
+  });
+
+const poweredOffMenu = new LinodeVolumeActionMenu({
+  onEdit: () => null,
+  onDelete: () => null,
+  onDetach: () => null,
+  onClone: () => null,
+  onResize: () => null,
+  poweredOff: true,
+  });
+
+const getActionTitles = (component:any) => {
+  const actionsGenerator = component.createLinodeActions();
+  return actionsGenerator(() => null).map((action:any) => action.title);
+}
+
+describe('Linode Volumes Action Menu', () => {
+  it('should not include a delete action when the Linode is powered on', () => {
+    const actions = getActionTitles(poweredOnMenu);
+    expect(actions.includes('Delete')).toBeFalsy();
+  });
+
+  it ('should display the delete action if the Linode is powered off', () => {
+    const actions = getActionTitles(poweredOffMenu);
+    expect(actions.includes('Delete')).toBeTruthy();
+  })
+});

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumesActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumesActionMenu.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
-  volume: Linode.Volume;
+  poweredOff: boolean;
   onDetach: () => void;
   onDelete: () => void;
   onClone: () => void;
@@ -22,10 +22,8 @@ class LinodeVolumeActionMenu extends React.Component<CombinedProps> {
       onClone,
       onEdit,
       onResize,
-      volume,
+      poweredOff,
     } = this.props;
-
-    const attached = Boolean(volume.linode_id);
 
     return (closeMenu: Function): Action[] => {
       const actions = [
@@ -63,8 +61,7 @@ class LinodeVolumeActionMenu extends React.Component<CombinedProps> {
         }
       ];
 
-      if (!attached) {
-        actions.pop();
+      if (poweredOff) {
         actions.push(
           {
             title: 'Delete',

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumesActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumesActionMenu.tsx
@@ -4,7 +4,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
-  volumeId: number;
+  volume: Linode.Volume;
   onDetach: () => void;
   onDelete: () => void;
   onClone: () => void;
@@ -22,9 +22,12 @@ class LinodeVolumeActionMenu extends React.Component<CombinedProps> {
       onClone,
       onEdit,
       onResize,
+      volume,
     } = this.props;
 
-    return function (closeMenu: Function): Action[] {
+    const attached = Boolean(volume.linode_id);
+
+    return (closeMenu: Function): Action[] => {
       const actions = [
         {
           title: 'Rename',
@@ -57,16 +60,21 @@ class LinodeVolumeActionMenu extends React.Component<CombinedProps> {
             closeMenu();
             e.preventDefault();
           },
-        },
-        {
-          title: 'Delete',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            onDelete();
-            closeMenu();
-            e.preventDefault();
-          },
-        },
+        }
       ];
+
+      if (!attached) {
+        actions.pop();
+        actions.push(
+          {
+            title: 'Delete',
+            onClick: (e: React.MouseEvent<HTMLElement>) => {
+              onDelete();
+              closeMenu();
+              e.preventDefault();
+            },
+        })
+      }
       return actions;
     };
   }

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumesActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumesActionMenu.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
@@ -12,9 +11,9 @@ interface Props {
   onResize: () => void;
 }
 
-type CombinedProps = Props & RouteComponentProps<{}>;
+type CombinedProps = Props;
 
-class LinodeVolumeActionMenu extends React.Component<CombinedProps> {
+export class LinodeVolumeActionMenu extends React.Component<CombinedProps> {
   createLinodeActions = () => {
     const {
       onDetach,
@@ -83,4 +82,4 @@ class LinodeVolumeActionMenu extends React.Component<CombinedProps> {
   }
 }
 
-export default withRouter(LinodeVolumeActionMenu);
+export default LinodeVolumeActionMenu;


### PR DESCRIPTION
When viewing Volumes attached to a Linode from that Linode's detail
view, the action menu previously included a delete option at all times. Since
the volume can't be deleted while the Linode is powered on, this PR hides
the delete option unless the Linode is powered off.
