### PR TITLE
Fix domains tests, add expand panel utility method

### DIFF
--- a/e2e/pageobjects/domain-detail/detail.page.js
+++ b/e2e/pageobjects/domain-detail/detail.page.js
@@ -16,6 +16,7 @@ class DomainDetail extends Page {
     get cancelButton() { return $('[data-qa-record-cancel]'); }
 
     addNsRecord(nameServer, subdomain) {
+        this.addNsRecordButton.waitForVisible(constants.wait.normal);
         this.addNsRecordButton.click();
         this.drawerTitle.waitForVisible();
         expect(this.drawerTitle.getText()).toBe('Create NS Record');

--- a/e2e/pageobjects/list-domains.page.js
+++ b/e2e/pageobjects/list-domains.page.js
@@ -109,6 +109,10 @@ class ListDomains extends Page {
         
         browser.trySetValue(`${this.cloneDomainName.selector} input`, newDomainName);
         this.submit.click();
+
+        browser.waitForVisible('[data-qa-domain-title]', constants.wait.normal);
+
+        browser.url(constants.routes.domains)
         
         browser.waitUntil(function() {
             const domains = $$('[data-qa-domain-cell] [data-qa-domain-label]');

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -63,10 +63,20 @@ export default class Page {
         browser.waitForVisible(`[data-value="${selectOption}"]`, constants.wait.normal, true);
     }
 
+    expandPanel(title) {
+        $(`[data-qa-panel-summary="${title}"]`).waitForVisible(constants.wait.normal);
+        $(`[data-qa-panel-summary="${title}"]`).click();
+
+        browser.waitUntil(function() {
+            return $(`[data-qa-panel-summary="${title}"]`)
+                .getAttribute('aria-expanded').includes('true');
+        }, constants.wait.normal, 'Panel failed to expand');
+    }
+
     expandPanels(numberOfPanels) {
         browser.waitUntil(function() {
             return $$('[data-qa-panel-summary]').length === numberOfPanels
-        }, constants.wait.normal);
+        }, constants.wait.normal, 'Number of expected panels failed to display');
         
         this.panels.forEach(panel => {
             panel.click();

--- a/e2e/specs/domains/detail-ns-records.spec.js
+++ b/e2e/specs/domains/detail-ns-records.spec.js
@@ -8,17 +8,16 @@ import { apiDeleteAllDomains } from '../../utils/common';
 describe('Domains - Detail - NS Actions Suite', () => {
     const domainName = `A${new Date().getTime()}.com`;
 
-    beforeAll(() => {
+    it('should setup the spec', () => {
         browser.url(constants.routes.domains);
         ListDomains.globalCreate.waitForVisible();
         ListDomains.progressBar.waitForVisible(constants.wait.normal, true);
         ListDomains.baseElemsDisplay(true);
         ListDomains.create(domainName,'foo@bar.com', true);
-        ListDomains.baseElemsDisplay();
-        ListDomains.domains[0].$(`${ListDomains.label.selector} a`).click();
-        
         // TODO - Update to use DomainDetail.baseElemsDisplay();
-        DomainDetail.domainTitle.waitForVisible();
+
+        DomainDetail.domainTitle.waitForVisible(constants.wait.normal);
+        DomainDetail.expandPanel('NS Record');
     });
 
     it('should add an ns record', () => {

--- a/e2e/specs/domains/list-domains.spec.js
+++ b/e2e/specs/domains/list-domains.spec.js
@@ -67,20 +67,26 @@ describe('Domains - List Suite', () => {
     });
 
     it('should fail to clone with the same domain name', () => {
-            ListDomains.selectActionMenuItem($(domainElement), 'Clone');
-            ListDomains.clone(initialDomain);
-            ListDomains.cloneDomainName.$('p').waitForVisible(constants.wait.normal);
-            ListDomains.closeDrawer();
+        ListDomains.selectActionMenuItem($(domainElement), 'Clone');
+        ListDomains.cloneDrawerElemsDisplay();
+        
+        browser.trySetValue(`${ListDomains.cloneDomainName.selector} input`, initialDomain);
+        
+        ListDomains.submit.click();
+        ListDomains.cloneDomainName.$('p').waitForVisible(constants.wait.normal);
+        ListDomains.closeDrawer();
     });
 
     it('should clone domain', () => {
+        browser.url(constants.routes.domains);
         browser.waitForVisible('[data-qa-action-menu]');
         ListDomains.selectActionMenuItem($(domainElement), 'Clone');
         ListDomains.clone(cloneDomain);
     });
 
     it('should remove domain', () => {
-        ListDomains.drawerTitle.waitForExist(constants.wait.normal, true);
+        browser.url(constants.routes.domains);
+        browser.waitForVisible('[data-qa-action-menu]');
         ListDomains.selectActionMenuItem($(domainElement), 'Remove');
         ListDomains.remove($(domainElement), initialDomain);
     });

--- a/src/components/ExpansionPanel/ExpansionPanel.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.tsx
@@ -105,7 +105,7 @@ class EExpansionPanel extends React.Component<CombinedProps> {
           onClick={this.handleClick}
           expandIcon={this.state.open ? <Minus /> : <Plus />}
           {...summaryProps}
-          data-qa-panel-summary
+          data-qa-panel-summary={this.props.heading}
         >
           <Typography
             role="header"


### PR DESCRIPTION
* Fixes regression introduced by UI change in https://github.com/linode/manager/pull/3776
* Fixes UI flow for clone domains test
* Adds a expand panel utility

## To Test

```bash
yarn && yarn start
yarn selenium
yarn e2e:modified
```
