### PR TITLE
Add support Landing/tickets e2e tests

### DIFF
--- a/e2e/pageobjects/support/landing.page.js
+++ b/e2e/pageobjects/support/landing.page.js
@@ -1,0 +1,31 @@
+const { constants } = require('../../constants');
+
+import Page from '../page';
+
+export class SupportLanding extends Page {
+    get searchHeading() { return $('[data-qa-search-heading]'); }
+    get searchField() { return $('[data-qa-enhanced-select] input'); }
+    get docLink() { return $('[data-qa-doc-link]'); }
+    get docLinks() { return $$('[data-qa-doc-link]'); }
+    get communityPost() { return $('[data-qa-community-post]'); }
+    get communityPosts() { return $$('[data-qa-community-post]'); }
+    get viewDocsTile() { return $('[data-qa-tile="View Documentation"]'); }
+    get communityTile() { return $('[data-qa-tile="Search the Community"]'); }
+    get adaTile() { return $('[data-qa-tile="Talk to Ada"]'); }
+    get supportTile() { return $('[data-qa-tile="Customer Support"]'); }
+
+    baseElemsDisplay() {
+        this.searchHeading.waitForVisible(constants.wait.normal);
+
+        expect(this.searchField.isVisible()).toBe(true);
+        expect(this.communityPosts.length).toBe(3);
+        expect(this.docLinks.length).toBe(3);
+
+        expect(this.viewDocsTile.isVisible()).toBe(true);
+        expect(this.communityTile.isVisible()).toBe(true);
+        expect(this.adaTile.isVisible()).toBe(true);
+        expect(this.supportTile.isVisible()).toBe(true);
+    }
+}
+
+export default new SupportLanding();

--- a/e2e/pageobjects/support/tickets.page.js
+++ b/e2e/pageobjects/support/tickets.page.js
@@ -1,0 +1,70 @@
+const { constants } = require('../../constants');
+
+import Page from '../page';
+
+export class SupportTickets extends Page {
+    get openTicketsTab() { return $('[data-qa-tab="Open Tickets"]'); }
+    get closedTicketsTab() { return $('[data-qa-tab="Closed Tickets"]'); }
+    get supportHeader() { return $('[data-qa-title]'); }
+    get openTicketButton() { return $('[data-qa-icon-text-link="Open New Ticket"]'); }
+
+    get supportCreateDateHeader() { return $('[data-qa-support-date-header]'); }
+    get supportSubjectHeader() { return $('[data-qa-support-subject-header]'); }
+    get supportIdHeader() { return $('[data-qa-support-id-header]'); }
+    get supportEntityHeader() { return $('[data-qa-support-regarding-header]'); }
+    get supportUpdateHeader() { return $('[data-qa-support-updated-header]'); }
+
+    get supportTicket() { return $('[data-qa-support-ticket]'); }
+    get supportTickets() { return $$('[data-qa-support-ticket]'); }
+    get supportSubject() { return $('[data-qa-support-subject]'); }
+    get supportId() { return $('[data-qa-support-id]'); }
+    get supportEntity() { return $('[data-qa-support-entity]'); }
+    get supportCreateDate() { return $('[data-qa-support-date]'); }
+    get supportUpdateDate() { return $('[data-qa-support-updated]'); }
+    
+    get ticketHelpText() { return $('[data-qa-support-ticket-helper-text]'); }
+    get ticketEntityType() { return $('[data-qa-ticket-entity-type]'); }
+    get ticketSummary() { return $('[data-qa-ticket-summary] input'); }
+    get ticketDescription() { return $('[data-qa-ticket-description] textarea'); }
+
+    get submit() { return $('[data-qa-submit]'); }
+    get cancel() { return $('[data-qa-cancel]'); }
+
+    baseElemsDisplay() {
+        this.supportHeader.waitForVisible(constants.wait.normal);
+        this.openTicketsTab.waitForVisible(constants.wait.normal);
+
+        expect(this.closedTicketsTab.isVisible()).toBe(true);
+        expect(this.openTicketButton.isVisible()).toBe(true);
+        expect(this.supportCreateDateHeader.isVisible()).toBe(true);
+        expect(this.supportSubjectHeader.isVisible()).toBe(true);
+        expect(this.supportIdHeader.isVisible()).toBe(true);
+        expect(this.supportEntityHeader.isVisible()).toBe(true);
+        expect(this.supportUpdateHeader.isVisible()).toBe(true);
+    }
+
+    openCreateTicketDrawer() {
+        this.openTicketButton.click();
+        this.drawerTitle.waitForVisible(constants.wait.normal);
+        this.ticketHelpText.waitForVisible(constants.wait.normal);
+
+        expect(this.ticketEntityType.isVisible()).toBe(true);
+        expect(this.ticketSummary.isVisible()).toBe(true);
+        expect(this.ticketDescription.isVisible()).toBe(true);
+        expect(this.submit.isVisible()).toBe(true);
+        expect(this.cancel.isVisible()).toBe(true);
+    }
+
+    openTicket(ticketObj) {
+        this.ticketEntityType.click();
+        browser.waitForVisible('[data-value]', constants.wait.normal);
+        browser.click(`[data-value="${ticketObj.entity}"]`);
+        browser.waitForVisible('[data-value]', constants.wait.normal, true);
+
+        this.ticketSummary.setValue(ticketObj.summary);
+        this.ticketDescription.setValue(ticketObj.description);
+
+        this.submit.click();
+    }
+}
+export default new SupportTickets();

--- a/e2e/specs/support/landing.spec.js
+++ b/e2e/specs/support/landing.spec.js
@@ -1,0 +1,13 @@
+const { constants } = require('../../constants');
+
+import SupportLanding from '../../pageobjects/support/landing.page.js';
+
+describe('Support - Landing Suite', () => {
+    beforeAll(() => {
+        browser.url(constants.routes.support.landing);
+    });
+
+    it('should display the support landing page elements', () => {
+        SupportLanding.baseElemsDisplay();
+    });
+});

--- a/e2e/specs/support/tickets.spec.js
+++ b/e2e/specs/support/tickets.spec.js
@@ -1,0 +1,17 @@
+const { constants } = require('../../constants');
+
+import SupportTickets from '../../pageobjects/support/tickets.page.js';
+
+describe('Support - Tickets Suite', () => {
+    beforeAll(() => {
+        browser.url(constants.routes.support.tickets);
+    });
+
+    it('should display ticket page base elements', () => {
+        SupportTickets.baseElemsDisplay();
+    });
+
+    it('should display the ticket create drawer', () => {
+        SupportTickets.openCreateTicketDrawer();
+    });
+});


### PR DESCRIPTION
* In https://github.com/linode/manager/pull/3783 i goofed and forgot to add the test specs to my PR :d'oh!: 
* Added page objects for support "Get Help" landing, and tickets page
* Added test specs for "Get Help" and Tickets pages

cc. @martinmckenna  since he reviewed the initial PR

## To Test
```bash
yarn && yarn start
yarn selenium
yarn e2e:modified
```
