### PR TITLE
Hide Hively feedback icons for old tickets

### DIFF
--- a/src/features/Support/ExpandableTicketPanel.test.tsx
+++ b/src/features/Support/ExpandableTicketPanel.test.tsx
@@ -1,0 +1,49 @@
+import * as moment from 'moment';
+
+import { ExpandableTicketPanel } from './ExpandableTicketPanel';
+
+const classes = {
+  root: '',
+  userWrapper: '',
+  leftIcon: '',
+  userName: '',
+  paper: '',
+  paperOpen: '',
+  avatarCol: '',
+  userCol: '',
+  descCol: '',
+  expCol: '',
+  expButton: '',
+  toggle: '',
+  isCurrentUser: '',
+  formattedText: '',
+  hivelyLink: '',
+  hivelyImage: '',
+  hivelyContainer: ''
+}
+
+const component = new ExpandableTicketPanel({
+  isCurrentUser: false,
+  classes,
+})
+
+const recent = moment().subtract(6, 'days').format();
+const old = moment().subtract(3, 'months').format();
+
+describe("shouldRenderHively function", () => {
+  it("should return true if an improperly formatted date is passed", () => {
+    expect(component.shouldRenderHively(true, 'blah')).toBeTruthy();
+  });
+  it("should return true if the date is now", () => {
+    expect(component.shouldRenderHively(true, moment().format())).toBeTruthy();
+  });
+  it("should return true if the date is within the past 7 days", () => {
+    expect(component.shouldRenderHively(true, recent)).toBeTruthy();
+  });
+  it("should return false for dates older than 7 days", () => {
+    expect(component.shouldRenderHively(true, old)).toBeFalsy();
+  });
+  it("should return false if the fromLinode parameter is false", () => {
+    expect(component.shouldRenderHively(false, recent)).toBeFalsy();
+  });
+});

--- a/src/features/Support/ExpandableTicketPanel.tsx
+++ b/src/features/Support/ExpandableTicketPanel.tsx
@@ -1,4 +1,5 @@
 import * as classNames from 'classnames';
+import * as moment from 'moment';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 
@@ -136,6 +137,7 @@ interface Props {
   open?: boolean;
   isCurrentUser: boolean;
   parentTicket?: number;
+  ticketUpdated?: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -154,6 +156,7 @@ interface Data {
   from_linode: boolean;
   ticket_id: string;
   reply_id: string;
+  updated: string;
 }
 
 export class ExpandableTicketPanel extends React.Component<CombinedProps, State> {
@@ -179,7 +182,7 @@ export class ExpandableTicketPanel extends React.Component<CombinedProps, State>
   }
 
   getData = () => {
-    const { parentTicket, ticket, reply } = this.props;
+    const { parentTicket, ticket, reply, ticketUpdated } = this.props;
     if (!ticket && !reply) { return; }
     let data: Data;
     if (ticket) {
@@ -192,6 +195,7 @@ export class ExpandableTicketPanel extends React.Component<CombinedProps, State>
         description: ticket.description,
         username: ticket.opened_by,
         from_linode: false,
+        updated: ticket.updated,
       }
     } else if (reply) {
       data = {
@@ -203,10 +207,28 @@ export class ExpandableTicketPanel extends React.Component<CombinedProps, State>
         description: reply.description,
         username: reply.created_by,
         from_linode: reply.from_linode,
+        updated: ticketUpdated!,
       }
     }
 
     return data!;
+  }
+
+  shouldRenderHively = (fromLinode: boolean, updated: string) => {
+    /* Render Hively only for replies marked as from_linode,
+    * and are on tickets less than 7 days old.
+    * Defaults to showing Hively if there are any errors parsing dates
+    * or the date is invalid.
+    */ 
+    try {
+      const lastUpdated = moment(updated);
+      if (!lastUpdated.isValid()) { return true; }
+      const diff = moment.duration(moment().diff(lastUpdated));
+      return fromLinode && diff <= moment.duration(7, 'days');
+    }
+    catch {
+      return true;
+    }
   }
 
   renderHively = (linodeUsername: string, ticketId: string, replyId: string) => {
@@ -310,7 +332,7 @@ export class ExpandableTicketPanel extends React.Component<CombinedProps, State>
               </Grid>
             }
           </Grid>
-          {data.from_linode &&
+          {this.shouldRenderHively(data.from_linode, data.updated) &&
             this.renderHively(data.username, data.ticket_id, data.reply_id)
           }
         </Paper>

--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -359,6 +359,7 @@ export class SupportTicketDetail extends React.Component<CombinedProps,State> {
         reply={reply}
         open={idx === replies.length - 1}
         parentTicket={ticket ? ticket.id : undefined}
+        ticketUpdated={ticket ? ticket.updated : ''}
         isCurrentUser={this.props.profileUsername === reply.created_by}
       />
     });


### PR DESCRIPTION
* Only show Hively for tickets less than 7 days old.
* Use the ticket.updated field (rather than the date of a specific reply)
to determine this. This matches behavior in the CF manager.