### PR TITLE
M3-1354 - Automate Axe Accessibility Testing

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -136,3 +136,20 @@ live in `src/components/ComponentName/ComponentName.spec.js`. The WDIO config li
     # OR if Yarn is installed:
 
     yarn docker:e2e
+
+
+# Accessibility Testing
+
+The axe-core accessibility testing script has been integrated into the webdriverIO-based testing framework to enable automated accessibility testing. At present, the script merely navigates to all routes described in `e2e/constants.js`, loads the page and runs the accessibility tests. 
+
+##### Dependencies
+
+* Same as E2E Manager tests
+
+#### Run Suite
+
+     yarn && yarn start # Starts the local development environment
+     yarn axe
+
+The test results will be saved as a JSON file with Critical accessibility violations appearing at the top of the list.
+

--- a/e2e/config/wdio.axe.conf.js
+++ b/e2e/config/wdio.axe.conf.js
@@ -1,0 +1,26 @@
+const { merge } = require('ramda');
+const { argv } = require('yargs');
+const wdioMaster = require('./wdio.conf.js');
+const { browserConf } = require('./browser-config');
+const selectedBrowser = () => {
+    if (argv.browser) {
+        return browserConf[argv.browser];
+    }
+    if (process.env.DOCKER || argv.debug) {
+     return browserConf['chrome'];
+    }
+    return browserConf['headlessChrome'];
+}
+
+const seleniumSettings = require('./selenium-config');
+const specsToRun = argv.story ? [ `./src/components/${argv.story}/${argv.story}.spec.js` ] : ['./src/components/**/*.spec.js'];
+const servicesToStart = process.env.DOCKER ? [] : ['selenium-standalone'];
+
+exports.config = merge(wdioMaster.config, {
+    specs: ['./e2e/setup/setup.spec.js', './e2e/specs/accessibility/*.spec.js'],
+    capabilities: [selectedBrowser()],
+    maxInstances: process.env.DOCKER || argv.debug ?  1 : 4,
+    services: servicesToStart,
+    seleniumInstallArgs: seleniumSettings,
+    seleniumArgs: seleniumSettings,
+});

--- a/e2e/specs/accessibility/axe.spec.js
+++ b/e2e/specs/accessibility/axe.spec.js
@@ -1,6 +1,8 @@
 const { constants } = require('../../constants');
 
 import { axeTest } from '../../utils/accessibility';
+import { writeFileSync } from 'fs';
+
 
 describe('Example Accessibility Test', () => {
     beforeAll(() => {
@@ -8,8 +10,17 @@ describe('Example Accessibility Test', () => {
     });
 
     it('should run an axe-core accessibility test', () => {
-        const testResults = axeTest();
-        testResults.forEach(res => console.log(res.nodes));
-        browser.debug();
+        const routesArray = _.flatten(Object.values(constants.routes).map(el => {if (typeof el === "object") { return Object.values(el) } return el;}));
+        const results = [];
+        const resultsFilePath = `./e2e/test-results/${new Date().getTime()}-axe-results.json`;
+
+        routesArray.forEach(route => {
+            browser.url(route);
+            const testResults = axeTest();
+            results.push(testResults);
+        });
+
+        writeFileSync(resultsFilePath, JSON.stringify(results));
+        console.log(`Results saved to ${resultsFilePath} !`);
     });
 });

--- a/e2e/specs/accessibility/axe.spec.js
+++ b/e2e/specs/accessibility/axe.spec.js
@@ -1,26 +1,34 @@
 const { constants } = require('../../constants');
 
+import { flatten, sortBy } from 'lodash';
 import { axeTest } from '../../utils/accessibility';
 import { writeFileSync } from 'fs';
 
-
 describe('Example Accessibility Test', () => {
-    beforeAll(() => {
-        browser.url(constants.routes.dashboard);
-    });
-
     it('should run an axe-core accessibility test', () => {
-        const routesArray = _.flatten(Object.values(constants.routes).map(el => {if (typeof el === "object") { return Object.values(el) } return el;}));
-        const results = [];
+        function removeDuplicateRoutes(array) {
+            const uniqueArray = array.filter((el, index, self) => {
+                return index == self.indexOf(el);
+            });
+            return uniqueArray; 
+        }
+
+        const routesArray = removeDuplicateRoutes(flatten(Object.values(constants.routes).map(el => {if (typeof el === "object") { return Object.values(el) } return el;})));
         const resultsFilePath = `./e2e/test-results/${new Date().getTime()}-axe-results.json`;
+        
+        let results = [];
 
         routesArray.forEach(route => {
             browser.url(route);
+
             const testResults = axeTest();
-            results.push(testResults);
+            testResults.forEach(res => res['manager-route'] = route);
+            results = results.concat(testResults);
         });
 
+        results = sortBy(sortBy(results, o => o.impact), o => o.impact !== 'critical');
+
         writeFileSync(resultsFilePath, JSON.stringify(results));
-        console.log(`Results saved to ${resultsFilePath} !`);
+        console.log(`\nAccessibility test results saved to ${resultsFilePath} !`);
     });
 });

--- a/e2e/specs/accessibility/axe.spec.js
+++ b/e2e/specs/accessibility/axe.spec.js
@@ -2,7 +2,7 @@ const { constants } = require('../../constants');
 
 import { flatten, sortBy } from 'lodash';
 import { axeTest } from '../../utils/accessibility';
-import { writeFileSync } from 'fs';
+import { writeFileSync, existsSync, mkdirSync } from 'fs';
 
 describe('Example Accessibility Test', () => {
     it('should run an axe-core accessibility test', () => {
@@ -14,7 +14,8 @@ describe('Example Accessibility Test', () => {
         }
 
         const routesArray = removeDuplicateRoutes(flatten(Object.values(constants.routes).map(el => {if (typeof el === "object") { return Object.values(el) } return el;})));
-        const resultsFilePath = `./e2e/test-results/${new Date().getTime()}-axe-results.json`;
+        const resultsPath = './e2e/test-results/';
+        const resultsFile = `${new Date().getTime()}-axe-results.json`;
         
         let results = [];
 
@@ -28,7 +29,12 @@ describe('Example Accessibility Test', () => {
 
         results = sortBy(sortBy(results, o => o.impact), o => o.impact !== 'critical');
 
-        writeFileSync(resultsFilePath, JSON.stringify(results));
-        console.log(`\nAccessibility test results saved to ${resultsFilePath} !`);
+
+        if (!existsSync(resultsPath)) {
+            mkdirSync(resultsPath);
+        }
+
+        writeFileSync(resultsPath+resultsFile, JSON.stringify(results));
+        console.log(`\nAccessibility test results saved to ${resultsPath+resultsFile} !`);
     });
 });

--- a/e2e/specs/accessibility/axe.spec.js
+++ b/e2e/specs/accessibility/axe.spec.js
@@ -1,0 +1,15 @@
+const { constants } = require('../../constants');
+
+import { axeTest } from '../../utils/accessibility';
+
+describe('Example Accessibility Test', () => {
+    beforeAll(() => {
+        browser.url(constants.routes.dashboard);
+    });
+
+    it('should run an axe-core accessibility test', () => {
+        const testResults = axeTest();
+        testResults.forEach(res => console.log(res.nodes));
+        browser.debug();
+    });
+});

--- a/e2e/utils/accessibility.js
+++ b/e2e/utils/accessibility.js
@@ -10,13 +10,5 @@ export const axeTest = () => {
         });
     });
 
-    const sortedViolations =
-        testResults.value.violations.sort(function(a,b) {
-            if (a.impact < b.impact) {
-                return -1;
-            } 
-            return 0;
-        });
-
-    return sortedViolations;
+    return testResults.value.violations;
 }

--- a/e2e/utils/accessibility.js
+++ b/e2e/utils/accessibility.js
@@ -10,7 +10,13 @@ export const axeTest = () => {
         });
     });
 
-    const criticalErrors = testResults.value.violations.filter(v => v.impact === 'critical');
+    const sortedViolations =
+        testResults.value.violations.sort(function(a,b) {
+            if (a.impact < b.impact) {
+                return -1;
+            } 
+            return 0;
+        });
 
-    return criticalErrors;
+    return sortedViolations;
 }

--- a/e2e/utils/accessibility.js
+++ b/e2e/utils/accessibility.js
@@ -1,0 +1,16 @@
+const axeSource = require('axe-core').source;
+
+export const axeTest = () => {
+
+    browser.execute(axeSource);
+    
+    const testResults = browser.executeAsync(function(done) {
+        axe.run(function(err, results) {
+            done(results);
+        });
+    });
+
+    const criticalErrors = testResults.value.violations.filter(v => v.impact === 'critical');
+
+    return criticalErrors;
+}

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "@types/why-did-you-update": "^0.0.8",
     "@types/xml2js": "^0.4.3",
     "@types/zxcvbn": "^4.4.0",
+    "axe-core": "^3.1.1",
     "babel-core": "^6.26.0",
     "babel-preset-react-app": "^3.1.1",
     "csstype": "^2.5.5",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "zxcvbn": "^4.4.2"
   },
   "scripts": {
+    "axe": "npx wdio ./e2e/config/wdio.axe.conf.js",
     "docker:e2e": "docker-compose -f integration-test.yml up --build --exit-code-from manager-e2e",
     "docker:test": "docker build -f Dockerfile . -t 'manager' && docker run -it --rm -v $(pwd)/src:/src/src manager test",
     "docker:local": "docker build -f Dockerfile . -t 'manager' && docker run -it --rm -p 3000:3000 -v $(pwd)/src:/src/src manager start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,10 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
+axe-core@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.1.1.tgz#c00515481b2abc47a87a3cbcd6ba2ae2d78d027f"
+
 axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"


### PR DESCRIPTION
* Integrated axe-core accessibility testing script into webdriverIO testing framework
* Accessibility tests will now run on routes defined in `e2e/constants.js`
* Does not pass or fail based on the number of violations , as right now we have many violations, but in the future we can adjust the script to do so.
* Sorts critical issues to the top of the results, for easy prioritization. (Everything else is alphabetical.. sorting collections is hard for my brain, but maybe someone can help me with this?)
* Search results are outputted to `e2e/test-results`

## To Test:

```bash
yarn && yarn start
yarn axe    ## Starts headless chrome instance that runs the tests!
```