### PR TITLE
M3-1218 Cloned Domain handling

### DIFF
--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -58,6 +58,7 @@ const masterIPsCountLens = lensPath(['masterIPsCount']);
 const updateMasterIPsCount = (fn: (s: any) => any) => (obj: any) => over(masterIPsCountLens, fn, obj);
 
 class DomainCreateDrawer extends React.Component<CombinedProps, State> {
+  mounted: boolean = false;
   defaultState: State = {
     domain: '',
     type: 'master',
@@ -72,6 +73,14 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
   state: State = {
     ...this.defaultState,
   };
+
+  componentDidMount() {
+    this.mounted = true;
+  }
+
+  componentWillUnmount() {
+    this.mounted = false;
+  }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
     if (this.props.mode === 'clone' &&
@@ -195,7 +204,9 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
     soa_email: 'SOA Email',
   };
 
-  reset = () => this.setState({ ...this.defaultState });
+  reset = () => {
+    if (this.mounted) { this.setState({ ...this.defaultState }); }
+  }
 
   create = () => {
     const { onClose, onSuccess } = this.props;
@@ -223,11 +234,13 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
     this.setState({ submitting: true });
     createDomain(data)
       .then((res) => {
+        if (!this.mounted) { return; }
         this.reset();
         onSuccess(res.data);
         onClose();
       })
       .catch((err) => {
+        if (!this.mounted) { return; }
         this.setState({
           submitting: false,
           errors: pathOr([], ['response', 'data', 'errors'], err),
@@ -250,11 +263,13 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
     this.setState({ submitting: true });
     cloneDomain(cloneID, cloneName)
       .then((res) => {
+        if (!this.mounted) { return; }
         this.reset();
-        onSuccess()
+        onSuccess(res.data)
         onClose();
       })
       .catch((err) => {
+        if (!this.mounted) { return; }
         this.setState({
           submitting: false,
           errors: pathOr([], ['response', 'data', 'errors'], err),

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -173,18 +173,21 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
   });
 
   openCreateDrawer = () => {
+    if (!this.mounted) { return; }
     this.setState({
       createDrawer: { open: true, mode: 'create' },
     });
   }
 
   openCloneDrawer = (domain: string, id: number) => {
+    if (!this.mounted) { return; }
     this.setState({
       createDrawer: { open: true, mode: 'clone', domain, cloneID: id },
     });
   }
 
   closeCreateDrawer = () => {
+    if (!this.mounted) { return; }
     this.setState({
       createDrawer: { open: false, mode: 'create' },
     });

--- a/src/services/domains.ts
+++ b/src/services/domains.ts
@@ -77,7 +77,7 @@ export const deleteDomain = (domainID: number) =>
   );
 
 export const cloneDomain = (domainID: number, cloneName: string) =>
-  Request(
+  Request<Domain>(
     setData({ domain: cloneName }),
     setURL(`${API_ROOT}/domains/${domainID}/clone`),
     setMethod('POST'),


### PR DESCRIPTION
After cloning a domain, the drawer was not being closed and the new
domain was not displayed. This was due to an update in the onSuccess
function, which tries to redirect the user to the new domain (if this
information is available). By passing the new (cloned) domain to the handler,
the user is redirected, matching the behavior of creating a new domain.

* Added typing for cloneDomain in domains.ts
* Passed res.data to the onSuccess handler in the domain drawer
* Added mount checking to avoid setting state on unmounted component