### PR TITLE
Migration Events

### DIFF
--- a/src/features/ToastNotifications/toasts.ts
+++ b/src/features/ToastNotifications/toasts.ts
@@ -7,6 +7,8 @@ export interface Toast {
   open: boolean;
 }
 
+type Level = 'success' | 'warning' | 'error'
+
 const toast$ = new Subject<Toast>();
 
 let id = 0;
@@ -21,7 +23,7 @@ export const createToast = (message: string, level = 'notice'): Toast => {
   };
 };
 
-export const sendToast = (message: string, level = 'notice'): void => {
+export const sendToast = (message: string, level: Level = 'success'): void => {
   if (!message) { return; }
   toast$.next(createToast(message, level));
 };

--- a/src/features/linodes/events.ts
+++ b/src/features/linodes/events.ts
@@ -13,6 +13,7 @@ export const newLinodeEvents = (mountTime: moment.Moment) =>
     'linode_rebuild',
     'linode_resize',
     'disk_resize',
+    'linode_migrate',
   ];
 
   const statusWhitelist = [


### PR DESCRIPTION
### Purpose

Listen for Migration Events and send toast, regardless of where you are on the site.

And update Linodes if you're on Linodes Landing or Detail

### To Test

Use Charles to give yourself a `linode_migrate` event and change the status to either `started`, `failed`, `finished`, or `scheduled`

Also can use Charles to test out the progress bar. To test, resize a Linode and set a breakpoint for `${API_ROOT}/linodes/instances*` and change the `linode_action` to `migirating`