### PR TITLE
Linode config refactor

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -321,26 +321,27 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
 
         <Grid item xs={12} className={classes.section}>
           <Typography role="header" variant="subheading">Boot Settings</Typography>
-          <TextField
-            label="Kernel"
-            select={true}
-            value={kernel || ''}
-            onChange={this.handleChangeKernel}
-            errorText={errorFor('kernel')}
-            errorGroup="linode-config-drawer"
-          >
-            <MenuItem value="none" disabled><em>Select a Kernel</em></MenuItem>
-            {kernels &&
-              kernels.map(eachKernel =>
-                <MenuItem
-                  // Can't use ID for key until DBA-162 is closed.
-                  key={`${eachKernel.id}-${eachKernel.label}`}
-                  value={eachKernel.id}
-                >
-                  {eachKernel.label}
-                </MenuItem>)
-            }
-          </TextField>
+          {kernels &&
+            <TextField
+              label="Kernel"
+              select={true}
+              value={kernel || 'linode/latest-64bit'}
+              onChange={this.handleChangeKernel}
+              errorText={errorFor('kernel')}
+              errorGroup="linode-config-drawer"
+            >
+              <MenuItem value="none" disabled><em>Select a Kernel</em></MenuItem>
+              {
+                kernels.map(eachKernel =>
+                  <MenuItem
+                    // Can't use ID for key until DBA-162 is closed.
+                    key={`${eachKernel.id}-${eachKernel.label}`}
+                    value={eachKernel.id}
+                  >
+                    {eachKernel.label}
+                  </MenuItem>)
+              }
+            </TextField>}
 
           <FormControl fullWidth component="fieldset">
             <FormLabel

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -210,12 +210,12 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { open, onClose } = this.props;
+    const { open, onClose, linodeConfigId } = this.props;
     const { errors } = this.state;
     const loading = Object.values(this.state.loading).some(v => v === true);
 
     return (
-      <Drawer title="Add Linode Configuration" open={open} onClose={onClose}>
+      <Drawer title={`${ linodeConfigId ? 'Edit' : 'Add'} Linode Configuration`} open={open} onClose={onClose}>
         <Grid container direction="row">
           {this.renderContent(errors, loading)}
         </Grid>

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -115,10 +115,10 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
         network: true,
         updatedb_disabled: true,
       },
-      kernel: '',
+      kernel: 'linode/latest-64bit',
       label: '',
       memory_limit: maxMemory,
-      root_device: '/dev/sba',
+      root_device: '/dev/sda',
       run_level: 'default',
       useCustomRoot: false,
       virt_mode: 'paravirt',
@@ -298,7 +298,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             <TextField
               label="Kernel"
               select={true}
-              value={kernel || 'linode/latest-64bit'}
+              value={kernel}
               onChange={this.handleChangeKernel}
               errorText={errorFor('kernel')}
               errorGroup="linode-config-drawer"
@@ -609,7 +609,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
   requestKernels = () => {
     this.setState({ loading: { ...this.state.loading, kernels: true } });
 
-    // Get first page of kernels.
     return getAllKernels()
       .then((kernels) => {
         this.setState({

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDisks.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDisks.tsx
@@ -161,6 +161,8 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
 
     if (!disks) { return null; }
 
+    if (!disks) { return; }
+
     return (
       <React.Fragment>
         <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 16 }}>

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDisks.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDisks.tsx
@@ -161,8 +161,6 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
 
     if (!disks) { return null; }
 
-    if (!disks) { return; }
-
     return (
       <React.Fragment>
         <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 16 }}>

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -1,6 +1,5 @@
 import { compose, lensPath, set } from 'ramda';
 import * as React from 'react';
-import { connect, MapStateToProps } from 'react-redux';
 
 import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
 
@@ -171,7 +170,6 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
         onChange={this.handlePanelChange}
       >
         {generalError && <Notice text={generalError} error />}
-
           <EnhancedSelect
             label="Disk"
             placeholder="Find a Disk"
@@ -182,7 +180,6 @@ class LinodeSettingsPasswordPanel extends React.Component<CombinedProps, State> 
             onInputChange={this.onInputChange}
             data-qa-select-linode
           />
-
         <PasswordInput
           label="Password"
           value={this.state.value}
@@ -200,18 +197,7 @@ const styled = withStyles(styles, { withTheme: true });
 
 const errorBoundary = PanelErrorBoundary({ heading: 'Reset Root Password' });
 
-interface StateProps {
-  linodeDisks: Linode.Disk[]
-}
-
-const mapStateToProps: MapStateToProps<StateProps, never, ApplicationState> = (state) => ({
-  linodeDisks: state.features.linodeDetail.disks.data || [],
-});
-
-const connected = connect(mapStateToProps);
-
 export default compose(
   errorBoundary,
   styled,
-  connected,
 )(LinodeSettingsPasswordPanel) as React.ComponentType<Props>;

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -1,5 +1,6 @@
 import { compose, lensPath, set } from 'ramda';
 import * as React from 'react';
+import { connect, MapStateToProps } from 'react-redux';
 
 import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
 
@@ -199,7 +200,18 @@ const styled = withStyles(styles, { withTheme: true });
 
 const errorBoundary = PanelErrorBoundary({ heading: 'Reset Root Password' });
 
+interface StateProps {
+  linodeDisks: Linode.Disk[]
+}
+
+const mapStateToProps: MapStateToProps<StateProps, never, ApplicationState> = (state) => ({
+  linodeDisks: state.features.linodeDetail.disks.data || [],
+});
+
+const connected = connect(mapStateToProps);
+
 export default compose(
   errorBoundary,
   styled,
+  connected,
 )(LinodeSettingsPasswordPanel) as React.ComponentType<Props>;

--- a/src/services/linodes.ts
+++ b/src/services/linodes.ts
@@ -213,7 +213,7 @@ export const getAllKernels: (params?: any, filters?: any) => Promise<Linode.Kern
           .map(remainingPages, nextPage =>
             getLinodeKernels({ ...pagination, page: nextPage }, filters).then(response => response.data),
           )
-          .then(pages => pages.reduce((result, nextPage) => [...result, ...nextPage], firstPageData));
+          .then(allPages => allPages.reduce((result, nextPage) => [...result, ...nextPage], firstPageData));
       });
   }
 
@@ -368,7 +368,7 @@ export const getAllLinodeDisks: (linodeId: number, params?: any, filters?: any) 
             listLinodeDisks(linodeId, { ...pagination, page: nextPage }, filters).then(response => response.data.data),
           )
           /** We're given Linode.Volume[][], so we flatten that, and append the first page response. */
-          .then(pages => pages.reduce((result, nextPage) => [...result, ...nextPage], firstPageData));
+          .then(allPages => allPages.reduce((result, nextPage) => [...result, ...nextPage], firstPageData));
       });
   }
 

--- a/src/services/linodes.ts
+++ b/src/services/linodes.ts
@@ -1,6 +1,9 @@
-import { omit } from 'ramda';
-import { API_ROOT } from 'src/constants';
+import * as Bluebird from 'bluebird';
+import { omit, range } from 'ramda';
 import { number, object, string } from 'yup';
+
+import { API_ROOT } from 'src/constants';
+
 import Request, { setData, setMethod, setParams, setURL, setXFilter } from '.';
 
 type Page<T> = Linode.ResourcePage<T>;
@@ -21,6 +24,13 @@ export const rescueLinode = (linodeId: number, devices: RescueRequestObject): Pr
 export const getLinodeConfigs = (id: number) =>
   Request<Page<Config>>(
     setURL(`${API_ROOT}/linode/instances/${id}/configs`),
+    setMethod('GET'),
+  )
+    .then(response => response.data);
+
+export const getLinodeConfig = (linodeId: number, configId: number) =>
+  Request<Config>(
+    setURL(`${API_ROOT}/linode/instances/${linodeId}/configs/${configId}`),
     setMethod('GET'),
   )
     .then(response => response.data);
@@ -176,13 +186,36 @@ export const createLinode = (data: any) =>
   )
     .then(response => response.data);
 
-export const getLinodeKernels = (page: number = 0) =>
+export const getLinodeKernels = (params: any = {}, filters: any = {}) =>
   Request<Page<Linode.Kernel>>(
     setURL(`${API_ROOT}/linode/kernels`),
     setMethod('GET'),
-    setParams({ page }),
+    setParams(params),
+    setXFilter(filters),
   )
     .then(response => response.data);
+
+export const getAllKernels: (params?: any, filters?: any) => Promise<Linode.Kernel[]> =
+  (linodeId, params = {}, filters = {}) => {
+    const pagination = { ...params, page_size: 100 };
+
+    return getLinodeKernels(params, filters)
+      .then(({ data: firstPageData, page, pages }) => {
+
+        // If we only have one page, return it.
+        if (page === pages) { return firstPageData; }
+
+        // Create an iterable list of the remaining pages.
+        const remainingPages = range(page + 1, pages + 1);
+
+        //
+        return Bluebird
+          .map(remainingPages, nextPage =>
+            getLinodeKernels({ ...pagination, page: nextPage }, filters).then(response => response.data),
+          )
+          .then(pages => pages.reduce((result, nextPage) => [...result, ...nextPage], firstPageData));
+      });
+  }
 
 export const getLinodeTypes = () =>
   Request<Page<Type>>(
@@ -293,14 +326,11 @@ export const deleteLinodeConfig = (linodeId: number, configId: number) =>
     setURL(`${API_ROOT}/linode/instances/${linodeId}/configs/${configId}`),
   );
 
-export const updateLinodeConfig = (
-  linodeId: number,
-  configId: number,
-  data: LinodeConfigCreationData,
-) => Request<Config>(
-  setURL(`${API_ROOT}/linode/instances/${linodeId}/configs/${configId}`),
-  setMethod('PUT'),
-  setData(data),
+export const updateLinodeConfig = (linodeId: number, configId: number, data: LinodeConfigCreationData) =>
+  Request<Config>(
+    setURL(`${API_ROOT}/linode/instances/${linodeId}/configs/${configId}`),
+    setMethod('PUT'),
+    setData(data),
   );
 
 export interface LinodeDiskCreationData {
@@ -309,12 +339,39 @@ export interface LinodeDiskCreationData {
   filesystem?: string;
 }
 
-export const listLinodeDisks = (
-  linodeId: number,
-) => Request<Page<Disk>>(
-  setURL(`${API_ROOT}/linode/instances/${linodeId}/disks`),
-  setMethod('GET'),
+export const listLinodeDisks = (linodeId: number, params: any = {}, filters: any = {}) =>
+  Request<Page<Disk>>(
+    setURL(`${API_ROOT}/linode/instances/${linodeId}/disks`),
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filters),
   );
+
+
+export const getAllLinodeDisks: (linodeId: number, params?: any, filters?: any) => Promise<Linode.Disk[]> =
+  (linodeId, params = {}, filters = {}) => {
+    const pagination = { ...params, page_size: 100 };
+
+    return listLinodeDisks(linodeId, pagination, filters)
+      .then(response => response.data)
+      .then(({ data: firstPageData, page, pages }) => {
+
+        // If we only have one page, return it.
+        if (page === pages) { return firstPageData; }
+
+        // Create an iterable list of the remaining pages.
+        const remainingPages = range(page + 1, pages + 1);
+
+        //
+        return Bluebird
+          .map(remainingPages, nextPage =>
+            listLinodeDisks(linodeId, { ...pagination, page: nextPage }, filters).then(response => response.data.data),
+          )
+          /** We're given Linode.Volume[][], so we flatten that, and append the first page response. */
+          .then(pages => pages.reduce((result, nextPage) => [...result, ...nextPage], firstPageData));
+      });
+  }
+
 
 export const createLinodeDisk = (
   linodeId: number,
@@ -323,7 +380,7 @@ export const createLinodeDisk = (
   setURL(`${API_ROOT}/linode/instances/${linodeId}/disks`),
   setMethod('POST'),
   setData(data),
-  );
+);
 
 export const getLinodeDisk = (
   linodeId: number,
@@ -331,7 +388,7 @@ export const getLinodeDisk = (
 ) => Request<Disk>(
   setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}`),
   setMethod('GET'),
-  );
+);
 
 export const updateLinodeDisk = (
   linodeId: number,
@@ -341,7 +398,7 @@ export const updateLinodeDisk = (
   setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}`),
   setMethod('PUT'),
   setData(data),
-  );
+);
 
 const resizeLinodeDiskSchema = object({
   size: number().required().min(1),
@@ -360,7 +417,7 @@ export const deleteLinodeDisk = (
 ) => Request<{}>(
   setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}`),
   setMethod('DELETE'),
-  );
+);
 
 export interface LinodeCloneData {
   // linode_id is missing here beacuse we removed the ability

--- a/src/services/volumes.ts
+++ b/src/services/volumes.ts
@@ -1,3 +1,6 @@
+import * as Bluebird from 'bluebird';
+import { range } from 'ramda';
+
 import { API_ROOT } from 'src/constants';
 
 import Request, { setData, setMethod, setParams, setURL, setXFilter } from './index';
@@ -6,14 +9,37 @@ import Request, { setData, setMethod, setParams, setURL, setXFilter } from './in
 type Page<T> = Linode.ResourcePage<T>;
 type Volume = Linode.Volume;
 
-export const getVolumes = (pagination: any = {}, filters: any = {}) =>
+export const getVolumes = (params: any = {}, filters: any = {}) =>
   Request<Page<Volume>>(
     setURL(`${API_ROOT}/volumes`),
     setMethod('GET'),
-    setParams(pagination),
+    setParams(params),
     setXFilter(filters),
   )
     .then(response => response.data);
+
+export const getAllVolumes: (params?: any, filters?: any) => Promise<Linode.Volume[]> =
+  (params = {}, filters = {}) => {
+    const pagination = { ...params, page_size: 100 };
+
+    return getVolumes(pagination, filters)
+      .then(({ data: firstPageData, page, pages }) => {
+
+        // If we only have one page, return it.
+        if (page === pages) { return firstPageData; }
+
+        // Create an iterable list of the remaining pages.
+        const remainingPages = range(page + 1, pages + 1);
+
+        //
+        return Bluebird
+          .map(remainingPages, nextPage =>
+            getVolumes({ ...pagination, page: nextPage }, filters).then(response => response.data),
+          )
+          /** We're given Linode.Volume[][], so we flatten that, and append the first page response. */
+          .then(volumePages => volumePages.reduce((result, nextPage) => [...result, ...nextPage], firstPageData));
+      });
+  }
 
 export const attachVolume = (volumeId: number, payload: {
   linode_id: number,
@@ -22,7 +48,7 @@ export const attachVolume = (volumeId: number, payload: {
   setURL(`${API_ROOT}/volumes/${volumeId}/attach`),
   setMethod('POST'),
   setData(payload),
-  );
+);
 
 export const detachVolume = (volumeId: number) => Request<{}>(
   setURL(`${API_ROOT}/volumes/${volumeId}/detach`),

--- a/src/utilities/createStringsFromDevices/createStringsFromDevices.ts
+++ b/src/utilities/createStringsFromDevices/createStringsFromDevices.ts
@@ -6,6 +6,10 @@ const rdx = (
   result: DevicesAsStrings,
   [key, device]: [string, null | Linode.DiskDevice | Linode.VolumeDevice]) => {
 
+  if (device === null) {
+    return result;
+  }
+
   if (isDisk(device)) {
     return { ...result, [key]: `disk-${device.disk_id}` };
   }
@@ -17,11 +21,11 @@ const rdx = (
   return result;
 };
 
-const isDisk = (d: null | Linode.DiskDevice | Linode.VolumeDevice): d is Linode.DiskDevice => {
-  return d !== null && (d as Linode.DiskDevice).disk_id !== undefined;
+const isDisk = (device: Linode.DiskDevice | Linode.VolumeDevice): device is Linode.DiskDevice => {
+  return typeof (device as Linode.DiskDevice).disk_id === 'number';
 }
-const isVolume = (d: null | Linode.DiskDevice | Linode.VolumeDevice): d is Linode.VolumeDevice => {
-  return d !== null && (d as Linode.VolumeDevice).volume_id !== undefined;
+const isVolume = (device: Linode.DiskDevice | Linode.VolumeDevice): device is Linode.VolumeDevice => {
+  return typeof (device as Linode.VolumeDevice).volume_id === 'number';
 }
 
 export default compose(


### PR DESCRIPTION
Part II of the Linode disks/configs refactor.

- Add get all requests for kernels, volumes, and Linode disks.
- Add get Linode config request.
- Moved creation of Linode config to config drawer.
- Moved editing of Linode config to config drawer.

Also, LinodeConfigs originally used PromiseLoader, context (then Redux). Now they're all removed. Simple requests are made in the CDU lifecycle method.

The drawer uses the presence of linodeConfigId to decide if it's editing or creating.