### PR TITLE
Add production flag for Survicate

### DIFF
--- a/integration-test.yml
+++ b/integration-test.yml
@@ -17,6 +17,7 @@ services:
       - REACT_APP_LOGIN_ROOT=${REACT_APP_LOGIN_ROOT}
       - REACT_APP_CLIENT_ID=${REACT_APP_CLIENT_ID}
       - REACT_APP_API_ROOT=${REACT_APP_API_ROOT}
+      - REACT_APP_TEST_ENVIRONMENT=true
     build:
       context: .
       dockerfile: Dockerfile

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { DocumentTitleSegment, withDocumentTitleProvider } from 'src/components/
 import Grid from 'src/components/Grid';
 import NotFound from 'src/components/NotFound';
 import SideMenu from 'src/components/SideMenu';
+import { isProduction } from 'src/constants';
 import { RegionsProvider, WithRegionsContext } from 'src/context/regions';
 import { TypesProvider, WithTypesContext } from 'src/context/types';
 import Footer from 'src/features/Footer';
@@ -275,9 +276,10 @@ export class App extends React.Component<CombinedProps, State> {
     const { userId } = this.props;
     /* userId is a connected prop; if it's loaded
     * (default value is 1) and we haven't already
-    * done this, initialize the survey.
+    * done this, initialize the survey. Also, shouldn't
+    * load the survey in development.
     * */
-    if (userId && userId !== 1 && !this.surveyed) {
+    if (userId && userId !== 1 && !this.surveyed && isProduction) {
       /* Initialize Survicate
       * Done here rather than in index.tsx so that
       * we have access to the logged in user's ID

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import { DocumentTitleSegment, withDocumentTitleProvider } from 'src/components/
 import Grid from 'src/components/Grid';
 import NotFound from 'src/components/NotFound';
 import SideMenu from 'src/components/SideMenu';
-import { isProduction } from 'src/constants';
+import { isProduction, isTest } from 'src/constants';
 import { RegionsProvider, WithRegionsContext } from 'src/context/regions';
 import { TypesProvider, WithTypesContext } from 'src/context/types';
 import Footer from 'src/features/Footer';
@@ -279,6 +279,10 @@ export class App extends React.Component<CombinedProps, State> {
     * done this, initialize the survey. Also, shouldn't
     * load the survey in development.
     * */
+    if (isTest) {
+      // Temporary hack until we implement NODE_ENV=test
+      return;
+    }
     if (userId && userId !== 1 && !this.surveyed && isProduction) {
       /* Initialize Survicate
       * Done here rather than in index.tsx so that

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const GA_ID = process.env.REACT_APP_GA_ID;
 export const GTM_ID = process.env.REACT_APP_GTM_ID;
 
 export const isProduction = process.env.NODE_ENV === PRODUCTION;
+export const isTest = process.env.REACT_APP_TEST_ENVIRONMENT === 'true';
 
 export const APP_ROOT = process.env.REACT_APP_APP_ROOT || 'http://localhost:3000';
 export const LOGIN_ROOT = process.env.REACT_APP_LOGIN_ROOT || 'https://login.linode.com';


### PR DESCRIPTION
Use `isProduction` from `src/constants` to only load the survey in production