### PR TITLE
M3-1380 fix volumes select bug

### DIFF
--- a/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
+++ b/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
@@ -103,6 +103,7 @@ class Example extends React.Component<{},State> {
       <React.Fragment>
         <Select
           label="Basic Select"
+          isLoading
           value={valueSingle}
           placeholder="Choose one fruit"
           onChange={this.handleChangeSingle}

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -114,6 +114,7 @@ export interface EnhancedSelectProps {
   components?: any;
   disabled?: boolean;
   isMulti?: boolean;
+  isLoading?: boolean;
   variant?: 'async' | 'creatable';
   value?: Item | Item[] | null;
   label?: string;
@@ -123,6 +124,7 @@ export interface EnhancedSelectProps {
   createNew?: (inputValue:string) => void;
   onInputChange?: (inputValue:string) => void;
   loadOptions?: (inputValue:string) => Promise<Item|Item[]> | undefined;
+  filterOption?: (item:Item, inputValue:string) => boolean | null;
 }
 
 // Material-UI versions of several React-Select components.
@@ -139,6 +141,7 @@ type CombinedProps = EnhancedSelectProps & WithStyles<ClassNames>;
 interface BaseSelectProps extends SelectProps<any> {
   classes: any;
   textFieldProps: any;
+  filterOption: any;
 }
 
 interface CreatableProps extends CreatableSelectProps<any> {
@@ -154,9 +157,11 @@ class Select extends React.PureComponent<CombinedProps,{}> {
       createNew,
       disabled,
       errorText,
+      filterOption,
       label,
       loadOptions,
       isMulti,
+      isLoading,
       placeholder,
       onChange,
       onInputChange,
@@ -192,7 +197,10 @@ class Select extends React.PureComponent<CombinedProps,{}> {
       <BaseSelect
         isClearable
         isSearchable
+        isLoading={isLoading}
         defaultOptions
+        cacheOptions={false}
+        filterOption={filterOption}
         loadOptions={loadOptions}
         isMulti={isMulti}
         isDisabled={disabled}

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -180,6 +180,7 @@ class Select extends React.PureComponent<CombinedProps,{}> {
     const combinedComponents = merge(_components, components);
 
     // If async, pass loadOptions instead of options. A Select can't be both Creatable and Async.
+    // (AsyncCreatable exists, but we have not adapted it.)
     type PossibleProps = BaseSelectProps | CreatableProps | AsyncProps<any>;
     const BaseSelect: React.ComponentClass<PossibleProps> = variant === 'creatable'
       ? CreatableSelect
@@ -194,6 +195,7 @@ class Select extends React.PureComponent<CombinedProps,{}> {
         defaultOptions
         loadOptions={loadOptions}
         isMulti={isMulti}
+        isDisabled={disabled}
         classes={classes}
         className={`${classes.root} ${className}`}
         classNamePrefix="react-select"

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -191,7 +191,6 @@ class Select extends React.PureComponent<CombinedProps,{}> {
       <BaseSelect
         isClearable
         isSearchable
-        cacheOptions
         defaultOptions
         loadOptions={loadOptions}
         isMulti={isMulti}

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -108,6 +108,10 @@ export interface SelectState {
   isSelected: boolean;
 }
 
+interface ActionMeta {
+  action: string;
+}
+
 export interface EnhancedSelectProps {
   options?: Item[];
   className?: string;
@@ -120,11 +124,11 @@ export interface EnhancedSelectProps {
   label?: string;
   placeholder?: string;
   errorText?: string;
-  onChange: (selected:Item | Item[]) => void;
-  createNew?: (inputValue:string) => void;
-  onInputChange?: (inputValue:string) => void;
-  loadOptions?: (inputValue:string) => Promise<Item|Item[]> | undefined;
-  filterOption?: (item:Item, inputValue:string) => boolean | null;
+  onChange: (selected: Item | Item[], actionMeta: ActionMeta) => void;
+  createNew?: (inputValue: string) => void;
+  onInputChange?: (inputValue: string, actionMeta: ActionMeta) => void;
+  loadOptions?: (inputValue: string) => Promise<Item| Item[]> | undefined;
+  filterOption?: (item: Item, inputValue:string) => boolean | null;
 }
 
 // Material-UI versions of several React-Select components.

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -81,7 +81,6 @@ interface State {
   errors?: Linode.ApiFieldError[];
   submitting: boolean;
   success?: string;
-  value: Item | null;
 }
 
 type CombinedProps =
@@ -135,7 +134,6 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     linodesLoading: false,
     linodeId: this.props.linodeId,
     configs: [],
-    value: null,
   };
 
   handleAPIErrorResponse = (errorResponse: any) => this.composeState([
@@ -361,13 +359,11 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     if (selected) { 
       this.setState({ 
         linodeId: Number(selected.value),
-        value: selected,
       });
     }
     else {
       this.setState({
         linodeId: 0,
-        value: null
       })
     }
   }
@@ -378,7 +374,6 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
         region: (e.target.value),
         linodeId: 0,
         configs: [],
-        value: null,
       }, this.searchLinodes);
     }
   }
@@ -500,7 +495,6 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       errors,
       linodes,
       linodesLoading,
-      value,
     } = this.state;
 
     const hasErrorFor = getAPIErrorFor({
@@ -626,7 +620,6 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
               placeholder="Select a Linode"
               isLoading={linodesLoading}
               errorText={linodeError}
-              value={value}
               disabled={
                 mode === modes.EDITING
                 || mode === modes.RESIZING

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -476,7 +476,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       * We optimize the lookup of the linodeLabel by providing it
       * explicitly when editing or resizing
       */
-        return [{ value: 'none', label: linodeLabel, data: { region: 'none'} }];
+      return [{ value: 'none', label: linodeLabel, data: { region: 'none'} }];
     }
     return options;
   }

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -382,6 +382,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
         region: (e.target.value),
         linodeId: 0,
         configs: [],
+        value: null,
       });
     }
   }

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -54,6 +54,10 @@ interface ActionCreatorProps {
   handleClose: typeof close;
 }
 
+interface ActionMeta {
+  action: string;
+}
+
 interface ReduxProps {
   mode: string;
   volumeID: number;
@@ -438,7 +442,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     }
   }
 
-  searchLinodes = (inputValue:string = '') => {
+  searchLinodes = (inputValue: string = '') => {
     this.setState({ linodesLoading: true });
     const filterLinodes = this.getLinodeFilter(inputValue);
     getLinodes({}, filterLinodes)
@@ -453,15 +457,16 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
 
   debouncedSearch = debounce(400, false, this.searchLinodes);
 
-  onInputChange = (inputValue:string) => {
+  onInputChange = (inputValue: string, actionMeta: ActionMeta) => {
+    if (actionMeta.action !== 'input-change') { return; }
     this.setState({ linodesLoading: true });
     this.debouncedSearch(inputValue);
   }
 
-  renderLinodeOptions = (linodes:Linode.Linode[]) => {
+  renderLinodeOptions = (linodes: Linode.Linode[]) => {
     const { linodeLabel, mode } = this.props;
     if (!linodes) { return []; }
-    const options: Item[] = linodes.map((linode:Linode.Linode) => {
+    const options: Item[] = linodes.map((linode: Linode.Linode) => {
         return {
           value: linode.id,
           label: linode.label,

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -192,12 +192,6 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       set(L.linodeId, nextProps.linodeId),
       set(L.errors, undefined),
     ]);
-
-    /* If the drawer is opening */
-    if ((this.props.mode === modes.CLOSED) && !(nextProps.mode === modes.CLOSED)) {
-      /* re-request the list of Linodes */
-      this.searchLinodes();
-    }
   }
 
   updateConfigs(linodeID: number) {
@@ -443,6 +437,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
   }
 
   searchLinodes = (inputValue: string = '') => {
+    if (!this.mounted) { return; }
     this.setState({ linodesLoading: true });
     const filterLinodes = this.getLinodeFilter(inputValue);
     getLinodes({}, filterLinodes)

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -425,7 +425,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
         label: {
           '+contains': inputValue,
         },
-        region: this.state.region
+        region
       }
     } else {
       return {
@@ -442,10 +442,12 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     const filterLinodes = this.getLinodeFilter(inputValue);
     getLinodes({}, filterLinodes)
       .then((response) => {
+        if (!this.mounted) { return; }
         const linodes = this.renderLinodeOptions(response.data);
         this.setState({ linodes, linodesLoading: false });
       })
       .catch(() => {
+        if (!this.mounted) { return; }
         this.setState({ linodesLoading: false });
       })
   }
@@ -453,6 +455,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
   debouncedSearch = debounce(400, false, this.searchLinodes);
 
   onInputChange = (inputValue: string, actionMeta: ActionMeta) => {
+    if (!this.mounted) { return; }
     if (actionMeta.action !== 'input-change') { return; }
     this.setState({ linodesLoading: true });
     this.debouncedSearch(inputValue);

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -625,7 +625,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
               onInputChange={this.onInputChange}
               data-qa-select-linode
             />
-            {region !== 'none' &&
+            {region !== 'none' && mode !== modes.RESIZING &&
               <FormHelperText>
                 Only Linodes in the selected region are displayed.
               </FormHelperText>

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -376,8 +376,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
         linodeId: 0,
         configs: [],
         value: null,
-      });
-      this.searchLinodes();
+      }, this.searchLinodes);
     }
   }
 
@@ -421,13 +420,27 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     ]);
   }
 
+  getLinodeFilter = (inputValue:string) => {
+    const { region } = this.state;
+    if (region && region !== 'none') {
+      return {
+        label: {
+          '+contains': inputValue,
+        },
+        region: this.state.region
+      }
+    } else {
+      return {
+        label: {
+          '+contains': inputValue,
+        }
+      }
+    }
+  }
+
   searchLinodes = (inputValue:string = '') => {
     this.setState({ linodesLoading: true });
-    const filterLinodes = {
-      label: {
-        '+contains': inputValue,
-      },
-    }
+    const filterLinodes = this.getLinodeFilter(inputValue);
     getLinodes({}, filterLinodes)
       .then((response) => {
         const linodes = this.renderLinodeOptions(response.data);
@@ -436,15 +449,6 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       .catch(() => {
         this.setState({ linodesLoading: false });
       })
-  }
-
-  filterOptions = (item:Item, inputValue:string) => {
-    const labelMatch = item.label.toLocaleLowerCase().includes(inputValue);
-    const { region } = this.state;
-    const linodeRegion = item.data.data.region;
-    if (region && region !== 'none') {
-      return labelMatch && (region === linodeRegion);
-    } else { return labelMatch }
   }
 
   debouncedSearch = debounce(400, false, this.searchLinodes);
@@ -619,7 +623,6 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
                 mode === modes.EDITING
                 || mode === modes.RESIZING
               }
-              filterOption={this.filterOptions}
               options={linodes}
               onChange={this.setSelectedLinode}
               onInputChange={this.onInputChange}

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -33,6 +33,8 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
 
+import { createFilter } from 'react-select';
+
 type ClassNames = 'root'
   | 'actionPanel';
 
@@ -448,6 +450,15 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       })
   }
 
+  filterOptions = (item:Item, inputValue:string) => {
+    const labelMatch = item.label.toLocaleLowerCase().includes(inputValue);
+    const { region } = this.state;
+    const linodeRegion = item.data.data.region;
+    if (region && region !== 'none') {
+      return labelMatch && (region === linodeRegion);
+    } else { return labelMatch }
+  }
+
   debouncedSearch = debounce(400, false, this.searchLinodes);
 
   onInputChange = (inputValue:string) => {
@@ -458,14 +469,18 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     const { linodeLabel, mode } = this.props;
     if (!linodes) { return []; }
     const options: Item[] = linodes.map((linode:Linode.Linode) => {
-        return { value: linode.id, label: linode.label }
+        return {
+          value: linode.id,
+          label: linode.label,
+          data: { region: linode.region }
+        }
       });
     if (mode === modes.EDITING || mode === modes.RESIZING) {
       /*
       * We optimize the lookup of the linodeLabel by providing it
       * explicitly when editing or resizing
       */
-        return [{ value: 'none', label: linodeLabel }];
+        return [{ value: 'none', label: linodeLabel, data: { region: 'none'} }];
     }
     return options;
   }
@@ -614,6 +629,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
                 || mode === modes.RESIZING
               }
               loadOptions={this.searchLinodes}
+              filterOption={this.filterOptions}
               onChange={this.setSelectedLinode}
               onInputChange={this.onInputChange}
               data-qa-select-linode

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -147,7 +147,6 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     this.mounted = true;
-    this.searchLinodes();
     this.eventsSub = events$
       .filter(event => (
         !event._initial
@@ -192,6 +191,12 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       set(L.linodeId, nextProps.linodeId),
       set(L.errors, undefined),
     ]);
+
+    /* If the drawer is opening */	
+    if ((this.props.mode === modes.CLOSED) && !(nextProps.mode === modes.CLOSED)) {	
+      /* re-request the list of Linodes */	
+      this.searchLinodes();	
+    }
   }
 
   updateConfigs(linodeID: number) {

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -450,6 +450,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
   debouncedSearch = debounce(400, false, this.searchLinodes);
 
   onInputChange = (inputValue:string) => {
+    this.setState({ linodesLoading: true });
     this.debouncedSearch(inputValue);
   }
 


### PR DESCRIPTION
## Purpose

Recent refactor of VolumesDrawer to use the new Select led to a few regressions and broken things:

1. `linodeID` was being set to 0 rather than null when no Linode had been manually selected, leading to an API error.
2. Filtering with React-Select's Async component really wasn't compatible with our filter-by-region behavior. I removed the Async variant and handled the Async stuff manually (as it was before).
3. Crosstalk between their async handling and ours also meant that the debounced search wasn't actually being debounced. Fixed this as well.

## Notes

Additional changes:

* moved filter logic entirely into the API.
* added support for RS's isLoading prop
* removed "Only Linodes in the selected region are displayed" message when resizing a volume

Issues:

* When selecting a Linode, the loading indicator shows up for a second. This could probably be fixed by using the same meta checking @martinmckenna did with his creation PR.
* The select will filter instantly on keyboard input, but we're instead debouncing an API request. This is necessary if the user has a ton of linodes (since if the search match isn't in the first 100 results it won't be displayed), but for most users this is slower and inefficient. We could, potentially, check to see if the user has more than 100 linodes, then otherwise only hit the API when the region changes.