### PR TITLE
M3-1445 Linode Detail - Delete modal message not visible in DT

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -70,7 +70,7 @@ class LinodeSettingsDeletPanel extends React.Component<CombinedProps, State> {
           actions={this.renderConfirmationActions}
           open={this.state.open}
         >
-          Deleting a Linode will result in permanent data loss. Are you sure?
+          <Typography>Deleting a Linode will result in permanent data loss. Are you sure?</Typography>
         </ConfirmationDialog>
       </React.Fragment>
     );


### PR DESCRIPTION
Attempting to delete a linode in dark theme mode resulted in the modal message being invisible. This updates the color for dark theme without impacting light theme.

See ticket for testing steps.