### PR TITLE
 M3-1756 Fix Enhanced Select Styles (w/ dynamic value)

### DIFF
--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -6,6 +6,10 @@ import { Props as SelectProps } from 'react-select/lib/Select';
 
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
 
+/* TODO will be refactoring enhanced select to be an abstraction. 
+Styles added in this file and the below imports will be utilized for the abstraction. */ 
+import DropdownIndicator from './components/DropdownIndicator';
+import LoadingIndicator from './components/LoadingIndicator';
 import MultiValue from './components/MultiValue';
 import NoOptionsMessage from './components/NoOptionsMessage';
 import Option from './components/Option';
@@ -65,7 +69,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
       margin: '-1px 0 0 0',
       borderRadius: 0,
       boxShadow: 'none',
-      border: `1px solid ${theme.palette.divider}`,
+      border: `1px solid ${theme.palette.primary.main}`,
       maxWidth: 415,
     },
     '& .react-select__menu-list': {
@@ -77,7 +81,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
       color: theme.palette.text.primary,
       backgroundColor: theme.bg.white,
       cursor: 'pointer',
-      padding: '10px 8px',
+      padding: '12px',
+      fontSize: '0.9rem',
     },
     '& .react-select__option--is-focused': {
       backgroundColor: theme.palette.primary.main,
@@ -97,16 +102,13 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
       display: 'none',
     },
     '& .react-select__dropdown-indicator': {
-      '& svg': {
-        color: '#999',
-      },
     },
     '& [class*="MuiFormHelperText-error"]': {
       paddingBottom: theme.spacing.unit,
     },
   },
   input: {
-    fontSize: '1rem',
+    fontSize: '0.9rem',
     padding: 0,
     display: 'flex',
     color: theme.palette.text.primary,
@@ -234,6 +236,8 @@ const _components = {
   Placeholder,
   MultiValue,
   Option,
+  DropdownIndicator,
+  LoadingIndicator
 };
 
 type CombinedProps = EnhancedSelectProps

--- a/src/components/EnhancedSelect/components/DropdownIndicator.tsx
+++ b/src/components/EnhancedSelect/components/DropdownIndicator.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
+import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
+
+import { IndicatorProps } from 'react-select/lib/components/indicators';
+
+type ClassNames = 'root'
+| 'enhancedSelectDropdown';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {},
+  enhancedSelectDropdown: {
+    top: 'calc(50% - 12px)',
+    right: 0,
+    color: '#aaa !important',
+    width: 28,
+    height: 28,
+    opacity: .5,
+    position: 'absolute',
+    marginTop: '-2px',
+    transition: 'color 225ms ease-in-out',
+    marginRight: '4px',
+    pointerEvents: 'none',
+  },
+});
+
+interface Props extends IndicatorProps<any> { }
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class DropdownIndicator extends React.PureComponent<CombinedProps> {
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+        <KeyboardArrowDown className={classes.enhancedSelectDropdown}
+        />
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(DropdownIndicator);
+

--- a/src/components/EnhancedSelect/components/DropdownIndicator.tsx
+++ b/src/components/EnhancedSelect/components/DropdownIndicator.tsx
@@ -11,13 +11,10 @@ type ClassNames = 'root'
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
   enhancedSelectDropdown: {
-    top: 'calc(50% - 12px)',
-    right: 0,
     color: '#aaa !important',
     width: 28,
     height: 28,
     opacity: .5,
-    position: 'absolute',
     marginTop: '-2px',
     transition: 'color 225ms ease-in-out',
     marginRight: '4px',

--- a/src/components/EnhancedSelect/components/LoadingIndicator.tsx
+++ b/src/components/EnhancedSelect/components/LoadingIndicator.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
+
+import { IndicatorProps } from 'react-select/lib/components/indicators';
+
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {
+    position: 'relative',
+    right: 40,
+  },
+});
+
+interface Props extends IndicatorProps<any> { }
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class LoadingIndicator extends React.PureComponent<CombinedProps> {
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+        <CircularProgress
+        size={20}
+        className={classes.root}
+        />
+    );
+  }
+}
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(LoadingIndicator);

--- a/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
+++ b/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
@@ -9,10 +9,11 @@ type ClassNames = 'root';
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {
     position: 'absolute',
-    left: '10px',
+    left: '16px', 
     wordWrap: 'normal',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
+    fontSize: '0.9rem',
   },
 });
 


### PR DESCRIPTION
This PR styles the enhanced select component to resemble a regular select, and applies new icons for dropdown and loading.

You can view/test this in action on the `/volumes` drawer with the 'select linode' enhanced select and/or view the enhanced select story. 