### PR TITLE
M3-1522 settings requests

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -29,6 +29,7 @@ it('renders without crashing', () => {
             userId={123456}
             profileLoading={false}
             actions={{
+              getAccountSettings: jest.fn(),
               getProfile: jest.fn(),
               getNotifications: jest.fn(),
             }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
 import { getDeprecatedLinodeTypes, getLinodeTypes } from 'src/services/linodes';
 import { getRegions } from 'src/services/misc';
 import { requestNotifications } from 'src/store/reducers/notifications';
+import { requestAccountSettings } from 'src/store/reducers/resources/accountSettings';
 import { requestProfile } from 'src/store/reducers/resources/profile';
 
 import composeState from 'src/utilities/composeState';
@@ -248,7 +249,7 @@ export class App extends React.Component<CombinedProps, State> {
   };
 
   componentDidMount() {
-    const { getNotifications, getProfile } = this.props.actions;
+    const { getAccountSettings, getNotifications, getProfile } = this.props.actions;
 
     /*
      * We want to listen for migration events side-wide
@@ -280,6 +281,7 @@ export class App extends React.Component<CombinedProps, State> {
 
     getProfile();
     getNotifications();
+    getAccountSettings();
 
     this.state.regionsContext.request();
     this.state.typesContext.request();
@@ -396,6 +398,7 @@ interface DispatchProps {
   actions: {
     getProfile: () => void;
     getNotifications: () => void;
+    getAccountSettings: () => void;
   },
 }
 
@@ -404,6 +407,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (dispatch, 
     actions: {
       getProfile: () => dispatch(requestProfile()),
       getNotifications: () => dispatch(requestNotifications()),
+      getAccountSettings: () => dispatch(requestAccountSettings()),
     }
   };
 };

--- a/src/store/ApplicationState.d.ts
+++ b/src/store/ApplicationState.d.ts
@@ -1,6 +1,7 @@
 declare interface ApplicationState {
   __resources: {
-    profile: RequestableData<Linode.Profile>;
+    profile: RequestableData<Linode.Profile>,
+    accountSettings: RequestableData<Linode.AccountSettings>
   },
   authentication: AuthState;
   documentation: DocumentationState;

--- a/src/store/reducers/resources/accountSettings.ts
+++ b/src/store/reducers/resources/accountSettings.ts
@@ -1,0 +1,65 @@
+import { compose, Dispatch } from 'redux';
+
+import { getAccountSettings } from 'src/services/account';
+
+// TYPES
+type State = RequestableData<Linode.AccountSettings>;
+
+interface Action {
+  type: string;
+  error?: Error;
+  data?: any;
+}
+
+type ActionCreator = (...args: any[]) => Action;
+
+// ACTIONS
+export const LOAD = '@manager/account/LOAD'
+export const ERROR = '@manager/account/ERROR'
+export const SUCCESS = '@manager/account/SUCCESS'
+export const UPDATE = '@manager/account/UPDATE'
+
+// ACTION CREATORS
+export const startRequest: ActionCreator = () => ({ type: LOAD });
+
+export const handleError: ActionCreator = (error: Error) => ({ type: ERROR, error });
+
+export const handleSuccess: ActionCreator = (data: Linode.AccountSettings) => ({ type: SUCCESS, data });
+
+export const handleUpdate: ActionCreator = (data: Linode.AccountSettings) => ({ type: UPDATE, data });
+
+// DEFAULT STATE
+export const DEFAULT_STATE: State = {
+  lastUpdated: 0,
+  loading: false,
+  data: undefined,
+  error: undefined,
+};
+
+// REDUCER
+export default (state: State = DEFAULT_STATE, action: Action) => {
+  switch (action.type) {
+    case LOAD:
+      return { ...state, loading: true };
+
+    case ERROR:
+      return { ...state, loading: false, lastUpdated: Date.now(), error: action.error };
+
+    case SUCCESS:
+      return { ...state, loading: false, lastUpdated: Date.now(), data: action.data };
+
+    case UPDATE:
+      return { ...state, loading: false, lastUpdated: Date.now(), data: action.data };
+
+    default:
+      return state;
+  }
+};
+
+
+export const requestAccountSettings = () => (dispatch: Dispatch<State>) => {
+  dispatch(startRequest());
+  getAccountSettings()
+    .then(compose(dispatch, handleSuccess))
+    .catch(compose(dispatch, handleError));
+};

--- a/src/store/reducers/resources/index.ts
+++ b/src/store/reducers/resources/index.ts
@@ -1,9 +1,11 @@
 import { combineReducers } from "redux";
 
+import accountSettings, { DEFAULT_STATE  as defaultAccountSettingsState } from './accountSettings';
 import profile, { DEFAULT_STATE as defaultProfileState } from './profile';
 
 export const defaultState = {
+  accountSettings: defaultAccountSettingsState,
   profile: defaultProfileState,
 }
 
-export default combineReducers({ profile });
+export default combineReducers({ accountSettings, profile });


### PR DESCRIPTION
## Purpose

2 separate requests to `/account/settings` were being made on initial page load. This was due to the fact that two instances of `PrimaryNav` are loaded in `SideMenu` (versions for mobile and larger screens), each of which queried the settings endpoint.

To resolve this, and prepare for upcoming settings interactions (such as automatic backups), I added the data from this endpoint to Redux. A single request to /settings is now made from `App.tsx` on page load, and the resulting value of `managed` is read from `PrimaryNav`, which is now a connected component.

## Notes

Having two copies of PrimaryNav still seems inefficient, but as that was an accessibility issue I left it pending @alioso 's feedback.