### PR TITLE
M3-1199 Lish Not Initiating from Linode List View

### DIFF
--- a/src/features/Lish/index.tsx
+++ b/src/features/Lish/index.tsx
@@ -2,7 +2,7 @@ import { LISH_ROOT, ZONES } from 'src/constants';
 
 import Lish from './Lish';
 
-export const lishLaunch = (linodeId: string) => {
+export const lishLaunch = (linodeId: number) => {
   window.open(
     `${window.location.protocol}//${window.location.host}/linodes/${linodeId}/lish/weblish`,
     `weblish_con_${linodeId}`,

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -556,7 +556,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
 
   launchLish = () => {
     const { data: linode } = this.state.context.linode;
-    lishLaunch(`${linode!.id}`);
+    lishLaunch(linode!.id);
   }
 
   render() {

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
+import { lishLaunch } from 'src/features/Lish';
+
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 import { powerOnLinode } from './powerActions';
@@ -26,7 +28,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         {
           title: 'Launch Console',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            push(`/linodes/${linodeId}/glish`);
+            lishLaunch(linodeId);
             e.preventDefault();
           },
         },

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -225,7 +225,7 @@ class LinodeCard extends React.Component<CombinedProps> {
 
   handleConsoleButtonClick = () => {
     const { linodeId } = this.props;
-    lishLaunch(`${linodeId}`);
+    lishLaunch(linodeId);
   }
 
   handleRebootButtonClick = () => {

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -230,34 +230,6 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
     localStorage.setItem('linodesViewStyle', style);
   }
 
-  renderListView = (
-    linodes: Linode.Linode[],
-    images: Linode.Image[],
-  ) => {
-    return (
-      <LinodesListView
-        linodes={linodes}
-        images={images}
-        openConfigDrawer={this.openConfigDrawer}
-        toggleConfirmation={this.toggleDialog}
-      />
-    );
-  }
-
-  renderGridView = (
-    linodes: Linode.Linode[],
-    images: Linode.Image[],
-  ) => {
-    return (
-      <LinodesGridView
-        linodes={linodes}
-        images={images}
-        openConfigDrawer={this.openConfigDrawer}
-        toggleConfirmation={this.toggleDialog}
-      />
-    );
-  }
-
   getLinodes = (page = 1, pageSize = 25) => {
     const lastPage = Math.ceil(this.state.results / pageSize);
     getLinodes({
@@ -322,6 +294,34 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
       powerOffLinode(selectedLinodeId!, selectedLinodeLabel);
     }
     this.setState({ powerAlertOpen: false });
+  }
+
+  renderListView = (
+    linodes: Linode.Linode[],
+    images: Linode.Image[],
+  ) => {
+    return (
+      <LinodesListView
+        linodes={linodes}
+        images={images}
+        openConfigDrawer={this.openConfigDrawer}
+        toggleConfirmation={this.toggleDialog}
+      />
+    );
+  }
+
+  renderGridView = (
+    linodes: Linode.Linode[],
+    images: Linode.Image[],
+  ) => {
+    return (
+      <LinodesGridView
+        linodes={linodes}
+        images={images}
+        openConfigDrawer={this.openConfigDrawer}
+        toggleConfirmation={this.toggleDialog}
+      />
+    );
   }
 
   render() {


### PR DESCRIPTION
### Purpose

Previously while on the Linode List View, opening the actions menu and selecting _Launch Console_ would trigger a route change to the Linodes Detail Page. Now, it launches lish as it should

#### Other notes
* Changed the arg type of `lishLaunch` to a number because we never are in a situation where we have a Linode ID as a string.
* Moved render methods in Linode Landing closer to the main render method