### PR TITLE
M3-1717 Support search results list is too wide on production builds

### DIFF
--- a/src/components/DebouncedSearchTextField/DebouncedSearchTextField.spec.js
+++ b/src/components/DebouncedSearchTextField/DebouncedSearchTextField.spec.js
@@ -20,14 +20,14 @@ describe('Debounced Search Suite', () => {
         it('should display select search bar', () => {
             const placeholderMsg = 'Search for something (i.e "er")'
             enhancedSelect = $(`[data-qa-enhanced-select='${placeholderMsg}']`);
-            
+
             expect(enhancedSelect.isVisible()).toBe(true);
             expect(enhancedSelect.getText()).toContain(placeholderMsg)
         });
 
         it('should not have options selected on pageload', () => {
             selectedOptionMsg = $(currentResultSelector);
-            
+
             expect(selectedOptionMsg.getText()).toBe(emptyResult);
         });
 
@@ -39,9 +39,8 @@ describe('Debounced Search Suite', () => {
         });
 
         it('should display options on a valid search query', () => {
-            // Add the value twice to fix test flakiness when running the entire functional test suite
-            enhancedSelect.$('..').$('input').setValue(validQuery);
-            enhancedSelect.$('..').$('input').setValue(validQuery);
+            const enhancedSelectInput = enhancedSelect.$('..').$('input').selector;
+            browser.trySetValue(enhancedSelectInput, validQuery);
 
             browser.waitForVisible(optionSelector, constants.wait.normal);
 

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -275,6 +275,7 @@ class Select extends React.PureComponent<CombinedProps,{}> {
       noOptionsMessage,
       onMenuClose,
       onBlur,
+      blurInputOnSelect,
       ...restOfProps
     } = this.props;
 
@@ -306,7 +307,7 @@ class Select extends React.PureComponent<CombinedProps,{}> {
         {...restOfProps}
         isClearable={isClearable  || true }
         isSearchable
-        blurInputOnSelect
+        blurInputOnSelect={blurInputOnSelect}
         isLoading={isLoading}
         defaultOptions
         cacheOptions={false}

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -114,6 +114,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
           InputProps={{
             disableUnderline: true,
             className: classNames(
+              'input',
               {
               [classes.expand]: expand,
               },

--- a/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -46,7 +46,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     margin: '0 auto',
     width: '100%s',
     maxHeight: 500,
-    '& [class*="formControl"]': {
+    '& .input': {
       maxWidth: '100%',
       '& > div': {
         marginRight: 0,

--- a/src/features/linodes/LinodesDetail/HeaderSections/TagsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/TagsPanel.tsx
@@ -61,7 +61,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     '& [class*="MuiFormControl"]': {
       width: 'auto',
     },
-    '& [class*="MuiInput-formControl"]': {
+    '& .input': {
       minHeight: 'auto',
       border: 0,
       backgroundColor: 'transparent',

--- a/src/features/linodes/LinodesDetail/HeaderSections/TagsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/TagsPanel.tsx
@@ -74,8 +74,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     '& .error-for-scroll p': {
       padding: theme.spacing.unit,
       marginLeft: 12,
+      marginTop: 0,
       position: 'absolute',
-      top: theme.spacing.unit * 2,
       boxShadow: '0 0 5px #ddd',
       backgroundColor: theme.bg.offWhite,
       lineHeight: 1.2,

--- a/src/features/linodes/LinodesDetail/HeaderSections/TagsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/TagsPanel.tsx
@@ -111,7 +111,7 @@ interface ActionMeta {
 interface Props {
   tags: Tags;
   onDeleteTag: (value: string) => void;
-  toggleCreateTag: () => void;
+  toggleTagInput: () => void;
   onCreateTag: (value: Item, actionMeta: ActionMeta) => void;
   tagInputValue: string;
   isCreatingTag: boolean;
@@ -125,7 +125,7 @@ const TagsPanel: React.StatelessComponent<CombinedProps> = (props) => {
     tags: { tagsToSuggest, tagsAlreadyAppliedToLinode, tagsQueuedForDeletion },
     tagError,
     onCreateTag,
-    toggleCreateTag,
+    toggleTagInput,
     onDeleteTag,
     tagInputValue,
     isCreatingTag,
@@ -158,12 +158,13 @@ const TagsPanel: React.StatelessComponent<CombinedProps> = (props) => {
             options={tagsToSuggest}
             variant='creatable'
             errorText={tagError}
-            onBlur={toggleCreateTag}
+            onBlur={toggleTagInput}
             placeholder="Create or Select a Tag"
             value={tagInputValue}
             createOptionPosition="first"
             autoFocus
             className={classes.selectTag}
+            blurInputOnSelect={false}
         />
         :
         <Tooltip
@@ -171,7 +172,7 @@ const TagsPanel: React.StatelessComponent<CombinedProps> = (props) => {
           placement="right"
         >
           <IconButton
-            onClick={toggleCreateTag}
+            onClick={toggleTagInput}
             className={classes.addButton}
           >
             <AddCircle data-qa-add-tag />

--- a/src/features/linodes/LinodesDetail/HeaderSections/TagsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/TagsPanel.tsx
@@ -58,7 +58,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     position: 'relative',
     zIndex: 3,
     animation: 'fadeIn .3s ease-in-out forwards',
-    '& [class*="MuiFormControl"]': {
+    '& .error-for-scroll > div': {
       width: 'auto',
     },
     '& .input': {
@@ -71,14 +71,15 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
         color: theme.color.grey1,
       },
     },
-    '& [class*="MuiFormHelperText-error"]': {
+    '& .error-for-scroll p': {
       padding: theme.spacing.unit,
       marginLeft: 12,
       position: 'absolute',
-      top: theme.spacing.unit * 4,
+      top: theme.spacing.unit * 2,
       boxShadow: '0 0 5px #ddd',
       backgroundColor: theme.bg.offWhite,
       lineHeight: 1.2,
+      zIndex: 5.
     },
     '& .react-select__input': {
       fontSize: '.9rem',

--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader.tsx
@@ -137,8 +137,11 @@ class LinodesDetailHeader extends React.Component<CombinedProps, State> {
     this.props.labelInput.onEdit(value)
   }
 
-  handleToggleCreate = () => {
-    this.setState({ isCreatingTag: !this.state.isCreatingTag })
+  handleToggleCreateTag = () => {
+    this.setState({
+      tagError: '',
+      isCreatingTag: !this.state.isCreatingTag
+    })
   }
 
   handleDeleteTag = (label: string) => {
@@ -278,7 +281,7 @@ class LinodesDetailHeader extends React.Component<CombinedProps, State> {
             tagsToSuggest: this.state.tagsToSuggest || []
           }}
           onDeleteTag={this.handleDeleteTag}
-          toggleCreateTag={this.handleToggleCreate}
+          toggleTagInput={this.handleToggleCreateTag}
           onCreateTag={this.handleCreateTag}
           tagInputValue={this.state.tagInputValue}
           isCreatingTag={this.state.isCreatingTag}


### PR DESCRIPTION
While the css 'bracket' targeting works locally, once compiled, we lose the styling that is being applied to material ui elements. The solution was to add a class globally to the base component itself and styling their usage in specific, custom components. 

Algolia Search:

Before:
<img width="527" alt="screen shot 2018-10-31 at 5 01 57 pm" src="https://user-images.githubusercontent.com/2565527/47818688-d2d1d080-dd2e-11e8-8c96-f1e67eec2ede.png">

After:
<img width="531" alt="screen shot 2018-10-31 at 5 02 40 pm" src="https://user-images.githubusercontent.com/2565527/47818689-d2d1d080-dd2e-11e8-8832-221ce1872e5e.png">

Tag Selects (note there is related work forthcoming for this component):

Before:
<img width="383" alt="screen shot 2018-10-31 at 5 08 24 pm" src="https://user-images.githubusercontent.com/2565527/47819006-9bafef00-dd2f-11e8-9c5a-1444ce13d9e2.png">

After:
<img width="352" alt="screen shot 2018-10-31 at 5 03 48 pm" src="https://user-images.githubusercontent.com/2565527/47819016-9fdc0c80-dd2f-11e8-8818-a24f1b298ada.png">

