### PR TITLE
M3-1169 Don't allow deletion of active user

### DIFF
--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -1,4 +1,4 @@
-import { clone, compose, path, pathOr } from 'ramda';
+import { clone, compose, path as pathRamda, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { matchPath, Route, RouteComponentProps, Switch } from 'react-router-dom';
@@ -212,7 +212,7 @@ class UserDetail extends React.Component<CombinedProps> {
   renderUserProfile = () => {
     const { username, email, profileSaving, profileSuccess, profileErrors } = this.state;
     return <UserProfile
-      username={username}
+      username={username || ''}
       email={email}
       changeUsername={this.onChangeUsername}
       save={this.onSave}
@@ -308,7 +308,7 @@ interface StateProps {
 }
 
 const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (state) => ({
-  profileUsername: path(['data', 'username'], state.__resources.profile),
+  profileUsername: pathRamda(['data', 'username'], state.__resources.profile),
 });
 
 interface DispatchProps {

--- a/src/features/Users/UserProfile.tsx
+++ b/src/features/Users/UserProfile.tsx
@@ -47,7 +47,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 });
 
 interface Props {
-  username?: string;
+  username: string;
   email?: string;
   changeUsername: (e: React.ChangeEvent<HTMLInputElement>) => void;
   save: () => void;
@@ -68,7 +68,7 @@ type CombinedProps = Props & StateProps & WithStyles<ClassNames> & RouteComponen
 class UserProfile extends React.Component<CombinedProps> {
   state: State = {
     deleteConfirmDialogOpen: false,
-    toDeleteUsername: '',
+    toDeleteUsername: this.props.username,
     userDeleteError: false,
   };
 


### PR DESCRIPTION
The logic that disabled the delete user button when viewing the
profile of the current user was flawed; on tab change, the
re-rendered component wasn't picking up the prop with the user-to-delete's
username.

Changed the username prop to be required and defaulted it to '', so that
it can be set when setting initial state in the UserProfile component.

## Note:

On creating a new user, you are left on the Users Landing page with a notice saying that the user was created successfully. If you delete and create a user, you end up with two stacked Notices. Should we redirect to the new user's detail page instead, as we do elsewhere?