### PR TITLE
M3-1479 Rename Oauth clients tab to 'My Apps'

### DIFF
--- a/e2e/pageobjects/profile.js
+++ b/e2e/pageobjects/profile.js
@@ -104,7 +104,7 @@ export class TokenCreateDrawer {
 export class Profile extends Page {
     get profileHeader() { return $('[data-qa-profile-header]'); }
     get apiTokensTab() { return $('[data-qa-tab="API Tokens"]'); }
-    get oauthClientsTab() { return $('[data-qa-tab="OAuth Clients"]'); }
+    get oauthClientsTab() { return $('[data-qa-tab="My Apps"]'); }
     get tableHeader() { return $$('[data-qa-table]'); }
     get tableHead() { return $$('[data-qa-table-head]'); }
     get tableRow() { return $$('[data-qa-table-row]'); }
@@ -135,7 +135,7 @@ export class Profile extends Page {
 
     oauthBaseElems() {
         browser.waitForVisible('[data-qa-profile-header]', constants.wait.normal);
-        const oauthSelected = browser.getAttribute('[data-qa-tab="OAuth Clients"]', 'aria-selected').includes('true');
+        const oauthSelected = browser.getAttribute('[data-qa-tab="My Apps"]', 'aria-selected').includes('true');
         expect(oauthSelected).toBe(true);
 
         browser.waitForVisible('[data-qa-oauth-label]', constants.wait.normal);

--- a/e2e/pageobjects/profile.js
+++ b/e2e/pageobjects/profile.js
@@ -1,7 +1,3 @@
-/*
-In the context of profile, the term 'Oauth Client(s)' is referred to as 'app' or 'My Apps' for user-facing displays.
-*/
-
 const { constants } = require('../constants');
 
 import Page from './page';
@@ -108,6 +104,9 @@ export class TokenCreateDrawer {
 export class Profile extends Page {
     get profileHeader() { return $('[data-qa-profile-header]'); }
     get apiTokensTab() { return $('[data-qa-tab="API Tokens"]'); }
+    
+    // TODO Need to unify internal & external usage of 'OAuth Clients'/'My Apps'.
+    // Currently in the context of profile, the term 'Oauth Client(s)' is referred to as 'app' or 'My Apps' for user-facing displays.
     get oauthClientsTab() { return $('[data-qa-tab="My Apps"]'); }
     get tableHeader() { return $$('[data-qa-table]'); }
     get tableHead() { return $$('[data-qa-table-head]'); }

--- a/e2e/pageobjects/profile.js
+++ b/e2e/pageobjects/profile.js
@@ -1,3 +1,7 @@
+/*
+In the context of profile, the term 'Oauth Client(s)' is referred to as 'app' or 'My Apps' for user-facing displays.
+*/
+
 const { constants } = require('../constants');
 
 import Page from './page';

--- a/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
@@ -150,7 +150,7 @@ class OAuthClientActionMenu extends React.Component<CombinedProps> {
           onClose={this.closeConfirmDelete}
         >
           <Typography>
-            Are you sure you want to permanently delete this OAuth client?
+            Are you sure you want to permanently delete this app?
           </Typography>
         </ConfirmationDialog>
         <ConfirmationDialog
@@ -160,7 +160,7 @@ class OAuthClientActionMenu extends React.Component<CombinedProps> {
           onClose={this.closeConfirmReset}
         >
           <Typography>
-            Are you sure you want to permanently reset the secret of this OAuth client?
+            Are you sure you want to permanently reset the secret of this app?
           </Typography>
         </ConfirmationDialog>
       </React.Fragment>

--- a/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
@@ -160,7 +160,7 @@ class OAuthClientActionMenu extends React.Component<CombinedProps> {
           onClose={this.closeConfirmReset}
         >
           <Typography>
-            Are you sure you want to permanently reset the secret of this app?
+            Are you sure you want to permanently reset the secret for this app?
           </Typography>
         </ConfirmationDialog>
       </React.Fragment>

--- a/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -1,7 +1,3 @@
-/*
-In the context of profile, the term 'Oauth Client(s)' is referred to as 'app' or 'My Apps' for user-facing displays.
-*/
-
 import { compose, path } from 'ramda';
 import * as React from 'react';
 
@@ -234,7 +230,9 @@ class OAuthClients extends React.Component<CombinedProps, State> {
 
   render() {
     const { classes } = this.props;
-
+    
+    // TODO Need to unify internal & external usage of 'OAuth Clients'/'My Apps'.
+    // Currently in the context of profile, the term 'Oauth Client(s)' is referred to as 'app' or 'My Apps' for user-facing displays.
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="My Apps" />

--- a/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -247,7 +247,7 @@ class OAuthClients extends React.Component<CombinedProps, State> {
           <Grid item>
             <AddNewLink
               onClick={this.openCreateDrawer}
-              label="Create an OAuth Client"
+              label="Create My App"
               data-qa-oauth-create
             />
           </Grid>

--- a/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -233,7 +233,7 @@ class OAuthClients extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <DocumentTitleSegment segment="OAuth Clients" />
+        <DocumentTitleSegment segment="My Apps" />
         <Grid
           container
           justify="space-between"
@@ -241,7 +241,7 @@ class OAuthClients extends React.Component<CombinedProps, State> {
         >
           <Grid item>
             <Typography role="header" className={classes.title} variant="title" data-qa-table={classes.title}>
-              OAuth Clients
+              My Apps
             </Typography>
           </Grid>
           <Grid item>
@@ -253,7 +253,7 @@ class OAuthClients extends React.Component<CombinedProps, State> {
           </Grid>
         </Grid>
         <Paper>
-          <Table aria-label="List of OAuth Clients">
+          <Table aria-label="List of My Apps">
             <TableHead data-qa-table-head>
               <TableRow>
                 <TableCell>Label</TableCell>

--- a/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -1,3 +1,7 @@
+/*
+In the context of profile, the term 'Oauth Client(s)' is referred to as 'app' or 'My Apps' for user-facing displays.
+*/
+
 import { compose, path } from 'ramda';
 import * as React from 'react';
 

--- a/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
+++ b/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
@@ -53,7 +53,7 @@ const OAuthCreationDrawer: React.StatelessComponent<CombinedProps> = (props) => 
   const hasErrorFor = getAPIErrorsFor(errorResources, errors);
 
   return (
-    <Drawer title={`${ edit ? 'Edit' : 'Create'} OAuth Client`} open={open} onClose={onClose}>
+    <Drawer title={`${ edit ? 'Edit' : 'Create'} My App`} open={open} onClose={onClose}>
       <TextField
         value={label || ''}
         errorText={hasErrorFor('label')}

--- a/src/features/Profile/Profile.tsx
+++ b/src/features/Profile/Profile.tsx
@@ -32,7 +32,7 @@ class Profile extends React.Component<Props> {
     { title: 'Password & Authentication', routeName: `${this.props.match.url}/auth` },
     { title: 'Settings', routeName: `${this.props.match.url}/settings` },
     { title: 'API Tokens', routeName: `${this.props.match.url}/tokens` },
-    { title: 'OAuth Clients', routeName: `${this.props.match.url}/clients` },
+    { title: 'My Apps', routeName: `${this.props.match.url}/clients` },
     { title: 'LISH', routeName: `${this.props.match.url}/lish` },
     { title: 'Referrals', routeName: `${this.props.match.url}/referrals` },
     { title: 'SSH Keys', routeName: `${this.props.match.url}/keys` },


### PR DESCRIPTION
I kept scope for this ticket to exclusively handle display and some QA verification instances, as I didn't want to change/break every instance that relies on the oauth naming pattern. Let me know if I missed any instances that should be included for this!
