### PR TITLE
M3-1827 Show public IP before private IP

### DIFF
--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -118,7 +118,7 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
     const formattedIPS = ips
       .map(ip => ip.replace('/64', ''))
-      .sort(ip => !!ip.match(privateIPRegex) ? 1 : 0);
+      .sort(ip => !!ip.match(privateIPRegex) ? 1 : -1);
 
     return (
       <div className={`dif ${classes.root}`}>


### PR DESCRIPTION
Currently, a linode's **private** IP is shown by default on Linodes Landing and Linodes Detail. We'd like to show the **public** IP by default. 

We're using the JS native `sort()` function to sort an array of a Linode's IPs, with a custom compare function that is supposed to sort private IPs at a lower index than public IPs.

But `sort()` is not guaranteed to be consistent across browsers. MDN documentation on `Array.prototype.sort()`:

> If compareFunction(a, b) returns 0, leave a and b unchanged with respect to each other, but sorted with respect to all different elements. Note: the ECMAscript standard does not guarantee this behaviour, and thus not all browsers (e.g. Mozilla versions dating back to at least 2003) respect this.

This explains why this behavior was different in Firefox.

Returning `-1` instead of `0` in the compare function fixed the issue. 

### To test:
- Have a Linode with a private IP.
- Use Chrome.
- Navigate to Linodes Landing.
- **Observe:**  The public IP address will be displayed, with a `+1` icon. Clicking that icon will show the private IP.