### PR TITLE
M3-1631 Launch Console button should be a link on mobile

### DIFF
--- a/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
@@ -41,21 +41,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     },
   },
   launchButton: {
-    marginRight: theme.spacing.unit,
-    padding: '12px 16px 13px',
-    minHeight: 50,
-    transition: theme.transitions.create(['background-color', 'color']),
-    [theme.breakpoints.down('sm')]: {
-      backgroundColor: theme.color.white,
-      border: `1px solid ${theme.color.border1}`,
-      marginTop: 0,
-      minHeight: 51,
-    },
+    padding: '12px 28px 14px 0',
     '&:hover': {
-      backgroundColor: theme.palette.primary.main,
-      color: 'white',
-      borderColor: theme.palette.primary.main,
+      backgroundColor: 'transparent',
+      textDecoration: 'underline',
     },
+    '&:focus > span:first-child': {
+      outline: '1px dotted #999',
+    }
   },
 });
 
@@ -113,7 +106,9 @@ const LabelPowerAndConsolePanel: React.StatelessComponent<CombinedProps> = (prop
           onClick={launchLish}
           className={classes.launchButton}
           data-qa-launch-console
-        >
+          disableFocusRipple={true}
+          disableRipple={true}
+          >
           Launch Console
     </Button>
         <LinodePowerControl


### PR DESCRIPTION
Ticket summary is a little misleading, Alban let me know this is supposed to change for all devices/breakpoints.

Before:
<img width="161" alt="screen shot 2018-10-23 at 5 08 49 pm" src="https://user-images.githubusercontent.com/2565527/47390859-5a439200-d6e6-11e8-955a-0fd4ca7a8d8a.png">
<img width="172" alt="screen shot 2018-10-23 at 5 07 28 pm" src="https://user-images.githubusercontent.com/2565527/47390823-3f711d80-d6e6-11e8-90e3-db6c22083128.png">

After:
<img width="309" alt="screen shot 2018-10-23 at 5 07 04 pm" src="https://user-images.githubusercontent.com/2565527/47390830-46982b80-d6e6-11e8-9b17-aadf9ff6d054.png">
