### PR TITLE
M3-1855 Prevent import of non-shakeable libraries.

### DIFF
--- a/src/components/EventListItem/EventListItem.stories.tsx
+++ b/src/components/EventListItem/EventListItem.stories.tsx
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 
-import { List } from '@material-ui/core';
+import List from '@material-ui/core/List';
 
 import ThemeDecorator from '../../utilities/storybookDecorators';
 import EventListItem from './EventListItem';

--- a/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/src/features/Profile/LishSettings/LishSettings.tsx
@@ -2,8 +2,8 @@ import { compose, dec, lensPath, path, pathOr, remove, set } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 
-import { FormHelperText } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
 import InputLabel from '@material-ui/core/InputLabel';
 import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';

--- a/src/features/Profile/Settings/Settings.tsx
+++ b/src/features/Profile/Settings/Settings.tsx
@@ -2,8 +2,8 @@ import { compose, path } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 
-import { Paper } from '@material-ui/core';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Paper from '@material-ui/core/Paper';
 import { StyleRulesCallback, withStyles, WithStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 
-import { Divider, StyleRulesCallback, Typography, WithStyles, withStyles } from '@material-ui/core';
+import Divider from '@material-ui/core/Divider';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import InputAdornment from '@material-ui/core/InputAdornment';
+import { StyleRulesCallback, WithStyles, withStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
 
 import Grid from 'src/components/Grid';
 import RenderGuard from 'src/components/RenderGuard';
@@ -109,7 +111,7 @@ class AlertSection extends React.Component<CombinedProps> {
                 value={this.props.value}
                 disabled={!this.props.state}
                 InputProps={{
-                  endAdornment: 
+                  endAdornment:
                   <InputAdornment position="end">
                     {this.props.endAdornment}
                   </InputAdornment>,

--- a/src/utilities/promiseToObservable.ts
+++ b/src/utilities/promiseToObservable.ts
@@ -1,16 +1,17 @@
-import { Observable } from 'rxjs';
+import 'rxjs/add/operator/switchMap';
+import { fromPromise } from 'rxjs/observable/fromPromise';
 
 /**
  * This function will transform a given promise into an observable
  * but also cancel the previous inner observable in favor of the new one
- * 
+ *
  * This lets us prevent overlapping network requests from occuring
- * 
+ *
  * learn more about switchMap:
  * https://www.learnrxjs.io/operators/transformation/switchmap.html
- * 
+ *
  * Exmaple usage:
- * 
+ *
  * transformPromiseToCancellableObservable(getLinodes)
  *      .subscribe(
  *          () => console.log('onSuccess'),
@@ -20,9 +21,7 @@ import { Observable } from 'rxjs';
  * @param promiseFn a function that returns a promise (i.e )
  */
 const transformPromiseToCancellableObservable = (promiseFn: () => Promise<any>) => {
-  return Observable
-    /** convert promise to observable */
-    .fromPromise(promiseFn())
+  return fromPromise(promiseFn())
     /** cancel previous subscribed request in favor of the new one */
     .switchMap(() => promiseFn())
 }

--- a/tslint.json
+++ b/tslint.json
@@ -31,6 +31,7 @@
     "no-unused-expression": { "severity": "warning" },
     "object-literal-sort-keys": false,
     "only-arrow-functions": { "severity": "warning" },
+    "import-blacklist": [true, "rxjs", "@material-ui/core", "@material-ui/icons"],
     "prefer-for-of": {"severity": "warning"},
     "trailing-comma": { "severity": "warning" },
     "variable-name": false


### PR DESCRIPTION
Importing `rxjs`, `@material-ui/core`, and `@material-ui/icons` directly significantly and unnecessarily increase individual chunk sizes.