### PR TITLE
M3-1490 Text overflow Adjustments

### DIFF
--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -40,6 +40,7 @@ const styles: StyleRulesCallback = (theme) => ({
     display: 'inline-block',
     borderBottom: '2px dotted transparent',
     transition: theme.transitions.create(['opacity']),
+    wordBreak: 'break-all',
   },
   container: {
     display: 'inline-flex',

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -40,6 +40,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   data: {
     [theme.breakpoints.down('sm')]: {
       textAlign: 'right',
+      wordBreak: 'break-all',
       marginLeft: theme.spacing.unit * 3,
     },
   },

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -23,7 +23,8 @@ import DashboardCard from '../DashboardCard';
 type ClassNames =
   'root'
   | 'labelCol'
-  | 'actionsCol';
+  | 'actionsCol'
+  | 'domainHeading';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
@@ -33,6 +34,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   actionsCol: {
     width: '10%',
   },
+  domainHeading: {
+    wordBreak: 'break-all',
+  }
 });
 
 interface State {
@@ -146,7 +150,7 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
           <Link to={`/domains/${id}/records`} className={'black nu block'}>
             <Grid container direction="column" spacing={8}>
               <Grid item className="py0">
-                <Typography variant="subheading" data-qa-domain-name>
+                <Typography className={classes.domainHeading} variant="subheading" data-qa-domain-name>
                   {domain}
                 </Typography>
               </Grid>

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -24,7 +24,7 @@ type ClassNames =
   'root'
   | 'labelCol'
   | 'actionsCol'
-  | 'domainHeading';
+  | 'wrapHeader';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
@@ -34,7 +34,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   actionsCol: {
     width: '10%',
   },
-  domainHeading: {
+  wrapHeader: {
     wordBreak: 'break-all',
   }
 });
@@ -150,7 +150,7 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
           <Link to={`/domains/${id}/records`} className={'black nu block'}>
             <Grid container direction="column" spacing={8}>
               <Grid item className="py0">
-                <Typography className={classes.domainHeading} variant="subheading" data-qa-domain-name>
+                <Typography className={classes.wrapHeader} variant="subheading" data-qa-domain-name>
                   {domain}
                 </Typography>
               </Grid>

--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -30,7 +30,8 @@ type ClassNames =
   | 'linodeWrapper'
   | 'labelCol'
   | 'moreCol'
-  | 'actionsCol';
+  | 'actionsCol'
+  | 'wrapHeader';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
@@ -46,6 +47,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   actionsCol: {
     width: '10%',
+  },
+  wrapHeader: {
+    wordBreak: 'break-all',
   },
 });
 
@@ -173,7 +177,7 @@ class LinodesDashboardCard extends React.Component<CombinedProps, State> {
               <Grid item>
                 <Grid container direction="column" spacing={8}>
                   <Grid item className="py0">
-                    <Typography variant="subheading">
+                    <Typography className={classes.wrapHeader} variant="subheading">
                       {label}
                     </Typography>
                   </Grid>

--- a/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -26,7 +26,8 @@ type ClassNames =
   'root'
   | 'labelCol'
   | 'moreCol'
-  | 'actionsCol';
+  | 'actionsCol'
+  | 'wrapHeader';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
@@ -38,6 +39,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   actionsCol: {
     width: '10%',
+  },
+  wrapHeader: {
+    wordBreak: 'break-all',
   },
 });
 
@@ -150,7 +154,7 @@ class NodeBalancersDashboardCard extends React.Component<CombinedProps, State> {
           <Link to={`/nodebalancers/${id}`} className="black nu block">
             <Grid container direction="column" spacing={8}>
               <Grid item className="py0">
-                <Typography variant="subheading">
+                <Typography className={classes.wrapHeader} variant="subheading">
                   {label}
                 </Typography>
               </Grid>

--- a/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
@@ -26,7 +26,8 @@ type ClassNames =
   'root'
   | 'labelCol'
   | 'moreCol'
-  | 'actionsCol';
+  | 'actionsCol'
+  | 'wrapHeader';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
@@ -38,6 +39,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   actionsCol: {
     width: '10%',
+  },
+  wrapHeader: {
+    wordBreak: 'break-all',
   },
 });
 
@@ -149,7 +153,7 @@ class VolumesDashboardCard extends React.Component<CombinedProps, State> {
         <TableCell className={classes.labelCol}>
           <Grid container direction="column" spacing={8}>
             <Grid item className="py0">
-              <Typography variant="subheading">
+              <Typography className={classes.wrapHeader} variant="subheading">
                 {label}
               </Typography>
             </Grid>

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -41,6 +41,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   titleWrapper: {
     display: 'flex',
     alignItems: 'center',
+    wordBreak: 'break-all',
   },
   backButton: {
     margin: '2px 0 0 -16px',

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -51,7 +51,8 @@ type CSSClasses =
   | 'flagContainer'
   | 'linkWrapper'
   | 'StatusIndicatorWrapper'
-  | 'link';
+  | 'link'
+  | 'wrapHeader';
 
 const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   customeMQ: {
@@ -78,7 +79,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     height: '100%',
     position: 'relative',
     '& .title': {
-      height: 48,
+      minHeight: 48,
       padding: `0 ${theme.spacing.unit * 3}px`,
     },
   },
@@ -180,6 +181,10 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     display: 'flex',
     alignItems: 'center',
     flex: 1,
+  },
+  wrapHeader: {
+    wordBreak: 'break-all',
+    padding: '20px',
   },
 });
 
@@ -377,7 +382,7 @@ class LinodeCard extends React.Component<CombinedProps, State> {
             <LinodeStatusIndicator status={linodeStatus} />
           </Grid>
           <Grid item className={classes.cardHeader + ' py0'}>
-            <Typography role="header" variant="subheading" data-qa-label>
+            <Typography role="header" className={classes.wrapHeader} variant="subheading" data-qa-label>
               {linodeLabel}
             </Typography>
           </Grid>


### PR DESCRIPTION
See ticket for original request. This grew as instances of styling issues with longer strings were found.

This handles headers in dashboard, headers in card details, and table cells. 

Example of issue (editable text header):
<img width="346" alt="screen shot 2018-10-04 at 3 18 17 pm" src="https://user-images.githubusercontent.com/2565527/46497750-7344db80-c7e9-11e8-9ab7-b1045467af09.png">

On this branch:
<img width="339" alt="screen shot 2018-10-04 at 3 18 10 pm" src="https://user-images.githubusercontent.com/2565527/46497796-9079aa00-c7e9-11e8-94f3-c0a38b47b50c.png">

Please navigate through on varying screen sizes and check longer strings throughout the sections. I'm sure I missed some instances!

