### PR TITLE
M3-1650 volume drawer pricing

### DIFF
--- a/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/src/components/CheckoutBar/CheckoutBar.tsx
@@ -6,14 +6,14 @@ import Button from '@material-ui/core/Button';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
+import DisplayPrice from 'src/components/DisplayPrice';
+
 
 type ClassNames = 'root'
   | 'checkoutSection'
   | 'noBorder'
   | 'sidebarTitle'
-  | 'detail'
-  | 'price'
-  | 'per';
+  | 'detail';
 
   const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   '@keyframes fadeIn': {
@@ -53,14 +53,6 @@ type ClassNames = 'root'
     color: theme.color.headline,
     lineHeight: '1.5em',
   },
-  price: {
-    fontSize: '1.5rem',
-    color: theme.color.green,
-    display: 'inline-block',
-  },
-  per: {
-    display: 'inline-block',
-  },
 });
 
 interface Props {
@@ -73,8 +65,6 @@ interface Props {
 }
 
 type CombinedProps = Props & StickyProps & WithStyles<ClassNames>;
-
-const displayPrice = (v: number) => `$${v.toFixed(2)}`;
 
 class CheckoutBar extends React.Component<CombinedProps> {
 
@@ -131,12 +121,7 @@ class CheckoutBar extends React.Component<CombinedProps> {
         }
         {
           <div className={`${classes.checkoutSection} ${classes.noBorder}`} data-qa-total-price>
-            <Typography role="header" variant="subheading" className={classes.price}>
-              {displayPrice(calculatedPrice!)}
-            </Typography>
-            <Typography role="header" variant="subheading" className={classes.per}>
-              &nbsp;/mo
-            </Typography>
+            <DisplayPrice price={calculatedPrice ? calculatedPrice : 0} interval="mo" />
           </div>
         }
 

--- a/src/components/DisplayPrice/DisplayPrice.test.tsx
+++ b/src/components/DisplayPrice/DisplayPrice.test.tsx
@@ -1,0 +1,46 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import Typography from '@material-ui/core/Typography';
+
+import { DisplayPrice, displayPrice } from './DisplayPrice';
+
+const classes = {
+  root:'',
+  price:'',
+  per:'',
+}
+
+const component = shallow(
+  <DisplayPrice
+    price={100}
+    classes={classes}
+  />
+);
+
+describe("DisplayPrice component", () => {
+  it("should format the price prop correctly", () => {
+    expect(displayPrice(0)).toEqual("$0.00");
+    expect(displayPrice(1.1)).toEqual("$1.10");
+    expect(displayPrice(100)).toEqual("$100.00");
+  });
+  it("should not display an interval unless specified", () => {
+    expect(component.find('WithStyles(Typography)')).toHaveLength(1);
+  });
+  it("should display the interval when specified", () => {
+    component.setProps({ interval: "mo" });
+    expect(component.find('WithStyles(Typography)')).toHaveLength(2);
+    expect(component.containsMatchingElement(
+      <Typography>
+        &nbsp;/mo
+      </Typography>
+    )).toBeTruthy();
+  });
+  it("should display the price", () => {
+    expect(component.containsMatchingElement(
+      <Typography>
+        $100.00
+      </Typography>
+    )).toBeTruthy();
+  });
+});

--- a/src/components/DisplayPrice/DisplayPrice.tsx
+++ b/src/components/DisplayPrice/DisplayPrice.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+
+type ClassNames = 'root' | 'price' | 'per';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+  price: {
+    fontSize: '1.5rem',
+    color: theme.color.green,
+    display: 'inline-block',
+  },
+  per: {
+    display: 'inline-block',
+  },
+});
+
+interface Props {
+  price: number;
+  interval?: string;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const displayPrice = (v: number) => `$${v.toFixed(2)}`;
+
+const DisplayPrice: React.StatelessComponent<CombinedProps> = (props) => {
+  const { classes, interval, price } = props;
+  return (
+    <React.Fragment>
+      <Typography role="header" variant="subheading" className={classes.price}>
+        {displayPrice(price)}
+      </Typography>
+      {interval &&
+        <Typography role="header" variant="subheading" className={classes.per}>
+          &nbsp;/{interval}
+        </Typography>
+      }
+    </React.Fragment>
+  );
+};
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled<Props>(DisplayPrice);

--- a/src/components/DisplayPrice/DisplayPrice.tsx
+++ b/src/components/DisplayPrice/DisplayPrice.tsx
@@ -24,9 +24,9 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const displayPrice = (v: number) => `$${v.toFixed(2)}`;
+export const displayPrice = (v: number) => `$${v.toFixed(2)}`;
 
-const DisplayPrice: React.StatelessComponent<CombinedProps> = (props) => {
+export const DisplayPrice: React.StatelessComponent<CombinedProps> = (props) => {
   const { classes, interval, price } = props;
   return (
     <React.Fragment>

--- a/src/components/DisplayPrice/index.tsx
+++ b/src/components/DisplayPrice/index.tsx
@@ -1,0 +1,1 @@
+export { default }  from './DisplayPrice';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,8 @@ export const DISABLE_EVENT_THROTTLE =
 
 export const ISO_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
+export const MAX_VOLUME_SIZE = 10240;
+
 export const ZONES = {
   'us-east': 'newark',
   'us-east-1a': 'newark',

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -5,7 +5,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import { append, clamp, filter, lensPath, over, path, set, view, when } from 'ramda';
+import { append, filter, lensPath, over, path, set, view, when } from 'ramda';
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
 import { bindActionCreators, compose } from 'redux';
@@ -417,7 +417,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       //   return prevState;
       // }
 
-      set(L.size, clamp(10, MAX_VOLUME_SIZE, +e.target.value || 0)),
+      set(L.size, +e.target.value || 0),
     ]);
   }
 

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -4,6 +4,7 @@ import InputAdornment from '@material-ui/core/InputAdornment';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
 import { append, filter, lensPath, over, path, set, view, when } from 'ramda';
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
@@ -14,6 +15,7 @@ import { debounce } from 'throttle-debounce';
 
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
+import DisplayPrice from 'src/components/DisplayPrice';
 import Drawer from 'src/components/Drawer';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
@@ -33,11 +35,15 @@ import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 type ClassNames = 'root'
-  | 'actionPanel';
+  | 'actionPanel'
+  | 'pricePanel';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
   actionPanel: {
+    marginTop: theme.spacing.unit * 2,
+  },
+  pricePanel: {
     marginTop: theme.spacing.unit * 2,
   },
 });
@@ -463,6 +469,10 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     return idx > -1 ? linodes[idx] : 0;
   }
 
+  getPrice = (size: number) => {
+    return size * 0.1;
+  }
+
   renderLinodeOptions = (linodes: Linode.Linode[]) => {
     const { linodeLabel, mode } = this.props;
     if (!linodes) { return []; }
@@ -484,7 +494,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { mode } = this.props;
+    const { classes, mode } = this.props;
     const regions = this.props.regionsData;
 
     const {
@@ -516,6 +526,8 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     const configError = hasErrorFor('config_id');
     const generalError = hasErrorFor('none');
 
+    const price = this.getPrice(size);
+
     return (
       <Drawer
         open={mode !== modes.CLOSED}
@@ -535,6 +547,13 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
             text={generalError}
             data-qa-notice
           />
+        }
+
+        {[modes.CREATING, modes.RESIZING].includes(mode) &&
+          <Typography variant="body1">
+            A single Volume can range from 1 to 10240 gibibytes in size and costs
+            $0.10/GiB per month. Up to eight volumes can be attached to a single Linode.
+          </Typography>
         }
 
         {mode === modes.CLONING &&
@@ -666,7 +685,11 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
             {Boolean(configError) && <FormHelperText error>{configError}</FormHelperText>}
           </FormControl>
         }
-
+        {[modes.CREATING, modes.RESIZING].includes(mode) &&
+          <div className={classes.pricePanel} >
+            <DisplayPrice price={price} interval="mo" />
+          </div>
+        }
         <ActionsPanel style={{ marginTop: 16 }}>
           <Button
             onClick={this.onSubmit}

--- a/src/features/Volumes/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer.tsx
@@ -551,7 +551,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
 
         {[modes.CREATING, modes.RESIZING].includes(mode) &&
           <Typography variant="body1">
-            A single Volume can range from 1 to 10240 gibibytes in size and costs
+            A single Volume can range from 10 to 10240 gibibytes in size and costs
             $0.10/GiB per month. Up to eight volumes can be attached to a single Linode.
           </Typography>
         }

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/LinodeVolumes.tsx
@@ -1,4 +1,4 @@
-import { append, clamp, compose, equals, filter, lensPath, over, pathOr, set, when } from 'ramda';
+import { append, compose, equals, filter, lensPath, over, pathOr, set, when } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -382,7 +382,7 @@ export class LinodeVolumes extends React.Component<CombinedProps, State> {
       (prevState) => prevState.volumeDrawer.size > MAX_VOLUME_SIZE,
       over(L.volumeDrawer.errors, append({ field: 'size', reason: `Size cannot be over ${MAX_VOLUME_SIZE}.` })),
     ),
-    set(L.volumeDrawer.size, clamp(10, MAX_VOLUME_SIZE, +newSize || 0)),
+    set(L.volumeDrawer.size, +newSize || 0),
   ]);
 
   /** Create / Edit / Resize / Cloning */

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/VolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/VolumeDrawer.tsx
@@ -3,10 +3,12 @@ import * as React from 'react';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
 
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
+import DisplayPrice from 'src/components/DisplayPrice';
 import Drawer from 'src/components/Drawer';
 import MenuItem from 'src/components/MenuItem';
 import Notice from 'src/components/Notice';
@@ -17,13 +19,16 @@ import { getVolumes } from 'src/services/volumes';
 import { formatRegion } from 'src/utilities';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 
-type ClassNames = 'root' | 'suffix';
+type ClassNames = 'root' | 'suffix' | 'pricePanel';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
   suffix: {
     fontSize: '.9rem',
     marginRight: theme.spacing.unit,
+  },
+  pricePanel: {
+    marginTop: theme.spacing.unit * 2,
   },
 });
 
@@ -126,9 +131,9 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       label="Size"
       onChange={this.onSizeChange}
       value={this.props.size}
-      helperText={'Maximum: 10240'}
+      helperText={'Maximum: 10240 GiB'}
       InputProps={{
-        endAdornment: <span className={this.props.classes.suffix}>GB</span>,
+        endAdornment: <span className={this.props.classes.suffix}>GiB</span>,
       }}
     />
   );
@@ -155,9 +160,16 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     />
   );
 
+  helperText: React.StatelessComponent<{}> = () =>
+    <Typography variant="body1">
+      A single Volume can range from 1 to 10240 gibibytes in size and costs
+      $0.10/GiB per month. Up to eight volumes can be attached to a single Linode.
+    </Typography>
+
   createForm = () => {
     return (
       <React.Fragment>
+        <this.helperText />
         <this.labelField />
         <this.sizeField />
       </React.Fragment>
@@ -169,7 +181,12 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
   }
 
   resizeForm = () => {
-    return <this.sizeField />
+    return (
+      <React.Fragment>
+        <this.helperText />
+        <this.sizeField />
+      </React.Fragment>
+    )
   }
 
   cloneForm = () => {
@@ -254,6 +271,17 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
     }
   }
 
+  renderPrice = () => {
+    const { classes, mode, size } = this.props;
+    const price = size * 0.1;
+    if (!['create', 'resize'].includes(mode)) { return null; }
+    return (
+      <div className={classes.pricePanel} >
+        <DisplayPrice price={price} interval="mo" />
+      </div>
+    )
+  }
+
   render() {
     const { open, title, onClose } = this.props;
     return (
@@ -289,6 +317,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
         {mode === 'resize' && this.resizeForm()}
         {mode === 'clone' && this.cloneForm()}
         {mode === 'attach' && this.attachForm()}
+        {this.renderPrice()}
         <this.actions updateFor={[]} />
       </React.Fragment>
     );

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/VolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/VolumeDrawer.tsx
@@ -162,7 +162,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
 
   helperText: React.StatelessComponent<{}> = () =>
     <Typography variant="body1">
-      A single Volume can range from 1 to 10240 gibibytes in size and costs
+      A single Volume can range from 10 to 10240 gibibytes in size and costs
       $0.10/GiB per month. Up to eight volumes can be attached to a single Linode.
     </Typography>
 

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/VolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/VolumeDrawer.tsx
@@ -15,6 +15,7 @@ import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
 import renderGuard from 'src/components/RenderGuard';
 import TextField from 'src/components/TextField';
+import { MAX_VOLUME_SIZE } from 'src/constants';
 import { getVolumes } from 'src/services/volumes';
 import { formatRegion } from 'src/utilities';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
@@ -129,9 +130,10 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
       disabled={disabled}
       errorText={getAPIErrorFor(jawn, this.props.errors)('size')}
       label="Size"
+      type="number"
       onChange={this.onSizeChange}
       value={this.props.size}
-      helperText={'Maximum: 10240 GiB'}
+      helperText={`Maximum: ${MAX_VOLUME_SIZE} GiB`}
       InputProps={{
         endAdornment: <span className={this.props.classes.suffix}>GiB</span>,
       }}


### PR DESCRIPTION
* Refactored the price display code in CheckoutBar.tsx to a new component
(for consistent styling of prices).
* Used the new component in VolumesDrawer (both of them) to give feedback
on the price of the volume to be created.
* This information is displayed on creation and resize.
* Added copy to help users understand the pricing
* Adjusted GB to GiB