### PR TITLE
Add Option wrapper for React Select

### DIFF
--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -9,6 +9,7 @@ import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/
 
 import MultiValue from './components/MultiValue';
 import NoOptionsMessage from './components/NoOptionsMessage';
+import Option from './components/Option';
 import Control from './components/SelectControl';
 import Placeholder from './components/SelectPlaceholder';
 
@@ -145,6 +146,7 @@ const _components = {
   NoOptionsMessage,
   Placeholder,
   MultiValue,
+  Option,
 };
 
 type CombinedProps = EnhancedSelectProps

--- a/src/components/EnhancedSelect/components/Option.tsx
+++ b/src/components/EnhancedSelect/components/Option.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import _Option, { OptionProps } from 'react-select/lib/components/Option';
+
+interface Props extends OptionProps<any> {
+  value: number;
+ }
+
+const Option: React.StatelessComponent<Props> = (props) => {
+  return (
+    <div data-qa-option={String(props.value)}><_Option {...props} /></div>
+  )
+}
+
+export default Option;


### PR DESCRIPTION
For testing, we need to add a data attribute to each option in the
new enhanced select. This PR overrides the default Option component
with a wrapper (just a div with the qa attribute).