### PR TITLE
Add missing font import for storybook

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,6 @@
 import { configure } from '@storybook/react';
 
-import 'typeface-lato';
+import '../public/fonts/fonts.css'
 import '../src/index.css';
 import '../.storybook/storybook.css';
 


### PR DESCRIPTION
I recently changed the font import on the manager and omitted to switch the import in storybook resulting the wrong fonts being displayed in the stories