### PR TITLE
switch order of HOC's in compose

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -431,6 +431,6 @@ export const connected = connect(mapStateToProps, undefined);
 
 export default compose<Linode.TodoAny, Linode.TodoAny, Linode.TodoAny, Linode.TodoAny>(
   withStyles(styles, { withTheme: true }),
-  connected,
   withRouter,
+  connected,
 )(PrimaryNav);


### PR DESCRIPTION
Currently active route was not being highlighted int he sidebar.

Due to https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/guides/blocked-updates.md,
React Router props were not updating in PrimaryNav. Switched order of connected and withRouter in compose() and
the issue was resolved.