### PR TITLE
M3-1471 update docs

### DIFF
--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -18,7 +18,7 @@
 
 export const Domains: Linode.Doc = {
   title: 'DNS Manager',
-  body: 'The Domains section of the Linode Manger is a comprehensive DNS management interface that allows you to add DNS records for all of your domain names. This guide covers the use of the Domains section and basic domain zone setup. For an introduction to DNS in general, see our Introduction to DNS Records guide.',
+  body: 'The Domains section of the Linode Manager is a comprehensive DNS management interface that allows you to add DNS records for all of your domain names. This guide covers the use of the Domains section and basic domain zone setup. For an introduction to DNS in general, see our Introduction to DNS Records guide.',
   src: 'https://linode.com/docs/platform/manager/dns-manager-new-manager/'
 }
 

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -1,0 +1,65 @@
+export const Domains: Linode.Doc = {
+  title: 'DNS Manager',
+  body: 'The Domains section of the Linode Manger is a comprehensive DNS management interface that allows you to add DNS records for all of your domain names. This guide covers the use of the Domains section and basic domain zone setup. For an introduction to DNS in general, see our Introduction to DNS Records guide.',
+  src: 'https://linode.com/docs/platform/manager/dns-manager-new-manager/'
+}
+
+export const SecurityControls: Linode.Doc = {
+  title: 'Linode Manager Security Controls',
+  body: 'The Linode Manager is the gateway to all of your Linode products and services, and you should take steps to protect it from unauthorized access. This guide documents several of Linode Manager’s features that can help mitigate your risk. Whether you’re worried about malicious users gaining access to your username and password, or authorized users abusing their access privileges, Linode Manager’s built-in security tools can help.',
+  src: 'https://linode.com/docs/security/linode-manager-security-controls-new-manager/'
+}
+
+export const BillingAndPayments: Linode.Doc = {
+  title: 'Billing and Payments',
+  body: 'We’ve done our best to create straightforward billing and payment policies. Still have questions? Use this guide to learn how our hosrcy billing works and how to make payments, update your billing information, get referral credits, and remove services. If you have a question that isn’t answered here, please feel free to contact support.',
+  src: 'https://linode.com/docs/platform/billing-and-support/billing-and-payments-new-manager/'
+}
+
+export const AccountsAndPasswords: Linode.Doc = {
+  title: 'Accounts and Passwords',
+  body: 'Maintaining your user Linode Manager accounts, passwords, and contact information is just as important as administering your Linode. This guide shows you how to control access to the Linode Manager, update your contact information, and modify account passwords. Note that the information in this guide applies to the Linode Manager only, except for the section on resetting the root password.',
+  src: 'https://linode.com/docs/platform/manager/accounts-and-passwords-new-manager/'
+}
+
+export const Images: Linode.Doc = {
+  title: 'Linode Images',
+  body: 'Linode Images allows you to take snapshots of your disks, and then deploy them to any Linode under your account. This can be useful for bootstrapping a master image for a large deployment, or retaining a disk for a configuration that you may not need running, but wish to return to in the future. Linode Images will be retained whether or not you have an active Linode on your account, which also makes them useful for long term storage of a private template that you may need in the future. There is no additional charge to store Images for Linode users, with a limit of 2GB per Image and 3 Images per account.',
+  src: 'https://linode.com/docs/platform/disk-images/linode-images-new-manager/'
+}
+
+export const StackScripts: Linode.Doc = {
+  title: 'Automate Deployment with StackScripts',
+  body: 'StackScripts provide Linode users with the ability to automate the deployment of custom systems on top of our default Linux distribution images. Linodes deployed with a StackScript run the script as part of the first boot process. This guide explains how StackScripts work, and offer several examples of how to use them.',
+  src: 'https://linode.com/docs/platform/stackscripts-new-manager/'
+}
+
+export const BlockStorage: Linode.Doc = {
+  title: 'How to Use Block Storage with Your Linode',
+  body: 'Linode’s Block Storage service allows you to attach additional storage volumes to your Linode. A single volume can range from 10 GiB to 10,000 GiB in size and costs $0.10/GiB per month. They can be partitioned however you like and can accommodate any filesystem type you choose. Up to eight volumes can be attached to a single Linode, be it new or already existing, so you do not need to recreate your server to add a Block Storage Volume.',
+  src: 'https://linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode-new-manager/'
+}
+
+export const MonitoringYourServer: Linode.Doc = {
+  title: 'Monitoring and Maintaining Your Server',
+  body: 'Now that your Linode is up and running, it’s time to think about monitoring and maintaining your server. This guide introduces the essential tools and skills you’ll need to keep your server up to date and minimize downtime. You’ll learn how to monitor the availability and performance of your system, manage your logs, and update your server’s software.',
+  src: 'https://linode.com/docs/uptime/monitoring-and-maintaining-your-server-new-manager/'
+}
+
+export const NodeBalancerReference: Linode.Doc = {
+  title: 'NodeBalancer Reference Guide',
+  body: 'This is the NodeBalancer reference guide. Please see the NodeBalancer Getting Started Guide for practical examples.',
+  src: 'https://linode.com/docs/platform/nodebalancer/nodebalancer-reference-guide-new-manager/',
+}
+
+export const NodeBalancerGettingStarted: Linode.Doc = {
+  title: 'Getting Started with NodeBalancers',
+  body: 'Nearly all applications that are built using Linodes can benefit from load balancing, and load balancing itself is the key to expanding an application to larger numbers of users. Linode now provides NodeBalancers, which can ease the deployment and administration of a load balancer.',
+  src: 'https://linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers-new-manager/'
+}
+
+export const LinodeAPI: Linode.Doc = {
+  title: 'Getting Started with the Linode API',
+  body: 'The Linode API allows you to automate any task that can be performed by the Linode Manager, such as creating Linodes, managing IP addresses and DNS, and opening support tickets.',
+  src: 'https://linode.com/docs/platform/api/getting-started-with-the-linode-api-new-manager/'
+}

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -1,3 +1,21 @@
+/**
+ * The docs in this file are intended for reuse throughout the app by means of the setDocs function.
+ * In a component that will use the Docs sidebar, import as many of the objects below as needed, then
+ * pass them as an array to the setDocs method. The usual pattern is:
+ * 
+ * import { Domains } from 'src/documentation';
+ * 
+ * ...
+ * 
+ * static docs = [ Domains ]
+ * 
+ * compose(
+ *  ...
+ *  setDocs(Domains.docs)
+ * )
+ */
+
+
 export const Domains: Linode.Doc = {
   title: 'DNS Manager',
   body: 'The Domains section of the Linode Manger is a comprehensive DNS management interface that allows you to add DNS records for all of your domain names. This guide covers the use of the Domains section and basic domain zone setup. For an introduction to DNS in general, see our Introduction to DNS Records guide.',

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -63,3 +63,23 @@ export const LinodeAPI: Linode.Doc = {
   body: 'The Linode API allows you to automate any task that can be performed by the Linode Manager, such as creating Linodes, managing IP addresses and DNS, and opening support tickets.',
   src: 'https://linode.com/docs/platform/api/getting-started-with-the-linode-api-new-manager/'
 }
+
+export const LISH: Linode.Doc = {
+  title: 'Using the Linode Shell (Lish)',
+  src: 'https://www.linode.com/docs/networking/using-the-linode-shell-lish/',
+  body: 'Learn how to use Lish as a shell for managing or rescuing your Linode.',
+}
+
+export const LinodeGettingStarted: Linode.Doc = {
+  title: 'Getting Started with Linode',
+  src: 'https://linode.com/docs/getting-started/',
+  body: `This guide will help you set up your first Linode.`,
+}
+
+export const SecuringYourServer: Linode.Doc = {
+  title: 'How to Secure your Server',
+  src: 'https://linode.com/docs/security/securing-your-server/',
+  body: `This guide covers basic best practices for securing a production server,
+  including setting up user accounts, configuring a firewall, securing SSH,
+  and disabling unused network services.`,
+}

--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -30,7 +30,7 @@ export const SecurityControls: Linode.Doc = {
 
 export const BillingAndPayments: Linode.Doc = {
   title: 'Billing and Payments',
-  body: 'We’ve done our best to create straightforward billing and payment policies. Still have questions? Use this guide to learn how our hosrcy billing works and how to make payments, update your billing information, get referral credits, and remove services. If you have a question that isn’t answered here, please feel free to contact support.',
+  body: 'We’ve done our best to create straightforward billing and payment policies. Still have questions? Use this guide to learn how our hourly billing works and how to make payments, update your billing information, get referral credits, and remove services. If you have a question that isn’t answered here, please feel free to contact support.',
   src: 'https://linode.com/docs/platform/billing-and-support/billing-and-payments-new-manager/'
 }
 

--- a/src/features/Account/AccountDetail.tsx
+++ b/src/features/Account/AccountDetail.tsx
@@ -6,6 +6,7 @@ import Typography from '@material-ui/core/Typography';
 
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { AccountsAndPasswords, BillingAndPayments } from 'src/documentation';
 import { Requestable } from 'src/requestableContext';
 import { getAccountInfo } from 'src/services/account';
 import composeState from 'src/utilities/composeState';
@@ -53,16 +54,8 @@ const L = {
 
 export class AccountDetail extends React.Component<CombinedProps, State> {
   static docs = [
-    {
-      title: 'Billing and Payments',
-      src: 'https://www.linode.com/docs/platform/billing-and-payments/',
-      body: `Our guide to billing and payments.`,
-    },
-    {
-      title: 'Accounts and Passwords',
-      src: 'https://www.linode.com/docs/platform/accounts-and-passwords/',
-      body: `Our guide to managing accounts and passwords.`,
-    },
+    BillingAndPayments,
+    AccountsAndPasswords,
   ];
 
   composeState = composeState;

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -23,6 +23,7 @@ import Placeholder from 'src/components/Placeholder';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
+import { Domains } from 'src/documentation';
 import { sendToast } from 'src/features/ToastNotifications/toasts';
 import { deleteDomain, getDomains$ } from 'src/services/domains';
 import scrollToTop from 'src/utilities/scrollToTop';
@@ -96,16 +97,7 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
   };
 
   static docs: Linode.Doc[] = [
-    {
-      title: 'Getting Started',
-      src: 'https://www.linode.com/docs/networking/dns/dns-manager-overview/#getting-started',
-      body: `The Domain Name System (DNS) attaches human-readable domain names to machine-usable IP
-      addresses. In many ways, it is the phone book of the Internet. Just like a phone book can
-      help you find the phone number of a business, DNS can take a domain name like google.com and
-      translate it into an IP address like 74.125.19.147, the IP address for Google’s homepage.
-      This global system allows users to remember the names of websites instead of their numeric
-      IP addresses.`,
-    },
+    Domains,
   ];
 
   cancelRequest: Function;

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -26,6 +26,7 @@ import PaginationFooter from 'src/components/PaginationFooter';
 import Placeholder from 'src/components/Placeholder';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
+import { Images } from 'src/documentation';
 import { events$ } from 'src/events';
 import { sendToast } from 'src/features/ToastNotifications/toasts';
 import { deleteImage, getImages } from 'src/services/images';
@@ -84,15 +85,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
   };
 
   static docs: Linode.Doc[] = [
-    {
-      title: 'Linode Images',
-      src: 'https://linode.com/docs/platform/linode-images/',
-      body: `Linode Images allows you to take snapshots of your disks,
-      and then deploy them to any Linode under your account.
-      This can be useful for bootstrapping a master image for a large deployment,
-      or retaining a disk for a configuration that you may not need running,
-      but wish to return to in the future.`,
-    },
+    Images,
     {
       title: 'Deploy an Image to a Linode',
       src: 'https://linode.com/docs/quick-answers/linode-platform/deploy-an-image-to-a-linode/',
@@ -213,7 +206,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
          * will not return the image scheduled for deletion. This request
          * is ensuring the image is removed from the list, to prevent the user
          * from taking any action on the Image.
-         * */
+         */
         this.props.request();
         sendToast('Image has been scheduled for deletion.');
       })

--- a/src/features/Longview/LongviewLanding.tsx
+++ b/src/features/Longview/LongviewLanding.tsx
@@ -12,6 +12,7 @@ import {
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Placeholder from 'src/components/Placeholder';
+import { MonitoringYourServer } from 'src/documentation';
 
 type ClassNames = 'root';
 
@@ -28,11 +29,7 @@ export class LongviewLanding extends React.Component<CombinedProps, {}> {
       src: 'https://www.linode.com/docs/platform/longview/longview/',
       body: `This guide shows how to install and use Linode Longview.`,
     },
-    {
-      title: 'Monitoring and Maintaining Your Server',
-      src: 'https://www.linode.com/docs/uptime/monitoring-and-maintaining-your-server/',
-      body: `This guide introdues concepts and tools for monitoring and maintaining your server.`,
-    },
+    MonitoringYourServer,
   ];
 
   render() {

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -26,6 +26,7 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableRowError from 'src/components/TableRowError';
+import { NodeBalancerGettingStarted, NodeBalancerReference } from 'src/documentation';
 import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
 import { deleteNodeBalancer, getNodeBalancerConfigs, getNodeBalancers } from 'src/services/nodebalancers';
@@ -107,16 +108,8 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
   };
 
   static docs = [
-    {
-      title: 'Getting Started with NodeBalancers',
-      src: 'https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/',
-      body: `Using a NodeBalancer to begin managing a simple web application`,
-    },
-    {
-      title: 'NodeBalancer Reference Guide',
-      src: 'https://www.linode.com/docs/platform/nodebalancer/nodebalancer-reference-guide/',
-      body: `NodeBalancer Reference Guide`,
-    },
+    NodeBalancerGettingStarted,
+    NodeBalancerReference,
   ];
 
   componentDidMount() {
@@ -415,12 +408,12 @@ const updatedRequest = (ownProps: any, params: any, filter: any) => {
 
 const paginated = paginate(updatedRequest);
 
-export const enhanced = compose(
+export const enhanced = compose<any, any, any, any, any, any>(
   styled,
   withRouter,
   SectionErrorBoundary,
+  paginated,
   setDocs(NodeBalancersLanding.docs),
-  paginated
 );
 
 export default enhanced(NodeBalancersLanding);

--- a/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
+++ b/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
@@ -7,6 +7,7 @@ import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/st
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Notice from 'src/components/Notice';
+import { AccountsAndPasswords, SecurityControls } from 'src/documentation';
 import { handleUpdate } from 'src/store/reducers/resources/profile';
 
 import SecuritySettings from './SecuritySettings';
@@ -80,11 +81,10 @@ export class AuthenticationSettings extends React.Component<CombinedProps, State
     );
   }
 
-  static docs = [{
-    title: 'Accounts and Passwords',
-    src: 'https://linode.com/docs/platform/accounts-and-passwords/',
-    body: 'Maintaining your user accounts, passwords, and contact information is just as important as administering your Linode.'
-  }];
+  static docs = [
+    AccountsAndPasswords,
+    SecurityControls,
+  ];
 
 }
 

--- a/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -6,6 +6,7 @@ import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/st
 
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { AccountsAndPasswords } from 'src/documentation';
 import { handleUpdate } from 'src/store/reducers/resources/profile';
 
 import EmailChangeForm from './EmailChangeForm';
@@ -66,11 +67,9 @@ export class DisplaySettings extends React.Component<CombinedProps, State> {
     );
   }
 
-  static docs = [{
-    title: 'Accounts and Passwords',
-    src: 'https://linode.com/docs/platform/accounts-and-passwords/',
-    body: 'Maintaining your user accounts, passwords, and contact information is just as important as administering your Linode.'
-  }];
+  static docs = [
+    AccountsAndPasswords,
+  ];
 
 }
 

--- a/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/src/features/Profile/LishSettings/LishSettings.tsx
@@ -18,6 +18,7 @@ import MenuItem from 'src/components/MenuItem';
 import Notice from 'src/components/Notice';
 import Select from 'src/components/Select';
 import TextField from 'src/components/TextField';
+import { LISH } from 'src/documentation';
 import { updateProfile } from 'src/services/profile';
 import { handleUpdate } from 'src/store/reducers/resources/profile';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
@@ -192,11 +193,9 @@ class LishSettings extends React.Component<CombinedProps, State> {
     );
   }
 
-  static docs = [{
-    title: 'Using the Linode Shell (Lish)',
-    src: 'https://www.linode.com/docs/networking/using-the-linode-shell-lish/',
-    body: 'Learn how to use Lish as a shell for managing or rescuing your Linode.',
-  }];
+  static docs = [
+    LISH,
+  ];
 
   addSSHPublicKeyField = () =>
     this.setState({ authorizedKeysCount: this.state.authorizedKeysCount + 1 });

--- a/src/features/Profile/OAuthClients/OAuthClients.test.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClients.test.tsx
@@ -1,6 +1,8 @@
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as React from 'react';
 
+import { clearDocs, setDocs } from 'src/store/reducers/documentation';
+
 import { OAuthClients } from './OAuthClients';
 
 describe('OAuth Clients', () => {
@@ -55,6 +57,8 @@ describe('OAuth Clients', () => {
         request={request}
         data={mockData}
         handleOrderChange={updateOrderBy}
+        setDocs={setDocs}
+        clearDocs={clearDocs}
       />
     );
   })

--- a/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -11,6 +11,7 @@ import Typography from '@material-ui/core/Typography';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
@@ -22,6 +23,7 @@ import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
+import { LinodeAPI } from 'src/documentation';
 import { createOAuthClient, deleteOAuthClient, getOAuthClients, resetOAuthClientSecret, updateOAuthClient } from 'src/services/account';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
@@ -63,7 +65,7 @@ interface State {
   form: FormState;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props & WithStyles<ClassNames> & SetDocsProps;
 
 export class OAuthClients extends React.Component<CombinedProps, State> {
   static defaultState = {
@@ -93,6 +95,10 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
   static defaultProps = {
     data: [],
   };
+
+  static docs = [
+    LinodeAPI,
+  ]
 
   reset = () => {
     this.setState({ ...OAuthClients.defaultState });
@@ -353,9 +359,10 @@ const updatedRequest = (ownProps: any, params: any, filters: any) => getOAuthCli
 
 const paginated = paginate(updatedRequest);
 
-const enhanced = compose<any, any, any>(
+const enhanced = compose<any, any, any, any>(
   styled,
   paginated,
+  setDocs(OAuthClients.docs),
 );
 
 export default enhanced(OAuthClients);

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -17,6 +17,7 @@ import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import PromiseLoader from 'src/components/PromiseLoader';
+import { StackScripts } from 'src/documentation';
 import ScriptForm from 'src/features/StackScripts/StackScriptForm';
 import { getLinodeImages } from 'src/services/images';
 import { createStackScript } from 'src/services/stackscripts';
@@ -95,11 +96,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
   };
 
   static docs = [
-    {
-      title: 'Automate Deployment with StackScripts',
-      src: 'https://www.linode.com/docs/platform/stackscripts/',
-      body: `Create Custom Instances and Automate Deployment with StackScripts.`,
-    },
+    StackScripts,
   ];
 
   mounted: boolean = false;

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -17,6 +17,7 @@ import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import PromiseLoader from 'src/components/PromiseLoader';
+import { StackScripts } from 'src/documentation';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import ScriptForm from 'src/features/StackScripts/StackScriptForm';
 import { getLinodeImages } from 'src/services/images';
@@ -121,11 +122,7 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
   }
 
   static docs = [
-    {
-      title: 'Automate Deployment with StackScripts',
-      src: 'https://www.linode.com/docs/platform/stackscripts/',
-      body: `Create Custom Instances and Automate Deployment with StackScripts.`,
-    },
+    StackScripts,
   ];
 
   mounted: boolean = false;

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -12,6 +12,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import PromiseLoader from 'src/components/PromiseLoader';
+import { StackScripts } from 'src/documentation';
 import { getLinodeImages } from 'src/services/images';
 
 import SelectStackScriptPanel from './SelectStackScriptPanel';
@@ -41,11 +42,7 @@ type CombinedProps = SetDocsProps
 
 export class StackScriptsLanding extends React.Component<CombinedProps, {}> {
   static docs = [
-    {
-      title: 'Automate Deployment with StackScripts',
-      src: 'https://www.linode.com/docs/platform/stackscripts/',
-      body: `Create Custom Instances and Automate Deployment with StackScripts.`,
-    },
+    StackScripts,
   ];
 
   goToCreateStackScript = () => {

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -24,6 +24,7 @@ import Placeholder from 'src/components/Placeholder';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRowError from 'src/components/TableRowError';
+import { BlockStorage } from 'src/documentation';
 import { generateInFilter, resetEventsPolling } from 'src/events';
 import { sendToast } from 'src/features/ToastNotifications/toasts';
 import { getLinodes } from 'src/services/linodes';
@@ -118,12 +119,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   mounted: boolean = false;
 
   static docs: Linode.Doc[] = [
-    {
-      title: 'How to Use Block Storage with Your Linode',
-      /* tslint:disable-next-line */
-      src: `https://www.linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode`,
-      body: `This tutorial explains how to use Linode's block storage service.`,
-    },
+    BlockStorage,
     {
       title: 'Boot a Linode from a Block Storage Volume',
       src: `https://www.linode.com/docs/platform/block-storage/boot-from-block-storage-volume/`,

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -16,6 +16,7 @@ import Grid from 'src/components/Grid';
 import Pagey, { PaginationProps } from 'src/components/Pagey';
 import PaginationFooter from 'src/components/PaginationFooter';
 import { withTypes } from 'src/context/types';
+import { LinodeGettingStarted, SecuringYourServer } from 'src/documentation';
 import LinodeConfigSelectionDrawer, { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 import { getImages } from 'src/services/images';
 import { getLinodes } from 'src/services/linodes';
@@ -92,19 +93,8 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
   };
 
   static docs = [
-    {
-      title: 'Getting Started with Linode',
-      src: 'https://linode.com/docs/getting-started/',
-      body: `This guide will help you set up your first Linode.`,
-    },
-    {
-      title: 'How to Secure your Server',
-      src: 'https://linode.com/docs/security/securing-your-server/',
-      body: `This guide covers basic best practices for securing a production server,
-      including setting up user accounts, configuring a firewall, securing SSH,
-      and disabling unused network services.`,
-    },
-
+    LinodeGettingStarted,
+    SecuringYourServer,
   ];
 
   getImages = () => {


### PR DESCRIPTION
## Purpose

The Dcos team has made updated versions of ~10 guides
to include screenshots nad updated information for the new Manager.
This PR links to the updated docs from the sidebar of the corresponding
sections of the Manager.

## Notes

* Add `src/documentation.ts`, which exports objects for the new docs
* Replace hard-coded docs with these exported objects