### PR TITLE
M3-1134 M3-1135 M3-1136

### DIFF
--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.test.tsx
@@ -13,6 +13,17 @@ const mockProps = {
   getTypeInfo: jest.fn(),
   getRegionInfo: jest.fn(),
   history: null,
+  tagObject: {
+    accountTags: [],
+    selectedTags: [],
+    newTags: [],
+    errors: [],
+    actions: {
+      addTag: jest.fn(),
+      createTag: jest.fn(),
+      getLinodeTagList: jest.fn(),
+    }
+  }
 };
 
 const mockPropsWithNotice = {
@@ -27,6 +38,17 @@ const mockPropsWithNotice = {
   getTypeInfo: jest.fn(),
   getRegionInfo: jest.fn(),
   history: null,
+  tagObject: {
+    accountTags: [],
+    selectedTags: [],
+    newTags: [],
+    errors: [],
+    actions: {
+      addTag: jest.fn(),
+      createTag: jest.fn(),
+      getLinodeTagList: jest.fn(),
+    }
+  }
 };
 
 describe('FromBackupsContent', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -23,6 +23,7 @@ import AddonsPanel from '../AddonsPanel';
 import SelectBackupPanel from '../SelectBackupPanel';
 import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
+import tagsHoc, { TagObject } from '../tagsHoc';
 
 type ClassNames = 'root' | 'main' | 'sidebar';
 
@@ -54,6 +55,9 @@ interface Props {
   history: any;
   selectedBackupFromQuery?: number;
   selectedLinodeFromQuery?: number;
+
+  /* From HOC */
+  tagObject: TagObject;
 }
 
 interface State {
@@ -196,7 +200,8 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
   }
 
   createLinode = () => {
-    const { history } = this.props;
+    const { history, tagObject } = this.props;
+    const { getLinodeTagList } = tagObject.actions;
     const {
       selectedRegionID,
       selectedTypeID,
@@ -215,6 +220,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
       label, /* optional */
       backups_enabled: backups, /* optional */
       booted: true,
+      tags: getLinodeTagList(),
     })
       .then((linode) => {
         if (privateIP) { allocatePrivateIP(linode.id) };
@@ -249,7 +255,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
       selectedTypeID, selectedRegionID, label, backups, linodesWithBackups, privateIP,
     selectedBackupInfo, isMakingRequest } = this.state;
     const { extendLinodes, getBackupsMonthlyPrice, classes,
-       notice, types, getRegionInfo, getTypeInfo } = this.props;
+       notice, types, getRegionInfo, getTypeInfo, tagObject } = this.props;
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
 
@@ -314,13 +320,15 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
           updateFor={[selectedTypeID, selectedDiskSize, errors]}
         />
         <LabelAndTagsPanel
+          tagObject={tagObject}
+          tagError={hasErrorFor('tag')}
           labelFieldProps={{
             label: 'Linode Label',
             value: label || '',
             onChange: this.handleSelectLabel,
             errorText: hasErrorFor('label'),
           }}
-          updateFor={[label]}
+          updateFor={[label, tagObject, errors]}
         />
         <AddonsPanel
           backups={backups}
@@ -392,4 +400,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled(FromBackupsContent);
+export default compose<any,any,any>(
+  styled,
+  tagsHoc)
+  (FromBackupsContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -14,6 +14,17 @@ const mockProps = {
   getTypeInfo: jest.fn(),
   history: null,
   userSSHKeys: [],
+  tagObject: {
+    accountTags: [],
+    selectedTags: [],
+    newTags: [],
+    errors: [],
+    actions: {
+      addTag: jest.fn(),
+      createTag: jest.fn(),
+      getLinodeTagList: jest.fn(),
+    }
+  }
 };
 
 describe('FromImageContent', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -25,6 +25,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
 import SelectImagePanel from '../SelectImagePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
+import tagsHoc, { TagObject } from '../tagsHoc';
 
 type ClassNames = 'root'
   | 'main'
@@ -75,6 +76,7 @@ interface Props {
 
   /** Comes from HOC */
   userSSHKeys: UserSSHKeyObject[];
+  tagObject: TagObject;
 }
 
 interface State {
@@ -229,7 +231,8 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
   }
 
   createLinode = () => {
-    const { history, userSSHKeys } = this.props;
+    const { history, tagObject, userSSHKeys } = this.props;
+    const { getLinodeTagList } = tagObject.actions;
     const {
       selectedImageID,
       selectedRegionID,
@@ -255,6 +258,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
       backups_enabled: backups, /* optional */
       booted: true,
       authorized_users: userSSHKeys.filter(u => u.selected).map((u) => u.username),
+      tags: getLinodeTagList(),
     })
       .then((linode) => {
         if (privateIP) { allocatePrivateIP(linode.id) };
@@ -299,7 +303,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
       selectedStackScriptUsername } = this.state;
 
     const { notice, getBackupsMonthlyPrice, regions, types, classes,
-      getRegionInfo, getTypeInfo, images, userSSHKeys } = this.props;
+      getRegionInfo, getTypeInfo, images, tagObject, userSSHKeys } = this.props;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
@@ -407,13 +411,15 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
             selectedID={selectedTypeID}
           />
           <LabelAndTagsPanel
+            tagObject={tagObject}
+            tagError={hasErrorFor('tag')}
             labelFieldProps={{
               label: 'Linode Label',
               value: label || '',
               onChange: this.handleTypeLabel,
               errorText: hasErrorFor('label'),
             }}
-            updateFor={[label]}
+            updateFor={[label, tagObject, errors]}
           />
           <AccessPanel
             error={hasErrorFor('root_pass')}
@@ -487,6 +493,6 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
 
 const styled = withStyles(styles, { withTheme: true });
 
-const enhanced = compose(styled, userSSHKeyHoc);
+const enhanced = compose(styled, userSSHKeyHoc, tagsHoc);
 
 export default enhanced(FromStackScriptContent) as any;

--- a/src/services/linodes.ts
+++ b/src/services/linodes.ts
@@ -216,7 +216,7 @@ export const getLinodeStats = (linodeId: number, year?: string, month?: string) 
   );
 };
 
-export const updateLinode = (id: number, values: any) =>
+export const updateLinode = (id: number, values: Partial<Linode>) =>
   Request<Linode>(
     setURL(`${API_ROOT}/linode/instances/${id}`),
     setMethod('PUT'),


### PR DESCRIPTION
## Purpose

Add tagsHoc to FromStackscriptContent and FromBackupsContent

## Notes
* cloneLinode doesn't take tags (yet) so we're punting on this one pending
design review
* Unable to verify that the from backups functionality works, because
tags don't work on prod and backups don't work on dev