### PR TITLE
M3-1706 - Prevent removing own oauth client on test session cleanup

### DIFF
--- a/e2e/setup/cleanup.js
+++ b/e2e/setup/cleanup.js
@@ -115,7 +115,13 @@ exports.deleteAll = (token, user) => {
                         return res.data;
                     }
 
-                    if(endpoint.includes('users')) {
+                    if (endpoint.includes('oauth-clients')) {
+                        const appClients = res.data.data.filter(client => !client['id'] === process.env.REACT_APP_CLIENT_ID);
+                        res.data['data'] = appClients;
+                        return res.data;
+                    }
+
+                    if (endpoint.includes('users')) {
                         const nonRootUsers = res.data.data.filter(u => u.username !== user);
                         res.data['data'] = nonRootUsers;
                         return res.data;


### PR DESCRIPTION
* Prior to this the onComplete test cleanup method was attempting to remove all oauth clients, even the client configured in your `.env` file. This will prevent that from happening

* However, this could become an issue if people are using oauth clients attached to test users. Ensure that you are not, otherwise your client could disappear when someone runs the test suite.