### PR TITLE
M3-1467 Blog Ellipses

### DIFF
--- a/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
+++ b/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
@@ -80,13 +80,19 @@ class BlogDashboardCard extends React.Component<CombinedProps, State> {
   renderItem = (item: BlogItem, idx: number) => {
     const { classes } = this.props;
 
+    /* 
+     * simple fix. Sometimes the description would come back with [&#8230;]
+     * instead of an ellipses
+     */
+    const cleanedDescription = item.description.replace(' [&#8230;]', '...');
+
     return (
       <Paper key={idx} className={classes.root}>
         <Typography variant="subheading" className={classes.itemTitle}>
           <a href={item.link} className="blue" target="_blank" data-qa-blog-post>{item.title}</a>
         </Typography>
         <Typography variant="caption" data-qa-post-desc>
-          {item.description}
+          {cleanedDescription}
         </Typography>
       </Paper>
     );


### PR DESCRIPTION
### Purpose

Blog descriptions would sometimes come back with the encoded `[&#8230;]` instead of an ellipses for whatever reason.

Added a simple replace to fix it