### PR TITLE
M3-1668 Fix hover border styles for sub menu item in primary nav

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -81,7 +81,6 @@ type ClassNames =
     transition: theme.transitions.create(['background-color', 'border-left-color']),
     flexShrink: 0,
     '&:hover': {
-      borderLeftColor: 'rgba(0, 0, 0, 0.1)',
       '& $linkItem': {
         color: 'white',
       },

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -49,7 +49,8 @@ type ClassNames =
   | 'switchWrapper'
   | 'toggle'
   | 'switchText'
-  | 'spacer';
+  | 'spacer'
+  | 'listItemAccount';
 
   const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   menuGrid: {
@@ -81,6 +82,7 @@ type ClassNames =
     transition: theme.transitions.create(['background-color', 'border-left-color']),
     flexShrink: 0,
     '&:hover': {
+      borderLeftColor: 'rgba(0, 0, 0, 0.1)',
       '& $linkItem': {
         color: 'white',
       },
@@ -90,6 +92,11 @@ type ClassNames =
         color: 'white',
         zIndex: 2,
       },
+    },
+  },
+  listItemAccount: {
+    '&:hover': {
+      borderLeftColor: 'transparent',
     },
   },
   collapsible: {
@@ -306,6 +313,7 @@ class PrimaryNav extends React.Component<CombinedProps, State> {
                 onClick={this.expandMenutItem}
                 className={classNames({
                   [classes.listItem]: true,
+                  [classes.listItemAccount]: true,
                   [classes.collapsible]: true,
                 })}
               >


### PR DESCRIPTION
Removed the border on hover that was being applied to account tab so its hover state will match the other tabs.