### PR TITLE
M3-1202 Fix support ticket ordering

### DIFF
--- a/src/features/Support/SupportTickets/TicketList.tsx
+++ b/src/features/Support/SupportTickets/TicketList.tsx
@@ -1,5 +1,3 @@
-import * as moment from 'moment';
-import { sort } from 'ramda';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/src/features/Support/SupportTickets/TicketList.tsx
+++ b/src/features/Support/SupportTickets/TicketList.tsx
@@ -58,10 +58,6 @@ class TicketList extends React.Component<Props, State> {
     this.mounted = false;
   }
 
-  compareTickets = (a:Linode.SupportTicket, b:Linode.SupportTicket) => {
-    return moment(b.updated).diff(moment(a.updated));
-  }
-
   getLinkTargets = (entity:any) => {
     switch (entity.type) {
       case 'linode':
@@ -79,11 +75,6 @@ class TicketList extends React.Component<Props, State> {
     }
   }
 
-  getSortedTickets = (incoming: Linode.SupportTicket[]) => {
-    // Sort by when each ticket was last updated
-    return sort(this.compareTickets, incoming);
-  }
-
   getTickets = (page:number = this.state.page, pageSize:number = this.state.pageSize) => {
     const { tickets } = this.state;
     this.setState({ errors: undefined, loading: tickets === undefined});
@@ -94,7 +85,7 @@ class TicketList extends React.Component<Props, State> {
         
         this.setState({
           loading: false,
-          tickets: this.getSortedTickets(response.data),
+          tickets: response.data,
           errors: undefined,
           count: response.results,
           page: response.page,
@@ -156,7 +147,7 @@ class TicketList extends React.Component<Props, State> {
         <TableCell data-qa-support-entity>{this.renderEntityLink(ticket)}</TableCell>
         <TableCell data-qa-support-subject>{ticket.summary}</TableCell>
         <TableCell data-qa-support-date><DateTimeDisplay value={ticket.opened} format={formatString} /></TableCell>
-        <TableCell data-qa-support-updated><DateTimeDisplay value={ticket.opened} format={formatString} /></TableCell>
+        <TableCell data-qa-support-updated><DateTimeDisplay value={ticket.updated} format={formatString} /></TableCell>
         <TableCell />
       </TableRow>
     );

--- a/src/services/support.ts
+++ b/src/services/support.ts
@@ -35,8 +35,10 @@ export const getTicketsPage = (pagination: Linode.PaginationOptions = {}, open?:
         { status: 'open'},
         { status: 'new' },
       ],
+      '+order_by': 'updated',
+      '+order': 'desc'
     }
-    : { status: 'closed'}
+    : { status: 'closed', '+order_by': 'updated', '+order': 'desc'}
 
   return getTickets(pagination, filter).then((response) => response.data);
 }


### PR DESCRIPTION
Fix sorting bug in the ticket landing page. Tickets should now be ordered by date updated, with the newest updates at the top.

* Tickets were displaying `created` for both created and updated table fields.
Replaced this with the correct value.
* Removed client-side sorting and added X-filtering to order results by
updated date (descending)