### PR TITLE
M3-1407 Error when user has no public IPs

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -12,6 +12,7 @@ import ExpansionPanel from 'src/components/ExpansionPanel';
 import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
 import MenuItem from 'src/components/MenuItem';
+import RenderGuard from 'src/components/RenderGuard';
 import Select from 'src/components/Select';
 import TextField from 'src/components/TextField';
 import { getLinodes } from 'src/services/linodes';
@@ -248,7 +249,7 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
       submitting: true,
     })
     shareAddresses({ linode_id: this.props.linodeID, ips: finalIPs })
-      .then((response) => {
+      .then((_) => {
         this.props.refreshIPs();
         if (!this.mounted) { return ;}
         this.setState({
@@ -271,6 +272,7 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
     if (!this.mounted) { return ;}
     this.setState({
       errors: undefined,
+      successMessage: undefined,
       ipsToShare: this.props.linodeSharedIPs,
     })
   }
@@ -357,4 +359,4 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled(IPSharingPanel);
+export default styled(RenderGuard<CombinedProps>(IPSharingPanel));

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -166,7 +166,9 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     return getLinodeIPs(this.props.linodeID)
       .then(ips => this.setState({ linodeIPs: ips }))
       .catch((errors) => {
-        this.setState({ IPRequestError: errors[0].reason })
+        const IPRequestError = pathOr('There was an error retrieving your network information.',
+          ['reason'], errors[0]);
+        this.setState({ IPRequestError });
       });
   }
 

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -85,6 +85,7 @@ interface IPRowState {
 interface State {
   submitting: boolean;
   loading: boolean;
+  successMessage?: string;
   ips: IPRowState;
   linodes: { id: number, label: string, ips: string[] }[];
   error?: Linode.ApiFieldError[];
@@ -313,7 +314,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<CombinedProps, Sta
   }
 
   onSubmit = () => {
-    this.setState({ submitting: true, error: undefined });
+    this.setState({ submitting: true, error: undefined, successMessage: undefined, });
 
     assignAddresses(
       createRequestData(this.state.ips, this.props.linodeRegion),
@@ -324,7 +325,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<CombinedProps, Sta
           this.getLinodes()
         ])
           .then(() => {
-            this.setState({ submitting: false, error: undefined })
+            this.setState({ submitting: false, error: undefined, successMessage: 'IP transferred successfully.' })
           })
           .catch(() => {
             this.setState({ error: [{ field: 'none', reason: 'Unable to refresh IPs. Please reload the screen.' }] })
@@ -350,6 +351,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<CombinedProps, Sta
   onReset = () => {
     this.setState({
       error: undefined,
+      successMessage: undefined,
       ips: this.props.ipAddresses.reduce((state, ip) => ({
         ...state,
         [ip]: LinodeNetworkingIPTransferPanel.defaultState(ip, this.props.linodeID),
@@ -412,12 +414,13 @@ class LinodeNetworkingIPTransferPanel extends React.Component<CombinedProps, Sta
 
   render() {
     const { classes } = this.props;
-    const { ips, error } = this.state;
+    const { ips, error, successMessage } = this.state;
 
     return (
       <ExpansionPanel
         heading="IP Transfer"
         actions={this.transferActions}
+        success={successMessage}
         data-qa-networking-actions-subheading
       >
         <Grid container>


### PR DESCRIPTION
* LinodeNetworking was checking to make sure linodeIPs was defined
after network request, but this returned true if the response was
an empty object/array, bypassing the check and resulting in a crash.
Added an ErrorState and checked using the isEmpty function from Ramda.

* Added IPRequestError to the catch method of refreshIps and added that
error to the ErrorState

* Added RenderGuard to IPSharingPanel (the select was going out of sync
for a second after submit)

* Refactored repeated .map() calls in LinodeNetworking's render

* Added success message to IPTransferPanel

* Add additional error handling

## To Test

1. Go to the Networking tab of a Linode
2. Use Charles to empty out the response to linode/instances/$id/ips
3. This crashes currently, you should see an ErrorState on this branch.


## Notes
ARB-909 has been logged; if you try to remove all shared IPs from a Linode nothing will actually happen.