### PR TITLE
M3-1671: fix linodes status update upon creation

### DIFF
--- a/src/features/linodes/LinodesLanding/withUpdatingLinodes.tsx
+++ b/src/features/linodes/LinodesLanding/withUpdatingLinodes.tsx
@@ -69,7 +69,7 @@ const withUpdatingLinodes = (WrappedComponent: React.ComponentType<PropsIn>) => 
       ) {
         this.setState({
           linodeIDs: data.map(l => l.id),
-          data,
+          data: this.state.data.length !== 0 ? this.state.data : data,
         });
       }
     }


### PR DESCRIPTION
The `componentDidUpdate` method was resetting linodes data upon each update which resulted in inconsistent status.
The fix makes sure that linodes data from state takes priority over the one from props.