### PR TITLE
API error handling

### DIFF
--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -15,7 +15,7 @@ import Radio from 'src/components/Radio';
 import TextField from 'src/components/TextField';
 import { sendToast } from 'src/features/ToastNotifications/toasts';
 import { cloneDomain, createDomain } from 'src/services/domains';
-import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+import { mapAPIErrorsToObject } from 'src/utilities/apiErrorHandling';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 type ClassNames = 'root' | 'masterIPErrorNotice';
@@ -93,10 +93,12 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
     const { classes, open, mode } = this.props;
     const { type, domain, soaEmail, cloneName, errors, submitting } = this.state;
 
-    const errorFor = getAPIErrorFor(this.errorResources, errors);
-
-    const generalError = errorFor('none');
-    const masterIPsError = errorFor('master_ips');
+    const {
+      __general: generalError,
+      domain: domainError,
+      soa_email: soaEmailError,
+      master_ips: masterIPsError,
+    } = mapAPIErrorsToObject(errors);
 
     return (
       <Drawer
@@ -121,7 +123,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
         </RadioGroup>
 
         <TextField
-          errorText={(mode === 'create' || '') && errorFor('domain')}
+          errorText={(mode === 'create' || '') && domainError}
           value={domain}
           disabled={mode === 'clone'}
           label="Domain"
@@ -130,7 +132,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
         />
         {mode === 'clone' &&
           <TextField
-            errorText={errorFor('domain')}
+            errorText={domainError}
             value={cloneName}
             label="New Domain"
             onChange={this.updateCloneLabel}
@@ -139,7 +141,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
         }
         {mode === 'create' && type === 'master' &&
           <TextField
-            errorText={errorFor('soa_email')}
+            errorText={soaEmailError}
             value={soaEmail}
             label="SOA Email Address"
             onChange={this.updateEmailAddress}
@@ -197,12 +199,6 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
       </Drawer>
     );
   }
-
-  errorResources = {
-    domain: 'Domain',
-    type: 'Type',
-    soa_email: 'SOA Email',
-  };
 
   reset = () => {
     if (this.mounted) { this.setState({ ...this.defaultState }); }

--- a/src/services/domains.ts
+++ b/src/services/domains.ts
@@ -1,15 +1,9 @@
+import { API_ROOT } from 'src/constants';
 import { object, string } from 'yup';
 
-import { API_ROOT } from 'src/constants';
+import { updateAPIErrorResponse } from 'src/utilities/apiErrorHandling';
 
-import Request,
-{
-  setData,
-  setMethod,
-  setParams,
-  setURL,
-  setXFilter,
-} from './index';
+import Request, { setData, setMethod, setParams, setURL, setXFilter } from './index';
 
 type Page<T> = Linode.ResourcePage<T>;
 type Domain = Linode.Domain;
@@ -56,17 +50,20 @@ export const updateDomainRecord = (
 );
 
 export const deleteDomainRecord = (domainID: number, recordId: number) =>
-  Request<{}>(
-    setURL(`${API_ROOT}/domains/${domainID}/records/${recordId}`),
-    setMethod('DELETE'),
+Request<{}>(
+  setURL(`${API_ROOT}/domains/${domainID}/records/${recordId}`),
+  setMethod('DELETE'),
   );
+
+const updateDomainCreationErrors = updateAPIErrorResponse((errors) => errors);
 
 export const createDomain = (data: Partial<Linode.Domain>) =>
   Request<Domain>(
     setData(data),
     setURL(`${API_ROOT}/domains`),
     setMethod('POST'),
-  );
+  )
+  .catch((response) => Promise.reject(updateDomainCreationErrors(response)));
 
 export const updateDomain = (
   domainId: number,

--- a/src/utilities/apiErrorHandling.test.ts
+++ b/src/utilities/apiErrorHandling.test.ts
@@ -1,0 +1,72 @@
+import { createAPIError, mapAPIErrorsToObject, mapErrorToObject } from './apiErrorHandling';
+
+describe('utilities/apiErrorHandling', () => {
+
+  describe('createAPIError', () => {
+    it('Creates general error.', () => {
+      expect(createAPIError('message')).toEqual({ reason: 'message' });
+    });
+
+    it('Create field error.', () => {
+      expect(createAPIError('message', 'field')).toEqual({ field: 'field', reason: 'message' });
+    });
+  });
+
+  describe('mapErrorToObject', () => {
+
+    describe('when given a general error', () => {
+      it('should return an object with a key of __general and a value of the error message.', () => {
+        const reason = 'This is a general error.';
+        const { __general } = mapErrorToObject(createAPIError(reason));
+
+        expect(__general).toEqual(reason)
+      });
+    });
+
+    describe('when given a field error', () => {
+      const reason = 'This is a field error.'
+      const field = 'shenanigans'
+      const { __general, shenanigans } = mapErrorToObject(createAPIError(reason, field));
+
+      it('should return an object with keys for each error field with values of the error message.', () => {
+        expect(shenanigans).toEqual(reason);
+      });
+      it('should return not return a __general error.', () => {
+        expect(__general).toBeUndefined();
+      });
+    });
+  });
+
+  describe('mapAPIErrorsToObject', () => {
+    it('should return an empty if given an empty object.', () => {
+      const result = mapAPIErrorsToObject([]);
+
+      expect(result).toEqual({})
+    });
+
+    it('should return a key:value pair for each error.', () => {
+      const result = mapAPIErrorsToObject([
+        createAPIError('general error'),
+        createAPIError('field a error', 'fieldA'),
+      ]);
+
+      expect(result).toEqual({
+        __general: 'general error',
+        fieldA: 'field a error'
+      })
+    });
+
+    it('should overwrite existing errors.', () => {
+      const result = mapAPIErrorsToObject([
+        createAPIError('general error'),
+        createAPIError('field a error', 'fieldA'),
+        createAPIError('updated field a error', 'fieldA'),
+      ]);
+
+      expect(result).toEqual({
+        __general: 'general error',
+        fieldA: 'updated field a error'
+      })
+    });
+  });
+});

--- a/src/utilities/apiErrorHandling.ts
+++ b/src/utilities/apiErrorHandling.ts
@@ -1,0 +1,59 @@
+import { AxiosError } from 'axios';
+import { lensPath, over, path } from 'ramda';
+
+/**
+ * Helper function to aide in creating consistently shaped error objects like those returned
+ * from the API.
+ */
+export const createAPIError: (reason: string, field?: string) => Linode.ApiFieldError
+  = (reason, field) => ({
+    reason,
+    ...(field && { field }),
+  });
+
+/**
+ * Maps a Linode.APIFieldError to an object where the field are the keys and the reasons are
+ * the values. In the case of a "general" error, where there is no field, the field will be set to
+ * __general.
+ */
+export const mapErrorToObject = (e: Linode.ApiFieldError): { [idx: string]: string } => {
+  const key = e.field ? e.field : '__general';
+  const value = e.reason;
+
+  return { [key]: value };
+};
+
+/**
+ * Reduce a list of Linode.ApiFieldError to an object.
+ */
+export const mapAPIErrorsToObject: (e?: Linode.ApiFieldError[]) => { [key: string]: string } =
+  (e = []) =>
+    e.reduce((obj, error) => ({ ...obj, ...mapErrorToObject(error) }), {});
+
+export const updateAPIFieldError = (field: string, reason: string) => (err: any) =>
+  err.field && err.field === field
+    ? { field, reason }
+    : err;
+
+
+export const isAxiosError = (err: AxiosError | Error): err is AxiosError => {
+  return (err as AxiosError).hasOwnProperty('config');
+};
+
+export const isResponse = (err: AxiosError) => {
+  return err.hasOwnProperty('response');
+};
+
+type MapErrors = (e: Linode.ApiFieldError[]) => Linode.ApiFieldError[];
+
+export const updateAPIErrorResponse = (fn: MapErrors) => (error: any) => {
+  const hasErrors = path(['response', 'data', 'errors'], error);
+  if (hasErrors) {
+    return updateErrors(fn, error);
+  }
+
+  return error;
+};
+
+const updateErrors = over(lensPath(['response', 'data', 'errors']));
+

--- a/src/utilities/getAPIErrorFor.ts
+++ b/src/utilities/getAPIErrorFor.ts
@@ -1,18 +1,17 @@
-export default (
-  errorMap: { [index: string]: string },
-  arr: Linode.ApiFieldError[] = [],
-) => (field: string): undefined | string => {
-  let err;
+import { mapAPIErrorsToObject } from "src/utilities/apiErrorHandling";
 
-  if (field === 'none') {
-    err = arr.find(e => !e.hasOwnProperty('field'));
-  } else {
-    err = arr.find(e => e.field === field);
-  }
+/** This is basically a bridge function to bridge between the old implementation and the new. */
+const getAPIErrorFor: (_: any, errors?: Linode.ApiFieldError[]) => (key: string) => undefined | string
+  = (_, errors = []) => {
+    /**
+     * If there are no errors we can return a function which will return
+     * undefined every time. This prevents calling mapAPIErrorsToObject.
+     */
+    if (errors.length === 0) { return () => undefined; }
 
-  if (!err) {
-    return;
-  }
+    const errorMap = mapAPIErrorsToObject(errors);
 
-  return err.field ? err.reason.replace(err.field, errorMap[err.field]) : err.reason;
-};
+    return (key) => errorMap[key];
+  };
+
+export default getAPIErrorFor;


### PR DESCRIPTION
## Purpose
It was found that we were unnecessarily updating client-side generated errors (via Joi/Yup) in the same way we were updating server-side errors. This was because all errors, regardless of their source, were ultimated read through "getAPIErrorFor".

This PR creates a more definitive separation between the two primary functions of the original getAPIErrorFor which were determining if a field had an error, and translating server side errors into user friendly errors.

In the example DomainCreateDrawer.tsx we use a new helper `mapAPIErrorsToObject` to create a key value map where the field is the key, and the reason is the value. In the event of a "general error", we set the key to `__general`. These field names aren't great when consuming, so you'll see I used ES6 destructured renaming.

The conversion of API errors to user friendly messages should be handled in the catch instance method of the request. In this case the createDomain request was updated to show how this can be done using a new helper function. Unfortunately (?) errors from this end-point are pretty good, so no need to update them. 