### PR TITLE
M3-1356 - Firefox & MS Edge E2E Fixes

### DIFF
--- a/e2e/config/browser-config.js
+++ b/e2e/config/browser-config.js
@@ -20,11 +20,13 @@ exports.browserConf = {
     edge: {
         'browserName': 'edge',
         'acceptSslCerts': true,
-        'os': 'Windows',
-        'os_version': '10',
-        'browser': 'Edge',
-        'browser_version': '17.0',
-        'resolution': '1440x900'
+        'os' : 'Windows',
+        'os_version' : '10',
+        'browserName' : 'Edge',
+        'browser_version' : 'insider preview',
+        'resolution' : '1440x900',
+        'browserstack.local' : 'true',
+        'browserstack.selenium_version' : '3.13.0', 
     },
     headlessChrome: {
         browserName: 'chrome',
@@ -59,7 +61,7 @@ exports.browserConf = {
         browserName: 'firefox',
         marionette: true,
         'moz:firefoxOptions' : {
-            'binary': '/Applications/Firefox Nightly.app/Contents/MacOS/firefox-bin',
+            'binary': '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
             'args': ['-headless']
         },
         maxInstances: 5,

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -107,7 +107,7 @@ exports.config = {
     baseUrl: process.env.DOCKER ? 'https://manager-local:3000' : process.env.REACT_APP_APP_ROOT,
     //
     // Default timeout for all waitFor* commands.
-    waitforTimeout: process.env.DOCKER ? 30000 : 10000,
+    waitforTimeout: process.env.DOCKER || process.env.BROWSERSTACK_USERNAME ? 30000 : 10000,
     //
     // Default timeout in milliseconds for request
     // if Selenium Grid doesn't send response

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -36,12 +36,12 @@ export default class Page {
     }
 
     logout() {
-        this.userMenu.waitForVisible();
+        this.userMenu.waitForVisible(constants.wait.normal);
         this.userMenu.click();
-        this.logoutButton.waitForVisible();
+        this.logoutButton.waitForVisible(constants.wait.normal);
         this.logoutButton.click();
-        this.logoutButton.waitForVisible(constants.wait.short, true);
-        this.globalCreate.waitForVisible(constants.wait.short, true);
+        this.logoutButton.waitForVisible(constants.wait.normal, true);
+        this.globalCreate.waitForVisible(constants.wait.normal, true);
 
         browser.waitUntil(function() {
             return browser.getUrl().includes('/login');

--- a/e2e/specs/account/restricted-users.spec.js
+++ b/e2e/specs/account/restricted-users.spec.js
@@ -33,8 +33,13 @@ describe('Account - Restricted User Suite', () => {
     });
 
     it('should display user as restricted in users table', () => {
-       const restrictedUser = Users.userRow(userConfig.username);
-       expect(restrictedUser.$(Users.userRestriction.selector).getText()).toMatch(/Restricted/ig);
+        browser.waitUntil(function() {
+            return Users.userRows.length > 1;
+        }, constants.wait.long);
+
+
+        const restrictedUser = Users.userRow(userConfig.username);
+        expect(restrictedUser.$(Users.userRestriction.selector).getText()).toMatch(/Restricted/ig);
     });
 
     it('should view restricted user profile', () => {

--- a/e2e/specs/domains/smoke-list-domains.spec.js
+++ b/e2e/specs/domains/smoke-list-domains.spec.js
@@ -53,9 +53,7 @@ describe('Domains - List Suite', () => {
         const actionMenuItems = $$(ListDomains.actionMenuItem.selector);
         actionMenuItems.forEach(i => expect(expectedMenuItems).toContain(i.getText()));
 
-        // Hit escape to get rid of action menu
-        // Refactor once Chrome implements actions api
-        browser.keys('\uE00C');
+        browser.click('body');
         ListDomains.actionMenuItem.waitForVisible(constants.wait.short, true);
     });
 

--- a/e2e/specs/linodes/detail/networking-allocate-ip.spec.js
+++ b/e2e/specs/linodes/detail/networking-allocate-ip.spec.js
@@ -62,7 +62,7 @@ describe('Linode Detail - Networking - Allocate IP Suite', () => {
             expect(Networking.cancel.isVisible()).toBe(true);
 
             Networking.cancel.click();
-            Networking.drawerTitle.waitForExist(constants.wait.normal);
+            Networking.drawerTitle.waitForExist(constants.wait.normal, true);
         });
     });
 });

--- a/e2e/specs/usermenu/smoke-logout.spec.js
+++ b/e2e/specs/usermenu/smoke-logout.spec.js
@@ -16,7 +16,7 @@ describe('Log out Suite', () => {
         browser.url(constants.routes.volumes);
         browser.waitUntil(function() {
             return browser.getUrl().includes('returnTo%253D%252Fvolumes');
-        }, 10000);
+        }, constants.wait.normal);
     });
 
     it('should not contain a token in local storage', () => {


### PR DESCRIPTION
* Adds an additional timeout to the restricted users test (waiting for a new user to appear in the table before proceeding with the test)
* Removes `browser.keys()` command in favor of clicking the `body` (which will dismiss an action menu the same as an `escape` key would).
* Updates MS Edge browserstack capabilities to use the webdriver api compatible "MS Edge Insider" version. 
* Removes some hardcoded timeouts in favor of the timeouts defined in constants.js

PM me for test results from CI 😄 