### PR TITLE
M3-1027 Add SSH key selection to Linode creation flow.

### DIFF
--- a/src/components/AccessPanel/AccessPanel.stories.tsx
+++ b/src/components/AccessPanel/AccessPanel.stories.tsx
@@ -29,34 +29,31 @@ class PasswordAndSSHAccess extends React.Component<{}, { password: string, users
     users: [
       {
         gravatarUrl: 'https://www.gravatar.com/avatar/00000000000000000000000000000000?s=24',
-        id: 1,
         username: 'Joe',
         selected: false,
         keys: ['some-key','some-key','some-key','some-key','some-key','some-key','some-key','some-key','some-key','some-key','some-key','some-key','some-key',],
-        onChange: (e: React.ChangeEvent<HTMLInputElement>, result: boolean) => this.toggleSSHUserKeys(1, result),
+        onChange: (e: React.ChangeEvent<HTMLInputElement>, result: boolean) => this.toggleSSHUserKeys('Joe', result),
       },
       {
         gravatarUrl: 'https://www.gravatar.com/avatar/00000000000000000000000000000000?s=24',
-        id: 2,
         username: 'Bob',
         selected: false,
         keys: ['some-key',],
-        onChange: (e: React.ChangeEvent<HTMLInputElement>, result: boolean) => this.toggleSSHUserKeys(2, result),
+        onChange: (e: React.ChangeEvent<HTMLInputElement>, result: boolean) => this.toggleSSHUserKeys('Bob', result),
       },
       {
         gravatarUrl: 'https://www.gravatar.com/avatar/00000000000000000000000000000000?s=24',
-        id: 3,
         username: 'Mark',
         selected: false,
         keys: ['some-key','some-key'],
-        onChange: (e: React.ChangeEvent<HTMLInputElement>, result: boolean) => this.toggleSSHUserKeys(3, result),
+        onChange: (e: React.ChangeEvent<HTMLInputElement>, result: boolean) => this.toggleSSHUserKeys('Mark', result),
       },
     ]
   };
 
-  toggleSSHUserKeys = (id: number, result: boolean) => this.setState((state) => ({
+  toggleSSHUserKeys = (username: string, result: boolean) => this.setState((state) => ({
     ...state,
-    users: state.users.map((user) => (id === user.id) ? { ...user, selected: result } : user)
+    users: state.users.map((user) => (username === user.username) ? { ...user, selected: result } : user)
   }));
 
   handlePasswordChange = (password: string) => this.setState({ password: password || '' });

--- a/src/components/AccessPanel/AccessPanel.tsx
+++ b/src/components/AccessPanel/AccessPanel.tsx
@@ -70,7 +70,6 @@ interface Props {
 
 export interface UserSSHKeyObject {
   gravatarUrl: string;
-  id: number;
   username: string;
   selected: boolean;
   keys: string[];
@@ -88,6 +87,7 @@ class AccessPanel extends React.Component<CombinedProps> {
       noPadding,
       required,
       placeholder,
+      users,
     } = this.props;
 
     return (
@@ -101,7 +101,7 @@ class AccessPanel extends React.Component<CombinedProps> {
             placeholder={placeholder || "Enter a password."}
             onChange={this.handleChange}
           />
-          {this.props.users && this.renderUserSSHKeyTable(this.props.users)}
+          {users && users.length > 0 && this.renderUserSSHKeyTable(users)}
         </div>
       </Paper>
     );
@@ -142,7 +142,7 @@ class AccessPanel extends React.Component<CombinedProps> {
                       {username}
                     </div>
                   </TableCell>
-                  <TableCell>{keys.join(',')}</TableCell>
+                  <TableCell>{keys.join(', ')}</TableCell>
                 </TableRow>
               ))}
           </TableBody>

--- a/src/components/Pagey/Pagey.test.tsx
+++ b/src/components/Pagey/Pagey.test.tsx
@@ -125,6 +125,7 @@ describe('Paginator 2: Pagement Day', () => {
       wrapper.update();
 
       expect(wrapper.prop('pageSize')).toEqual(100);
+      expect(wrapper.prop('page')).toEqual(1);
     });
 
     it('should result in the request being called with updated params', () => {

--- a/src/components/Pagey/Pagey.ts
+++ b/src/components/Pagey/Pagey.ts
@@ -77,7 +77,7 @@ export default (requestFn: PaginatedRequest) => (Component: React.ComponentType<
     };
 
     public handlePageSizeChange = (pageSize: number) => {
-      this.setState({ pageSize }, () => { this.request() });
+      this.setState({ pageSize, page: 1 }, () => { this.request() });
     };
 
     public handlePageChange = (page: number) => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
@@ -11,6 +11,7 @@ const mockProps = {
   history: null,
   getTypeInfo: jest.fn(),
   getRegionInfo: jest.fn(),
+  userSSHKeys: [],
 };
 
 describe('FromImageContent', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -1,10 +1,10 @@
-import { pathOr } from 'ramda';
+import { compose, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
-import AccessPanel from 'src/components/AccessPanel';
+import AccessPanel, { UserSSHKeyObject } from 'src/components/AccessPanel';
 import CheckoutBar from 'src/components/CheckoutBar';
 import Grid from 'src/components/Grid';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
@@ -19,6 +19,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
 import SelectImagePanel from '../SelectImagePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
+import userSSHKeyHoc from './userSSHKeyHoc';
 
 type ClassNames = 'root' | 'main' | 'sidebar';
 
@@ -47,6 +48,9 @@ interface Props {
   getTypeInfo: (selectedTypeID: string | null) => TypeInfo;
   getRegionInfo: (selectedRegionID: string | null) => Info;
   history: any;
+
+  /** Comes from HOC */
+  userSSHKeys: UserSSHKeyObject[];
 }
 
 interface State {
@@ -130,7 +134,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
   }
 
   createNewLinode = () => {
-    const { history } = this.props;
+    const { history, userSSHKeys } = this.props;
     const {
       selectedImageID,
       selectedRegionID,
@@ -151,6 +155,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
       image: selectedImageID, /* optional */
       backups_enabled: backups, /* optional */
       booted: true,
+      authorized_users: userSSHKeys.filter(u => u.selected).map((u) => u.username),
     })
       .then((linode) => {
         if (privateIP) { allocatePrivateIP(linode.id); }
@@ -186,7 +191,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
       selectedRegionID, selectedTypeID, password, isMakingRequest, initTab } = this.state;
 
     const { classes, notice, types, regions, images, getBackupsMonthlyPrice,
-      getRegionInfo, getTypeInfo } = this.props;
+      getRegionInfo, getTypeInfo, userSSHKeys } = this.props;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
@@ -247,7 +252,8 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
             error={hasErrorFor('root_pass')}
             password={password}
             handleChange={this.handleTypePassword}
-            updateFor={[password, errors]}
+            updateFor={[password, errors, userSSHKeys, selectedImageID]}
+            users={userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []}
           />
           <AddonsPanel
             backups={backups}
@@ -314,4 +320,6 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled(FromImageContent);
+const enhanced = compose(styled, userSSHKeyHoc);
+
+export default enhanced(FromImageContent) as any;

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -13,6 +13,7 @@ const mockProps = {
   getRegionInfo: jest.fn(),
   getTypeInfo: jest.fn(),
   history: null,
+  userSSHKeys: [],
 };
 
 describe('FromImageContent', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/userSSHKeyHoc.ts
+++ b/src/features/linodes/LinodesCreate/TabbedContent/userSSHKeyHoc.ts
@@ -90,7 +90,7 @@ export default (Component: React.ComponentType<any>) => {
     createUserObject = (username: string, email: string, keys: string[]) => ({
       keys,
       username,
-      gravatarUrl: `https://www.gravatar.com/avatar/${getEmailHash(email)}?s=24`,
+      gravatarUrl: `https://www.gravatar.com/avatar/${getEmailHash(email)}?d=mp&s=24`,
       selected: false,
       onChange: (_: any, result: boolean) => this.toggleSSHUserKeys(username, result),
     })

--- a/src/features/linodes/LinodesCreate/TabbedContent/userSSHKeyHoc.ts
+++ b/src/features/linodes/LinodesCreate/TabbedContent/userSSHKeyHoc.ts
@@ -1,0 +1,105 @@
+import { path } from 'ramda';
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { UserSSHKeyObject } from 'src/components/AccessPanel';
+import { getUsers } from 'src/services/account';
+import { getSSHKeys } from 'src/services/profile';
+import { getEmailHash } from 'src/utilities/gravatar';
+
+interface Props {
+  username: string;
+  userEmailAddress: string;
+}
+
+interface State {
+  userSSHKeys: UserSSHKeyObject[];
+}
+
+export default (Component: React.ComponentType<any>) => {
+  class WrappedComponent extends React.PureComponent<Props, State> {
+    state = {
+      userSSHKeys: [],
+    }
+
+    mounted: boolean = false;
+
+    componentWillUnmount() {
+      this.mounted = false;
+    }
+
+    componentDidMount() {
+      this.mounted = true;
+      const { username, userEmailAddress } = this.props;
+      if (!username || !userEmailAddress) { return; }
+
+      getSSHKeys()
+        .then((response) => {
+          const keys = response.data
+          if (!this.mounted || !keys || keys.length === 0) { return; }
+
+          this.setState({
+            userSSHKeys: [
+              ...this.state.userSSHKeys,
+              this.createUserObject(username, userEmailAddress, keys.map(k => k.label)),
+            ],
+          })
+        })
+        .catch(console.error);
+
+      getUsers()
+        .then((response) => {
+          const users = response.data;
+          if (!this.mounted || !users || users.length === 0) { return; }
+
+          this.setState({
+            userSSHKeys: [
+              ...this.state.userSSHKeys,
+              ...users.reduce((users, user) => {
+                const keys = user.ssh_keys;
+                if (
+                  !keys || keys.length === 0 ||
+                  /** We don't want the current user added again. */
+                  user.username === this.props.username
+                ) {
+                  return users;
+                }
+
+                return [
+                  ...users,
+                  this.createUserObject(user.username, user.email, keys),
+                ];
+              }, [])
+            ],
+          })
+        })
+        .catch(console.error);
+    }
+
+    render() {
+      return React.createElement(Component, {
+        ...this.props,
+        ...this.state,
+      });
+    }
+
+    toggleSSHUserKeys = (username: string, result: boolean) => this.setState((state) => ({
+      ...state,
+      userSSHKeys: state.userSSHKeys.map((user) => (username === user.username) ? { ...user, selected: result } : user)
+    }));
+
+    createUserObject = (username: string, email: string, keys: string[]) => ({
+      keys,
+      username,
+      gravatarUrl: `https://www.gravatar.com/avatar/${getEmailHash(email)}?s=24`,
+      selected: false,
+      onChange: (_: any, result: boolean) => this.toggleSSHUserKeys(username, result),
+    })
+  }
+
+  return connected<Props>(WrappedComponent);
+}
+
+const connected = connect((state: Linode.AppState) => ({
+  username: path<string>(['data', 'username'], state.resources.profile),
+  userEmailAddress: path<string>(['data', 'email'], state.resources.profile),
+}))

--- a/src/features/linodes/LinodesCreate/TabbedContent/userSSHKeyHoc.ts
+++ b/src/features/linodes/LinodesCreate/TabbedContent/userSSHKeyHoc.ts
@@ -44,7 +44,7 @@ export default (Component: React.ComponentType<any>) => {
             ],
           })
         })
-        .catch(console.error);
+        .catch(() => { /* We don't need to do anything here, we just don't add the keys. */});
 
       getUsers()
         .then((response) => {
@@ -72,7 +72,7 @@ export default (Component: React.ComponentType<any>) => {
             ],
           })
         })
-        .catch(console.error);
+        .catch(() => { /* We don't need to do anything here, we just don't add the keys. */});
     }
 
     render() {

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -4,6 +4,7 @@ namespace Linode {
     email: string;
     restricted: boolean;
     gravatarUrl?: string;
+    ssh_keys: string[];
   }
 
   export interface Account {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -188,4 +188,10 @@ namespace Linode {
     from_linode: boolean;
     gravatarUrl: string | undefined;
   }
+  export interface SSHKey {
+    created: string;
+    id: number;
+    label: string;
+    ssh_key: string;
+  }
 }


### PR DESCRIPTION
## Purpose
Add SSH key selection to the Linode creation flow.

I created a HOC to eliminate duplication. Ill use the same on the rebuild as well. 

The creation of the UserSSHKeyObjects is contained in the HOC so the consumers just use whatever is passed down.
