### PR TITLE
M3-1735 - Enable Parallel browsers on CI

### DIFF
--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -41,7 +41,7 @@ if (argv.log) {
 
 exports.config = {
     // Selenium Host/Port
-    host: process.env.DOCKER ? 'selenium-standalone' : 'localhost',
+    host: process.env.DOCKER ? 'selenium' : 'localhost',
     port: 4444,
     //
     // ==================

--- a/e2e/config/wdio.storybook.conf.js
+++ b/e2e/config/wdio.storybook.conf.js
@@ -16,7 +16,7 @@ const selectedBrowser = () => {
 
 const seleniumSettings = require('./selenium-config');
 const specsToRun = argv.story ? [ `./src/components/${argv.story}/${argv.story}.spec.js` ] : ['./src/components/**/*.spec.js'];
-const servicesToStart = process.env.DOCKER || argv.debug ? [] : ['selenium-standalone'];
+const servicesToStart = process.env.DOCKER || argv.debug ? [] : ['selenium'];
 
 exports.config = merge(wdioMaster.config, {
     specs: specsToRun,

--- a/e2e/config/wdio.storybook.conf.js
+++ b/e2e/config/wdio.storybook.conf.js
@@ -16,7 +16,7 @@ const selectedBrowser = () => {
 
 const seleniumSettings = require('./selenium-config');
 const specsToRun = argv.story ? [ `./src/components/${argv.story}/${argv.story}.spec.js` ] : ['./src/components/**/*.spec.js'];
-const servicesToStart = process.env.DOCKER || argv.debug ? [] : ['selenium'];
+const servicesToStart = process.env.DOCKER || argv.debug ? [] : ['selenium-standalone'];
 
 exports.config = merge(wdioMaster.config, {
     specs: specsToRun,

--- a/e2e/config/wdio.storybook.conf.js
+++ b/e2e/config/wdio.storybook.conf.js
@@ -37,6 +37,9 @@ exports.config = merge(wdioMaster.config, {
     beforeSuite: function(suite) {
         // Do nothing before suites
     },
+    after: function (result, capabilities, specs) {
+
+    },
     onComplete: function(exitCode, config, capabilities) {
     }
 });

--- a/integration-test.yml
+++ b/integration-test.yml
@@ -35,6 +35,8 @@ services:
       - MANAGER_PASS=${MANAGER_PASS}
       - MANAGER_USER_2=${MANAGER_USER_2}
       - MANAGER_PASS_2=${MANAGER_PASS_2}
+      - MANAGER_OAUTH=${MANAGER_OAUTH}
+      - MANAGER_OAUTH_2=${MANAGER_OAUTH_2}
     build:
       context: .
       dockerfile: Dockerfile

--- a/integration-test.yml
+++ b/integration-test.yml
@@ -1,12 +1,18 @@
 version: '3.1'
-services: 
-  selenium-standalone:
-    image: selenium/standalone-chrome:3.13.0-argon
+services:
+  selenium:
+    image: selenium/hub:3.13.0-argon
+  chrome:
+    image: selenium/node-chrome:3.13.0-argon
     volumes:
       - /dev/shm:/dev/shm #Mitigates the Chromium issue described at https://code.google.com/p/chromium/issues/detail?id=519952
     environment:
+      - HUB_PORT_4444_TCP_ADDR=selenium
+      - HUB_PORT_4444_TCP_PORT=4444
       - SCREEN_HEIGHT=1080
       - SCREEN_WIDTH=1600
+    depends_on:
+      - selenium
   manager-local:
     environment:
       - HTTPS=true
@@ -20,13 +26,15 @@ services:
       dockerfile: Dockerfile
     entrypoint: ["/src/scripts/start_manager.sh"]
     depends_on:
-      - selenium-standalone
+      - chrome
   manager-e2e:
     environment:
       - DOCKER=true
       - REACT_APP_API_ROOT=${REACT_APP_API_ROOT}
       - MANAGER_USER=${MANAGER_USER}
       - MANAGER_PASS=${MANAGER_PASS}
+      - MANAGER_USER_2=${MANAGER_USER_2}
+      - MANAGER_PASS_2=${MANAGER_PASS_2}
     build:
       context: .
       dockerfile: Dockerfile
@@ -35,4 +43,3 @@ services:
     entrypoint: ["./scripts/wait-for-it.sh", "-t", "250", "-s", "manager-local:3000", "--", "yarn","e2e", "--log"]
     depends_on:
       - manager-local
-

--- a/storybook-test.yml
+++ b/storybook-test.yml
@@ -1,6 +1,6 @@
 version: '3.1'
-services: 
-  selenium-standalone:
+services:
+  selenium:
     image: selenium/standalone-chrome:3.4.0-francium
     volumes:
       - /dev/shm:/dev/shm #Mitigates the Chromium issue described at https://code.google.com/p/chromium/issues/detail?id=519952


### PR DESCRIPTION
* Updates the `integration-test.yml` docker compose file to use selenium-hub instead of selenium-standalone.
* Adds chrome selenium-node image to `integration-test.yml` to connect to selenium hub (this allows scaling the number of chrome nodes to enable parallel tests, each running in their own container
* Updated the wdio config files to no longer reference `selenium-standalone` as the host name for selenium when running via docker. It's now simply "selenium" since the storybook tests when running via docker still use standalone (for the time being, but these could also be updated to use hub, will create a ticket)

PM me for the results of these changes running on CI. 