### PR TITLE
M3-1540 breadcrumb component

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -7,8 +7,8 @@ import Breadcrumb from './Breadcrumb';
 
 class InteractiveStaticBreadcrumb extends React.Component {
   state = {
-    backLink: '/linodes',
-    backText: 'Linodes',
+    linkTo: '/linodes',
+    linkText: 'Linodes',
     text: 'Static text',
   }
 
@@ -16,8 +16,8 @@ class InteractiveStaticBreadcrumb extends React.Component {
     return (
       <React.Fragment>
         <Breadcrumb
-          backLink={this.state.backLink}
-          backText={this.state.backText}
+          linkTo={this.state.linkTo}
+          linkText={this.state.linkText}
           text={this.state.text}
         />
       </React.Fragment>
@@ -27,8 +27,8 @@ class InteractiveStaticBreadcrumb extends React.Component {
 
 class InteractiveEditableBreadcrumb extends React.Component {
   state = {
-    backLink: '/linodes',
-    backText: 'Linodes',
+    linkTo: '/linodes',
+    linkText: 'Linodes',
     text: 'Editable text!',
   }
 
@@ -44,8 +44,8 @@ class InteractiveEditableBreadcrumb extends React.Component {
     return (
       <React.Fragment>
         <Breadcrumb
-          backLink={this.state.backLink}
-          backText={this.state.backText}
+          linkTo={this.state.linkTo}
+          linkText={this.state.linkText}
           text={this.state.text}
           onEdit={this.onEdit}
           onCancel={this.onCancel}

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -59,10 +59,14 @@ storiesOf('Breadcrumb', module)
   .addDecorator(ThemeDecorator)
   .add('Static Text', () => (
     <StaticRouter location="/" context={{}}>
-      <InteractiveStaticBreadcrumb />
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <InteractiveStaticBreadcrumb />
+      </div>
     </StaticRouter>
   )).add('Editable Text', () => (
     <StaticRouter location="/" context={{}}>
-      <InteractiveEditableBreadcrumb />
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <InteractiveEditableBreadcrumb />
+      </div>
     </StaticRouter>
   ));

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -18,7 +18,7 @@ class InteractiveStaticBreadcrumb extends React.Component {
         <Breadcrumb
           linkTo={this.state.linkTo}
           linkText={this.state.linkText}
-          text={this.state.text}
+          label={this.state.text}
         />
       </React.Fragment>
     )
@@ -46,7 +46,7 @@ class InteractiveEditableBreadcrumb extends React.Component {
         <Breadcrumb
           linkTo={this.state.linkTo}
           linkText={this.state.linkText}
-          text={this.state.text}
+          label={this.state.text}
           onEdit={this.onEdit}
           onCancel={this.onCancel}
         />

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,68 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { StaticRouter } from 'react-router-dom';
+
+import ThemeDecorator from '../../utilities/storybookDecorators';
+import Breadcrumb from './Breadcrumb';
+
+class InteractiveStaticBreadcrumb extends React.Component {
+  state = {
+    backLink: '/linodes',
+    backText: 'Linodes',
+    text: 'Static text',
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <Breadcrumb
+          backLink={this.state.backLink}
+          backText={this.state.backText}
+          text={this.state.text}
+        />
+      </React.Fragment>
+    )
+  }
+}
+
+class InteractiveEditableBreadcrumb extends React.Component {
+  state = {
+    backLink: '/linodes',
+    backText: 'Linodes',
+    text: 'Editable text!',
+  }
+
+  onEdit = (value: string) => {
+    this.setState({ text: value });
+  }
+
+  onCancel = () => {
+    this.forceUpdate();
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <Breadcrumb
+          backLink={this.state.backLink}
+          backText={this.state.backText}
+          text={this.state.text}
+          onEdit={this.onEdit}
+          onCancel={this.onCancel}
+        />
+      </React.Fragment>
+    )
+  }
+}
+
+storiesOf('Breadcrumb', module)
+  .addDecorator(ThemeDecorator)
+  .add('Static Text', () => (
+    <StaticRouter location="/" context={{}}>
+      <InteractiveStaticBreadcrumb />
+    </StaticRouter>
+  )).add('Editable Text', () => (
+    <StaticRouter location="/" context={{}}>
+      <InteractiveEditableBreadcrumb />
+    </StaticRouter>
+  ));

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -29,8 +29,10 @@ class InteractiveEditableBreadcrumb extends React.Component<Props, {}> {
           linkTo={this.state.linkTo}
           linkText={this.state.linkText}
           label={this.state.text}
-          onEdit={this.onEdit}
-          onCancel={this.onCancel}
+          onEditHandlers={{
+            onEdit: this.onEdit,
+            onCancel: this.onCancel
+          }}
           labelLink={this.props.labelLink}
         />
       </React.Fragment>

--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -4,28 +4,10 @@ import { StaticRouter } from 'react-router-dom';
 
 import ThemeDecorator from '../../utilities/storybookDecorators';
 import Breadcrumb from './Breadcrumb';
-
-class InteractiveStaticBreadcrumb extends React.Component {
-  state = {
-    linkTo: '/linodes',
-    linkText: 'Linodes',
-    text: 'Static text',
-  }
-
-  render() {
-    return (
-      <React.Fragment>
-        <Breadcrumb
-          linkTo={this.state.linkTo}
-          linkText={this.state.linkText}
-          label={this.state.text}
-        />
-      </React.Fragment>
-    )
-  }
+interface Props {
+  labelLink?: string;
 }
-
-class InteractiveEditableBreadcrumb extends React.Component {
+class InteractiveEditableBreadcrumb extends React.Component<Props, {}> {
   state = {
     linkTo: '/linodes',
     linkText: 'Linodes',
@@ -49,6 +31,7 @@ class InteractiveEditableBreadcrumb extends React.Component {
           label={this.state.text}
           onEdit={this.onEdit}
           onCancel={this.onCancel}
+          labelLink={this.props.labelLink}
         />
       </React.Fragment>
     )
@@ -57,16 +40,38 @@ class InteractiveEditableBreadcrumb extends React.Component {
 
 storiesOf('Breadcrumb', module)
   .addDecorator(ThemeDecorator)
-  .add('Static Text', () => (
+  .add('Static text', () => (
     <StaticRouter location="/" context={{}}>
       <div style={{ display: 'flex', alignItems: 'center' }}>
-        <InteractiveStaticBreadcrumb />
+        <Breadcrumb
+          linkTo={'/linodes'}
+          linkText={'Linodes'}
+          label={'Static text'}
+        />
       </div>
     </StaticRouter>
-  )).add('Editable Text', () => (
+
+  )).add('Static text with label link', () => (
+    <StaticRouter location="/" context={{}}>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <Breadcrumb
+          linkTo="/linodes"
+          linkText="Linodes"
+          label="Static text"
+          labelLink="/summary"
+        />
+      </div>
+    </StaticRouter>
+  )).add('Editable text', () => (
     <StaticRouter location="/" context={{}}>
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <InteractiveEditableBreadcrumb />
+      </div>
+    </StaticRouter>
+  )).add('Editable text with label link', () => (
+    <StaticRouter location="/" context={{}}>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <InteractiveEditableBreadcrumb labelLink="/summary"/>
       </div>
     </StaticRouter>
   ));

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -1,0 +1,43 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { Breadcrumb } from './Breadcrumb';
+
+describe('Breadcrumb component', () => {
+  const wrapper = shallow(
+    <Breadcrumb
+      linkTo="/linodes"
+      linkText="Linodes"
+      label="MyTestLinode"
+
+      classes={{root: '', backButton: '', linkText: '', staticText: ''}}
+    />
+  );
+
+  it('renders static text when not given editable props', () => {
+    expect(wrapper.find('[data-qa-static-text]')).toHaveLength(1);
+    expect(wrapper.find('[data-qa-editable-text]')).toHaveLength(0);
+  });
+
+  it('renders editable text when given editable props', () => {
+    wrapper.setProps({
+      onEdit: jest.fn(),
+      onCancel: jest.fn()
+    });
+    expect(wrapper.find('[data-qa-static-text]')).toHaveLength(0);
+    expect(wrapper.find('[data-qa-editable-text]')).toHaveLength(1);
+  });
+
+  it('doesn\'t render label link when not given prop', () => {
+    expect(wrapper.find('[data-qa-label-link]')).toHaveLength(0);
+  });
+
+  it('renders label link when given prop', () => {
+    wrapper.setProps({
+      labelLink: '/summary',
+      onEdit: undefined,
+      onCancel: undefined
+    });
+    expect(wrapper.find('[data-qa-label-link]')).toHaveLength(1);
+  });
+});

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -21,8 +21,10 @@ describe('Breadcrumb component', () => {
 
   it('renders editable text when given editable props', () => {
     wrapper.setProps({
-      onEdit: jest.fn(),
-      onCancel: jest.fn()
+      onEditHandlers: {
+        onEdit: jest.fn(),
+        onCancel: jest.fn()
+      }
     });
     expect(wrapper.find('[data-qa-static-text]')).toHaveLength(0);
     expect(wrapper.find('[data-qa-editable-text]')).toHaveLength(1);
@@ -35,8 +37,7 @@ describe('Breadcrumb component', () => {
   it('renders label link when given prop', () => {
     wrapper.setProps({
       labelLink: '/summary',
-      onEdit: undefined,
-      onCancel: undefined
+      onEditHandlers: undefined
     });
     expect(wrapper.find('[data-qa-label-link]')).toHaveLength(1);
   });

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -10,7 +10,7 @@ describe('Breadcrumb component', () => {
       linkText="Linodes"
       label="MyTestLinode"
 
-      classes={{root: '', backButton: '', linkText: '', staticText: ''}}
+      classes={{root: '', backButton: '', linkText: '', labelText: '', underlineOnHover: ''}}
     />
   );
 

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom';
 import IconButton from '@material-ui/core/IconButton';
 import {
   StyleRulesCallback,
-
   withStyles,
   WithStyles,
 } from '@material-ui/core/styles';
@@ -15,7 +14,7 @@ import EditableText from 'src/components/EditableText';
 
 type ClassNames = 'root' | 'backButton';
 
-const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+const styles: StyleRulesCallback<ClassNames> = () => ({
   root: {},
   backButton: {
     margin: '5px 0 0 -16px',
@@ -30,7 +29,6 @@ export interface Props {
   backLink: string;
   backText: string;
   text: string;
-  isEditable?: boolean;
   errorText?: string;
   onCancel?: () => void;
   onEdit?: (value: string) => void;
@@ -49,35 +47,35 @@ const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
 
   return (
     <React.Fragment>
-    <Link to={backLink}>
-      <IconButton
-        className={classes.backButton}
-        >
-      < KeyboardArrowLeft />
-      <Typography variant="subheading">
-        {backText}
-      </Typography>
-     </IconButton>
-    </Link>
+      <Link to={backLink}>
+        <IconButton
+          className={classes.backButton}
+          >
+        <KeyboardArrowLeft />
+        <Typography variant="subheading">
+          {backText}
+        </Typography>
+      </IconButton>
+      </Link>
 
-    { isEditable() ?
-    <EditableText
-      role="header"
-      variant="headline"
-      text={text}
-      errorText={props.errorText!}
-      onEdit={props.onEdit!}
-      onCancel={props.onCancel!}
-      data-qa-label
-    />
-    :
-    <Typography role="header" variant="headline">
-      {text}
-    </Typography>
-    }
+      { isEditable() ?
+      <EditableText
+        role="header"
+        variant="headline"
+        text={text}
+        errorText={props.errorText!}
+        onEdit={props.onEdit!}
+        onCancel={props.onCancel!}
+        data-qa-label
+      />
+      :
+      <Typography role="header" variant="headline">
+        {text}
+      </Typography>
+      }
 
     </React.Fragment>
-  )
+  );
 }
 
 const styled = withStyles(styles, { withTheme: true });

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -12,7 +12,7 @@ import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 
 import EditableText from 'src/components/EditableText';
 
-type ClassNames = 'root' | 'backButton' | 'linkText' | 'staticText';
+type ClassNames = 'root' | 'backButton' | 'linkText' | 'labelText' | 'underlineOnHover';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
@@ -41,8 +41,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
       display: 'none',
     },
   },
-  staticText: {
+  labelText: {
     padding: '5px 10px'
+  },
+  underlineOnHover: {
+    '&:hover, &:focus': {
+      textDecoration: 'underline',
+      color: theme.color.black,
+    },
   }
 });
 
@@ -63,11 +69,11 @@ export const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
 
   const isEditable = Boolean(props.onCancel && props.onEdit);
 
-  const staticText = (
+  const labelText = (
     <Typography
       role="header"
       variant="headline"
-      className={classes.staticText}
+      className={classes.labelText}
       data-qa-static-text
     >
       {label}
@@ -103,8 +109,10 @@ export const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
           data-qa-editable-text
         />
         : props.labelLink
-          ? <Link to={props.labelLink!} data-qa-label-link>{staticText}</Link>
-          :  staticText
+          ? <Link to={props.labelLink!} data-qa-label-link>
+              <span className={classes.underlineOnHover}>{labelText}</span>
+            </Link>
+          :  labelText
       }
     </React.Fragment>
   );

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -26,8 +26,8 @@ const styles: StyleRulesCallback<ClassNames> = () => ({
 });
 
 export interface Props {
-  backLink: string;
-  backText: string;
+  linkTo: string;
+  linkText: string;
   text: string;
   errorText?: string;
   onCancel?: () => void;
@@ -37,7 +37,7 @@ export interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, backLink, backText, text } = props;
+  const { classes, linkTo, linkText, text } = props;
 
   // If `onCancel` and `onEdit` props are passed in, render an EditableText
   // component; otherwise render a Typography component
@@ -47,13 +47,13 @@ const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
 
   return (
     <React.Fragment>
-      <Link to={backLink}>
+      <Link to={linkTo}>
         <IconButton
           className={classes.backButton}
           >
         <KeyboardArrowLeft />
         <Typography variant="subheading">
-          {backText}
+          {linkText}
         </Typography>
       </IconButton>
       </Link>

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -51,23 +51,23 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     },
   }
 });
-
+interface EditableProps {
+  onCancel: () => void;
+  onEdit: (value: string) => void;
+  errorText?: string;
+}
 export interface Props {
   linkTo: string;
   linkText: string;
   label: string;
   labelLink?: string | undefined;
-  errorText?: string;
-  onCancel?: () => void;
-  onEdit?: (value: string) => void;
+  onEditHandlers?: EditableProps
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
   const { classes, linkTo, linkText, label } = props;
-
-  const isEditable = Boolean(props.onCancel && props.onEdit);
 
   const labelText = (
     <Typography
@@ -96,15 +96,15 @@ export const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
         </Typography>
       </IconButton>
       </Link>
-      {isEditable
+      {props.onEditHandlers
         ?
         <EditableText
           role="header"
           variant="headline"
           text={label}
-          errorText={props.errorText!}
-          onEdit={props.onEdit!}
-          onCancel={props.onCancel!}
+          errorText={props.onEditHandlers!.errorText}
+          onEdit={props.onEditHandlers!.onEdit}
+          onCancel={props.onEditHandlers!.onCancel}
           labelLink={props.labelLink}
           data-qa-editable-text
         />

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -12,23 +12,35 @@ import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 
 import EditableText from 'src/components/EditableText';
 
-type ClassNames = 'root' | 'backButton';
+type ClassNames = 'root' | 'backButton' | 'linkText' | 'staticText';
 
-const styles: StyleRulesCallback<ClassNames> = () => ({
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
   backButton: {
-    margin: '5px 0 0 -16px',
+    margin: '5px 0 0 0',
+    width: 'auto',
     '& svg': {
       width: 34,
       height: 34,
     },
   },
+  linkText: {
+    color: '#3683DC',
+    textDecoration: 'underline',
+    borderRight: '1px solid grey',
+    paddingRight: '16px',
+    borderColor: theme.color.grey
+  },
+  staticText: {
+    padding: '5px 10px'
+  }
 });
 
 export interface Props {
   linkTo: string;
   linkText: string;
-  text: string;
+  label: string;
+  labelLink?: string | undefined;
   errorText?: string;
   onCancel?: () => void;
   onEdit?: (value: string) => void;
@@ -36,44 +48,67 @@ export interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, linkTo, linkText, text } = props;
+export const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
+  const { classes, linkTo, linkText, label } = props;
 
-  // If `onCancel` and `onEdit` props are passed in, render an EditableText
-  // component; otherwise render a Typography component
-  const isEditable = (): boolean => {
-    return Boolean(props.onCancel && props.onEdit);
+  const renderText = (): JSX.Element => {
+    // If onCancel and onEdit props are provided, make text editable
+    if (isEditable) {
+      return (
+        <EditableText
+          role="header"
+          variant="headline"
+          text={label}
+          errorText={props.errorText!}
+          onEdit={props.onEdit!}
+          onCancel={props.onCancel!}
+          labelLink={props.labelLink}
+          data-qa-editable-text
+        />
+        );
+    }
+
+    // If a labelLink is provided, wrap the text in a Link component
+    else if (props.labelLink) {
+      return (
+        <Link to={props.labelLink} data-qa-label-link>
+          {staticText}
+        </Link>
+      );
+    }
+
+    return staticText;
   }
+  const isEditable = Boolean(props.onCancel && props.onEdit);
+
+  const staticText = (
+    <Typography
+      role="header"
+      variant="headline"
+      className={classes.staticText}
+      data-qa-static-text
+    >
+      {label}
+    </Typography>
+  );
 
   return (
     <React.Fragment>
-      <Link to={linkTo}>
+      <Link to={linkTo} data-qa-link>
         <IconButton
           className={classes.backButton}
           >
         <KeyboardArrowLeft />
-        <Typography variant="subheading">
+        <Typography
+          variant="subheading"
+          className={classes.linkText}
+          data-qa-link-text
+        >
           {linkText}
         </Typography>
       </IconButton>
       </Link>
-
-      { isEditable() ?
-      <EditableText
-        role="header"
-        variant="headline"
-        text={text}
-        errorText={props.errorText!}
-        onEdit={props.onEdit!}
-        onCancel={props.onCancel!}
-        data-qa-label
-      />
-      :
-      <Typography role="header" variant="headline">
-        {text}
-      </Typography>
-      }
-
+      {renderText()}
     </React.Fragment>
   );
 }

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -61,34 +61,6 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
   const { classes, linkTo, linkText, label } = props;
 
-  const renderText = (): JSX.Element => {
-    // If onCancel and onEdit props are provided, make text editable
-    if (isEditable) {
-      return (
-        <EditableText
-          role="header"
-          variant="headline"
-          text={label}
-          errorText={props.errorText!}
-          onEdit={props.onEdit!}
-          onCancel={props.onCancel!}
-          labelLink={props.labelLink}
-          data-qa-editable-text
-        />
-        );
-    }
-
-    // If a labelLink is provided, wrap the text in a Link component
-    else if (props.labelLink) {
-      return (
-        <Link to={props.labelLink} data-qa-label-link>
-          {staticText}
-        </Link>
-      );
-    }
-
-    return staticText;
-  }
   const isEditable = Boolean(props.onCancel && props.onEdit);
 
   const staticText = (
@@ -118,7 +90,22 @@ export const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
         </Typography>
       </IconButton>
       </Link>
-      {renderText()}
+      {isEditable
+        ?
+        <EditableText
+          role="header"
+          variant="headline"
+          text={label}
+          errorText={props.errorText!}
+          onEdit={props.onEdit!}
+          onCancel={props.onCancel!}
+          labelLink={props.labelLink}
+          data-qa-editable-text
+        />
+        : props.labelLink
+          ? <Link to={props.labelLink!} data-qa-label-link>{staticText}</Link>
+          :  staticText
+      }
     </React.Fragment>
   );
 }

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -20,16 +20,26 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     margin: '5px 0 0 0',
     width: 'auto',
     '& svg': {
-      width: 34,
-      height: 34,
+      width: 26,
+      height: 26,
     },
   },
   linkText: {
+    display: 'flex',
+    alignItems: 'center',
     color: '#3683DC',
     textDecoration: 'underline',
-    borderRight: '1px solid grey',
-    paddingRight: '16px',
-    borderColor: theme.color.grey
+    borderColor: theme.color.grey,
+    '&:after': {
+      content: "''",
+      display: 'inline-block',
+      padding: '0 8px 0 6px',
+      height: '38px',
+      borderRight: `1px solid ${theme.color.grey1}`,
+    },
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
+    },
   },
   staticText: {
     padding: '5px 10px'

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import IconButton from '@material-ui/core/IconButton';
+import {
+  StyleRulesCallback,
+
+  withStyles,
+  WithStyles,
+} from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
+
+import EditableText from 'src/components/EditableText';
+
+type ClassNames = 'root' | 'backButton';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {},
+  backButton: {
+    margin: '5px 0 0 -16px',
+    '& svg': {
+      width: 34,
+      height: 34,
+    },
+  },
+});
+
+export interface Props {
+  backLink: string;
+  backText: string;
+  text: string;
+  isEditable?: boolean;
+  errorText?: string;
+  onCancel?: () => void;
+  onEdit?: (value: string) => void;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
+  const { classes, backLink, backText, text } = props;
+
+  // If `onCancel` and `onEdit` props are passed in, render an EditableText
+  // component; otherwise render a Typography component
+  const isEditable = (): boolean => {
+    return Boolean(props.onCancel && props.onEdit);
+  }
+
+  return (
+    <React.Fragment>
+    <Link to={backLink}>
+      <IconButton
+        className={classes.backButton}
+        >
+      < KeyboardArrowLeft />
+      <Typography variant="subheading">
+        {backText}
+      </Typography>
+     </IconButton>
+    </Link>
+
+    { isEditable() ?
+    <EditableText
+      role="header"
+      variant="headline"
+      text={text}
+      errorText={props.errorText!}
+      onEdit={props.onEdit!}
+      onCancel={props.onCancel!}
+      data-qa-label
+    />
+    :
+    <Typography role="header" variant="headline">
+      {text}
+    </Typography>
+    }
+
+    </React.Fragment>
+  )
+}
+
+const styled = withStyles(styles, { withTheme: true });
+export default styled<Props>(Breadcrumb);

--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -1,0 +1,2 @@
+import Breadcrumb from './Breadcrumb';
+export default Breadcrumb;

--- a/src/components/Breadcrumb/index.tsx
+++ b/src/components/Breadcrumb/index.tsx
@@ -1,2 +1,1 @@
-import Breadcrumb from './Breadcrumb';
-export default Breadcrumb;
+export { default } from './Breadcrumb';

--- a/src/components/EditableText/EditableText.spec.js
+++ b/src/components/EditableText/EditableText.spec.js
@@ -6,7 +6,8 @@ describe('Editable Text Suite', () => {
         'Headline %26 Title',
     ];
 
-    const editableTextSelector = '[data-qa-editable-text]';
+    const editableTextField = '[data-qa-editable-text]';
+    const editableTextButton = '[data-qa-edit-button]';
     const editField = '[data-qa-edit-field]';
     const saveEdit = '[data-qa-save-edit]';
     const cancelEdit = '[data-qa-cancel-edit]';
@@ -16,29 +17,36 @@ describe('Editable Text Suite', () => {
 
     beforeAll(() => {
         navigateToStory(component, childStories[0]);
-        browser.waitForVisible(editableTextSelector);
+        browser.waitForVisible(editableTextField);
     });
 
     it('should become an editable field on click', () => {
-        originalLabel = $(editableTextSelector).getText();
+        originalLabel = $(editableTextField).getText();
 
-        $(editableTextSelector).click();
+        $(editableTextField).moveToObject();
+        browser.waitForVisible(editableTextButton);
+
+        $(editableTextButton).click();
         browser.waitForVisible(editField);
     });
 
     it('should edit the textfield', () => {
         $(editField).$('input').setValue(newLabel);
         browser.click(saveEdit);
-        expect($(editableTextSelector).getText()).toBe(newLabel);
+        expect($(editableTextField).getText()).toBe(newLabel);
     });
 
     it('should not update the textfield on cancel', () => {
-        $(editableTextSelector).click();
+        $(editableTextField).moveToObject();
+        browser.waitForVisible(editableTextButton);
+
+        $(editableTextButton).click();
         $(cancelEdit).waitForVisible();
+
         $(editField).$('input').setValue(originalLabel);
         browser.click(cancelEdit);
 
         // Should contain the new label from the prior test
-        expect($(editableTextSelector).getText()).toBe(newLabel);
+        expect($(editableTextField).getText()).toBe(newLabel);
     });
 });

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -49,6 +49,8 @@ const styles: StyleRulesCallback = (theme) => ({
     justifyContent: 'flex-start',
     alignItems: 'center',
     maxHeight: 48,
+    position: 'relative',
+    top: 1,
   },
   initial: {
     border: '1px solid transparent',
@@ -60,6 +62,9 @@ const styles: StyleRulesCallback = (theme) => ({
       },
       '& $icon': {
         color: theme.color.grey1,
+        '&:hover': {
+          color: theme.color.black,
+        },
       },
     },
   },

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -53,6 +53,7 @@ const styles: StyleRulesCallback = (theme) => ({
     maxHeight: 48,
     position: 'relative',
     top: 1,
+    left: -2.
   },
   initial: {
     border: '1px solid transparent',

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -1,5 +1,6 @@
 import * as classnames from 'classnames';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 
 import Button from '@material-ui/core/Button';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
@@ -129,6 +130,7 @@ interface Props {
   onCancel: () => void;
   text: string;
   errorText?: string;
+  labelLink?: string;
 }
 
 interface State {
@@ -140,7 +142,7 @@ type PassThroughProps = Props & TextFieldProps & TypographyProps;
 
 type FinalProps =  PassThroughProps & WithStyles<ClassNames>;
 
-class EditableText extends React.Component<FinalProps, State> {
+export class EditableText extends React.Component<FinalProps, State> {
   state: State = {
     isEditing: Boolean(this.props.errorText),
     text: this.props.text,
@@ -185,8 +187,17 @@ class EditableText extends React.Component<FinalProps, State> {
     if (e.key === 'Escape' || e.key === 'Esc') { this.cancelEditing(); }
   }
 
+  staticText = (attr: Partial<Props>) =>
+    <Typography
+      className={this.props.classes.root}
+      { ...attr }
+      data-qa-editable-text
+    >
+      {this.state.text}
+    </Typography>;
+
   render() {
-    const { classes, onEdit, errorText, ...rest } = this.props;
+    const { classes, labelLink, onEdit, errorText, ...rest } = this.props;
     const { isEditing, text } = this.state;
 
     return (
@@ -194,13 +205,12 @@ class EditableText extends React.Component<FinalProps, State> {
         ? (
             <div className={`${classes.container} ${classes.initial}`}>
               <React.Fragment>
-                <Typography
-                  className={classes.root}
-                  {...rest}
-                  data-qa-editable-text
-                >
-                  {text}
-                </Typography>
+                {labelLink ?
+                  <Link to={labelLink}>
+                    {this.staticText(rest)}
+                  </Link>
+                : this.staticText(rest)
+                }
                 <Button
                   className={`${classes.button} ${classes.editIcon}`}
                   onClick={this.toggleEditing}

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -52,7 +52,6 @@ const styles: StyleRulesCallback = (theme) => ({
   initial: {
     border: '1px solid transparent',
     '&:hover, &:focus': {
-      border: '1px solid #abadaf',
       '& $editIcon': {
         position: 'relative',
         top: 0,
@@ -197,7 +196,6 @@ class EditableText extends React.Component<FinalProps, State> {
               <React.Fragment>
                 <Typography
                   className={classes.root}
-                  onClick={this.toggleEditing}
                   {...rest}
                   data-qa-editable-text
                 >

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -26,7 +26,8 @@ type ClassNames = 'root'
 | 'close'
 | 'headline'
 | 'title'
-| 'editIcon';
+| 'editIcon'
+| 'underlineOnHover';
 
 const styles: StyleRulesCallback = (theme) => ({
   '@keyframes fadeIn': {
@@ -43,6 +44,7 @@ const styles: StyleRulesCallback = (theme) => ({
     border: '1px solid transparent',
     transition: theme.transitions.create(['opacity']),
     wordBreak: 'break-all',
+    textDecoration: 'inherit'
   },
   container: {
     display: 'flex',
@@ -128,6 +130,11 @@ const styles: StyleRulesCallback = (theme) => ({
       },
     },
   },
+  underlineOnHover: {
+    '&:hover, &:focus': {
+      textDecoration: 'underline !important',
+    },
+  }
 });
 
 interface Props {
@@ -197,8 +204,8 @@ export class EditableText extends React.Component<FinalProps, State> {
     const { classes, labelLink, onEdit, errorText, ...rest } = this.props;
     const { isEditing, text } = this.state;
 
-    const staticText = (
-      <Typography className={this.props.classes.root} { ...rest } data-qa-editable-text>
+    const labelText = (
+      <Typography className={classes.root} { ...rest } data-qa-editable-text>
         {this.state.text}
       </Typography>
     );
@@ -210,11 +217,11 @@ export class EditableText extends React.Component<FinalProps, State> {
               <React.Fragment>
                 {!!labelLink
                   ?
-                    <Link to={labelLink!}>
-                      {staticText}
+                    <Link to={labelLink!} className={classes.underlineOnHover}>
+                      {labelText}
                     </Link>
                   :
-                    staticText
+                    labelText
                 }
                 <Button
                   className={`${classes.button} ${classes.editIcon}`}

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -192,29 +192,29 @@ export class EditableText extends React.Component<FinalProps, State> {
     if (e.key === 'Escape' || e.key === 'Esc') { this.cancelEditing(); }
   }
 
-  staticText = (attr: Partial<Props>) =>
-    <Typography
-      className={this.props.classes.root}
-      { ...attr }
-      data-qa-editable-text
-    >
-      {this.state.text}
-    </Typography>;
 
   render() {
     const { classes, labelLink, onEdit, errorText, ...rest } = this.props;
     const { isEditing, text } = this.state;
+
+    const staticText = (
+      <Typography className={this.props.classes.root} { ...rest } data-qa-editable-text>
+        {this.state.text}
+      </Typography>
+    );
 
     return (
       !isEditing
         ? (
             <div className={`${classes.container} ${classes.initial}`}>
               <React.Fragment>
-                {labelLink ?
-                  <Link to={labelLink}>
-                    {this.staticText(rest)}
-                  </Link>
-                : this.staticText(rest)
+                {!!labelLink
+                  ?
+                    <Link to={labelLink!}>
+                      {staticText}
+                    </Link>
+                  :
+                    staticText
                 }
                 <Button
                   className={`${classes.button} ${classes.editIcon}`}

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -171,7 +171,7 @@ class DomainDetail extends React.Component<CombinedProps, State> {
             <Breadcrumb
               linkTo="/domains"
               linkText="Domains"
-              text={domain.domain}
+              label={domain.domain}
             />
           </Grid>
         </Grid>

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -1,15 +1,13 @@
 import { compose, pathOr } from 'ramda';
 import * as React from 'react';
+import { matchPath, Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 
 import AppBar from '@material-ui/core/AppBar';
-import IconButton from '@material-ui/core/IconButton';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
-import Typography from '@material-ui/core/Typography';
-import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 
-import { matchPath, Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
+import Breadcrumb from 'src/components/Breadcrumb';
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
@@ -170,13 +168,11 @@ class DomainDetail extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <Grid container justify="space-between">
           <Grid item className={classes.titleWrapper}>
-            <IconButton
-              onClick={this.goToDomains}
-              className={classes.backButton}
-            >
-              <KeyboardArrowLeft />
-            </IconButton>
-            <Typography role="header" variant="headline" data-qa-domain-title>{domain.domain}</Typography>
+            <Breadcrumb
+              linkTo="/domains"
+              linkText="Domains"
+              text={domain.domain}
+            />
           </Grid>
         </Grid>
         <AppBar position="static" color="default">

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -178,9 +178,11 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
               linkText="NodeBalancers"
               label={nodeBalancerLabel}
               labelLink={this.getLabelLink()}
-              onEdit={this.updateLabel}
-              onCancel={this.cancelUpdate}
-              errorText={apiErrorText}
+              onEditHandlers={{
+                onEdit: this.updateLabel,
+                onCancel: this.cancelUpdate,
+                errorText: apiErrorText
+              }}
             />
           </Grid>
         </Grid>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -3,14 +3,12 @@ import * as React from 'react';
 import { matchPath, Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 
 import AppBar from '@material-ui/core/AppBar';
-import IconButton from '@material-ui/core/IconButton';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
-import  KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 
+import Breadcrumb from 'src/components/Breadcrumb';
 import setDocs from 'src/components/DocsSidebar/setDocs';
-import EditableText from 'src/components/EditableText';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader/PromiseLoader';
@@ -173,19 +171,13 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <Grid container justify="space-between">
           <Grid item className={classes.titleWrapper}>
-            <IconButton
-              onClick={this.handleGoBack}
-              className={classes.backButton}
-            >
-              <KeyboardArrowLeft />
-            </IconButton>
-            <EditableText
-              variant="headline"
+            <Breadcrumb
+              linkTo="/nodebalancers"
+              linkText="Nodebalancers"
               text={nodeBalancerLabel}
               onEdit={this.updateLabel}
               onCancel={this.cancelUpdate}
               errorText={apiErrorText}
-              data-qa-label
             />
           </Grid>
         </Grid>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -1,4 +1,4 @@
-import { compose, pathOr } from 'ramda';
+import { compose, last, pathOr } from 'ramda';
 import * as React from 'react';
 import { matchPath, Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 
@@ -120,9 +120,11 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
     this.setState({ ApiError: undefined, labelInput: this.state.nodeBalancer.label });
   }
 
-  handleGoBack = () => {
-    const { history } = this.props;
-    history.push('/nodebalancers')
+
+  getLabelLink = (): string | undefined => {
+    return last(location.pathname.split('/')) !== 'summary'
+      ? 'summary'
+      : undefined;
   }
 
   static docs: Linode.Doc[] = [
@@ -173,8 +175,9 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
           <Grid item className={classes.titleWrapper}>
             <Breadcrumb
               linkTo="/nodebalancers"
-              linkText="Nodebalancers"
-              text={nodeBalancerLabel}
+              linkText="NodeBalancers"
+              label={nodeBalancerLabel}
+              labelLink={this.getLabelLink()}
               onEdit={this.updateLabel}
               onCancel={this.cancelUpdate}
               errorText={apiErrorText}

--- a/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
@@ -92,9 +92,11 @@ const LabelPowerAndConsolePanel: React.StatelessComponent<CombinedProps> = (prop
           linkText="Linodes"
           label={labelInput.label}
           labelLink={getLabelLink()}
-          errorText={labelInput.errorText}
-          onEdit={labelInput.onEdit}
-          onCancel={labelInput.onCancel}
+          onEditHandlers={{
+            onEdit: labelInput.onEdit,
+            onCancel: labelInput.onCancel,
+            errorText: labelInput.errorText
+          }}
         />
       </Grid>
       <Grid item className={classes.cta}>

--- a/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
@@ -1,17 +1,14 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 
 import Button from '@material-ui/core/Button';
-import IconButton from '@material-ui/core/IconButton';
 import {
   StyleRulesCallback,
-  
+
   withStyles,
   WithStyles,
 } from '@material-ui/core/styles';
-import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 
-import EditableText from 'src/components/EditableText';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Grid from 'src/components/Grid';
 
 import LinodePowerControl from '../LinodePowerControl';
@@ -84,21 +81,13 @@ const LabelPowerAndConsolePanel: React.StatelessComponent<CombinedProps> = (prop
       justify="space-between"
     >
       <Grid item className={classes.titleWrapper}>
-        <Link to={`/linodes`}>
-          <IconButton
-            className={classes.backButton}
-          >
-            <KeyboardArrowLeft />
-          </IconButton>
-        </Link>
-        <EditableText
-          role="header"
-          variant="headline"
+        <Breadcrumb
+          linkTo="/linodes"
+          linkText="Linodes"
           text={labelInput.label}
           errorText={labelInput.errorText}
           onEdit={labelInput.onEdit}
           onCancel={labelInput.onCancel}
-          data-qa-label
         />
       </Grid>
       <Grid item className={classes.cta}>

--- a/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
@@ -1,9 +1,9 @@
+import { last } from 'ramda';
 import * as React from 'react';
 
 import Button from '@material-ui/core/Button';
 import {
   StyleRulesCallback,
-
   withStyles,
   WithStyles,
 } from '@material-ui/core/styles';
@@ -75,6 +75,12 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 const LabelPowerAndConsolePanel: React.StatelessComponent<CombinedProps> = (props) => {
   const { classes, linode, launchLish, openConfigDrawer, labelInput } = props;
 
+  const getLabelLink = (): string | undefined => {
+    return last(location.pathname.split('/')) !== 'summary'
+      ? 'summary'
+      : undefined;
+  }
+
   return (
     <Grid
       container
@@ -84,7 +90,8 @@ const LabelPowerAndConsolePanel: React.StatelessComponent<CombinedProps> = (prop
         <Breadcrumb
           linkTo="/linodes"
           linkText="Linodes"
-          text={labelInput.label}
+          label={labelInput.label}
+          labelLink={getLabelLink()}
           errorText={labelInput.errorText}
           onEdit={labelInput.onEdit}
           onCancel={labelInput.onCancel}

--- a/src/features/linodes/LinodesDetail/HeaderSections/TabsAndStatusBarPanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/TabsAndStatusBarPanel.tsx
@@ -4,7 +4,7 @@ import { matchPath, Redirect, Route, Switch } from 'react-router-dom';
 import AppBar from '@material-ui/core/AppBar';
 import {
   StyleRulesCallback,
-  
+
   withStyles,
   WithStyles,
 } from '@material-ui/core/styles';


### PR DESCRIPTION
This PR includes a new Breadcrumb component with the following shape:

```javascript
<Breadcrumb
  linkTo="/linodes"
  linkText="Linodes"
  label="test-linode-001"
/>
```

Which looks like: 

<img width="314" alt="screen shot 2018-11-06 at 2 37 19 pm" src="https://user-images.githubusercontent.com/16911484/48089052-8de7e700-e1d1-11e8-9899-a14cd88b4010.png">

You can also pass in `onCancel()` and `onEdit()`, which will make the text editable:

<img width="531" alt="screen shot 2018-11-06 at 2 37 40 pm" src="https://user-images.githubusercontent.com/16911484/48089149-c4bdfd00-e1d1-11e8-822a-03951d8960dd.png">

Passing in `labelLink` (a string) is also possible (this will wrap the label in a link).

~Currently styling is non-existent: margins, padding, placement, etc. need some work. In accordance with the epic (M3-1468), hover states, borders, etc. need adjustments as well.~

EDIT: I added some basic styling, but it still needs tweaking.

I implemented the new Breadcrumb component on **Domains** (M3-1537), **Linodes** (M3-1536), and **NodeBalancers** (M3-1538) on this PR so that the component could be seen in the context of the app.