### PR TITLE
M3-1623 FIX: Deploy new linode from snapshot 

### DIFF
--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -76,6 +76,7 @@ interface State {
   selectedBackupIDFromQueryString: number | undefined;
   selectedStackScriptIDFromQueryString: number | undefined;
   selectedStackScriptTabFromQueryString: string | undefined;
+  selectedRegionIDFromLinode: string | undefined;
 }
 
 interface QueryStringOptions {
@@ -112,6 +113,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
     selectedBackupIDFromQueryString: undefined,
     selectedStackScriptIDFromQueryString: undefined,
     selectedStackScriptTabFromQueryString: undefined,
+    selectedRegionIDFromLinode: undefined
   };
 
   mounted: boolean = false;
@@ -149,11 +151,22 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
     }
 
     if (options.linodeID) {
+      this.setSelectedRegionByLinodeID(Number(options.linodeID));
       this.setState({ selectedLinodeIDFromQueryString: Number(options.linodeID) || undefined });
     }
 
     if (options.backupID) {
       this.setState({ selectedBackupIDFromQueryString: Number(options.backupID) || undefined });
+    }
+  }
+
+  setSelectedRegionByLinodeID(linodeID: number): void {
+    const selectedLinode = filter(
+      (linode: Linode.LinodeWithBackups) => linode.id === linodeID,
+      this.props.linodes.response
+    );
+    if (selectedLinode.length > 0) {
+      this.setState({ selectedRegionIDFromLinode: selectedLinode[0].region });
     }
   }
 
@@ -221,6 +234,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
             }}
             selectedBackupFromQuery={this.state.selectedBackupIDFromQueryString}
             selectedLinodeFromQuery={this.state.selectedLinodeIDFromQueryString}
+            selectedRegionIDFromLinode={this.state.selectedRegionIDFromLinode}
             linodes={this.props.linodes.response}
             types={this.props.typesData}
             extendLinodes={this.extendLinodes}
@@ -307,7 +321,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
     };
   }
 
-  getRegionInfo = (selectedRegionID: string | null): Info => {
+  getRegionInfo = (selectedRegionID?: string | null): Info => {
     const selectedRegion = this.props.regionsData.find(
       region => region.id === selectedRegionID);
 

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -55,6 +55,7 @@ interface Props {
   history: any;
   selectedBackupFromQuery?: number;
   selectedLinodeFromQuery?: number;
+  selectedRegionIDFromLinode?: string;
 
   /* From HOC */
   tagObject: TagObject;
@@ -67,8 +68,8 @@ interface State {
   selectedLinodeID: number | undefined;
   selectedBackupID: number | undefined;
   selectedDiskSize: number | undefined;
+  selectedRegionID: string | undefined;
   selectedTypeID: string | null;
-  selectedRegionID: string | null;
   label: string;
   errors?: Linode.ApiFieldError[];
   backups: boolean;
@@ -110,8 +111,8 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     selectedLinodeID: this.props.selectedLinodeFromQuery || undefined,
     selectedBackupID: this.props.selectedBackupFromQuery || undefined,
     selectedDiskSize: undefined,
+    selectedRegionID: this.props.selectedRegionIDFromLinode || undefined,
     selectedTypeID: null,
-    selectedRegionID: null,
     label: '',
     backups: false,
     privateIP: false,
@@ -261,7 +262,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
 
     const imageInfo = selectedBackupInfo;
 
-    const regionInfo = getRegionInfo(selectedRegionID);
+    const regionInfo = selectedRegionID && getRegionInfo(selectedRegionID);
 
     const typeInfo = getTypeInfo(selectedTypeID);
 


### PR DESCRIPTION
This PR fixes a bug where users were unable to deploy a new linode from a snapshot after landing on the Create From Backup flow from the Linode Detail - Backups page.

This bug was due to the fact that the regionID was not being selected by default, even though the Linode was. To fix this, I added behavior to `<LinodesCreate />` so that it finds the regionID of the selected Linode, and passes it down to `<FromBackupsContent />`.

**To test:**
* Have a linode with an existing snapshot
1) Navigate to Linode detail of Linode containing a snapshot
2) Navigate to Backups tab
3) Click "Snapshot" action menu
4) Select "Deploy new linode"
5) Select an equivalent linode plan
6) Do not enter a label
7) Click Deploy
8) **Observe:** _You should be taken back to the Linodes Landing page, and the new Linode should be being created_