### PR TITLE
Fix missing input background color

### DIFF
--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -521,6 +521,7 @@ const themeDefaults: ThemeOptions = {
         minHeight: 48,
         color: primaryColors.text,
         boxSizing: 'border-box',
+        backgroundColor: '#fff',
         [breakpoints.down('xs')]: {
           maxWidth: '100%',
           width: '100%',


### PR DESCRIPTION
we had a small regression with default input bg colors (see /support) that probably stems from the theme refactor. DT has the proper bg but light theme had none.