### PR TITLE
M3-1571 Remove early return for unknown image.

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -222,7 +222,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
     /* If the panel is opening, increment the number of open panels. Otherwise decrement.
     *  This allows us to keep track of when all of the panels are closed.
-    */ 
+    */
     const updatedOpenPanels = expanded ? openPanels + 1 : openPanels - 1;
     this.setState({ openPanels: updatedOpenPanels });
 
@@ -253,7 +253,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
       })
       .catch((errorResponse) => {
         if (!this.mounted) { return; }
-        const errorText = pathOr("There was an error retrieving information for this Linode.", 
+        const errorText = pathOr("There was an error retrieving information for this Linode.",
           ['reason'], errorResponse[0]);
         this.setState({ dataIsLoading: false, statsError: errorText, })
       });
@@ -455,7 +455,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
     const { dataIsLoading, statsError, rangeSelection } = this.state;
 
-    if (!linode || !image || !volumes) {
+    if (!linode || !volumes) {
       return null;
     }
 


### PR DESCRIPTION
## Purpose
It was found that the LinodeSummary was not rendering when a Linode had an unknown image.