### PR TITLE
M3-1793 Add CTA to dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,14 +80,6 @@ const SupportTicketDetail = DefaultLoader({
   loader: () => import('src/features/Support/SupportTicketDetail'),
 })
 
-const InvoiceDetail = DefaultLoader({
-  loader: () => import('src/features/Billing/InvoiceDetail'),
-});
-
-const UserDetail = DefaultLoader({
-  loader: () => import('src/features/Users/UserDetail'),
-});
-
 const Longview = DefaultLoader({
   loader: () => import('src/features/Longview'),
 });
@@ -352,8 +344,6 @@ export class App extends React.Component<CombinedProps, State> {
                               <Route exact path="/longview" component={Longview} />
                               <Route exact path="/images" component={Images} />
                               <Route path="/stackscripts" component={StackScripts} />
-                              <Route exact path="/account/billing/invoices/:invoiceId" component={InvoiceDetail} />
-                              <Route path="/account/users/:username" component={UserDetail} />
                               <Route path="/account" component={Account} />
                               <Route exact path="/support/tickets" component={SupportTickets} />
                               <Route path="/support/tickets/:ticketId" component={SupportTicketDetail} />

--- a/src/components/CircleProgress/CircleProgress.tsx
+++ b/src/components/CircleProgress/CircleProgress.tsx
@@ -21,11 +21,10 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     justifyContent: 'center',
     position: 'relative',
     width: '100%',
-    margin: '0 auto',
+    margin: '0 auto 20px',
     [theme.breakpoints.up('md')]: {
-      top: '8vh',
-      height: '100%',
       flex: 1,
+      height: 300,
     },
   },
   progress: {

--- a/src/features/Account/AccountLanding.tsx
+++ b/src/features/Account/AccountLanding.tsx
@@ -14,7 +14,7 @@ import GlobalSettings from './GlobalSettings';
 
 type Props = RouteComponentProps<{}>;
 
-class Account extends React.Component<Props> {
+class AccountLanding extends React.Component<Props> {
   handleTabChange = (event: React.ChangeEvent<HTMLDivElement>, value: number) => {
     const { history } = this.props;
     const routeName = this.tabs[value].routeName;
@@ -65,4 +65,4 @@ class Account extends React.Component<Props> {
   }
 }
 
-export default withRouter(Account);
+export default withRouter(AccountLanding);

--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -85,12 +85,14 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
               />
             </Grid>
           </Grid>
-          <Grid item>
-            <Typography variant="body1" className={classes.footnote}>
-              {`For existing Linodes without backups, `}
-              <span className={classes.link} onClick={openBackupsDrawer}>enable now</span>.
-            </Typography>
-          </Grid>
+          {!backups_enabled &&
+            <Grid item>
+              <Typography variant="body1" className={classes.footnote}>
+                {`For existing Linodes without backups, `}
+                <span className={classes.link} onClick={openBackupsDrawer}>enable now</span>.
+              </Typography>
+            </Grid>
+          }
         </Grid>
       </ExpansionPanel>
     </React.Fragment>

--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import OpenInNew from '@material-ui/icons/OpenInNew';
 
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import Grid from 'src/components/Grid';
@@ -11,20 +12,27 @@ import Notice from 'src/components/Notice';
 import Toggle from 'src/components/Toggle';
 
 
-type ClassNames = 'root' | 'footnote' | 'link';
+type ClassNames = 'root' | 'footnote' | 'link' | 'icon';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {},
   footnote: {
     fontSize: 14,
+    cursor: 'pointer',
   },
   link: {
     textDecoration: 'underline',
+  },
+  icon: {
+    display: 'inline-block',
+    fontSize: '0.8em',
+    marginLeft: theme.spacing.unit / 3,
   }
 });
 
 interface Props {
   backups_enabled: boolean;
+  hasLinodesWithoutBackups: boolean;
   errors?: Linode.ApiFieldError[];
   handleToggle: () => void;
   openBackupsDrawer: () => void;
@@ -42,7 +50,14 @@ const displayError = (errors: Linode.ApiFieldError[]) => {
 
 const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
 
-  const { backups_enabled, classes, errors, handleToggle, openBackupsDrawer } = props;
+  const {
+    backups_enabled,
+    classes,
+    errors,
+    hasLinodesWithoutBackups,
+    handleToggle,
+    openBackupsDrawer
+  } = props;
 
   return (
     <React.Fragment>
@@ -60,7 +75,10 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
             <Typography variant="body1">
               This controls whether Linode Backups are enabled, by default, for all Linodes when
               they are initially created. For each Linode with Backups enabled, your account will
-              be billed the additional hourly rate noted on the <a href="https://linode.com/backups">{` Backups pricing page`}</a>.
+              be billed the additional hourly rate noted on the
+              <a href="https://linode.com/backups" target="_blank">{` Backups pricing page`}
+                <OpenInNew className={classes.icon} />
+              </a>.
             </Typography>
           </Grid>
           {errors &&
@@ -85,7 +103,7 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
               />
             </Grid>
           </Grid>
-          {!backups_enabled &&
+          {!backups_enabled && hasLinodesWithoutBackups &&
             <Grid item>
               <Typography variant="body1" className={classes.footnote}>
                 {`For existing Linodes without backups, `}

--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -1,6 +1,7 @@
 import { pathOr } from 'ramda';
 import * as React from 'react';
 
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
@@ -69,18 +70,19 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
           }
           <Grid item container direction="row" alignItems="center">
             <Grid item>
-              <Toggle
-                onChange={handleToggle}
-                checked={backups_enabled}
+              <FormControlLabel
+                className="toggleLabel"
+                control={
+                  <Toggle
+                    onChange={handleToggle}
+                    checked={backups_enabled}
+                  />
+                }
+                label={backups_enabled
+                  ? "Enabled (Auto Enroll All New Linodes in Backups)"
+                  : "Disabled (Don't Enroll New Linodes in Backups Automatically)"
+                }
               />
-            </Grid>
-            <Grid item>
-            <Typography variant="body1">
-              {backups_enabled
-                ? "Enabled (Auto Enroll All New Linodes in Backups)"
-                : "Disabled (Don't Enroll New Linodes in Backups Automatically)"
-              }
-            </Typography>
             </Grid>
           </Grid>
           <Grid item>

--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -80,12 +80,11 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
             </Typography>
             </Grid>
           </Grid>
-          {/* Uncomment after BackupDrawer is merged */}
-          {/* <Grid item>
+          <Grid item>
             <Typography variant="body1" className={classes.footnote}>
               For existing Linodes without backups, <a>enable now</a>.
             </Typography>
-          </Grid> */}
+          </Grid>
         </Grid>
       </ExpansionPanel>
     </React.Fragment>

--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -10,19 +10,23 @@ import Notice from 'src/components/Notice';
 import Toggle from 'src/components/Toggle';
 
 
-type ClassNames = 'root' | 'footnote';
+type ClassNames = 'root' | 'footnote' | 'link';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {},
   footnote: {
     fontSize: 14,
   },
+  link: {
+    textDecoration: 'underline',
+  }
 });
 
 interface Props {
   backups_enabled: boolean;
   errors?: Linode.ApiFieldError[];
   handleToggle: () => void;
+  openBackupsDrawer: () => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -37,7 +41,7 @@ const displayError = (errors: Linode.ApiFieldError[]) => {
 
 const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
 
-  const { backups_enabled, classes, errors, handleToggle } = props;
+  const { backups_enabled, classes, errors, handleToggle, openBackupsDrawer } = props;
 
   return (
     <React.Fragment>
@@ -55,8 +59,7 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
             <Typography variant="body1">
               This controls whether Linode Backups are enabled, by default, for all Linodes when
               they are initially created. For each Linode with Backups enabled, your account will
-              be billed the additional hourly rate noted on the
-              <a href="https://linode.com/backups">{` Backups pricing page`}</a>.
+              be billed the additional hourly rate noted on the <a href="https://linode.com/backups">{` Backups pricing page`}</a>.
             </Typography>
           </Grid>
           {errors &&
@@ -82,7 +85,8 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
           </Grid>
           <Grid item>
             <Typography variant="body1" className={classes.footnote}>
-              For existing Linodes without backups, <a>enable now</a>.
+              {`For existing Linodes without backups, `}
+              <span className={classes.link} onClick={openBackupsDrawer}>enable now</span>.
             </Typography>
           </Grid>
         </Grid>

--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -71,7 +71,7 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
           <Grid item container direction="row" alignItems="center">
             <Grid item>
               <FormControlLabel
-                className="toggleLabel"
+                // className="toggleLabel"
                 control={
                   <Toggle
                     onChange={handleToggle}

--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -107,7 +107,7 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
             <Grid item>
               <Typography variant="body1" className={classes.footnote}>
                 {`For existing Linodes without backups, `}
-                <span className={classes.link} onClick={openBackupsDrawer}>enable now</span>.
+                <a className={classes.link} onClick={openBackupsDrawer}>enable now</a>.
               </Typography>
             </Grid>
           }

--- a/src/features/Account/GlobalSettings.tsx
+++ b/src/features/Account/GlobalSettings.tsx
@@ -6,6 +6,7 @@ import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/
 
 import CircleProgress from 'src/components/CircleProgress';
 import ErrorState from 'src/components/ErrorState';
+import { handleOpen } from 'src/store/reducers/backupDrawer';
 import { updateAccountSettings } from 'src/store/reducers/resources/accountSettings';
 
 import AutoBackups from './AutoBackups';
@@ -26,6 +27,7 @@ interface StateProps {
 interface DispatchProps {
   actions: {
     updateAccount: (data: Partial<Linode.AccountSettings>) => void;
+    openBackupsDrawer: () => void;
   }
 }
 
@@ -39,7 +41,13 @@ class GlobalSettings extends React.Component<CombinedProps,{}> {
   }
 
   render() {
-    const { backups_enabled, error, loading, updateError } = this.props;
+    const {
+      actions: { openBackupsDrawer },
+      backups_enabled,
+      error,
+      loading,
+      updateError
+    } = this.props;
 
     if (loading) { return <CircleProgress /> }
     if (error) { return <ErrorState errorText={"There was an error retrieving your account data."} /> }
@@ -49,6 +57,7 @@ class GlobalSettings extends React.Component<CombinedProps,{}> {
         backups_enabled={backups_enabled}
         errors={updateError}
         handleToggle={this.handleToggle}
+        openBackupsDrawer={openBackupsDrawer}
       />
     )
   }
@@ -65,6 +74,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch, own
   return {
     actions: {
       updateAccount: (data: Partial<Linode.AccountSettings>) => dispatch(updateAccountSettings(data)),
+      openBackupsDrawer: () => dispatch(handleOpen())
     }
   };
 };

--- a/src/features/Account/GlobalSettings.tsx
+++ b/src/features/Account/GlobalSettings.tsx
@@ -1,4 +1,4 @@
-import { compose, path, pathOr } from 'ramda';
+import { compose, isEmpty, path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 
@@ -21,6 +21,7 @@ interface StateProps {
   loading: boolean;
   backups_enabled: boolean;
   error?: Error;
+  linodesWithoutBackups: Linode.Linode[];
   updateError?: Linode.ApiFieldError[];
 }
 
@@ -46,6 +47,7 @@ class GlobalSettings extends React.Component<CombinedProps,{}> {
       backups_enabled,
       error,
       loading,
+      linodesWithoutBackups,
       updateError
     } = this.props;
 
@@ -58,6 +60,7 @@ class GlobalSettings extends React.Component<CombinedProps,{}> {
         errors={updateError}
         handleToggle={this.handleToggle}
         openBackupsDrawer={openBackupsDrawer}
+        hasLinodesWithoutBackups={!isEmpty(linodesWithoutBackups)}
       />
     )
   }
@@ -68,6 +71,7 @@ const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (stat
   backups_enabled: pathOr(false, ['__resources', 'accountSettings', 'data', 'backups_enabled'], state),
   error: path(['__resources', 'accountSettings','error'], state),
   updateError: path(['__resources', 'accountSettings','updateError'], state),
+  linodesWithoutBackups: pathOr([], ['backups', 'data'], state)
 });
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch, ownProps) => {

--- a/src/features/Account/index.tsx
+++ b/src/features/Account/index.tsx
@@ -1,1 +1,34 @@
-export { default } from './Account';
+import * as React from 'react';
+import { Route, RouteComponentProps, Switch, withRouter } from 'react-router-dom';
+
+import DefaultLoader from 'src/components/DefaultLoader';
+
+const InvoiceDetail = DefaultLoader({
+  loader: () => import('src/features/Billing/InvoiceDetail'),
+});
+
+const UserDetail = DefaultLoader({
+  loader: () => import('src/features/Users/UserDetail'),
+});
+
+const AccountLanding = DefaultLoader({
+  loader: () => import('src/features/Account/AccountLanding'),
+});
+
+
+type Props = RouteComponentProps<{}>;
+
+class Account extends React.Component<Props> {
+  render() {
+    const { match: { path } } = this.props;
+
+    return (
+      <Switch>
+        <Route path={`${path}/users/:username`} component={UserDetail} />
+        <Route exact path={`${path}/billing/invoices/:invoiceId`} component={InvoiceDetail} />
+        <Route path={`${path}`} component={AccountLanding} />
+      </Switch>
+    );
+  }
+}
+export default withRouter(Account);

--- a/src/features/Backups/AutoEnroll.test.tsx
+++ b/src/features/Backups/AutoEnroll.test.tsx
@@ -28,13 +28,4 @@ describe("AutoEnroll display component", () => {
       <Notice error text="Error" />
     )).toBeTruthy();
   });
-  it("should toggle the enabled value on click", () => {
-    component.find('[data-qa-enable-toggle]').simulate('click');
-    expect(props.toggle).toHaveBeenCalled();
-  });
-  it("should reflect the enabled state (passed from Redux)", () => {
-    expect(component.find('WithStyles(LinodeSwitchControl)').props()).toHaveProperty('checked', true);
-    component.setProps({ enabled: false });
-    expect(component.find('WithStyles(LinodeSwitchControl)').props()).toHaveProperty('checked', false);
-  });
 });

--- a/src/features/Backups/AutoEnroll.test.tsx
+++ b/src/features/Backups/AutoEnroll.test.tsx
@@ -1,0 +1,40 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import Notice from 'src/components/Notice';
+
+import { AutoEnroll } from './AutoEnroll';
+
+const props = {
+  enabled: true,
+  error: undefined,
+  toggle: jest.fn(),
+  classes: {
+    root: '', header: ''
+  }
+}
+
+const component = shallow(
+  <AutoEnroll {...props} />
+)
+
+describe("AutoEnroll display component", () => {
+  it("should render", () => {
+    expect(component).toBeDefined();
+  });
+  it("should render its error prop", () => {
+    component.setProps({ error: "Error"});
+    expect(component.containsMatchingElement(
+      <Notice error text="Error" />
+    )).toBeTruthy();
+  });
+  it("should toggle the enabled value on click", () => {
+    component.find('[data-qa-enable-toggle]').simulate('click');
+    expect(props.toggle).toHaveBeenCalled();
+  });
+  it("should reflect the enabled state (passed from Redux)", () => {
+    expect(component.find('WithStyles(LinodeSwitchControl)').props()).toHaveProperty('checked', true);
+    component.setProps({ enabled: false });
+    expect(component.find('WithStyles(LinodeSwitchControl)').props()).toHaveProperty('checked', false);
+  });
+});

--- a/src/features/Backups/AutoEnroll.test.tsx
+++ b/src/features/Backups/AutoEnroll.test.tsx
@@ -10,7 +10,7 @@ const props = {
   error: undefined,
   toggle: jest.fn(),
   classes: {
-    root: '', header: ''
+    root: '', header: '', toggleLabel: '', toggleLabelText: '',
   }
 }
 

--- a/src/features/Backups/AutoEnroll.test.tsx
+++ b/src/features/Backups/AutoEnroll.test.tsx
@@ -10,7 +10,7 @@ const props = {
   error: undefined,
   toggle: jest.fn(),
   classes: {
-    root: '', header: '', toggleLabel: '', toggleLabelText: '',
+    root: '', header: '', icon: '', toggleLabel: '', toggleLabelText: '',
   }
 }
 

--- a/src/features/Backups/AutoEnroll.tsx
+++ b/src/features/Backups/AutoEnroll.tsx
@@ -4,6 +4,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import OpenInNew from '@material-ui/icons/OpenInNew';
 
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
@@ -11,6 +12,7 @@ import Toggle from 'src/components/Toggle';
 
 type ClassNames = 'root'
   | 'header'
+  | 'icon'
   | 'toggleLabel'
   | 'toggleLabelText';
 
@@ -22,6 +24,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   header: {
     marginBottom: theme.spacing.unit,
     fontSize: 17
+  },
+  icon: {
+    display: 'inline-block',
+    fontSize: '0.8em',
   },
   toggleLabel: {
     display: 'flex',
@@ -68,9 +74,16 @@ export const AutoEnroll: React.StatelessComponent<CombinedProps> = (props) => {
                   Auto Enroll All New Linodes in Backups
                 </Typography>
                 <Typography variant="caption" >
-                  Enroll all future Linodes in backups. Your account will be billed
-                  the additional hourly rate noted on the
-                  <a href="https://www.linode.com/backups" target="_blank"> Backups pricing page</a>.
+                  {
+                    `Enroll all future Linodes in backups. Your account will be billed
+                    the additional hourly rate noted on the `
+                  }
+                  <a href="https://www.linode.com/backups"
+                    target="_blank"
+                  >
+                    Backups pricing page <OpenInNew className={classes.icon} />.
+                  </a>
+
                 </Typography>
               </div>
             }

--- a/src/features/Backups/AutoEnroll.tsx
+++ b/src/features/Backups/AutoEnroll.tsx
@@ -42,7 +42,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const AutoEnroll: React.StatelessComponent<CombinedProps> = (props) => {
+export const AutoEnroll: React.StatelessComponent<CombinedProps> = (props) => {
   const { classes, enabled, error, toggle } = props;
   return (
     <Paper className={classes.root}>
@@ -59,6 +59,7 @@ const AutoEnroll: React.StatelessComponent<CombinedProps> = (props) => {
               <Toggle
                 checked={enabled}
                 onChange={toggle}
+                data-qa-enable-toggle
               />
             }
             label={

--- a/src/features/Backups/AutoEnroll.tsx
+++ b/src/features/Backups/AutoEnroll.tsx
@@ -5,6 +5,7 @@ import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/
 import Typography from '@material-ui/core/Typography';
 
 import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
 import Toggle from 'src/components/Toggle';
 
 type ClassNames = 'root' | 'header';
@@ -22,15 +23,21 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 
 interface Props {
   enabled: boolean;
+  error?: string;
   toggle: () => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const AutoEnroll: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, enabled, toggle } = props;
+  const { classes, enabled, error, toggle } = props;
   return (
     <Paper className={classes.root}>
+      {error &&
+        <Grid item>
+          <Notice error text={error} />
+        </Grid>
+      }
       <Grid container direction="row" wrap="nowrap">
         <Grid item>
           <Toggle checked={enabled} onChange={toggle} />
@@ -44,7 +51,7 @@ const AutoEnroll: React.StatelessComponent<CombinedProps> = (props) => {
             the additional hourly rate noted on the
             <a href="https://www.linode.com/backups" target="_blank"> Backups pricing page</a>.
           </Typography>
-          </Grid>
+        </Grid>
       </Grid>
     </Paper>
   );

--- a/src/features/Backups/AutoEnroll.tsx
+++ b/src/features/Backups/AutoEnroll.tsx
@@ -25,7 +25,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   },
   toggleLabel: {
     display: 'flex',
-    alignItems: 'flex-start'
+    alignItems: 'flex-start',
+    marginLeft: 0,
+    marginBottom: theme.spacing.unit,
   },
   toggleLabelText: {
     marginTop: 12

--- a/src/features/Backups/AutoEnroll.tsx
+++ b/src/features/Backups/AutoEnroll.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
@@ -8,7 +9,10 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import Toggle from 'src/components/Toggle';
 
-type ClassNames = 'root' | 'header';
+type ClassNames = 'root'
+  | 'header'
+  | 'toggleLabel'
+  | 'toggleLabelText';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
@@ -19,6 +23,13 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     marginBottom: theme.spacing.unit,
     fontSize: 17
   },
+  toggleLabel: {
+    display: 'flex',
+    alignItems: 'flex-start'
+  },
+  toggleLabelText: {
+    marginTop: 12
+  }
 });
 
 interface Props {
@@ -40,17 +51,27 @@ const AutoEnroll: React.StatelessComponent<CombinedProps> = (props) => {
       }
       <Grid container direction="row" wrap="nowrap">
         <Grid item>
-          <Toggle checked={enabled} onChange={toggle} />
-        </Grid>
-        <Grid item>
-          <Typography className={classes.header} variant="body1" >
-            Auto Enroll All New Linodes in Backups
-          </Typography>
-          <Typography variant="body1" >
-            Enroll all future Linodes in backups. Your account will be billed
-            the additional hourly rate noted on the
-            <a href="https://www.linode.com/backups" target="_blank"> Backups pricing page</a>.
-          </Typography>
+          <FormControlLabel
+            className={classes.toggleLabel}
+            control={
+              <Toggle
+                checked={enabled}
+                onChange={toggle}
+              />
+            }
+            label={
+              <div className={classes.toggleLabelText}>
+                <Typography className={classes.header} >
+                  Auto Enroll All New Linodes in Backups
+                </Typography>
+                <Typography variant="caption" >
+                  Enroll all future Linodes in backups. Your account will be billed
+                  the additional hourly rate noted on the
+                  <a href="https://www.linode.com/backups" target="_blank"> Backups pricing page</a>.
+                </Typography>
+              </div>
+            }
+          />
         </Grid>
       </Grid>
     </Paper>

--- a/src/features/Backups/BackupDrawer.test.tsx
+++ b/src/features/Backups/BackupDrawer.test.tsx
@@ -126,10 +126,10 @@ describe("BackupDrawer component", () => {
       component.setProps({ enableErrors: [error]});
       expect(component.find('WithStyles(Notice)')).toHaveLength(1);
     });
-    it("should call enableBackups on submit", () => {
+    it("should call enrollAutoBackups on submit", () => {
       const button = component.find('[data-qa-submit]');
       button.simulate('click');
-      expect(actions.enable).toHaveBeenCalled();
+      expect(actions.enroll).toHaveBeenCalled();
     });
     it("should close the drawer on Cancel", () => {
       const cancel = component.find('[data-qa-cancel]');

--- a/src/features/Backups/BackupDrawer.test.tsx
+++ b/src/features/Backups/BackupDrawer.test.tsx
@@ -38,6 +38,8 @@ const actions = {
   dismissError: jest.fn(),
   dismissSuccess: jest.fn(),
   clearSidebar: jest.fn(),
+  enroll: jest.fn(),
+  toggle: jest.fn(),
 }
 
 const classes = { root: ''}
@@ -55,6 +57,9 @@ const props = {
   enableErrors: [],
   typesLoading: false,
   typesData: types.types,
+  enrolling: false,
+  autoEnroll: false,
+  autoEnrollError: undefined,
 }
 
 const component = shallow(

--- a/src/features/Backups/BackupDrawer.test.tsx
+++ b/src/features/Backups/BackupDrawer.test.tsx
@@ -45,6 +45,7 @@ const actions = {
 const classes = { root: ''}
 
 const props = {
+  accountBackups: false,
   actions,
   classes,
   open: true,

--- a/src/features/Backups/BackupDrawer.tsx
+++ b/src/features/Backups/BackupDrawer.tsx
@@ -16,6 +16,8 @@ import { withTypes } from 'src/context/types';
 import { sendToast } from 'src/features/ToastNotifications/toasts';
 import {
   enableAllBackups,
+  enableAutoEnroll,
+  handleAutoEnrollToggle,
   handleClose,
   handleResetError,
   handleResetSuccess,
@@ -23,7 +25,7 @@ import {
 } from 'src/store/reducers/backupDrawer';
 import { getTypeInfo } from 'src/utilities/typesHelpers';
 
-// import AutoEnroll from './AutoEnroll';
+import AutoEnroll from './AutoEnroll';
 import BackupsTable from './BackupsTable';
 
 type ClassNames = 'root';
@@ -47,10 +49,12 @@ interface TypesContextProps {
 interface DispatchProps {
   actions: {
     enable: () => void;
+    enroll: () => void;
     getLinodesWithoutBackups: () => void;
     close: () => void;
     dismissError: () => void;
     dismissSuccess: () => void;
+    toggle: () => void;
   },
 }
 
@@ -63,10 +67,9 @@ interface StateProps {
   backupsLoading: boolean;
   enableSuccess: boolean;
   enableErrors?: BackupError[];
-}
-
-interface State {
-  backupsToggle: boolean;
+  autoEnroll: boolean;
+  autoEnrollError?: string;
+  enrolling: boolean;
 }
 
 type CombinedProps = DispatchProps
@@ -80,10 +83,7 @@ export const getTotalPrice = (linodes: ExtendedLinode[]) => {
     return prevValue + pathOr(0, ['typeInfo','addons','backups','price','monthly'], linode);
   }, 0)
 }
-export class BackupDrawer extends React.Component<CombinedProps, State> {
-  state: State = {
-    backupsToggle: false,
-  };
+export class BackupDrawer extends React.Component<CombinedProps, {}> {
 
   componentDidMount() {
     if (isEmpty(this.props.linodesWithoutBackups)) {
@@ -93,11 +93,15 @@ export class BackupDrawer extends React.Component<CombinedProps, State> {
 
   componentDidUpdate() {
     const { close, dismissSuccess } = this.props.actions;
-    const { enableSuccess } = this.props;
+    const { autoEnroll, enableSuccess } = this.props;
 
     if (enableSuccess) {
+      const text = autoEnroll
+        ? `All of your Linodes have been enrolled in automatic backups, and
+        all new Linodes will automatically be backed up.`
+        : `All of your Linodes have been enrolled in automatic backups.`
       sendToast(
-        'All of your Linodes have been enrolled in automatic backups.',
+        text,
         'success'
       );
       dismissSuccess();
@@ -105,25 +109,18 @@ export class BackupDrawer extends React.Component<CombinedProps, State> {
     }
   }
 
-  toggleBackups = () => {
-    this.setState({ backupsToggle: !this.state.backupsToggle });
-  }
-
-  handleSubmit = () => {
-    const { enable } = this.props.actions;
-    enable()
-  }
-
   render() {
     const {
-      actions: { close },
+      actions: { close, enroll, toggle },
+      autoEnroll,
+      autoEnrollError,
       enableErrors,
       enabling,
+      enrolling,
       linodesWithoutBackups,
       loading,
       open,
     } = this.props;
-    // const { backupsToggle } = this.state;
     const linodeCount = linodesWithoutBackups.length;
     return (
       <Drawer
@@ -155,17 +152,18 @@ export class BackupDrawer extends React.Component<CombinedProps, State> {
               interval="mo"
             />
           </Grid>
-          {/* <Grid item>
+          <Grid item>
             <AutoEnroll
-              enabled={backupsToggle}
-              toggle={this.toggleBackups}
+              enabled={autoEnroll}
+              error={autoEnrollError}
+              toggle={toggle}
             />
-          </Grid> */}
+          </Grid>
           <Grid item>
             <ActionsPanel style={{ marginTop: 16 }} >
               <Button
-                onClick={this.handleSubmit}
-                loading={loading || enabling}
+                onClick={enroll}
+                loading={loading || enabling || enrolling}
                 type="primary"
                 data-qa-submit
               >
@@ -196,6 +194,8 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch, own
       close: () => dispatch(handleClose()),
       dismissError: () => dispatch(handleResetError()),
       dismissSuccess: () => dispatch(handleResetSuccess()),
+      enroll: () => dispatch(enableAutoEnroll()),
+      toggle: () => dispatch(handleAutoEnrollToggle())
     }
   };
 };
@@ -240,6 +240,9 @@ const mapStateToProps = (state: ApplicationState, ownProps: CombinedProps) => {
     loading: pathOr(false, ['backups','loading'], state),
     enabling: pathOr(false, ['backups','enabling'], state),
     linodesWithoutBackups: enhanceLinodes(linodes, enableErrors, ownProps.typesData),
+    autoEnroll: pathOr(false, ['backups', 'autoEnroll'], state),
+    enrolling: pathOr(false, ['backups', 'enrolling'], state),
+    autoEnrollError: path(['backups', 'autoEnrollError'], state)
   })
 };
 

--- a/src/features/Backups/BackupDrawer.tsx
+++ b/src/features/Backups/BackupDrawer.tsx
@@ -59,6 +59,7 @@ interface DispatchProps {
 }
 
 interface StateProps {
+  accountBackups: boolean;
   open: boolean;
   loading: boolean;
   enabling: boolean;
@@ -111,6 +112,7 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
 
   render() {
     const {
+      accountBackups,
       actions: { close, enroll, toggle },
       autoEnroll,
       autoEnrollError,
@@ -152,13 +154,16 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
               interval="mo"
             />
           </Grid>
-          <Grid item>
-            <AutoEnroll
-              enabled={autoEnroll}
-              error={autoEnrollError}
-              toggle={toggle}
-            />
-          </Grid>
+          {/* Don't show this if the setting is already active. */}
+          {!accountBackups &&
+            <Grid item>
+              <AutoEnroll
+                enabled={autoEnroll}
+                error={autoEnrollError}
+                toggle={toggle}
+              />
+            </Grid>
+          }
           <Grid item>
             <ActionsPanel style={{ marginTop: 16 }} >
               <Button
@@ -232,6 +237,7 @@ const mapStateToProps = (state: ApplicationState, ownProps: CombinedProps) => {
   const enableErrors = pathOr([], ['backups','enableErrors'], state);
   const linodes = pathOr([], ['backups','data'], state);
   return ({
+    accountBackups: pathOr(false, ['__resources', 'accountSettings', 'data', 'backups_enabled'], state),
     backupLoadError: path(['backups','error'], state),
     backupsLoading: path(['backups','loading'], state),
     enableErrors,

--- a/src/features/Backups/BackupDrawer.tsx
+++ b/src/features/Backups/BackupDrawer.tsx
@@ -110,10 +110,19 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
     }
   }
 
+  handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const { actions: { enable, enroll }, accountBackups } = this.props;
+    if (accountBackups) {
+      enable();
+    } else {
+      enroll();
+    }
+  }
+
   render() {
     const {
       accountBackups,
-      actions: { close, enroll, toggle },
+      actions: { close, toggle },
       autoEnroll,
       autoEnrollError,
       enableErrors,
@@ -167,7 +176,7 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
           <Grid item>
             <ActionsPanel style={{ marginTop: 16 }} >
               <Button
-                onClick={enroll}
+                onClick={this.handleSubmit}
                 loading={loading || enabling || enrolling}
                 type="primary"
                 data-qa-submit

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
@@ -13,6 +13,7 @@ const classes = {
   section: '',
   sectionLink: '',
   title: '',
+  ctaLink: '',
 }
 
 const props = {

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
@@ -1,0 +1,50 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
+
+import { BackupsDashboardCard } from './BackupsDashboardCard';
+
+const classes = {
+  root: '',
+  header: '',
+  icon: '',
+  itemTitle: '',
+  section: '',
+  title: '',
+}
+
+const props = {
+  linodesWithoutBackups: 0,
+  openBackupDrawer: jest.fn(),
+  classes
+}
+
+const component = shallow(
+  <BackupsDashboardCard {...props} {...reactRouterProps} />
+)
+
+describe("Backups dashboard card", () => {
+  it("should render a link to /account/settings", () => {
+    expect(component.find('[data-qa-account-link]')).toHaveLength(1);
+  });
+  it("should not render Enable Backups for Existing Linodes if there are no Linodes w/out backups", () => {
+    expect(component.find('[data-qa-backup-existing]')).toHaveLength(0);
+  });
+  it("should render the backup-existing section if there are Linodes to be backed up", () => {
+    component.setProps({ linodesWithoutBackups: 2 });
+    expect(component.find('[data-qa-backup-existing]')).toHaveLength(1);
+  });
+  it("should open the backup drawer when backup-existing is clicked", () => {
+    component.find('[data-qa-backup-existing]').simulate('click');
+    expect(props.openBackupDrawer).toHaveBeenCalled();
+  });
+  it("should display the number of Linodes to be backed up", () => {
+    component.setProps({ linodesWithoutBackups: 3 });
+    expect(component.find('[data-qa-linodes-message]').dive().dive().text()).toMatch("3 Linodes");
+  });
+  it("should pluralize the displayed number of Linodes correctly", () => {
+    component.setProps({ linodesWithoutBackups: 1 });
+    expect(component.find('[data-qa-linodes-message]').dive().dive().text()).toMatch("1 Linode");
+  });
+});

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
@@ -11,6 +11,7 @@ const classes = {
   icon: '',
   itemTitle: '',
   section: '',
+  sectionLink: '',
   title: '',
 }
 

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -97,9 +97,8 @@ export const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (pr
       </Link>
       {/* Only show this section if the user has Linodes without backups */}
       {Boolean(linodesWithoutBackups) &&
-        <a onClick={openBackupDrawer}>
+        <a onClick={openBackupDrawer} data-qa-backup-existing>
           <Paper
-            data-qa-backup-existing
             className={classNames(
               {
                 [classes.section]: true,

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -1,0 +1,110 @@
+import { compose } from 'ramda';
+import * as React from 'react';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+
+import Paper from '@material-ui/core/Paper';
+import { StyleRulesCallback, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import Backup from '@material-ui/icons/Backup';
+
+import DashboardCard from '../DashboardCard';
+
+type ClassNames = 'root'
+| 'itemTitle'
+| 'header'
+| 'icon'
+| 'section'
+| 'title';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {
+    width: '100%',
+  },
+  header: {
+    textAlign: 'center',
+    fontSize: 18,
+  },
+  icon: {
+    color: theme.color.blueDTwhite,
+    margin: theme.spacing.unit,
+    fontSize: 32,
+  },
+  itemTitle: {
+    marginBottom: theme.spacing.unit,
+    color: theme.color.blueDTwhite,
+  },
+  section: {
+    padding: theme.spacing.unit * 3,
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  title: {
+    background: theme.bg.offWhite,
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: `${theme.spacing.unit}px !important`,
+  },
+});
+
+interface Props {
+  accountBackups: boolean,
+  linodesWithoutBackups: number,
+  openBackupDrawer: () => void,
+}
+
+type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<ClassNames>;
+
+const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) => {
+  const { accountBackups, classes, linodesWithoutBackups, openBackupDrawer } = props;
+
+  // Don't display if neither section is relevant.
+  if (!Boolean(linodesWithoutBackups) && !accountBackups) { return null; }
+
+  return (
+    <DashboardCard>
+      <Paper className={[classes.section, classes.title].join(' ')} >
+        <Backup className={classes.icon} />
+        <Typography className={classes.header} variant="headline">
+          Back Up Your Data and Keep it Safe
+        </Typography>
+      </Paper>
+      {/* @todo should this section be conditionally rendered? */}
+      {!accountBackups &&
+        <Link to="/account/settings">
+          <Paper className={classes.section} >
+            <Typography variant="subheading" className={classes.itemTitle} >
+              Linode Backup Auto-Enrollment
+            </Typography>
+            <Typography variant="caption" >
+              If you enable this global setting, new Linodes will be automatically enrolled
+              in the Backups service unless you explicitly disable the setting.
+            </Typography>
+          </Paper>
+        </Link>
+      }
+      {/* Only show this section if the user has Linodes without backups */}
+      {Boolean(linodesWithoutBackups) &&
+        <Paper className={classes.section} onClick={openBackupDrawer} >
+          <Typography variant="subheading" className={classes.itemTitle} >
+            Enable Backups for Existing Linodes
+          </Typography>
+          <Typography variant="caption" >
+            You currently have {linodesWithoutBackups} Linodes without backups.
+            Enable backups to protect your data.
+          </Typography>
+        </Paper>
+      }
+
+    </DashboardCard>
+  );
+};
+
+const styled = withStyles(styles, { withTheme: true });
+
+const enhanced: any = compose(
+  styled,
+  withRouter,
+)(BackupsDashboardCard)
+
+export default enhanced;

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -97,27 +97,28 @@ export const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (pr
       </Link>
       {/* Only show this section if the user has Linodes without backups */}
       {Boolean(linodesWithoutBackups) &&
-        <Paper
-          onClick={openBackupDrawer}
-          data-qa-backup-existing
-          className={classNames(
-            {
-              [classes.section]: true,
-              [classes.sectionLink]: true
-            }
-          )}
-        >
-          <Typography variant="subheading" className={classes.itemTitle} >
-            Enable Backups for Existing Linodes
-          </Typography>
-          <Typography variant="caption" data-qa-linodes-message>
-            {
-              `You currently have
-              ${linodesWithoutBackups} ${linodesWithoutBackups > 1 ? 'Linodes' : 'Linode'}
-              without backups. Enable backups to protect your data.`
-            }
-          </Typography>
-        </Paper>
+        <a onClick={openBackupDrawer}>
+          <Paper
+            data-qa-backup-existing
+            className={classNames(
+              {
+                [classes.section]: true,
+                [classes.sectionLink]: true
+              }
+            )}
+          >
+            <Typography variant="subheading" className={classes.itemTitle} >
+              Enable Backups for Existing Linodes
+            </Typography>
+            <Typography variant="caption" data-qa-linodes-message>
+              {
+                `You currently have
+                ${linodesWithoutBackups} ${linodesWithoutBackups > 1 ? 'Linodes' : 'Linode'}
+                without backups. Enable backups to protect your data.`
+              }
+            </Typography>
+          </Paper>
+        </a>
       }
     </DashboardCard>
   );

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -83,8 +83,11 @@ const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) =>
             Enable Backups for Existing Linodes
           </Typography>
           <Typography variant="caption" >
-            You currently have {linodesWithoutBackups} Linodes without backups.
-            Enable backups to protect your data.
+            {
+              `You currently have
+              ${linodesWithoutBackups} ${linodesWithoutBackups > 1 ? 'Linodes' : 'Linode'}
+              without backups. Enable backups to protect your data.`
+            }
           </Typography>
         </Paper>
       }

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import { compose } from 'ramda';
 import * as React from 'react';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
@@ -59,7 +60,12 @@ const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) =>
 
   return (
     <DashboardCard>
-      <Paper className={[classes.section, classes.title].join(' ')} >
+      <Paper className={classNames(
+        {
+          [classes.section]: true,
+          [classes.title]: true
+        }
+      )}>
         <Backup className={classes.icon} />
         <Typography className={classes.header} variant="headline">
           Back Up Your Data and Keep it Safe
@@ -91,7 +97,6 @@ const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) =>
           </Typography>
         </Paper>
       }
-
     </DashboardCard>
   );
 };

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -16,7 +16,8 @@ type ClassNames = 'root'
 | 'icon'
 | 'section'
 | 'sectionLink'
-| 'title';
+| 'title'
+| 'ctaLink';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
@@ -50,6 +51,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     justifyContent: 'center',
     padding: `${theme.spacing.unit}px !important`,
   },
+  ctaLink: {
+    display: 'block',
+  },
 });
 
 interface Props {
@@ -78,7 +82,7 @@ export const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (pr
           Back Up Your Data and Keep it Safe
         </Typography>
       </Paper>
-      <Link to="/account/settings" data-qa-account-link>
+      <Link to="/account/settings" data-qa-account-link className={classes.ctaLink}>
         <Paper className={classNames(
           {
             [classes.section]: true,
@@ -97,7 +101,7 @@ export const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (pr
       </Link>
       {/* Only show this section if the user has Linodes without backups */}
       {Boolean(linodesWithoutBackups) &&
-        <a onClick={openBackupDrawer} data-qa-backup-existing>
+        <a onClick={openBackupDrawer} data-qa-backup-existing className={classes.ctaLink} href="javascript:;">
           <Paper
             className={classNames(
               {

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -59,7 +59,7 @@ const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) =>
   const { accountBackups, classes, linodesWithoutBackups, openBackupDrawer } = props;
 
   // Don't display if neither section is relevant.
-  if (!Boolean(linodesWithoutBackups) && !accountBackups) { return null; }
+  if (!Boolean(linodesWithoutBackups) && accountBackups) { return null; }
 
   return (
     <DashboardCard>
@@ -69,20 +69,17 @@ const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) =>
           Back Up Your Data and Keep it Safe
         </Typography>
       </Paper>
-      {/* @todo should this section be conditionally rendered? */}
-      {!accountBackups &&
-        <Link to="/account/settings">
-          <Paper className={classes.section} >
-            <Typography variant="subheading" className={classes.itemTitle} >
-              Linode Backup Auto-Enrollment
-            </Typography>
-            <Typography variant="caption" >
-              If you enable this global setting, new Linodes will be automatically enrolled
-              in the Backups service unless you explicitly disable the setting.
-            </Typography>
-          </Paper>
-        </Link>
-      }
+      <Link to="/account/settings">
+        <Paper className={classes.section} >
+          <Typography variant="subheading" className={classes.itemTitle} >
+            Linode Backup Auto-Enrollment
+          </Typography>
+          <Typography variant="caption" >
+            If you enable this global setting, new Linodes will be automatically enrolled
+            in the Backups service.
+          </Typography>
+        </Paper>
+      </Link>
       {/* Only show this section if the user has Linodes without backups */}
       {Boolean(linodesWithoutBackups) &&
         <Paper className={classes.section} onClick={openBackupDrawer} >

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -15,6 +15,7 @@ type ClassNames = 'root'
 | 'header'
 | 'icon'
 | 'section'
+| 'sectionLink'
 | 'title';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
@@ -37,6 +38,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   section: {
     padding: theme.spacing.unit * 3,
     borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+  sectionLink: {
+    cursor: 'pointer',
   },
   title: {
     background: theme.bg.offWhite,
@@ -72,7 +76,13 @@ export const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (pr
         </Typography>
       </Paper>
       <Link to="/account/settings" data-qa-account-link>
-        <Paper className={classes.section} >
+        <Paper className={classNames(
+          {
+            [classes.section]: true,
+            [classes.sectionLink]: true
+          }
+          )}
+        >
           <Typography variant="subheading" className={classes.itemTitle} >
             Linode Backup Auto-Enrollment
           </Typography>
@@ -84,7 +94,16 @@ export const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (pr
       </Link>
       {/* Only show this section if the user has Linodes without backups */}
       {Boolean(linodesWithoutBackups) &&
-        <Paper className={classes.section} onClick={openBackupDrawer} data-qa-backup-existing >
+        <Paper
+          onClick={openBackupDrawer}
+          data-qa-backup-existing
+          className={classNames(
+            {
+              [classes.section]: true,
+              [classes.sectionLink]: true
+            }
+          )}
+        >
           <Typography variant="subheading" className={classes.itemTitle} >
             Enable Backups for Existing Linodes
           </Typography>

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -55,7 +55,7 @@ interface Props {
 
 type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<ClassNames>;
 
-const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) => {
+export const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) => {
   const { classes, linodesWithoutBackups, openBackupDrawer } = props;
 
   return (
@@ -71,7 +71,7 @@ const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) =>
           Back Up Your Data and Keep it Safe
         </Typography>
       </Paper>
-      <Link to="/account/settings">
+      <Link to="/account/settings" data-qa-account-link>
         <Paper className={classes.section} >
           <Typography variant="subheading" className={classes.itemTitle} >
             Linode Backup Auto-Enrollment
@@ -84,11 +84,11 @@ const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) =>
       </Link>
       {/* Only show this section if the user has Linodes without backups */}
       {Boolean(linodesWithoutBackups) &&
-        <Paper className={classes.section} onClick={openBackupDrawer} >
+        <Paper className={classes.section} onClick={openBackupDrawer} data-qa-backup-existing >
           <Typography variant="subheading" className={classes.itemTitle} >
             Enable Backups for Existing Linodes
           </Typography>
-          <Typography variant="caption" >
+          <Typography variant="caption" data-qa-linodes-message>
             {
               `You currently have
               ${linodesWithoutBackups} ${linodesWithoutBackups > 1 ? 'Linodes' : 'Linode'}
@@ -100,6 +100,8 @@ const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) =>
     </DashboardCard>
   );
 };
+
+BackupsDashboardCard.displayName = "BackupsDashboardCard";
 
 const styled = withStyles(styles, { withTheme: true });
 

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -48,7 +48,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 });
 
 interface Props {
-  accountBackups: boolean,
   linodesWithoutBackups: number,
   openBackupDrawer: () => void,
 }
@@ -56,10 +55,7 @@ interface Props {
 type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<ClassNames>;
 
 const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) => {
-  const { accountBackups, classes, linodesWithoutBackups, openBackupDrawer } = props;
-
-  // Don't display if neither section is relevant.
-  if (!Boolean(linodesWithoutBackups) && accountBackups) { return null; }
+  const { classes, linodesWithoutBackups, openBackupDrawer } = props;
 
   return (
     <DashboardCard>

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -53,14 +53,17 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 });
 
 interface Props {
-  linodesWithoutBackups: number,
-  openBackupDrawer: () => void,
+  accountBackups: boolean;
+  linodesWithoutBackups: number;
+  openBackupDrawer: () => void;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<ClassNames>;
 
 export const BackupsDashboardCard: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, linodesWithoutBackups, openBackupDrawer } = props;
+  const { accountBackups, classes, linodesWithoutBackups, openBackupDrawer } = props;
+
+  if (accountBackups && !linodesWithoutBackups) { return null; }
 
   return (
     <DashboardCard>

--- a/src/features/Dashboard/BackupsDashboardCard/index.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './BackupsDashboardCard';

--- a/src/features/Dashboard/Dashboard.test.tsx
+++ b/src/features/Dashboard/Dashboard.test.tsx
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { linode1, linode2 } from 'src/__data__/linodes';
+
+import { Dashboard } from './Dashboard';
+
+const props = {
+  actions: {
+    getLinodesWithoutBackups: jest.fn(),
+    openBackupDrawer: jest.fn(),
+  },
+  linodesWithoutBackups: [linode1, linode2],
+  managed: false,
+  backupError: undefined,
+  classes: { root: ''}
+}
+
+const component = shallow(
+  <Dashboard {...props} />
+)
+
+describe("Dashboard view", () => {
+  describe("Backups CTA card", () => {
+    it("should always display for non-managed users", () => {
+      expect(component.find('WithStyles(withRouter(BackupsDashboardCard))')).toHaveLength(1);
+    });
+    it("should never display for managed users", () => {
+      component.setProps({ managed: true });
+      expect(component.find('WithStyles(withRouter(BackupsDashboardCard))')).toHaveLength(0);
+    });
+  });
+});

--- a/src/features/Dashboard/Dashboard.test.tsx
+++ b/src/features/Dashboard/Dashboard.test.tsx
@@ -1,8 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { linode1, linode2 } from 'src/__data__/linodes';
-
 import { Dashboard } from './Dashboard';
 
 const props = {
@@ -10,7 +8,7 @@ const props = {
     getLinodesWithoutBackups: jest.fn(),
     openBackupDrawer: jest.fn(),
   },
-  linodesWithoutBackups: [linode1, linode2],
+  linodesWithoutBackups: [],
   managed: false,
   backupError: undefined,
   classes: { root: ''}

--- a/src/features/Dashboard/Dashboard.test.tsx
+++ b/src/features/Dashboard/Dashboard.test.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { Dashboard } from './Dashboard';
 
 const props = {
+  accountBackups: false,
   actions: {
     getLinodesWithoutBackups: jest.fn(),
     openBackupDrawer: jest.fn(),
@@ -20,7 +21,7 @@ const component = shallow(
 
 describe("Dashboard view", () => {
   describe("Backups CTA card", () => {
-    it("should always display for non-managed users", () => {
+    it("display for non-managed users", () => {
       expect(component.find('WithStyles(withRouter(BackupsDashboardCard))')).toHaveLength(1);
     });
     it("should never display for managed users", () => {

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -39,7 +39,7 @@ interface DispatchProps {
 
 type CombinedProps = StateProps & DispatchProps & WithStyles<ClassNames>;
 
-class Dashboard extends React.Component<CombinedProps, {}> {
+export class Dashboard extends React.Component<CombinedProps, {}> {
 
   render() {
     const {

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -25,7 +25,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 });
 
 interface StateProps {
-  accountBackups: boolean;
   linodesWithoutBackups: Linode.Linode[];
   managed: boolean;
   backupError?: Error;
@@ -44,7 +43,6 @@ class Dashboard extends React.Component<CombinedProps, {}> {
 
   render() {
     const {
-      accountBackups,
       actions: { openBackupDrawer },
       backupError,
       linodesWithoutBackups,
@@ -67,7 +65,6 @@ class Dashboard extends React.Component<CombinedProps, {}> {
           {(!managed && !backupError) &&
             <BackupsDashboardCard
               linodesWithoutBackups={linodesWithoutBackups.length}
-              accountBackups={accountBackups}
               openBackupDrawer={openBackupDrawer}
             />
           }
@@ -79,7 +76,6 @@ class Dashboard extends React.Component<CombinedProps, {}> {
 }
 
 const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (state, ownProps) => ({
-  accountBackups: pathOr(false, ['__resources', 'accountSettings', 'data', 'backups_enabled'], state),
   linodesWithoutBackups: pathOr([],['backups', 'data'], state),
   managed: pathOr(false, ['__resources', 'accountSettings', 'data', 'managed'], state),
   backupError: pathOr(false, ['backups', 'error'], state)

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -1,11 +1,15 @@
+import { compose, pathOr } from 'ramda';
 import * as React from 'react';
+import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
+import { handleOpen, requestLinodesWithoutBackups } from 'src/store/reducers/backupDrawer';
 
+import BackupsDashboardCard from './BackupsDashboardCard';
 import BlogDashboardCard from './BlogDashboardCard';
 import DomainsDashboardCard from './DomainsDashboardCard';
 import LinodesDashboardCard from './LinodesDashboardCard';
@@ -20,11 +24,32 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
 });
 
-type CombinedProps = WithStyles<ClassNames>;
+interface StateProps {
+  accountBackups: boolean;
+  linodesWithoutBackups: Linode.Linode[];
+  managed: boolean;
+  backupError?: Error;
+}
+
+interface DispatchProps {
+  actions: {
+    getLinodesWithoutBackups: () => void;
+    openBackupDrawer: () => void;
+  }
+}
+
+type CombinedProps = StateProps & DispatchProps & WithStyles<ClassNames>;
 
 class Dashboard extends React.Component<CombinedProps, {}> {
 
   render() {
+    const {
+      accountBackups,
+      actions: { openBackupDrawer },
+      backupError,
+      linodesWithoutBackups,
+      managed,
+    } = this.props;
     return (
       <Grid container spacing={24}>
         <DocumentTitleSegment segment="Dashboard" />
@@ -39,6 +64,13 @@ class Dashboard extends React.Component<CombinedProps, {}> {
         </Grid>
         <Grid item xs={12} md={5}>
           <TransferDashboardCard />
+          {(!managed && !backupError) &&
+            <BackupsDashboardCard
+              linodesWithoutBackups={linodesWithoutBackups.length}
+              accountBackups={accountBackups}
+              openBackupDrawer={openBackupDrawer}
+            />
+          }
           <BlogDashboardCard />
         </Grid>
       </Grid>
@@ -46,6 +78,29 @@ class Dashboard extends React.Component<CombinedProps, {}> {
   }
 }
 
+const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (state, ownProps) => ({
+  accountBackups: pathOr(false, ['__resources', 'accountSettings', 'data', 'backups_enabled'], state),
+  linodesWithoutBackups: pathOr([],['backups', 'data'], state),
+  managed: pathOr(false, ['__resources', 'accountSettings', 'data', 'managed'], state),
+  backupError: pathOr(false, ['backups', 'error'], state)
+});
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch, ownProps) => {
+  return {
+    actions: {
+      getLinodesWithoutBackups: () => dispatch(requestLinodesWithoutBackups()),
+      openBackupDrawer: () => dispatch(handleOpen())
+    }
+  };
+};
+
+const connected = connect(mapStateToProps, mapDispatchToProps);
+
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled(Dashboard);
+const enhanced: any = compose(
+  styled,
+  connected,
+)(Dashboard);
+
+export default enhanced;

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -25,6 +25,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 });
 
 interface StateProps {
+  accountBackups: boolean;
   linodesWithoutBackups: Linode.Linode[];
   managed: boolean;
   backupError?: Error;
@@ -43,6 +44,7 @@ export class Dashboard extends React.Component<CombinedProps, {}> {
 
   render() {
     const {
+      accountBackups,
       actions: { openBackupDrawer },
       backupError,
       linodesWithoutBackups,
@@ -64,6 +66,7 @@ export class Dashboard extends React.Component<CombinedProps, {}> {
           <TransferDashboardCard />
           {(!managed && !backupError) &&
             <BackupsDashboardCard
+              accountBackups={accountBackups}
               linodesWithoutBackups={linodesWithoutBackups.length}
               openBackupDrawer={openBackupDrawer}
             />
@@ -76,9 +79,10 @@ export class Dashboard extends React.Component<CombinedProps, {}> {
 }
 
 const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (state, ownProps) => ({
+  accountBackups: pathOr(false, ['__resources', 'accountSettings', 'data', 'backups_enabled'], state),
   linodesWithoutBackups: pathOr([],['backups', 'data'], state),
   managed: pathOr(false, ['__resources', 'accountSettings', 'data', 'managed'], state),
-  backupError: pathOr(false, ['backups', 'error'], state)
+  backupError: pathOr(false, ['backups', 'error'], state),
 });
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch, ownProps) => {

--- a/src/features/Dashboard/DashboardCard.tsx
+++ b/src/features/Dashboard/DashboardCard.tsx
@@ -1,5 +1,6 @@
 import { StyleRulesCallback, WithStyles, withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import * as classNames from 'classnames';
 import * as React from 'react';
 import Grid from 'src/components/Grid';
 
@@ -20,16 +21,24 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 
 interface Props {
   title?: string;
+  className?: string;
   headerAction?: () => JSX.Element | JSX.Element[] | null;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const DashboardCard: React.StatelessComponent<CombinedProps> = (props) => {
-  const { title, headerAction, classes } = props;
+  const { title, headerAction, classes, className } = props;
   return (
-    <Grid container className={classes.container} data-qa-card={title}>
-      <Grid item xs={12}>
+    <Grid
+      container
+      className={classNames(
+        className,
+        {
+        [classes.container]: true,
+      })}
+      data-qa-card={title}>
+      <Grid item xs={12} className={!title || !headerAction ? 'p0' : ''}>
         <Grid container justify="space-between" alignItems="flex-start">
           {title && 
             <Grid item className={'py0'}>

--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -34,7 +34,9 @@ type ClassNames =
   | 'wrapHeader';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
-  root: {},
+  root: {
+    marginTop: 0
+  },
   linodeWrapper: {
     display: 'inline-flex',
     width: 'auto',
@@ -119,8 +121,9 @@ class LinodesDashboardCard extends React.Component<CombinedProps, State> {
   }
 
   render() {
+    const { classes } = this.props;
     return (
-      <DashboardCard title="Linodes" headerAction={this.renderAction}>
+      <DashboardCard title="Linodes" headerAction={this.renderAction} className={classes.root}>
         <Paper>
           <Table>
             <TableBody>

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -11,6 +11,7 @@ import { getNetworkUtilization } from 'src/services/account';
 import DashboardCard from '../DashboardCard';
 
 type ClassNames = 'root'
+  | 'card'
   | 'grid'
   | 'poolUsageProgress'
   | 'circleChildren'
@@ -20,9 +21,15 @@ type ClassNames = 'root'
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {
+    marginTop: 0,
     padding: theme.spacing.unit * 4,
     [theme.breakpoints.up('md')]: {
-      marginTop: theme.spacing.unit,
+      marginTop: theme.spacing.unit * 3,
+    },
+  },
+  card: {
+    [theme.breakpoints.down('sm')]: {
+      marginTop: 0
     },
   },
   grid: {
@@ -112,7 +119,7 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
     const poolUsagePct = ((used / quota) * 100) < 1 ? 1 : (used / quota) * 100;
 
     return (
-      <DashboardCard>
+      <DashboardCard className={classes.card}>
         <Paper className={classes.root}>
           <Grid
             container

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -23,9 +23,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {
     marginTop: 0,
     padding: theme.spacing.unit * 4,
-    [theme.breakpoints.up('md')]: {
-      marginTop: theme.spacing.unit * 3,
-    },
   },
   card: {
     [theme.breakpoints.down('sm')]: {
@@ -54,6 +51,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   poolUsageProgress: {
     marginRight: theme.spacing.unit * 4,
+    height: 'auto',
   },
   circleChildren: {
     textAlign: 'center',

--- a/src/features/Users/UserProfile.tsx
+++ b/src/features/Users/UserProfile.tsx
@@ -151,7 +151,7 @@ class UserProfile extends React.Component<CombinedProps> {
     });
     deleteUser(username)
       .then(() => {
-        push(`/users`, { deletedUsername: username });
+        push(`/account/users`, { deletedUsername: username });
       })
       .catch(() => {
         this.setState({

--- a/src/store/ApplicationState.d.ts
+++ b/src/store/ApplicationState.d.ts
@@ -37,6 +37,9 @@ declare interface BackupDrawerState extends RequestableData<Linode.Linode[]> {
   enabling: boolean;
   enableErrors: BackupError[];
   enableSuccess: boolean;
+  autoEnroll: boolean;
+  autoEnrollError?: string;
+  enrolling: boolean;
 }
 
 declare interface RequestableData<D> {

--- a/src/store/reducers/backupDrawer.test.ts
+++ b/src/store/reducers/backupDrawer.test.ts
@@ -21,10 +21,16 @@ mockFn.mockReturnValueOnce(Promise.reject());
 describe("Redux backups", () => {
   describe("reducer", () => {
     it("should handle OPEN", () => {
-      const newState = backups({...B.defaultState, error: apiError, enableErrors: [error]}, B.handleOpen());
+      const newState = backups(
+        {...B.defaultState,
+          error: apiError,
+          enableErrors: [error],
+          autoEnrollError: "Error"
+        }, B.handleOpen());
         expect(newState).toHaveProperty('open', true);
         expect(newState).toHaveProperty('error', undefined);
         expect(newState).toHaveProperty('enableErrors', []);
+        expect(newState).toHaveProperty('autoEnrollError', undefined);
     });
     it("should handle CLOSE", () => {
       const newState = backups(
@@ -81,6 +87,36 @@ describe("Redux backups", () => {
         B.handleResetSuccess()
       )
       expect(newState).toHaveProperty('enableSuccess', false)
+    });
+    it("should handle AUTO_ENROLL", () => {
+      const newState = backups(
+        B.defaultState,
+        B.handleAutoEnroll()
+      )
+      expect(newState).toHaveProperty('enrolling', true)
+    });
+    it("should handle AUTO_ENROLL_TOGGLE", () => {
+      const newState = backups(
+        {...B.defaultState, autoEnroll: false },
+        B.handleAutoEnrollToggle()
+      )
+      expect(newState).toHaveProperty('autoEnroll', true);
+      expect(backups(newState, B.handleAutoEnrollToggle()))
+        .toHaveProperty('autoEnroll', false);
+    });
+    it("should handle AUTO_ENROLL_SUCCESS", () => {
+      const newState = backups(
+        {...B.defaultState, enrolling: true },
+        B.handleAutoEnrollSuccess()
+      )
+      expect(newState).toHaveProperty('enrolling', false)
+    });
+    it("should handle AUTO_ENROLL_ERROR", () => {
+      const newState = backups(
+        {...B.defaultState, enableSuccess: true },
+        B.handleAutoEnrollError('Error')
+      )
+      expect(newState).toHaveProperty('autoEnrollError', 'Error')
     });
   });
   describe("magic error reducer", () => {

--- a/src/store/reducers/backupDrawer.ts
+++ b/src/store/reducers/backupDrawer.ts
@@ -210,7 +210,8 @@ export const enableAutoEnroll = () => (dispatch: Dispatch<State>, getState: () =
   .then((response) => {
     dispatch(handleAutoEnrollSuccess());
     dispatch(enableAllBackups());
-    dispatch(handleUpdate(response))
+    // Have to let the rest of the store know that the backups setting has been updated.
+    dispatch(handleUpdate(response));
   })
   .catch((errors) => {
     const defaultError = "Your account settings could not be updated. Please try again.";

--- a/src/store/reducers/backupDrawer.ts
+++ b/src/store/reducers/backupDrawer.ts
@@ -4,6 +4,7 @@ import { compose, Dispatch } from 'redux';
 
 import { updateAccountSettings } from 'src/services/account';
 import { enableBackups, getLinodes } from 'src/services/linodes';
+import { handleUpdate } from 'src/store/reducers/resources/accountSettings';
 import { getAll } from 'src/utilities/getAll';
 
 // HELPERS
@@ -206,9 +207,10 @@ export const enableAutoEnroll = () => (dispatch: Dispatch<State>, getState: () =
   const backups_enabled = pathOr(false,['backups', 'autoEnroll'], getState());
   dispatch(handleAutoEnroll());
   updateAccountSettings({ backups_enabled })
-  .then(() => {
+  .then((response) => {
     dispatch(handleAutoEnrollSuccess());
     dispatch(enableAllBackups());
+    dispatch(handleUpdate(response))
   })
   .catch((errors) => {
     const defaultError = "Your account settings could not be updated. Please try again.";

--- a/src/store/reducers/backupDrawer.ts
+++ b/src/store/reducers/backupDrawer.ts
@@ -154,7 +154,7 @@ export const requestLinodesWithoutBackups = () => (dispatch: Dispatch<State>) =>
 }
 
 /**
- * reducer
+ * gatherResponsesAndErrors
  *
  * This magic is needed to accumulate errors from any failed requests, since
  * we need to enable backups for each Linode individually. The final response
@@ -203,6 +203,10 @@ export const enableAllBackups = () => (dispatch: Dispatch<State>, getState: () =
     ));
 }
 
+/* Dispatches an async action that will set the backups_enabled account setting.
+*  When complete, it will dispatch appropriate actions to handle the result, including
+* updating state.__resources.accountSettings.data.backups_enabled.
+*/
 export const enableAutoEnroll = () => (dispatch: Dispatch<State>, getState: () => State) => {
   const backups_enabled = pathOr(false,['backups', 'autoEnroll'], getState());
   dispatch(handleAutoEnroll());

--- a/src/store/reducers/backupDrawer.ts
+++ b/src/store/reducers/backupDrawer.ts
@@ -211,15 +211,15 @@ export const enableAutoEnroll = () => (dispatch: Dispatch<State>, getState: () =
   const backups_enabled = pathOr(false,['backups', 'autoEnroll'], getState());
   dispatch(handleAutoEnroll());
   updateAccountSettings({ backups_enabled })
-  .then((response) => {
-    dispatch(handleAutoEnrollSuccess());
-    dispatch(enableAllBackups());
-    // Have to let the rest of the store know that the backups setting has been updated.
-    dispatch(handleUpdate(response));
-  })
-  .catch((errors) => {
-    const defaultError = "Your account settings could not be updated. Please try again.";
-    const finalError =  pathOr(defaultError, ['response', 'data', 'errors', 0, 'reason'], errors);
-    dispatch(handleAutoEnrollError(finalError));
-  });
+    .then((response) => {
+      dispatch(handleAutoEnrollSuccess());
+      dispatch(enableAllBackups());
+      // Have to let the rest of the store know that the backups setting has been updated.
+      dispatch(handleUpdate(response));
+    })
+    .catch((errors) => {
+      const defaultError = "Your account settings could not be updated. Please try again.";
+      const finalError =  pathOr(defaultError, ['response', 'data', 'errors', 0, 'reason'], errors);
+      dispatch(handleAutoEnrollError(finalError));
+    });
 }


### PR DESCRIPTION
* Add BackupsDashboardCard component
* Connect to Redux
* render conditionally based on manged, backups_enabled, and the
existence of Linodes without backups

## Notes

* BackupDrawer now calls both /account/settings and linodes/*/backups-enable on Submit. I chose to do this in series: if the call to settings (the toggle at the bottom of the drawer) fails, the submit process will stop, an error will be displayed, and the user can retry.
* Everything in the drawer is reduxed to connect with the accountSettings reducer (which needs to be updated) and handle the drawer open/close state adjustments needed.