### PR TITLE
M3-1210-close-modals-on-escape

### DIFF
--- a/src/WelcomeBanner.tsx
+++ b/src/WelcomeBanner.tsx
@@ -91,6 +91,7 @@ class WelcomeBanner extends React.Component<CombinedProps, {}> {
         open={this.props.open}
         title="Welcome to the New Cloud Manager!"
         className={classes.dialog}
+        onClose={this.props.onClose}
       >
         <Grid container className={classes.content}>
           <Grid item xs={12}>

--- a/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -23,6 +23,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 interface Props extends DialogProps {
   actions?: (props: any) => JSX.Element;
   error?: string;
+  onClose: () => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -598,6 +598,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
           title="Confirm Cancellation"
           actions={this.renderConfirmCancellationActions}
           open={this.state.cancelBackupsAlertOpen}
+          onClose={this.handleCloseBackupsAlert}
         >
           Cancelling backups associated with this Linode will
            delete all existing backups. Are you sure?

--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -250,6 +250,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
           title={(bootOption === 'reboot') ? 'Confirm Reboot' : 'Powering Off'}
           actions={this.renderActions}
           open={powerAlertOpen}
+          onClose={this.closePowerAlert}
         >
           {bootOption === 'reboot'
             ? <Typography>Are you sure you want to reboot your Linode?</Typography>

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -26,7 +26,7 @@ interface State { open: boolean; }
 
 type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<ClassNames>;
 
-class LinodeSettingsDeletPanel extends React.Component<CombinedProps, State> {
+class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
   state: State = {
     open: false,
   };
@@ -46,6 +46,10 @@ class LinodeSettingsDeletPanel extends React.Component<CombinedProps, State> {
 
   openDeleteDialog = () => {
     this.setState({ open: true });
+  }
+
+  closeDeleteDialog = () => {
+    this.setState({ open: false });
   }
 
   render() {
@@ -69,6 +73,7 @@ class LinodeSettingsDeletPanel extends React.Component<CombinedProps, State> {
           title="Confirm Deletion"
           actions={this.renderConfirmationActions}
           open={this.state.open}
+          onClose={this.closeDeleteDialog}
         >
           <Typography>Deleting a Linode will result in permanent data loss. Are you sure?</Typography>
         </ConfirmationDialog>
@@ -76,11 +81,9 @@ class LinodeSettingsDeletPanel extends React.Component<CombinedProps, State> {
     );
   }
 
-  closeConfirmation = () => this.setState({ open: false })
-
   renderConfirmationActions = () => (
     <ActionsPanel style={{ padding: 0 }}>
-      <Button type="cancel" onClick={this.closeConfirmation} data-qa-cancel-delete>
+      <Button type="cancel" onClick={this.closeDeleteDialog} data-qa-cancel-delete>
         Cancel
       </Button>
       <Button type="secondary" destructive onClick={this.deleteLinode} data-qa-confirm-delete>
@@ -99,4 +102,4 @@ export default compose(
   errorBoundary,
   withRouter,
   styled,
-)(LinodeSettingsDeletPanel) as React.ComponentType<Props>;
+)(LinodeSettingsDeletePanel) as React.ComponentType<Props>;

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -404,6 +404,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           title={(bootOption === 'reboot') ? 'Confirm Reboot' : 'Powering Off'}
           actions={this.renderConfirmationActions}
           open={powerAlertOpen}
+          onClose={this.closePowerAlert}
         >
           <Typography>
             {bootOption === 'reboot'


### PR DESCRIPTION
The material-ui Dialog component, on which our ConfirmationDialog
component is based, is meant to close when the user presses the Esc
key, and includes an onClose handler to provide for this.

Several instancas of ConfirmationDialog in the Manager didn't have
this property, leading ot inconsistent behavior. This commit adds
the onClose prop to these instances (the handler function was already
defined in each case as part of the actions object, so no new functions were
needed). I also made the prop required in the ConfirmationDialog interface
so that future instances of the component will fail the build if a close
function is not included.