### PR TITLE
M3-1483 Eliminate the pencil site-wide, use hover/edit state instead

### DIFF
--- a/e2e/pageobjects/linode-detail/linode-detail.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail.page.js
@@ -18,7 +18,7 @@ class LinodeDetail extends Page {
     get setPowerOff() { return $('[data-qa-set-power="powerOff"]'); }
     get setPowerOn() { return $('[data-qa-set-power="powerOn"]'); }
     get linodeLabel() { return $('[data-qa-label]'); }
-    get editLabel() { return $('[data-qa-edit-button]'); }
+    get editLabel() { return $('[data-qa-editable-text]'); }
 
     changeName(name) {
         this.linodeLabel.waitForVisible();

--- a/src/components/EditableText/EditableText.spec.js
+++ b/src/components/EditableText/EditableText.spec.js
@@ -8,7 +8,6 @@ describe('Editable Text Suite', () => {
 
     const editableTextSelector = '[data-qa-editable-text]';
     const editField = '[data-qa-edit-field]';
-    const editButtonSelector = '[data-qa-edit-button]';
     const saveEdit = '[data-qa-save-edit]';
     const cancelEdit = '[data-qa-cancel-edit]';
     const newLabel = 'someNewValue!';
@@ -23,7 +22,7 @@ describe('Editable Text Suite', () => {
     it('should become an editable field on click', () => {
         originalLabel = $(editableTextSelector).getText();
 
-        $(editButtonSelector).click();
+        $(editableTextSelector).click();
         browser.waitForVisible(editField);
     });
 

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -24,7 +24,8 @@ type ClassNames = 'root'
 | 'save'
 | 'close'
 | 'headline'
-| 'title';
+| 'title'
+| 'editIcon';
 
 const styles: StyleRulesCallback = (theme) => ({
   '@keyframes fadeIn': {
@@ -36,29 +37,33 @@ const styles: StyleRulesCallback = (theme) => ({
     },
   },
   root: {
-    padding: '12px 12px 10px 0',
+    padding: '5px 10px',
     display: 'inline-block',
-    borderBottom: '2px dotted transparent',
+    border: '1px solid transparent',
     transition: theme.transitions.create(['opacity']),
     wordBreak: 'break-all',
   },
   container: {
-    display: 'inline-flex',
+    display: 'flex',
     justifyContent: 'flex-start',
-    alignItems: 'flex-start',
+    alignItems: 'center',
+    maxHeight: 48,
   },
   initial: {
+    border: '1px solid transparent',
     '&:hover, &:focus': {
-      '& $root': {
-        opacity: .5,
+      border: '1px solid #abadaf',
+      '& $editIcon': {
+        visibility: 'visible',
       },
       '& $icon': {
-        color: theme.palette.primary.light,
+        color: theme.color.grey1,
       },
     },
   },
   edit: {
     fontSize: 22,
+    border: '1px solid transparent',
   },
   textField: {
     opacity: 0,
@@ -66,17 +71,12 @@ const styles: StyleRulesCallback = (theme) => ({
     margin: 0,
   },
   inputRoot: {
-    borderTop: 0,
-    borderLeft: 0,
-    borderRight: 0,
-    borderBottomWidth: 2,
-    borderBottomStyle: 'dotted',
-    backgroundColor: 'transparent',
+    borderColor: `${theme.palette.primary.main} !important`,
   },
   button: {
     minWidth: 'auto',
     padding: 0,
-    marginTop: 10,
+    marginTop: 0,
     background: 'transparent !important',
   },
   icon: {
@@ -94,13 +94,16 @@ const styles: StyleRulesCallback = (theme) => ({
     fontSize: 26,
   },
   input: {
-    padding: '12px 12px 10px 0',
+    padding: '5px 10px',
   },
   headline: {
     ...theme.typography.headline,
   },
   title: {
     ...theme.typography.title,
+  },
+  editIcon: {
+    visibility: 'hidden',
   },
 });
 
@@ -183,7 +186,7 @@ class EditableText extends React.Component<FinalProps, State> {
                   {text}
                 </Typography>
                 <Button
-                  className={classes.button}
+                  className={`${classes.button} ${classes.editIcon}`}
                   onClick={this.toggleEditing}
                   data-qa-edit-button
                 >

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -71,7 +71,12 @@ const styles: StyleRulesCallback = (theme) => ({
     margin: 0,
   },
   inputRoot: {
+    maxWidth: 170,
     borderColor: `${theme.palette.primary.main} !important`,
+    [theme.breakpoints.up('md')]: {
+      maxWidth: 415,
+      width: '100%',
+    },
   },
   button: {
     minWidth: 'auto',

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -110,11 +110,15 @@ class LinodeTextField extends React.Component<CombinedProps> {
             shrink: true,
           }}
           InputProps={{
-            ...finalProps.InputProps,
             disableUnderline: true,
-            className: classNames({
+            className: classNames(
+              {
               [classes.expand]: expand,
-            })}
+              },
+              className,
+            ),
+            ...finalProps.InputProps,
+            }
           }
           SelectProps={{
             IconComponent: KeyboardArrowDown,

--- a/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
@@ -22,6 +22,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
   titleWrapper: {
     display: 'flex',
+    alignItems: 'center',
     marginTop: 5,
   },
   backButton: {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -521,7 +521,6 @@ const themeDefaults: ThemeOptions = {
         minHeight: 48,
         color: primaryColors.text,
         boxSizing: 'border-box',
-        backgroundColor: 'white',
         [breakpoints.down('xs')]: {
           maxWidth: '100%',
           width: '100%',

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -513,7 +513,7 @@ const themeDefaults: ThemeOptions = {
     },
     MuiInput: {
       root: {
-        maxWidth: 415,
+        maxWidth: 170,
         border: '1px solid #ccc',
         alignItems: 'center',
         transition: 'border-color 225ms ease-in-out',
@@ -521,8 +521,8 @@ const themeDefaults: ThemeOptions = {
         minHeight: 48,
         color: primaryColors.text,
         boxSizing: 'border-box',
-        [breakpoints.down('xs')]: {
-          maxWidth: '100%',
+        [breakpoints.up('md')]: {
+          maxWidth: 415,
           width: '100%',
         },
         '& svg': {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -513,7 +513,7 @@ const themeDefaults: ThemeOptions = {
     },
     MuiInput: {
       root: {
-        maxWidth: 170,
+        maxWidth: 415,
         border: '1px solid #ccc',
         alignItems: 'center',
         transition: 'border-color 225ms ease-in-out',
@@ -521,8 +521,8 @@ const themeDefaults: ThemeOptions = {
         minHeight: 48,
         color: primaryColors.text,
         boxSizing: 'border-box',
-        [breakpoints.up('md')]: {
-          maxWidth: 415,
+        [breakpoints.down('xs')]: {
+          maxWidth: '100%',
           width: '100%',
         },
         '& svg': {


### PR DESCRIPTION
Adjustments to editable text states (default, hover, editing states)
 See ticket for details + comps. 
Some tests were adjusted to match the new interaction as well. 

Default:
<img width="192" alt="screen shot 2018-10-09 at 4 09 33 pm" src="https://user-images.githubusercontent.com/2565527/46695515-c4840f00-cbdd-11e8-8902-a882993641f0.png">

Hover State:
<img width="266" alt="screen shot 2018-10-09 at 4 09 39 pm" src="https://user-images.githubusercontent.com/2565527/46695528-cf3ea400-cbdd-11e8-8952-f3671c01bb6d.png">

Actively Editing State:
<img width="396" alt="screen shot 2018-10-09 at 4 09 46 pm" src="https://user-images.githubusercontent.com/2565527/46695538-d49bee80-cbdd-11e8-874e-c918c82c109b.png">


