### PR TITLE
M3-1622 FIX: Restore From Snapshot - Linodes displayed in Select

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.test.tsx
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { RestoreToLinodeDrawer } from './RestoreToLinodeDrawer';
+
+describe('RestoreToLinodeDrawer', () => {
+  const props = {
+    open: true,
+    linodeID: 1234,
+    linodeRegion: 'us-east',
+    backupCreated: '12 hours ago',
+    onClose: jest.fn(),
+    onSubmit: jest.fn()
+  }
+
+  const wrapper = shallow<RestoreToLinodeDrawer>(
+    <RestoreToLinodeDrawer
+      {...props}
+      classes={{ root: '' }}
+    />
+  );
+
+  it('doesn\'t wipe linodes when calling reset() method', () => {
+    const mockLinodes = [
+      ['123456', 'test-label']
+    ];
+
+    wrapper.setState({ linodes: mockLinodes });
+    const instance = wrapper.instance() as any;
+    instance.reset();
+    expect(wrapper.instance().state.linodes).toBe(mockLinodes);
+  });
+});

--- a/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -43,7 +43,7 @@ interface State {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-class RestoreToLinodeDrawer extends React.Component<CombinedProps, State> {
+export class RestoreToLinodeDrawer extends React.Component<CombinedProps, State> {
   defaultState = {
     linodes: [],
     overwrite: false,

--- a/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -57,7 +57,7 @@ class RestoreToLinodeDrawer extends React.Component<CombinedProps, State> {
 
   reset = () => {
     if (!this.mounted) { return; }
-    this.setState({ ...this.defaultState });
+    this.setState({ ...this.defaultState, linodes: this.state.linodes });
   }
 
   componentDidMount() {


### PR DESCRIPTION
This PR fixes a bug in the Restore From Snapshots drawer where Linodes would not be displayed in the Select component after re-opening the drawer which had previously been closed.

This was fixed by retaining `linodes` state when resetting other state values on drawer close.

**To Test:**

_Pre-conditions:_
- Have a Linode with backups enabled and a snapshot taken
- Navigate to the Backups tab of Linode detail

_Test:_
1) Click the action menu on a snapshot
2) Select "Restore to Existing Linode"
3) **Observe:** Drawer opens
4) Click the Linode Select component
5) **Observe:** Linodes are displayed in the Select component
6) Dismiss the restore drawer by clicking "Cancel" or "X"
7) Open the restore drawer again (action menu --> "Restore to Existing Linode")
8) Click the Linodes Select component
9) **Observe:** _Available Linodes should be displayed in the Select component_