### PR TITLE
M3-1458 Fix NodeBalancer Node Errors Not Rendering

### DIFF
--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -79,16 +79,14 @@ class LinodeTextField extends React.Component<CombinedProps> {
 
     const finalProps: TextFieldProps = { ...textFieldProps };
 
+    let errorScrollClassName = '';
+
     if (errorText) {
       finalProps.error = true;
       finalProps.helperText = errorText;
-      const errorScrollClassName = errorGroup
+      errorScrollClassName = errorGroup
         ? `error-for-scroll-${errorGroup}`
         : `error-for-scroll`;
-      finalProps.InputProps = {
-        className: errorScrollClassName,
-        ...finalProps.InputProps
-      };
     }
 
     if (affirmative) {
@@ -104,6 +102,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
     return (
       <div className={classNames({
         [classes.helpWrapper]: Boolean(tooltipText),
+        [errorScrollClassName]: !!errorText,
       })}
       >
         <TextField

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -172,7 +172,15 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
     */
     const nodePathErrors = errors.reduce(
       (acc: any, error: Linode.ApiFieldError) => {
-        const match = /^nodes_(\d+)_(\w+)$/.exec(error.field!);
+        /**
+         * Regex conditions are as follows:
+         * 
+         * must match "nodes["
+         * must have a digit 0-9
+         * then have "]"
+         * must end with ".anywordhere"
+         */
+        const match = /^nodes\[(\d+)\].(\w+)$/.exec(error.field!);
         if (match && match[1] && match[2]) {
           return [
             ...acc,
@@ -395,6 +403,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
         const errors = path<Linode.ApiFieldError[]>(['response', 'data', 'errors'], errorResponse);
         const newErrors = clone(this.state.configErrors);
         newErrors[idx] = errors || [];
+        this.setNodeErrors(idx, newErrors[idx]);
         this.setState({
           configErrors: newErrors,
         }, () => {

--- a/src/services/nodebalancers/nodebalancers.schema.ts
+++ b/src/services/nodebalancers/nodebalancers.schema.ts
@@ -35,7 +35,7 @@ export const createNodeBalancerConfigSchema = object({
   check_timeout: number().integer(),
   check: string(),
   cipher_suite: string(),
-  port: number().integer().min(1).max(65535).required(),
+  port: number().integer().min(1).max(65535).required('Port is required'),
   protocol: string().oneOf(['http', 'https', 'tcp']),
   ssl_key: string()
     .when('protocol', { is: 'https', then: string()


### PR DESCRIPTION
### Purpose

Previously while in the NodeBalancer configurations tab of an existing NodeBalancer, no errors would appear for the following scenario

1. Click _Add Another Configuration_
2. Fill out a port
3. Click _Save_
4. Observe: no error appears but nothing happens

Now, the backend node errors will appear

I also added a fix for the TextField errors not properly being scrolled to