### PR TITLE
M3-1784 - Add WebdriverIO user agent to requests/browser settings

### DIFF
--- a/e2e/config/browser-config.js
+++ b/e2e/config/browser-config.js
@@ -9,6 +9,7 @@ exports.browserConf = {
             '--no-sandbox',
             '--disable-dev-shm-usage',
             '--window-size=1600,1080',
+            '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36 WebdriverIO',
             ]
         },
         'os': 'Windows',
@@ -26,7 +27,7 @@ exports.browserConf = {
         'browser_version' : 'insider preview',
         'resolution' : '1440x900',
         'browserstack.local' : 'true',
-        'browserstack.selenium_version' : '3.13.0', 
+        'browserstack.selenium_version' : '3.13.0',
     },
     headlessChrome: {
         browserName: 'chrome',
@@ -38,6 +39,7 @@ exports.browserConf = {
                 '--headless','--no-sandbox','--disable-gpu',
                 'window-size=1920,1080','--allow-running-insecure-content',
                 '--ignore-certificate-errors','--disable-dev-shm-usage',
+                '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36 WebdriverIO',
             ]
         }
     },
@@ -45,14 +47,22 @@ exports.browserConf = {
         browserName: 'firefox',
         marionette: true,
         maxInstances: 5,
-        acceptInsecureCerts: true
+        acceptInsecureCerts: true,
+        'moz:firefoxOptions': {
+            prefs: {
+                'general.useragent.override': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:65.0) Gecko/20100101 Firefox/63.0 WebdriverIO'
+            },
+        }
     },
 
     firefoxNightly: {
         browserName: 'firefox',
         marionette: true,
          'moz:firefoxOptions' : {
-            'binary': '/Applications/Firefox Nightly.app/Contents/MacOS/firefox-bin'
+            binary: '/Applications/Firefox Nightly.app/Contents/MacOS/firefox-bin',
+            prefs: {
+                'general.useragent.override': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:65.0) Gecko/20100101 Firefox/63.0 WebdriverIO'
+            },
         },
         maxInstances: 5,
         acceptInsecureCerts: true
@@ -61,8 +71,11 @@ exports.browserConf = {
         browserName: 'firefox',
         marionette: true,
         'moz:firefoxOptions' : {
-            'binary': '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
-            'args': ['-headless']
+            binary: '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
+            args: ['-headless'],
+            prefs: {
+                'general.useragent.override': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:65.0) Gecko/20100101 Firefox/63.0 WebdriverIO'
+            },
         },
         maxInstances: 5,
         acceptInsecureCerts: true

--- a/e2e/setup/cleanup.js
+++ b/e2e/setup/cleanup.js
@@ -14,7 +14,10 @@ const getAxiosInstance = function(token) {
       }),
       baseURL: API_ROOT,
       timeout: 10000,
-      headers: { 'Authorization': `Bearer ${token}`},
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'User-Agent': 'WebdriverIO',
+      },
     });
     return axiosInstance;
 }
@@ -27,7 +30,7 @@ exports.removeAllLinodes = token => {
         const removeInstance = (linode, endpoint) => {
             return getAxiosInstance(token).delete(`${endpoint}/${linode.id}`)
                 .then(res => {
-                    
+
                 })
                 .catch((error) => {
                     console.error('Error was', error);
@@ -37,7 +40,7 @@ exports.removeAllLinodes = token => {
 
         return getAxiosInstance(token).get(linodesEndpoint)
             .then(res => {
-                const promiseArray = 
+                const promiseArray =
                     res.data.data.map(l => removeInstance(l, linodesEndpoint));
 
                 Promise.all(promiseArray)
@@ -81,7 +84,7 @@ exports.removeAllVolumes = token => {
 
         return getAxiosInstance(token).get(endpoint).then(volumesResponse => {
             return exports.pause(volumesResponse).then(res => {
-                const removeVolumesArray = 
+                const removeVolumesArray =
                     res.data.data.map(v => removeVolume(v, endpoint));
 
                 Promise.all(removeVolumesArray).then(function(res) {

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -13,7 +13,10 @@ const getAxiosInstance = function(token) {
         }),
         baseURL: API_ROOT,
         timeout: 10000,
-        headers: { 'Authorization': `Bearer ${token}`},
+        headers: {
+            'Authorization': `Bearer ${token}`,
+            'User-Agent': 'WebdriverIO',
+        },
       });
     } else if (!token && axiosInstance === undefined) {
        throw new Error("getting axiosInstance without having initialized it");
@@ -99,7 +102,7 @@ exports.removeAllLinodes = token => {
 
         return getAxiosInstance(token).get(linodesEndpoint)
             .then(res => {
-                const promiseArray = 
+                const promiseArray =
                     res.data.data.map(l => removeInstance(l, linodesEndpoint));
 
                 Promise.all(promiseArray).then(function(res) {
@@ -115,7 +118,7 @@ exports.removeAllLinodes = token => {
 exports.createLinode = (token, password, linodeLabel, tags) => {
     return new Promise((resolve, reject) => {
         const linodesEndpoint = '/linode/instances';
-        
+
         const linodeConfig = {
             backups_enabled: false,
             booted: true,
@@ -200,7 +203,7 @@ exports.removeAllVolumes = token => {
         }
 
         return getAxiosInstance(token).get(endpoint).then(res => {
-            const removeVolumesArray = 
+            const removeVolumesArray =
                 res.data.data.map(v => removeVolume(v, endpoint));
 
             Promise.all(removeVolumesArray).then(function(res) {
@@ -245,7 +248,8 @@ exports.getMyStackScripts = token => {
         getAxiosInstance(token).get(endpoint, {
             headers: {
                 'Authorization': `Bearer ${token}`,
-                'X-Filter': `{"username":"${browser.options.testUser}","+order_by":"deployments_total","+order":"desc"}`
+                'X-Filter': `{"username":"${browser.options.testUser}","+order_by":"deployments_total","+order":"desc"}`,
+                'User-Agent': 'WebdriverIO',
             }
         })
         .then(response => resolve(response.data))
@@ -277,7 +281,8 @@ exports.getPrivateImages = token => {
             return getAxiosInstance(token).get(endpoint, {
                 headers: {
                     'Authorization': `Bearer ${token}`,
-                    'X-Filter': '{"is_public":false}'
+                    'X-Filter': '{"is_public":false}',
+                    'User-Agent': 'WebdriverIO',
                 }
             })
             .then(response => resolve(response.data))


### PR DESCRIPTION
* Adds a custom user agent to browser configs and axios requests (now includes `WebdriverIO`) this will allow us to filter out e2e test runs from our API usage reporting. 

## To Test

In a spec file, after the `browser.url()` command, add:
```javascript
browser.debug()
```

* Run the modified test spec with `yarn e2e --spec=e2e/specs/path/to/spec.js` 
* Once the debug REPL is available, open the browser's dev tools and look at the request headers for individual requests in the network tab.
* Confirm WebdriverIO is in the user-agent header
* Run the same test in Firefox ``yarn e2e --spec=e2e/specs/path/to/spec.js --browser=firefox` 
* Confirm WebdriverIO is in the user-agent header