### PR TITLE
default DNS expansion panels to open

### DIFF
--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -531,6 +531,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
               <ExpansionPanel
                 key={eachTypeIdx}
                 heading={type.title}
+                defaultExpanded={true}
               >
                 <Grid
                   container


### PR DESCRIPTION
**To test:**

- Use production account 1
- Click "Domains", then click on any domain
- Observe: All DNS record expansion panels should be open by default. 