### PR TITLE
Stackscript search by username

### DIFF
--- a/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
+++ b/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
@@ -26,6 +26,7 @@ interface Props {
   onSearch: (value: string) => void;
   className?: string;
   isSearching?: boolean;
+  toolTipText?: string;
 }
 
 interface State {
@@ -54,12 +55,14 @@ class DebouncedSearchTextField extends React.Component<CombinedProps, State> {
       classes,
       className,
       placeholderText,
-      isSearching
+      isSearching,
+      toolTipText
     } = this.props;
 
     return (
       <React.Fragment>
         <TextField
+          tooltipText={toolTipText}
           fullWidth
           InputProps={{
             placeholder: placeholderText,

--- a/src/components/HelpIcon/HelpIcon.tsx
+++ b/src/components/HelpIcon/HelpIcon.tsx
@@ -56,19 +56,19 @@ class HelpIcon extends React.Component<CombinedProps, State> {
     const { text, className } = this.props;
     return (
       <React.Fragment>
-        <Tooltip
-          title={text}
-          data-qa-help-tooltip
-          enterTouchDelay={0}
-          leaveTouchDelay={5000}
-        >
-          <IconButton
-            className={className}
-            data-qa-help-button
+          <Tooltip
+            title={text}
+            data-qa-help-tooltip
+            enterTouchDelay={0}
+            leaveTouchDelay={5000}
           >
+            <IconButton
+              className={className}
+              data-qa-help-button
+            >
             <HelpOutline />
-          </IconButton>
-        </Tooltip>
+            </IconButton>
+          </Tooltip>
       </React.Fragment>
     );
   }

--- a/src/features/StackScripts/SelectStackScriptPanel/PanelContent/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/PanelContent/StackScriptTableHead.tsx
@@ -43,6 +43,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     paddingTop: 0,
     paddingBottom: 0,
     height: 48,
+    zIndex: 5,
   },
 });
 

--- a/src/features/StackScripts/SelectStackScriptPanel/PanelContent/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/PanelContent/StackScriptTableHead.tsx
@@ -40,7 +40,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     position: 'sticky',
     top: 72,
     backgroundColor: theme.bg.offWhite,
-    zIndex: 10,
     paddingTop: 0,
     paddingBottom: 0,
     height: 48,

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -679,8 +679,9 @@ class SelectStackScriptPanelContent extends React.Component<CombinedProps, State
                 onSearch={this.handleSearch}
                 className={classes.searchBar}
                 isSearching={isSearching}
-                toolTipText={`Hint: try searching for a specific item by prepending your
-                search term with "username:", "label:", or "description:"`}
+                /** uncomment when we upgrade to MUI v3 */
+                // toolTipText={`Hint: try searching for a specific item by prepending your
+                // search term with "username:", "label:", or "description:"`}
               />
             </div>
             <Table

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -675,7 +675,7 @@ class SelectStackScriptPanelContent extends React.Component<CombinedProps, State
           : <React.Fragment>
             <div className={classes.searchWrapper}>
               <DebouncedSearch
-                placeholderText='Search for StackScript by Label, Userrname, or Description'
+                placeholderText='Search by Label, Username, or Description'
                 onSearch={this.handleSearch}
                 className={classes.searchBar}
                 isSearching={isSearching}

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanelContent.tsx
@@ -555,7 +555,7 @@ class SelectStackScriptPanelContent extends React.Component<CombinedProps, State
     const { currentFilter } = this.state;
     const filteredUser = (isLinodeStackScripts) ? 'linode' : currentUser;
 
-    const lowerCaseValue = value.toLowerCase();
+    const lowerCaseValue = value.toLowerCase().trim();
 
     let filter: any;
 


### PR DESCRIPTION
### Purpose

Adds the ability to search by stackscript by username

Also, adds a more advanced search. Trying searching for a term with the folllowing prepended:
* `username:`
* `label:`
* `description:`

Example: 
_username:tory_

### Notes

Merged in PR #3959 because the table had some visual regressions