### PR TITLE
M3-1752 - remove explicit height on table headers

### DIFF
--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -902,6 +902,7 @@ const themeDefaults: ThemeOptions = {
         },
       },
       head: {
+        height: 'auto',
         backgroundColor: '#fbfbfb',
         '&:before': {
           borderLeftColor: '#fbfbfb',


### PR DESCRIPTION
Some legacy table headers still have an explicit height assigned to them from MUI. This PR removes that in order to remove MOAR whitespace. 