### PR TITLE
Add Lish SSH Keys E2E Tests

### DIFF
--- a/e2e/constants.js
+++ b/e2e/constants.js
@@ -2,6 +2,7 @@ exports.constants = {
 	testAccounts: {
 
 	},
+	testPublicKey: `ssh-rsa MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAq5X9wwTT0hnEgyXnHaWZCfBp4z3DGdxaDsp1m+mdaDBUEDqtZ+6/GNAjkq7JipeXmg8YD3oKdlwm2jupv2lji4LbLHPu9umhRWpQsIOPS8pcEAvpzvA99fpdZYrMI03DZyuSiK5NjRRsusbLVaMhkv3/9dkChyly0d0JSCjA2/C71VOXSUAljxtRFIQ3qtMeN+EsMNDRYrLjMBCJmuGr2/my3mGHapa4QbwdOgqhCyerr/W7/nZeqEIyTWpIkX9dMppCGq2gcqW40s4ISGnFXN8YoTlbnXtq18jrZG6O0D1+HNUJvc4RdSxq+xZPILM40xQFUb0YdqLcPXcW/yZjQ7runP3cHndN72t0JYabu0+YL14t6ZS9gX7lc3vDv7Y1exYwgaup+H5kPCpaEYzRmMEtaOn0oVAeBrunAsIFoOiAOLn/SdmU7jtG9eWCskDRwchCm1rz9CeDkOQllUZg6RItbJGUqfV7GvK/8byfhdjzsD2QPW0b+xCWjPjTJXBzhudm9FESQJ+uLA7cQisM9iLF3R9KAmRotM/X9UdlBLqy1Kjp/6JBR89DXgco/XKAGZOA97n/H3agoJ+KA4hw7Mi68XccKcBQiNY0v9I6RKCzaa4wEeTxmk69oRK57iXp1BG8mqYnaiDZF2fXqrIG/IUq+qtU3p7u7QwhTqRYjYcCAwEAAQ== pthiel@linode.com`,
 	wait: {
 		short: process.env.DOCKER || process.env.BROWSERSTACK_USERNAME ? 10000 : 5000,
 		normal: process.env.DOCKER || process.env.BROWSERSTACK_USERNAME ? 20000 : 12000,
@@ -28,7 +29,8 @@ exports.constants = {
 		profile: {
 			view: '/profile/',
 			tokens: '/profile/tokens',
-			oauth: '/profile/clients'
+			oauth: '/profile/clients',
+			lish: '/profile/lish',
 		},
 		support: {
 			docs: '/documentation',

--- a/e2e/pageobjects/profile/lish.page.js
+++ b/e2e/pageobjects/profile/lish.page.js
@@ -1,0 +1,55 @@
+const { constants } = require('../../constants');
+
+import Page from '../page';
+
+export class Lish extends Page {
+    get authModeSelect() { return $('[data-qa-select]'); }
+    get sshKey() { return $('[data-qa-public-key] textarea' ); }
+    get addSshKey() { return $('[data-qa-icon-text-link="Add SSH Public Key"]'); }
+    get removeButton() { return $('[data-qa-remove]'); }
+    get saveButton() { return $('[data-qa-save]'); }
+    get passwordKeysOption() { return $('[data-value="password_keys"]'); }
+    get keysOnlyOption() { return $('[data-value="keys_only"]'); }
+    get disableLishOption() { return $('[data-value="disabled"]'); }
+
+    baseElemsDisplay() {
+        this.authModeSelect.waitForVisible(constants.wait.normal);
+        
+        expect(this.sshKey.isVisible()).toBe(true);
+        expect(this.removeButton.isVisible()).toBe(true);
+        expect(this.saveButton.isVisible()).toBe(true);
+        expect(this.authModeSelect.isVisible()).toBe(true);
+    }
+
+
+    disable(statusMsg) {
+        this.authModeSelect.click();
+        this.disableLishOption.waitForVisible(constants.wait.normal);
+        this.disableLishOption.click();
+        this.disableLishOption.waitForExist(constants.wait.normal, true);
+        this.saveButton.click();
+        this.waitForNotice(statusMsg, constants.wait.normal);
+    }
+
+    allowKeyAuthOnly(publicKey,statusMsg) {
+        this.authModeSelect.click();
+        this.keysOnlyOption.waitForVisible(constants.wait.normal);
+        this.keysOnlyOption.click();
+        this.keysOnlyOption.waitForExist(constants.wait.normal, true);
+        this.sshKey.setValue(publicKey);
+        this.saveButton.click();
+        this.waitForNotice(statusMsg, constants.wait.normal);
+    }
+
+    allowPassAndKey(publicKey,statusMsg) {
+        this.authModeSelect.click();
+        this.passwordKeysOption.waitForVisible(constants.wait.normal);
+        this.passwordKeysOption.click();
+        this.passwordKeysOption.waitForExist(constants.wait.normal, true);
+        this.sshKey.setValue(publicKey);
+        this.saveButton.click();
+        this.waitForNotice(statusMsg, constants.wait.normal);
+    }
+}
+
+export default new Lish();

--- a/e2e/specs/profile/lish.spec.js
+++ b/e2e/specs/profile/lish.spec.js
@@ -1,0 +1,51 @@
+const { constants } = require('../../constants');
+
+import Lish from '../../pageobjects/profile/lish.page';
+
+describe('Profile - Lish SSH Key Suite', () => {
+    const successMsg = 'LISH authentication settings have been updated.';
+    const validPublicKey = constants.testPublicKey;
+
+    beforeAll(() => {
+        browser.url(constants.routes.profile.lish);
+    });
+
+    it('should display the lish authentication methods', () => {
+        Lish.baseElemsDisplay();
+    });
+
+    it('should disable lish', () => {
+        Lish.disable(successMsg);
+    });
+
+    it('should update to key only, and fail to save a bad ssh key', () => {
+        const invalidPublicKey = 'badKey!';
+        const failureMsg = 'SSH Key 1 key-type must be ssh-dss, ssh-rsa, ecdsa-sha2-nistp, or ssh-ed25519.';
+
+        Lish.allowKeyAuthOnly(invalidPublicKey, failureMsg);
+    });
+
+    it('should display an additional ssh key field ', () => {
+        Lish.addSshKey.click();
+
+        browser.waitUntil(function() {
+            return $$(Lish.sshKey.selector).length === 2;
+        }, constants.wait.normal);
+    });
+
+    it('should remove the additional ssh key field', () => {
+        $$(Lish.removeButton.selector)[1].click();
+        
+        browser.waitUntil(function() {
+            return $$(Lish.sshKey.selector).length === 1;
+        }, constants.wait.normal);
+    });
+
+    it('should accept ssh key only with a valid ssh key', () => {
+        Lish.allowKeyAuthOnly(validPublicKey, successMsg);
+    });
+
+    it('should update to allow password and ssh key authentication', () => {
+        Lish.allowPassAndKey(validPublicKey, successMsg);
+    });
+});

--- a/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/src/features/Profile/LishSettings/LishSettings.tsx
@@ -165,11 +165,13 @@ class LishSettings extends React.Component<CombinedProps, State> {
                           multiline
                           rows="4"
                           className={classes.keyTextarea}
+                          data-qa-public-key
                         />
                         <Button
                           type="remove"
                           onClick={this.onPublicKeyRemove(idx)}
                           className={classes.remove}
+                          data-qa-remove
                         />
                       </div>
                     ))
@@ -188,6 +190,7 @@ class LishSettings extends React.Component<CombinedProps, State> {
               type="primary"
               onClick={this.onSubmit}
               loading={this.state.submitting}
+              data-qa-save
             >
               Save
             </Button>


### PR DESCRIPTION
* Adds tests for adding SSH key auth methods to lish
* Adds a test ssh public key to constants (will be useful when testing other ssh key functionality in the manager later)
* Added qa tags to profile - Lish page

To Test

```bash
yarn && yarn start
yarn selenium
yarn e2e --file e2e/specs/profile/lish.spec.js
```
