### PR TITLE
M3-481 Clear keyboard on mobile after search

### DIFF
--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -343,6 +343,18 @@ class SearchBar extends React.Component<CombinedProps, State> {
     });
   }
 
+  onSelect = (item: SearchSuggestionT) => {
+    const { history } = this.props;
+    /* Need to unfocus the search bar so the
+    *  keyboard disappears on mobile.
+    *  This is a known issue with Downshift (https://github.com/paypal/downshift/issues/32),
+    *  hopefully this kludge won't be needed with React-Select.
+    */ 
+    const node = document.getElementById('searchbar-simple');
+    if (node) { node.blur(); }
+    history.push(item.path);
+  } 
+
   renderSuggestion(
     suggestion: SearchSuggestionT,
     index: number,
@@ -412,7 +424,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
             data-qa-search-icon
           />
           <Downshift
-            onSelect={(item: SearchSuggestionT) => history.push(item.path)}
+            onSelect={this.onSelect}
             stateReducer={this.downshiftStateReducer}
             itemToString={(item: SearchSuggestionT) => (item && item.title) || ''}
             render={({

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -400,7 +400,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { classes, history } = this.props;
+    const { classes } = this.props;
     const { searchActive } = this.state;
 
     return (

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -197,7 +197,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
     imageId: string,
   ) {
     const { images } = this.state;
-    const image = (images && images.find(image => image.id === imageId))
+    const image = (images && images.find((img:Linode.Image) => img.id === imageId))
       || { label: 'Unknown Image' };
     const imageDesc = image.label;
     const typeDesc = typeLabelLong(typeLabel, memory, disk, vcpus);
@@ -352,6 +352,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
     */ 
     const node = document.getElementById('searchbar-simple');
     if (node) { node.blur(); }
+    this.toggleSearch();
     history.push(item.path);
   } 
 


### PR DESCRIPTION
Due to an issue with Downshift, after a user on mobile searches
and selects a search result, the search bar remains focused after
redirection, and the mobile keyboard remains open. This turns out
to be tricky to fix, as React refs no longer have DOM element
methods and findDOMNode is discouraged/semi-deprecated and comes
with its own set of issues.

Using document.getElementById().blur() solves the issue; hopefully React
Select will allow us to remove this hack.