### PR TITLE
M3-1290 volume labels update

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -142,6 +142,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
 
   static getDerivedStateFromProps(props: CombinedProps, state: State) {
     const attachedVolumesUpdate = !equals(props.linodeVolumes, state.attachedVolumes);
+    console.log("checking some things here", props.linodeVolumes);
 
     if (attachedVolumesUpdate) {
       return {
@@ -602,7 +603,12 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     updateVolume(id, label)
       .then((response) => {
         this.closeUpdatingDrawer();
-        this.getVolumes();
+        this.props.actions.updateVolumes((volumes) => {
+          const idx = volumes.findIndex((volume) => volume.id === response.data.id);
+          volumes[idx] = response.data;
+          return volumes;
+        });
+        // this.getVolumes();
       })
       .catch((errorResponse: any) => {
         this.setState({
@@ -770,6 +776,8 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     if (attachedVolumes.length === 0) {
       return null;
     }
+
+    console.log('rendering with', attachedVolumes[0]);
 
     return (
       <React.Fragment>

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -156,7 +156,6 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     this.mounted = true;
-
     this.eventSubscription = events$
       /** @todo filter on mount time. */
       .filter(e => [
@@ -601,7 +600,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     }
 
     updateVolume(id, label)
-      .then(() => {
+      .then((response) => {
         this.closeUpdatingDrawer();
         this.getVolumes();
       })
@@ -860,9 +859,11 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     const {
       linodeConfigs: { error: linodeConfigsError },
       linodeLabel,
+      linodeVolumes,
+      linodeStatus,
     } = this.props;
 
-    const { volumeDrawer } = this.state;
+    const { attachedVolumes, volumeDrawer } = this.state;
 
 
     if (linodeConfigsError) {
@@ -878,7 +879,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <DocumentTitleSegment segment={`${linodeLabel} - Volumes`} />
         <this.placeholder />
-        <this.table updateFor={[this.props.linodeVolumes, this.props.linodeStatus]} />
+        <this.table updateFor={[attachedVolumes, linodeVolumes, linodeStatus]} />
         <VolumeDrawer {...volumeDrawer} />
         <this.updateDialog />
       </React.Fragment>

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -142,7 +142,6 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
 
   static getDerivedStateFromProps(props: CombinedProps, state: State) {
     const attachedVolumesUpdate = !equals(props.linodeVolumes, state.attachedVolumes);
-    console.log("checking some things here", props.linodeVolumes);
 
     if (attachedVolumesUpdate) {
       return {
@@ -181,7 +180,6 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
   }
 
   getVolumes = () => {
-
     getLinodeVolumes(this.props.linodeID)
       .then((response) => {
         this.setState({
@@ -604,11 +602,11 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
       .then((response) => {
         this.closeUpdatingDrawer();
         this.props.actions.updateVolumes((volumes) => {
+          const newVolumes = [...volumes];
           const idx = volumes.findIndex((volume) => volume.id === response.data.id);
-          volumes[idx] = response.data;
-          return volumes;
+          newVolumes[idx] = response.data;
+          return newVolumes;
         });
-        // this.getVolumes();
       })
       .catch((errorResponse: any) => {
         this.setState({
@@ -776,8 +774,6 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
     if (attachedVolumes.length === 0) {
       return null;
     }
-
-    console.log('rendering with', attachedVolumes[0]);
 
     return (
       <React.Fragment>

--- a/src/services/volumes.ts
+++ b/src/services/volumes.ts
@@ -47,7 +47,7 @@ export const resizeVolume = (volumeId: number, size: number) => Request<{}>(
   setData({ size }),
 );
 
-export const updateVolume = (volumeId: number, label: string) => Request<{}>(
+export const updateVolume = (volumeId: number, label: string) => Request<Linode.Volume>(
   setURL(`${API_ROOT}/volumes/${volumeId}`),
   setMethod('PUT'),
   setData({ label }),


### PR DESCRIPTION
## Purpose

For mysterious mutability reasons that would never have been a problem in Elm, the LinodeVolumes view would not be updated after changes to a Volume's label from the action menu on that page; whereas changes to Size etc. were reflected after the completion notification was received.

Added a call to the Redux update method to update the store, and forced a copy of the array with some inelegant syntax.

## Note

This component needs a larger-scale refactor (ideally combining it with the logic in /volumes). As is there are two sources of truth, with some actions updating the store and others calling getLinodeVolumes from the API directly.