### PR TITLE
M3-1675 - Debounced Search Functional Tests

### DIFF
--- a/src/components/DebouncedSearchTextField/DebouncedSearchTextField.spec.js
+++ b/src/components/DebouncedSearchTextField/DebouncedSearchTextField.spec.js
@@ -5,9 +5,13 @@ describe('Debounced Search Suite', () => {
     const component = 'Debounced Search';
     const childStories = ['Select Field', 'Text Field'];
 
-
     describe('Select Field Suite', () => {
         let enhancedSelect, selectedOptionMsg, selectOptions;
+
+        const currentResultSelector = '[data-qa-selected-result]';
+        const optionSelector = '[data-qa-option]';
+        const emptyResult = 'You selected:';
+        const validQuery = 'keyboard';
 
         beforeAll(() => {
             navigateToStory(component, childStories[0]);
@@ -22,8 +26,7 @@ describe('Debounced Search Suite', () => {
         });
 
         it('should not have options selected on pageload', () => {
-            const emptyResult = 'You selected:';
-            selectedOptionMsg = $('[data-qa-selected-result]');
+            selectedOptionMsg = $(currentResultSelector);
             
             expect(selectedOptionMsg.getText()).toBe(emptyResult);
         });
@@ -36,16 +39,13 @@ describe('Debounced Search Suite', () => {
         });
 
         it('should display options on a valid search query', () => {
-            const validQuery = 'keyboard';
-
+            // Add the value twice to fix test flakiness when running the entire functional test suite
             enhancedSelect.$('..').$('input').setValue(validQuery);
-            
-            // Adding the value twice to fix test flakiness when running the entire functional test suite
             enhancedSelect.$('..').$('input').setValue(validQuery);
 
-            browser.waitForVisible('[data-qa-option]', constants.wait.normal);
+            browser.waitForVisible(optionSelector, constants.wait.normal);
 
-            selectOptions = $$('[data-qa-option]');
+            selectOptions = $$(optionSelector);
             expect(selectOptions.length).toBe(1);
         });
 
@@ -53,17 +53,29 @@ describe('Debounced Search Suite', () => {
             selectOptions[0].click();
 
             browser.waitForVisible(selectOptions[0].selector, constants.wait.normal, true);
-            selectedOptionMsg = $('[data-qa-selected-result]');
+            selectedOptionMsg = $(currentResultSelector);
             expect(selectedOptionMsg.getText()).toBe('You selected: keyboards');
         });
 
         xit('should clear the result on click clear', () => {
-            
+            validQuery.split('').forEach(i => {
+                enhancedSelect.$('..').$('input').addValue('\uE003');
+            });
+
+            browser.waitUntil(() => {
+                return $(currentResultSelector).getText() === emptyResult;
+            }, constants.wait.normal);
         });
     });
 
     describe('Text Field Suite', () => {
-        let searchTextfield, displayedListItems, validQuery, initialOptions = [];
+        let searchTextfield,
+            displayedListItems,
+            initialOptions = [];
+
+        const debouncedSearchSelector = '[data-qa-debounced-search]';
+        const listItemSelector = '[data-qa-list-item]';
+        const validQuery = 'apples';
 
         beforeAll(() => {
             navigateToStory(component, childStories[1]);
@@ -71,13 +83,13 @@ describe('Debounced Search Suite', () => {
 
         it('should display the debounced search text field', () => {
             const placeholderMsg = 'Search for something';
-            searchTextfield = $('[data-qa-debounced-search]').$('input');
+            searchTextfield = $(debouncedSearchSelector).$('input');
 
             expect(searchTextfield.getAttribute('placeholder')).toBe(placeholderMsg);
         });
 
         it('should display unfiltered list of options', () => {
-            displayedListItems = $$('[data-qa-list-item]');
+            displayedListItems = $$(listItemSelector);
             displayedListItems.forEach(i => {
                 expect(i.isVisible()).toBe(true);
                 expect(i.getText()).toMatch(/\w/ig);
@@ -94,12 +106,10 @@ describe('Debounced Search Suite', () => {
         });
 
         it('should display a single option on query of a single matching list item', () => {
-            validQuery = 'apples';
-
             searchTextfield.setValue(validQuery);
 
             browser.waitUntil(() => {
-                displayedListItems = $$('[data-qa-list-item]');
+                displayedListItems = $$(listItemSelector);
                 return displayedListItems.length === 1;
             }, constants.wait.normal);
 
@@ -108,15 +118,15 @@ describe('Debounced Search Suite', () => {
 
         it('should display all list options on clear', () => {
             validQuery.split('').forEach(i => {
-                $('[data-qa-debounced-search]').$('input').addValue('\uE003');
+                $(debouncedSearchSelector).$('input').addValue('\uE003');
             });
 
             browser.waitUntil(() => {
-                displayedListItems = $$('[data-qa-list-item]');
+                displayedListItems = $$(listItemSelector);
                 return displayedListItems.length === initialOptions.length;
             }, constants.wait.normal);
 
-            const currentOptions = $$('[data-qa-list-item]').map(i => i.getText());
+            const currentOptions = $$(listItemSelector).map(i => i.getText());
 
             expect(currentOptions).toEqual(initialOptions);
         });

--- a/src/components/DebouncedSearchTextField/DebouncedSearchTextField.spec.js
+++ b/src/components/DebouncedSearchTextField/DebouncedSearchTextField.spec.js
@@ -1,0 +1,124 @@
+const { constants } = require('../../../e2e/constants');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
+
+describe('Debounced Search Suite', () => {
+    const component = 'Debounced Search';
+    const childStories = ['Select Field', 'Text Field'];
+
+
+    describe('Select Field Suite', () => {
+        let enhancedSelect, selectedOptionMsg, selectOptions;
+
+        beforeAll(() => {
+            navigateToStory(component, childStories[0]);
+        });
+
+        it('should display select search bar', () => {
+            const placeholderMsg = 'Search for something (i.e "er")'
+            enhancedSelect = $(`[data-qa-enhanced-select='${placeholderMsg}']`);
+            
+            expect(enhancedSelect.isVisible()).toBe(true);
+            expect(enhancedSelect.getText()).toContain(placeholderMsg)
+        });
+
+        it('should not have options selected on pageload', () => {
+            const emptyResult = 'You selected:';
+            selectedOptionMsg = $('[data-qa-selected-result]');
+            
+            expect(selectedOptionMsg.getText()).toBe(emptyResult);
+        });
+
+        it('should display no options on a bad search query', () => {
+            const badQuery = 'akjsdhfklj';
+
+            enhancedSelect.$('..').$('input').setValue(badQuery);
+            browser.waitForVisible('[data-qa-no-options]', constants.wait.normal);
+        });
+
+        it('should display options on a valid search query', () => {
+            const validQuery = 'keyboard';
+
+            enhancedSelect.$('..').$('input').setValue(validQuery);
+            
+            // Adding the value twice to fix test flakiness when running the entire functional test suite
+            enhancedSelect.$('..').$('input').setValue(validQuery);
+
+            browser.waitForVisible('[data-qa-option]', constants.wait.normal);
+
+            selectOptions = $$('[data-qa-option]');
+            expect(selectOptions.length).toBe(1);
+        });
+
+        it('should update the selected option text on select', () => {
+            selectOptions[0].click();
+
+            browser.waitForVisible(selectOptions[0].selector, constants.wait.normal, true);
+            selectedOptionMsg = $('[data-qa-selected-result]');
+            expect(selectedOptionMsg.getText()).toBe('You selected: keyboards');
+        });
+
+        xit('should clear the result on click clear', () => {
+            
+        });
+    });
+
+    describe('Text Field Suite', () => {
+        let searchTextfield, displayedListItems, validQuery, initialOptions = [];
+
+        beforeAll(() => {
+            navigateToStory(component, childStories[1]);
+        });
+
+        it('should display the debounced search text field', () => {
+            const placeholderMsg = 'Search for something';
+            searchTextfield = $('[data-qa-debounced-search]').$('input');
+
+            expect(searchTextfield.getAttribute('placeholder')).toBe(placeholderMsg);
+        });
+
+        it('should display unfiltered list of options', () => {
+            displayedListItems = $$('[data-qa-list-item]');
+            displayedListItems.forEach(i => {
+                expect(i.isVisible()).toBe(true);
+                expect(i.getText()).toMatch(/\w/ig);
+                initialOptions.push(i.getText());
+            });
+        });
+
+        it('should display no options on a bad search query', () => {
+            const badQuery = 'lkajsdkhsdklf';
+
+            searchTextfield.setValue(badQuery);
+
+            displayedListItems.forEach(i => i.waitForVisible(constants.wait.normal, true));
+        });
+
+        it('should display a single option on query of a single matching list item', () => {
+            validQuery = 'apples';
+
+            searchTextfield.setValue(validQuery);
+
+            browser.waitUntil(() => {
+                displayedListItems = $$('[data-qa-list-item]');
+                return displayedListItems.length === 1;
+            }, constants.wait.normal);
+
+            expect(displayedListItems[0].getText()).toBe(validQuery);
+        });
+
+        it('should display all list options on clear', () => {
+            validQuery.split('').forEach(i => {
+                $('[data-qa-debounced-search]').$('input').addValue('\uE003');
+            });
+
+            browser.waitUntil(() => {
+                displayedListItems = $$('[data-qa-list-item]');
+                return displayedListItems.length === initialOptions.length;
+            }, constants.wait.normal);
+
+            const currentOptions = $$('[data-qa-list-item]').map(i => i.getText());
+
+            expect(currentOptions).toEqual(initialOptions);
+        });
+    });
+});

--- a/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
+++ b/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
@@ -82,6 +82,7 @@ class DebouncedSearchTextField extends React.Component<CombinedProps, State> {
           className={ClassNames(
             className,
           )}
+          data-qa-debounced-search
         />
       </React.Fragment>
     );

--- a/src/components/DebouncedSearchTextField/StoryComponents/SelectExample.tsx
+++ b/src/components/DebouncedSearchTextField/StoryComponents/SelectExample.tsx
@@ -49,7 +49,7 @@ class Example extends React.Component<Props, State> {
           isSearching: false,
         });
       },
-      2000
+      800
     )
   }
 
@@ -77,7 +77,9 @@ class Example extends React.Component<Props, State> {
           better demonstrate the async functionality</i></p>
           <p><i>This component utilizes React-Select which has the added
             functionality of filtering as you type and is not debounced</i></p>
-        <div style={{ marginTop: '2em' }}>You selected: {this.state.selectedItem}</div>
+        <div style={{ marginTop: '2em' }} data-qa-selected-result={this.state.selectedItem}>
+          You selected: {this.state.selectedItem}
+        </div>
       </React.Fragment>
     );
   }

--- a/src/components/DebouncedSearchTextField/StoryComponents/TextFieldExample.tsx
+++ b/src/components/DebouncedSearchTextField/StoryComponents/TextFieldExample.tsx
@@ -31,7 +31,7 @@ class Example extends React.Component<Props, State> {
           isSearching: false,
         });
       },
-      2000
+      800
     )
   }
 
@@ -45,7 +45,7 @@ class Example extends React.Component<Props, State> {
         />
         <ul>
           {this.state.list.map((eachThing: string) => {
-            return <li key={eachThing}>{eachThing}</li>
+            return <li key={eachThing} data-qa-list-item>{eachThing}</li>
           })}
         </ul>
       </React.Fragment>

--- a/src/components/EnhancedSelect/components/NoOptionsMessage.tsx
+++ b/src/components/EnhancedSelect/components/NoOptionsMessage.tsx
@@ -22,6 +22,7 @@ const NoOptionsMessage: React.StatelessComponent<CombinedProps> = (props) => {
     <Typography
       className={selectProps.classes.noOptionsMessage}
       {...innerProps}
+      data-qa-no-options
     >
       {children}
     </Typography>


### PR DESCRIPTION
* Added functional tests for the debounced search component stories
* Updated the examples return results in `800` ms instead of `2000` ms. 
* Added data-qa attributes to the tests

* Disabled the clear test on the select field suite, need to chat with @martinmckenna as to why clearing the select does not seem to reset the selected item state

## Running the Tests

```bash
yarn storybook:e2e --story DebouncedSearchTextField
```