### PR TITLE
Move LinodeDetails volumes to Redux.

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -13,12 +13,14 @@ import ExpansionPanel from 'src/components/ExpansionPanel';
 import LineGraph from 'src/components/LineGraph';
 import Select from 'src/components/Select';
 import { withTypes } from 'src/context/types';
-import { withImage, withLinode, withVolumes } from 'src/features/linodes/LinodesDetail/context';
+import { withImage, withLinode } from 'src/features/linodes/LinodesDetail/context';
 import { displayType, typeLabelLong } from 'src/features/linodes/presentation';
 import { getLinodeStats } from 'src/services/linodes';
 import { setUpCharts } from 'src/utilities/charts';
 
 import SummaryPanel from './SummaryPanel';
+
+import { connect, MapStateToProps } from 'react-redux';
 
 setUpCharts();
 
@@ -479,18 +481,24 @@ const imageContext = withImage((context) => ({
   imageData: context.data!,
 }))
 
-const volumesContext = withVolumes((context) => ({
-  volumesData: context.data!,
-}))
-
 const typesContext = withTypes(({ data: typesData }) => ({ typesData }))
 
+interface StateProps {
+  volumesData?: Linode.Volume[]
+}
+
+const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (state, ownProps) => ({
+  volumesData: state.features.linodeDetail.volumes.data,
+});
+
+const connected = connect(mapStateToProps);
+
 const enhanced = compose(
+  connected,
   styled,
   typesContext,
   linodeContext,
   imageContext,
-  volumesContext,
 );
 
 export default enhanced(LinodeSummary);

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.test.tsx
@@ -12,7 +12,6 @@ import { LinodeVolumes } from './LinodeVolumes';
 
 describe('Linode Volumes', () => {
   const linodeConfigsAsPromiseResponse = createPromiseLoaderResponse(linodeConfigs);
-  const volumesAsPromiseResponse = createPromiseLoaderResponse(volumes);
 
   const mockLocation = {
     pathname: 'localhost',
@@ -23,15 +22,16 @@ describe('Linode Volumes', () => {
 
   const component = shallow(
     <LinodeVolumes
-      updateVolumes={jest.fn()}
       classes={{ title: '' }}
-      volumes={volumesAsPromiseResponse}
       linodeConfigs={linodeConfigsAsPromiseResponse}
       linodeVolumes={volumes}
       linodeLabel="test"
       linodeRegion="us-east"
       linodeStatus="running"
       linodeID={100}
+      actions={{
+        updateVolumes: jest.fn()
+      }}
       history={{
         length: 2,
         action: 'PUSH',
@@ -65,9 +65,10 @@ describe('Linode Volumes', () => {
       <StaticRouter context={{}}>
         <LinodeThemeWrapper>
           <LinodeVolumes
-            updateVolumes={jest.fn()}
+            actions={{
+              updateVolumes: jest.fn()
+            }}
             classes={{ title: '' }}
-            volumes={volumesAsPromiseResponse}
             linodeConfigs={createPromiseLoaderResponse([])}
             linodeVolumes={[]}
             linodeLabel="test"
@@ -89,9 +90,10 @@ describe('Linode Volumes', () => {
       <StaticRouter context={{}}>
         <LinodeThemeWrapper>
           <LinodeVolumes
-            updateVolumes={jest.fn()}
+            actions={{
+              updateVolumes: jest.fn()
+            }}
             classes={{ title: '' }}
-            volumes={volumesAsPromiseResponse}
             linodeConfigs={linodeConfigsAsPromiseResponse}
             linodeVolumes={[]}
             linodeLabel="test"
@@ -116,9 +118,10 @@ describe('Linode Volumes', () => {
         <StaticRouter context={{}}>
           <LinodeThemeWrapper>
             <LinodeVolumes
-              updateVolumes={jest.fn()}
+              actions={{
+                updateVolumes: jest.fn()
+              }}
               classes={{ title: '' }}
-              volumes={volumesAsPromiseResponse}
               linodeConfigs={linodeConfigsAsPromiseResponse}
               linodeVolumes={volumes}
               linodeLabel="test"

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -1,5 +1,6 @@
 import { append, compose, equals, filter, lensPath, over, pathOr, set, when } from 'ramda';
 import * as React from 'react';
+import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import 'rxjs/add/operator/filter';
 import { Subscription } from 'rxjs/Subscription';
@@ -30,10 +31,11 @@ import { events$, resetEventsPolling } from 'src/events';
 import { sendToast } from 'src/features/ToastNotifications/toasts';
 import { getLinodeConfigs, getLinodeVolumes } from 'src/services/linodes';
 import { attachVolume, cloneVolume, createVolume, deleteVolume, detachVolume, resizeVolume, updateVolume } from 'src/services/volumes';
+import { handleUpdate } from 'src/store/reducers/features/linodeDetail/volumes';
 import composeState from 'src/utilities/composeState';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
-import { withLinode, withVolumes } from '../context';
+import { withLinode } from '../context';
 import ActionMenu from './LinodeVolumesActionMenu';
 import VolumeDrawer, { Modes, Props as VolumeDrawerProps } from './VolumeDrawer';
 
@@ -48,13 +50,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 
 interface Props {
   /** PromiseLoader */
-  volumes: PromiseLoaderResponse<Linode.Volume[]>;
   linodeConfigs: PromiseLoaderResponse<Linode.Config[]>;
-}
-
-interface VolumesContextProps {
-  linodeVolumes: Linode.Volume[];
-  updateVolumes: (update: (volumes: Linode.Volume[]) => Linode.Volume[]) => void;
 }
 
 interface LinodeContextProps {
@@ -84,7 +80,7 @@ interface State {
 }
 
 type CombinedProps = Props
-  & VolumesContextProps
+  & StateProps & DispatchProps
   & LinodeContextProps
   & RouteComponentProps<{}>
   & WithStyles<ClassNames>;
@@ -201,7 +197,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
 
   /** Attachment */
   attachVolume = () => {
-    const { linodeID, updateVolumes } = this.props;
+    const { linodeID, actions } = this.props;
     const { volumeDrawer: { selectedVolume } } = this.state;
 
     /** This should be handled by Joi */
@@ -220,7 +216,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     attachVolume(Number(selectedVolume), { linode_id: Number(linodeID) })
       .then(({ data }) => {
         this.closeUpdatingDrawer();
-        updateVolumes((volumes) => ([...volumes, data]));
+        actions.updateVolumes((volumes) => ([...volumes, data]));
       })
       .catch((errorResponse) => {
         const fallbackError = [{ reason: 'Unable to attach volume.' }];
@@ -253,7 +249,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     const fallbackError = [{ reason: 'Unable to detach volume.' }];
     const apiError = pathOr(fallbackError, ['response', 'data', 'errors'], errorResponse);
     const error = apiError[0].reason;
-    this.setState({ 
+    this.setState({
       updateDialog: {
         ...updateDialog,
         error,
@@ -862,7 +858,6 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
    */
   render() {
     const {
-      volumes: { error: volumesError },
       linodeConfigs: { error: linodeConfigsError },
       linodeLabel,
     } = this.props;
@@ -870,7 +865,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     const { volumeDrawer } = this.state;
 
 
-    if (volumesError || linodeConfigsError) {
+    if (linodeConfigsError) {
       return (
         <React.Fragment>
           <DocumentTitleSegment segment={`${linodeLabel} - Volumes`} />
@@ -893,13 +888,9 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles, { withTheme: true });
 
-const preloaded = PromiseLoader<Props & LinodeContextProps & VolumesContextProps>({
+const preloaded = PromiseLoader<Props & LinodeContextProps>({
   linodeConfigs: (props) => getLinodeConfigs(props.linodeID)
     .then(response => response.data),
-
-  volumes: (props) => getLinodeVolumes(props.linodeID)
-    .then(response => response.data
-      .filter(volume => volume.region === props.linodeRegion && volume.linode_id === null)),
 });
 
 const linodeContext = withLinode((context) => ({
@@ -909,14 +900,31 @@ const linodeContext = withLinode((context) => ({
   linodeStatus: context.data!.status
 }));
 
-const volumesContext = withVolumes((context) => ({
-  linodeVolumes: context.data,
-  updateVolumes: context.update,
-}));
+interface StateProps {
+  linodeVolumes?: Linode.Volume[];
+}
+
+const mapStateToProps: MapStateToProps<StateProps, Props, ApplicationState> = (state, ownProps) => ({
+  linodeVolumes: state.features.linodeDetail.volumes.data
+});
+
+interface DispatchProps {
+  actions: {
+    updateVolumes: (fn: (v: Linode.Volume[])=> Linode.Volume[]) => void;
+  },
+}
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (dispatch, ownProps) => ({
+  actions: {
+    updateVolumes: (fn) => dispatch(handleUpdate(fn)),
+  }
+});
+
+const connected = connect(mapStateToProps, mapDispatchToProps);
 
 export default compose<any, any, any, any, any, any, any>(
+  connected,
   linodeContext,
-  volumesContext,
   styled,
   withRouter,
   SectionErrorBoundary,

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -2,6 +2,7 @@ import { Location } from 'history';
 import * as moment from 'moment';
 import { allPass, compose, filter, has, Lens, lensPath, pathEq, pathOr, set } from 'ramda';
 import * as React from 'react';
+import { connect, MapDispatchToProps } from 'react-redux';
 import { Link, matchPath, Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import 'rxjs/add/observable/timer';
 import 'rxjs/add/operator/debounce';
@@ -34,15 +35,12 @@ import { sendToast } from 'src/features/ToastNotifications/toasts';
 import notifications$ from 'src/notifications';
 import { Requestable } from 'src/requestableContext';
 import { getImage } from 'src/services/images';
-import {
-  getLinode, getLinodeConfigs, getLinodeDisks,
-  getLinodeVolumes, getType, renameLinode, startMutation,
-} from 'src/services/linodes';
-
+import { getLinode, getLinodeConfigs, getLinodeDisks, getType, renameLinode, startMutation } from 'src/services/linodes';
+import { _getLinodeVolumes } from 'src/store/reducers/features/linodeDetail/volumes';
 import haveAnyBeenModified from 'src/utilities/haveAnyBeenModified';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
-import { ConfigsProvider, DisksProvider, ImageProvider, LinodeProvider, VolumesProvider } from './context';
+import { ConfigsProvider, DisksProvider, ImageProvider, LinodeProvider } from './context';
 import LinodeBackup from './LinodeBackup';
 import LinodeDetailErrorBoundary from './LinodeDetailErrorBoundary';
 import LinodeNetworking from './LinodeNetworking';
@@ -85,7 +83,6 @@ interface State {
     disks: Requestable<Linode.Disk[]>;
     image: Requestable<Linode.Image>;
     linode: Requestable<Linode.Linode>;
-    volumes: Requestable<Linode.Volume[]>;
   };
   configDrawer: ConfigDrawerState;
   labelInput: { label: string; errorText: string; };
@@ -152,14 +149,13 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   }
 });
 
-type CombinedProps = RouteProps & WithStyles<ClassNames>;
+type CombinedProps = DispatchProps & RouteProps & WithStyles<ClassNames>;
 
 const labelInputLens = lensPath(['labelInput']);
 const configsLens = lensPath(['context', 'configs']);
 const disksLens = lensPath(['context', 'disks']);
 const imageLens = lensPath(['context', 'image']);
 const linodeLens = lensPath(['context', 'linode']);
-const volumesLens = lensPath(['context', 'volumes']);
 
 const L = {
   configs: {
@@ -194,13 +190,6 @@ const L = {
     lastUpdated: compose(linodeLens, lensPath(['lastUpdated'])) as Lens,
     linode: linodeLens,
     loading: compose(linodeLens, lensPath(['loading'])) as Lens,
-  },
-  volumes: {
-    data: compose(volumesLens, lensPath(['data'])) as Lens,
-    errors: compose(volumesLens, lensPath(['errors'])) as Lens,
-    lastUpdated: compose(volumesLens, lensPath(['lastUpdated'])) as Lens,
-    loading: compose(volumesLens, lensPath(['loading'])) as Lens,
-    volumes: volumesLens,
   },
 };
 
@@ -369,38 +358,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
           );
         },
       },
-      volumes: {
-        lastUpdated: 0,
-        loading: true,
-        request: () => {
-          this.setState(set(L.volumes.loading, true));
-
-          return getLinodeVolumes(this.props.match.params.linodeId!)
-            .then(({ data }) => {
-              this.composeState(
-                set(L.volumes.loading, false),
-                set(L.volumes.data, data),
-                set(L.volumes.lastUpdated, Date.now()),
-              );
-              return data;
-            })
-            .catch((r) => {
-              this.composeState(
-                set(L.volumes.lastUpdated, Date.now()),
-                set(L.volumes.loading, false),
-                set(L.volumes.errors, r)
-              );
-            });
-        },
-        update: (updater) => {
-          const { data: volumes } = this.state.context.volumes;
-          if (!volumes) { return }
-
-          this.composeState(
-            set(L.volumes.data, updater(volumes)),
-          );
-        },
-      },
     },
     labelInput: {
       label: '',
@@ -492,9 +449,9 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
   componentDidMount() {
     this.mounted = true;
 
-    const { context: { configs, disks, image, linode, volumes } } = this.state;
+    const { context: { configs, disks, image, linode } } = this.state;
     const mountTime = moment().subtract(5, 'seconds');
-    const { match: { params: { linodeId } } } = this.props;
+    const { actions, match: { params: { linodeId } } } = this.props;
 
     this.diskResizeSubscription = events$
       .filter((e) => !e._initial)
@@ -509,7 +466,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       .subscribe((linodeEvent) => {
         configs.request();
         disks.request();
-        volumes.request();
+        actions.getLinodeVolumes();
         linode.request(linodeEvent)
           .then((l) => {
             if (l) { image.request(l.image) }
@@ -529,8 +486,9 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       ].includes(e.action))
       .filter(e => !e._initial)
       .subscribe((v) => {
-        volumes.request();
+        actions.getLinodeVolumes();
       });
+
     /** Get /notifications relevant to this Linode */
     this.notificationsSubscription = notifications$
       .map(filter(allPass([
@@ -542,7 +500,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
 
     configs.request();
     disks.request();
-    volumes.request();
+    actions.getLinodeVolumes();
     linode.request()
       .then((l) => {
         if (l) { image.request(l.image) }
@@ -711,11 +669,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       mutateDrawer,
       mutateInfo,
       context: {
-        volumes: {
-          data: volumes,
-          lastUpdated: volumesLastUpdated,
-          errors: volumesErrors,
-        },
         linode: {
           data: linode,
           lastUpdated: linodeLastUpdated,
@@ -738,7 +691,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
 
     const initialLoad =
       linodeLastUpdated === 0 ||
-      volumesLastUpdated === 0 ||
       configsLastUpdated === 0 ||
       disksLastUpdated === 0;
 
@@ -756,18 +708,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
         linodeErrors,
       )
       return <ErrorState errorText="Error while loading Linode." />;
-    }
-
-    if (!volumes) {
-      throw Error('Volumes undefined on LinodeLanding.');
-    }
-
-    if (volumesErrors) {
-      reportException(
-        Error('Error loading volumes data.'),
-        volumesErrors,
-      )
-      return <ErrorState errorText="Error while loading volumes." />;
     }
 
     if (!configs) {
@@ -800,7 +740,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
           <DisksProvider value={this.state.context.disks}>
             <ImageProvider value={this.state.context.image}>
               <LinodeProvider value={this.state.context.linode}>
-                <VolumesProvider value={this.state.context.volumes}>
+                <React.Fragment>
                   {this.state.showPendingMutation && linode &&
                     <Notice important warning>
                       {`This Linode has pending upgrades available. To learn more about
@@ -909,7 +849,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
                       initMutation={this.initMutation}
                     />
                   }
-                </VolumesProvider>
+                </React.Fragment>
               </LinodeProvider>
             </ImageProvider>
           </DisksProvider>
@@ -917,7 +857,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       </React.Fragment>
     );
   }
-
 }
 
 const styled = withStyles(styles, { withTheme: true });
@@ -926,7 +865,28 @@ const reloadable = reloadableWithRouter<CombinedProps, MatchProps>((routePropsOl
   return routePropsOld.match.params.linodeId !== routePropsNew.match.params.linodeId;
 });
 
+interface DispatchProps {
+  actions: {
+    getLinodeVolumes: () => void;
+  },
+}
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, RouteProps> = (dispatch, ownProps) => {
+  const { match: { params: { linodeId } } } = ownProps;
+
+  return {
+    actions: {
+      getLinodeVolumes: typeof linodeId === 'string'
+        ? () => dispatch(_getLinodeVolumes(linodeId))
+        : () => null
+    },
+  };
+};
+
+const connected = connect(undefined, mapDispatchToProps);
+
 const enhanced = compose(
+  connected,
   styled,
   reloadable,
   LinodeDetailErrorBoundary,

--- a/src/features/linodes/LinodesDetail/context.tsx
+++ b/src/features/linodes/LinodesDetail/context.tsx
@@ -24,11 +24,6 @@ export const withLinode = createHOCForConsumer<Linode.Linode>(linodeContext.Cons
 export const LinodeProvider = linodeContext.Provider;
 export const LinodeConsumer = linodeContext.Consumer;
 
-const volumesContext = React.createContext<Requestable<Linode.Volume[]>>({...initialState});
-export const withVolumes = createHOCForConsumer<Linode.Volume[]>(volumesContext.Consumer, 'WithVolumes');
-export const VolumesProvider = volumesContext.Provider;
-export const VolumesConsumer = volumesContext.Consumer;
-
 const imageContext = React.createContext<Requestable<Linode.Image>>({...initialState});
 export const withImage = createHOCForConsumer<Linode.Image>(imageContext.Consumer, 'WithImage');
 export const ImageProvider = imageContext.Provider;

--- a/src/store/ApplicationState.d.ts
+++ b/src/store/ApplicationState.d.ts
@@ -4,6 +4,7 @@ declare interface ApplicationState {
   },
   authentication: AuthState;
   documentation: DocumentationState;
+  features: FeaturesState;
   volumeDrawer: VolumeDrawerState;
 }
 
@@ -23,4 +24,10 @@ declare interface RequestableData<D> {
   loading: boolean;
   data?: D;
   error?: Error;
+}
+
+declare interface FeaturesState {
+  linodeDetail: {
+    volumes: RequestableData<Linode.Volume[]>
+  }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,8 @@ import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
 
 import thunk from 'redux-thunk';
 import authentication, { defaultState as defaultAuthenticationState } from './reducers/authentication';
-import documentation, {defaultState as defaultDocumentationState } from './reducers/documentation';
+import documentation, { defaultState as defaultDocumentationState } from './reducers/documentation';
+import features, { defaultState as defaultFeaturesState } from './reducers/features';
 import resources, { defaultState as defaultResourcesState } from './reducers/resources';
 import volumeDrawer, { defaultState as defaultVolumeDrawerState } from './reducers/volumeDrawer';
 
@@ -10,6 +11,7 @@ const defaultState: ApplicationState = {
   __resources: defaultResourcesState,
   authentication: defaultAuthenticationState,
   documentation: defaultDocumentationState,
+  features: defaultFeaturesState,
   volumeDrawer: defaultVolumeDrawerState,
 };
 
@@ -19,6 +21,7 @@ const reducers = combineReducers<ApplicationState>({
   __resources: resources,
   authentication,
   documentation,
+  features,
   volumeDrawer,
 });
 

--- a/src/store/reducers/features/index.ts
+++ b/src/store/reducers/features/index.ts
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import linodeDetail, { defaultState as linodeDetailDefaultState } from './linodeDetail';
+
+export const defaultState = {
+  linodeDetail: linodeDetailDefaultState
+}
+
+export default combineReducers({ linodeDetail });

--- a/src/store/reducers/features/linodeDetail/index.ts
+++ b/src/store/reducers/features/linodeDetail/index.ts
@@ -1,0 +1,11 @@
+import { combineReducers } from 'redux';
+
+import volumes, { defaultState as defaultVolumesState } from './volumes';
+
+export const defaultState = {
+  volumes: defaultVolumesState
+};
+
+export default combineReducers({
+  volumes
+});

--- a/src/store/reducers/features/linodeDetail/volumes.ts
+++ b/src/store/reducers/features/linodeDetail/volumes.ts
@@ -1,0 +1,61 @@
+import { ThunkAction } from 'redux-thunk';
+import { getLinodeVolumes } from 'src/services/linodes';
+
+// ACTIONS
+const actionTypeGenerator = (s: string) => `@manager/features/linodeDetail/volumes/${s}`;
+
+const LOAD = actionTypeGenerator('LOAD');
+const SUCCESS = actionTypeGenerator('SUCCESS');
+const ERROR = actionTypeGenerator('ERROR');
+const UPDATE = actionTypeGenerator('UPDATE');
+
+// STATE
+type State = FeaturesState['linodeDetail']['volumes']
+
+export const defaultState: State = {
+  lastUpdated: 0,
+  loading: false,
+}
+
+// ACTION CREATORS
+export const load = () => ({ type: LOAD });
+
+export const handleSuccess = (payload: Linode.Volume[]) => ({ type: SUCCESS, payload });
+
+export const handleError = (payload: Error) => ({ type: ERROR, payload });
+
+export const handleUpdate = (updateFn: (v: Linode.Volume[]) => Linode.Volume[]) => ({ type: UPDATE, updateFn });
+
+// REDUCER
+export default (state = defaultState, action: any) => {
+  switch (action.type) {
+
+    case LOAD:
+      return { ...state, loading: true };
+
+    case SUCCESS:
+      return { ...state, loading: false, lastUpdated: Date.now(), data: action.payload };
+
+    case ERROR:
+      return { ...state, loading: false, lastUpdated: Date.now(), error: action.payload };
+
+    case UPDATE:
+      return { ...state, loading: false, lastUpdated: Date.now(), data: action.updateFn(state.data) };
+
+    default:
+      return state;
+  }
+};
+
+// ASYNC
+export const _getLinodeVolumes = (linodeId: number): ThunkAction<void, State, void> => (dispatch, getState) => {
+  dispatch(load());
+
+  getLinodeVolumes(linodeId)
+    .then(response => dispatch(handleSuccess(response.data)))
+    .catch(error => dispatch(handleError(error)));
+};
+
+// HELPERS
+
+


### PR DESCRIPTION
## Purpose
- Delete volumes context.
- Create nested 'features' slice of Redux state. [here](https://github.com/rjstires/manager/blob/5a1a2b4c9928289a873ba0b2f0812b256a9e9f4a/src/store/reducers/features/index.ts)
- Created nested 'linodeDetail' slice of features state with volumes data. [here](https://github.com/rjstires/manager/blob/5a1a2b4c9928289a873ba0b2f0812b256a9e9f4a/src/store/reducers/features/linodeDetail/index.ts)
- Created 'volumes' duck. [here](https://github.com/rjstires/manager/blob/5a1a2b4c9928289a873ba0b2f0812b256a9e9f4a/src/store/reducers/features/linodeDetail/volumes.ts)
- Updates LinodeDetail.
  - I converted LinodeContext to a [React.Fragment](https://github.com/linode/manager/compare/develop...rjstires:redux-cleanup-volumes?expand=1#diff-f32390e715c6e7c385a4f5df6fc174cbR743) for review purposes, otherwise the diff was crazy. I will remove this before merge.
  - I removed [this guard](https://github.com/linode/manager/compare/develop...rjstires:redux-cleanup-volumes?expand=1#diff-f32390e715c6e7c385a4f5df6fc174cbL761) since not having volumes is irrelevant to the remainder of the Linode.
  - I removed [this error](https://github.com/linode/manager/compare/develop...rjstires:redux-cleanup-volumes?expand=1#diff-f32390e715c6e7c385a4f5df6fc174cbL765) handling. Reporting should be done in the thunk if it's necessary. Since the Linode is probably fine, there's no reason to render ErrorState.
- Updates LinodeVolumes.
  - [This](https://github.com/linode/manager/compare/develop...rjstires:redux-cleanup-volumes?expand=1#diff-f8fe22d51447774b61bff3178cd03d7bL51) isn't even used anywhere in the component.
  - Removed volumesContext.
  - Added mapStateToProps, mapDispatchToProps, and connect.
  - Updated reference to updateVolumes to match DispatchProps.
- Updates LinodeSummary.
  - Removed context.
  - Added mapStateToProps and connect.
- Updates ApplicationState.d.ts.