### PR TITLE
M3 1542 Breadcrumb on StackScriptCreate and StackScriptUpdate

### DIFF
--- a/e2e/pageobjects/configure-stackscript.page.js
+++ b/e2e/pageobjects/configure-stackscript.page.js
@@ -5,8 +5,8 @@ import ListStackScripts from './list-stackscripts.page';
 
 class ConfigureStackScript extends Page {
 
-    get createHeader() { return $('[data-qa-create-header]'); }
-    get editHeader() { return $('[data-qa-edit-header]'); }
+    get createHeader() { return $(this.breadcrumbStaticText.selector); }
+    get editHeader() { return $(this.breadcrumbStaticText.selector); }
     get label() { return $('[data-qa-stackscript-label]'); }
     get labelHelp() { return $('[data-qa-stackscript-label]').$('..').$(this.helpButton.selector); }
     get description() { return $('[data-qa-stackscript-description]'); }

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -14,6 +14,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
   backButton: {
     margin: '0',
+    padding: '0',
     width: 'auto',
     height: 'auto',
     '& svg': {

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -42,7 +42,8 @@ const styles: StyleRulesCallback = (theme) => ({
     border: '1px solid transparent',
     transition: theme.transitions.create(['opacity']),
     wordBreak: 'break-all',
-    textDecoration: 'inherit'
+    textDecoration: 'inherit',
+    ...theme.typography.headline,
   },
   container: {
     display: 'flex',
@@ -108,6 +109,7 @@ const styles: StyleRulesCallback = (theme) => ({
   },
   input: {
     padding: '5px 10px',
+    ...theme.typography.headline,
   },
   headline: {
     ...theme.typography.headline,

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.test.tsx
@@ -49,4 +49,17 @@ describe('StackScriptCreate', () => {
       expect(parentLink.prop('to')).toBe('/stackscripts');
     });
   });
+
+  describe('Breadcrumb', () => {
+    const breadcrumb = component.find('[data-qa-create-stackscript-breadcrumb]');
+    it('should render', () => {
+      expect(breadcrumb).toHaveLength(1);
+    });
+    it('should include "Create New StackScript" as the label title', () => {
+      expect(breadcrumb.prop('labelTitle')).toBe('Create New StackScript');
+    });
+    it('should take you back to the StackScripts page', () => {
+      expect(breadcrumb.prop('linkTo')).toBe('/stackscripts');
+    });
+  });
 });

--- a/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -1,12 +1,11 @@
-import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import { compose, path } from 'ramda';
 import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
-import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import IconButton from 'src/components/core/IconButton';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
@@ -42,6 +41,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   titleWrapper: {
     display: 'flex',
     marginTop: 5,
+    marginBottom: 20,
+    alignItems: 'center',
+    wordBreak: 'break-all',
   },
 });
 
@@ -268,7 +270,7 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
     const generalError = hasErrorFor('none');
 
     if (!username) {
-      return <ErrorState errorText="An error has occured. Please try again." />
+      return <ErrorState errorText="An error has occurred. Please try again." />
     }
 
     return (
@@ -282,21 +284,12 @@ export class StackScriptCreate extends React.Component<CombinedProps, State> {
           justify="space-between"
         >
           <Grid item className={classes.titleWrapper}>
-            <Link to={`/stackscripts`}>
-              <IconButton
-                className={classes.backButton}
-              >
-                <KeyboardArrowLeft />
-              </IconButton>
-            </Link>
-            <Typography
-              role="header"
-              className={classes.createTitle}
-              variant="headline"
-              data-qa-create-header
-            >
-              Create New StackScript
-            </Typography>
+            <Breadcrumb
+              linkTo="/stackscripts"
+              linkText="StackScripts"
+              labelTitle="Create New StackScript"
+              data-qa-create-stackscript-breadcrumb
+            />
           </Grid>
         </Grid>
         <ScriptForm

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.test.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.test.tsx
@@ -24,11 +24,6 @@ describe('StackScriptUpdate', () => {
     />
   )
 
-  it('should render a title that reads "Edit StackScript', () => {
-    const titleText = component.find('WithStyles(Typography)').first().children().text();
-    expect(titleText).toBe('Edit StackScript');
-  });
-
   it(`should render a confirmation dialog with the title "Clear StackScript Configuration?"`, () => {
     const modalTitle = component.find('WithStyles(ConfirmationDialog)').prop('title');
     expect(modalTitle).toBe('Clear StackScript Configuration?');
@@ -38,17 +33,16 @@ describe('StackScriptUpdate', () => {
     expect(component.find('WithStyles(StackScriptForm)')).toHaveLength(1);
   });
 
-  describe('Back Arrow Icon Button', () => {
-
-    it('should render back array icon button', () => {
-      const backIcon = component.find('WithStyles(IconButton)').first();
-      expect(backIcon.find('pure(KeyboardArrowLeftIcon)')).toHaveLength(1);
+  describe('Breadcrumb', () => {
+    const breadcrumb = component.find('[data-qa-update-stackscript-breadcrumb]');
+    it('should render', () => {
+      expect(breadcrumb).toHaveLength(1);
     });
-
-    it('back arrow icon should link back to stackscripts landing', () => {
-      const backIcon = component.find('WithStyles(IconButton)').first();
-      const parentLink = backIcon.closest('Link');
-      expect(parentLink.prop('to')).toBe('/stackscripts');
+    it('should include "Edit StackScript" as the label title', () => {
+      expect(breadcrumb.prop('labelTitle')).toBe('Edit StackScript');
+    });
+    it('should take you back to the StackScripts page', () => {
+      expect(breadcrumb.prop('linkTo')).toBe('/stackscripts');
     });
   });
 });

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -1,12 +1,11 @@
-import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import { clone, compose, path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
-import { Link, RouteComponentProps } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import IconButton from 'src/components/core/IconButton';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
@@ -43,6 +42,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   titleWrapper: {
     display: 'flex',
     marginTop: 5,
+    marginBottom: 20,
+    alignItems: 'center',
+    wordBreak: 'break-all',
   },
 });
 
@@ -308,7 +310,7 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
     const generalError = hasErrorFor('none');
 
     if (!username) {
-      return <ErrorState errorText="An error has occured, please reload and try again." />
+      return <ErrorState errorText="An error has occurred, please reload and try again." />
     }
 
     return (
@@ -322,21 +324,12 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
           justify="space-between"
         >
           <Grid item className={classes.titleWrapper}>
-            <Link to={`/stackscripts`}>
-              <IconButton
-                className={classes.backButton}
-              >
-                <KeyboardArrowLeft />
-              </IconButton>
-            </Link>
-            <Typography
-              role="header"
-              className={classes.createTitle}
-              variant="headline"
-              data-qa-edit-header
-            >
-              Edit StackScript
-            </Typography>
+            <Breadcrumb
+              linkTo="/stackscripts"
+              linkText="StackScripts"
+              labelTitle="Edit StackScript"
+              data-qa-update-stackscript-breadcrumb
+            />
           </Grid>
         </Grid>
         <ScriptForm


### PR DESCRIPTION
This PR adds the Breadcrumb component to the `Create` and `Edit` StackScript pages. These changes are purely presentational.

@alioso and @WilkinsKa1 I added `20px` of bottom margin between the Breadcrumb and the rest of the component. I was just eyeballing it, so I'd appreciate your input.


