### PR TITLE
M3-1189 community search

### DIFF
--- a/src/__data__/searchResults.ts
+++ b/src/__data__/searchResults.ts
@@ -1,0 +1,31 @@
+export const community_question = {
+  objectID: 'q_98',
+  title: "This is a community question.",
+  description: "Short description",
+  _highlightResult: {
+    title: {
+      value: "<em>This</em> is a community question."
+    }
+  }
+}
+
+export const community_answer = {
+  objectID: 'a_98',
+  description: "Short description",
+  _highlightResult: {
+    description: {
+      value: "<em>Short</em> description."
+    }
+  }
+}
+
+export const docs_result = {
+  objectID: '123456',
+  title: "Update and Secure Drupal 8 on Ubuntu or Debian",
+  _highlightResult: {
+    title: {
+      value: '<em>Update</em> and Secure Drupal 8 on Ubunto or Debian'
+    }
+  },
+  href: "/docs/websites/cms/update-and-secure-drupal-8-on-ubuntu/"
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export const LOGIN_SESSION_LIFETIME_MS = 45 * 60 * 1000;
 export const OAUTH_TOKEN_REFRESH_TIMEOUT = LOGIN_SESSION_LIFETIME_MS / 2;
 
 export const DOCS_BASE_URL = 'https://linode.com/';
+export const COMMUNITY_BASE_URL = 'https://linode.com/community/';
 export const DOCS_SEARCH_URL = 'https://linode.com/docs/search/?q=';
 export const COMMUNITY_SEARCH_URL = 'https://linode.com/community/questions/search?query=';
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,7 +18,7 @@ export const SENTRY_URL = process.env.REACT_APP_SENTRY_URL;
 export const LOGIN_SESSION_LIFETIME_MS = 45 * 60 * 1000;
 export const OAUTH_TOKEN_REFRESH_TIMEOUT = LOGIN_SESSION_LIFETIME_MS / 2;
 
-export const DOCS_BASE_URL = 'https://linode.com/';
+export const DOCS_BASE_URL = 'https://linode.com';
 export const COMMUNITY_BASE_URL = 'https://linode.com/community/';
 export const DOCS_SEARCH_URL = 'https://linode.com/docs/search/?q=';
 export const COMMUNITY_SEARCH_URL = 'https://linode.com/community/questions/search?query=';

--- a/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -1,4 +1,3 @@
-import * as Algolia from 'algoliasearch';
 import { compose, concat, pathOr } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -11,10 +10,9 @@ import {
 
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect';
 import Notice from 'src/components/Notice';
-import { ALGOLIA_APPLICATION_ID, ALGOLIA_SEARCH_KEY, COMMUNITY_BASE_URL, DOCS_BASE_URL } from 'src/constants';
 import windowIsNarrowerThan from 'src/utilities/breakpoints';
-import truncate from 'src/utilities/truncateText';
 
+import withSearch from '../SearchHOC';
 import SearchItem from './SearchItem';
 
 type ClassNames = 'root'
@@ -61,33 +59,26 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 });
 
 interface State {
-  enabled: boolean;
   value: string;
   inputValue: string;
-  options: Item[];
-  error?: string; 
 }
 
-interface SearchHit {
-  title?: string;
-  description: string;
-  keywords: string;
-  objectID: string;
-  href?: string;
-  _highlightResult?: any;
-  _rankingInfo?: any;
+interface Props {
+  /** Comes from HOC */
+  searchAlgolia: (inputValue: string) => void;
+  searchEnabled: boolean;
+  searchError?: string;
+  searchResults: [Item[], Item[]];
 }
 
-type CombinedProps = WithStyles<ClassNames> & RouteComponentProps<{}>;
+type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{}>;
 class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
   searchIndex: any = null;
   mounted: boolean = false;
   isMobile: boolean = false;
   state: State = {
-    enabled: true,
     value: '',
     inputValue: '',
-    options: [],
   };
 
   componentDidMount() {
@@ -96,135 +87,23 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
     if (theme) {
       this.isMobile = windowIsNarrowerThan(theme.breakpoints.values.sm);
     }
-    // initialize Algolia API Client
-    this.initializeSearchIndices();
   }
 
   componentWillUnmount() {
     this.mounted = false;
   }
 
-  initializeSearchIndices = () => {
-    try {
-      const client = Algolia(ALGOLIA_APPLICATION_ID, ALGOLIA_SEARCH_KEY);
-      this.searchIndex = client;
-    }
-    catch {
-      // Credentials were incorrect or couldn't be found;
-      // Disable search functionality in the component.
-      this.setState({ enabled: false, error: "Search could not be enabled." });
-      return;
-    }
-  }
-
   getDataFromOptions = () => {
-    const { options, inputValue } = this.state;
+    const { inputValue } = this.state;
+    const [docs, community] = this.props.searchResults;
+    const options = [...docs,...community];
     return concat(options,[{value: 'search', label: inputValue, data: { source: 'finalLink'}}]);
-  }
-
-  searchAlgolia = (inputValue:string) => {
-    if (!this.mounted) { return; }
-    if (!inputValue) { 
-      this.setState({ options: [] }); 
-      return; 
-    }
-    if (!this.searchIndex) {
-      this.setState({ options: [], error: "Search could not be enabled."});
-      return;
-    }
-    this.searchIndex.search([{
-      indexName: 'linode-docs',
-      query: inputValue,
-      params: {
-        hitsPerPage: 10,
-        attributesToRetrieve: [
-          'title',
-          'description',
-          '_highlightResult',
-          'href',
-        ]
-      }
-    }, {
-      indexName: 'linode-community',
-      query: inputValue,
-      params: {
-        hitsPerPage: 10,
-        distinct: true,
-        attributesToRetrieve: [
-          'title',
-          'description',
-          '_highlightResult',
-        ]
-      }
-    }], this.searchSuccess);
-  }
-
-  searchSuccess = (err:any, content:any) => {
-    if (!this.mounted) { return; }
-    if (err) {
-      /*
-      * Errors from Algolia have the format: {'message': string, 'code': number}
-      * We do not want to push these messages on to the user as they are not under
-      * our control and can be account-related (e.g. "You have exceeded your quota").
-      */
-      this.setState({ error: "There was an error retrieving your search results." });
-      return;
-    }
-
-    const { results } = content;
-    const docsResults = this.convertDocsToItems(results[0].hits);
-    const commResults = this.convertCommunityToItems(results[1].hits);
-    const combinedResults = [...docsResults, ...commResults];
-    this.setState({ options: combinedResults, error: undefined });
-  }
-
-  convertDocsToItems = (hits: SearchHit[]) : Item[] => {
-    if (!hits) { return []; }
-    return hits.map((hit: SearchHit, idx: number) => {
-      return { value: idx, label: hit._highlightResult.title.value, data: {
-        source: 'Linode documentation',
-        href: DOCS_BASE_URL + hit.href,
-      } }
-    })
-  }
-
-  convertCommunityToItems = (hits: SearchHit[]) : Item[] => {
-    if (!hits) { return []; }
-    return hits.map((hit: SearchHit, idx: number) => {
-      return { value: idx, label: this.getCommunityResultLabel(hit), data: {
-        source: 'Linode Community Site',
-        href: this.getCommunityUrl(hit.objectID),
-      }}
-    })
-  }
-
-  getCommunityUrl = (id: string) => {
-    // Rather than crash here, better to redirect to the base community site.
-    if (!id) { return COMMUNITY_BASE_URL; }
-    const [prefix, value] = id.split('_');
-    return prefix === 'q' // Prefix is q for question, a for answer.
-    ? `${COMMUNITY_BASE_URL}questions/${value}`
-    : `${COMMUNITY_BASE_URL}questions/answer/${value}`;
-  }
-
-  getCommunityResultLabel = (hit: any) => {
-    /* If a word in the title matched the search query, return a string
-    * with the matched word highlighted.
-    *
-    * NOTE: It's currently planned to add the title of the parent question
-    * to the index entry for each answer. When that is done, the ternaries
-    * below can be removed. In the meantime, answers don't include
-    * a title, so use the truncated description.
-    */
-    return hit._highlightResult.title
-    ? hit._highlightResult.title.value
-    : truncate(hit.description, 30)
   }
 
   onInputValueChange = (inputValue: string) => {
     if (!this.mounted) { return; }
     this.setState({ inputValue });
-    this.searchAlgolia(inputValue);
+    this.props.searchAlgolia(inputValue);
   }
 
   renderOptionsHelper = (item:Item, currentIndex:number, highlighted:boolean, itemProps:any) => {
@@ -263,15 +142,15 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { classes } = this.props;
-    const { enabled, error, inputValue, value } = this.state;
+    const { classes, searchEnabled, searchError } = this.props;
+    const { inputValue, value } = this.state;
     const data = this.getDataFromOptions();
 
     return (
       <React.Fragment>
-      {error && <Notice error spacingTop={8} spacingBottom={0} >{error}</Notice>}
+      {searchError && <Notice error spacingTop={8} spacingBottom={0} >{searchError}</Notice>}
         <EnhancedSelect
-          disabled={!enabled}
+          disabled={!searchEnabled}
           options={data}
           value={value}
           inputValue={inputValue}
@@ -291,7 +170,9 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
 }
 
 const styled = withStyles(styles, { withTheme: true });
+const search = withSearch({hitsPerPage: 10, highlight: true});
 
-export default compose<any,any,any>(
+export default compose<any,any,any,any>(
   styled,
+  search,
   withRouter)(AlgoliaSearchBar);

--- a/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -12,7 +12,7 @@ import EnhancedSelect, { Item } from 'src/components/EnhancedSelect';
 import Notice from 'src/components/Notice';
 import windowIsNarrowerThan from 'src/utilities/breakpoints';
 
-import withSearch from '../SearchHOC';
+import withSearch, { AlgoliaState as AlgoliaProps } from '../SearchHOC';
 import SearchItem from './SearchItem';
 
 type ClassNames = 'root'
@@ -63,15 +63,7 @@ interface State {
   inputValue: string;
 }
 
-interface Props {
-  /** Comes from HOC */
-  searchAlgolia: (inputValue: string) => void;
-  searchEnabled: boolean;
-  searchError?: string;
-  searchResults: [Item[], Item[]];
-}
-
-type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{}>;
+type CombinedProps = AlgoliaProps & WithStyles<ClassNames> & RouteComponentProps<{}>;
 class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
   searchIndex: any = null;
   mounted: boolean = false;

--- a/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -69,6 +69,16 @@ interface State {
   error?: string; 
 }
 
+interface SearchHit {
+  title?: string;
+  description: string;
+  keywords: string;
+  objectID: string;
+  href?: string;
+  _highlightResult?: any;
+  _rankingInfo?: any;
+}
+
 type CombinedProps = WithStyles<ClassNames> & RouteComponentProps<{}>;
 class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
   searchIndex: any = null;
@@ -163,13 +173,13 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
 
   sortByRank = (a: Item, b: Item) => {
     if (a.data.rank > b.data.rank) { return 1; }
-    else if (a.data.rank === b.data.rank) { return -1;}
+    else if (a.data.rank < b.data.rank) { return -1;}
     return 0;
   }
 
-  convertDocsToItems = (hits: any) : Item[] => {
+  convertDocsToItems = (hits: SearchHit[]) : Item[] => {
     if (!hits) { return []; }
-    return hits.map((hit: any, idx: number) => {
+    return hits.map((hit: SearchHit, idx: number) => {
       return { value: idx, label: hit._highlightResult.title.value, data: {
         source: 'Linode documentation',
         href: DOCS_BASE_URL + hit.href,
@@ -178,9 +188,9 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
     })
   }
 
-  convertCommunityToItems = (hits: any) : Item[] => {
+  convertCommunityToItems = (hits: SearchHit[]) : Item[] => {
     if (!hits) { return []; }
-    return hits.map((hit: any, idx: number) => {
+    return hits.map((hit: SearchHit, idx: number) => {
       return { value: idx, label: this.getCommunityResultLabel(hit), data: {
         source: 'Linode Community Site',
         href: this.getCommunityUrl(hit.objectID),
@@ -200,12 +210,11 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
 
   getCommunityResultLabel = (hit: any) => {
     /* If a word in the title matched the search query, return a string
-    * with the matched word highlighted. Otherwise, this isn't defined,
-    * so return the title.
-    * 
+    * with the matched word highlighted.
+    *
     * NOTE: It's currently planned to add the title of the parent question
-    * to the index entry for each answer. When that is done, the second
-    * ternary below can be removed. In the meantime, answers don't include
+    * to the index entry for each answer. When that is done, the ternaries
+    * below can be removed. In the meantime, answers don't include
     * a title, so use the truncated description.
     */
     return hit._highlightResult.title

--- a/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -137,7 +137,12 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
       query: inputValue,
       params: {
         hitsPerPage: 10,
-        getRankingInfo: true
+        attributesToRetrieve: [
+          'title',
+          'description',
+          '_highlightResult',
+          'href',
+        ]
       }
     }, {
       indexName: 'linode-community',
@@ -145,7 +150,11 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
       params: {
         hitsPerPage: 10,
         distinct: true,
-        getRankingInfo: true
+        attributesToRetrieve: [
+          'title',
+          'description',
+          '_highlightResult',
+        ]
       }
     }], this.searchSuccess);
   }

--- a/src/features/Help/SearchHOC.test.tsx
+++ b/src/features/Help/SearchHOC.test.tsx
@@ -3,12 +3,16 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import withSearch, {
+  cleanDescription,
+  convertCommunityToItems,
+  convertDocsToItems,
   getCommunityResultLabel,
+  getCommunityUrl,
   getDocsResultLabel,
 } from './SearchHOC';
 
 import { community_answer, community_question, docs_result } from 'src/__data__/searchResults';
-// import { DOCS_BASE_URL } from 'src/constants';
+import { COMMUNITY_BASE_URL, DOCS_BASE_URL } from 'src/constants';
 
 const HITS_PER_PAGE = 10;
 
@@ -107,7 +111,29 @@ describe("Algolia Search HOC", () => {
         result._highlightResult = {};
         const label3 = getDocsResultLabel(result, true);
         expect(label3).toBe(result.title);
-      })
+      });
+    });
+    describe("getCommunityUrl", () => {
+      it("should parse a community question", () => {
+        expect(getCommunityUrl('q_123')).toMatch('/questions/123');
+      });
+      it("should parse a community answer", () => {
+        expect(getCommunityUrl('a_123')).toMatch('/questions/answer/123');
+      });
+      it("should handle strange input", () => {
+        expect(getCommunityUrl("I'm not a URL")).toEqual(COMMUNITY_BASE_URL);
+      });
+    });
+    describe("cleanDescription", () => {
+      it("should return a normal string unchanged", () => {
+        expect(cleanDescription('just a description')).toBe('just a description');
+      });
+      it("should trim a <t> tag", () => {
+        expect(cleanDescription('<t>I have a tag')).toBe('I have a tag');
+      });
+      it("should trim a <r> tag", () => {
+        expect(cleanDescription('<r>I also have a tag')).toBe('I also have a tag')
+      });
     });
     describe("getCommunityResultLabel", () => {
       it("should use the highlighted title if available", () => {
@@ -127,6 +153,45 @@ describe("Algolia Search HOC", () => {
         result.description = "A much longer description that can't possibly fit on one line of a results list.";
         const label7 = getCommunityResultLabel(result, true);
         expect(label7).toBe("A much longer description that can ...");
+      });
+    });
+    describe("convertDocsToItems", () => {
+      it("should convert docs to a correctly formatted Item[]", () => {
+        const formattedResults = convertDocsToItems([docs_result], false);
+        expect(formattedResults).toEqual([{
+          value: 0,
+          label: docs_result.title,
+          data: {
+            href: DOCS_BASE_URL + docs_result.href,
+            source: 'Linode documentation'
+          }
+        }]);
+      });
+      it("should handle empty results lists correctly", () => {
+        const results = convertDocsToItems([], false);
+        expect(results).toEqual([]);
+      });
+    });
+    describe("convertCommunityToItems", () => {
+      it("should convert a community question to a correctly formatted Item", () => {
+        const formattedResults = convertCommunityToItems([community_question] as any, false);
+        expect(formattedResults).toEqual([{
+          value: 0,
+          label: community_question.title,
+          data: {
+            source: 'Linode Community Site',
+            href: expect.any(String),
+          }}]);
+        });
+      it("should convert a community answer to a correctly formatted Item", () => {
+        const formattedResults = convertCommunityToItems([community_answer] as any, false);
+        expect(formattedResults).toEqual([{
+          value: 0,
+          label: community_question.description,
+          data: {
+            source: 'Linode Community Site',
+            href: expect.any(String),
+          }}]);
       });
     });
   });

--- a/src/features/Help/SearchHOC.test.tsx
+++ b/src/features/Help/SearchHOC.test.tsx
@@ -1,0 +1,63 @@
+import * as algoliasearch from 'algoliasearch';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import withSearch from './SearchHOC';
+
+const HITS_PER_PAGE = 10;
+
+const mockFn = jest.fn();
+
+jest.mock('algoliasearch', () => jest.fn((key: string, appId: string) => {
+  return {
+    search: mockFn,
+  }
+}));
+
+const getSearchFromQuery = (query: string) => [{
+  indexName: 'linode-docs',
+  query,
+  params: {
+    hitsPerPage: HITS_PER_PAGE,
+    attributesToRetrieve: [
+      'title',
+      'description',
+      '_highlightResult',
+      'href',
+    ]
+  }
+}, {
+  indexName: 'linode-community',
+  query,
+  params: {
+    hitsPerPage: HITS_PER_PAGE,
+    distinct: true,
+    attributesToRetrieve: [
+      'title',
+      'description',
+      '_highlightResult',
+    ]
+  }
+}];
+
+const searchable = withSearch({hitsPerPage: HITS_PER_PAGE, highlight: false});
+const RawComponent = searchable(React.Component);
+
+const component = shallow(<RawComponent />);
+
+describe("Algolia Search HOC", () => {
+  it("should initialize the index", () => {
+    expect(algoliasearch).toHaveBeenCalled();
+    expect(component.props().searchEnabled).toBe(true);
+  });
+  it("should search the Algolia indices", () => {
+    const query = getSearchFromQuery('hat')
+    component.props().searchAlgolia('hat');
+    expect(mockFn).toHaveBeenCalledWith(query, expect.any(Function));
+  });
+  it("should save an error to state if the request to Algolia fails", () => {
+    mockFn.mockImplementationOnce((queries: any, callback: any) => callback({message: "I reject this request.", code: 500}, undefined));
+    component.props().searchAlgolia('existentialism');
+    expect(component.props().searchError).toEqual("There was an error retrieving your search results.");
+  });
+});

--- a/src/features/Help/SearchHOC.test.tsx
+++ b/src/features/Help/SearchHOC.test.tsx
@@ -157,7 +157,7 @@ describe("Algolia Search HOC", () => {
     });
     describe("convertDocsToItems", () => {
       it("should convert docs to a correctly formatted Item[]", () => {
-        const formattedResults = convertDocsToItems([docs_result], false);
+        const formattedResults = convertDocsToItems(false, [docs_result]);
         expect(formattedResults).toEqual([{
           value: 0,
           label: docs_result.title,
@@ -168,13 +168,13 @@ describe("Algolia Search HOC", () => {
         }]);
       });
       it("should handle empty results lists correctly", () => {
-        const results = convertDocsToItems([], false);
+        const results = convertDocsToItems(false, []);
         expect(results).toEqual([]);
       });
     });
     describe("convertCommunityToItems", () => {
       it("should convert a community question to a correctly formatted Item", () => {
-        const formattedResults = convertCommunityToItems([community_question] as any, false);
+        const formattedResults = convertCommunityToItems(false, [community_question] as any);
         expect(formattedResults).toEqual([{
           value: 0,
           label: community_question.title,
@@ -184,7 +184,7 @@ describe("Algolia Search HOC", () => {
           }}]);
         });
       it("should convert a community answer to a correctly formatted Item", () => {
-        const formattedResults = convertCommunityToItems([community_answer] as any, false);
+        const formattedResults = convertCommunityToItems(false, [community_answer] as any);
         expect(formattedResults).toEqual([{
           value: 0,
           label: community_question.description,

--- a/src/features/Help/SearchHOC.test.tsx
+++ b/src/features/Help/SearchHOC.test.tsx
@@ -2,7 +2,13 @@ import * as algoliasearch from 'algoliasearch';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import withSearch from './SearchHOC';
+import withSearch, {
+  getCommunityResultLabel,
+  getDocsResultLabel,
+} from './SearchHOC';
+
+import { community_answer, community_question, docs_result } from 'src/__data__/searchResults';
+// import { DOCS_BASE_URL } from 'src/constants';
 
 const HITS_PER_PAGE = 10;
 
@@ -14,6 +20,17 @@ jest.mock('algoliasearch', () => jest.fn((key: string, appId: string) => {
   }
 }));
 
+const mockResults = {
+  results: [
+    { hits: [docs_result] },
+    { hits: [community_question] }
+  ]
+}
+
+const emptyResults = {
+  results: [{ hits: []}, { hits: []}]
+}
+
 const getSearchFromQuery = (query: string) => [{
   indexName: 'linode-docs',
   query,
@@ -21,7 +38,6 @@ const getSearchFromQuery = (query: string) => [{
     hitsPerPage: HITS_PER_PAGE,
     attributesToRetrieve: [
       'title',
-      'description',
       '_highlightResult',
       'href',
     ]
@@ -46,18 +62,72 @@ const RawComponent = searchable(React.Component);
 const component = shallow(<RawComponent />);
 
 describe("Algolia Search HOC", () => {
-  it("should initialize the index", () => {
-    expect(algoliasearch).toHaveBeenCalled();
-    expect(component.props().searchEnabled).toBe(true);
+  describe("external API", () => {
+    afterEach(() => jest.resetAllMocks());
+    it("should initialize the index", () => {
+      expect(algoliasearch).toHaveBeenCalled();
+      expect(component.props().searchEnabled).toBe(true);
+    });
+    it("should search the Algolia indices", () => {
+      const query = getSearchFromQuery('hat')
+      component.props().searchAlgolia('hat');
+      expect(mockFn).toHaveBeenCalledWith(query, expect.any(Function));
+    });
+    it("should save an error to state if the request to Algolia fails", () => {
+      mockFn.mockImplementationOnce((queries: any, callback: any) => callback({message: "I reject this request.", code: 500}, undefined));
+      component.props().searchAlgolia('existentialism');
+      expect(component.props().searchError).toEqual("There was an error retrieving your search results.");
+    });
+    it("should set search results based on the Algolia response", () => {
+      mockFn.mockImplementationOnce((queries: any, callback: any) => callback(undefined, mockResults));
+      component.props().searchAlgolia('existentialism');
+      expect(component.props().searchResults[0]).toHaveLength(1);
+      expect(component.props().searchResults[1]).toHaveLength(1);
+    });
+    it("should set results list to empty on a blank query", () => {
+      expect(component.props().searchResults[0]).toHaveLength(1);
+      mockFn.mockImplementationOnce((queries: any, callback: any) => callback(undefined, emptyResults));
+      component.props().searchAlgolia('existentialism');
+      expect(component.props().searchResults[0]).toHaveLength(0);
+      expect(component.props().searchResults[1]).toHaveLength(0);
+    });
   });
-  it("should search the Algolia indices", () => {
-    const query = getSearchFromQuery('hat')
-    component.props().searchAlgolia('hat');
-    expect(mockFn).toHaveBeenCalledWith(query, expect.any(Function));
-  });
-  it("should save an error to state if the request to Algolia fails", () => {
-    mockFn.mockImplementationOnce((queries: any, callback: any) => callback({message: "I reject this request.", code: 500}, undefined));
-    component.props().searchAlgolia('existentialism');
-    expect(component.props().searchError).toEqual("There was an error retrieving your search results.");
+  describe("internal methods", () => {
+    describe("getDocsResultLabel", () => {
+      it("should return a label with highlighted content marked as <em>", () => {
+        const label = getDocsResultLabel(docs_result, true);
+        expect(label).toBe(docs_result._highlightResult.title.value);
+      });
+      it("should use the unformatted title when highlighting is set to false", () => {
+        const label2 = getDocsResultLabel(docs_result, false);
+        expect(label2).toBe(docs_result.title);
+      });
+      it("should return an unformatted label if there is no highlighted result", () => {
+        const result = {...docs_result} as any;
+        result._highlightResult = {};
+        const label3 = getDocsResultLabel(result, true);
+        expect(label3).toBe(result.title);
+      })
+    });
+    describe("getCommunityResultLabel", () => {
+      it("should use the highlighted title if available", () => {
+        const label4 = getCommunityResultLabel(community_question, true);
+        expect(label4).toBe(community_question._highlightResult.title.value);
+      });
+      it("should use the unformatted title if highlight is false", () => {
+        const label5 = getCommunityResultLabel(community_question, false);
+        expect(label5).toBe(community_question.title);
+      });
+      it("should use the description if no title is available", () => {
+        const label6 = getCommunityResultLabel(community_answer, true);
+        expect(label6).toBe(community_answer.description);
+      });
+      it("should truncate the title", () => {
+        const result = {...community_answer} as any;
+        result.description = "A much longer description that can't possibly fit on one line of a results list.";
+        const label7 = getCommunityResultLabel(result, true);
+        expect(label7).toBe("A much longer description that can ...");
+      });
+    });
   });
 });

--- a/src/features/Help/SearchHOC.tsx
+++ b/src/features/Help/SearchHOC.tsx
@@ -51,7 +51,7 @@ export const convertCommunityToItems = (hits: SearchHit[], highlight: boolean) :
 
 export const getCommunityUrl = (id: string) => {
   // Rather than crash here, better to redirect to the base community site.
-  if (!id) { return COMMUNITY_BASE_URL; }
+  if (!id || (!id.startsWith('q_') && !id.startsWith('a_'))) { return COMMUNITY_BASE_URL; }
   const [prefix, value] = id.split('_');
   return prefix === 'q' // Prefix is q for question, a for answer.
   ? `${COMMUNITY_BASE_URL}questions/${value}`
@@ -79,6 +79,10 @@ export const getCommunityResultLabel = (hit: any, highlight: boolean) => {
   return title
     ? title
     : truncate(hit.description, 30)
+}
+
+export const cleanDescription = (description: string): string => {
+  return(description.replace(/<r>|<t>/, ''));
 }
 
 export default (options: SearchOptions) => (Component: React.ComponentType<any>) => {

--- a/src/features/Help/SearchHOC.tsx
+++ b/src/features/Help/SearchHOC.tsx
@@ -15,7 +15,7 @@ interface SearchHit {
   _rankingInfo?: any;
 }
 
-interface State {
+export interface AlgoliaState {
   searchAlgolia: (inputValue: string) => void;
   searchEnabled: boolean;
   searchError?: string;
@@ -29,7 +29,7 @@ interface SearchOptions {
 
 export default (options: SearchOptions) => (Component: React.ComponentType<any>) => {
   const { hitsPerPage, highlight } = options;
-  class WrappedComponent extends React.PureComponent<{},State> {
+  class WrappedComponent extends React.PureComponent<{},AlgoliaState> {
     searchIndex: any;
     mounted: boolean = false;
 
@@ -163,7 +163,7 @@ export default (options: SearchOptions) => (Component: React.ComponentType<any>)
         : truncate(hit.description, 30)
     }
 
-    state: State = {
+    state: AlgoliaState = {
       searchAlgolia: this.searchAlgolia,
       searchEnabled: false,
       searchError: undefined,

--- a/src/features/Help/SearchHOC.tsx
+++ b/src/features/Help/SearchHOC.tsx
@@ -141,7 +141,9 @@ export default (options: SearchOptions) => (Component: React.ComponentType<any>)
     }
 
     getDocsResultLabel = (hit: any) => {
-      return highlight ? hit._highlightResult.title.value : hit.title;
+      return (highlight && hit._highlightResult.title)
+        ? hit._highlightResult.title.value
+        : hit.title;
     }
 
     getCommunityResultLabel = (hit: any) => {
@@ -153,10 +155,12 @@ export default (options: SearchOptions) => (Component: React.ComponentType<any>)
       * below can be removed. In the meantime, answers don't include
       * a title, so use the truncated description.
       */
-     const title = highlight ? hit._highlightResult.title.value : hit.title;
+      const title = (highlight && hit._highlightResult.title)
+        ? hit._highlightResult.title.value
+        : hit.title;
       return title
-      ? title
-      : truncate(hit.description, 30)
+        ? title
+        : truncate(hit.description, 30)
     }
 
     state: State = {

--- a/src/features/Help/SearchHOC.tsx
+++ b/src/features/Help/SearchHOC.tsx
@@ -78,7 +78,7 @@ export const getCommunityResultLabel = (hit: any, highlight: boolean) => {
     : hit.title;
   return title
     ? title
-    : truncate(hit.description, 30)
+    : truncate(cleanDescription(hit.description), 30)
 }
 
 export const cleanDescription = (description: string): string => {

--- a/src/features/Help/SearchHOC.tsx
+++ b/src/features/Help/SearchHOC.tsx
@@ -1,0 +1,179 @@
+import * as Algolia from 'algoliasearch';
+import * as React from 'react';
+
+import { Item } from 'src/components/EnhancedSelect/Select';
+import { ALGOLIA_APPLICATION_ID, ALGOLIA_SEARCH_KEY, COMMUNITY_BASE_URL, DOCS_BASE_URL } from 'src/constants';
+import truncate from 'src/utilities/truncateText';
+
+interface SearchHit {
+  title?: string;
+  description: string;
+  keywords: string;
+  objectID: string;
+  href?: string;
+  _highlightResult?: any;
+  _rankingInfo?: any;
+}
+
+interface State {
+  searchAlgolia: (inputValue: string) => void;
+  searchEnabled: boolean;
+  searchError?: string;
+  searchResults: [Item[], Item[]];
+}
+
+interface SearchOptions {
+  hitsPerPage: number;
+  highlight: boolean;
+}
+
+export default (options: SearchOptions) => (Component: React.ComponentType<any>) => {
+  const { hitsPerPage, highlight } = options;
+  class WrappedComponent extends React.PureComponent<{},State> {
+    searchIndex: any;
+    mounted: boolean = false;
+
+    componentDidMount() {
+      this.mounted = true;
+      this.initializeSearchIndices();
+    }
+
+    componentWillUnmount() {
+      this.mounted = false;
+    }
+
+    initializeSearchIndices = () => {
+      try {
+        const client = Algolia(ALGOLIA_APPLICATION_ID, ALGOLIA_SEARCH_KEY);
+        this.searchIndex = client;
+        this.setState({ searchEnabled: true, searchError: undefined })
+      }
+      catch {
+        // Credentials were incorrect or couldn't be found;
+        // Disable search functionality in the component.
+        this.setState({ searchEnabled: false, searchError: "Search could not be enabled." });
+        return;
+      }
+    }
+
+    searchAlgolia = (inputValue:string) => {
+      if (!this.mounted) { return; }
+      if (!inputValue) {
+        this.setState({ searchResults: [[],[]] });
+        return;
+      }
+      if (!this.searchIndex) {
+        this.setState({ searchResults: [[],[]], searchError: "Search could not be enabled."});
+        return;
+      }
+      this.searchIndex.search([{
+        indexName: 'linode-docs',
+        query: inputValue,
+        params: {
+          hitsPerPage,
+          attributesToRetrieve: [
+            'title',
+            'description',
+            '_highlightResult',
+            'href',
+          ]
+        }
+      }, {
+        indexName: 'linode-community',
+        query: inputValue,
+        params: {
+          hitsPerPage,
+          distinct: true,
+          attributesToRetrieve: [
+            'title',
+            'description',
+            '_highlightResult',
+          ]
+        }
+      }], this.searchSuccess);
+    }
+
+    searchSuccess = (err:any, content:any) => {
+      if (!this.mounted) { return; }
+      if (err) {
+        /*
+        * Errors from Algolia have the format: {'message': string, 'code': number}
+        * We do not want to push these messages on to the user as they are not under
+        * our control and can be account-related (e.g. "You have exceeded your quota").
+        */
+        this.setState({ searchError: "There was an error retrieving your search results." });
+        return;
+      }
+
+      const { results } = content;
+      const docsResults = this.convertDocsToItems(results[0].hits);
+      const commResults = this.convertCommunityToItems(results[1].hits);
+      this.setState({ searchResults: [docsResults, commResults], searchError: undefined });
+    }
+
+    convertDocsToItems = (hits: SearchHit[]) : Item[] => {
+      if (!hits) { return []; }
+      return hits.map((hit: SearchHit, idx: number) => {
+        return { value: idx, label: this.getDocsResultLabel(hit), data: {
+          source: 'Linode documentation',
+          href: DOCS_BASE_URL + hit.href,
+        } }
+      })
+    }
+
+    convertCommunityToItems = (hits: SearchHit[]) : Item[] => {
+      if (!hits) { return []; }
+      return hits.map((hit: SearchHit, idx: number) => {
+        return { value: idx, label: this.getCommunityResultLabel(hit), data: {
+          source: 'Linode Community Site',
+          href: this.getCommunityUrl(hit.objectID),
+        }}
+      })
+    }
+
+    getCommunityUrl = (id: string) => {
+      // Rather than crash here, better to redirect to the base community site.
+      if (!id) { return COMMUNITY_BASE_URL; }
+      const [prefix, value] = id.split('_');
+      return prefix === 'q' // Prefix is q for question, a for answer.
+      ? `${COMMUNITY_BASE_URL}questions/${value}`
+      : `${COMMUNITY_BASE_URL}questions/answer/${value}`;
+    }
+
+    getDocsResultLabel = (hit: any) => {
+      return highlight ? hit._highlightResult.title.value : hit.title;
+    }
+
+    getCommunityResultLabel = (hit: any) => {
+      /* If a word in the title matched the search query, return a string
+      * with the matched word highlighted.
+      *
+      * NOTE: It's currently planned to add the title of the parent question
+      * to the index entry for each answer. When that is done, the ternaries
+      * below can be removed. In the meantime, answers don't include
+      * a title, so use the truncated description.
+      */
+     const title = highlight ? hit._highlightResult.title.value : hit.title;
+      return title
+      ? title
+      : truncate(hit.description, 30)
+    }
+
+    state: State = {
+      searchAlgolia: this.searchAlgolia,
+      searchEnabled: false,
+      searchError: undefined,
+      searchResults: [[],[]],
+    }
+
+    render() {
+      return React.createElement(Component, {
+        ...this.props,
+        ...this.state,
+      });
+    }
+  }
+  return WrappedComponent;
+}
+
+

--- a/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -17,7 +17,7 @@ import Search from '@material-ui/icons/Search';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import { DOCS_SEARCH_URL } from 'src/constants';
+import { COMMUNITY_SEARCH_URL, DOCS_SEARCH_URL } from 'src/constants';
 import { parseQueryParams } from 'src/utilities/queryParams';
 
 import withSearch, { AlgoliaState as AlgoliaProps } from '../SearchHOC';
@@ -86,9 +86,14 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
     query: '',
   }
 
+  componentDidMount() {
+    this.searchFromParams();
+  }
+
   searchFromParams() {
     const queryFromParams = parseQueryParams(this.props.location.search)['?query'];
-    const query = queryFromParams ? queryFromParams : '';
+    const query = queryFromParams ? decodeURIComponent(queryFromParams) : '';
+    this.setState({ query });
     this.props.searchAlgolia(query);
   }
 
@@ -128,7 +133,7 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
             </Grid>
             <Grid item>
               <Typography variant="headline" >
-                {query ? `Search results for "${query}"` : "Search"}
+                {query.length > 1 ? `Search results for "${query}"` : "Search"}
               </Typography>
             </Grid>
           </Grid>
@@ -138,7 +143,7 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
           <TextField
             className={classes.searchBoxInner}
             placeholder="Search Linode documentation and community questions"
-            value={query || ''}
+            value={query}
             onChange={this.onInputChange}
             disabled={!Boolean(searchEnabled)}
             InputProps={{
@@ -154,7 +159,7 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
           <DocumentationResults sectionTitle="Documentation" results={docs as SearchResult[]} target={DOCS_SEARCH_URL + query} />
         </Grid>
         <Grid item>
-          <DocumentationResults sectionTitle="Community Posts" results={community as SearchResult[]} target="google.com" />
+          <DocumentationResults sectionTitle="Community Posts" results={community as SearchResult[]} target={COMMUNITY_SEARCH_URL + query} />
         </Grid>
         <Grid container item>
           <HelpResources />

--- a/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -171,8 +171,10 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles, { withTheme: true });
 const searchable = withSearch({hitsPerPage: 5, highlight: false});
-
-export default compose<any,any,any,any>(
+const enhanced: any = compose(
   styled,
   searchable,
-  withRouter)(SupportSearchLanding);
+  withRouter
+)(SupportSearchLanding)
+
+export default enhanced;

--- a/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -14,14 +14,13 @@ import Typography from '@material-ui/core/Typography';
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import Search from '@material-ui/icons/Search';
 
-import { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { DOCS_SEARCH_URL } from 'src/constants';
 import { parseQueryParams } from 'src/utilities/queryParams';
 
-import withSearch from '../SearchHOC';
+import withSearch, { AlgoliaState as AlgoliaProps } from '../SearchHOC';
 import DocumentationResults, { SearchResult } from './DocumentationResults';
 import HelpResources from './HelpResources';
 
@@ -79,15 +78,7 @@ interface State {
   query: string;
 }
 
-interface Props {
-  /** Comes from HOC */
-  searchAlgolia: (inputValue: string) => void;
-  searchEnabled: boolean;
-  searchError?: string;
-  searchResults: [Item[], Item[]];
-}
-
-type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{}>;
+type CombinedProps = AlgoliaProps & WithStyles<ClassNames> & RouteComponentProps<{}>;
 
 class SupportSearchLanding extends React.Component<CombinedProps, State> {
   searchIndex:any = null;
@@ -101,7 +92,7 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
     this.props.searchAlgolia(query);
   }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
+  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
     if (!prevProps.searchEnabled && this.props.searchEnabled) {
       this.searchFromParams();
     }

--- a/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -1,4 +1,3 @@
-import * as Algolia from 'algoliasearch';
 import { compose } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -7,7 +6,7 @@ import IconButton from '@material-ui/core/IconButton';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import {
   StyleRulesCallback,
-  
+
   withStyles,
   WithStyles,
 } from '@material-ui/core/styles';
@@ -15,12 +14,14 @@ import Typography from '@material-ui/core/Typography';
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import Search from '@material-ui/icons/Search';
 
+import { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import { ALGOLIA_APPLICATION_ID, ALGOLIA_SEARCH_KEY, DOCS_BASE_URL, DOCS_SEARCH_URL } from 'src/constants';
+import { DOCS_SEARCH_URL } from 'src/constants';
 import { parseQueryParams } from 'src/utilities/queryParams';
 
+import withSearch from '../SearchHOC';
 import DocumentationResults, { SearchResult } from './DocumentationResults';
 import HelpResources from './HelpResources';
 
@@ -75,46 +76,40 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 });
 
 interface State {
-  enabled: boolean;
-  error?: string;
   query: string;
-  results: SearchResult[];
 }
 
-type CombinedProps = WithStyles<ClassNames> & RouteComponentProps<{}>;
+interface Props {
+  /** Comes from HOC */
+  searchAlgolia: (inputValue: string) => void;
+  searchEnabled: boolean;
+  searchError?: string;
+  searchResults: [Item[], Item[]];
+}
 
-type index = 'linode-docs';
+type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{}>;
 
 class SupportSearchLanding extends React.Component<CombinedProps, State> {
   searchIndex:any = null;
   state: State = {
-    enabled: true,
     query: '',
-    results: [],
   }
 
-  componentDidMount() {
+  searchFromParams() {
     const queryFromParams = parseQueryParams(this.props.location.search)['?query'];
     const query = queryFromParams ? queryFromParams : '';
-    this.setState({ query });
-    // initialize Algolia API Client
-    try {
-      const client = Algolia(ALGOLIA_APPLICATION_ID, ALGOLIA_SEARCH_KEY);
-      const idx: index = 'linode-docs';
-      this.searchIndex = client.initIndex(idx);
+    this.props.searchAlgolia(query);
+  }
+
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (!prevProps.searchEnabled && this.props.searchEnabled) {
+      this.searchFromParams();
     }
-    catch {
-      // Credentials were incorrect or couldn't be found;
-      // Disable the search functionality in the component.
-      this.setState({ enabled: false, error: "Search could not be enabled." });
-      return;
-    }
-    this.searchAlgolia(query);
   }
 
   onInputChange = (e:React.ChangeEvent<HTMLInputElement>) => {
     this.setState({ query: e.target.value });
-    this.searchAlgolia(e.target.value);
+    this.props.searchAlgolia(e.target.value);
   }
 
   onBackButtonClick = () => {
@@ -122,48 +117,11 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
     history.push('/support');
   }
 
-  searchAlgolia = (inputValue:string) => {
-    if (!inputValue) { 
-      this.setState({ results: [] });
-      return;
-    }
-    if (!this.searchIndex) {
-      this.setState({ results: [], error: "Search could not be enabled."});
-      return;
-    }
-    this.searchIndex.search({
-      query: inputValue,
-      hitsPerPage: 3,
-    }, this.searchSuccess);
-  }
-
-  searchSuccess = (err:any, content:any) => {
-    if (err) {
-      /*
-      * Errors from Algolia have the format: {'message':string, 'code':number}
-      * We do not want to push these messages on to the user as they are not under
-      * our control and can be account-related (e.g. "You have exceeded your quota").
-      */
-      this.setState({ error: "There was an error retrieving your search results." });
-      return;
-    }
-    const results  = this.convertHitsToItems(content.hits);
-    this.setState({ results, error: undefined });
-  }
-
-  convertHitsToItems = (hits:any) => {
-    if (!hits) { return []; }
-    return hits.map((hit:any, idx:number) => {
-      return { value: idx, label: hit.title, data: {
-        source: 'Linode documentation',
-        href: DOCS_BASE_URL + hit.href,
-      } }
-    })
-  }
-
   render() {
-    const { classes } = this.props;
-    const { error, query, results } = this.state;
+    const { classes, searchEnabled, searchError, searchResults } = this.props;
+    const { query } = this.state;
+
+    const [docs, community] = searchResults;
 
     return (
       <Grid container direction="column">
@@ -179,19 +137,19 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
             </Grid>
             <Grid item>
               <Typography variant="headline" >
-                {query ? `Search results for "${query}"` : "Search"} 
+                {query ? `Search results for "${query}"` : "Search"}
               </Typography>
             </Grid>
           </Grid>
         </Grid>
         <Grid item>
-          {error && <Notice error>{error}</Notice>}
+          {searchError && <Notice error>{searchError}</Notice>}
           <TextField
             className={classes.searchBoxInner}
             placeholder="Search Linode documentation and community questions"
-            value={query}
+            value={query || ''}
             onChange={this.onInputChange}
-            disabled={Boolean(error)}
+            disabled={!Boolean(searchEnabled)}
             InputProps={{
               className: classes.searchBar,
               startAdornment:
@@ -202,12 +160,11 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
           />
         </Grid>
         <Grid item>
-          <DocumentationResults sectionTitle="Documentation" results={results} target={DOCS_SEARCH_URL + query} />
+          <DocumentationResults sectionTitle="Documentation" results={docs as SearchResult[]} target={DOCS_SEARCH_URL + query} />
         </Grid>
-        {/* Blocked until Community Site implements Algolia indexing */}
-        {/* <Grid item>
-          <DocumentationResults sectionTitle="Community Posts" results={[]} target="google.com" />
-        </Grid> */}
+        <Grid item>
+          <DocumentationResults sectionTitle="Community Posts" results={community as SearchResult[]} target="google.com" />
+        </Grid>
         <Grid container item>
           <HelpResources />
         </Grid>
@@ -217,7 +174,9 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
 }
 
 const styled = withStyles(styles, { withTheme: true });
+const searchable = withSearch({hitsPerPage: 5, highlight: false});
 
-export default compose<any,any,any>(
+export default compose<any,any,any,any>(
   styled,
+  searchable,
   withRouter)(SupportSearchLanding);


### PR DESCRIPTION
M3-1189 Incorporate community results into Get Help search  …
* Adds the linode-community index to AlgoliaSearchBar.
* The two indices have different structures, so extra functions
were added for processing community search results into Items
consumable by our searchbar.
* Current results are a list of 10 docs results followed by a list of 10 community results. This is from the AC; in addition, weighting the results properly turns out to be a problem due to differences in index structure and size. Will require more information and work if stakeholders decide they don't like the separate lists.