### PR TITLE
Add spacingTop to Notice

### DIFF
--- a/src/features/Profile/AuthenticationSettings/TwoFactor/ConfirmToken.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/ConfirmToken.tsx
@@ -82,7 +82,9 @@ const ConfirmToken: React.StatelessComponent<CombinedProps> = (props) => {
         {twoFactorConfirmed &&
           <Notice 
             warning
+            spacingTop={8}
             className={classes.warning}
+            
             text={"Confirming a new key will invalidate codes generated from any previous key."}
           />
         }


### PR DESCRIPTION
This component is from before we had the `spacingTop` prop available. Adds it to the caution Notice when resetting TFA.