### PR TITLE
Init Google Tag Manager script

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,10 +5,10 @@ import * as ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 
-import { initAnalytics } from 'src/analytics';
+import { initAnalytics, initTagManager } from 'src/analytics';
 import AuthenticationWrapper from 'src/components/AuthenticationWrapper';
 import DefaultLoader from 'src/components/DefaultLoader';
-import { GA_ID, isProduction } from 'src/constants';
+import { GA_ID, GTM_ID, isProduction } from 'src/constants';
 import 'src/exceptionReporting';
 import Logout from 'src/layouts/Logout';
 import OAuthCallbackPage from 'src/layouts/OAuth';
@@ -37,6 +37,7 @@ const Lish = DefaultLoader({
  * Initialize Analytic and Google Tag Manager
  */
 initAnalytics(GA_ID, isProduction);
+initTagManager(GTM_ID);
 
 if (theme.get() === 'dark') {
   sendEvent({

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -117,7 +117,47 @@ export default <T>(...fns: Function[]): AxiosPromise<T> => {
     });
   }
 
-  return Axios(config);
+  return Axios(config)
+
+  /*
+   * If in the future, we want to hook into every single
+   * async action for the purpose of sending the request data
+   * to Google Tag Manager, we can uncomment out the following
+   * .then() and .catch() on return Axios(config)
+   */
+
+    // .then(response => {
+    //   /*
+    //    * This is sending an event to the Google Tag Manager
+    //    * data layer. This is important because it lets us track
+    //    * async actions as custom events
+    //    */
+    //   if ((window as any).dataLayer) {
+    //     (window as any).dataLayer = (window as any).dataLayer || [];
+    //     (window as any).dataLayer.push({
+    //       'event': 'asyncActionSuccess',
+    //       'url': response.config.url,
+    //       'method': response.config.method,
+    //     });
+    //   };
+    //   return response;
+    // })
+    // .catch(e => {
+    //   /*
+    //    * This is sending an event to the Google Tag Manager
+    //    * data layer. This is important because it lets us track
+    //    * async actions as custom events
+    //    */
+    //   if ((window as any).dataLayer) {
+    //     (window as any).dataLayer = (window as any).dataLayer || [];
+    //     (window as any).dataLayer.push({
+    //       'event': 'asyncActionFailure',
+    //       'url': e.response.config.url,
+    //       'method': e.response.config.method,
+    //     });
+    //   };
+    //   return Promise.reject(e);
+    // });
 };
 
 /**


### PR DESCRIPTION
### Purpose

Add Tag Manager script back in so we can start tracking events

### To Test
Add `REACT_APP_GTM_ID='GTM_ID_GOES_HERE'` to your `.env` file. Feel free to ask me what the ID is and how to properly test that the triggers are working

### Performance Testing

As a test, I reloaded both `/linodes/${id}/summary` and `/linodes` 5 times with the Tag Manager script included and 5 times without. These are the results:

On Linodes Landing page:
* page load times ranged from 2572ms to 3522ms with the Google Tag Manager script
* page load times ranged from 2183ms to 3173ms without the Google Tag Manager script

On Linodes Detail page:
* page load times ranged from 2325ms to 3682ms with the Google Tag Manager script
* page load times ranged from 2303ms to 2725ms without the Google Tag Manager script

Also note that when the code to trigger a change to the `dataLayer` on the `then` and `catch` of async requests, the page loads didn't appear that much worse, but I commented out the code because until we start using Tag Manager for async actions, there isn't much need to send request data to GTM