### PR TITLE
M3-17 Linode Action Menu Analytics

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -17,6 +17,13 @@ const initGTM = (w: any, d: any, s: any, l: any, i: any) => {
 }
 /* tslint:enable */
 
+/**
+ * Initiates Google Analytics Tracking Script.
+ * Should be called when the app loads
+ * 
+ * @param gaId Your Google Analytics Tracking ID
+ * @param production current environment of the app
+ */
 export const initAnalytics = (gaId?: string, production: boolean = false) => {
   if (!gaId) {
     return;
@@ -32,6 +39,12 @@ export const initAnalytics = (gaId?: string, production: boolean = false) => {
   (window as any).ga('send', 'pageview');
 }
 
+/**
+ * Initiates Google Tag Manager Tracking Script.
+ * Should be called when the app loads
+ * 
+ * @param gtmId Your Google Tag Manager Tracking ID
+ */
 export const initTagManager = (gtmId?: string) => {
   if (!gtmId) {
     return;

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -66,6 +66,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme: Theme & Linode.Theme) => 
 
 interface Props {
   createActions: (closeMenu: Function) => Action[];
+  toggleOpenCallback?: () => void;
 }
 
 interface State {
@@ -98,6 +99,7 @@ class ActionMenu extends React.Component<CombinedProps, State> {
   }
 
   handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (this.props.toggleOpenCallback) { this.props.toggleOpenCallback() };
     this.setState({ anchorEl: event.currentTarget });
   }
 

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -7,6 +7,8 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 import { powerOnLinode } from './powerActions';
 
+import { sendEvent } from 'src/utilities/analytics';
+
 interface Props {
   linodeId: number;
   linodeLabel: string;
@@ -22,12 +24,16 @@ type CombinedProps = Props & RouteComponentProps<{}>;
 class LinodeActionMenu extends React.Component<CombinedProps> {
   createLinodeActions = () => {
     const { linodeId, linodeLabel, linodeBackups, linodeStatus,
-       openConfigDrawer, toggleConfirmation, history: { push } } = this.props;
+      openConfigDrawer, toggleConfirmation, history: { push } } = this.props;
     return (closeMenu: Function): Action[] => {
       const actions = [
         {
           title: 'Launch Console',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendEvent({
+              category: 'Linode Action Menu Item',
+              action: 'Launch Console',
+            })
             lishLaunch(linodeId);
             e.preventDefault();
           },
@@ -35,6 +41,10 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         {
           title: 'View Graphs',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendEvent({
+              category: 'Linode Action Menu Item',
+              action: 'View Linode Graphs',
+            })
             push(`/linodes/${linodeId}/summary`);
             e.preventDefault();
           },
@@ -42,6 +52,10 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         {
           title: 'Resize',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendEvent({
+              category: 'Linode Action Menu Item',
+              action: 'Navigate to Resize Page',
+            })
             push(`/linodes/${linodeId}/resize`);
             e.preventDefault();
           },
@@ -49,6 +63,10 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         {
           title: 'View Backups',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendEvent({
+              category: 'Linode Action Menu Item',
+              action: 'Navigate to Backups Page',
+            })
             push(`/linodes/${linodeId}/backup`);
             e.preventDefault();
           },
@@ -56,6 +74,10 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         {
           title: 'Settings',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendEvent({
+              category: 'Linode Action Menu Item',
+              action: 'Navigate to Settings Page',
+            })
             push(`/linodes/${linodeId}/settings`);
             e.preventDefault();
           },
@@ -66,6 +88,10 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         actions.unshift({
           title: 'Power On',
           onClick: (e) => {
+            sendEvent({
+              category: 'Linode Action Menu Item',
+              action: 'Power On Linode',
+            })
             powerOnLinode(openConfigDrawer, linodeId, linodeLabel);
             closeMenu();
           },
@@ -77,6 +103,10 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
           {
             title: 'Reboot',
             onClick: (e: React.MouseEvent<HTMLElement>) => {
+              sendEvent({
+                category: 'Linode Action Menu Item',
+                action: 'Reboot Linode',
+              })
               e.preventDefault();
               toggleConfirmation('reboot', linodeId, linodeLabel);
               closeMenu();
@@ -85,6 +115,10 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
           {
             title: 'Power Off',
             onClick: (e) => {
+              sendEvent({
+                category: 'Linode Action Menu Item',
+                action: 'Power Off Linode',
+              })
               toggleConfirmation('power_down', linodeId, linodeLabel);
               closeMenu();
             },
@@ -96,6 +130,10 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         actions.splice(-2, 1, {
           title: 'Enable Backups',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendEvent({
+              category: 'Linode Action Menu Item',
+              action: 'Enable Backups',
+            })
             push({
               pathname: `/linodes/${linodeId}/backup`,
               state: { enableOnLoad: true }
@@ -111,9 +149,19 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
 
   render() {
     return (
-      <ActionMenu createActions={this.createLinodeActions()} />
+      <ActionMenu
+        toggleOpenCallback={toggleOpenActionMenu}
+        createActions={this.createLinodeActions()}
+      />
     );
   }
+}
+
+const toggleOpenActionMenu = () => {
+  sendEvent({
+    category: 'Linode Action Menu',
+    action: 'Open Action Menu',
+  })
 }
 
 export default withRouter(LinodeActionMenu);

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -20,6 +20,8 @@ import { withTypes } from 'src/context/types';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 import { linodeInTransition, transitionText } from 'src/features/linodes/transitions';
 import { lishLaunch } from 'src/features/Lish';
+
+import { sendEvent } from 'src/utilities/analytics';
 import haveAnyBeenModified from 'src/utilities/haveAnyBeenModified';
 
 import { getType } from 'src/services/linodes';
@@ -258,11 +260,19 @@ class LinodeCard extends React.Component<CombinedProps, State> {
   }
 
   handleConsoleButtonClick = () => {
+    sendEvent({
+      category: 'Linode Action Menu Item',
+      action: 'Launch Console',
+    })
     const { linodeId } = this.props;
     lishLaunch(linodeId);
   }
 
   handleRebootButtonClick = () => {
+    sendEvent({
+      category: 'Linode Action Menu Item',
+      action: 'Reboot Linode',
+    })
     const { linodeId, linodeLabel, toggleConfirmation} = this.props;
     toggleConfirmation('reboot', linodeId, linodeLabel);
   }

--- a/src/utilities/analytics.ts
+++ b/src/utilities/analytics.ts
@@ -3,7 +3,7 @@ import { event } from 'react-ga';
 interface AnalyticsEvent {
   category: string,
   action: string,
-  label: string,
+  label?: string,
 }
 
 /*


### PR DESCRIPTION
### Purpose

Send event to Google Analytics for each click of a Linode Action Menu Item (and the action menu itself)

### To Test

Add the manager.dev.linode.com Analytics Tag as your `REACT_APP_GA_ID` variable and then navigate to the Real time events section in Google Analytics and start clicking buttons