### PR TITLE
M3-350 Cannot read property 'getBoundingClientRect' of null

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
-    "react-sticky": "^6.0.1",
+    "react-sticky": "^6.0.3",
     "react-text-mask": "^5.4.3",
     "react-waypoint": "^8.0.3",
     "redux": "^3.7.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -317,19 +317,21 @@ export class App extends React.Component<CombinedProps, State> {
                             <Route component={NotFound} />
                           </Switch>
                         </Grid>
-                        <Grid className={`${hasDoc ? 'mlSidebar': ''}`}>
-                          <Sticky topOffset={-24} disableCompensation>
-                          {(props: StickyProps) => {
-                            return (
-                              <DocsSidebar
-                                docs={documentation}
-                                {...props}
-                              />
-                              )
-                            }
-                          }
-                          </Sticky>
-                        </Grid>
+                        {hasDoc &&
+                          <Grid className='mlSidebar'>
+                            <Sticky topOffset={-24} disableCompensation>
+                              {(props: StickyProps) => {
+                                return (
+                                  <DocsSidebar
+                                    docs={documentation}
+                                    {...props}
+                                  />
+                                )
+                              }
+                              }
+                            </Sticky>
+                          </Grid>
+                        }
                       </Grid>
                       </StickyContainer>
                     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9185,9 +9185,9 @@ react-split-pane@^0.1.77:
     prop-types "^15.5.10"
     react-style-proptype "^3.0.0"
 
-react-sticky@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/react-sticky/-/react-sticky-6.0.2.tgz#d301c1b5307649220dbc045fcbacd077885c5ede"
+react-sticky@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/react-sticky/-/react-sticky-6.0.3.tgz#7a18b643e1863da113d7f7036118d2a75d9ecde4"
   dependencies:
     prop-types "^15.5.8"
     raf "^3.3.0"


### PR DESCRIPTION
### Purpose

Fixes react-sticky console error where if nothing was being rendered in `StickyContainer`, it would throw an error.

Now we should only be rendering the `<Sticky />` component if we have docs