### PR TITLE
M3-1289 Hide empty support tickets

### DIFF
--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -417,12 +417,14 @@ export class SupportTicketDetail extends React.Component<CombinedProps,State> {
         </Grid>
         {ticket.entity && this.renderEntityLabelWithIcon()}
         <Grid container direction="column" justify="center" alignItems="center" className={classes.listParent} >
-          {/* Display the contents of the ticket, followed by replies (if any) */}
-          <ExpandableTicketPanel
-            key={ticket!.id}
-            ticket={ticket}
-            isCurrentUser={profileUsername === ticket.opened_by}
-          />
+          {/* If the ticket isn't blank, display it, followed by replies (if any). */}
+          {ticket.description &&
+            <ExpandableTicketPanel
+              key={ticket!.id}
+              ticket={ticket}
+              isCurrentUser={profileUsername === ticket.opened_by}
+            />
+          }
           {replies && this.renderReplies(replies)}
           {ticket.attachments.length > 0 && this.renderAttachments(ticket.attachments)}
           {/* If the ticket is open, allow users to reply to it. */}


### PR DESCRIPTION
On SupportTicketDetail, if a support ticket has a blank description
it will no longer be displayed. This is often the case for migration tickets
opened by Linode. The first reply will now be at the top of the list.