### PR TITLE
Route to /linodes instead of / on Linode delete

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -35,7 +35,7 @@ class LinodeSettingsDeletPanel extends React.Component<CombinedProps, State> {
     this.setState(set(lensPath(['submitting']), true));
     deleteLinode(this.props.linodeId)
       .then((response) => {
-        this.props.history.push('/');
+        this.props.history.push('/linodes');
       })
       .catch((error) => {
         this.setState(set(lensPath(['errors']), error.response.data.errors), () => {

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -168,6 +168,9 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
               updatedLinodes[targetIndex].recentEvent = linodeEvent;
               return { linodes: updatedLinodes };
             });
+          })
+          .catch((error) => {
+            /* Nothing to do here; in most cases the subscriber is trying to retrieve a recently deleted Linode. */
           });
       });
 


### PR DESCRIPTION
After the switch to using the Dashboard as the default route, deleting a Linode would redirect you to the dashboard rather than the Linodes landing page. 

## Note

The cDM method of LinodesLanding subscribes to events and runs `getLinode` if the event concerns a Linode. In this case, several shutdown progress events are received for the deleted Linode, and the getLinode request gets a 404 for each one. I added a `catch` to avoid some of the error logging associated with this, but this logic might need a larger refactor.