### PR TITLE
M3-1689 Fix bug when requesting disks

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -26,7 +26,7 @@ import { createLinodeConfig, getLinodeConfig, getLinodeDisks, getLinodeKernels, 
 import { getVolumes } from 'src/services/volumes';
 import createDevicesFromStrings, { DevicesAsStrings } from 'src/utilities/createDevicesFromStrings';
 import createStringsFromDevices from 'src/utilities/createStringsFromDevices';
-import { getAll } from 'src/utilities/getAll';
+import { getAll, getAllFromEntity } from 'src/utilities/getAll';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 
 type ClassNames = 'root'
@@ -94,7 +94,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 const getAllKernels = getAll(getLinodeKernels);
 const getAllVolumes = getAll(getVolumes);
-const getAllLinodeDisks = getAll(getLinodeDisks);
+const getAllLinodeDisks = getAllFromEntity(getLinodeDisks);
 
 class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
   state: State = {
@@ -481,7 +481,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
 
   getAvailableDevices = () => {
     const { linodeId, linodeRegion } = this.props;
-
     /** Get all volumes for usage in the block device assignment. */
     getAllVolumes()
       .then((volumes) => volumes.reduce((result: Linode.Volume[], volume: Linode.Volume) => {

--- a/src/utilities/getAll.ts
+++ b/src/utilities/getAll.ts
@@ -9,6 +9,7 @@ export interface APIResponsePage<T> {
 }
 
 export type GetFunction = (params?: any, filters?: any) => Promise<APIResponsePage<any>>;
+export type GetFromEntity = (entityId?: number, params?: any, filters?: any) => Promise<APIResponsePage<any>>;
 
 /**
  * getAll
@@ -50,3 +51,26 @@ export const getAll: (getter: GetFunction) => (params?: any, filter?: any) => Pr
             .then(resultPages => resultPages.reduce((result, nextPage) => [...result, ...nextPage], firstPageData));
         });
   }
+
+export const getAllFromEntity: (getter: GetFromEntity) => (params?: any, filter?: any) => Promise<any> =
+(getter) =>
+  (entityId: number, params?: any, filter?: any) => {
+    const pagination = { ...params, page_size: 100 };
+    return getter(entityId, pagination, filter)
+      .then(({ data: firstPageData, page, pages }) => {
+
+        // If we only have one page, return it.
+        if (page === pages) { return firstPageData; }
+
+        // Create an iterable list of the remaining pages.
+        const remainingPages = range(page + 1, pages + 1);
+
+        //
+        return Bluebird
+          .map(remainingPages, nextPage =>
+            getter({ ...pagination, page: nextPage }, filter).then(response => response.data),
+          )
+          /** We're given Linode.NodeBalancer[][], so we flatten that, and append the first page response. */
+          .then(resultPages => resultPages.reduce((result, nextPage) => [...result, ...nextPage], firstPageData));
+      });
+}


### PR DESCRIPTION
Recent refactor didn't take into account paginated API methods that also take an entity ID. This was causing requests to linode/.../disks to fail.

## To Test

* Have a Linode with at least one Disk
* Go to settings/advanced settings and open the configuration drawer (e.g. "Add Config")
* Open one of the device selection dropdowns.
* You should see your disk listed.