### PR TITLE
Test fix - Dismiss welcome modal

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,4 @@ node_modules
 dist
 build
 localStorage.json
-src
-e2e
+e2e/test-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,12 @@ RUN apt-get install -y apt-transport-https ca-certificates
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash
 RUN $HOME/.yarn/bin/yarn install
 
-COPY . .
-
 # Install Deps
+COPY package.json .
+COPY yarn.lock .
+
 RUN yarn
+
+COPY . .
 
 ENTRYPOINT ["yarn"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM node:8.11.2-stretch
 
 WORKDIR /src
 
-COPY . .
-
 RUN apt-get update
 RUN apt-get install -y apt-transport-https ca-certificates
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash
 RUN $HOME/.yarn/bin/yarn install
+
+COPY . .
 
 # Install Deps
 RUN yarn

--- a/Dockerfile-storyshots
+++ b/Dockerfile-storyshots
@@ -12,9 +12,13 @@ RUN apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 lib
   libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
   ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
 
-COPY . .
+# Install Deps
+COPY package.json .
+COPY yarn.lock .
 
 # Install Deps
 RUN yarn
+
+COPY . .
 
 ENTRYPOINT ["yarn", "storyshots"]

--- a/Dockerfile-storyshots
+++ b/Dockerfile-storyshots
@@ -2,8 +2,6 @@ FROM node:8.11.3-stretch
 
 WORKDIR /src
 
-COPY . .
-
 RUN apt-get update
 RUN apt-get install -y apt-transport-https
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash
@@ -13,6 +11,8 @@ RUN apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 lib
   libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 \
   libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
   ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+
+COPY . .
 
 # Install Deps
 RUN yarn

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -48,6 +48,7 @@ exports.config = {
         specsToRun(),
     // Patterns to exclude.
     exclude: [
+        './e2e/specs/accessibility/*.spec.js'
         // 'path/to/excluded/files'
     ],
     //
@@ -256,8 +257,8 @@ exports.config = {
      */
     beforeSuite: function (suite) {
         // Click beta notice button
-        browser.waitForVisible('[data-qa-beta-notice]');
-        browser.click('[data-qa-beta-notice] button');
+        browser.waitForVisible('[data-qa-dialog-content] button');
+        browser.click('[data-qa-dialog-content] button');
     },
     /**
      * Function to be executed before a test (in Mocha/Jasmine) or a step (in Cucumber) starts.

--- a/integration-test.yml
+++ b/integration-test.yml
@@ -4,13 +4,10 @@ services:
     image: selenium/standalone-chrome:3.13.0-argon
     volumes:
       - /dev/shm:/dev/shm #Mitigates the Chromium issue described at https://code.google.com/p/chromium/issues/detail?id=519952
-    networks:
-      - backend
     environment:
       - SCREEN_HEIGHT=1080
       - SCREEN_WIDTH=1600
   manager-local:
-    container_name: manager_local
     environment:
       - HTTPS=true
       - REACT_APP_APP_ROOT=https://manager-local:3000
@@ -21,15 +18,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    volumes:
-      - ./src:/src/src
     entrypoint: ["/src/scripts/start_manager.sh"]
     depends_on:
       - selenium-standalone
-    networks:
-      - backend
   manager-e2e:
-    container_name: manager_e2e
     environment:
       - DOCKER=true
       - REACT_APP_API_ROOT=${REACT_APP_API_ROOT}
@@ -39,12 +31,8 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ./src:/src/src
-      - ./e2e:/src/e2e
+      - ./e2e/test-results:/src/e2e/test-results
     entrypoint: ["./scripts/wait-for-it.sh", "-t", "250", "-s", "manager-local:3000", "--", "yarn","e2e", "--log"]
     depends_on:
       - manager-local
-    networks:
-      - backend
-networks:
-  backend:
+

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "scripts": {
     "axe": "npx wdio ./e2e/config/wdio.axe.conf.js",
-    "docker:e2e": "docker-compose -f integration-test.yml up --build --exit-code-from manager-e2e",
+    "docker:e2e": "docker-compose -f integration-test.yml up --exit-code-from manager-e2e",
     "docker:test": "docker build -f Dockerfile . -t 'manager' && docker run -it --rm -v $(pwd)/src:/src/src manager test",
     "docker:local": "docker build -f Dockerfile . -t 'manager' && docker run -it --rm -p 3000:3000 -v $(pwd)/src:/src/src manager start",
     "docker:storybook": "docker build -f Dockerfile . -t 'storybook' && docker run -it --rm -p 6006:6006 -v $(pwd)/src:/src/src storybook storybook",

--- a/storybook-test.yml
+++ b/storybook-test.yml
@@ -12,7 +12,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ./src:/src/src
+      - ./src/components:/src/src/components
     entrypoint: yarn storybook
     depends_on:
       - selenium-standalone
@@ -26,8 +26,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ./src:/src/src
-      - ./e2e:/src/e2e
+      - ./src/components:/src/src/components
       - ./storybook-test-results:/src/storybook-test-results
       - /etc/passwd:/etc/passwd
       - /etc/group:/etc/group

--- a/storyshots.yml
+++ b/storyshots.yml
@@ -1,28 +1,20 @@
 version: '3.1'
 services:
   manager-storybook:
-    container_name: manager_storybook
     build:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ./src:/src/src
+      - ./src/components:/src/src/components
     entrypoint: ["./scripts/storybook_static.sh"]
-    networks:
-      - backend
   manager-storyshots:
-    container_name: manager_storyshots
     environment:
       - UPDATE=${UPDATE}
     build:
         context: .
         dockerfile: Dockerfile-storyshots
     volumes:
-      - ./src:/src/src
+      - ./src/components:/src/src/components
     depends_on:
       - manager-storybook
     entrypoint: ["./scripts/storyshots_entrypoint.sh"]
-    networks:
-        - backend
-networks:
-  backend:


### PR DESCRIPTION
* Dismiss the welcome modal instead of the beta modal
* Exclude the accessibility tests on normal test runs
* Move `COPY . .` in dockerfiles for more efficient caching of docker image creation. 

## To Test:

* Run a single test or group of tests, observe for each session it dismisses the welcome modal.

### Example
```bash
yarn && yarn start
yarn selenium
yarn e2e --dir profile
```