### PR TITLE
M3-1322 Add closeMenu function to subnav in PrimaryNav

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -273,7 +273,7 @@ class PrimaryNav extends React.Component<Props, State> {
   }
 
   render() {
-    const { classes, toggleTheme } = this.props;
+    const { classes, toggleTheme, closeMenu } = this.props;
     const { expandedMenus, userHasManaged } = this.state;
     const themeName = (this.props.theme as any).name;
 
@@ -350,6 +350,7 @@ class PrimaryNav extends React.Component<Props, State> {
                       [classes.sublink]: true,
                       [classes.sublinkActive]: this.linkIsActive('/billing') === true,
                     })}
+                    onClick={() => closeMenu()}
                   >
                     Account &amp; Billing
                 </Link>
@@ -361,6 +362,7 @@ class PrimaryNav extends React.Component<Props, State> {
                       [classes.sublink]: true,
                       [classes.sublinkActive]: this.linkIsActive('/users') === true,
                     })}
+                    onClick={() => closeMenu()}
                   >
                     Users
                 </Link>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -350,7 +350,7 @@ class PrimaryNav extends React.Component<Props, State> {
                       [classes.sublink]: true,
                       [classes.sublinkActive]: this.linkIsActive('/billing') === true,
                     })}
-                    onClick={() => closeMenu()}
+                    onClick={closeMenu}
                   >
                     Account &amp; Billing
                 </Link>
@@ -362,7 +362,7 @@ class PrimaryNav extends React.Component<Props, State> {
                       [classes.sublink]: true,
                       [classes.sublinkActive]: this.linkIsActive('/users') === true,
                     })}
-                    onClick={() => closeMenu()}
+                    onClick={closeMenu}
                   >
                     Users
                 </Link>


### PR DESCRIPTION
When clicking on Account & Billing or Users in the primary nav on mobile, the navigation drawer would not close. This PR fixes that.