### PR TITLE
M3-1483 Eliminate the pencil site-wide, use hover/edit state instead

### DIFF
--- a/e2e/pageobjects/linode-detail/linode-detail.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail.page.js
@@ -18,7 +18,7 @@ class LinodeDetail extends Page {
     get setPowerOff() { return $('[data-qa-set-power="powerOff"]'); }
     get setPowerOn() { return $('[data-qa-set-power="powerOn"]'); }
     get linodeLabel() { return $('[data-qa-label]'); }
-    get editLabel() { return $('[data-qa-edit-button]'); }
+    get editLabel() { return $('[data-qa-editable-text]'); }
 
     changeName(name) {
         this.linodeLabel.waitForVisible();

--- a/e2e/specs/create/create-from-stackscript-with-tags.spec.js
+++ b/e2e/specs/create/create-from-stackscript-with-tags.spec.js
@@ -1,0 +1,87 @@
+const crypto = require('crypto');
+const { constants } = require('../../constants');
+
+import ListLinodes from '../../pageobjects/list-linodes';
+import ConfigureLinode from '../../pageobjects/configure-linode';
+import { apiDeleteAllLinodes, timestamp } from '../../utils/common';
+
+describe('Create Linode From StackScript - Tags Suite', () => {
+    let existingTag, newTag;
+    const stackConfig = {
+        label: `${new Date().getTime()}-MyStackScript`,
+        description: 'test stackscript example',
+        revisionNote: new Date().getTime(),
+        script: 'bad script',
+    }
+
+    beforeAll(() => {
+        browser.url(constants.routes.create.linode);
+        ConfigureLinode.baseDisplay();
+        ConfigureLinode.createFrom('StackScript');
+        ConfigureLinode.stackScriptsBaseElemsDisplay();
+    });
+
+    afterAll(() => {
+        apiDeleteAllLinodes();
+    });
+
+    it('should display tags select', () => {
+        expect(ConfigureLinode.multiSelect.isVisible()).toBe(true);
+    });
+
+    it('should create a new tag to the linode', () => {
+        newTag = timestamp();
+       
+       // Terrible Selector, but it seems to work for now:
+       ConfigureLinode.multiSelect.$('..').$('input').setValue(newTag);
+       ConfigureLinode.selectOption.waitForVisible(constants.wait.normal);
+       ConfigureLinode.selectOption.click();
+       ConfigureLinode.selectOption.waitForVisible(constants.wait.normal, true);
+       ConfigureLinode.multiOption.waitForVisible(constants.wait.normal);
+       
+       expect(ConfigureLinode.multiOption.getText()).toBe(newTag);
+    });
+
+    it('should add an existing tag to the linode', () => {
+        ConfigureLinode.multiOption.click();
+        existingTag = ConfigureLinode.selectOptions[0].getText();
+        ConfigureLinode.selectOptions[0].click();
+        
+        browser.waitUntil(function() {
+            const tagsAdded = $$(ConfigureLinode.multiOption.selector).length === 2;
+            const tagsIncludeExisting =
+                $$(ConfigureLinode.multiOption.selector)
+                    .map(t => t.getText())
+                    .includes(existingTag);
+            return tagsAdded && tagsIncludeExisting;
+        }, constants.wait.normal);
+    });
+
+    it('should deploy the stackscript with tags', () => {
+        const stackscript = 'StackScript Bash Library';
+        const password = crypto.randomBytes(20).toString('hex');
+        const label = `L${timestamp()}`;
+
+        ConfigureLinode.linodeStackScriptTab.click();
+        ConfigureLinode.progressBar.waitForVisible(constants.wait.normal, true);
+        ConfigureLinode.stackScriptRow.waitForVisible(constants.wait.normal);
+        // Select a stackscript without UDF fields
+        const scriptElem = $$(ConfigureLinode.stackScriptTitle.selector)
+            .filter(el => el.getText().includes(stackscript));
+        scriptElem[0].click();
+        ConfigureLinode.images[0].click();
+        ConfigureLinode.regions[0].click();
+        ConfigureLinode.plans[0].click();
+        ConfigureLinode.label.setValue(label);
+        ConfigureLinode.password.setValue(password);
+        ConfigureLinode.deploy.click();
+        ListLinodes.waitUntilBooted(label);
+    });
+
+    it('should display the tagged linode created from a stackscript on list linodes', () => {
+        const tagsDisplayed = ListLinodes.tags.map(t => t.getText());
+        
+        expect(tagsDisplayed).toContain(existingTag);
+        expect(tagsDisplayed).toContain(newTag);
+    });
+});

--- a/e2e/specs/create/create-linode-from-stackscript.spec.js
+++ b/e2e/specs/create/create-linode-from-stackscript.spec.js
@@ -6,8 +6,7 @@ import { apiDeleteAllLinodes } from '../../utils/common';
 describe('Create Linode - Create from StackScript Suite', () => {
 
     beforeAll(() => {
-        browser.url(constants.routes.linodes);
-        ConfigureLinode.selectGlobalCreateItem('Linode');
+        browser.url(constants.routes.create.linode);
         ConfigureLinode.baseDisplay();
     });
 
@@ -21,7 +20,7 @@ describe('Create Linode - Create from StackScript Suite', () => {
     });
 
     it('should display stackscript table', () => {
-        ConfigureLinode.changeTab('Community StackScripts');
+        ConfigureLinode.changeTab('Linode StackScripts');
         ConfigureLinode.stackScriptTableDisplay();
     });
 
@@ -37,15 +36,17 @@ describe('Create Linode - Create from StackScript Suite', () => {
     });
 
     it('should display an error when creating without selecting a region', () => {
-        const noticeMsg = 'A region selection is required';
+        const linodeScript = 'StackScript Bash Library';
+        const noticeMsg = 'Region is required.';
 
-        ConfigureLinode.stackScriptRows[0].$('[data-qa-radio]').click();
+        $$(ConfigureLinode.stackScriptTitle.selector)
+            .filter(el => el.getText().includes(linodeScript))[0].click();
         ConfigureLinode.deploy.click();
         ConfigureLinode.waitForNotice(noticeMsg);
     });
 
     it('should display an error when creating without selecting a plan', () => {
-        const noticeMsg = 'A plan selection is required';
+        const noticeMsg = 'Plan is required.';
 
         ConfigureLinode.regions[0].click();
         ConfigureLinode.deploy.click();
@@ -54,31 +55,34 @@ describe('Create Linode - Create from StackScript Suite', () => {
 
     it('should display user-defined fields on selection of a stackscript containing UD fields', () => {
         let i = 0;
-        const stackScripts = ConfigureLinode.stackScriptRows;
+        const stackScripts = ConfigureLinode.stackScriptRows
+            .map(s => s.getAttribute('data-qa-table-row'));
         
         while (!ConfigureLinode.userDefinedFieldsHeader.isVisible()) {
-            stackScripts[i].$('[data-qa-radio]').click();
+            browser.jsClick(`[data-qa-table-row="${stackScripts[i]}"]`);
             i++;
         }
     });
 
     it('should create from stackscript', () => {
         ConfigureLinode.plans[0].click();
-        ConfigureLinode.randomPassword();
 
-        const stackScripts = ConfigureLinode.stackScriptRows;
+        const stackScripts = ConfigureLinode.stackScriptRows
+            .map(s => s.getAttribute('data-qa-table-row'));
         let i = 0;
 
         // Select a stackscript that does not have user-defined fields
         while (ConfigureLinode.userDefinedFieldsHeader.isVisible()) {
-            stackScripts[i].$('[data-qa-radio]').click();
+            browser.jsClick(`[data-qa-table-row="${stackScripts[i]}"]`);
             i++;
         }
 
         ConfigureLinode.images[0].click();
         const imageName = ConfigureLinode.images[0].$('[data-qa-select-card-subheading]').getText();
 
+        ConfigureLinode.randomPassword();
         ConfigureLinode.deploy.click();
+        
         browser.waitForVisible('[data-qa-linode]');
         browser.waitForVisible('[data-qa-image]', constants.wait.minute * 3);
 

--- a/src/components/DateTimeDisplay/DateTimeDisplay.stories.tsx
+++ b/src/components/DateTimeDisplay/DateTimeDisplay.stories.tsx
@@ -1,0 +1,110 @@
+import { storiesOf } from '@storybook/react';
+import * as moment from 'moment-timezone';
+import * as React from 'react';
+
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import RadioGroup from '@material-ui/core/RadioGroup';
+
+import Radio from 'src/components/Radio';
+
+import ThemeDecorator from '../../utilities/storybookDecorators';
+
+import { DateTimeDisplay, TimeInterval } from './DateTimeDisplay';
+
+interface State {
+  time: any;
+  cutoff: TimeInterval;
+}
+
+class Example extends React.Component<{},State> {
+  state: State = {
+    time: moment(),
+    cutoff: 'day',
+  }
+
+  toggleCutoff = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const cutoff: TimeInterval = e.target.value as TimeInterval;
+    this.setState({ cutoff });
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <p>{'Default display: '}
+          <DateTimeDisplay
+            value={"2018-07-20T04:23:17"}
+            timezone={'America/New_York'}
+            classes={{root:''}}
+          />
+        </p>
+        <p>{'You have been on this page since: '}
+          <DateTimeDisplay
+            value={this.state.time}
+            timezone={'America/New_York'}
+            classes={{root:''}}
+            humanizeCutoff={this.state.cutoff}
+          />
+        </p>
+        <p>{'You last checked Slack: '}
+          <DateTimeDisplay
+            value={moment().subtract(5,'minutes').format()}
+            timezone={'America/New_York'}
+            classes={{root:''}}
+            humanizeCutoff={this.state.cutoff}
+          />
+        </p>
+        <p>{'Last Thursday was: '}
+          <DateTimeDisplay
+            value={moment().day(-4).format()}
+            timezone={'America/New_York'}
+            classes={{root:''}}
+            humanizeCutoff={this.state.cutoff}
+          />
+        </p>
+        <p>{'Three Wednesdays ago was: '}
+          <DateTimeDisplay
+            value={moment().day(-25).format()}
+            timezone={'America/New_York'}
+            classes={{root:''}}
+            humanizeCutoff={this.state.cutoff}
+          />
+        </p>
+        <p>{'You were so young '}
+          <DateTimeDisplay
+            value={moment().subtract(11,'months').format()}
+            timezone={'America/New_York'}
+            classes={{root:''}}
+            humanizeCutoff={this.state.cutoff}
+          />
+        </p>
+        <p>{'Elvis was born: '}
+          <DateTimeDisplay
+            value={moment('1-8-1935').format()}
+            timezone={'America/New_York'}
+            classes={{root:''}}
+            humanizeCutoff={this.state.cutoff}
+          />
+        </p>
+        <p>{'humanizeCutoff prop is set to: '}</p>
+        <RadioGroup
+          aria-label="gender"
+          name="gender"
+          value={this.state.cutoff}
+          onChange={this.toggleCutoff}
+        >
+          <FormControlLabel value="day" label="day" control={<Radio />} />
+          <FormControlLabel value="week" label="week" control={<Radio />} />
+          <FormControlLabel value="month" label="month" control={<Radio />} />
+          <FormControlLabel value="year" label="year" control={<Radio />} />
+          <FormControlLabel value="never" label="never" control={<Radio />} />
+        </RadioGroup>
+      </React.Fragment>
+    )
+  }
+}
+
+storiesOf('DateTimeDisplay', module)
+  .addDecorator(ThemeDecorator)
+  .add('Example', () => (
+    <Example />
+  ));

--- a/src/components/DateTimeDisplay/DateTimeDisplay.test.tsx
+++ b/src/components/DateTimeDisplay/DateTimeDisplay.test.tsx
@@ -1,0 +1,51 @@
+import { shallow } from 'enzyme';
+import * as moment from 'moment-timezone';
+import * as React from 'react';
+
+import { DateTimeDisplay } from './DateTimeDisplay';
+
+const APIDate = "2018-07-20T04:23:17";
+
+const component = shallow(
+  <DateTimeDisplay 
+    value={APIDate}
+    timezone={"America/New_York"}
+    classes={{ root: '' }}
+  />)
+
+describe("DateTimeDisplay component", () => {
+  describe("Non-humanized dates", () => {
+    it("should be displayed in 24-hour ISO format", () => {
+      component.setProps({ value: APIDate, humanizeCutoff: undefined })
+      expect(component.text()).toContain('2018-07-20 00:23:17');
+    });
+  });
+
+  describe("Humanized dates", () => {
+    describe("should output humanized strings if the date is earlier than the cutoff", () => {
+      component.setProps({ 
+        value: moment().subtract(5,'minutes'),
+        humanizeCutoff: 'day',
+      });
+      expect(component.text()).toContain('5 minutes ago');
+    });
+    describe("should output ISO strings if the date is older than the cutoff", () => {
+      const almostOneWeek = moment().subtract(6,'days');
+      component.setProps({ 
+        value: almostOneWeek,
+        humanizeCutoff: 'month',
+      });
+      expect(component.text()).toContain('6 days ago');
+      component.setProps({ humanizeCutoff: 'day' });
+      expect(component.text()).toContain(almostOneWeek.year());
+    });
+    describe("should always output formatted text if humanizedCutoff is set to never", () => {
+      const aLongTimeAgo = moment().subtract(10,'years');
+      component.setProps({
+        value: aLongTimeAgo,
+        humanizeCutoff: 'never'
+      });
+      expect(component.text()).toContain('10 years ago');
+    })
+  })
+});

--- a/src/components/DateTimeDisplay/DateTimeDisplay.tsx
+++ b/src/components/DateTimeDisplay/DateTimeDisplay.tsx
@@ -9,28 +9,55 @@ import { ISO_FORMAT } from 'src/constants';
 
 type ClassNames = 'root';
 
+export type TimeInterval = 'day' | 'week' | 'month' | 'year' | 'never';
+
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
 });
 
 export interface Props {
   value: string;
-  format?: string
+  format?: string;
+  humanizeCutoff?: TimeInterval;
 }
 
 type CombinedProps = Props & StateProps & WithStyles<ClassNames>;
 
-const DateTimeDisplay: React.StatelessComponent<CombinedProps> = (props) => {
+const durationMap = {
+  'day': () => moment.duration(1,'days'),
+  'week': () => moment.duration(1,'weeks'),
+  'month': () => moment.duration(1,'months'),
+  'year': () => moment.duration(1,'years'),
+  'never': () => moment.duration(1000,'years'),
+}
+
+const shouldHumanize = (time: any, cutoff?: TimeInterval): boolean => {
+  // If cutoff is not provided, use the default ISO output.
+  if (!cutoff) { return false; }
+  const duration = durationMap[cutoff]();
+  const diff =  moment.duration(moment().diff(time));
+  // Humanize the date if it is earlier than the cutoff:
+  return diff <= duration;
+}
+
+export const DateTimeDisplay: React.StatelessComponent<CombinedProps> = (props) => {
+  let time;
   try {
-    return (
-      <React.Fragment>
-        {moment.utc(props.value).tz(props.timezone).format(props.format || ISO_FORMAT)}
-      </React.Fragment>
-    )
+    // Unknown error was causing this to crash in rare situations.
+    time = moment.utc(props.value).tz(props.timezone);
   }
   catch {
+    // Better to return a blank date than an error or incorrect information.
     return null;
   }
+  const formattedTime = shouldHumanize(time, props.humanizeCutoff)
+    ? time.fromNow()
+    : time.format(props.format || ISO_FORMAT)
+    return (
+      <React.Fragment>
+        {formattedTime}
+      </React.Fragment>
+    )
 };
 
 const styled = withStyles(styles, { withTheme: true });

--- a/src/components/EditableText/EditableText.spec.js
+++ b/src/components/EditableText/EditableText.spec.js
@@ -8,7 +8,7 @@ describe('Editable Text Suite', () => {
 
     const editableTextSelector = '[data-qa-editable-text]';
     const editField = '[data-qa-edit-field]';
-    const editButtonSelector = '[data-qa-edit-button]';
+    //const editButtonSelector = '[data-qa-edit-button]';
     const saveEdit = '[data-qa-save-edit]';
     const cancelEdit = '[data-qa-cancel-edit]';
     const newLabel = 'someNewValue!';
@@ -23,7 +23,7 @@ describe('Editable Text Suite', () => {
     it('should become an editable field on click', () => {
         originalLabel = $(editableTextSelector).getText();
 
-        $(editButtonSelector).click();
+        $(editableTextSelector).click();
         browser.waitForVisible(editField);
     });
 

--- a/src/components/EditableText/EditableText.spec.js
+++ b/src/components/EditableText/EditableText.spec.js
@@ -8,7 +8,6 @@ describe('Editable Text Suite', () => {
 
     const editableTextSelector = '[data-qa-editable-text]';
     const editField = '[data-qa-edit-field]';
-    //const editButtonSelector = '[data-qa-edit-button]';
     const saveEdit = '[data-qa-save-edit]';
     const cancelEdit = '[data-qa-cancel-edit]';
     const newLabel = 'someNewValue!';

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -24,7 +24,8 @@ type ClassNames = 'root'
 | 'save'
 | 'close'
 | 'headline'
-| 'title';
+| 'title'
+| 'editIcon';
 
 const styles: StyleRulesCallback = (theme) => ({
   '@keyframes fadeIn': {
@@ -36,7 +37,7 @@ const styles: StyleRulesCallback = (theme) => ({
     },
   },
   root: {
-    padding: '12px 12px 10px 0',
+    padding: '12px 12px 10px',
     display: 'inline-block',
     borderBottom: '2px dotted transparent',
     transition: theme.transitions.create(['opacity']),
@@ -46,19 +47,32 @@ const styles: StyleRulesCallback = (theme) => ({
     display: 'inline-flex',
     justifyContent: 'flex-start',
     alignItems: 'flex-start',
+    border: '1px solid transparent',
+    '&:hover, &:focus': {
+      border: '1px solid #abadaf',
+    },
   },
   initial: {
     '&:hover, &:focus': {
       '& $root': {
         opacity: .5,
       },
+      '& $editIcon': {
+        visibility: 'visible',
+      },
       '& $icon': {
-        color: theme.palette.primary.light,
+        color: theme.color.grey1,
       },
     },
   },
   edit: {
     fontSize: 22,
+    '& $inputRoot': {
+      borderColor: `${theme.palette.primary.main} !important`,
+    },
+    '&:hover, &:focus': {
+      border: '1px solid transparent',
+    },
   },
   textField: {
     opacity: 0,
@@ -94,13 +108,16 @@ const styles: StyleRulesCallback = (theme) => ({
     fontSize: 26,
   },
   input: {
-    padding: '12px 12px 10px 0',
+    padding: '12px 12px 10px',
   },
   headline: {
     ...theme.typography.headline,
   },
   title: {
     ...theme.typography.title,
+  },
+  editIcon: {
+    visibility: 'hidden',
   },
 });
 
@@ -183,7 +200,7 @@ class EditableText extends React.Component<FinalProps, State> {
                   {text}
                 </Typography>
                 <Button
-                  className={classes.button}
+                  className={`${classes.button} ${classes.editIcon}`}
                   onClick={this.toggleEditing}
                   data-qa-edit-button
                 >

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -37,26 +37,22 @@ const styles: StyleRulesCallback = (theme) => ({
     },
   },
   root: {
-    padding: '12px 12px 10px',
+    padding: '5px 10px',
     display: 'inline-block',
-    borderBottom: '2px dotted transparent',
+    border: '1px solid transparent',
     transition: theme.transitions.create(['opacity']),
     wordBreak: 'break-all',
   },
   container: {
-    display: 'inline-flex',
+    display: 'flex',
     justifyContent: 'flex-start',
-    alignItems: 'flex-start',
+    alignItems: 'center',
+    maxHeight: '48px',
+  },
+  initial: {
     border: '1px solid transparent',
     '&:hover, &:focus': {
       border: '1px solid #abadaf',
-    },
-  },
-  initial: {
-    '&:hover, &:focus': {
-      '& $root': {
-        opacity: .5,
-      },
       '& $editIcon': {
         visibility: 'visible',
       },
@@ -67,30 +63,21 @@ const styles: StyleRulesCallback = (theme) => ({
   },
   edit: {
     fontSize: 22,
-    '& $input': {
-      border: `1px solid ${theme.palette.primary.main} !important`,
-    },
-    '&:hover, &:focus': {
-      border: '1px solid transparent',
-    },
+    border: '1px solid transparent',
+    
+  },
+  inputRoot: {
+    borderColor: `${theme.palette.primary.main} !important`,
   },
   textField: {
     opacity: 0,
     animation: 'fadeIn .3s ease-in-out forwards',
     margin: 0,
   },
-  inputRoot: {
-    borderTop: 0,
-    borderLeft: 0,
-    borderRight: 0,
-    borderBottomWidth: 2,
-    borderBottomStyle: 'dotted',
-    backgroundColor: 'transparent',
-  },
   button: {
     minWidth: 'auto',
     padding: 0,
-    marginTop: 10,
+    marginTop: 0,
     background: 'transparent !important',
   },
   icon: {
@@ -99,7 +86,7 @@ const styles: StyleRulesCallback = (theme) => ({
     transition: theme.transitions.create(['color']),
     '&:hover, &:focus': {
       color: theme.palette.primary.light,
-    },
+    }
   },
   save: {
     fontSize: 26,
@@ -108,7 +95,7 @@ const styles: StyleRulesCallback = (theme) => ({
     fontSize: 26,
   },
   input: {
-    padding: '12px 12px 10px',
+    padding: '5px 10px',
   },
   headline: {
     ...theme.typography.headline,

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -67,8 +67,8 @@ const styles: StyleRulesCallback = (theme) => ({
   },
   edit: {
     fontSize: 22,
-    '& $inputRoot': {
-      borderColor: `${theme.palette.primary.main} !important`,
+    '& $input': {
+      border: `1px solid ${theme.palette.primary.main} !important`,
     },
     '&:hover, &:focus': {
       border: '1px solid transparent',
@@ -202,7 +202,6 @@ class EditableText extends React.Component<FinalProps, State> {
                 <Button
                   className={`${classes.button} ${classes.editIcon}`}
                   onClick={this.toggleEditing}
-                  data-qa-edit-button
                 >
                   <ModeEdit className={`${classes.icon} ${classes.edit}`}/>
                 </Button>

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -67,8 +67,8 @@ const styles: StyleRulesCallback = (theme) => ({
   },
   edit: {
     fontSize: 22,
-    '& $input': {
-      border: `1px solid ${theme.palette.primary.main} !important`,
+    '& $inputRoot': {
+      borderColor: `${theme.palette.primary.main} !important`,
     },
     '&:hover, &:focus': {
       border: '1px solid transparent',

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -67,8 +67,8 @@ const styles: StyleRulesCallback = (theme) => ({
   },
   edit: {
     fontSize: 22,
-    '& $inputRoot': {
-      borderColor: `${theme.palette.primary.main} !important`,
+    '& $input': {
+      border: `1px solid ${theme.palette.primary.main} !important`,
     },
     '&:hover, &:focus': {
       border: '1px solid transparent',

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -110,11 +110,15 @@ class LinodeTextField extends React.Component<CombinedProps> {
             shrink: true,
           }}
           InputProps={{
-            ...finalProps.InputProps,
             disableUnderline: true,
-            className: classNames({
-              [classes.expand]: expand,
-            })}
+            className: classNames(
+              {
+                [classes.expand]: expand,
+              },
+              className,
+            ),
+            ...finalProps.InputProps,
+            }
           }
           SelectProps={{
             IconComponent: KeyboardArrowDown,

--- a/src/features/Support/ExpandableTicketPanel.tsx
+++ b/src/features/Support/ExpandableTicketPanel.tsx
@@ -284,7 +284,7 @@ export class ExpandableTicketPanel extends React.Component<CombinedProps, State>
                 <Grid item>
                   <Typography className={classes.userName}>{data.username}</Typography>
                   {data.from_linode && <Typography variant="body1">Linode Expert</Typography>}
-                  <Typography><DateTimeDisplay value={data.date} /></Typography>
+                  <Typography><DateTimeDisplay value={data.date} humanizeCutoff={'month'} /></Typography>
                   </Grid>
                 </Grid>
               </Grid>

--- a/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
@@ -22,6 +22,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
   titleWrapper: {
     display: 'flex',
+    alignItems: 'center',
     marginTop: 5,
   },
   backButton: {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -521,7 +521,6 @@ const themeDefaults: ThemeOptions = {
         minHeight: 48,
         color: primaryColors.text,
         boxSizing: 'border-box',
-        backgroundColor: 'white',
         [breakpoints.down('xs')]: {
           maxWidth: '100%',
           width: '100%',


### PR DESCRIPTION
Adjustments to editable text states (default, hover, editing states)
 See ticket for details + comps. 

Default:
<img width="205" alt="screen shot 2018-10-08 at 10 46 03 am" src="https://user-images.githubusercontent.com/2565527/46622979-2e2aed00-cafa-11e8-886a-fc86996e5a7a.png">

Hover:
<img width="275" alt="screen shot 2018-10-08 at 10 46 12 am" src="https://user-images.githubusercontent.com/2565527/46622980-2e2aed00-cafa-11e8-9600-c39ee6ea26ab.png">

Actively Editing:
<img width="408" alt="screen shot 2018-10-08 at 10 46 21 am" src="https://user-images.githubusercontent.com/2565527/46622981-2e2aed00-cafa-11e8-985f-2b9b15538ccf.png">
