### PR TITLE
M3-1767 - Update pre-push hook to allow develop, master, release branch names

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -2,7 +2,7 @@
 
 # Confirm Branch includes M3 Ticket
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-BRANCH_INCLUDES_TICKET=$(git rev-parse --abbrev-ref HEAD | egrep -i '(M3-[0-9]*)')
+BRANCH_INCLUDES_TICKET=$(git rev-parse --abbrev-ref HEAD | egrep -i '(M3-[0-9]*)|develop|master|release-.*')
 RED='\033[0;31m'
 
 if [ $BRANCH_INCLUDES_TICKET ]


### PR DESCRIPTION
* Updating your remote fork (or pushing a release/master branch) was prevented by the pre-push hook (since these do not have jira tickets in their branch names). 
* Updated the pre-push hook regex to allow for master/develop/release- branch names

