### PR TITLE
LinodeDetail disk refactor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -374,7 +374,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (dispatch, 
 interface StateProps {
   /** Profile */
   profileLoading: boolean;
-  profileError?: Error;
+  profileError?: Error | Linode.ApiFieldError[];
   userId?: number;
 
   documentation: Linode.Doc[];

--- a/src/components/Pagey/Pagey.test.tsx
+++ b/src/components/Pagey/Pagey.test.tsx
@@ -97,7 +97,7 @@ describe('Paginator 2: Pagement Day', () => {
 
       wrapper.update();
 
-      expect(mockRequest).toBeCalledWith({ page: 9, page_size: 25 }, {});
+      expect(mockRequest).toBeCalledWith({}, { page: 9, page_size: 25 }, {});
     });
   });
 
@@ -125,7 +125,7 @@ describe('Paginator 2: Pagement Day', () => {
 
       wrapper.update();
 
-      expect(mockRequest).toBeCalledWith({ page: 1, page_size: 100 }, {});
+      expect(mockRequest).toBeCalledWith({}, { page: 1, page_size: 100 }, {});
     });
   })
 
@@ -195,25 +195,25 @@ describe('Paginator 2: Pagement Day', () => {
     it('should send request with sort by prop asecending on first call', () => {
       updateOrderBy('label');
 
-      expect(mockRequest).toHaveBeenCalledWith({ page: 1, page_size: 25 }, { '+order_by': 'label', '+order': 'asc' })
+      expect(mockRequest).toHaveBeenCalledWith({}, { page: 1, page_size: 25 }, { '+order_by': 'label', '+order': 'asc' })
     });
 
     it('should send request with sort by prop descending on second call', () => {
       updateOrderBy('label');
 
-      expect(mockRequest).toHaveBeenCalledWith({ page: 1, page_size: 25 }, { '+order_by': 'label', '+order': 'desc' })
+      expect(mockRequest).toHaveBeenCalledWith({}, { page: 1, page_size: 25 }, { '+order_by': 'label', '+order': 'desc' })
     });
 
     it('should send request with sort by prop ascending on third call', () => {
       updateOrderBy('label');
 
-      expect(mockRequest).toHaveBeenCalledWith({ page: 1, page_size: 25 }, { '+order_by': 'label', '+order': 'asc' })
+      expect(mockRequest).toHaveBeenCalledWith({}, { page: 1, page_size: 25 }, { '+order_by': 'label', '+order': 'asc' })
     });
 
     it('should send request with sort by prop ascending on first call of new label', () => {
       updateOrderBy('other');
 
-      expect(mockRequest).toHaveBeenCalledWith({ page: 1, page_size: 25 }, { '+order_by': 'other', '+order': 'asc' })
+      expect(mockRequest).toHaveBeenCalledWith({}, { page: 1, page_size: 25 }, { '+order_by': 'other', '+order': 'asc' })
     });
   });
 });

--- a/src/components/Pagey/Pagey.test.tsx
+++ b/src/components/Pagey/Pagey.test.tsx
@@ -146,7 +146,7 @@ describe('Paginator 2: Pagement Day', () => {
       });
 
       it('should set data to response.data', () => {
-        expect(wrapper.prop('result')).toEqual([1, 2, 3, 4]);
+        expect(wrapper.prop('data')).toEqual([1, 2, 3, 4]);
       });
 
       it('should set page to response.page', () => {
@@ -161,7 +161,7 @@ describe('Paginator 2: Pagement Day', () => {
         const fn = (numbers: number[]) => numbers.map((n) => n + 1);
         await wrapper.prop('request')(fn);
         wrapper.update();
-        expect(wrapper.prop('result')).toEqual([2, 3, 4, 5]);
+        expect(wrapper.prop('data')).toEqual([2, 3, 4, 5]);
       });
     });
 

--- a/src/components/Pagey/Pagey.ts
+++ b/src/components/Pagey/Pagey.ts
@@ -28,7 +28,7 @@ interface State<T={}> {
   loading: boolean;
   page: number;
   pageSize: number;
-  result?: T[];
+  data?: T[];
   orderBy?: string;
   order: 'asc' | 'desc';
 }
@@ -67,7 +67,7 @@ export default (requestFn: PaginatedRequest) => (Component: React.ComponentType<
           this.setState({
             count: response.results,
             page: response.page,
-            result: map ? map(response.data) : response.data,
+            data: map ? map(response.data) : response.data,
             loading: false,
           });
         })

--- a/src/components/Pagey/Pagey.ts
+++ b/src/components/Pagey/Pagey.ts
@@ -17,6 +17,7 @@ export interface PaginationParams {
 export type FilterParams = any;
 
 export type PaginatedRequest<T = {}> = (
+  ownProps?: any,
   p?: PaginationParams,
   f?: FilterParams,
 ) => Promise<Linode.ResourcePage<T>>;
@@ -61,8 +62,7 @@ export default (requestFn: PaginatedRequest) => (Component: React.ComponentType<
         filters['+order_by'] = this.state.orderBy;
         filters['+order'] = this.state.order;
       }
-
-      return requestFn({ page: this.state.page, page_size: this.state.pageSize }, filters)
+      return requestFn(this.props, { page: this.state.page, page_size: this.state.pageSize }, filters)
         .then((response) => {
           this.setState({
             count: response.results,

--- a/src/features/Profile/SSHKeys/SSHKeys.test.tsx
+++ b/src/features/Profile/SSHKeys/SSHKeys.test.tsx
@@ -27,7 +27,7 @@ describe('SSHKeys', () => {
         page={1}
         pageSize={25}
         request={request}
-        result={[
+        data={[
           { id: 1, label: '', ssh_key: '', created: '', fingerprint: '', },
           { id: 2, label: '', ssh_key: '', created: '', fingerprint: '', },
           { id: 3, label: '', ssh_key: '', created: '', fingerprint: '', },
@@ -68,7 +68,7 @@ describe('SSHKeys', () => {
         page={1}
         pageSize={25}
         request={request}
-        result={undefined}
+        data={undefined}
         timezone={'GMT'}
         updateOrderBy={updateOrderBy}
       />
@@ -91,7 +91,7 @@ describe('SSHKeys', () => {
         page={1}
         pageSize={25}
         request={request}
-        result={undefined}
+        data={undefined}
         timezone={'GMT'}
         updateOrderBy={updateOrderBy}
       />
@@ -114,7 +114,7 @@ describe('SSHKeys', () => {
         page={1}
         pageSize={25}
         request={request}
-        result={undefined}
+        data={undefined}
         timezone={'GMT'}
         updateOrderBy={updateOrderBy}
       />

--- a/src/features/Profile/SSHKeys/SSHKeys.tsx
+++ b/src/features/Profile/SSHKeys/SSHKeys.tsx
@@ -95,7 +95,7 @@ export class SSHKeys extends React.Component<CombinedProps, State> {
               <TableRow>
                 <TableCell data-qa-label-column>Label</TableCell>
                 <TableCell data-qa-key-column>Key</TableCell>
-                <TableCell data-qa-created-column>Created</TableCell> 
+                <TableCell data-qa-created-column>Created</TableCell>
                 <TableCell />
               </TableRow>
             </TableHead>
@@ -230,7 +230,7 @@ const styled = withStyles(styles, { withTheme: true });
 
 const documented = setDocs(SSHKeys.docs);
 
-const updatedRequest = (p: any, f: any) => getSSHKeys(p, f)
+const updatedRequest = (ownProps: any, params: any, filters: any) => getSSHKeys(params, filters)
   .then((response) => ({
     ...response,
     data: updateResponseData(response.data),

--- a/src/features/Profile/SSHKeys/SSHKeys.tsx
+++ b/src/features/Profile/SSHKeys/SSHKeys.tsx
@@ -128,7 +128,7 @@ export class SSHKeys extends React.Component<CombinedProps, State> {
   }
 
   renderContent = () => {
-    const { loading, error, result, count } = this.props;
+    const { loading, error, data, count } = this.props;
 
     if (loading) {
       return SSHKeys.renderLoading();
@@ -138,8 +138,8 @@ export class SSHKeys extends React.Component<CombinedProps, State> {
       return SSHKeys.renderError(error);
     }
 
-    if (result && count > 0) {
-      return this.renderData(result);
+    if (data && count > 0) {
+      return this.renderData(data);
     }
 
     return SSHKeys.renderEmptyState();

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDisks.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDisks.tsx
@@ -147,7 +147,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
     const {
       classes,
 
-      result: disks,
+      data: disks,
       error: disksErrors,
 
       linodeError,
@@ -563,11 +563,11 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
     /**
      * So if there's more than 100 disks, then this count will be off.
      */
-    const { linodeTotalDisk, result, } = this.props;
-    if (!linodeTotalDisk || !result) {
+    const { linodeTotalDisk, data, } = this.props;
+    if (!linodeTotalDisk || !data) {
       return 0;
     }
-    return linodeTotalDisk - result.reduce((acc: number, disk: Linode.Disk) => {
+    return linodeTotalDisk - data.reduce((acc: number, disk: Linode.Disk) => {
       return diskId === disk.id ? acc : acc + disk.size
     }, 0);
   }

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -5,7 +5,7 @@ import Typography from '@material-ui/core/Typography';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 
-import { ConfigsConsumer, DisksConsumer, LinodeConsumer } from '../context';
+import { ConfigsConsumer, LinodeConsumer } from '../context';
 import LinodeAdvancedConfigurationsPanel from './LinodeAdvancedConfigurationsPanel';
 import LinodeSettingsAlertsPanel from './LinodeSettingsAlertsPanel';
 import LinodeSettingsDeletePanel from './LinodeSettingsDeletePanel';
@@ -31,56 +31,47 @@ const LinodeSettings: React.StatelessComponent<CombinedProps> = (props) => {
     <LinodeConsumer>
       {(linodeContext) => {
         return (
-          <DisksConsumer>
-            {(disksContext) => {
-              return (
-                <ConfigsConsumer>
-                  {(configsContext) => {
-                    const { data: linode } = linodeContext;
-                    const { data: disks } = disksContext;
-                    const { data: configs } = configsContext;
+          <ConfigsConsumer>
+            {(configsContext) => {
+              const { data: linode } = linodeContext;
+              const { data: configs } = configsContext;
 
-                    if (!linode) { return null; }
-                    if (!disks) { return null; }
-                    if (!configs) { return null; }
-                    return (
-                      <React.Fragment>
-                        <DocumentTitleSegment segment={`${linodeContext.data!.label} - Settings`} />
-                        <Typography
-                          role="header"
-                          variant="headline"
-                          className={classes.title}
-                          data-qa-settings-header
-                        >
-                          Settings
-                        </Typography>
-                        <LinodeSettingsLabelPanel />
-                        <LinodeSettingsPasswordPanel
-                          linodeDisks={disks}
-                          linodeLabel={linode.label}
-                          linodeId={linode.id}
-                          linodeStatus={linode.status}
-                        />
-                        <LinodeSettingsAlertsPanel
-                          linodeId={linode.id}
-                          linodeLabel={linode.label}
-                          linodeAlerts={linode.alerts}
-                        />
-                        <LinodeWatchdogPanel
-                          linodeId={linode.id}
-                          currentStatus={linode.watchdog_enabled}
-                        />
-                        <LinodeAdvancedConfigurationsPanel />
-                        <LinodeSettingsDeletePanel
-                          linodeId={linode.id}
-                        />
-                      </React.Fragment>
-                    )
-                  }}
-                </ConfigsConsumer>
-              );
+              if (!linode) { return null; }
+              if (!configs) { return null; }
+              return (
+                <React.Fragment>
+                  <DocumentTitleSegment segment={`${linodeContext.data!.label} - Settings`} />
+                  <Typography
+                    role="header"
+                    variant="headline"
+                    className={classes.title}
+                    data-qa-settings-header
+                  >
+                    Settings
+                  </Typography>
+                  <LinodeSettingsLabelPanel />
+                  <LinodeSettingsPasswordPanel
+                    linodeLabel={linode.label}
+                    linodeId={linode.id}
+                    linodeStatus={linode.status}
+                  />
+                  <LinodeSettingsAlertsPanel
+                    linodeId={linode.id}
+                    linodeLabel={linode.label}
+                    linodeAlerts={linode.alerts}
+                  />
+                  <LinodeWatchdogPanel
+                    linodeId={linode.id}
+                    currentStatus={linode.watchdog_enabled}
+                  />
+                  <LinodeAdvancedConfigurationsPanel />
+                  <LinodeSettingsDeletePanel
+                    linodeId={linode.id}
+                  />
+                </React.Fragment>
+              )
             }}
-          </DisksConsumer>
+          </ConfigsConsumer>
         );
       }}
     </LinodeConsumer>

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -170,7 +170,7 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
         onChange={this.handlePanelChange}
       >
         {generalError && <Notice text={generalError} error />}
-        {this.state.disks.length > 1 &&
+
           <EnhancedSelect
             label="Disk"
             placeholder="Find a Disk"
@@ -181,7 +181,7 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
             onInputChange={this.onInputChange}
             data-qa-select-linode
           />
-        }
+
         <PasswordInput
           label="Password"
           value={this.state.value}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -1,5 +1,6 @@
 import { compose, lensPath, pathOr, set } from 'ramda';
 import * as React from 'react';
+import { connect, MapStateToProps } from 'react-redux';
 
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
@@ -27,7 +28,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 interface Props {
   linodeId: number;
   linodeLabel: string;
-  linodeDisks: Linode.Disk[];
   linodeStatus: string;
 }
 
@@ -40,7 +40,9 @@ interface State {
   errors?: Linode.ApiFieldError[];
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props
+  & StateProps
+  & WithStyles<ClassNames>;
 
 class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> {
   constructor(props: CombinedProps) {
@@ -187,7 +189,18 @@ const styled = withStyles(styles, { withTheme: true });
 
 const errorBoundary = PanelErrorBoundary({ heading: 'Reset Root Password' });
 
+interface StateProps {
+  linodeDisks: Linode.Disk[]
+}
+
+const mapStateToProps: MapStateToProps<StateProps, never, ApplicationState> = (state) => ({
+  linodeDisks: state.features.linodeDetail.disks.data || [],
+});
+
+const connected = connect(mapStateToProps);
+
 export default compose(
   errorBoundary,
   styled,
+  connected,
 )(LinodeSettingsPasswordPanel) as React.ComponentType<Props>;

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -125,8 +125,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
 
   notificationsSubscription: Subscription;
 
-  diskResizeSubscription: Subscription;
-
   mounted: boolean = false;
 
   state: State = {
@@ -282,7 +280,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
   componentWillUnmount() {
     this.mounted = false;
     this.eventsSubscription.unsubscribe();
-    this.diskResizeSubscription.unsubscribe();
     this.notificationsSubscription.unsubscribe();
     this.volumeEventsSubscription.unsubscribe();
   }
@@ -343,12 +340,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
     const { context: { configs, image, linode } } = this.state;
     const mountTime = moment().subtract(5, 'seconds');
     const { actions, match: { params: { linodeId } } } = this.props;
-
-    this.diskResizeSubscription = events$
-      .filter((e) => !e._initial)
-      .filter(pathEq(['entity', 'id'], Number(this.props.match.params.linodeId)))
-      .filter((e) => e.status === 'finished' && e.action === 'disk_resize')
-      .subscribe((e) => actions.getLinodeDisks())
 
     this.eventsSubscription = events$
       .filter(pathEq(['entity', 'id'], Number(this.props.match.params.linodeId)))

--- a/src/features/linodes/LinodesDetail/context.tsx
+++ b/src/features/linodes/LinodesDetail/context.tsx
@@ -14,11 +14,6 @@ export const withConfigs = createHOCForConsumer<Linode.Config[]>(configsContext.
 export const ConfigsProvider = configsContext.Provider;
 export const ConfigsConsumer = configsContext.Consumer;
 
-const disksContext = React.createContext<Requestable<Linode.Disk[]>>({...initialState});
-export const withDisks = createHOCForConsumer<Linode.Disk[]>(disksContext.Consumer, 'WithDisks');
-export const DisksProvider = disksContext.Provider;
-export const DisksConsumer = disksContext.Consumer;
-
 const linodeContext = React.createContext<Requestable<Linode.Linode>>({...initialState});
 export const withLinode = createHOCForConsumer<Linode.Linode>(linodeContext.Consumer, 'WithLinode');
 export const LinodeProvider = linodeContext.Provider;

--- a/src/services/linodes.ts
+++ b/src/services/linodes.ts
@@ -63,10 +63,12 @@ export const getLinodeVolumes = (id: number) =>
   )
     .then(response => response.data);
 
-export const getLinodeDisks = (id: number) =>
+export const getLinodeDisks = (id: number, params: any = {}, filters: any = {}) =>
   Request<Page<Linode.Disk>>(
     setURL(`${API_ROOT}/linode/instances/${id}/disks`),
     setMethod('GET'),
+    setParams(params),
+    setXFilter(filters),
   )
     .then(response => response.data);
 

--- a/src/store/ApplicationState.d.ts
+++ b/src/store/ApplicationState.d.ts
@@ -23,7 +23,7 @@ declare interface RequestableData<D> {
   lastUpdated: number;
   loading: boolean;
   data?: D;
-  error?: Error;
+  error?: Error | Linode.ApiFieldError[];
 }
 
 declare interface FeaturesState {

--- a/src/store/ApplicationState.d.ts
+++ b/src/store/ApplicationState.d.ts
@@ -29,5 +29,6 @@ declare interface RequestableData<D> {
 declare interface FeaturesState {
   linodeDetail: {
     volumes: RequestableData<Linode.Volume[]>
+    disks: RequestableData<Linode.Disk[]>
   }
 }

--- a/src/store/reducers/features/linodeDetail/disks.ts
+++ b/src/store/reducers/features/linodeDetail/disks.ts
@@ -1,0 +1,59 @@
+import { ThunkAction } from 'redux-thunk';
+import { getLinodeDisks } from 'src/services/linodes';
+
+// ACTIONS
+const actionTypeGenerator = (s: string) => `@manager/features/linodeDetail/disks/${s}`;
+
+const LOAD = actionTypeGenerator('LOAD');
+const SUCCESS = actionTypeGenerator('SUCCESS');
+const ERROR = actionTypeGenerator('ERROR');
+const UPDATE = actionTypeGenerator('UPDATE');
+
+// STATE
+type State = FeaturesState['linodeDetail']['disks']
+
+export const defaultState: State = {
+  lastUpdated: 0,
+  loading: false,
+}
+
+// ACTION CREATORS
+export const load = () => ({ type: LOAD });
+
+export const handleSuccess = (payload: Linode.Disk[]) => ({ type: SUCCESS, payload });
+
+export const handleError = (payload: Error) => ({ type: ERROR, payload });
+
+export const handleUpdate = (updateFn: (v: Linode.Disk[]) => Linode.Disk[]) => ({ type: UPDATE, updateFn });
+
+// REDUCER
+export default (state = defaultState, action: any) => {
+  switch (action.type) {
+
+    case LOAD:
+      return { ...state, loading: true };
+
+    case SUCCESS:
+      return { ...state, loading: false, lastUpdated: Date.now(), data: action.payload };
+
+    case ERROR:
+      return { ...state, loading: false, lastUpdated: Date.now(), error: action.payload };
+
+    case UPDATE:
+      return { ...state, loading: false, lastUpdated: Date.now(), data: action.updateFn(state.data) };
+
+    default:
+      return state;
+  }
+};
+
+// ASYNC
+export const _getLinodeDisks = (linodeId: number): ThunkAction<void, State, void> => (dispatch, getState) => {
+  dispatch(load());
+
+  getLinodeDisks(linodeId)
+    .then(response => dispatch(handleSuccess(response.data)))
+    .catch(error => dispatch(handleError(error)));
+};
+
+// HELPERS

--- a/src/store/reducers/features/linodeDetail/index.ts
+++ b/src/store/reducers/features/linodeDetail/index.ts
@@ -1,11 +1,14 @@
 import { combineReducers } from 'redux';
 
+import disks, { defaultState as defaultDisksState } from './volumes';
 import volumes, { defaultState as defaultVolumesState } from './volumes';
 
 export const defaultState = {
-  volumes: defaultVolumesState
+  volumes: defaultVolumesState,
+  disks: defaultDisksState,
 };
 
 export default combineReducers({
-  volumes
+  disks,
+  volumes,
 });

--- a/src/store/reducers/features/linodeDetail/index.ts
+++ b/src/store/reducers/features/linodeDetail/index.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 
-import disks, { defaultState as defaultDisksState } from './volumes';
+import disks, { defaultState as defaultDisksState } from './disks';
 import volumes, { defaultState as defaultVolumesState } from './volumes';
 
 export const defaultState = {


### PR DESCRIPTION
- Use EnhanceSelect for Disk selection linodes/:id settings PasswordRest (removes context/redux)
- Use Pagey on linodes/:id/settings AdvancedSettings to list Disks. (Adds pagination, removes context/redux)
  - Pagey was updated to pass ownProps (the props of the component being extended) to the request. The request footprint is now `T(ownProps, params, filters) => Promise<T>`.
- Add Disk reducer under `features/linodeDetail/disks` (currently only used on LinodeConfigs)

Part two is to remove the reducer entirely and move configuration creation into the drawer for better performance. 