### PR TITLE
M3-1031 Disable Password Input Pre-Image Selection

### DIFF
--- a/src/components/AccessPanel/AccessPanel.tsx
+++ b/src/components/AccessPanel/AccessPanel.tsx
@@ -56,9 +56,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 
 const styled = withStyles(styles, { withTheme: true });
 
-interface Disabled {
+export interface Disabled {
   disabled: boolean;
-  reason: string;
+  reason?: string;
 }
 
 interface Props {
@@ -94,6 +94,7 @@ class AccessPanel extends React.Component<CombinedProps> {
       required,
       placeholder,
       users,
+      passwordFieldDisabled,
     } = this.props;
 
     return (
@@ -102,7 +103,8 @@ class AccessPanel extends React.Component<CombinedProps> {
           {error && <Notice text={error} error />}
           <PasswordInput
             required={required}
-            disabledWithReason={this.props.passwordFieldDisabled}
+            disabled={passwordFieldDisabled && passwordFieldDisabled.disabled}
+            disabledReason={passwordFieldDisabled && passwordFieldDisabled.reason}
             value={this.props.password || ''}
             label={label || 'Root Password'}
             placeholder={placeholder || "Enter a password."}

--- a/src/components/AccessPanel/AccessPanel.tsx
+++ b/src/components/AccessPanel/AccessPanel.tsx
@@ -56,6 +56,11 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
 
 const styled = withStyles(styles, { withTheme: true });
 
+interface Disabled {
+  disabled: boolean;
+  reason: string;
+}
+
 interface Props {
   password: string | null;
   error?: string;
@@ -66,6 +71,7 @@ interface Props {
   required?: boolean;
   placeholder?: string;
   users?: UserSSHKeyObject[];
+  passwordFieldDisabled?: Disabled;
 }
 
 export interface UserSSHKeyObject {
@@ -96,6 +102,7 @@ class AccessPanel extends React.Component<CombinedProps> {
           {error && <Notice text={error} error />}
           <PasswordInput
             required={required}
+            disabledWithReason={this.props.passwordFieldDisabled}
             value={this.props.password || ''}
             label={label || 'Root Password'}
             placeholder={placeholder || "Enter a password."}

--- a/src/components/AccessPanel/index.ts
+++ b/src/components/AccessPanel/index.ts
@@ -1,1 +1,1 @@
-export { default, UserSSHKeyObject } from './AccessPanel';
+export { default, UserSSHKeyObject, Disabled } from './AccessPanel';

--- a/src/components/PasswordInput/HideShowText.tsx
+++ b/src/components/PasswordInput/HideShowText.tsx
@@ -12,6 +12,7 @@ interface State {
 
 interface Props extends TextFieldProps {
   required?: boolean;
+  tooltipText?: string;
  }
 
 class HideShowText extends React.Component<Props, State> {

--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -10,15 +10,10 @@ import { Props as TextFieldProps } from 'src/components/TextField';
 import StrengthIndicator from '../PasswordInput/StrengthIndicator';
 import HideShowText from './HideShowText';
 
-interface Disabled {
-  disabled: boolean;
-  reason: string;
-}
-
 interface Props extends TextFieldProps {
   value?: string;
   required?: boolean;
-  disabledWithReason?: Disabled;
+  disabledReason?: string;
 }
 
 interface State {
@@ -64,7 +59,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
 
   render() {
     const { strength } = this.state;
-    const { classes, value, required, disabled, disabledWithReason, ...rest } = this.props;
+    const { classes, value, required, disabledReason, ...rest } = this.props;
 
     return (
       <Grid container className={classes.container}>
@@ -73,8 +68,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
         >
           <HideShowText
             {...rest}
-            tooltipText={(disabledWithReason) && disabledWithReason.reason}
-            disabled={(disabledWithReason) ? disabledWithReason.disabled : disabled}
+            tooltipText={disabledReason}
             value={value}
             onChange={this.onChange}
             fullWidth

--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -10,9 +10,15 @@ import { Props as TextFieldProps } from 'src/components/TextField';
 import StrengthIndicator from '../PasswordInput/StrengthIndicator';
 import HideShowText from './HideShowText';
 
+interface Disabled {
+  disabled: boolean;
+  reason: string;
+}
+
 interface Props extends TextFieldProps {
   value?: string;
   required?: boolean;
+  disabledWithReason?: Disabled;
 }
 
 interface State {
@@ -58,14 +64,18 @@ class PasswordInput extends React.Component<CombinedProps, State> {
 
   render() {
     const { strength } = this.state;
-    const { classes, value, required, ...rest } = this.props;
+    const { classes, value, required, disabled, disabledWithReason, ...rest } = this.props;
 
     return (
       <Grid container className={classes.container}>
-        <Grid item xs={12}>
+        <Grid
+          item xs={12}
+        >
           <HideShowText
-            value={value}
             {...rest}
+            tooltipText={(disabledWithReason) && disabledWithReason.reason}
+            disabled={(disabledWithReason) ? disabledWithReason.disabled : disabled}
+            value={value}
             onChange={this.onChange}
             fullWidth
             required={required}

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -202,6 +202,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
             getTypeInfo={this.getTypeInfo}
             getRegionInfo={this.getRegionInfo}
             history={this.props.history}
+            handleDisablePasswordField={this.handleDisablePasswordField}
           />
         );
       },
@@ -311,6 +312,16 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
       title: selectedRegion.country.toUpperCase(),
       details: selectedRegion.display,
     }
+  }
+
+  handleDisablePasswordField = (imageSelected: boolean) => {
+    if (!imageSelected) {
+      return {
+        disabled: true,
+        reason: 'You must first select an image to enter a root password',
+      }
+    }
+    return;
   }
 
   render() {

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -266,6 +266,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
             history={this.props.history}
             selectedStackScriptFromQuery={this.state.selectedStackScriptIDFromQueryString}
             selectedTabFromQuery={this.state.selectedStackScriptTabFromQueryString}
+            handleDisablePasswordField={this.handleDisablePasswordField}
           />
         );
       },

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
@@ -28,6 +28,7 @@ const mockProps = {
 describe('FromImageContent', () => {
   const componentWithNotice = shallow(
     <FromImageContent
+      handleDisablePasswordField={jest.fn()}
       classes={{ root: '', main: '', sidebar: '' }}
       {...mockProps}
       notice={{
@@ -39,6 +40,7 @@ describe('FromImageContent', () => {
 
   const component = shallow(
     <FromImageContent
+      handleDisablePasswordField={jest.fn()}
       classes={{ root: '', main: '', sidebar: '' }}
       {...mockProps}
     />,

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -129,6 +129,16 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
     this.setState({ privateIP: !this.state.privateIP });
   }
 
+  handleDisablePasswordField = () => {
+    if (!this.state.selectedImageID) {
+      return {
+        disabled: true,
+        reason: 'You must first select an image to enter a root password',
+      }
+    }
+    return;
+  }
+
   getImageInfo = (image: Linode.Image | undefined): Info => {
     return image && {
       title: `${image.vendor || image.label}`,
@@ -257,6 +267,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
             updateFor={[tagObject, label, errors]}
           />
           <AccessPanel
+            passwordFieldDisabled={this.handleDisablePasswordField()}
             error={hasErrorFor('root_pass')}
             password={password}
             handleChange={this.handleTypePassword}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -4,7 +4,7 @@ import { Sticky, StickyProps } from 'react-sticky';
 
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
-import AccessPanel, { UserSSHKeyObject } from 'src/components/AccessPanel';
+import AccessPanel, { Disabled, UserSSHKeyObject } from 'src/components/AccessPanel';
 import CheckoutBar from 'src/components/CheckoutBar';
 import Grid from 'src/components/Grid';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
@@ -54,6 +54,7 @@ interface Props {
   /** Comes from HOC */
   userSSHKeys: UserSSHKeyObject[];
   tagObject: TagObject;
+  handleDisablePasswordField: (imageSelected: boolean) => Disabled | undefined;
 }
 
 interface State {
@@ -127,16 +128,6 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
   handleTogglePrivateIP = () => {
     this.setState({ privateIP: !this.state.privateIP });
-  }
-
-  handleDisablePasswordField = () => {
-    if (!this.state.selectedImageID) {
-      return {
-        disabled: true,
-        reason: 'You must first select an image to enter a root password',
-      }
-    }
-    return;
   }
 
   getImageInfo = (image: Linode.Image | undefined): Info => {
@@ -267,7 +258,8 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
             updateFor={[tagObject, label, errors]}
           />
           <AccessPanel
-            passwordFieldDisabled={this.handleDisablePasswordField()}
+           /* disable the password field if we haven't selected an image */
+            passwordFieldDisabled={this.props.handleDisablePasswordField(!!selectedImageID)}
             error={hasErrorFor('root_pass')}
             password={password}
             handleChange={this.handleTypePassword}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -30,6 +30,7 @@ const mockProps = {
 describe('FromImageContent', () => {
   const componentWithNotice = shallow(
     <FromStackScriptContent
+      handleDisablePasswordField={jest.fn()}
       classes={{
         root: '',
         main: '',
@@ -47,6 +48,7 @@ describe('FromImageContent', () => {
 
   const component = shallow(
     <FromStackScriptContent
+      handleDisablePasswordField={jest.fn()}
       classes={{
         root: '',
         main: '',

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -6,7 +6,7 @@ import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
-import AccessPanel, { UserSSHKeyObject } from 'src/components/AccessPanel';
+import AccessPanel, { Disabled, UserSSHKeyObject } from 'src/components/AccessPanel';
 import CheckoutBar from 'src/components/CheckoutBar';
 import Grid from 'src/components/Grid';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
@@ -77,6 +77,7 @@ interface Props {
   /** Comes from HOC */
   userSSHKeys: UserSSHKeyObject[];
   tagObject: TagObject;
+  handleDisablePasswordField: (imageSelected: boolean) => Disabled | undefined;
 }
 
 interface State {
@@ -207,16 +208,6 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
 
   handleTogglePrivateIP = () => {
     this.setState({ privateIP: !this.state.privateIP });
-  }
-
-  handleDisablePasswordField = () => {
-    if (!this.state.selectedImageID) {
-      return {
-        disabled: true,
-        reason: 'You must first select an image to enter a root password',
-      }
-    }
-    return;
   }
 
   getImageInfo = (image: Linode.Image | undefined): Info => {
@@ -432,7 +423,8 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
             updateFor={[label, tagObject, errors]}
           />
           <AccessPanel
-            passwordFieldDisabled={this.handleDisablePasswordField()}
+            /* disable the password field if we haven't selected an image */
+            passwordFieldDisabled={this.props.handleDisablePasswordField(!!selectedImageID)}
             error={hasErrorFor('root_pass')}
             updateFor={[password, errors, userSSHKeys, selectedImageID]}
             password={password}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -209,6 +209,16 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
     this.setState({ privateIP: !this.state.privateIP });
   }
 
+  handleDisablePasswordField = () => {
+    if (!this.state.selectedImageID) {
+      return {
+        disabled: true,
+        reason: 'You must first select an image to enter a root password',
+      }
+    }
+    return;
+  }
+
   getImageInfo = (image: Linode.Image | undefined): Info => {
     return image && {
       title: `${image.vendor || image.label}`,
@@ -422,6 +432,7 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
             updateFor={[label, tagObject, errors]}
           />
           <AccessPanel
+            passwordFieldDisabled={this.handleDisablePasswordField()}
             error={hasErrorFor('root_pass')}
             updateFor={[password, errors, userSSHKeys, selectedImageID]}
             password={password}


### PR DESCRIPTION
### Purpose

Prevent user from entering a root password on the Linode Creation flow until they first select an image because a root password without an image is meaningless