### PR TITLE
M3-1422 - Create Linode from Stackscript w/Tags

### DIFF
--- a/e2e/specs/create/create-from-stackscript-with-tags.spec.js
+++ b/e2e/specs/create/create-from-stackscript-with-tags.spec.js
@@ -1,0 +1,87 @@
+const crypto = require('crypto');
+const { constants } = require('../../constants');
+
+import ListLinodes from '../../pageobjects/list-linodes';
+import ConfigureLinode from '../../pageobjects/configure-linode';
+import { apiDeleteAllLinodes, timestamp } from '../../utils/common';
+
+describe('Create Linode From StackScript - Tags Suite', () => {
+    let existingTag, newTag;
+    const stackConfig = {
+        label: `${new Date().getTime()}-MyStackScript`,
+        description: 'test stackscript example',
+        revisionNote: new Date().getTime(),
+        script: 'bad script',
+    }
+
+    beforeAll(() => {
+        browser.url(constants.routes.create.linode);
+        ConfigureLinode.baseDisplay();
+        ConfigureLinode.createFrom('StackScript');
+        ConfigureLinode.stackScriptsBaseElemsDisplay();
+    });
+
+    afterAll(() => {
+        apiDeleteAllLinodes();
+    });
+
+    it('should display tags select', () => {
+        expect(ConfigureLinode.multiSelect.isVisible()).toBe(true);
+    });
+
+    it('should create a new tag to the linode', () => {
+        newTag = timestamp();
+       
+       // Terrible Selector, but it seems to work for now:
+       ConfigureLinode.multiSelect.$('..').$('input').setValue(newTag);
+       ConfigureLinode.selectOption.waitForVisible(constants.wait.normal);
+       ConfigureLinode.selectOption.click();
+       ConfigureLinode.selectOption.waitForVisible(constants.wait.normal, true);
+       ConfigureLinode.multiOption.waitForVisible(constants.wait.normal);
+       
+       expect(ConfigureLinode.multiOption.getText()).toBe(newTag);
+    });
+
+    it('should add an existing tag to the linode', () => {
+        ConfigureLinode.multiOption.click();
+        existingTag = ConfigureLinode.selectOptions[0].getText();
+        ConfigureLinode.selectOptions[0].click();
+        
+        browser.waitUntil(function() {
+            const tagsAdded = $$(ConfigureLinode.multiOption.selector).length === 2;
+            const tagsIncludeExisting =
+                $$(ConfigureLinode.multiOption.selector)
+                    .map(t => t.getText())
+                    .includes(existingTag);
+            return tagsAdded && tagsIncludeExisting;
+        }, constants.wait.normal);
+    });
+
+    it('should deploy the stackscript with tags', () => {
+        const stackscript = 'StackScript Bash Library';
+        const password = crypto.randomBytes(20).toString('hex');
+        const label = `L${timestamp()}`;
+
+        ConfigureLinode.linodeStackScriptTab.click();
+        ConfigureLinode.progressBar.waitForVisible(constants.wait.normal, true);
+        ConfigureLinode.stackScriptRow.waitForVisible(constants.wait.normal);
+        // Select a stackscript without UDF fields
+        const scriptElem = $$(ConfigureLinode.stackScriptTitle.selector)
+            .filter(el => el.getText().includes(stackscript));
+        scriptElem[0].click();
+        ConfigureLinode.images[0].click();
+        ConfigureLinode.regions[0].click();
+        ConfigureLinode.plans[0].click();
+        ConfigureLinode.label.setValue(label);
+        ConfigureLinode.password.setValue(password);
+        ConfigureLinode.deploy.click();
+        ListLinodes.waitUntilBooted(label);
+    });
+
+    it('should display the tagged linode created from a stackscript on list linodes', () => {
+        const tagsDisplayed = ListLinodes.tags.map(t => t.getText());
+        
+        expect(tagsDisplayed).toContain(existingTag);
+        expect(tagsDisplayed).toContain(newTag);
+    });
+});

--- a/e2e/specs/create/create-linode-from-stackscript.spec.js
+++ b/e2e/specs/create/create-linode-from-stackscript.spec.js
@@ -6,8 +6,7 @@ import { apiDeleteAllLinodes } from '../../utils/common';
 describe('Create Linode - Create from StackScript Suite', () => {
 
     beforeAll(() => {
-        browser.url(constants.routes.linodes);
-        ConfigureLinode.selectGlobalCreateItem('Linode');
+        browser.url(constants.routes.create.linode);
         ConfigureLinode.baseDisplay();
     });
 
@@ -21,7 +20,7 @@ describe('Create Linode - Create from StackScript Suite', () => {
     });
 
     it('should display stackscript table', () => {
-        ConfigureLinode.changeTab('Community StackScripts');
+        ConfigureLinode.changeTab('Linode StackScripts');
         ConfigureLinode.stackScriptTableDisplay();
     });
 
@@ -37,15 +36,17 @@ describe('Create Linode - Create from StackScript Suite', () => {
     });
 
     it('should display an error when creating without selecting a region', () => {
-        const noticeMsg = 'A region selection is required';
+        const linodeScript = 'StackScript Bash Library';
+        const noticeMsg = 'Region is required.';
 
-        ConfigureLinode.stackScriptRows[0].$('[data-qa-radio]').click();
+        $$(ConfigureLinode.stackScriptTitle.selector)
+            .filter(el => el.getText().includes(linodeScript))[0].click();
         ConfigureLinode.deploy.click();
         ConfigureLinode.waitForNotice(noticeMsg);
     });
 
     it('should display an error when creating without selecting a plan', () => {
-        const noticeMsg = 'A plan selection is required';
+        const noticeMsg = 'Plan is required.';
 
         ConfigureLinode.regions[0].click();
         ConfigureLinode.deploy.click();
@@ -54,31 +55,34 @@ describe('Create Linode - Create from StackScript Suite', () => {
 
     it('should display user-defined fields on selection of a stackscript containing UD fields', () => {
         let i = 0;
-        const stackScripts = ConfigureLinode.stackScriptRows;
+        const stackScripts = ConfigureLinode.stackScriptRows
+            .map(s => s.getAttribute('data-qa-table-row'));
         
         while (!ConfigureLinode.userDefinedFieldsHeader.isVisible()) {
-            stackScripts[i].$('[data-qa-radio]').click();
+            browser.jsClick(`[data-qa-table-row="${stackScripts[i]}"]`);
             i++;
         }
     });
 
     it('should create from stackscript', () => {
         ConfigureLinode.plans[0].click();
-        ConfigureLinode.randomPassword();
 
-        const stackScripts = ConfigureLinode.stackScriptRows;
+        const stackScripts = ConfigureLinode.stackScriptRows
+            .map(s => s.getAttribute('data-qa-table-row'));
         let i = 0;
 
         // Select a stackscript that does not have user-defined fields
         while (ConfigureLinode.userDefinedFieldsHeader.isVisible()) {
-            stackScripts[i].$('[data-qa-radio]').click();
+            browser.jsClick(`[data-qa-table-row="${stackScripts[i]}"]`);
             i++;
         }
 
         ConfigureLinode.images[0].click();
         const imageName = ConfigureLinode.images[0].$('[data-qa-select-card-subheading]').getText();
 
+        ConfigureLinode.randomPassword();
         ConfigureLinode.deploy.click();
+        
         browser.waitForVisible('[data-qa-linode]');
         browser.waitForVisible('[data-qa-image]', constants.wait.minute * 3);
 


### PR DESCRIPTION
* Added tests for creating a linode from a stackscript with tags
* Fixed existing test issues for create a linode from stackscript (error messages had been updated and had to adjust the tests to set a password after distro image selection).. I may update the error tests to be more general in their assertions, rather than relying on hardcoded text

## Running the Tests

```bash
yarn && yarn start # Run your typical local env
yarn selenium # run this in a separate shell
yarn e2e:modified #this will run only the tests modified in this PR (add: `--browser=headlessChrome` to run headlessly.. 
```

