### PR TITLE
08-27 e2e Test Maintenance

### DIFF
--- a/e2e/pageobjects/account/permissions.page.js
+++ b/e2e/pageobjects/account/permissions.page.js
@@ -3,7 +3,6 @@ const { constants } = require('../../constants');
 import Page from '../page';
 
 class Permissions extends Page {
-    get updatePermissionsHeader() { return $('[data-qa-update-permissions-header]'); }
     get globalPermissionsHeader() { return $('[data-qa-permissions-header="Global Permissions"]'); }
     get billingAccessHeader() { return $('[data-qa-permissions-header="billing"]'); }
     get specificPermissionsHeader() { return $('[data-qa-permissions-header="Specific Permissions"]'); }
@@ -42,7 +41,7 @@ class Permissions extends Page {
     get unrestrictedMsg() { return $('[data-qa-unrestricted-msg'); }
 
     baseElementsDisplay(restricted) {
-        this.updatePermissionsHeader.waitForVisible(constants.wait.normal);
+        this.restrictAccessToggle.waitForVisible(constants.wait.normal);
         if (restricted) {
             expect(this.globalPermissionsHeader.isVisible()).toBe(true);
             expect(this.billingAccessHeader.isVisible()).toBe(true);

--- a/e2e/pageobjects/configure-stackscript.page.js
+++ b/e2e/pageobjects/configure-stackscript.page.js
@@ -92,8 +92,8 @@ class ConfigureStackScript extends Page {
             browser.waitForVisible(`[data-value="${imageName}"]`, constants.wait.normal, true);
         }
 
-        // Refactor to use actions API 
-        browser.keys('\uE00C');
+        // Click outside the select
+        browser.click('body');
 
         this.targetImagesSelect.waitForVisible(constants.wait.normal);
         browser.waitForVisible('#menu-image', constants.wait.normal, true);

--- a/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
@@ -91,8 +91,9 @@ export class VolumeDetail extends Page {
         } else {
             this.createIconLink.click();
         }
-        this.drawerTitle.waitForVisible();
+        this.drawerTitle.waitForVisible(constants.wait.normal);
 
+        browser.waitForVisible('[data-qa-volume-label] input', constants.wait.normal);
         browser.trySetValue('[data-qa-volume-label] input', volume.label);
         browser.trySetValue('[data-qa-size] input', volume.size);
 

--- a/e2e/pageobjects/list-linodes.js
+++ b/e2e/pageobjects/list-linodes.js
@@ -125,8 +125,7 @@ export class ListLinodes extends Page {
     }
 
     powerOff(linode) {
-        linode.$(this.linodeActionMenu.selector).click();
-        this.powerOffMenu.click();
+        this.selectActionMenuItem(linode, 'Power Off');
         this.acceptDialog('Powering Off');
         
         browser.waitUntil(function() {
@@ -135,8 +134,7 @@ export class ListLinodes extends Page {
     }
 
     powerOn(linode) {
-        linode.$(this.linodeActionMenu.selector).click();
-        this.powerOnMenu.click();
+        this.selectActionMenuItem(linode, 'Power On');
 
         browser.waitUntil(function() {
             return browser.isVisible('[data-qa-status="running"]');
@@ -147,14 +145,6 @@ export class ListLinodes extends Page {
         if (this.getStatus(linode) === 'running') {
             this.powerOff(linode);
         }
-    }
-
-    selectMenuItem(linode, item) {
-        if (this.getStatus(linode) === 'rebooting') {
-            browser.waitForVisible('[data-qa-status="running"]', 45000);
-        }
-        linode.$(this.linodeActionMenu.selector).click();
-        browser.jsClick(`[data-qa-action-menu-item="${item}"]`);
     }
 
     switchView(view) {

--- a/e2e/pageobjects/list-linodes.js
+++ b/e2e/pageobjects/list-linodes.js
@@ -34,6 +34,7 @@ export class ListLinodes extends Page {
     get viewGraphsMenu() { return $('[data-qa-action-menu-item="View Graphs"]'); }
     get resizeMenu() { return $('[data-qa-action-menu-item="Resize"]'); }
     get viewBackupsMenu() { return $('[data-qa-action-menu-item="View Backups"]'); }
+    get enableBackupsMenu() { return $('[data-qa-action-menu-item="Enable Backups"]'); }
     get settingsMenu() { return $('[data-qa-action-menu-item="Settings"]'); }
     get copyIp() { return $('[data-qa-copy-ip] svg'); }
 

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -95,7 +95,7 @@ export default class Page {
             }
 
             return noticeMsgDisplays.length > 0;
-        }, timeout, `${noticeMsg} failed to display`);
+        }, timeout, `${noticeMsg} failed to display after ${timeout}ms`);
     }
 
     assertDocsDisplay() {

--- a/e2e/pageobjects/search.page.js
+++ b/e2e/pageobjects/search.page.js
@@ -46,11 +46,8 @@ class SearchBar extends Page {
     }
 
     selectByKeyDown() {
-        if (browser.options.desiredCapabilities.browserName.includes('chrome')) {
-            this.searchInput.setValue('\uE015');
-        } else {
-            browser.keys('ArrowDown');
-        }
+        this.searchInput.setValue('\uE015');
+
         browser.waitForVisible('[data-qa-suggestion]', constants.wait.normal);
         // key down and enter fails to work on firefox
         const selected = this.suggestions[0].getAttribute('data-qa-selected');

--- a/e2e/specs/account/users.spec.js
+++ b/e2e/specs/account/users.spec.js
@@ -31,8 +31,7 @@ describe('Account - Users Suite', () => {
         expect(deleteToolTip.isVisible()).toBe(false);
         expect(deleteToolTip.isExisting()).toBe(true);
 
-        // Refactor to use actions api
-        browser.keys('Escape');
+        browser.click('body');
         Users.actionMenuItem.waitForExist(constants.wait.normal, true);
     });
 
@@ -52,7 +51,8 @@ describe('Account - Users Suite', () => {
             expect($('[data-qa-action-menu-item="Delete"]').isVisible()).toBe(true);
             expect($('[data-qa-action-menu-item="Delete"]').isEnabled()).toBe(true);
             
-            browser.keys('Escape');
+            browser.click('body');
+
             Users.actionMenuItem.waitForExist(constants.wait.normal, true);
         });
 

--- a/e2e/specs/linodes/linodes.spec.js
+++ b/e2e/specs/linodes/linodes.spec.js
@@ -11,7 +11,7 @@ describe('List Linodes Suite', () => {
         expect(ListLinodes.rebootMenu.isVisible()).toBe(true);
         expect(ListLinodes.viewGraphsMenu.isVisible()).toBe(true);
         expect(ListLinodes.resizeMenu.isVisible()).toBe(true);
-        expect(ListLinodes.viewBackupsMenu.isVisible()).toBe(true);
+        expect(ListLinodes.enableBackupsMenu.isVisible()).toBe(true);
         expect(ListLinodes.settingsMenu.isVisible()).toBe(true);
     }
 
@@ -61,6 +61,8 @@ describe('List Linodes Suite', () => {
         it('should display action menu and linode action menu items', () => {
             // Click first Linode Action Menu
             ListLinodes.linode[0].$(ListLinodes.linodeActionMenu.selector).click();
+
+            ListLinodes.actionMenuItem.waitForVisible(constants.wait.normal);
             assertActionMenuItems();
 
             browser.refresh();
@@ -120,6 +122,7 @@ describe('List Linodes Suite', () => {
             });
             linodes[0].$(ListLinodes.linodeActionMenu.selector).click();
 
+            ListLinodes.actionMenuItem.waitForVisible(constants.wait.normal);
             assertActionMenuItems();
         });
     });

--- a/e2e/specs/linodes/linodes.spec.js
+++ b/e2e/specs/linodes/linodes.spec.js
@@ -69,7 +69,7 @@ describe('List Linodes Suite', () => {
         });
 
         it('should display launch console button', () => {
-            ListLinodes.linodeLabel.waitForVisible();
+            ListLinodes.linodeLabel.waitForVisible(constants.wait.normal);
             const consoleButton = ListLinodes.linode[0].$(ListLinodes.launchConsole.selector);
             expect(consoleButton.isVisible()).toBe(true);
         });

--- a/e2e/specs/linodes/reboot-linodes.spec.js
+++ b/e2e/specs/linodes/reboot-linodes.spec.js
@@ -63,8 +63,7 @@ describe('List Linodes - Actions - Reboot Suite', () => {
         });
 
         it('should update status on reboot to rebooting', () => {
-            const currentStatus = linodes[0].$(ListLinodes.status.selector).getAttribute('data-qa-status');
-            expect(currentStatus).toBe('rebooting');
+            browser.waitForVisible('[data-qa-status="rebooting"]', constants.wait.normal);
         });
 
         it('should hide action menu', () => {

--- a/e2e/specs/linodes/reboot-linodes.spec.js
+++ b/e2e/specs/linodes/reboot-linodes.spec.js
@@ -11,7 +11,7 @@ describe('List Linodes - Actions - Reboot Suite', () => {
         browser.url(constants.routes.linodes);
         apiCreateLinode();
 
-        browser.waitForVisible('[data-qa-linode]');
+        browser.waitForVisible('[data-qa-linode]', constants.wait.normal);
     });
 
     afterAll(() => {
@@ -50,16 +50,16 @@ describe('List Linodes - Actions - Reboot Suite', () => {
         
         beforeAll(() => {
             ListLinodes.switchView('list');
-            ListLinodes.tableHead.waitForVisible();
+            ListLinodes.tableHead.waitForVisible(constants.wait.normal);
 
             linodes = ListLinodes.linode;
             totalLinodes = linodes.length;
         });
 
         it('should reboot linode on click', () => {
-            ListLinodes.selectMenuItem(linodes[0], 'Reboot');
+            ListLinodes.selectActionMenuItem(linodes[0], 'Reboot');
             ListLinodes.acceptDialog('Confirm Reboot');
-            browser.waitForVisible('[data-qa-loading]');
+            browser.waitForVisible('[data-qa-loading]', constants.wait.normal);
         });
 
         it('should update status on reboot to rebooting', () => {

--- a/e2e/specs/search/search-volumes.spec.js
+++ b/e2e/specs/search/search-volumes.spec.js
@@ -23,13 +23,7 @@ describe('Header - Search - Volumes Suite', () => {
         LinodeDetail
             .landingElemsDisplay()
             .changeTab('Volumes');
-        try {
-            VolumeDetail.volumeCellElem.isVisible();
-        } catch (err) {
-            if (!VolumeDetail.placeholderText.waitForVisible(constants.wait.normal)) {
-                throw err;
-            }
-        }
+        browser.waitForVisible('[data-qa-circle-progress]', constants.wait.normal, true);
     }
 
     afterAll(() => {
@@ -41,7 +35,6 @@ describe('Header - Search - Volumes Suite', () => {
         
         apiCreateLinode();
 
-        ListLinodes.linodesDisplay();
         linodeName = ListLinodes.linode[0].$(ListLinodes.linodeLabel.selector).getText();
 
         ListLinodes.shutdownIfRunning(ListLinodes.linode[0]);

--- a/e2e/specs/search/search.spec.js
+++ b/e2e/specs/search/search.spec.js
@@ -49,15 +49,19 @@ describe('Header - Search Suite', () => {
     });
 
     it('should select result on arrow down', () => {
+        if (!browser.options.desiredCapabilities.browserName.includes('chrome')) {
+            pending();
+        }
         SearchBar.selectByKeyDown();
     });
 
     it('should navigate to result on enter', () => {
-        if (browser.options.desiredCapabilities.browserName.includes('chrome')) {
-            SearchBar.searchInput.setValue('\uE006');
-        } else {
-            browser.keys('Enter');
+        if (!browser.options.desiredCapabilities.browserName.includes('chrome')) {
+            pending();
         }
+
+        SearchBar.searchInput.setValue('\uE006');
+
         const currentUrl = browser.getUrl();
         
         browser.waitUntil(function() {
@@ -70,7 +74,7 @@ describe('Header - Search Suite', () => {
         const currentUrl = browser.getUrl();
         
         SearchBar.executeSearch(testLinode);
-        browser.waitForVisible('[data-qa-suggestion]');
+        browser.waitForVisible('[data-qa-suggestion]', constants.wait.normal);
 
         SearchBar.suggestions[0].click();
 

--- a/e2e/specs/stackscripts/configure-stackscript.spec.js
+++ b/e2e/specs/stackscripts/configure-stackscript.spec.js
@@ -32,12 +32,8 @@ describe('StackScript - Create Suite', () => {
     });
 
     it('should fail to create the stackscript', () => {
-        const errorMsg = 'Script must begin with a shebang';
-
         ConfigureStackScripts.saveButton.click();
-        
-        ConfigureStackScripts.script.$('p').waitForVisible(constants.wait.normal);
-        expect(ConfigureStackScripts.script.$('p').getText()).toBe(errorMsg);
+        ConfigureStackScripts.script.$('p').waitForText(constants.wait.normal);
     });
 
     it('should clear the config fields on cancel', () => {

--- a/e2e/specs/stackscripts/configure-stackscript.spec.js
+++ b/e2e/specs/stackscripts/configure-stackscript.spec.js
@@ -35,7 +35,9 @@ describe('StackScript - Create Suite', () => {
         const errorMsg = 'Script must begin with a shebang';
 
         ConfigureStackScripts.saveButton.click();
-        ConfigureStackScripts.waitForNotice(errorMsg);
+        
+        ConfigureStackScripts.script.$('p').waitForVisible(constants.wait.normal);
+        expect(ConfigureStackScripts.script.$('p').getText()).toBe(errorMsg);
     });
 
     it('should clear the config fields on cancel', () => {

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "selenium": "npx selenium-standalone install --config=./e2e/config/selenium-config.js && ./node_modules/.bin/selenium-standalone start --config=./e2e/config/selenium-config.js",
     "e2e": "npx wdio ./e2e/config/wdio.conf.js",
     "e2e:all": "npx wdio ./e2e/config/wdio.conf.js; ./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js",
+    "e2e:modified": "./scripts/run-modified-e2e.sh",
     "e2e:browserstack": "npx wdio ./e2e/config/browserstack.conf.js",
     "mb": "npx mb"
   },

--- a/scripts/run-modified-e2e.sh
+++ b/scripts/run-modified-e2e.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for spec in $(git diff --name-only develop | grep 'spec.js'); do
+  yarn e2e --file $spec
+done
+

--- a/src/components/Tile/Tile.tsx
+++ b/src/components/Tile/Tile.tsx
@@ -101,11 +101,11 @@ class Tile extends React.Component<CombinedProps> {
           [classes.clickableTile]: link !== undefined,
         },
         className,
-      )}>
+      )} data-qa-tile>
         {icon &&
-          <span className={classes.icon}>{icon}</span>
+          <span className={classes.icon} data-qa-tile-icon>{icon}</span>
         }
-        <Typography variant="subheading" className={classes.tileTitle}>
+        <Typography variant="subheading" className={classes.tileTitle} data-qa-tile-title>
           <React.Fragment>
             {link
               ?
@@ -116,7 +116,7 @@ class Tile extends React.Component<CombinedProps> {
           </React.Fragment>
         </Typography>
           {description &&
-            <Typography variant="caption" align="center">
+            <Typography variant="caption" align="center" data-qa-tile-desc>
               {description}
             </Typography>
           }

--- a/src/components/Tile/Tile.tsx
+++ b/src/components/Tile/Tile.tsx
@@ -101,11 +101,11 @@ class Tile extends React.Component<CombinedProps> {
           [classes.clickableTile]: link !== undefined,
         },
         className,
-      )} data-qa-tile>
+      )}>
         {icon &&
-          <span className={classes.icon} data-qa-tile-icon>{icon}</span>
+          <span className={classes.icon}>{icon}</span>
         }
-        <Typography variant="subheading" className={classes.tileTitle} data-qa-tile-title>
+        <Typography variant="subheading" className={classes.tileTitle}>
           <React.Fragment>
             {link
               ?
@@ -116,7 +116,7 @@ class Tile extends React.Component<CombinedProps> {
           </React.Fragment>
         </Typography>
           {description &&
-            <Typography variant="caption" align="center" data-qa-tile-desc>
+            <Typography variant="caption" align="center">
               {description}
             </Typography>
           }

--- a/src/features/linodes/LinodesLanding/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow.tsx
@@ -206,6 +206,7 @@ class LinodeRow extends React.Component<CombinedProps> {
         key={linodeId}
         className={`${classes.bodyRow} 'fade-in-table'`}
         data-qa-loading
+        data-qa-linode={linodeLabel}
         rowLink={`/linodes/${linodeId}`}
         arial-label={linodeLabel}
       >


### PR DESCRIPTION
* Updated e2e tests based on UI changes and updated a few tests to be compatible with firefox
* Adds back the `data-qa-linode` attribute that was removed mistakenly in https://github.com/linode/manager/pull/3735/
* Use selectActionMenuItem global utility method wherever possible
* Refactor tests to no longer use "keys" wherever possible, as this is incompatible with Firefox. 
* Updated configure stackscripts tests to assert for field errors now returned from the api.

* Added a handy "e2e:modified" script that will run a diff on the current branch against develop and filter for e2e test specs and then run them 🙃 , this will be very helpful moving forward.

### Since there are quite a few tests changed in this PR, feel free to PM me for the results of running this branch on CI!

## To Test

```bash
yarn && yarn start
yarn selenium
yarn e2e:modified
```