### PR TITLE
M3-908 Prevent "Unknown Plan" from appearing for deprecated types

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -19,7 +19,8 @@ describe('LinodeResize', () => {
       }}
       linodeId={12}
       linodeType={null}
-      typesData={mockTypes}
+      currentTypesData={mockTypes}
+      deprecatedTypesData={mockTypes}
       linodeLabel=""
     />,
   );
@@ -36,7 +37,8 @@ describe('LinodeResize', () => {
           }}
           linodeId={12}
           linodeType={null}
-          typesData={mockTypes}
+          currentTypesData={mockTypes}
+          deprecatedTypesData={mockTypes}
           linodeLabel=""
         />
       </LinodeThemeWrapper>,
@@ -63,7 +65,8 @@ describe('LinodeResize', () => {
               }}
               linodeId={12}
               linodeType={null}
-              typesData={mockTypes}
+              currentTypesData={mockTypes}
+              deprecatedTypesData={mockTypes}
               linodeLabel=""
             />
           </LinodeThemeWrapper>,
@@ -92,7 +95,8 @@ describe('LinodeResize', () => {
               }}
               linodeId={12}
               linodeType={'_something_unexpected_'}
-              typesData={mockTypes}
+              currentTypesData={mockTypes}
+              deprecatedTypesData={mockTypes}
               linodeLabel=""
             />
           </LinodeThemeWrapper>,

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -47,7 +47,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 });
 
 interface TypesContextProps {
-  typesData: ExtendedType[];
+  currentTypesData: ExtendedType[];
+  deprecatedTypesData: ExtendedType[];
 }
 
 interface LinodeContextProps {
@@ -114,8 +115,8 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { typesData, linodeType, linodeLabel, classes } = this.props;
-    const type = typesData.find(t => t.id === linodeType);
+    const { currentTypesData, deprecatedTypesData, linodeType, linodeLabel, classes } = this.props;
+    const type = [...currentTypesData, ...deprecatedTypesData].find(t => t.id === linodeType);
 
     const currentPlanHeading = linodeType
       ? type
@@ -169,7 +170,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
         </Paper>
         <SelectPlanPanel
           currentPlanHeading={currentPlanHeading}
-          types={this.props.typesData}
+          types={this.props.currentTypesData}
           onSelect={this.handleSelectPlan}
           selectedID={this.state.selectedId}
         />
@@ -192,13 +193,12 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
 const styled = withStyles(styles, { withTheme: true });
 
 const typesContext = withTypes(({ data }) => ({
-  typesData: (data || []).map(LinodeResize.extendType).filter((eachType) => {
-    /* filter out all the deprecated types because we don't to display them */
-    if (!eachType.successor) {
-      return true;
-    }
+  currentTypesData: (data || []).map(LinodeResize.extendType).filter((eachType) => {
     return eachType.successor === null
   }),
+  deprecatedTypesData: (data || []).map(LinodeResize.extendType).filter((eachType) => {
+    return eachType.successor !== null;
+  })
 }));
 
 const linodeContext = withLinode((context) => ({


### PR DESCRIPTION
### Purpose

previously, when resizing a Linode with a deprecated type, the current plan would appear as "Unknown Plan."

Now, we are leveraging the new `/types/legacy` endpoint to properly display deprecated types data.

### To Test
You will need to use a proxying service like Charles to edit your `GET /linodes/instance/:id` data. Try making the type `g5-standard-1` on the Linodes Detail page then navigate to the resize page

![untitled](https://user-images.githubusercontent.com/7387001/45758578-e9dfb780-bbf3-11e8-8569-c2d66a2b1ce3.png)
