### PR TITLE
Pagey error-scrolling fix

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -104,7 +104,7 @@ const SSelect: React.StatelessComponent<CombinedProps> = ({
   const c = classNames({
     [classes.inputSucess]: success === true,
     [classes.inputError]: error === true,
-    [errorScrollClassName]: !!errorScrollClassName,
+    [errorScrollClassName]: !!errorText && !!errorScrollClassName,
     [classes.helpWrapperSelectField]: Boolean(tooltipText),
     [classes.pagination]: Boolean(pagination),
   });


### PR DESCRIPTION
**Purpose:**

When `scrollErrorIntoView` was being triggered on a drawer on the same page as a paginated component, the window was scrolling down to the pagination footer. 

**To reproduce,** use prod account 002 and navigate to Profile -> OAuth Clients. Scroll down just a bit, then click "Create an OAuth Client. Leave the form blank and click "Submit". 

![pagey-error-scrolling](https://user-images.githubusercontent.com/16911484/46958704-6dac8880-d068-11e8-8f62-cd08e23fe6f2.gif)

