### PR TITLE
M3-1327 Implement responsive Tabs

### DIFF
--- a/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/src/components/TabbedPanel/TabbedPanel.tsx
@@ -19,7 +19,11 @@ type ClassNames = 'root'
   | 'copy'
   | 'tabs'
   | 'panelBody'
-  | 'caret';
+  | 'caret'
+  | 'button'
+  | 'menu'
+  | 'mobileTabs'
+  | 'mobileTab';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -27,6 +31,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     width: '100%',
     backgroundColor: theme.color.white,
   },
+  button: {
+    marginTop: theme.spacing.unit * 2,
+    '&[aria-expanded]': {
+      background: theme.palette.primary.main,
+      color: theme.color.white,
+    },
+  },
+  menu: {},
   inner: {
     padding: theme.spacing.unit * 3,
   },
@@ -46,6 +58,19 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
     left: 2,
     marginLeft: theme.spacing.unit / 2,
   },
+  mobileTabs: {
+    margin: 0,
+    '& [class*="MuiTabs-flexContainer"]': {
+      flexDirection: 'column',
+    },
+    '& [class*="TabIndicator-root"]': {
+      display: 'none',
+    },
+    '& [class*="MuiTab-wrapper"]': {
+      alignItems: 'flex-start',
+    },
+  },
+  mobileTab: {},
 });
 
 export interface Tab {
@@ -122,45 +147,52 @@ class TabbedPanel extends React.Component<CombinedProps, State> {
                 {tabs.map((tab, idx) => <Tab key={idx} label={tab.title} data-qa-tab={tab.title} />)}
               </Tabs>
             </Hidden>
-            <Hidden mdUp>
-              <Button
-                variant="raised"
-                color="primary"
-                aria-owns={anchorEl ? 'navigate' : undefined}
-                aria-expanded={anchorEl ? true : undefined}
-                aria-haspopup="true"
-                onClick={this.handleClick}
-                // className={classes.button}
-              >
-                {tabText ? tabText : tabs[0].title} {
-                  anchorEl
-                    ? <KeyboardArrowUp className={classes.caret} />
-                    : <KeyboardArrowDown className={classes.caret} />
-                }
-              </Button>
-              <Menu
-                id="navigate"
-                anchorEl={anchorEl}
-                open={Boolean(anchorEl)}
-                onClose={this.handleClose}
-                getContentAnchorEl={undefined}
-                PaperProps={{ square: true }}
-                anchorOrigin={{ vertical: 45, horizontal: 'left' }}
-                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                // className={classes.menu}
-              >
-                <Tabs
-                  value={value}
-                  onChange={this.handleChange}
-                  indicatorColor="primary"
-                  textColor="primary"
-                  className={`${classes.tabs}`}
-                >
-                  {tabs.map((tab, idx) => <Tab key={idx} label={tab.title} data-qa-tab={tab.title} />)}
-                </Tabs>
-              </Menu>
-            </Hidden>
           </AppBar>
+          <Hidden mdUp>
+            <Button
+              type="secondary"
+              aria-owns={anchorEl ? 'navigate' : undefined}
+              aria-expanded={anchorEl ? true : undefined}
+              aria-haspopup="true"
+              onClick={this.handleClick}
+              className={classes.button}
+            >
+              {tabText ? tabText : tabs[0].title} {
+                anchorEl
+                  ? <KeyboardArrowUp className={classes.caret} />
+                  : <KeyboardArrowDown className={classes.caret} />
+              }
+            </Button>
+            <Menu
+              id="navigate"
+              anchorEl={anchorEl}
+              open={Boolean(anchorEl)}
+              onClose={this.handleClose}
+              getContentAnchorEl={undefined}
+              PaperProps={{ square: true }}
+              anchorOrigin={{ vertical: 50, horizontal: 'left' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+              className={classes.menu}
+            >
+              <Tabs
+                value={value}
+                onChange={this.handleChange}
+                indicatorColor="primary"
+                textColor="primary"
+                className={`${classes.mobileTabs}`}
+              >
+                {tabs.map((tab, idx) =>
+                  <Tab
+                    key={idx}
+                    label={tab.title}
+                    data-qa-tab={tab.title}
+                    className={classes.mobileTab}
+                    onClick={this.handleClose}
+                  />
+                )}
+              </Tabs>
+            </Menu>
+          </Hidden>
           <Typography component="div" className={`${classes.panelBody} ${shrinkTabContent}`}
             data-qa-tab-body>
             {render(rest)}

--- a/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/src/components/TabbedPanel/TabbedPanel.tsx
@@ -122,7 +122,7 @@ class TabbedPanel extends React.Component<CombinedProps, State> {
                 {tabs.map((tab, idx) => <Tab key={idx} label={tab.title} data-qa-tab={tab.title} />)}
               </Tabs>
             </Hidden>
-            <Hidden smUp>
+            <Hidden mdUp>
               <Button
                 variant="raised"
                 color="primary"

--- a/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/src/components/TabbedPanel/TabbedPanel.tsx
@@ -1,19 +1,25 @@
 import * as React from 'react';
 
 import AppBar from '@material-ui/core/AppBar';
+import Hidden from '@material-ui/core/Hidden';
+import Menu from '@material-ui/core/Menu';
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, WithStyles, withStyles } from '@material-ui/core/styles';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import Typography from '@material-ui/core/Typography';
+import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
+import KeyboardArrowUp from '@material-ui/icons/KeyboardArrowUp'; 
 
+import Button from 'src/components/Button';
 import Notice from '../Notice';
 
 type ClassNames = 'root'
   | 'inner'
   | 'copy'
   | 'tabs'
-  | 'panelBody';
+  | 'panelBody'
+  | 'caret';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => ({
   root: {
@@ -34,12 +40,25 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme & Linode.Theme) => 
   panelBody: {
     padding: `${theme.spacing.unit * 2}px 0 0`,
   },
+  caret: {
+    position: 'relative',
+    top: 2,
+    left: 2,
+    marginLeft: theme.spacing.unit / 2,
+  },
 });
 
 export interface Tab {
   title: string;
   render: (props: any) => JSX.Element | null;
 }
+
+interface State {
+  anchorEl?: HTMLElement;
+  value: number;
+  tabText: any;
+}
+
 interface Props {
   header: string;
   error?: string;
@@ -54,19 +73,34 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-class TabbedPanel extends React.Component<CombinedProps> {
-  state = { value: this.props.initTab || 0 };
+class TabbedPanel extends React.Component<CombinedProps, State> {
+  state = {
+    anchorEl: undefined,
+    value: this.props.initTab || 0,
+    tabText: '',
+  };
 
   handleChange = (event: React.ChangeEvent<HTMLDivElement>, value: number) => {
     if (this.props.handleTabChange) {
       this.props.handleTabChange();
     }
-    this.setState({ value });
+    this.setState({
+      value,
+      tabText: event.currentTarget.textContent
+    });
+  }
+
+  handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    this.setState({ anchorEl: event.currentTarget });
+  }
+
+  handleClose = () => {
+    this.setState({ anchorEl: undefined });
   }
 
   render() {
     const { classes, header, tabs, shrinkTabContent, copy, error, rootClass, ...rest } = this.props;
-    const { value } = this.state;
+    const { anchorEl, value, tabText } = this.state;
     const render = tabs[value].render;
 
     return (
@@ -77,15 +111,55 @@ class TabbedPanel extends React.Component<CombinedProps> {
           {copy && <Typography component="div" className={classes.copy}
             data-qa-tp-copy>{copy}</Typography>}
           <AppBar position="static" color="default">
-            <Tabs
-              value={value}
-              onChange={this.handleChange}
-              indicatorColor="primary"
-              textColor="primary"
-              className={`${classes.tabs}`}
-            >
-              {tabs.map((tab, idx) => <Tab key={idx} label={tab.title} data-qa-tab={tab.title} />)}
-            </Tabs>
+            <Hidden smDown>
+              <Tabs
+                value={value}
+                onChange={this.handleChange}
+                indicatorColor="primary"
+                textColor="primary"
+                className={`${classes.tabs}`}
+              >
+                {tabs.map((tab, idx) => <Tab key={idx} label={tab.title} data-qa-tab={tab.title} />)}
+              </Tabs>
+            </Hidden>
+            <Hidden smUp>
+              <Button
+                variant="raised"
+                color="primary"
+                aria-owns={anchorEl ? 'navigate' : undefined}
+                aria-expanded={anchorEl ? true : undefined}
+                aria-haspopup="true"
+                onClick={this.handleClick}
+                // className={classes.button}
+              >
+                {tabText ? tabText : tabs[0].title} {
+                  anchorEl
+                    ? <KeyboardArrowUp className={classes.caret} />
+                    : <KeyboardArrowDown className={classes.caret} />
+                }
+              </Button>
+              <Menu
+                id="navigate"
+                anchorEl={anchorEl}
+                open={Boolean(anchorEl)}
+                onClose={this.handleClose}
+                getContentAnchorEl={undefined}
+                PaperProps={{ square: true }}
+                anchorOrigin={{ vertical: 45, horizontal: 'left' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                // className={classes.menu}
+              >
+                <Tabs
+                  value={value}
+                  onChange={this.handleChange}
+                  indicatorColor="primary"
+                  textColor="primary"
+                  className={`${classes.tabs}`}
+                >
+                  {tabs.map((tab, idx) => <Tab key={idx} label={tab.title} data-qa-tab={tab.title} />)}
+                </Tabs>
+              </Menu>
+            </Hidden>
           </AppBar>
           <Typography component="div" className={`${classes.panelBody} ${shrinkTabContent}`}
             data-qa-tab-body>


### PR DESCRIPTION
to be tested in story book for TabbedPanel and their implementation through the /linode/create panes.

if approved, will need to be ported to the main tabs (linode details, users etc) and this would probably need an abstraction as they are not using the TabbedPanel. I did not want to build the abstraction until this POC was approved, and not sure we can actually do that considering the router implication.