### PR TITLE
M3-1763 - Update test form validation assertions, general e2e test maintenance

### DIFF
--- a/e2e/config/custom-commands.js
+++ b/e2e/config/custom-commands.js
@@ -121,7 +121,7 @@ exports.browserCommands = () => {
     });
 
     /*
-    * Executes a Javascript Click event via the browser console. 
+    * Executes a Javascript Click event via the browser console.
     * Useful when an element is not clickable via browser.click()
     * @param { String } elementToClick Selector to execute click event on
     * @returns { undefined } Returns nothing
@@ -155,6 +155,19 @@ exports.browserCommands = () => {
             browser.waitForVisible(elementToClick);
             return browser.click(elementToClick).state === 'success';
         }, timeout);
+    });
+
+    browser.addCommand('tryClick', function(elementToClick, timeout=5000) {
+        let errorObject;
+        browser.waitUntil(function() {
+            try {
+                browser.click(elementToClick);
+                return true;
+            } catch (err) {
+                errorObject = err;
+                return false;
+            }
+        }, timeout, `failed to click ${elementToClick} due to ${JSON.stringify(errorObject)}`);
     });
 
     /* Continuously try to set a value on a given selector

--- a/e2e/pageobjects/linode-detail/linode-detail-backups.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-backups.page.js
@@ -42,7 +42,7 @@ class Backups extends Page {
         if (this.backupInstances.length < 1) {
             expect(this.description.isVisible()).toBe(true);
         }
-        
+
         expect(this.heading.isVisible()).toBe(true);
         expect(this.manualSnapshotHeading.isVisible()).toBe(true);
         expect(this.manualDescription.isVisible()).toBe(true);

--- a/e2e/pageobjects/linode-detail/linode-detail-settings.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-settings.page.js
@@ -15,7 +15,10 @@ class Settings extends Page {
     get labelSave() { return $('[data-qa-label-save]'); }
     get notice() { return $('[data-qa-notice]'); }
     get notices() { return $$('[data-qa-notice]'); }
-    get selectDisk() { return $('[data-qa-select-disk]'); }
+    get selectDisk() {
+        return $$('[data-qa-enhanced-select]')
+            .find(s => s.getAttribute('data-qa-enhanced-select').includes('Disk'));
+    }
     get disk() { return $('[data-qa-disk]'); }
     get disks() { return $$('[data-qa-disk]'); }
     get password() { return $('[data-qa-hide] input'); }
@@ -38,7 +41,7 @@ class Settings extends Page {
 
         browser.click(`[data-qa-config="${configLabel}"] [data-qa-action-menu]`);
         browser.waitForVisible('[data-qa-action-menu-item]');
-        
+
         // Click action menu item, regardless of anything blocking it
         browser.jsClick('[data-qa-action-menu-item="Delete"]');
         browser.waitForVisible('[data-qa-dialog-title]');
@@ -67,7 +70,7 @@ class Settings extends Page {
 
         this.confirm.click();
         browser.waitForVisible('[data-qa-circle-progress]', constants.wait.normal, true);
-        
+
         browser.waitUntil(function() {
             if (browser.isVisible('[data-qa-placeholder-title]')) {
                 return true;
@@ -101,7 +104,7 @@ class Settings extends Page {
 
     resetPassword(newPassword, diskLabel='none') {
         const successMsg = 'Linode password changed successfully.';
-        
+
         if (diskLabel !== 'none') {
             this.selectDisk.click();
             this.disk.waitForVisible();

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -99,7 +99,7 @@ export default class Page {
 
     selectGlobalCreateItem(menuItem) {
         this.globalCreate.waitForVisible(constants.wait.normal);
-        this.globalCreate.click();
+        browser.tryClick(this.globalCreate.selector);
         browser.waitForVisible('[data-qa-add-new-menu]', constants.wait.normal);
         browser.click(`[data-qa-add-new-menu="${menuItem}"]`);
         browser.waitForVisible('[data-qa-add-new-menu]', constants.wait.normal, true);
@@ -133,7 +133,7 @@ export default class Page {
         const displayedMsg = browser.getText('[data-qa-toast-message]');
         expect(displayedMsg).toBe(expectedMessage);
         browser.click('[data-qa-toast] button');
-        browser.waitForExist('[data-qa-toast]', constants.wait.short, true);
+        browser.waitForExist('[data-qa-toast]', constants.wait.normal, true);
     }
 
     dismissToast() {

--- a/e2e/specs/create/smoke-configure-linode.spec.js
+++ b/e2e/specs/create/smoke-configure-linode.spec.js
@@ -5,8 +5,7 @@ import CheckoutSummary from '../../pageobjects/checkout-summary';
 
 describe('Create Linode - Configure Linode Suite', () => {
     beforeAll(() => {
-        Create.menuButton.click();
-        Create.linode();
+        ConfigureLinode.selectGlobalCreateItem('Linode');
     });
 
     it('should display configure elements', () => {
@@ -43,7 +42,7 @@ describe('Create Linode - Configure Linode Suite', () => {
                 return r.getAttribute('aria-selected').includes('true');
             }, 10000);
         });
-        browser.waitForVisible('[data-qa-selection-card]');
+        browser.waitForVisible('[data-qa-tp="Region"] [data-qa-selection-card]');
     });
 
     it('should select a specific image', () => {

--- a/e2e/specs/linodes/detail/backups.spec.js
+++ b/e2e/specs/linodes/detail/backups.spec.js
@@ -45,9 +45,9 @@ describe('Linode Detail - Backups Suite', () => {
     it('should fail to take a snapshot without a name', () => {
         Backups.snapshotButton.click();
 
-        const toastMsg = 'Snapshot label must be a string of 1 to 255 characters';
+        const toastMsg = 'A snapshot label is required.';
         Backups.toastDisplays(toastMsg);
-        browser.waitForExist('[data-qa-toast]', constants.wait.short, true);
+        browser.waitForExist('[data-qa-toast]', constants.wait.normal, true);
     });
 
     it('should cancel backups', () => {

--- a/e2e/specs/linodes/detail/smoke-settings.spec.js
+++ b/e2e/specs/linodes/detail/smoke-settings.spec.js
@@ -38,9 +38,9 @@ describe('Linode Detail - Settings Suite', () =>{
         });
 
         it('should display a disk in the select, password field and save button', () => {
-            Settings.selectDisk.waitForVisible();
-            Settings.password.waitForVisible();
-            Settings.passwordSave.waitForVisible();
+            Settings.selectDisk.waitForVisible(constants.wait.normal);
+            Settings.password.waitForVisible(constants.wait.normal);
+            Settings.passwordSave.waitForVisible(constants.wait.normal);
         });
 
         it('should successfully change root password', () => {
@@ -57,9 +57,9 @@ describe('Linode Detail - Settings Suite', () =>{
         it('should disable a notification threshold on toggle off', () => {
             const initialEnabledAlerts = $$('[data-qa-alert] :checked');
             const alertLabels = Settings.alerts.map(a => a.getAttribute('data-qa-alert'));
-            
+
             Settings.toggleAlert(alertLabels[0]);
-            
+
             const enabledAlerts = $$('[data-qa-alert] :checked');
 
             expect(enabledAlerts.length).not.toEqual(initialEnabledAlerts.length);
@@ -90,7 +90,7 @@ describe('Linode Detail - Settings Suite', () =>{
 
     describe('Advanced Configurations Suite', () => {
         xit('should add a configuration', () => {
-            
+
         });
 
         it('should remove a configuration', () => {

--- a/e2e/specs/nodebalancers/error-handling.spec.js
+++ b/e2e/specs/nodebalancers/error-handling.spec.js
@@ -53,7 +53,7 @@ describe('NodeBalancer - Negative Tests Suite', () => {
     it('should fail to create a configuration with an invalid. ip', () => {
         const invalidIp = { privateIp:'192.168.1.1'};
         const invalidConfig = merge(linode, invalidIp);
-        const serviceError = 'This address is not allowed.';
+        const serviceError = 'Must be a valid IPv4 address.';
 
         NodeBalancers.configure(invalidConfig,  {
             label: `NB-${new Date().getTime()}`,

--- a/e2e/specs/nodebalancers/error-handling.spec.js
+++ b/e2e/specs/nodebalancers/error-handling.spec.js
@@ -28,7 +28,7 @@ describe('NodeBalancer - Negative Tests Suite', () => {
             label: 'Something-NotLegit',
         }
         const invalidConfig = merge(linode, invalidLabel);
-        const serviceError = 'label must not contain any special characters. Only a-z0-9.-_ allowed';
+        const serviceError = `Label can't contain special characters, uppercase characters, or whitespace.`;
 
         NodeBalancers.configure(invalidConfig, {
             label: `NB-${new Date().getTime()}`,

--- a/e2e/specs/nodebalancers/error-handling.spec.js
+++ b/e2e/specs/nodebalancers/error-handling.spec.js
@@ -51,9 +51,9 @@ describe('NodeBalancer - Negative Tests Suite', () => {
     });
 
     it('should fail to create a configuration with an invalid. ip', () => {
-        const invalidIp = { privateIp:'192.168.1.1'};
+        const invalidIp = { privateIp:'192.168.1.1' };
         const invalidConfig = merge(linode, invalidIp);
-        const serviceError = 'Must be a valid IPv4 address.';
+        const serviceError = 'This address is not allowed.';
 
         NodeBalancers.configure(invalidConfig,  {
             label: `NB-${new Date().getTime()}`,

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "selenium": "npx selenium-standalone install --config=./e2e/config/selenium-config.js && ./node_modules/.bin/selenium-standalone start --config=./e2e/config/selenium-config.js",
     "e2e": "npx wdio ./e2e/config/wdio.conf.js",
     "e2e:all": "npx wdio ./e2e/config/wdio.conf.js; ./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js",
-    "e2e:modified": "yarn e2e --spec=$(git diff --name-only upstream/develop | grep 'spec.js' | tr '\n' ',' | sed 's/.$//')",
+    "e2e:modified": "yarn e2e --spec=$(git diff --name-only upstream/develop | egrep 'e2e\/specs\/.*\/*spec.js' | tr '\n' ',' | sed 's/.$//')",
     "e2e:browserstack": "npx wdio ./e2e/config/browserstack.conf.js",
     "mb": "npx mb"
   },


### PR DESCRIPTION
* Updates form validation assertions in the e2e tests (related to the API Wrapper refactor)
* Added a "tryClick" custom command that attempts to click an element for a given timeout and will display the selenium stacktrace if the timeout is exceeded (needed to address test failures when attempting to click the Create button in the header in the beginning of a test)

## Running the Tests

```bash
yarn && yarn start  # Run your local manager
yarn selenium # start selenium in a separate shell
yarn e2e:modified
```