### PR TITLE
M3-1683 User links in sidebar on mobile

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -5,6 +5,8 @@ import { connect, MapStateToProps } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 
 import Collapse from '@material-ui/core/Collapse';
+import Divider from '@material-ui/core/Divider';
+import Hidden from '@material-ui/core/Hidden';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
@@ -50,7 +52,8 @@ type ClassNames =
   | 'toggle'
   | 'switchText'
   | 'spacer'
-  | 'listItemAccount';
+  | 'listItemAccount'
+  | 'divider';
 
   const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   menuGrid: {
@@ -81,6 +84,10 @@ type ClassNames =
     borderLeft: '6px solid transparent',
     transition: theme.transitions.create(['background-color', 'border-left-color']),
     flexShrink: 0,
+    [theme.breakpoints.down('xs')]: {
+      paddingTop: 10,
+      paddingBottom: 10,
+    },
     '&:hover': {
       borderLeftColor: 'rgba(0, 0, 0, 0.1)',
       '& $linkItem': {
@@ -177,6 +184,9 @@ type ClassNames =
   spacer: {
     padding: 25,
   },
+  divider: {
+    backgroundColor: 'rgba(0, 0, 0, 0.12)',
+  },
 });
 
 interface Props extends WithStyles<ClassNames>, RouteComponentProps<{}> {
@@ -235,6 +245,14 @@ class PrimaryNav extends React.Component<CombinedProps, State> {
 
   goToHelp = () => {
     this.navigate('/support');
+  }
+
+  goToProfile = () => {
+    this.navigate('/profile');
+  }
+
+  logOut = () => {
+    this.navigate('/logout');
   }
 
   renderPrimaryLink(primaryLink: PrimaryLink) {
@@ -329,7 +347,7 @@ class PrimaryNav extends React.Component<CombinedProps, State> {
                 >
                   <KeyboardArrowRight className={classes.arrow} />
                   Account
-              </ListItemText>
+                </ListItemText>
               </ListItem>
               <Collapse
                 in={expandedMenus.account
@@ -366,8 +384,11 @@ class PrimaryNav extends React.Component<CombinedProps, State> {
                 </li>
               </Collapse>
 
+              <Divider className={classes.divider} />
+
               <ListItem
                 button
+                component="li"
                 focusRipple={true}
                 onClick={this.goToHelp}
                 className={classNames({
@@ -386,8 +407,58 @@ class PrimaryNav extends React.Component<CombinedProps, State> {
                   })}
                 >
                   Get Help
-              </ListItemText>
+                </ListItemText>
               </ListItem>
+
+              <Hidden mdUp>
+                <Divider className={classes.divider} />
+                <ListItem
+                  button
+                  component="li"
+                  focusRipple={true}
+                  onClick={this.goToProfile}
+                  className={classNames({
+                    [classes.listItem]: true,
+                    [classes.collapsible]: true,
+                    [classes.active]: this.linkIsActive('/profile') === true,
+                  })}
+                >
+                  <ListItemText
+                    disableTypography={true}
+                    className={classNames({
+                      [classes.linkItem]: true,
+                      [classes.activeLink]:
+                        expandedMenus.support
+                        || this.linkIsActive('/profile') === true,
+                    })}
+                  >
+                    My Profile
+                  </ListItemText>
+                </ListItem>
+                <ListItem
+                  button
+                  component="li"
+                  focusRipple={true}
+                  onClick={this.logOut}
+                  className={classNames({
+                    [classes.listItem]: true,
+                    [classes.collapsible]: true,
+                    [classes.active]: this.linkIsActive('/logout') === true,
+                  })}
+                >
+                  <ListItemText
+                    disableTypography={true}
+                    className={classNames({
+                      [classes.linkItem]: true,
+                      [classes.activeLink]:
+                        expandedMenus.support
+                        || this.linkIsActive('/logout') === true,
+                    })}
+                  >
+                    Log Out
+                  </ListItemText>
+                </ListItem>
+              </Hidden>
 
               <div className={classes.spacer} />
 

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -150,36 +150,22 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
 
     return (
       <div className={classes.wrapper}>
-        <Hidden xsDown>
-          <Button
-            variant="raised"
-            color="primary"
-            aria-owns={anchorEl ? 'add-new-menu' : undefined}
-            aria-expanded={anchorEl ? true : undefined}
-            aria-haspopup="true"
-            onClick={this.handleClick}
-            className={classes.button}
-            data-qa-add-new-menu-button
-          >
-            Create {
-              anchorEl
-                ? <KeyboardArrowUp className={classes.caret} />
-                : <KeyboardArrowDown className={classes.caret} />
-            }
-          </Button>
-        </Hidden>
-        <Hidden smUp>
-          <IconButton
-            aria-owns={anchorEl ? 'add-new-menu' : undefined}
-            aria-expanded={anchorEl ? true : undefined}
-            aria-haspopup="true"
-            onClick={this.handleClick}
-            className={classes.mobileButton}
-            data-qa-add-new-menu-button
-          >
-            <AddCircle className={classes.mobileCreate} />
-          </IconButton>
-        </Hidden>
+        <Button
+          variant="raised"
+          color="primary"
+          aria-owns={anchorEl ? 'add-new-menu' : undefined}
+          aria-expanded={anchorEl ? true : undefined}
+          aria-haspopup="true"
+          onClick={this.handleClick}
+          className={classes.button}
+          data-qa-add-new-menu-button
+        >
+          Create {
+            anchorEl
+              ? <KeyboardArrowUp className={classes.caret} />
+              : <KeyboardArrowDown className={classes.caret} />
+          }
+        </Button>
         <Menu
           id="add-new-menu"
           anchorEl={anchorEl}

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -4,11 +4,8 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { bindActionCreators, compose } from 'redux';
 
 import Button from '@material-ui/core/Button';
-import Hidden from '@material-ui/core/Hidden';
-import IconButton from '@material-ui/core/IconButton';
 import Menu from '@material-ui/core/Menu';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
-import AddCircle from '@material-ui/icons/AddCircle';
 import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUp from '@material-ui/icons/KeyboardArrowUp';
 

--- a/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 
 import ButtonBase from '@material-ui/core/ButtonBase';
+import Hidden from '@material-ui/core/Hidden';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
@@ -188,38 +189,40 @@ export class UserMenu extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <ButtonBase
-          onClick={this.handleMenu}
-          className={` ${classes.button} ${anchorEl && 'active'}`}
-          data-qa-user-menu
-        >
-          {username &&
-            <React.Fragment>
-              {this.renderAvatar()}
-              <span className={classes.username}>
-                {username && username}
-              </span>
-            </React.Fragment>
-          }
-        </ButtonBase>
-        <Menu
-          anchorEl={anchorEl}
-          getContentAnchorEl={undefined}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'right',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'right',
-          }}
-          open={open}
-          onClose={this.handleClose}
-          className={classes.menu}
-        >
-          <MenuItem key="placeholder" className={classes.hidden} />
-          {menuLinks.map(menuLink => this.renderMenuLink(menuLink))}
-        </Menu>
+        <Hidden smDown>
+          <ButtonBase
+            onClick={this.handleMenu}
+            className={` ${classes.button} ${anchorEl && 'active'}`}
+            data-qa-user-menu
+          >
+            {username &&
+              <React.Fragment>
+                {this.renderAvatar()}
+                <span className={classes.username}>
+                  {username && username}
+                </span>
+              </React.Fragment>
+            }
+          </ButtonBase>
+          <Menu
+            anchorEl={anchorEl}
+            getContentAnchorEl={undefined}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'right',
+            }}
+            open={open}
+            onClose={this.handleClose}
+            className={classes.menu}
+          >
+            <MenuItem key="placeholder" className={classes.hidden} />
+            {menuLinks.map(menuLink => this.renderMenuLink(menuLink))}
+          </Menu>
+        </Hidden>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
This PR does:

- keep the create button on all viewports
- hides the user icon on mobile sizes
- add the user profile and logout link in sidebar menu on mobile