### PR TITLE
Refactor e2e modified script

### DIFF
--- a/e2e/setup/cleanup.js
+++ b/e2e/setup/cleanup.js
@@ -115,7 +115,13 @@ exports.deleteAll = (token, user) => {
                         return res.data;
                     }
 
-                    if(endpoint.includes('users')) {
+                    if (endpoint.includes('oauth-clients')) {
+                        const appClients = res.data.data.filter(client => !client['id'] === process.env.REACT_APP_CLIENT_ID);
+                        res.data['data'] = appClients;
+                        return res.data;
+                    }
+
+                    if (endpoint.includes('users')) {
                         const nonRootUsers = res.data.data.filter(u => u.username !== user);
                         res.data['data'] = nonRootUsers;
                         return res.data;

--- a/e2e/specs/domains/detail-ns-records.spec.js
+++ b/e2e/specs/domains/detail-ns-records.spec.js
@@ -17,7 +17,6 @@ describe('Domains - Detail - NS Actions Suite', () => {
         // TODO - Update to use DomainDetail.baseElemsDisplay();
 
         DomainDetail.domainTitle.waitForVisible(constants.wait.normal);
-        DomainDetail.expandPanel('NS Record');
     });
 
     it('should add an ns record', () => {

--- a/e2e/utils/config-utils.js
+++ b/e2e/utils/config-utils.js
@@ -111,7 +111,7 @@ exports.generateCreds = (credFilePath, config) => {
         }
 
         // If We have a second manager user defined and multiple specs (glob in our specs array), add a second test user
-        if (key === 'MANAGER_USER_2' && config.specs[0].includes('**')) {
+        if (key === 'MANAGER_USER_2' && (config.specs[0].includes('**') || config.specs.length > 1)) {
             const pass = process.env.MANAGER_PASS_2;
             credCollection.push({username: value, password: pass, inUse: false, token: '', spec: ''});
         }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "selenium": "npx selenium-standalone install --config=./e2e/config/selenium-config.js && ./node_modules/.bin/selenium-standalone start --config=./e2e/config/selenium-config.js",
     "e2e": "npx wdio ./e2e/config/wdio.conf.js",
     "e2e:all": "npx wdio ./e2e/config/wdio.conf.js; ./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js",
-    "e2e:modified": "yarn e2e --spec=$(git diff --name-only develop | grep 'spec.js' | tr '\n' ',' | sed 's/.$//')",
+    "e2e:modified": "yarn e2e --spec=$(git diff --name-only upstream/develop | grep 'spec.js' | tr '\n' ',' | sed 's/.$//')",
     "e2e:browserstack": "npx wdio ./e2e/config/browserstack.conf.js",
     "mb": "npx mb"
   },

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "selenium": "npx selenium-standalone install --config=./e2e/config/selenium-config.js && ./node_modules/.bin/selenium-standalone start --config=./e2e/config/selenium-config.js",
     "e2e": "npx wdio ./e2e/config/wdio.conf.js",
     "e2e:all": "npx wdio ./e2e/config/wdio.conf.js; ./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js",
-    "e2e:modified": "yarn e2e --spec=$(git diff --name-only develop | grep 'spec.js' | tr '\n' ',')",
+    "e2e:modified": "yarn e2e --spec=$(git diff --name-only develop | grep 'spec.js' | tr '\n' ',' | sed 's/.$//')",
     "e2e:browserstack": "npx wdio ./e2e/config/browserstack.conf.js",
     "mb": "npx mb"
   },

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "selenium": "npx selenium-standalone install --config=./e2e/config/selenium-config.js && ./node_modules/.bin/selenium-standalone start --config=./e2e/config/selenium-config.js",
     "e2e": "npx wdio ./e2e/config/wdio.conf.js",
     "e2e:all": "npx wdio ./e2e/config/wdio.conf.js; ./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js",
-    "e2e:modified": "./scripts/run-modified-e2e.sh",
+    "e2e:modified": "yarn e2e --spec=$(git diff --name-only develop | grep 'spec.js' | tr '\n' ',')",
     "e2e:browserstack": "npx wdio ./e2e/config/browserstack.conf.js",
     "mb": "npx mb"
   },

--- a/scripts/run-modified-e2e.sh
+++ b/scripts/run-modified-e2e.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-for spec in $(git diff --name-only develop | grep 'spec.js'); do
-  yarn e2e --file $spec
-done
-


### PR DESCRIPTION
Before the script was just looping through the test files `yarn e2e --file xxxxx.spec.js` following by `yarn e2e --file xxx2.spec.js`, now it passes the specs in a comma separated list to test runner, significantly speeding things up (only runs the test account teardown function once now, instead of each time a test spec is run)


* Also fixed a domains test that was attempting to manually expand the panels on the domains page. Now that they're open by default, this is unneccessary


## To Test

```bash
yarn && yarn start # Run your local manager
yarn selenium # run selenium in a new tab
yarn e2e:modified # Should only run the single spec modified in this PR.
```

(I based this off of the Oauth clients PR, so that's why you see those files changed. I will rebase off develop once it is merged)