### PR TITLE
ActionMenu functional test - fix disabled with tooltip issue

### DIFF
--- a/src/components/ActionMenu/ActionMenu.spec.js
+++ b/src/components/ActionMenu/ActionMenu.spec.js
@@ -45,11 +45,12 @@ describe('Action Menu Suite', () => {
         browser.click(actionMenu);
         
         $(disabledMenuItem).waitForVisible();
+
+        // HACK** REPLACE WITH ACTIONS API
+        browser.moveToObject(tooltipIcon);
+
         expect($(disabledMenuItem).getAttribute('class')).toContain('disabled');
-
         expect($(tooltipIcon).isVisible()).toBe(true);
-        browser.click(tooltipIcon);
-
         expect($(tooltipIcon).getTagName()).toBe('button');
         expect($(tooltip).getText()).toBe('An explanation as to why this item is disabled');
     });


### PR DESCRIPTION
* This test was failing occasionally in CI and locally, i added a deprecated method (only available in Chrome) to hover over the tool tip icon. This reveals the help text as expected. I added a note to replace this code once we upgrade to WebdriverIO v5.

## Running this test:

```bash
yarn storybook
yarn storybook:e2e --story ActionMenu # in another shell
```