### PR TITLE
M3-1829 - Changelog comparison script fixes/enhancements

### DIFF
--- a/scripts/jira-changelog.sh
+++ b/scripts/jira-changelog.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-CHANGES_WITH_TIX=$(git log --color=always --oneline $1...$2 | egrep -i '(M3-[0-9]*)')
-CHANGES_WITHOUT_TIX=$(git log --color=always --oneline $1...$2 | egrep -iv '(M3-[0-9]*)')
-JQL_QUERY=$(echo "key in ($(git log --color=always --oneline $1...$2 | egrep -oi --color=always '(M3-[0-9]*)' | tr '\n' ',' | sed 's/.$//'))" )
+CHANGES_WITH_TIX=$(git log --color=always --no-merges --oneline $1...HEAD | egrep -i '(M3(-|\s)[0-9]*)')
+CHANGES_WITHOUT_TIX=$(git log --color=always --no-merges --oneline $1...HEAD | egrep -iv '(M3(-|\s)[0-9]*)')
+JQL_QUERY=$(echo "key in ($(git log --color=always --no-merges --oneline $1...HEAD | egrep -oi --color=always '(M3(-|\s)[0-9]*)' | tr '\n' ',' | sed 's/.$//' | tr ' ' '-'))" )
 
 echo -e "Tracked Changes in $1:\n"
 echo "$CHANGES_WITH_TIX"

--- a/scripts/jira-changelog.sh
+++ b/scripts/jira-changelog.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
-CHANGES_WITH_TIX=$(git log --color=always --no-merges --oneline $1...HEAD | egrep -i '(M3(-|\s)[0-9]*)')
-CHANGES_WITHOUT_TIX=$(git log --color=always --no-merges --oneline $1...HEAD | egrep -iv '(M3(-|\s)[0-9]*)')
-JQL_QUERY=$(echo "key in ($(git log --color=always --no-merges --oneline $1...HEAD | egrep -oi --color=always '(M3(-|\s)[0-9]*)' | tr '\n' ',' | sed 's/.$//' | tr ' ' '-'))" )
+# Compare first tag/commit argument to Second commit/tag argument OR head
+COMPARE_TO=${2:-HEAD}
+
+CHANGES_WITH_TIX=$(git log --color=always --no-merges --oneline $1...$COMPARE_TO | egrep -i '(M3(-|\s)[0-9]*)')
+CHANGES_WITHOUT_TIX=$(git log --color=always --no-merges --oneline $1...$COMPARE_TO | egrep -iv '(M3(-|\s)[0-9]*)')
+JQL_QUERY=$(echo "key in ($(git log --color=always --no-merges --oneline $1...$COMPARE_TO | egrep -oi --color=always '(M3(-|\s)[0-9]*)' | tr '\n' ',' | sed 's/.$//' | tr ' ' '-'))" )
 
 echo -e "Tracked Changes in $1:\n"
 echo "$CHANGES_WITH_TIX"


### PR DESCRIPTION
* Refactored the changelog script to be more useful 
* `--no-merges` is the same as `set-max-parents=1`
* Default second argument to HEAD (For comparing Previous version to now)

## To Test

```bash
# Compare a version to HEAD
yarn compare v0.38.1

# Compare a version against another version:
yarn compare v0.37.0 v0.38.0
```