### PR TITLE
M3-1751 remove linode accordions

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -196,7 +196,9 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     this.mounted = true;
-    this.getStats();
+    // Only use loading state on initial data load. This will be set to false
+    // in the getStats then and catch handlers.
+    this.setState({ dataIsLoading: true, }, this.getStats);
     this.statsInterval = window.setInterval(this.getStats, statsFetchInterval);
   }
 
@@ -209,7 +211,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     const { linodeId } = this.props;
     const { rangeSelection } = this.state;
     if (!linodeId) { return; }
-    this.setState({ statsError: undefined, dataIsLoading: true });
+    this.setState({ statsError: undefined, });
     let req;
     if (rangeSelection === '24') {
       req = getLinodeStats(linodeId);

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -10,7 +10,6 @@ import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/st
 import Typography from '@material-ui/core/Typography';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import ExtendedExpansionPanel from 'src/components/ExtendedExpansionPanel';
 import LineGraph from 'src/components/LineGraph';
 import Select from 'src/components/Select';
 import { withTypes } from 'src/context/types';
@@ -19,6 +18,7 @@ import { displayType, typeLabelLong } from 'src/features/linodes/presentation';
 import { getLinodeStats, getLinodeStatsByDate } from 'src/services/linodes';
 import { setUpCharts } from 'src/utilities/charts';
 
+import StatsPanel from './StatsPanel';
 import SummaryPanel from './SummaryPanel';
 
 setUpCharts();
@@ -127,7 +127,6 @@ interface State {
   statsLoadError?: string;
   dataIsLoading: boolean;
   statsError?: string;
-  openPanels: number;
 }
 
 type CombinedProps = LinodeContextProps &
@@ -146,7 +145,6 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     stats: undefined,
     rangeSelection: '24',
     dataIsLoading: false,
-    openPanels: 0,
   };
 
   rangeSelectOptions: (typeof MenuItem)[] = [];
@@ -198,37 +196,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     this.mounted = true;
+    this.getStats();
+    this.statsInterval = window.setInterval(this.getStats, statsFetchInterval);
   }
 
   componentWillUnmount() {
     this.mounted = false;
     window.clearInterval(this.statsInterval as number);
-  }
-
-  handleToggleExpand = (e: any, expanded: boolean) => {
-    const { openPanels, stats } = this.state;
-    if (expanded && !stats) {
-      /* Only set loading state on initial load
-      *  so the graphs are not disrupted on future updates. */
-      this.setState({ dataIsLoading: true });
-      this.getStats();
-    }
-
-    if (expanded && openPanels <= 0) {
-      /* We will regularly update the stats as long as at least one panel is open. */
-      this.statsInterval = window.setInterval(() => this.getStats(), statsFetchInterval);
-    }
-
-    /* If the panel is opening, increment the number of open panels. Otherwise decrement.
-    *  This allows us to keep track of when all of the panels are closed.
-    */
-    const updatedOpenPanels = expanded ? openPanels + 1 : openPanels - 1;
-    this.setState({ openPanels: updatedOpenPanels });
-
-    /* If all panels are closed, stop updating the stats. */
-    if (!expanded && updatedOpenPanels <= 0) {
-      window.clearInterval(this.statsInterval as number);
-    }
   }
 
   getStats = () => {
@@ -489,41 +463,34 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
             </FormControl>
           </div>
 
-          <ExtendedExpansionPanel
-            heading={"CPU %"}
-            height={chartHeight}
-            onChange={this.handleToggleExpand}
-            renderMainContent={this.renderCPUChart}
-            loading={dataIsLoading}
+          <StatsPanel
+            title="CPU usage"
             error={statsError}
+            loading={dataIsLoading}
+            renderBody={this.renderCPUChart}
           />
 
-          <ExtendedExpansionPanel
-            heading={"IPv4 Traffic"}
-            height={chartHeight}
-            onChange={this.handleToggleExpand}
-            renderMainContent={this.renderIPv4TrafficChart}
-            loading={dataIsLoading}
+          <StatsPanel
+            title="IPv4 Traffic"
             error={statsError}
+            loading={dataIsLoading}
+            renderBody={this.renderIPv4TrafficChart}
           />
 
-          <ExtendedExpansionPanel
-            heading={"IPv6 Traffic"}
-            height={chartHeight}
-            onChange={this.handleToggleExpand}
-            renderMainContent={this.renderIPv6TrafficChart}
-            loading={dataIsLoading}
+          <StatsPanel
+            title="IPv6 Traffic"
             error={statsError}
+            loading={dataIsLoading}
+            renderBody={this.renderIPv6TrafficChart}
           />
 
-          <ExtendedExpansionPanel
-            heading={"Disk I/O"}
-            height={chartHeight}
-            onChange={this.handleToggleExpand}
-            renderMainContent={this.renderDiskIOChart}
-            loading={dataIsLoading}
+          <StatsPanel
+            title="Disk IO"
             error={statsError}
+            loading={dataIsLoading}
+            renderBody={this.renderDiskIOChart}
           />
+
         </React.Fragment>
       </React.Fragment>
     );

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -209,7 +209,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     const { linodeId } = this.props;
     const { rangeSelection } = this.state;
     if (!linodeId) { return; }
-    this.setState({ statsError: undefined, });
+    this.setState({ statsError: undefined, dataIsLoading: true });
     let req;
     if (rangeSelection === '24') {
       req = getLinodeStats(linodeId);
@@ -428,6 +428,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
     const { dataIsLoading, statsError, rangeSelection } = this.state;
 
+    // Shared props for all stats charts
+    const chartProps = {
+      loading: dataIsLoading,
+      error: statsError,
+      height: chartHeight
+    }
+
     if (!linode || !volumes) {
       return null;
     }
@@ -464,31 +471,27 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           </div>
 
           <StatsPanel
-            title="CPU usage"
-            error={statsError}
-            loading={dataIsLoading}
+            title="CPU Usage"
             renderBody={this.renderCPUChart}
+            {...chartProps}
           />
 
           <StatsPanel
             title="IPv4 Traffic"
-            error={statsError}
-            loading={dataIsLoading}
             renderBody={this.renderIPv4TrafficChart}
+            {...chartProps}
           />
 
           <StatsPanel
             title="IPv6 Traffic"
-            error={statsError}
-            loading={dataIsLoading}
             renderBody={this.renderIPv6TrafficChart}
+            {...chartProps}
           />
 
           <StatsPanel
             title="Disk IO"
-            error={statsError}
-            loading={dataIsLoading}
             renderBody={this.renderDiskIOChart}
+            {...chartProps}
           />
 
         </React.Fragment>

--- a/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.test.tsx
@@ -1,0 +1,38 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import CircleProgress from 'src/components/CircleProgress';
+import ErrorState from 'src/components/ErrorState';
+
+import { StatsPanel } from './StatsPanel';
+
+const renderMain = jest.fn();
+const title = "Stats About My Linode";
+
+const component = shallow(
+  <StatsPanel
+    classes={{'root':'','title':''}}
+    title={title}
+    loading={true}
+    error={undefined}
+    renderBody={renderMain}
+  />
+)
+
+describe("StatsPanel component", () => {
+  it("should render a loading spinner on loading state", () => {
+    expect(component.containsMatchingElement(<CircleProgress mini />)).toBeTruthy();
+    expect(renderMain).not.toHaveBeenCalled();
+  });
+  it("should render an error on error state", () => {
+    const error = "This is an error."
+    component.setProps({ loading: false, error });
+    expect(component.containsMatchingElement(<CircleProgress mini />)).toBeFalsy();
+    expect(component.containsMatchingElement(<ErrorState errorText={error} />)).toBeTruthy();
+    expect(renderMain).not.toHaveBeenCalled();
+  });
+  it("should call its renderContent function if neither error or loading", () => {
+    component.setProps({ error: undefined });
+    expect(renderMain).toHaveBeenCalled();
+  });
+});

--- a/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.test.tsx
@@ -11,7 +11,11 @@ const title = "Stats About My Linode";
 
 const component = shallow(
   <StatsPanel
-    classes={{'root':'','title':''}}
+    classes={{
+      'root':'',
+      'spinner':'',
+      'title':'',
+    }}
     title={title}
     loading={true}
     error={undefined}

--- a/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.test.tsx
@@ -17,6 +17,7 @@ const component = shallow(
       'title':'',
     }}
     title={title}
+    height={300}
     loading={true}
     error={undefined}
     renderBody={renderMain}

--- a/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+import Paper from '@material-ui/core/Paper';
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+
+import CircleProgress from 'src/components/CircleProgress';
+import ErrorState from 'src/components/ErrorState';
+
+type ClassNames = 'root' | 'title';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {
+    padding: theme.spacing.unit * 2,
+    margin: theme.spacing.unit,
+  },
+  title: {
+    padding: theme.spacing.unit * 2
+  }
+
+});
+
+interface Props {
+  renderBody: () => JSX.Element;
+  loading: boolean;
+  error?: string;
+  title: string;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export const StatsPanel: React.StatelessComponent<CombinedProps> = (props) => {
+  const { classes, error, loading, renderBody, title } = props;
+  return (
+    <Paper className={classes.root} >
+      <Typography
+        className={classes.title}
+        variant="title"
+        data-qa-stats-title
+      >
+        {title}
+      </Typography>
+      {loading
+        ? <CircleProgress mini />
+        : error
+          ? <ErrorState errorText={error} />
+          : renderBody()
+      }
+    </Paper>
+  );
+};
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled<Props>(StatsPanel);

--- a/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
@@ -30,12 +30,13 @@ interface Props {
   loading: boolean;
   error?: string;
   title: string;
+  height: number;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const StatsPanel: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, error, loading, renderBody, title } = props;
+  const { classes, error, height, loading, renderBody, title } = props;
   return (
     <Paper className={classes.root} >
       <Typography
@@ -46,7 +47,7 @@ export const StatsPanel: React.StatelessComponent<CombinedProps> = (props) => {
         {title}
       </Typography>
       {loading
-        ? <div className={classes.spinner}><CircleProgress mini /></div>
+        ? <div className={classes.spinner} style={{minHeight: height}}><CircleProgress mini /></div>
         : error
           ? <ErrorState errorText={error} />
           : renderBody()

--- a/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
@@ -7,17 +7,22 @@ import Typography from '@material-ui/core/Typography';
 import CircleProgress from 'src/components/CircleProgress';
 import ErrorState from 'src/components/ErrorState';
 
-type ClassNames = 'root' | 'title';
+type ClassNames = 'root' | 'spinner' | 'title';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
     padding: theme.spacing.unit * 2,
-    margin: theme.spacing.unit,
+    marginBottom: theme.spacing.unit * 2,
+  },
+  spinner: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
   },
   title: {
     padding: theme.spacing.unit * 2
   }
-
 });
 
 interface Props {
@@ -41,7 +46,7 @@ export const StatsPanel: React.StatelessComponent<CombinedProps> = (props) => {
         {title}
       </Typography>
       {loading
-        ? <CircleProgress mini />
+        ? <div className={classes.spinner}><CircleProgress mini /></div>
         : error
           ? <ErrorState errorText={error} />
           : renderBody()


### PR DESCRIPTION
Remove stats panels from accordions on the Linode detail page.

## Notes

- Refactored the ExpansionPanels into a smaller StatsPanel component that uses Paper.
- Each Panel includes loading and error states, which may not be ideal.
- Restored statsInterval call, so stats will be reloaded every 30 seconds. Loading spinner is only shown on the initial load.