### PR TITLE
M3-1395 clean services/images

### DIFF
--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -163,7 +163,9 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
             if(!this.mounted){ return; }
 
             this.setState({
-              errors: [{ field: 'label', reason: 'Label cannot be blank.' }],
+              errors: pathOr([
+                { reason: 'Unable to edit image' }],
+                ['response', 'data', 'errors'], errorResponse),
             });
           });
         return;
@@ -356,7 +358,8 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
             color="primary"
             data-qa-submit
           >
-            Create
+            {mode === modes.CREATING && 'Create'}
+            {mode === modes.EDITING && 'Submit'}
           </Button>
           <Button
             onClick={this.close}

--- a/src/services/images/image.schema.ts
+++ b/src/services/images/image.schema.ts
@@ -1,0 +1,28 @@
+import { number, object, string } from 'yup';
+
+export const createImageSchema = object().shape({
+  disk_id: number()
+    .typeError('Disk is required')
+    .required('Disk is required'),
+  label: string()
+    .notRequired()
+    .min(1)
+    .max(50)
+    .matches(/^[a-zA-Z0-9,.?\-_']+$/),
+  description: string()
+    .notRequired()
+    .min(1)
+    .max(65000)
+});
+
+export const updateImageSchema = object().shape({
+  label: string()
+    .notRequired()
+    .min(1)
+    .max(50)
+    .matches(/^[a-zA-Z0-9,.?\-_']+$/),
+  description: string()
+    .notRequired()
+    .min(1)
+    .max(65000)
+});

--- a/src/services/images/image.schema.ts
+++ b/src/services/images/image.schema.ts
@@ -6,9 +6,9 @@ export const createImageSchema = object().shape({
     .required('Disk is required'),
   label: string()
     .notRequired()
-    .min(1)
-    .max(50)
-    .matches(/^[a-zA-Z0-9,.?\-_']+$/),
+    .min(1, 'Length must be 1-50 characters')
+    .max(50, 'Length must be 1-50 characters')
+    .matches(/^[a-zA-Z0-9,.?\-_']+$/, 'Image labels can not contain special characters.'),
   description: string()
     .notRequired()
     .min(1)
@@ -18,11 +18,11 @@ export const createImageSchema = object().shape({
 export const updateImageSchema = object().shape({
   label: string()
     .notRequired()
-    .min(1)
-    .max(50)
-    .matches(/^[a-zA-Z0-9,.?\-_']+$/),
+    .min(1, 'Length must be 1-50 characters')
+    .max(50, 'Length must be 1-50 characters')
+    .matches(/^[a-zA-Z0-9,.?\-_']+$/, 'Image labels can not contain special characters.'),
   description: string()
     .notRequired()
-    .min(1)
-    .max(65000)
+    .min(1, 'Length must be 1-50 characters')
+    .max(65000, 'Length must be 1-65000 characters')
 });

--- a/src/services/images/image.schema.ts
+++ b/src/services/images/image.schema.ts
@@ -2,13 +2,12 @@ import { number, object, string } from 'yup';
 
 export const createImageSchema = object().shape({
   disk_id: number()
-    .typeError('Disk is required')
-    .required('Disk is required'),
+    .typeError('Disk is required.')
+    .required('Disk is required.'),
   label: string()
     .notRequired()
-    .min(1, 'Length must be 1-50 characters')
-    .max(50, 'Length must be 1-50 characters')
-    .matches(/^[a-zA-Z0-9,.?\-_']+$/, 'Image labels can not contain special characters.'),
+    .max(50, 'Length must be 50 characters or less.')
+    .matches(/^[a-zA-Z0-9,.?\-_\s']+$/, 'Image labels cannot contain special characters.'),
   description: string()
     .notRequired()
     .min(1)
@@ -18,11 +17,9 @@ export const createImageSchema = object().shape({
 export const updateImageSchema = object().shape({
   label: string()
     .notRequired()
-    .min(1, 'Length must be 1-50 characters')
-    .max(50, 'Length must be 1-50 characters')
-    .matches(/^[a-zA-Z0-9,.?\-_']+$/, 'Image labels can not contain special characters.'),
+    .max(50, 'Length must be 50 characters or less.')
+    .matches(/^[a-zA-Z0-9,.?\-_\s']+$/, 'Image labels cannot contain special characters.'),
   description: string()
     .notRequired()
-    .min(1, 'Length must be 1-50 characters')
-    .max(65000, 'Length must be 1-65000 characters')
+    .max(65000, 'Length must be 65000 characters or less.')
 });

--- a/src/services/images/images.test.ts
+++ b/src/services/images/images.test.ts
@@ -1,0 +1,166 @@
+import { AxiosRequestConfig } from 'axios';
+
+import { API_ROOT } from 'src/constants';
+
+import { createImage, deleteImage, getImage, getImages, updateImage } from './images';
+
+const mockFn = jest.fn((config: AxiosRequestConfig) => Promise.resolve({data: config}));
+
+jest.mock('axios', () => ({
+  default: (config:AxiosRequestConfig) => mockFn(config),
+}));
+
+describe('images', () => {
+  describe('GET', () => {
+    it('should GET a single image when specifying ID', async () => {
+      await getImage('100');
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'GET',
+        url: `${API_ROOT}/images/100`
+      });
+      mockFn.mockClear();
+    });
+
+    it('should GET multiple images', async () => {
+      await getImages();
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'GET',
+        url: `${API_ROOT}/images`
+      });
+      mockFn.mockClear();
+    });
+
+    it('should GET multiple images with pagination', async () => {
+      const pagination = { page: 1, pageSize: 25 };
+      await getImages(pagination);
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'GET',
+        url: `${API_ROOT}/images`,
+        params: {
+          page: 1,
+          pageSize: 25,
+        }
+      });
+      mockFn.mockClear();
+    });
+  });
+
+  describe('POST', () => {
+    it('should create an image with POST', async () => {
+      await createImage(1234, 'test-image', 'my test-image');
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'POST',
+        url: `${API_ROOT}/images`,
+        data: {
+          disk_id: 1234,
+          label: 'test-image',
+          description: 'my test-image'
+        }
+      });
+      mockFn.mockClear();
+    });
+
+    it('should be able to create an image without a label', async () => {
+      await createImage(1234, undefined, 'my test-image');
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'POST',
+        url: `${API_ROOT}/images`,
+        data: {
+          disk_id: 1234,
+          description: 'my test-image'
+        }
+      });
+      mockFn.mockClear();
+    });
+
+    it('should be able to create an image without a description', async () => {
+      await createImage(1234, 'my-image');
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'POST',
+        url: `${API_ROOT}/images`,
+        data: {
+          disk_id: 1234,
+          label: 'my-image'
+        }
+      });
+      mockFn.mockClear();
+    });
+
+    it('should be able to create an image without a label or description', async () => {
+      await createImage(1234);
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'POST',
+        url: `${API_ROOT}/images`,
+        data: {
+          disk_id: 1234
+        }
+      });
+      mockFn.mockClear();
+    });
+
+    it('should fail when label does not match schema', async () => {
+      try {
+        await createImage(1234, 'my-image@');
+      } catch(err) {;
+        expect(err).toBeDefined();
+      }
+      expect(mockFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PUT', () => {
+    it('should update an image with PUT', async () => {
+      await updateImage('private/1234', 'new-test-image', 'my new test-image');
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'PUT',
+        url: `${API_ROOT}/images/private/1234`,
+        data: {
+          label: 'new-test-image',
+          description: 'my new test-image'
+        }
+      });
+      mockFn.mockClear();
+    });
+
+    it('should be able to update an image without a description', async () => {
+      await updateImage('private/1234', 'test-image');
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'PUT',
+        url: `${API_ROOT}/images/private/1234`,
+        data: {
+          label: 'test-image'
+        }
+      });
+      mockFn.mockClear();
+    });
+
+    it('should be able to update without a label or description', async () => {
+      await updateImage('private/1234');
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'PUT',
+        url: `${API_ROOT}/images/private/1234`,
+        data: {}
+      });
+      mockFn.mockClear();
+    });
+
+    it('should fail when label does not match schema', async () => {
+      try {
+        await updateImage('private/1234', 'my-image@');
+      } catch(err) {;
+        expect(err).toBeDefined();
+      }
+      expect(mockFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DELETE', () => {
+    it('should DELETE an image', async () => {
+      await deleteImage('private/1234');
+      expect(mockFn).toHaveBeenLastCalledWith({
+        method: 'DELETE',
+        url: `${API_ROOT}/images/private/1234`
+      })
+    });
+  });
+});

--- a/src/services/images/images.ts
+++ b/src/services/images/images.ts
@@ -20,22 +20,15 @@ export const getImage = (imageId: string) =>
 /**
  * Returns a paginated list of Images.
  *
- * @param pagination { Object }
- * @param pagination.page { number }
- * @param pagination.pageSize { number }
  */
-export const getImages = (pagination: any = {}, filters: any = {}) =>
+export const getImages = (params: any = {}, filters: any = {}) =>
   Request<Page<Image>>(
     setURL(`${API_ROOT}/images`),
     setMethod('GET'),
-    setParams(pagination),
+    setParams(params),
     setXFilter(filters),
   )
   .then(response => response.data);
-
-// Convenience method
-export const getLinodeImages = () =>
-  getImages({ page: 1 }, { "is_public": true });
 
 /**
  * Create a private gold-master Image from a Linode Disk.

--- a/src/services/images/images.ts
+++ b/src/services/images/images.ts
@@ -53,7 +53,7 @@ export const createImage = (
   const data = {
     disk_id: diskId,
     ...(label && { label }),
-    ...(description && { description: getSafeDescription(description) })
+    ...(description && { description })
   };
 
   return Request<Image>(
@@ -78,7 +78,7 @@ export const updateImage = (
 
   const data = {
     ...(label && { label }),
-    ...(description && { description: getSafeDescription(description) })
+    ...(description && { description })
   };
 
   return Request<Image>(
@@ -98,13 +98,4 @@ export const deleteImage = (imageId: string) => {
     setURL(`${API_ROOT}/images/${imageId}`),
     setMethod('DELETE'),
   )
-}
-
-const getSafeDescription = (description: string) => {
-  // Blank descriptions are represented as ' ' in the API;
-  // API will return an error if passed the empty string.
-  const trimmed = description.trim();
-  return trimmed
-         ? trimmed
-         : ' ';
 }

--- a/src/services/images/imagesUtils.ts
+++ b/src/services/images/imagesUtils.ts
@@ -1,0 +1,4 @@
+import { getImages } from './images';
+
+export const getLinodeImages = () =>
+  getImages({ page: 1 }, { "is_public": true });

--- a/src/services/images/index.ts
+++ b/src/services/images/index.ts
@@ -1,7 +1,6 @@
 export {
   getImages,
   getImage,
-  getImagesPage,
   getLinodeImages,
   createImage,
   updateImage,

--- a/src/services/images/index.ts
+++ b/src/services/images/index.ts
@@ -1,8 +1,9 @@
 export {
   getImages,
   getImage,
-  getLinodeImages,
   createImage,
   updateImage,
   deleteImage,
 } from './images';
+
+export { getLinodeImages } from './imagesUtils';


### PR DESCRIPTION
- Add Yup validation for image creation and updating images
- Match `createImage` and `updateImage` signatures with the API (making `label` and `description` optional)
- Add tests