### PR TITLE
M3-997 Fix Attach Volumes Bug

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -174,6 +174,10 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
       .filter(e => !e._initial)
       .subscribe((v) => {
         if (this.mounted) {
+          console.log(v);
+          if (v.action === 'volume_detach' && ['finished','notification'].includes(v.status)) {
+            sendToast('Volume has been detached.')
+          }
           this.getVolumes();
         }
       });

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -174,10 +174,6 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
       .filter(e => !e._initial)
       .subscribe((v) => {
         if (this.mounted) {
-          console.log(v);
-          if (v.action === 'volume_detach' && ['finished','notification'].includes(v.status)) {
-            sendToast('Volume has been detached.')
-          }
           this.getVolumes();
         }
       });

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -26,8 +26,9 @@ import renderGuard from 'src/components/RenderGuard';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import Table from 'src/components/Table';
 import { events$, resetEventsPolling } from 'src/events';
+import { sendToast } from 'src/features/ToastNotifications/toasts';
 import { getLinodeConfigs, getLinodeVolumes } from 'src/services/linodes';
-import { attachVolume, cloneVolume, createVolume, deleteVolume, detachVolume, getVolumes, resizeVolume, updateVolume } from 'src/services/volumes';
+import { attachVolume, cloneVolume, createVolume, deleteVolume, detachVolume, resizeVolume, updateVolume } from 'src/services/volumes';
 import composeState from 'src/utilities/composeState';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
@@ -248,14 +249,14 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
   }
 
   detachVolume = () => {
-    const { updateVolumes } = this.props;
     const { updateDialog: { id } } = this.state;
     if (!id) { return; }
 
     detachVolume(id)
       .then(() => {
         this.closeUpdateDialog();
-        updateVolumes((volumes) => volumes.filter((v) => v.id !== id));
+        sendToast('Volume is being detached from this Linode.')
+        this.getVolumes();
       })
       .catch((errorResponse) => {
         const fallbackError = [{ reason: 'Unable to attach volume.' }];
@@ -870,7 +871,7 @@ const preloaded = PromiseLoader<Props & LinodeContextProps & VolumesContextProps
   linodeConfigs: (props) => getLinodeConfigs(props.linodeID)
     .then(response => response.data),
 
-  volumes: (props) => getVolumes()
+  volumes: (props) => getLinodeVolumes(props.linodeID)
     .then(response => response.data
       .filter(volume => volume.region === props.linodeRegion && volume.linode_id === null)),
 });

--- a/src/services/volumes.ts
+++ b/src/services/volumes.ts
@@ -1,6 +1,6 @@
 import { API_ROOT } from 'src/constants';
 
-import Request, { mockAPIError, setData, setMethod, setParams, setURL, setXFilter } from './index';
+import Request, { setData, setMethod, setParams, setURL, setXFilter } from './index';
 
 /** Alises for short lines. */
 type Page<T> = Linode.ResourcePage<T>;
@@ -24,16 +24,16 @@ export const attachVolume = (volumeId: number, payload: {
   setData(payload),
   );
 
-export const detachVolume = (volumeId: number) => mockAPIError(400, 'whatever', { errors: [ { reason: 'Shenanigans' } ] }) // Request<{}>(
-//   setURL(`${API_ROOT}/volumes/${volumeId}/detach`),
-//   setMethod('POST'),
-// );
+export const detachVolume = (volumeId: number) => Request<{}>(
+  setURL(`${API_ROOT}/volumes/${volumeId}/detach`),
+  setMethod('POST'),
+);
 
 // delete is a reserve word
-export const deleteVolume = (volumeId: number) => mockAPIError(400, 'whatever', { errors: [ { reason: 'Shenanigans' } ] }) // Request<{}>(
-//   setURL(`${API_ROOT}/volumes/${volumeId}`),
-//   setMethod('DELETE'),
-// );
+export const deleteVolume = (volumeId: number) => Request<{}>(
+  setURL(`${API_ROOT}/volumes/${volumeId}`),
+  setMethod('DELETE'),
+);
 
 export const cloneVolume = (volumeId: number, label: string) => Request<{}>(
   setURL(`${API_ROOT}/volumes/${volumeId}/clone`),

--- a/src/services/volumes.ts
+++ b/src/services/volumes.ts
@@ -1,6 +1,6 @@
 import { API_ROOT } from 'src/constants';
 
-import Request, { setData, setMethod, setParams, setURL, setXFilter } from './index';
+import Request, { mockAPIError, setData, setMethod, setParams, setURL, setXFilter } from './index';
 
 /** Alises for short lines. */
 type Page<T> = Linode.ResourcePage<T>;
@@ -24,16 +24,16 @@ export const attachVolume = (volumeId: number, payload: {
   setData(payload),
   );
 
-export const detachVolume = (volumeId: number) => Request<{}>(
-  setURL(`${API_ROOT}/volumes/${volumeId}/detach`),
-  setMethod('POST'),
-);
+export const detachVolume = (volumeId: number) => mockAPIError(400, 'whatever', { errors: [ { reason: 'Shenanigans' } ] }) // Request<{}>(
+//   setURL(`${API_ROOT}/volumes/${volumeId}/detach`),
+//   setMethod('POST'),
+// );
 
 // delete is a reserve word
-export const deleteVolume = (volumeId: number) => Request<{}>(
-  setURL(`${API_ROOT}/volumes/${volumeId}`),
-  setMethod('DELETE'),
-);
+export const deleteVolume = (volumeId: number) => mockAPIError(400, 'whatever', { errors: [ { reason: 'Shenanigans' } ] }) // Request<{}>(
+//   setURL(`${API_ROOT}/volumes/${volumeId}`),
+//   setMethod('DELETE'),
+// );
 
 export const cloneVolume = (volumeId: number, label: string) => Request<{}>(
   setURL(`${API_ROOT}/volumes/${volumeId}/clone`),


### PR DESCRIPTION
On detaching a Volume from the Linode detail view, the list of attached
volumes was being filtered immediately. Since detaching takes time,
this made it possible for users to:

1. detach a volume
2. view the empty state and click "Add a Volume"
3. not have the volume listed as an option for attachment (as it isn't available
yet).

To fix this, I removed the updateVolumes method from the post-detach `.then` handler.
I also added a toast notification so the user sees that the volume is being detached,
even though it continues to appear on the list. In this flow, once the detaching is
finished, the volume is immediately available for re-attachment.

I also changed `getVolumes()` to `getLinodeVolumes()` in the preloaded handler. Please
let me know if this is correct (I'm basing it on the `getDerivedStateFromProps` method,
where it seems like the conditional will always evaluate to `true`).

* Remove unused import