### PR TITLE
M3-1484 - Run E2E Tests in Parallel (across multiple test accounts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ localStorage.json
 e2e/drivers
 storybook-test-results/*.xml
 .tmp*.status
+e2e/creds.js
 
 # storybook static files
 .out

--- a/e2e/config/custom-commands.js
+++ b/e2e/config/custom-commands.js
@@ -64,8 +64,8 @@ exports.browserCommands = () => {
             .catch(error => console.error(error));
     });
 
-    browser.addCommand('readToken', function() {
-        const token = readToken();
+    browser.addCommand('readToken', function(username) {
+        const token = readToken(username);
         return token;
     });
 

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -2,7 +2,7 @@
 
 const { readFileSync } = require('fs');
 const { argv } = require('yargs');
-const { login, checkoutCreds, checkInCreds, resetCreds } = require('../utils/config-utils');
+const { login, checkoutCreds, checkInCreds, resetCreds, cleanupAccounts } = require('../utils/config-utils');
 const { browserCommands } = require('./custom-commands');
 const { browserConf } = require('./browser-config');
 const { constants } = require('../constants');
@@ -67,7 +67,7 @@ exports.config = {
     // and 30 processes will get spawned. The property handles how many capabilities
     // from the same test should run tests.
     //
-    maxInstances: 1,
+    maxInstances: 2,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -339,7 +339,7 @@ exports.config = {
      */
     onComplete: function(exitCode, config, capabilities) {
         // Run delete all, on every credential
-        // teardownAll('./e2e/creds.js');
+        cleanupAccounts('./e2e/creds.js');
 
         // Reset creds
         resetCreds('./e2e/creds.js');

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -2,7 +2,7 @@ require('dotenv').config();
 
 const { readFileSync } = require('fs');
 const { argv } = require('yargs');
-const { login } = require('../utils/config-utils');
+const { login, getCreds, checkInCreds, resetCreds } = require('../utils/config-utils');
 const { browserCommands } = require('./custom-commands');
 const { browserConf } = require('./browser-config');
 const { constants } = require('../constants');
@@ -67,7 +67,7 @@ exports.config = {
     // and 30 processes will get spawned. The property handles how many capabilities
     // from the same test should run tests.
     //
-    maxInstances: 1,
+    maxInstances: 2,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -182,7 +182,8 @@ exports.config = {
             mutualAuth: true,
         }
     },
-    
+
+    testUser: '', // SET IN THE BEFORE HOOK PRIOR TO EACH TEST
     //
     // =====
     // Hooks
@@ -241,7 +242,9 @@ exports.config = {
             browser.windowHandleMaximize();
         }
 
-        login(username, password);
+        const testCreds = getCreds('./e2e/creds.js', specs[0]);
+
+        login(testCreds.username, testCreds.password, './e2e/creds.js');
     },
     /**
      * Runs before a WebdriverIO command gets executed.
@@ -317,6 +320,8 @@ exports.config = {
         if (argv.replay) {
             browser.deleteImposters();
         }
+
+        checkInCreds('./e2e/creds.js', specs[0]);
     },
     /**
      * Gets executed right after terminating the webdriver session.
@@ -332,6 +337,7 @@ exports.config = {
      * @param {Object} config wdio configuration object
      * @param {Array.<Object>} capabilities list of capabilities details
      */
-    // onComplete: function(exitCode, config, capabilities) {
-    // }
+    onComplete: function(exitCode, config, capabilities) {
+        resetCreds('./e2e/creds.js');
+    }
 }

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -1,8 +1,8 @@
-require('dotenv').config();
+ require('dotenv').config();
 
 const { readFileSync } = require('fs');
 const { argv } = require('yargs');
-const { login, getCreds, checkInCreds, resetCreds } = require('../utils/config-utils');
+const { login, checkoutCreds, checkInCreds, resetCreds } = require('../utils/config-utils');
 const { browserCommands } = require('./custom-commands');
 const { browserConf } = require('./browser-config');
 const { constants } = require('../constants');
@@ -12,11 +12,11 @@ const password = process.env.MANAGER_PASS;
 
 const specsToRun = () => {
     if (argv.file) {
-        return ['./e2e/setup/setup.spec.js', argv.file];
+        return [argv.file];
     }
     
     if (argv.dir || argv.d) {
-        return ['./e2e/setup/setup.spec.js', `./e2e/specs/${argv.dir || argv.d}/**/*.spec.js`]
+        return [`./e2e/specs/${argv.dir || argv.d}/**/*.spec.js`]
     }
 
     if (argv.smoke) {
@@ -67,7 +67,7 @@ exports.config = {
     // and 30 processes will get spawned. The property handles how many capabilities
     // from the same test should run tests.
     //
-    maxInstances: 2,
+    maxInstances: 1,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -242,7 +242,7 @@ exports.config = {
             browser.windowHandleMaximize();
         }
 
-        const testCreds = getCreds('./e2e/creds.js', specs[0]);
+        const testCreds = checkoutCreds('./e2e/creds.js', specs[0]);
 
         login(testCreds.username, testCreds.password, './e2e/creds.js');
     },
@@ -338,6 +338,10 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      */
     onComplete: function(exitCode, config, capabilities) {
+        // Run delete all, on every credential
+        // teardownAll('./e2e/creds.js');
+
+        // Reset creds
         resetCreds('./e2e/creds.js');
     }
 }

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -1,4 +1,4 @@
- require('dotenv').config();
+require('dotenv').config();
 
 const { readFileSync, unlinkSync } = require('fs');
 const { argv } = require('yargs');

--- a/e2e/pageobjects/configure-linode.js
+++ b/e2e/pageobjects/configure-linode.js
@@ -70,7 +70,7 @@ class ConfigureLinode extends Page {
         this.notice.waitForVisible();
         const notices = $$(this.notice.selector);
 
-        const cloneSLA = 'This newly created Linode wil be created with the same password as the original Linode';
+        const cloneSLA = 'This newly created Linode wil be created with the same password and SSH Keys (if any) as the original Linode';
         const cloneFromHeader = 'Select Linode to Clone From';
         const selectLinodePanelText = $$('[data-qa-select-linode-header]').map(h => h.getText());
 

--- a/e2e/pageobjects/profile/ssh-keys.page.js
+++ b/e2e/pageobjects/profile/ssh-keys.page.js
@@ -48,6 +48,7 @@ export class SshKeys extends Page {
     }
 
     removeKey(label) {
+        browser.waitForVisible(`[data-qa-content-row="${label}"]`, constants.wait.normal);
         const keyToRemove = $(`[data-qa-content-row="${label}"]`);
         this.selectActionMenuItem(keyToRemove, 'Delete');
         

--- a/e2e/pageobjects/profile/ssh-keys.page.js
+++ b/e2e/pageobjects/profile/ssh-keys.page.js
@@ -60,7 +60,7 @@ export class SshKeys extends Page {
         this.dialogConfirmDelete.click();
         this.dialogTitle.waitForExist(constants.wait.normal, true);
 
-        $(`[data-qa-content-row="${label}"]`).waitForVisible(constants.wait.normal, true);
+        $(`[data-qa-content-row="${label}"]`).waitForVisible(constants.wait.long, true);
     }
 }
 

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -256,7 +256,7 @@ exports.getMyStackScripts = token => {
         getAxiosInstance(token).get(endpoint, {
             headers: {
                 'Authorization': `Bearer ${token}`,
-                'X-Filter': `{"username":"${process.env.MANAGER_USER}","+order_by":"deployments_total","+order":"desc"}`
+                'X-Filter': `{"username":"${browser.options.testUser}","+order_by":"deployments_total","+order":"desc"}`
             }
         })
         .then(response => resolve(response.data))

--- a/e2e/setup/setup.spec.js
+++ b/e2e/setup/setup.spec.js
@@ -8,7 +8,6 @@ describe('Setup Tests Suite', () => {
     });
 
     it('should remove all account data', () => {
-        browser.debug();
         const token = readToken(browser.options.testUser);
         browser.deleteAll(token);
     });

--- a/e2e/setup/setup.spec.js
+++ b/e2e/setup/setup.spec.js
@@ -8,7 +8,8 @@ describe('Setup Tests Suite', () => {
     });
 
     it('should remove all account data', () => {
-        const token = readToken();
+        browser.debug();
+        const token = readToken(browser.options.testUser);
         browser.deleteAll(token);
     });
 

--- a/e2e/specs/account/user-detail-spec.js
+++ b/e2e/specs/account/user-detail-spec.js
@@ -49,7 +49,7 @@ describe('Account - User Detail - Username Suite', () => {
         });
 
         it('should fail to update when submitting an existing username', () => {
-            UserDetail.usernameField.$('input').setValue(process.env.MANAGER_USER);
+            UserDetail.usernameField.$('input').setValue(browser.options.testUser);
             UserDetail.saveButton.click();
             UserDetail.usernameField.$('p').waitForVisible(constants.wait.normal);
             expect(UserDetail.usernameField.$('p').getText()).toContain('Username taken');

--- a/e2e/specs/account/users.spec.js
+++ b/e2e/specs/account/users.spec.js
@@ -18,7 +18,7 @@ describe('Account - Users Suite', () => {
     });
 
     it('should display root user in the table', () => {
-        expect(Users.userRows[0].$(Users.username.selector).getText()).toBe(process.env.MANAGER_USER);
+        expect(Users.userRows[0].$(Users.username.selector).getText()).toBe(browser.options.testUser);
         expect(Users.userRows[0].$(Users.userRestriction.selector).getText()).toMatch(/unrestricted/ig);
     });
 

--- a/e2e/specs/create/clone-from-existing-linode.spec.js
+++ b/e2e/specs/create/clone-from-existing-linode.spec.js
@@ -10,6 +10,10 @@ describe('Create Linode - Clone from Existing Suite', () => {
         ConfigureLinode.selectGlobalCreateItem('Linode');
     });
 
+    afterAll(() => {
+        apiDeleteAllLinodes();
+    });
+
     it('should display clone elements', () => {
         ConfigureLinode.baseDisplay();
         ConfigureLinode.createFromExisting.click();
@@ -46,9 +50,5 @@ describe('Create Linode - Clone from Existing Suite', () => {
         ConfigureLinode.regions[0].click();
         ConfigureLinode.deploy.click();
         ConfigureLinode.waitForNotice(noticeMsg);
-    });
-
-    afterAll(() => {
-        apiDeleteAllLinodes();
     });
 });

--- a/e2e/specs/create/create-linode.spec.js
+++ b/e2e/specs/create/create-linode.spec.js
@@ -8,7 +8,7 @@ describe('Create - Menu Suite', () => {
 
     it('should display create linode in header and link to create linode page', () => {
         browser.waitForVisible('[data-qa-add-new-menu-button]', constants.wait.normal);
-        browser.waitForVisible('[data-qa-circular-progress]', constants.wait.normal, true);
+        browser.waitForExist('[data-qa-circular-progress]', constants.wait.normal, true);
         browser.click('[data-qa-add-new-menu-button]');
         Create.linodeMenuItem.waitForVisible(constants.wait.normal);
         expect(Create.linodeMenuItem.isVisible()).toBe(true);

--- a/e2e/specs/images/smoke-create.spec.js
+++ b/e2e/specs/images/smoke-create.spec.js
@@ -17,7 +17,7 @@ describe('Images - Create Suite', () => {
 
     afterAll(() => {
         apiDeleteAllLinodes();
-        apiDeletePrivateImages(browser.readToken());
+        apiDeletePrivateImages(browser.readToken(browser.options.testUser));
     });
 
     it('should display create image drawer', () => {

--- a/e2e/specs/nodebalancers/configurations.spec.js
+++ b/e2e/specs/nodebalancers/configurations.spec.js
@@ -42,8 +42,8 @@ describe('NodeBalancer - Configurations Suite', () => {
     it('should display error on save configuration without a cert and private key', () => {
         NodeBalancers.saveButton.click();
 
-        expect(NodeBalancers.certTextField.$('p').getText()).toBe('"SSL certificate" is required');
-        expect(NodeBalancers.privateKeyTextField.$('p').getText()).toBe('"SSL private key" is required');
+        expect(NodeBalancers.certTextField.$('p').getText()).toBe('SSL certificate is a required field');
+        expect(NodeBalancers.privateKeyTextField.$('p').getText()).toBe('SSL private key is a required field');
 
         // Revert choice to HTTP
         NodeBalancers.selectMenuOption(NodeBalancers.protocolSelect, 'http');

--- a/e2e/specs/nodebalancers/error-handling.spec.js
+++ b/e2e/specs/nodebalancers/error-handling.spec.js
@@ -11,7 +11,7 @@ describe('NodeBalancer - Negative Tests Suite', () => {
     let linode;
 
     beforeAll(() => {
-        const token = browser.readToken();
+        const token = browser.readToken(browser.options.testUser);
         linode = apiCreateLinode();
         linode['privateIp'] = browser.allocatePrivateIp(token, linode.id).address;
         browser.url(constants.routes.nodeBalancers);

--- a/e2e/specs/nodebalancers/settings.spec.js
+++ b/e2e/specs/nodebalancers/settings.spec.js
@@ -15,6 +15,7 @@ describe('NodeBalancer - Settings Suite', () => {
     });
 
     it('should display base elements', () => {
+        NodeBalancerDetail.baseElemsDisplay();
         NodeBalancerDetail.changeTab('Settings');
         NodeBalancerSettings.baseElemsDisplay();
     });

--- a/e2e/specs/nodebalancers/smoke-create.spec.js
+++ b/e2e/specs/nodebalancers/smoke-create.spec.js
@@ -33,14 +33,14 @@ describe('Nodebalancer - Create Suite', () => {
     });
 
     it('should fail to create without selecting a region', () => {
-        const noticeMsg = '"region" is required';
+        const noticeMsg = 'Region is required.';
         browser.jsClick('[data-qa-deploy-linode]');
         NodeBalancers.waitForNotice(noticeMsg);
     });
 
     it('should fail to create without choosing a backend ip', () => {
-        const labelError = 'Label must be at least 3 characters';
-        const addressError = 'IP Address must be a Linode private address';
+        const labelError = 'Label is required.';
+        const addressError = 'IP address is required.';
 
         NodeBalancers.regionCards[0].click();
         browser.jsClick('[data-qa-deploy-linode]');

--- a/e2e/specs/nodebalancers/smoke-create.spec.js
+++ b/e2e/specs/nodebalancers/smoke-create.spec.js
@@ -13,7 +13,7 @@ describe('Nodebalancer - Create Suite', () => {
         token;
 
     beforeAll(() => {
-        token = browser.readToken();
+        token = browser.readToken(browser.options.testUser);
         linode = apiCreateLinode();
         linode['privateIp'] = browser.allocatePrivateIp(token, linode.id).address;
         browser.url(constants.routes.nodeBalancers);

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -45,7 +45,7 @@ export const createLinodeIfNone = () => {
 }
 
 export const apiCreateLinode = (linodeLabel=false, privateIp=false, tags=[]) => {
-    const token = readToken();
+    const token = readToken(browser.options.testUser);
     const newLinodePass = crypto.randomBytes(20).toString('hex');
     const linode = browser.createLinode(token, newLinodePass, linodeLabel, tags);
 
@@ -67,31 +67,31 @@ export const apiCreateLinode = (linodeLabel=false, privateIp=false, tags=[]) => 
 }
 
 export const apiDeleteAllLinodes = () => {
-    const token = readToken();
+    const token = readToken(browser.options.testUser);
     const removeAll = browser.removeAllLinodes(token);
     return removeAll;
 }
 
 
 export const apiDeleteAllVolumes = () => {
-    const token = readToken();
+    const token = readToken(browser.options.testUser);
     browser.removeAllVolumes(token);
 }
 
 export const apiDeleteAllDomains = () => {
-    const token = readToken();
+    const token = readToken(browser.options.testUser);
     const domains = browser.getDomains(token);
     domains.data.forEach(domain => browser.removeDomain(token, domain.id));
 }
 
 export const apiDeleteMyStackScripts = () => {
-    const token = readToken();
+    const token = readToken(browser.options.testUser);
     const stackScripts = browser.getMyStackScripts(token);
     stackScripts.data.forEach(script => browser.removeStackScript(token, script.id));
 }
 
 export const createNodeBalancer = () => {
-    const token = readToken();
+    const token = readToken(browser.options.testUser);
     const linode = apiCreateLinode();
     linode['privateIp'] = browser.allocatePrivateIp(token, linode.id).address;
     browser.url(constants.routes.nodeBalancers);
@@ -102,7 +102,7 @@ export const createNodeBalancer = () => {
 }
 
 export const removeNodeBalancers = () => {
-    const token = readToken();
+    const token = readToken(browser.options.testUser);
     apiDeleteAllLinodes();
     const availableNodeBalancers = browser.getNodeBalancers(token);
     availableNodeBalancers.data.forEach(nb => browser.removeNodeBalancer(token, nb.id));
@@ -114,7 +114,7 @@ export const apiDeletePrivateImages = token => {
 }
 
 export const apiRemoveSshKeys = () => {
-    const token = readToken();
+    const token = readToken(browser.options.testUser);
     const userKeys = getPublicKeys(token).data;
 
     userKeys.forEach(key => removePublicKey(token, key.id));

--- a/e2e/utils/config-utils.js
+++ b/e2e/utils/config-utils.js
@@ -25,7 +25,6 @@ exports.storeToken = (credFilePath, username) => {
 }
 
 exports.readToken = (username) => {
-    console.log(process.cwd());
     const credCollection = JSON.parse(readFileSync('./e2e/creds.js'));
     const currentUserCreds = credCollection.find(cred => cred.username === username);
 
@@ -73,20 +72,18 @@ exports.login = (username, password, credFilePath) => {
     exports.storeToken(credFilePath, username);
 }
 
-exports.getCreds = (credFilePath, specFile) => {
+exports.checkoutCreds = (credFilePath, specFile) => {
     let credCollection = JSON.parse(readFileSync(credFilePath));
-    console.log(credCollection);
     return credCollection.find((cred, i) => {
         if (!cred.inUse) {
             credCollection[i].inUse = true;
             credCollection[i].spec = specFile;
-            // browser.options.testUser = credCollection[i].username;
+            browser.options.testUser = credCollection[i].username;
             writeFileSync(credFilePath, JSON.stringify(credCollection));
             return cred;
         }
     });
 }
-
 
 exports.checkInCreds = (credFilePath, specFile) => {
     let credCollection = JSON.parse(readFileSync(credFilePath));
@@ -97,7 +94,6 @@ exports.checkInCreds = (credFilePath, specFile) => {
             credCollection[i].spec = '';
             credCollection[i].token = '';
             writeFileSync(credFilePath, JSON.stringify(credCollection));
-            console.log('written!');
             return cred;
         }
         return;
@@ -106,7 +102,7 @@ exports.checkInCreds = (credFilePath, specFile) => {
 
 exports.resetCreds = (credFilePath) => {
     const credCollection = JSON.parse(readFileSync(credFilePath));
-    const cleanCreds = credCollection.map(el => { return {...el, spec: '', inUse: 'false', token: ''} });
+    const cleanCreds = credCollection.map(el => { return {...el, spec: '', inUse: false, token: ''} });
     writeFileSync(credFilePath, JSON.stringify(cleanCreds));
 }
 

--- a/e2e/utils/config-utils.js
+++ b/e2e/utils/config-utils.js
@@ -105,17 +105,18 @@ exports.generateCreds = (credFilePath) => {
     const credCollection = [];
 
     for (const [key, value] of Object.entries(process.env)) {
-        if (key.includes('MANAGER_USER')) {
-            const pass = // GET EQUIVALENT USER PASSWORD HERE, SET AS A VARIABLE
-            credCollection.push({username: value, password: pass token: '', spec: ''});
+        if (key === 'MANAGER_USER') {
+            const pass = process.env.MANAGER_PASS;
+            credCollection.push({username: value, password: pass, inUse: false, token: '', spec: ''});
+        }
+
+        if (key === 'MANAGER_USER_2') {
+            const pass = process.env.MANAGER_PASS_2;
+            credCollection.push({username: value, password: pass, inUse: false, token: '', spec: ''});
         }
     }
-}
 
-exports.resetCreds = (credFilePath) => {
-    const credCollection = JSON.parse(readFileSync(credFilePath));
-    const cleanCreds = credCollection.map(el => { return {...el, spec: '', inUse: false, token: ''} });
-    writeFileSync(credFilePath, JSON.stringify(cleanCreds));
+    return writeFileSync(credFilePath, JSON.stringify(credCollection));
 }
 
 exports.cleanupAccounts = (credFilePath) => {

--- a/e2e/utils/config-utils.js
+++ b/e2e/utils/config-utils.js
@@ -101,6 +101,17 @@ exports.checkInCreds = (credFilePath, specFile) => {
     });
 }
 
+exports.generateCreds = (credFilePath) => {
+    const credCollection = [];
+
+    for (const [key, value] of Object.entries(process.env)) {
+        if (key.includes('MANAGER_USER')) {
+            const pass = // GET EQUIVALENT USER PASSWORD HERE, SET AS A VARIABLE
+            credCollection.push({username: value, password: pass token: '', spec: ''});
+        }
+    }
+}
+
 exports.resetCreds = (credFilePath) => {
     const credCollection = JSON.parse(readFileSync(credFilePath));
     const cleanCreds = credCollection.map(el => { return {...el, spec: '', inUse: false, token: ''} });

--- a/e2e/utils/config-utils.js
+++ b/e2e/utils/config-utils.js
@@ -1,6 +1,7 @@
 const moment = require('moment');
 const { existsSync, statSync, writeFileSync, readFileSync } = require('fs');
 const { constants } = require('../constants');
+const { deleteAll } = require('../setup/setup');
 
 /*
 * Get localStorage after landing on homepage
@@ -104,6 +105,13 @@ exports.resetCreds = (credFilePath) => {
     const credCollection = JSON.parse(readFileSync(credFilePath));
     const cleanCreds = credCollection.map(el => { return {...el, spec: '', inUse: false, token: ''} });
     writeFileSync(credFilePath, JSON.stringify(cleanCreds));
+}
+
+exports.cleanupAccounts = (credFilePath) => {
+    const credCollection = JSON.parse(readFileSync(credFilePath));
+    credCollection.forEach(cred => {
+        return deleteAll(cred.token).then(() => {});
+    });
 }
 
 /*


### PR DESCRIPTION
* This PR allows the e2e tests to run on two tests accounts in parallel (this could theoretically scale to as many test accounts as we'd want , but it'd need some minor refactoring to allow for that)
* Tests that made assertions based on the test user defined in `process.env.MANAGER_USER` have now been updated to use `browser.options.testUser` which is dynamically set per each browser session.
* Updated the  readToken command to get the token of the user being used for the test run (defined in`browser.options.testUser`. This will allow API calls made during test setup/teardown to be tied to the test run account. 

## How the test runner runs tests in parallel across different users:

1. In the `onPrepare` hook, we generate a temporary file for our test credentials based on having `MANAGER_USER`/`MANAGER_PASS` and `MANAGER_USER_2`/`MANAGER_PASS_2` defined with test user credentials in the `.env` file.. We can't store this in memory because each browser is a child process and does not have access to values declared in `onPrepare()`. We create a collection that has a few other helpful bits of information that will be used by our browser sessions:
```js
[
    {
        "username": MANAGER_USER,
        "password": MANAGER_PASS,
        "inUse": false, // Updated by the before() / after() hooks
        "token": '' // Updated after login
        "spec": '' // path to spec file under test by browser session
    }
]
```
2. Then, before each test runs, it looks to the `creds.json` file for a test user in the collection that has `inUse:false` and "check-out" that user by setting `inUse:true`.. That way, following browser sessions are never able to check out the same user. 
3. After the test is complete, it will "check-in" the user, by looking at the creds.json file for a credential that's `spec` key value matches it's spec (this informs it the user the browser session tied to that spec used).. It will then set "inUse:false" for this user (allowing the next browser child process spawned to "check-out" the same user)..
4. After all test sessions for a test run have completed, the user credentials collection will be iterated through and the "deleteAll" method will send API requests to delete Linodes/Images/Nodebalancers/Volumes/Domains attached to those accounts
5. Finally, it will delete the temporary creds file. 

## To Test:

* Make sure you have `MANAGER_USER` `MANAGER_PASS` and `MANAGER_USER_2` and `MANAGER_PASS_2` defined in your `.env` file.. PM me if you do not have this setup.

```bash
yarn && yarn start
yarn selenium
yarn e2e --dir profile --browser=headlessChrome # runs headlessly 👻  
```

* Finally, reach out to me if you have any questions!