### PR TITLE
Remove Mutation Flow

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -41,7 +41,6 @@ import {
 
 import haveAnyBeenModified from 'src/utilities/haveAnyBeenModified';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { notifications } from 'src/utilities/storage';
 
 import { ConfigsProvider, DisksProvider, ImageProvider, LinodeProvider, VolumesProvider } from './context';
 import LinodeBackup from './LinodeBackup';
@@ -451,13 +450,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
     if (!!linode
       && prevState.context.linode.data !== linode
       && linode.type) {
-      /*
-      * Check local storage to see if user has opted out to upgrades on this specific Linode
-      */
-      const userHasOptedOut = notifications.linodeMutation.get().some((optedOutLinode) => {
-        return optedOutLinode === linode.id;
-      });
-      if (userHasOptedOut) { return; }
 
       getType(linode.type)
         .then((currentType: Linode.LinodeType) => {
@@ -667,14 +659,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
     });
   }
 
-  optOut = (linodeId: number) => {
-    /* close the drawer, remove the warning, and set local storage */
-    this.closeMutateDrawer();
-    this.setState({ showPendingMutation: false });
-    notifications.linodeMutation.set(linodeId);
-    sendToast('You have successfully opted out of this Linode upgrade')
-  }
-
   initMutation = () => {
     const { mutateDrawer, context: { linode } } = this.state;
 
@@ -712,6 +696,11 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
           }
         })
       });
+  }
+
+  goToOldManager = () => {
+    const { context: { linode: { data: linode } } } = this.state;
+    window.open(`https://manager.linode.com/linodes/mutate/${linode!.label}`)
   }
 
   render() {
@@ -816,8 +805,9 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
                     <Notice important warning>
                       {`This Linode has pending upgrades available. To learn more about
                       this upgrade and what it includes, `}
-                      <span className={classes.link} onClick={this.openMutateDrawer}>
-                        click here.
+                      {/** @todo change onClick to open mutate drawer once migrate exists */}
+                      <span className={classes.link} onClick={this.goToOldManager}>
+                        please visit the classic Linode Manager.
                       </span>
                     </Notice>
                   }
@@ -917,7 +907,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
                         network_out: this.state.currentNetworkOut,
                       }}
                       initMutation={this.initMutation}
-                      optOut={this.optOut}
                     />
                   }
                 </VolumesProvider>

--- a/src/features/linodes/LinodesDetail/MutateDrawer/MutateDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/MutateDrawer/MutateDrawer.tsx
@@ -51,7 +51,6 @@ interface Props {
   linodeId: number;
   loading: boolean;
   error: string;
-  optOut: (linodeId: number) => void;
 }
 
 interface State {
@@ -82,7 +81,7 @@ class MutateDrawer extends React.Component<CombinedProps, State> {
           label: 'Storage',
           newAmount: props.mutateInfo.disk,
           currentAmount: props.currentTypeInfo.disk,
-          unit: 'GB'
+          unit: 'MB'
         },
         transfer: {
           label: 'Transfer',
@@ -98,10 +97,6 @@ class MutateDrawer extends React.Component<CombinedProps, State> {
         }
       }
     } as State;
-  }
-
-  handleOptOut = () => {
-    this.props.optOut(this.props.linodeId)
   }
 
   render() {
@@ -163,13 +158,6 @@ class MutateDrawer extends React.Component<CombinedProps, State> {
             compact
           >
             Enter the Upgrade Queue
-          </Button>
-          <Button 
-            onClick={this.handleOptOut}
-            type="secondary"
-            compact
-          >
-            Opt Out of Upgrade
           </Button>
         </ActionsPanel>
         {/*

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -22,7 +22,6 @@ export const setStorage = (key: string, value: string) => {
 const THEME = 'themeChoice';
 const BETA_NOTIFICATION = 'BetaNotification';
 const LINODE_VIEW = 'linodesViewStyle';
-const OPTED_OUT_LINODES = 'optedOutLinodes';
 
 type Theme = 'dark' | 'light';
 type Beta = 'open' | 'closed';
@@ -37,12 +36,6 @@ export const storage = {
     beta: {
       get: (): Beta => getStorage(BETA_NOTIFICATION, 'open'),
       set: (open: Beta) => setStorage(BETA_NOTIFICATION, open),
-    },
-    linodeMutation: {
-      get: (): number[] => getStorage(OPTED_OUT_LINODES, []),
-      set(linodeId: number) {
-        setStorage(OPTED_OUT_LINODES, JSON.stringify([...this.get(), linodeId]))
-      },
     }
   },
   views: {


### PR DESCRIPTION
### Purpose

Changes "click here" link on Linode Mutation flow from opening up the mutation drawer to redirecting the user to CF Manager in a new tab

Also removes _Opt Out of Mutation_ feature altogether, as per review

### To Test

Login to `dev-test-003`. There should be one more Linode that has a pending mutation available
