### PR TITLE
M3-1313 Collapse Attachements

### DIFF
--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -1,6 +1,6 @@
 import * as Bluebird from 'bluebird';
 import * as classNames from 'classnames';
-import { compose, concat, path, pathOr } from 'ramda';
+import { compose, concat, path, pathOr, slice } from 'ramda';
 import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
@@ -127,6 +127,7 @@ interface State {
   errors?: Linode.ApiFieldError[];
   replies?: Linode.SupportReply[];
   ticket?: Linode.SupportTicket;
+  showMoreAttachments: boolean;
 }
 
 type CombinedProps = RouteProps & StateProps & WithStyles<ClassNames>;
@@ -143,6 +144,7 @@ export class SupportTicketDetail extends React.Component<CombinedProps,State> {
   mounted: boolean = false;
   state: State = {
     loading: true,
+    showMoreAttachments: false,
   }
 
   static docs: Linode.Doc[] = [
@@ -296,32 +298,57 @@ export class SupportTicketDetail extends React.Component<CombinedProps,State> {
     return (
       <React.Fragment>
         {attachments.length !== 0 &&
-        <Grid item xs={12} container justify="flex-start" className="px0">
-          <Grid item xs={12}>
-            <Typography variant="subheading">Attachments</Typography>
+          <Grid item xs={12} container justify="flex-start" className="px0">
+            <Grid item xs={12}>
+              <Typography variant="subheading">Attachments</Typography>
+            </Grid>
+            <Grid item xs={12} className={classes.attachmentPaperWrapper}>
+              {this.renderAttachmentsRows(slice(0, 5, attachments), icons)}
+              {
+                (attachments.length > 5) &&
+                <Typography
+                  onClick={this.toggleShowMoreAttachments}
+                  variant="subheading">
+                  {!this.state.showMoreAttachments
+                    ? "Show More Files"
+                    : "Show Less Files"
+                  }
+                </Typography>
+              }
+              {(this.state.showMoreAttachments) &&
+                this.renderAttachmentsRows(slice(5, Infinity, attachments), icons)
+              }
+            </Grid>
           </Grid>
-          <Grid item xs={12} className={classes.attachmentPaperWrapper}>
-            <Paper className={classes.attachmentPaper}>
-                {attachments.map((attachment, idx) => {
-                  return (
-                    <Grid container wrap="nowrap" key={idx} className={classes.attachmentRow}>
-                      <Grid item className={classes.attachmentIcon}>
-                        {icons[idx]}
-                      </Grid>
-                      <Grid item>
-                        <Typography component="span">
-                          {attachment}
-                        </Typography>
-                      </Grid>
-                    </Grid>
-                  )
-                })}
-            </Paper>
-          </Grid>
-        </Grid>
         }
       </React.Fragment>
     );
+  }
+
+  toggleShowMoreAttachments = () => {
+    this.setState({ showMoreAttachments: !this.state.showMoreAttachments });
+  }
+
+  renderAttachmentsRows = (attachments: string[], icons: JSX.Element[]) => {
+    const { classes } = this.props;
+    return (
+      <Paper className={classes.attachmentPaper}>
+        {attachments.map((attachment, idx) => {
+          return (
+            <Grid container wrap="nowrap" key={idx} className={classes.attachmentRow}>
+              <Grid item className={classes.attachmentIcon}>
+                {icons[idx]}
+              </Grid>
+              <Grid item>
+                <Typography component="span">
+                  {attachment}
+                </Typography>
+              </Grid>
+            </Grid>
+          )
+        })}
+      </Paper>
+    )
   }
 
   renderReplies = (replies: Linode.SupportReply[]) => {

--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -23,6 +23,7 @@ import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
+import ShowMoreExpansion from 'src/components/ShowMoreExpansion';
 import { getTicket, getTicketReplies, SupportTicket } from 'src/services/support';
 import { getGravatarUrlFromHash } from 'src/utilities/gravatar';
 
@@ -99,9 +100,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   },
   attachmentPaper: {
     padding: `
-      ${theme.spacing.unit * 2}px
+      12px
       ${theme.spacing.unit * 3}px
-      ${theme.spacing.unit}px
+      0
     `,
     overflowX: 'auto',
     width: 500,
@@ -306,17 +307,14 @@ export class SupportTicketDetail extends React.Component<CombinedProps,State> {
               {this.renderAttachmentsRows(slice(0, 5, attachments), icons)}
               {
                 (attachments.length > 5) &&
-                <Typography
-                  onClick={this.toggleShowMoreAttachments}
-                  variant="subheading">
-                  {!this.state.showMoreAttachments
+                <ShowMoreExpansion
+                  name={!this.state.showMoreAttachments
                     ? "Show More Files"
                     : "Show Less Files"
                   }
-                </Typography>
-              }
-              {(this.state.showMoreAttachments) &&
-                this.renderAttachmentsRows(slice(5, Infinity, attachments), icons)
+                >
+                  {this.renderAttachmentsRows(slice(5, Infinity, attachments), icons)}
+                </ShowMoreExpansion>
               }
             </Grid>
           </Grid>

--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -307,14 +307,16 @@ export class SupportTicketDetail extends React.Component<CombinedProps,State> {
               {this.renderAttachmentsRows(slice(0, 5, attachments), icons)}
               {
                 (attachments.length > 5) &&
-                <ShowMoreExpansion
-                  name={!this.state.showMoreAttachments
-                    ? "Show More Files"
-                    : "Show Less Files"
-                  }
-                >
-                  {this.renderAttachmentsRows(slice(5, Infinity, attachments), icons)}
-                </ShowMoreExpansion>
+                <div onClick={this.toggleShowMoreAttachments} style={{ display: 'inline-block' }}>
+                  <ShowMoreExpansion
+                    name={!this.state.showMoreAttachments
+                      ? "Show More Files"
+                      : "Show Less Files"
+                    }
+                  >
+                    {this.renderAttachmentsRows(slice(5, Infinity, attachments), icons)}
+                  </ShowMoreExpansion>
+                </div>
               }
             </Grid>
           </Grid>


### PR DESCRIPTION
### Purpose

If support ticket has greater than 5 attachments, hide the rest behind a "Show More Files" toggle