### PR TITLE
M3-1446 Fix bug in selecting region in VolumeDrawer

### DIFF
--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -461,6 +461,12 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     this.debouncedSearch(inputValue);
   }
 
+  getSelectedLinode = (linodeId: number) => {
+    const { linodes } = this.state;
+    const idx = linodes.findIndex((linode) => Number(linodeId) === Number(linode.value));
+    return idx > -1 ? linodes[idx] : 0;
+  }
+
   renderLinodeOptions = (linodes: Linode.Linode[]) => {
     const { linodeLabel, mode } = this.props;
     if (!linodes) { return []; }
@@ -495,6 +501,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       errors,
       linodes,
       linodesLoading,
+      linodeId,
     } = this.state;
 
     const hasErrorFor = getAPIErrorFor({
@@ -618,6 +625,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
             <EnhancedSelect
               label="Linode"
               placeholder="Select a Linode"
+              value={this.getSelectedLinode(linodeId)}
               isLoading={linodesLoading}
               errorText={linodeError}
               disabled={


### PR DESCRIPTION
Previous refactor caused a(nother) bug in the VolumeDrawer. Change in selected Linode was not being passed to the select component, so it was possible to select a Linode, select a different region, then successfully create a Volume with no warning that the Linode isn't available in that region and is no longer selected.

## To Test
1. Go to /volumes
2. Open the volume creation drawer
3. Choose a region
4. Choose a Linode in that region
5. Change the region
6. Observe: if the Linode is not in the selected region, the Linode select should be cleared. 