### PR TITLE
Fix NodeBalancer case in Search Placeholder

### DIFF
--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -424,7 +424,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
               searchActive ?
                 "Search"
                 :
-                "Search for Linodes, Volumes, Nodebalancers, Domains, Tags..."
+                "Search for Linodes, Volumes, NodeBalancers, Domains, Tags..."
             }
             components={{ Control, Option: SearchSuggestion }}
             styleOverrides={selectStyles}


### PR DESCRIPTION
* Changes `Nodebalancers` to `NodeBalancers`
* Checked the code base for other instances of this spelling, none were found.