### PR TITLE
fix: Prevent full rerender during theme switching.

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -13,6 +13,12 @@ it('renders without crashing', () => {
       <Provider store={store}>
         <StaticRouter location="/" context={{}}>
           <App
+            location={{
+              pathname: '',
+              hash: '',
+              search: '',
+              state: {},
+            }}
             classes={{
               appFrame: '',
               content: '',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { shim } from 'promise.prototype.finally';
 import { lensPath, path, set } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Redirect, Route, RouteProps, Switch } from 'react-router-dom';
 import { Sticky, StickyContainer, StickyProps } from 'react-sticky';
 import { compose } from 'redux';
 import { Subscription } from 'rxjs/Subscription';
@@ -156,6 +156,7 @@ const styles: StyleRulesCallback = (theme) => ({
 
 interface Props {
   toggleTheme: () => void;
+  location: RouteProps['location'];
 }
 
 interface State {

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -16,6 +16,12 @@ class LinodeThemeWrapper extends React.Component<{}, State> {
     themeChoice: 'light',
   };
 
+  componentDidUpdate() {
+    setTimeout(() => {
+      document.body.classList.remove('no-transition');
+    }, 500)
+  }
+
   componentDidMount() {
     if (themeStorage.get() === 'dark') {
       return this.setState({ themeChoice: 'dark' });
@@ -25,6 +31,7 @@ class LinodeThemeWrapper extends React.Component<{}, State> {
   }
 
   toggleTheme = () => {
+    document.body.classList.add('no-transition');
     if (this.state.themeChoice === 'light') {
       this.setState({ themeChoice: 'dark' });
       themeStorage.set('dark');

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -5,11 +5,8 @@ import { MuiThemeProvider } from '@material-ui/core/styles';
 import { dark, light } from 'src/themes';
 import { theme as themeStorage } from 'src/utilities/storage';
 
-import { init } from './events';
-
 interface State {
   themeChoice: 'light' | 'dark';
-  render: boolean;
 }
 
 const themes = { light, dark }
@@ -17,22 +14,14 @@ const themes = { light, dark }
 class LinodeThemeWrapper extends React.Component<{}, State> {
   state: State = {
     themeChoice: 'light',
-    render: true,
   };
 
   componentDidMount() {
     if (themeStorage.get() === 'dark') {
-      this.setState({
-        themeChoice: 'dark'
-      });
-    }
-    else {
-      this.setState({
-        themeChoice: 'light'
-      });
+      return this.setState({ themeChoice: 'dark' });
     }
 
-    this.forceUpdate();
+    return this.setState({ themeChoice: 'light' });
   }
 
   toggleTheme = () => {
@@ -43,36 +32,15 @@ class LinodeThemeWrapper extends React.Component<{}, State> {
       this.setState({ themeChoice: 'light' });
       themeStorage.set('light');
     }
-
-    /**
-     * This re-renders the "themed" children upon theme change.
-     * It's a workaround for some theme styles not being applied
-     * upon switching the theme. Perhaps when we fully type our
-     * theme using module augmentation, then we can remove this.
-     * For now, it's fine, because switching the theme is rare.
-     */
-    this.setState(
-      { render: false },
-      () => { this.setState({ render: true }); init(); },
-    );
   }
 
   render() {
-    const { themeChoice, render } = this.state;
+    const { themeChoice } = this.state;
     const theme = themes[themeChoice];
     return (
-      <React.Fragment>
-        {render &&
-          <MuiThemeProvider theme={theme}>
-            {React.cloneElement(
-              this.props.children as Linode.TodoAny,
-              {
-                toggleTheme: () => this.toggleTheme(),
-              },
-            )}
-          </MuiThemeProvider>
-        }
-      </React.Fragment>
+      <MuiThemeProvider theme={theme}>
+        {React.cloneElement(this.props.children as any, { toggleTheme: this.toggleTheme })}
+      </MuiThemeProvider>
     );
   }
 }

--- a/src/components/RenderGuard.tsx
+++ b/src/components/RenderGuard.tsx
@@ -1,20 +1,25 @@
 import { equals } from 'ramda';
 import * as React from 'react';
 
-interface Props {
+import { withTheme, WithTheme } from '@material-ui/core/styles';
+
+interface RenderGuardProps {
   updateFor?: any[];
 }
 
 /* tslint:disable-next-line */
-export default function renderGuard<P>(Component: React.ComponentType) {
-  return class ComponentWithRenderGuard extends React.Component<Props & P> {
+const renderGuard = <P extends {}>(Component: React.ComponentType<P & RenderGuardProps>) => {
+  type EnhancedProps = P & RenderGuardProps & WithTheme;
+
+  class ComponentWithRenderGuard extends React.Component<EnhancedProps> {
     static displayName = `WithRenderGuard(${getDisplayName(Component)})`;
 
-    shouldComponentUpdate(nextProps: Props & P) {
+    shouldComponentUpdate(nextProps: EnhancedProps) {
       if (Array.isArray(this.props.updateFor)) {
         // don't update if the values of the updateFor Array are equal
         // this is a deep comparison
-        return !equals(this.props.updateFor, nextProps.updateFor);
+        return !equals(this.props.updateFor, nextProps.updateFor)
+          || this.props.theme.name !== nextProps.theme.name;
       }
       // if updateFor isn't provided, always update (this is React's default behavior)
       return true;
@@ -29,10 +34,13 @@ export default function renderGuard<P>(Component: React.ComponentType) {
       );
     }
   };
+
+  return themed<EnhancedProps>(ComponentWithRenderGuard) as React.ComponentType<P & RenderGuardProps>;
 }
 
-const getDisplayName = (Component: React.ComponentType) => {
-  return Component.displayName ||
-    Component.name ||
-    'Component';
-}
+const themed = withTheme();
+
+const getDisplayName = (Component: React.ComponentType) =>
+  Component.displayName || Component.name || 'Component';
+
+export default renderGuard;

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -4,7 +4,7 @@ import { equals } from 'ramda';
 
 import * as classNames from 'classnames';
 
-import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
+import { StyleRulesCallback, withStyles, WithStyles, WithTheme } from '@material-ui/core/styles';
 
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
@@ -43,10 +43,12 @@ export interface Props extends TextFieldProps {
   expand?: boolean;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props
+  & WithTheme
+  & WithStyles<ClassNames>;
 
 class LinodeTextField extends React.Component<CombinedProps> {
-  shouldComponentUpdate(nextProps: Props) {
+  shouldComponentUpdate(nextProps: CombinedProps) {
     return nextProps.value !== this.props.value
       || nextProps.error !== this.props.error
       || nextProps.errorText !== this.props.errorText
@@ -56,7 +58,8 @@ class LinodeTextField extends React.Component<CombinedProps> {
       || nextProps.disabled !== this.props.disabled
       || nextProps.helperText !== this.props.helperText
       || Boolean(this.props.select && nextProps.children !== this.props.children)
-      || !equals(nextProps.InputProps, this.props.InputProps);
+      || !equals(nextProps.InputProps, this.props.InputProps)
+      || nextProps.theme.name !== this.props.theme.name;
   }
 
   render() {

--- a/src/features/StackScripts/StackScriptsLanding.test.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.test.tsx
@@ -2,10 +2,9 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { clearDocs, setDocs } from 'src/store/reducers/documentation';
 
-import { StackScriptsLanding } from './StackScriptsLanding';
-
 import { images } from 'src/__data__/images';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import { StackScriptsLanding } from './StackScriptsLanding';
 
 describe('StackScripts Landing', () => {
   const component = shallow(
@@ -34,7 +33,7 @@ describe('StackScripts Landing', () => {
   });
 
   it('should render SelectStackScriptPanel', () => {
-    expect(component.find('Connect(WithRenderGuard(WithStyles(SelectStackScriptPanel)))'))
+    expect(component.find('Connect(WithTheme(WithRenderGuard(WithStyles(SelectStackScriptPanel))))'))
       .toHaveLength(1);
   });
 });

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.test.tsx
@@ -74,11 +74,16 @@ describe('FromBackupsContent', () => {
   });
 
   describe('FromBackupsContent When Valid Backups Exist', () => {
+    beforeAll(async () => {
+      componentWithNotice.setState({ linodesWithBackups: LinodesWithBackups });
+      await componentWithNotice.update();
+
+      component.setState({ linodesWithBackups: LinodesWithBackups });
+      await component.update();
+    });
 
     it('should render a notice when passed a Notice prop', () => {
       // give our components a Linode with a valid backup
-      componentWithNotice.setState({ linodesWithBackups: LinodesWithBackups });
-      component.setState({ linodesWithBackups: LinodesWithBackups });
       expect(componentWithNotice.find('WithStyles(Notice)')).toHaveLength(1);
     });
 
@@ -87,23 +92,23 @@ describe('FromBackupsContent', () => {
     });
 
     it('should render SelectLinode panel', () => {
-      expect(component.find('WithStyles(WithRenderGuard(SelectLinodePanel))')).toHaveLength(1);
+      expect(component.find('WithStyles(WithTheme(WithRenderGuard(SelectLinodePanel)))')).toHaveLength(1);
     });
 
     it('should render SelectBackup panel', () => {
-      expect(component.find('WithStyles(WithRenderGuard(SelectBackupPanel))')).toHaveLength(1);
+      expect(component.find('WithStyles(WithTheme(WithRenderGuard(SelectBackupPanel)))')).toHaveLength(1);
     });
 
     it('should render SelectPlan panel', () => {
-      expect(component.find('WithStyles(WithRenderGuard(SelectPlanPanel))')).toHaveLength(1);
+      expect(component.find('WithStyles(WithTheme(WithRenderGuard(SelectPlanPanel)))')).toHaveLength(1);
     });
 
     it('should render SelectLabel panel', () => {
-      expect(component.find('WithStyles(WithRenderGuard(InfoPanel))')).toHaveLength(1);
+      expect(component.find('WithStyles(WithTheme(WithRenderGuard(InfoPanel)))')).toHaveLength(1);
     });
 
     it('should render SelectAddOns panel', () => {
-      expect(component.find('WithStyles(WithRenderGuard(AddonsPanel))')).toHaveLength(1);
+      expect(component.find('WithStyles(WithTheme(WithRenderGuard(AddonsPanel)))')).toHaveLength(1);
     });
   });
 });

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
@@ -55,26 +55,26 @@ describe('FromImageContent', () => {
   });
 
   it('should render SelectImage panel', () => {
-    expect(component.find('WithRenderGuard(WithStyles(CreateFromImage))')).toHaveLength(1);
+    expect(component.find('WithTheme(WithRenderGuard(WithStyles(CreateFromImage)))')).toHaveLength(1);
   });
 
   it('should render SelectRegion panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(SelectRegionPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(SelectRegionPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectPlan panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(SelectPlanPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(SelectPlanPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectLabel panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(InfoPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(InfoPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectPassword panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(AccessPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(AccessPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectAddOns panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(AddonsPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(AddonsPanel)))')).toHaveLength(1);
   });
 });

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.test.tsx
@@ -57,26 +57,26 @@ describe('FromImageContent', () => {
 
   it('should render SelectLinode panel', () => {
     expect(componentWithLinodes
-      .find('WithStyles(WithRenderGuard(SelectLinodePanel))')).toHaveLength(1);
-  });
+      .find('WithStyles(WithTheme(WithRenderGuard(SelectLinodePanel)))')).toHaveLength(1);
+    });
 
-  it('should render SelectRegion panel', () => {
+    it('should render SelectRegion panel', () => {
     expect(componentWithLinodes.
-      find('WithStyles(WithRenderGuard(SelectRegionPanel))')).toHaveLength(1);
+      find('WithStyles(WithTheme(WithRenderGuard(SelectRegionPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectPlan panel', () => {
     expect(componentWithLinodes
-      .find('WithStyles(WithRenderGuard(SelectPlanPanel))')).toHaveLength(1);
+      .find('WithStyles(WithTheme(WithRenderGuard(SelectPlanPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectLabel panel', () => {
     expect(componentWithLinodes
-      .find('WithStyles(WithRenderGuard(InfoPanel))')).toHaveLength(1);
+      .find('WithStyles(WithTheme(WithRenderGuard(InfoPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectAddOns panel', () => {
     expect(componentWithLinodes
-      .find('WithStyles(WithRenderGuard(AddonsPanel))')).toHaveLength(1);
+      .find('WithStyles(WithTheme(WithRenderGuard(AddonsPanel)))')).toHaveLength(1);
   });
 });

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -69,45 +69,45 @@ describe('FromImageContent', () => {
   });
 
   it('should render SelectStackScript panel', () => {
-    expect(component.find('Connect(WithRenderGuard(WithStyles(SelectStackScriptPanel)))')).toHaveLength(1);
+    expect(component.find('Connect(WithTheme(WithRenderGuard(WithStyles(SelectStackScriptPanel))))')).toHaveLength(1);
   });
 
   it('should render UserDefinedFields panel', () => {
     component.setState({ userDefinedFields: mockUserDefinedFields }); // give us some dummy fields
-    expect(component.find('WithStyles(WithRenderGuard(UserDefinedFieldsPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(UserDefinedFieldsPanel)))')).toHaveLength(1);
   });
 
   it('should not render UserDefinedFields panel if no UDFs', () => {
     component.setState({ userDefinedFields: [] }); // give us some dummy fields
-    expect(component.find('WithStyles(WithRenderGuard(UserDefinedFieldsPanel))')).toHaveLength(0);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(UserDefinedFieldsPanel)))')).toHaveLength(0);
   });
 
   it('should render SelectImage panel if no compatibleImages', () => {
-    expect(component.find('WithRenderGuard(WithStyles(CreateFromImage))')).toHaveLength(0);
+    expect(component.find('WithTheme(WithRenderGuard(WithStyles(CreateFromImage)))')).toHaveLength(0);
   });
 
   it('should render SelectImage panel if no compatibleImages', () => {
     component.setState({ compatibleImages: [{label: 'linode/centos7', is_public: true}] });
-    expect(component.find('WithRenderGuard(WithStyles(CreateFromImage))')).toHaveLength(1);
+    expect(component.find('WithTheme(WithRenderGuard(WithStyles(CreateFromImage)))')).toHaveLength(1);
   });
 
   it('should render SelectRegion panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(SelectRegionPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(SelectRegionPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectPlan panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(SelectPlanPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(SelectPlanPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectLabel panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(InfoPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(InfoPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectPassword panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(AccessPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(AccessPanel)))')).toHaveLength(1);
   });
 
   it('should render SelectAddOns panel', () => {
-    expect(component.find('WithStyles(WithRenderGuard(AddonsPanel))')).toHaveLength(1);
+    expect(component.find('WithStyles(WithTheme(WithRenderGuard(AddonsPanel)))')).toHaveLength(1);
   });
 });

--- a/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
@@ -9,7 +9,7 @@ import { createPromiseLoaderResponse } from 'src/utilities/testHelpers';
 import { ExtendedVolume } from './DeviceSelection';
 import { LinodeRescue } from './LinodeRescue';
 
-describe('LinodeRescue', () => {
+describe.skip('LinodeRescue', () => {
   describe('volumes', () => {
 
     const extendedDisks = disks.map(disk => {

--- a/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
@@ -3,13 +3,12 @@ import * as React from 'react';
 
 import { disks } from 'src/__data__/disks';
 import { volumes } from 'src/__data__/volumes';
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 import { createPromiseLoaderResponse } from 'src/utilities/testHelpers';
 
 import { ExtendedVolume } from './DeviceSelection';
 import { LinodeRescue } from './LinodeRescue';
 
-describe.skip('LinodeRescue', () => {
+describe('LinodeRescue', () => {
   describe('volumes', () => {
 
     const extendedDisks = disks.map(disk => {
@@ -28,30 +27,27 @@ describe.skip('LinodeRescue', () => {
     const volumesAsPromise = createPromiseLoaderResponse(extendedVolumes);
 
     const component = shallow(
-      <LinodeThemeWrapper>
-        <LinodeRescue
-          classes={{
-            root: '',
-            title: '',
-            intro: '',
-          }}
-          disks={disksAsPromise}
-          linodeId={7843027}
-          linodeRegion="us-east"
-          volumes={volumesAsPromise}
-          linodeLabel=""
-        />
-      </LinodeThemeWrapper>,
+      <LinodeRescue
+        classes={{
+          root: '',
+          title: '',
+          intro: '',
+        }}
+        disks={disksAsPromise}
+        linodeId={7843027}
+        linodeRegion="us-east"
+        volumes={volumesAsPromise}
+        linodeLabel=""
+      />
     );
-    const rescueComponent: any = component.find('LinodeRescue').dive();
-    const rescueComponentProps = component.props().children.props.children.props;
+    const rescueComponentProps = component.instance().props;
     it(
       `volumes in the rescue dropdowns should only display volumes
       that are in the same region as the Linode`,
       () => {
         const linodeRegion = rescueComponentProps.linodeRegion;
         let volumesAndLinodeSameRegion = true;
-        rescueComponent
+        component
           .state()
           .devices
           .volumes
@@ -69,7 +65,7 @@ describe.skip('LinodeRescue', () => {
       () => {
         const linodeId = rescueComponentProps.linodeId;
         let volumeCanBeRescued = true;
-        rescueComponent
+        component
           .state()
           .devices
           .volumes

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -9,7 +9,7 @@ import CardContent from '@material-ui/core/CardContent';
 import CardHeader from '@material-ui/core/CardHeader';
 import Divider from '@material-ui/core/Divider';
 import IconButton from '@material-ui/core/IconButton';
-import { StyleRulesCallback, WithStyles, withStyles } from '@material-ui/core/styles';
+import { StyleRulesCallback, withStyles, WithStyles, WithTheme } from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 
@@ -216,9 +216,10 @@ interface TypesContextProps {
 }
 
 type CombinedProps =
-  Props &
-  TypesContextProps &
-  WithStyles<CSSClasses>;
+  & Props
+  & TypesContextProps
+  & WithTheme
+  & WithStyles<CSSClasses>;
 
 class LinodeCard extends React.Component<CombinedProps, State> {
   state: State = {
@@ -246,6 +247,7 @@ class LinodeCard extends React.Component<CombinedProps, State> {
         this.state,
         ['mutationAvailable']
       )
+      || this.props.theme.name !== nextProps.theme.name
   }
 
   componentDidMount() {
@@ -274,7 +276,7 @@ class LinodeCard extends React.Component<CombinedProps, State> {
       category: 'Linode Action Menu Item',
       action: 'Reboot Linode',
     })
-    const { linodeId, linodeLabel, toggleConfirmation} = this.props;
+    const { linodeId, linodeLabel, toggleConfirmation } = this.props;
     toggleConfirmation('reboot', linodeId, linodeLabel);
   }
 
@@ -317,7 +319,7 @@ class LinodeCard extends React.Component<CombinedProps, State> {
       <CardContent className={`${classes.cardContent} ${classes.customeMQ}`}>
         <div>
           <div className={classes.cardSection} data-qa-linode-summary>
-            { typesData && `${displayType(linodeType, typesData || [])}: ` }
+            {typesData && `${displayType(linodeType, typesData || [])}: `}
             {typeLabelDetails(linodeSpecMemory, linodeSpecDisk, linodeSpecVcpus)}
           </div>
           <div className={classes.cardSection} data-qa-region>

--- a/src/features/linodes/LinodesLanding/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow.tsx
@@ -2,7 +2,7 @@ import { compose } from 'ramda';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
-import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
+import { StyleRulesCallback, withStyles, WithStyles, WithTheme } from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 
@@ -144,9 +144,10 @@ interface TypesContextProps {
 }
 
 type CombinedProps =
-  Props &
-  TypesContextProps &
-  WithStyles<ClassNames>;
+  & Props
+  & TypesContextProps
+  & WithTheme
+  & WithStyles<ClassNames>;
 
 class LinodeRow extends React.Component<CombinedProps, State> {
   state: State = {
@@ -174,6 +175,7 @@ class LinodeRow extends React.Component<CombinedProps, State> {
         this.state,
         ['mutationAvailable']
       )
+      || this.props.theme.name !== nextProps.theme.name
   }
 
   componentDidMount() {

--- a/src/index.css
+++ b/src/index.css
@@ -181,3 +181,9 @@ a.black:not(.nu):active {
 .fade-in-table {
   animation: fadeIn .3s ease-in-out;
 }
+
+.no-transition *,
+.no-transition *::before,
+.no-transition *::after {
+  transition: none !important;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import createBrowserHistory from 'history/createBrowserHistory';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route, RouteProps, Switch } from 'react-router-dom';
 
 import { initAnalytics } from 'src/analytics';
 import AuthenticationWrapper from 'src/components/AuthenticationWrapper';
@@ -13,7 +13,6 @@ import 'src/exceptionReporting';
 import Logout from 'src/layouts/Logout';
 import OAuthCallbackPage from 'src/layouts/OAuth';
 import store from 'src/store';
-
 import { sendEvent } from 'src/utilities/analytics';
 import 'src/utilities/createImageBitmap';
 import 'src/utilities/request';
@@ -25,9 +24,6 @@ import './events';
 import './index.css';
 import LinodeThemeWrapper from './LinodeThemeWrapper';
 import { initialize as sessionInitialize, refreshOAuthOnUserInteraction, refreshOAuthToken } from './session';
-
-// import { whyDidYouUpdate } from 'why-did-you-update';
-// whyDidYouUpdate(React);
 
 const Lish = DefaultLoader({
   loader: () => import('src/features/Lish'),
@@ -85,9 +81,9 @@ const renderLish = () =>
  */
 const mock = () => null;
 
-const renderApp = () =>
+const renderApp = (props: RouteProps) =>
   <LinodeThemeWrapper>
-    <App toggleTheme={mock} />
+    <App toggleTheme={mock} location={props.location} />
   </LinodeThemeWrapper>
 
 const renderAuthentication = () =>


### PR DESCRIPTION
## Purpose
The entire component tree was re-renderd when switching themes. It was found that SCU lifecycle methods and the use of "RenderGuard" were preventing certain elements from updating with the appropriate styles.

@Jskobos @martinmckenna Can you have a look at [these tests](https://github.com/linode/manager/compare/develop...rjstires:theme-switch-fix?expand=1#diff-c2450243f3546f95c069a576a6abe599)? They're the only ones I couldn't get working. Maybe you know something I don't.