### PR TITLE
M3-1175 tag search

### DIFF
--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -242,8 +242,8 @@ class SearchBar extends React.Component<CombinedProps, State> {
 
   // Helper can be extended to other entities once tags are supported for them.
   // @todo Inefficient to call this function twice for each search result. 
-  getMatchingTags = (entity:Linode.Linode, query:string): string[] => {
-    return entity.tags.filter((tag:string) => tag.toLowerCase().includes(query));
+  getMatchingTags = (tags:string[], query:string): string[] => {
+    return tags.filter((tag:string) => tag.toLowerCase().includes(query));
   }
 
   getSearchSuggestions = (query: string | null) => {
@@ -256,7 +256,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
     if (this.state.linodes && typesData) {
       const linodesByLabel = this.state.linodes.filter(
         linode => {
-          const matchingTags = this.getMatchingTags(linode, queryLower);
+          const matchingTags = this.getMatchingTags(linode.tags, queryLower);
           return or(
             linode.label.toLowerCase().includes(queryLower),
             matchingTags.length > 0
@@ -265,7 +265,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
       );
       searchResults.push(...(linodesByLabel.map(linode => ({
         title: linode.label,
-        tags: this.getMatchingTags(linode, queryLower),
+        tags: this.getMatchingTags(linode.tags, queryLower),
         description: this.linodeDescription(
           displayType(linode.type, typesData),
           linode.specs.memory,

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -240,9 +240,10 @@ class SearchBar extends React.Component<CombinedProps, State> {
     this.getAllPagesFor('images', getImagesPage);
   }
 
-  // Helper can be extended to other entities once tags are supported for them
-  hasMatchingTag = (entity:Linode.Linode, query:string): boolean => {
-    return entity.tags.some((tag:string) => tag.toLowerCase().includes(query));
+  // Helper can be extended to other entities once tags are supported for them.
+  // @todo Inefficient to call this function twice for each search result. 
+  getMatchingTags = (entity:Linode.Linode, query:string): string[] => {
+    return entity.tags.filter((tag:string) => tag.toLowerCase().includes(query));
   }
 
   getSearchSuggestions = (query: string | null) => {
@@ -255,15 +256,16 @@ class SearchBar extends React.Component<CombinedProps, State> {
     if (this.state.linodes && typesData) {
       const linodesByLabel = this.state.linodes.filter(
         linode => {
+          const matchingTags = this.getMatchingTags(linode, queryLower);
           return or(
             linode.label.toLowerCase().includes(queryLower),
-            this.hasMatchingTag(linode, queryLower)
+            matchingTags.length > 0
           )
         }
       );
       searchResults.push(...(linodesByLabel.map(linode => ({
         title: linode.label,
-        tags: linode.tags,
+        tags: this.getMatchingTags(linode, queryLower),
         description: this.linodeDescription(
           displayType(linode.type, typesData),
           linode.specs.memory,

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -394,6 +394,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
           path={suggestion.path}
           history={history}
           tags={suggestion.tags}
+          isHighlighted={isHighlighted}
         />
       </MenuItem>
     );

--- a/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
+++ b/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
@@ -11,6 +11,8 @@ type ClassNames = 'root'
  | 'suggestionTitle'
  | 'suggestionDescription';
 
+ import Tag from 'src/components/Tag';
+
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
     cursor: 'pointer',
@@ -50,6 +52,7 @@ export interface SearchSuggestionT {
   title: string;
   description: string;
   path: string;
+  tags?: string[];
 }
 
 interface Props extends SearchSuggestionT {
@@ -71,6 +74,11 @@ const maybeStyleSegment = (text: string, searchText: string, hlClass: string): R
   );
 };
 
+const renderTags = (tags:string[]) => {
+  if (tags.length === 0) { return; }
+  return tags.map((tag:string) => <Tag key={`tag-${tag}`} label={tag} /> );
+}
+
 const SearchSuggestion: React.StatelessComponent<CombinedProps> = (props) => {
   const {
     title,
@@ -81,6 +89,7 @@ const SearchSuggestion: React.StatelessComponent<CombinedProps> = (props) => {
     path,
     history,
     classes,
+    tags,
   } = props;
 
   const handleClick = () => {
@@ -108,6 +117,9 @@ const SearchSuggestion: React.StatelessComponent<CombinedProps> = (props) => {
         <div className={classes.suggestionDescription} data-qa-suggestion-desc>
           {description}
         </div>
+        <span>
+          {tags && renderTags(tags)}
+        </span>
       </div>
     </div>
   );

--- a/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
+++ b/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
@@ -9,7 +9,9 @@ type ClassNames = 'root'
  | 'suggestionIcon'
  | 'suggestionContent'
  | 'suggestionTitle'
- | 'suggestionDescription';
+ | 'suggestionDescription'
+ | 'resultContainer'
+ | 'tagContainer';
 
  import Tag from 'src/components/Tag';
 
@@ -17,6 +19,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   root: {
     cursor: 'pointer',
     display: 'flex',
+    width: '100%',
+    alignItems: 'space-between',
+    justifyContent: 'space-between',
   },
   highlight: {
     color: theme.palette.primary.main,
@@ -45,6 +50,15 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     fontWeight: 600,
     marginTop: 2,
   },
+  resultContainer: {
+    display: 'flex',
+    flexFlow: 'row nowrap'
+  },
+  tagContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  }
 });
 
 export interface SearchSuggestionT {
@@ -101,25 +115,27 @@ const SearchSuggestion: React.StatelessComponent<CombinedProps> = (props) => {
       onClick={handleClick}
       className={root}
     >
-      <div className={`
-        ${classes.suggestionItem}
-        ${classes.suggestionIcon}
-      `}>
-        <Icon />
+      <div className={classes.resultContainer}>
+        <div className={`
+          ${classes.suggestionItem}
+          ${classes.suggestionIcon}
+        `}>
+          <Icon />
+        </div>
+        <div className={`
+          ${classes.suggestionItem}
+          ${classes.suggestionContent}
+        `}>
+          <div className={classes.suggestionTitle} data-qa-suggestion-title>
+            {maybeStyleSegment(title, searchText, highlight)}
+          </div>
+          <div className={classes.suggestionDescription} data-qa-suggestion-desc>
+            {description}
+          </div>
+        </div>
       </div>
-      <div className={`
-        ${classes.suggestionItem}
-        ${classes.suggestionContent}
-      `}>
-        <div className={classes.suggestionTitle} data-qa-suggestion-title>
-          {maybeStyleSegment(title, searchText, highlight)}
-        </div>
-        <div className={classes.suggestionDescription} data-qa-suggestion-desc>
-          {description}
-        </div>
-        <span>
+      <div className={classes.tagContainer}>
           {tags && renderTags(tags)}
-        </span>
       </div>
     </div>
   );

--- a/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
+++ b/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
@@ -58,6 +58,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+    '& > div': {
+      margin: '2px',
+    }
   }
 });
 
@@ -67,6 +70,7 @@ export interface SearchSuggestionT {
   description: string;
   path: string;
   tags?: string[];
+  isHighlighted?: boolean;
 }
 
 interface Props extends SearchSuggestionT {
@@ -88,9 +92,15 @@ const maybeStyleSegment = (text: string, searchText: string, hlClass: string): R
   );
 };
 
-const renderTags = (tags:string[]) => {
+const renderTags = (tags:string[], selected:boolean) => {
   if (tags.length === 0) { return; }
-  return tags.map((tag:string) => <Tag key={`tag-${tag}`} label={tag} /> );
+  return tags.map((tag:string) =>
+    <Tag
+      key={`tag-${tag}`}
+      label={tag}
+      variant={selected ? 'blue' : 'lightGray'}
+    />
+  );
 }
 
 const SearchSuggestion: React.StatelessComponent<CombinedProps> = (props) => {
@@ -104,6 +114,7 @@ const SearchSuggestion: React.StatelessComponent<CombinedProps> = (props) => {
     history,
     classes,
     tags,
+    isHighlighted,
   } = props;
 
   const handleClick = () => {
@@ -135,7 +146,7 @@ const SearchSuggestion: React.StatelessComponent<CombinedProps> = (props) => {
         </div>
       </div>
       <div className={classes.tagContainer}>
-          {tags && renderTags(tags)}
+          {tags && renderTags(tags, Boolean(isHighlighted))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Purpose

Main search bar now includes results with matching tags. As per tech refinement/AC, only tags that match the search query will appear in the listed results (e.g. if a search query matches a Linode's label but none of its tags, the Linode will appear in the results list but none of its tags will appear in its listing).

## Notes

* Styling is good enough for demo, but will need revisiting once we have further design for this feature.
* Tag logic only applied to Linode search results for now, until other entities are taggable.
* Still need a solution for extreme cases where the number of matching tags is very high. I would recommend just using whatever this overflow solution ends up being, then listing all tags, with matching tags highlighted as per the original comps.