### PR TITLE
M3-1794 - Fix automated accessibility testing config

### DIFF
--- a/e2e/utils/config-utils.js
+++ b/e2e/utils/config-utils.js
@@ -73,7 +73,9 @@ exports.login = (username, password, credFilePath) => {
     browser.waitForVisible('[data-qa-add-new-menu-button]', constants.wait.long);
     browser.waitForVisible('[data-qa-circle-progress]', constants.wait.long, true);
 
-    exports.storeToken(credFilePath, username);
+    if (credFilePath) {
+        exports.storeToken(credFilePath, username);
+    }
 }
 
 exports.checkoutCreds = (credFilePath, specFile) => {


### PR DESCRIPTION
* Updates Wdio accessibility testing config to override the wdio test hooks that were previously being inherited from the base configuration.
* Updates the login method to store the token if provided a cred path, overwise, the token will not be stored (we don't need to store tokens for accessibility testing)