### PR TITLE
M3-1503 Implement Pagey on Volumes Landing

### DIFF
--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -23,7 +23,7 @@ import TextField from 'src/components/TextField';
 import { withRegions } from 'src/context/regions';
 import { events$, resetEventsPolling } from 'src/events';
 import { sendToast } from 'src/features/ToastNotifications/toasts';
-import { updateVolumes$ } from 'src/features/Volumes/VolumesLanding';
+import { updateVolumes$ } from 'src/features/Volumes/WithEvents';
 import { getLinodeConfigs, getLinodes } from 'src/services/linodes';
 import { cloneVolume, createVolume, resizeVolume, updateVolume, VolumeRequestPayload } from 'src/services/volumes';
 import { close } from 'src/store/reducers/volumeDrawer';

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -498,12 +498,6 @@ const progressFromEvent = (e?: Linode.Event) => {
   return undefined;
 }
 
-const maybeAddEvent = (e: boolean | Linode.Event, volume: Linode.Volume) => {
-  if (typeof e === 'boolean') { return {} };
-  if (!e.entity || e.entity.id !== volume.id) { return {} }
-  return { recentEvent: e };
-};
-
 const mapDispatchToProps = (dispatch: Dispatch<any>) => bindActionCreators(
   { openForEdit, openForResize, openForClone, openForCreating },
   dispatch,

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -1,4 +1,4 @@
-import { compose, equals, pathOr } from 'ramda';
+import { compose, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -22,7 +22,8 @@ import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
-import PaginationFooter, { PaginationProps } from 'src/components/PaginationFooter';
+import paginate, { PaginationProps } from 'src/components/Pagey';
+import PaginationFooter from 'src/components/PaginationFooter';
 import Placeholder from 'src/components/Placeholder';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
@@ -33,7 +34,6 @@ import { getLinodes } from 'src/services/linodes';
 import { deleteVolume, detachVolume, getVolumes } from 'src/services/volumes';
 import { openForClone, openForCreating, openForEdit, openForResize } from 'src/store/reducers/volumeDrawer';
 import { formatRegion } from 'src/utilities';
-import scrollToTop from 'src/utilities/scrollToTop';
 
 import DestructiveVolumeDialog from './DestructiveVolumeDialog';
 import VolumeAttachmentDrawer from './VolumeAttachmentDrawer';
@@ -72,20 +72,21 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   }
 });
 
-interface Props {
+interface ExtendedVolume extends Linode.Volume {
+  linodeLabel: string;
+  linodeStatus: string;
+}
+
+interface Props extends PaginationProps<ExtendedVolume> {
   openForEdit: typeof openForEdit;
   openForResize: typeof openForResize;
   openForClone: typeof openForClone;
   openForCreating: typeof openForCreating;
+  recentEvent?: Linode.Event;
 }
 
-interface State extends PaginationProps {
-  loading: boolean;
-  labelsLoading: boolean;
-  errors?: Linode.ApiFieldError[];
-  volumes: Linode.Volume[];
-  linodeLabels: { [id: number]: string };
-  linodeStatuses: { [id: number]: string };
+interface State {
+  volumes?: ExtendedVolume[];
   configDrawer: {
     open: boolean;
     volumePath?: string;
@@ -108,14 +109,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 class VolumesLanding extends React.Component<CombinedProps, State> {
   state: State = {
-    page: 1,
-    count: 0,
-    pageSize: 25,
     volumes: [],
-    loading: true,
-    labelsLoading: true,
-    linodeLabels: {},
-    linodeStatuses: {},
     configDrawer: {
       open: false,
     },
@@ -149,9 +143,12 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   componentDidMount() {
     this.mounted = true;
 
-    this.getVolumes(undefined, undefined, true);
-
-    this.getLinodeLabels();
+    this.props.request()
+      .then(() => {
+        this.setState({
+          volumes: this.props.data,
+        })
+      });
 
     this.eventsSub = events$
       .filter(event => (
@@ -167,35 +164,22 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
       ))
       .merge(updateVolumes$)
       .subscribe((event) => {
-        this.getVolumes()
-          .then((volumes) => {
-            if (!volumes || !this.mounted) { return; }
+        this.props.request()
+          .then(() => {
+            if (!this.mounted || !this.props.data) { return; }
 
             this.setState({
-              volumes: volumes.map((v) => ({
-                ...v,
-                ...maybeAddEvent(event, v),
-              })),
-            });
+              volumes: this.props.data.map((eachVolume) => ({
+                ...eachVolume,
+                ...maybeAddEvent(event, eachVolume),
+              }))
+            })
           })
-          .catch(() => {
-            /* @todo: how do we want to display this error? */
-          });
       });
   }
 
   componentWillUnmount() {
     this.mounted = false;
-  }
-
-  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
-    /*
-    We just need to know if different volumes are now on the state, so we can compare a list of
-    IDs rather than the whole object.
-    */
-    if (!equals(prevState.volumes.map(v => v.id), this.state.volumes.map(v => v.id))) {
-      this.getLinodeLabels();
-    }
   }
 
   handleCloseConfigDrawer = () => {
@@ -298,10 +282,15 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { classes } = this.props;
-    const { count, loading, labelsLoading } = this.state;
+    const {
+      classes,
+      loading,
+      count,
+      page,
+      pageSize,
+    } = this.props;
 
-    if (loading || labelsLoading) {
+    if (loading) {
       return this.renderLoading();
     }
 
@@ -347,11 +336,11 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           </Table>
         </Paper>
         <PaginationFooter
-          count={this.state.count}
-          page={this.state.page}
-          pageSize={this.state.pageSize}
-          handlePageChange={this.handlePageChange}
-          handleSizeChange={this.handlePageSizeChange}
+          count={count}
+          page={page}
+          pageSize={pageSize}
+          handlePageChange={this.props.handlePageChange}
+          handleSizeChange={this.props.handlePageSizeChange}
         />
         <VolumeConfigDrawer
           open={this.state.configDrawer.open}
@@ -378,15 +367,15 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   }
 
   renderContent = () => {
-    const { errors, volumes, count, linodeLabels, linodeStatuses } = this.state;
+    const { error, data } = this.props;
 
-    if (errors) {
-      return this.renderErrors(errors);
+    if (error) {
+      return this.renderErrors(error);
     }
 
 
-    if (volumes && count > 0) {
-      return this.renderData(volumes, linodeLabels, linodeStatuses);
+    if (data && this.props.count > 0) {
+      return this.renderData(data);
     }
 
     return null;
@@ -396,7 +385,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     return <CircleProgress />;
   };
 
-  renderErrors = (errors: Linode.ApiFieldError[]) => {
+  renderErrors = (errors: Error) => {
     return (
       <TableRowError colSpan={5} message="There was an error loading your volumes." />
     );
@@ -419,11 +408,9 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     );
   };
 
-  renderData = (volumes: Linode.Volume[], linodeLabels: any, linodeStatuses: any) => {
+  renderData = (volumes: ExtendedVolume[]) => {
     return volumes.map((volume) => {
       const label = pathOr('', ['label'], volume);
-      const linodeLabel = volume.linode_id ? linodeLabels[volume.linode_id] : '';
-      const linodeStatus = volume.linode_id ? linodeStatuses[volume.linode_id] : '';
       const size = pathOr('', ['size'], volume);
       const filesystemPath = pathOr(
         /** @todo Remove path default when API releases filesystem_path. */
@@ -446,10 +433,10 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
         : (
           <TableRow key={volume.id} data-qa-volume-cell={volume.id} className="fade-in-table">
             <TableCell parentColumn="Label" data-qa-volume-cell-label>{volume.label}</TableCell>
-            <TableCell parentColumn="Attached To" data-qa-volume-cell-attachment={linodeLabel}>
-              {linodeLabel &&
+            <TableCell parentColumn="Attached To" data-qa-volume-cell-attachment={volume.linodeLabel}>
+              {volume.linodeLabel &&
                 <Link to={`/linodes/${volume.linode_id}`}>
-                  {linodeLabel}
+                  {volume.linodeLabel}
                 </Link>
               }</TableCell>
             <TableCell parentColumn="Size" data-qa-volume-size>{size} GB</TableCell>
@@ -459,7 +446,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
               <VolumesActionMenu
                 onShowConfig={this.handleShowConfig}
                 filesystemPath={filesystemPath}
-                linodeLabel={linodeLabel}
+                linodeLabel={volume.linodeLabel}
                 regionID={regionID}
                 volumeID={volume.id}
                 size={size}
@@ -467,10 +454,10 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                 onEdit={this.handleEdit}
                 onResize={this.handleResize}
                 onClone={this.handleClone}
-                attached={Boolean(linodeLabel)}
+                attached={Boolean(volume.linodeLabel)}
                 onAttach={this.handleAttach}
                 onDetach={this.handleDetach}
-                poweredOff={linodeStatus === 'offline'}
+                poweredOff={volume.linodeStatus === 'offline'}
                 onDelete={this.handleDelete}
               />
             </TableCell>
@@ -478,67 +465,6 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
         );
     });
   };
-
-  getVolumes = (
-    page: number = this.state.page,
-    pageSize: number = this.state.pageSize,
-    initial: boolean = false,
-  ) => {
-
-    if (initial) {
-      this.setState({ loading: true });
-    }
-
-    return getVolumes({ page, page_size: pageSize })
-      .then((response) => {
-        if (!this.mounted) { return response.data; }
-
-        this.setState({
-          count: response.results,
-          page: response.page,
-          loading: false,
-          volumes: response.data,
-        });
-
-        return response.data;
-      })
-      .catch((err) => this.mounted && this.setState({
-        loading: false,
-        errors: pathOr([{ reason: 'Unable to load Volumes.' }], ['response', 'data', 'errors'], err),
-      }));
-  };
-
-  handlePageChange = (page: number) => {
-    this.setState({ page }, () => { this.getVolumes() });
-    scrollToTop();
-  }
-
-  handlePageSizeChange = (pageSize: number) => {
-    this.setState({ pageSize }, () => { this.getVolumes() });
-  }
-
-  getLinodeLabels = () => {
-    const linodeIDs = this.state.volumes.map(volume => volume.linode_id).filter(Boolean);
-    const xFilter = generateInFilter('id', linodeIDs);
-    this.setState({ labelsLoading: true });
-
-    getLinodes(undefined, xFilter)
-      .then((response) => {
-        if (!this.mounted) { return; }
-        const linodeLabels = {};
-        for (const linode of response.data) {
-          linodeLabels[linode.id] = linode.label;
-        }
-        this.setState({ linodeLabels });
-
-        const linodeStatuses = {};
-        for (const linode of response.data) {
-          linodeStatuses[linode.id] = linode.status;
-        }
-        this.setState({ linodeStatuses, labelsLoading: false });
-      })
-      .catch((err) => { /** @todo how do we want to display this error */ });
-  }
 
   closeDestructiveDialog = () => {
     this.setState({
@@ -618,8 +544,62 @@ const styled = withStyles(styles, { withTheme: true });
 
 const documented = setDocs(VolumesLanding.docs);
 
-export default compose<Linode.TodoAny, Linode.TodoAny, Linode.TodoAny, Linode.TodoAny>(
-  connected,
-  documented,
-  styled,
-)(VolumesLanding);
+const updatedRequest = (ownProps: any, params: any, filters: any) => {
+  return getVolumes(params, filters)
+    .then((volumesResponse) => {
+      /*
+       * Iterate over all the volumes data and find the ones that
+       * have a linodeId property that is not null and create an X-Filter
+       * that we can use in the getLinodes() request
+       */
+      const linodeIDs = volumesResponse.data.map(volume => volume.linode_id).filter(Boolean);
+      const xFilter = generateInFilter('id', linodeIDs);
+
+      return getLinodes(undefined, xFilter)
+        .then((linodesResponse) => {
+          const volumesWithLinodeData = volumesResponse.data.map(eachVolume => {
+            /*
+             * Iterate over all the linode data and find a match between
+             * the volumes linode ID and the Linode data id. If there's a match
+             * it means that the Linode is attached to the volume and the Linode
+             * status and label needs needs to be appended to the result data 
+             */
+            for (const eachLinode of linodesResponse.data) {
+              if (eachLinode.id === eachVolume.linode_id) {
+                return {
+                  ...eachVolume,
+                  linodeLabel: eachLinode.label,
+                  linodeStatus: eachLinode.status
+                }
+              }
+            }
+            /*
+             * Otherwise, this volume is not attached to a Linode 
+             */
+            return eachVolume;
+          });
+
+          return {
+            ...volumesResponse,
+            data: volumesWithLinodeData,
+          }
+        })
+        .catch((err) => {
+          /*
+           * If getting the Linode data fails, no problem.
+           * Just return the volumes 
+           */
+          return volumesResponse;
+        });
+    });
+}
+
+const paginated = paginate(updatedRequest);
+
+export default
+  compose<Linode.TodoAny, Linode.TodoAny, Linode.TodoAny, Linode.TodoAny, Linode.TodoAny>(
+    connected,
+    documented,
+    paginated,
+    styled,
+  )(VolumesLanding);

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -3,10 +3,6 @@ import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
-import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/merge';
-import { Subject } from 'rxjs/Subject';
-import { Subscription } from 'rxjs/Subscription';
 
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
@@ -39,11 +35,7 @@ import DestructiveVolumeDialog from './DestructiveVolumeDialog';
 import VolumeAttachmentDrawer from './VolumeAttachmentDrawer';
 import VolumeConfigDrawer from './VolumeConfigDrawer';
 import VolumesActionMenu from './VolumesActionMenu';
-
-
 import WithEvents from './WithEvents';
-
-export const updateVolumes$ = new Subject<boolean>();
 
 type ClassNames = 'root'
   | 'title'
@@ -89,7 +81,6 @@ interface Props extends PaginationProps<ExtendedVolume> {
 }
 
 interface State {
-  volumes?: ExtendedVolume[];
   configDrawer: {
     open: boolean;
     volumePath?: string;
@@ -112,7 +103,6 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 class VolumesLanding extends React.Component<CombinedProps, State> {
   state: State = {
-    volumes: [],
     configDrawer: {
       open: false,
     },
@@ -124,8 +114,6 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
       mode: 'detach',
     },
   };
-
-  eventsSub: Subscription;
 
   mounted: boolean = false;
 

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -367,15 +367,16 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   }
 
   renderContent = () => {
-    const { error, data } = this.props;
+    const { error } = this.props;
+    const { volumes } = this.state;
 
     if (error) {
       return this.renderErrors(error);
     }
 
 
-    if (data && this.props.count > 0) {
-      return this.renderData(data);
+    if (volumes && this.props.count > 0) {
+      return this.renderData(volumes);
     }
 
     return null;
@@ -514,7 +515,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
 const isVolumeUpdating = (e?: Linode.Event) => {
   return e
     && ['volume_attach', 'volume_detach', 'volume_create'].includes(e.action)
-    && ['scheculed', 'started'].includes(e.status);
+    && ['scheduled', 'started'].includes(e.status);
 };
 
 const progressFromEvent = (e?: Linode.Event) => {

--- a/src/features/Volumes/WithEvents.tsx
+++ b/src/features/Volumes/WithEvents.tsx
@@ -105,6 +105,17 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
       this.mounted = false;
     }
 
+    componentDidUpdate(prevProps: any, prevState: any) {
+      /*
+       * If our data returned from Pagey is different from the original data,
+       * it means we either changed pages or page size. In this case, override
+       * whatever state we might have set in the events stream logic 
+       */
+      if (prevProps.data !== this.props.data) {
+        this.setState({ volumes: this.props.data })
+      }
+    }
+
     render() {
       return (
         /* 

--- a/src/features/Volumes/WithEvents.tsx
+++ b/src/features/Volumes/WithEvents.tsx
@@ -41,8 +41,11 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
         .subscribe((event: Linode.Event) => {
           const entityId = event.entity!.id
 
+          /*
+           * If we're deleting a Volume, don't do anything fancy.
+           * Just re-request the page of Volumes 
+           */
           if (event.action === 'volume_delete') {
-            console.log('deleting')
             return this.props.request();
           }
           

--- a/src/features/Volumes/WithEvents.tsx
+++ b/src/features/Volumes/WithEvents.tsx
@@ -40,6 +40,12 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
         .merge(updateVolumes$)
         .subscribe((event: Linode.Event) => {
           const entityId = event.entity!.id
+
+          if (event.action === 'volume_delete') {
+            console.log('deleting')
+            return this.props.request();
+          }
+          
           getVolume(entityId)
             .then((volume: Linode.Volume) => {
               if (!this.mounted || !this.props.data) { return; }
@@ -52,7 +58,12 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
               const targetIndex = (this.state.volumes || this.props.data)
                 .findIndex((eachVolume: Linode.Volume) => {
                   return eachVolume.id === entityId;
-                })
+                });
+
+              // if the volume never appeared in original list of Linodes, no updating needed
+              if (targetIndex === -1) {
+                return;
+              }
 
               /*
                * make a clone of state or prop data, depending on whether if
@@ -60,11 +71,6 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
                * be updating old data
                */
               const clonedVolumes = clone(this.state.volumes || this.props.data);
-
-              // if the volume never appeared in original list of Linodes, no updating needed
-              if (targetIndex === -1) {
-                return;
-              }
 
               /*
                * If the volume has a Linode ID, it means that it's just been

--- a/src/features/Volumes/WithEvents.tsx
+++ b/src/features/Volumes/WithEvents.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Subject } from 'rxjs/Subject';
+import { Subscription } from 'rxjs/Subscription';
+
+import { events$ } from 'src/events';
+
+export const updateVolumes$ = new Subject<boolean>();
+
+interface State {
+  volumes?: Linode.Volume[];
+}
+
+export default () => (WrappedComponent: React.ComponentType<any>) => {
+  return class extends React.Component<any, State> {
+    state: State = {
+      volumes: undefined,
+    }
+    eventsSub: Subscription;
+
+    mounted: boolean = false;
+
+    componentDidMount() {
+      this.mounted = true;
+      this.eventsSub = events$
+        .filter(event => (
+          !event._initial
+          && [
+            'volume_create',
+            'volume_attach',
+            'volume_delete',
+            'volume_detach',
+            'volume_resize',
+            'volume_clone',
+          ].includes(event.action)
+        ))
+        .merge(updateVolumes$)
+        .subscribe((event) => {
+          this.props.request()
+            .then(() => {
+              if (!this.mounted || !this.props.data) { return; }
+
+              this.setState({
+                volumes: this.props.data.map((eachVolume: Linode.Volume) => ({
+                  ...eachVolume,
+                  ...maybeAddEvent(event, eachVolume),
+                }))
+              })
+            })
+        });
+    }
+
+    componentWillMount() {
+      this.mounted = false;
+    }
+
+    render() {
+      return (
+        <WrappedComponent {...this.props} data={this.state.volumes || this.props.data} />
+      )
+    }
+  }
+};
+
+const maybeAddEvent = (e: boolean | Linode.Event, volume: Linode.Volume) => {
+  if (typeof e === 'boolean') { return {} };
+  if (!e.entity || e.entity.id !== volume.id) { return {} }
+  return { recentEvent: e };
+};

--- a/src/features/Volumes/WithEvents.tsx
+++ b/src/features/Volumes/WithEvents.tsx
@@ -44,13 +44,22 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
             .then((volume: Linode.Volume) => {
               if (!this.mounted || !this.props.data) { return; }
 
-              // find the index of the volume we have to update/replace
-              const targetIndex = this.props.data.findIndex((eachVolume: Linode.Volume) => {
-                return eachVolume.id === entityId;
-              })
+              /*
+               * find the index of the volume we have to update/replace, depending on whether if
+               * state exists. This solves the problem where the component would
+               * be updating old data
+               */
+              const targetIndex = (this.state.volumes || this.props.data)
+                .findIndex((eachVolume: Linode.Volume) => {
+                  return eachVolume.id === entityId;
+                })
 
-              // make a clone of it
-              const clonedVolumes = clone(this.props.data);
+              /*
+               * make a clone of state or prop data, depending on whether if
+               * state exists. This solves the problem where the component would
+               * be updating old data
+               */
+              const clonedVolumes = clone(this.state.volumes || this.props.data);
 
               // if the volume never appeared in original list of Linodes, no updating needed
               if (targetIndex === -1) {

--- a/src/services/volumes/index.ts
+++ b/src/services/volumes/index.ts
@@ -1,4 +1,5 @@
 export {
+  getVolume,
   getVolumes,
   getAllVolumes,
   createVolume,

--- a/src/services/volumes/volumes.ts
+++ b/src/services/volumes/volumes.ts
@@ -16,6 +16,13 @@ export interface VolumeRequestPayload {
   linode_id?: number,
 };
 
+export const getVolume = (id: number) =>
+  Request<Volume>(
+    setURL(`${API_ROOT}/volumes/${id}`),
+    setMethod('GET'),
+  )
+    .then(response => response.data);
+
 export const getVolumes = (params: any = {}, filters: any = {}) =>
   Request<Page<Volume>>(
     setURL(`${API_ROOT}/volumes`),


### PR DESCRIPTION
### Purpose

Use Pagey HOC on VolumesLanding instead of tracking pagination inside the component

### Notes

* Created a `WithEvents` HOC component to handle injecting the event data into the updating Volume.
   * Take special notice of the `data` prop passed to it's child. It's either going to be the plain old data it gets from `<Pagey />` or it will pass down augmented data if an event has occurred on a Volume

### Todo
- [ ] Sorting table headers, but I wanted feedback on this PR first