### PR TITLE
M3-1188 Don't clear disk on successful password change

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -76,7 +76,6 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
           set(lensPath(['success']), `Linode password changed successfully.`),
           set(lensPath(['submitting']), false),
           set(lensPath(['value']), ''),
-          set(lensPath(['diskId']), ''),
         ));
       })
       .catch((error) => {


### PR DESCRIPTION
After changing a Linode's root password, the dropdown that
allows you choose what disk to reset the passwrod for was being
cleared. Removed that field from the setState call to prevent this.