### PR TITLE
M3-1695 Linode extra long names should truncate with ellipsis on Grid View

### DIFF
--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -49,10 +49,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     width: '10%',
   },
   wrapHeader: {
-    width: 170,
     whiteSpace: 'nowrap',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
   },
 });
 

--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -49,7 +49,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     width: '10%',
   },
   wrapHeader: {
-    wordBreak: 'break-all',
+    width: 170,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
 });
 

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -87,6 +87,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     fontFamily: 'LatoWebBold',
     color: 'black',
     marginLeft: theme.spacing.unit,
+    minWidth: 0,
   },
   cardContent: {
     flex: 1,
@@ -181,9 +182,9 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     display: 'flex',
     alignItems: 'center',
     flex: 1,
+    minWidth: 0,
   },
   wrapHeader: {
-    width: 170,
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -183,8 +183,10 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     flex: 1,
   },
   wrapHeader: {
-    wordBreak: 'break-all',
-    padding: '20px',
+    width: 170,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   },
 });
 

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -87,6 +87,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     fontFamily: 'LatoWebBold',
     color: 'black',
     marginLeft: theme.spacing.unit,
+    // This is necessary for text to ellipsis responsively without the need for a hard set width value that won't play well with flexbox.
     minWidth: 0,
   },
   cardContent: {
@@ -182,6 +183,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     display: 'flex',
     alignItems: 'center',
     flex: 1,
+    // This is necessary for text to ellipsis responsively without the need for a hard set width value that won't play well with flexbox.
     minWidth: 0,
   },
   wrapHeader: {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -318,6 +318,9 @@ const themeDefaults: ThemeOptions = {
       root: {
         backgroundColor: '#fbfbfb',
       },
+      content: {
+        minWidth: 0,
+      },
     },
     MuiChip: {
       root: {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -319,6 +319,7 @@ const themeDefaults: ThemeOptions = {
         backgroundColor: '#fbfbfb',
       },
       content: {
+        // This is necessary for text to ellipsis responsively without the need for a hard set width value that won't play well with flexbox.
         minWidth: 0,
       },
     },


### PR DESCRIPTION
This PR also includes some work for M3-1681- a bug on the dashboard (in safari only) was randomly line breaking names with dashes in the name.

On linodes grid view, if the Linode name exceeds our specced width, it will truncate with an ellipsis:
<img width="297" alt="screen shot 2018-10-25 at 2 47 25 pm" src="https://user-images.githubusercontent.com/2565527/47530058-90fce200-d877-11e8-80c3-b7abbf8d11ab.png">
<img width="461" alt="screen shot 2018-10-25 at 2 47 34 pm" src="https://user-images.githubusercontent.com/2565527/47530059-90fce200-d877-11e8-866b-28c8d5e830f4.png">
<img width="509" alt="screen shot 2018-10-25 at 2 59 08 pm" src="https://user-images.githubusercontent.com/2565527/47530061-90fce200-d877-11e8-8e54-8b605fd2731b.png">


