### PR TITLE
Hf v0.37.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Linodes with flags/long names breaking the layout on list linodes
   - Issue where a users settings are erroneously requested multiple times
   - Linodes with unknown images failing to display in the linode summary panel
+  - Backup restore not restoring to destination Linode
 
 ## [0.36.0] - 2018-10.08
 

--- a/src/services/linodes/backups.ts
+++ b/src/services/linodes/backups.ts
@@ -38,7 +38,7 @@ export const restoreBackup = (
   Request<{}>(
     setURL(`${API_ROOT}/linode/instances/${linodeID}/backups/${backupID}/restore`),
     setMethod('POST'),
-    setData({ linodeId: targetLinodeID, overwrite }),
+    setData({ linode_id: targetLinodeID, overwrite }),
   )
     .then(response => response.data);
 


### PR DESCRIPTION
This was reported by a customer this morning. I briefly looked into it and confirmed locally that it was a quick fix.

I changed `linodeId` to `linode_id` to align with v4 api:

https://developers.linode.com/api/v4#operation/restoreBackup

I tried to follow the hotfix guide in contributing.md. Let me know if I did something wrong!