### PR TITLE
Update PAT edit test

### DIFF
--- a/e2e/specs/profile/tokens.spec.js
+++ b/e2e/specs/profile/tokens.spec.js
@@ -93,7 +93,7 @@ describe('View - Personal Access Tokens', () => {
 
         describe('Edit - Personal Access Tokens', () => {
             it('should display edit drawer', () => {
-                profile.selectActionMenuItem($(newToken), 'Edit')
+                profile.selectActionMenuItem($(newToken), 'Rename Token')
                 
                 expect(tokenCreateDrawer.label.waitForVisible()).toBe(true);
                 expect(tokenCreateDrawer.title.getText()).toBe('Edit this Personal Access Token');


### PR DESCRIPTION
* Missed this in @martinmckenna's PR, updating the test to account for the new action menu name

```bash
yarn && yarn start
yarn selenium
yarn e2e:modified --browser=headlessChrome # run headless if you want it to be non-intrusive
```