### PR TITLE
Edit Migration Toasts

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -272,10 +272,6 @@ export class App extends React.Component<CombinedProps, State> {
         if (event.action === 'linode_migrate' && event.status === 'failed') {
           sendToast(`Linode ${migratedLinode!.label} migration failed.`, 'error');
         }
-
-        if (event.action === 'linode_migrate' && event.status === 'scheduled') {
-          sendToast(`Linode ${migratedLinode!.label} scheduled for migration.`);
-        }
       });
 
     if (notifications.beta.get() === 'open') {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -276,17 +276,11 @@ export class App extends React.Component<CombinedProps, State> {
         if (event.action === 'linode_migrate' && event.status === 'scheduled') {
           sendToast(`Linode ${migratedLinode!.label} scheduled for migration.`);
         }
-
-        if (event.action === 'linode_migrate' && event.status === 'started') {
-          sendToast(`Linode ${migratedLinode!.label} migration started.`);
-        }
       });
 
     if (notifications.beta.get() === 'open') {
       this.setState({ betaNotification: true });
     }
-
-
 
     getProfile();
 


### PR DESCRIPTION
### Purpose

Stop toasting on `linode_migrate` events with a status of `started` because they have a percentage, meaning that a toast would appear for each percentage update.