### PR TITLE
M3-1232 Updating Contact Information

### DIFF
--- a/src/features/Account/AccountPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/src/features/Account/AccountPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -609,7 +609,17 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
 
     updateAccountInfo(this.state.fields)
       .then((updatedAccount) => {
-        this.props.update((existingAccount) => ({ ...existingAccount, ...updatedAccount }));
+        this.props.update((existingAccount) => {
+          const account = {...existingAccount, ...updatedAccount}
+          /* API returns:
+          * credit_card: {"expiry": null, "last_four": null}
+          * rather than credit_card = null. The merge will therefore
+          * overwrite the previous values for expiration/last 4 digits
+          * with null, so we need to manually set them here.
+          */
+          account.credit_card = existingAccount.credit_card;
+          return account;
+        });
 
         this.setState({
           success: 'Contact information successfully updated.',

--- a/src/features/Account/AccountPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/src/features/Account/AccountPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -610,15 +610,16 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
     updateAccountInfo(this.state.fields)
       .then((updatedAccount) => {
         this.props.update((existingAccount) => {
-          const account = {...existingAccount, ...updatedAccount}
           /* API returns:
           * credit_card: {"expiry": null, "last_four": null}
           * rather than credit_card = null. The merge will therefore
           * overwrite the previous values for expiration/last 4 digits
           * with null, so we need to manually set them here.
           */
-          account.credit_card = existingAccount.credit_card;
-          return account;
+          return {...existingAccount,
+                  ...updatedAccount,
+                  credit_card: existingAccount.credit_card
+                 }
         });
 
         this.setState({


### PR DESCRIPTION
API returns:
`credit_card: {"expiry": null, "last_four": null}`
rather than credit_card = null. Previously, after updating contact information,
the updated state was being merged with the previous state, but the null values
were overwriting the existing credit card values, causing the user to see None for
their credit card information as soon as they updated e.g. their address.

This PR manually sets the new account state object being sent to the Context API
with the existing credit card values, so they will not be overwritten in the context.