### PR TITLE
 M3-1629 Fix bug in deploy Linode from backup flow

### DIFF
--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -47,10 +47,10 @@ export class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNam
     const { selectedID, currentPlanHeading } = this.props;
     const selectedDiskSize = (this.props.selectedDiskSize) ? this.props.selectedDiskSize : 0;
     let tooltip;
-    const planToSmall = selectedDiskSize > type.disk
+    const planTooSmall = selectedDiskSize > type.disk
     const isSamePlan = type.heading === currentPlanHeading;
 
-    if(planToSmall){
+    if(planTooSmall){
       tooltip = `This plan is too small for the selected image.`;
     }
 
@@ -64,7 +64,7 @@ export class SelectPlanPanel extends React.Component<Props & WithStyles<ClassNam
       onClick={this.onSelect(type.id)}
       heading={type.heading}
       subheadings={type.subHeadings}
-      disabled={planToSmall || isSamePlan}
+      disabled={planTooSmall || isSamePlan}
       tooltip={tooltip}
     />;
   }

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -18,6 +18,7 @@ import { createLinode, getLinodeBackups } from 'src/services/linodes';
 import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
 
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
+import getLinodeInfo from 'src/utilities/getLinodeInfo';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 import AddonsPanel from '../AddonsPanel';
@@ -250,6 +251,20 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
   componentDidMount() {
     this.mounted = true;
     this.getLinodesWithBackups(this.props.linodes);
+    const { selectedLinodeID } = this.state;
+    // If there is a selected Linode ID (from props), make sure its information
+    // is set to state as if it had been selected manually.
+    if (selectedLinodeID) {
+      const selectedLinode = getLinodeInfo(selectedLinodeID, this.props.linodes);
+      if (selectedLinode) {
+        this.setState({
+          selectedLinodeID: selectedLinode.id,
+          selectedTypeID: null,
+          selectedRegionID: selectedLinode.region,
+          selectedDiskSize: selectedLinode.specs.disk,
+        });
+       }
+    }
   }
 
   render() {

--- a/src/utilities/getLinodeInfo.test.ts
+++ b/src/utilities/getLinodeInfo.test.ts
@@ -1,0 +1,18 @@
+import getLinodeInfo from './getLinodeInfo';
+
+import { linode1, linode2 } from 'src/__data__/linodes';
+
+
+const linodes = [linode1, linode2];
+
+describe("getLinodeInfo", () => {
+  it("should return a full Linode if a match is found", () => {
+    expect(getLinodeInfo(linode1.id, linodes)).toBe(linode1);
+  });
+  it("should return undefined if no match is found", () => {
+    expect(getLinodeInfo(123456, linodes)).toBeUndefined();
+  });
+  it("should return undefined with an empty list", () => {
+    expect(getLinodeInfo(linode1.id, [])).toBeUndefined();
+  });
+});

--- a/src/utilities/getLinodeInfo.ts
+++ b/src/utilities/getLinodeInfo.ts
@@ -9,7 +9,7 @@
  */
 const getLinodeInfo = (linodeId: number, linodes: Linode.Linode[]) : Linode.Linode | undefined => {
   if (!linodes) { throw new Error("You must provide a list of Linodes.") }
-  return linodes.find((linode: Linode.Linode) => String(linode.id) === String(linodeId))
+  return linodes.find((linode: Linode.Linode) => linode.id === linodeId)
 }
 
 export default getLinodeInfo;

--- a/src/utilities/getLinodeInfo.ts
+++ b/src/utilities/getLinodeInfo.ts
@@ -1,0 +1,15 @@
+/**
+ * getLinodeInfo
+ *
+ * Searches a list of Linodes by LinodeId and returns the full matching Linode
+ * object, or undefined if no matching Linode is found.
+ *
+ * @param linodeId { number } The id of the Linode to retrieve information for.
+ * @param linodes { array } An array of Linodes to search.
+ */
+const getLinodeInfo = (linodeId: number, linodes: Linode.Linode[]) : Linode.Linode | undefined => {
+  if (!linodes) { throw new Error("You must provide a list of Linodes.") }
+  return linodes.find((linode: Linode.Linode) => String(linode.id) === String(linodeId))
+}
+
+export default getLinodeInfo;


### PR DESCRIPTION
When navigating to the Create From Backup tab from the Backups tab
(the action menu for a particular snapshot), the Linode that the
backup came from was pre-selected, but the event handler for Linode
selection was not being run. Information about the selected Linode was
therefore not available in state.
Added a check to cDM to avoid this situation.

## To Test
1. Create a large Linode (e.g. 8GB)
2. Create a snapshot
3. When the snapshot finishes, click on "Deploy to New Linode" from its action menu
4. Observe: you should see the smaller plans (2GB and 4GB) disabled in the list of available plans.