### PR TITLE
M3-1515 Unified List Volumes Component

### DIFF
--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -412,7 +412,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                 onEdit={this.handleEdit}
                 onResize={this.handleResize}
                 onClone={this.handleClone}
-                attached={Boolean(volume.linodeLabel)}
+                attached={Boolean(volume.linode_id)}
                 onAttach={this.handleAttach}
                 onDetach={this.handleDetach}
                 poweredOff={volume.linodeStatus === 'offline'}

--- a/src/features/linodes/LinodesDetail/HeaderSections/TabsAndStatusBarPanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/TabsAndStatusBarPanel.tsx
@@ -5,6 +5,7 @@ import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import { linodeInTransition } from 'src/features/linodes/transitions';
+import VolumesLanding from 'src/features/Volumes/VolumesLanding';
 import LinodeBackup from '../LinodeBackup';
 import LinodeNetworking from '../LinodeNetworking';
 import LinodeRebuild from '../LinodeRebuild';
@@ -13,7 +14,6 @@ import LinodeResize from '../LinodeResize';
 import LinodeSettings from '../LinodeSettings';
 import LinodeSummary from '../LinodeSummary';
 import LinodeBusyStatus from '../LinodeSummary/LinodeBusyStatus';
-import LinodeVolumes from '../LinodeVolumes';
 
 type ClassNames = 'root';
 
@@ -74,14 +74,14 @@ const TabsAndStatusBarPanel: React.StatelessComponent<CombinedProps> = (props) =
         </Tabs>
       </AppBar>
       <Switch>
-        <Route exact path={`${url}/summary`} component={LinodeSummary} />
-        <Route exact path={`${url}/volumes`} component={LinodeVolumes} />
-        <Route exact path={`${url}/networking`} component={LinodeNetworking} />
-        <Route exact path={`${url}/resize`} component={LinodeResize} />
-        <Route exact path={`${url}/rescue`} component={LinodeRescue} />
-        <Route exact path={`${url}/rebuild`} component={LinodeRebuild} />
-        <Route exact path={`${url}/backup`} component={LinodeBackup} />
-        <Route exact path={`${url}/settings`} component={LinodeSettings} />
+        <Route exact path={`/linodes/:linodeId/summary`} component={LinodeSummary} />
+        <Route exact path={`/linodes/:linodeId/volumes`} component={VolumesLanding} />
+        <Route exact path={`/linodes/:linodeId/networking`} component={LinodeNetworking} />
+        <Route exact path={`/linodes/:linodeId/resize`} component={LinodeResize} />
+        <Route exact path={`/linodes/:linodeId/rescue`} component={LinodeRescue} />
+        <Route exact path={`/linodes/:linodeId/rebuild`} component={LinodeRebuild} />
+        <Route exact path={`/linodes/:linodeId/backup`} component={LinodeBackup} />
+        <Route exact path={`/linodes/:linodeId/settings`} component={LinodeSettings} />
         {/* 404 */}
         <Redirect to={`${url}/summary`} />
       </Switch>

--- a/src/services/linodes/linodes.ts
+++ b/src/services/linodes/linodes.ts
@@ -30,9 +30,9 @@ export interface CreateLinodeRequest {
 
 /**
  * getLinode
- * 
+ *
  * View details for a single Linode.
- * 
+ *
  * @param linodeId { number } The id of the Linode to retrieve.
  */
 export const getLinode = (linodeId: number) =>
@@ -43,9 +43,9 @@ export const getLinode = (linodeId: number) =>
 
 /**
  * getLinodeLishToken
- * 
+ *
  * Generates a token which can be used to authenticate with LISH.
- * 
+ *
  * @param linodeId { number } The id of the Linode.
  */
 export const getLinodeLishToken = (linodeId: number) =>
@@ -56,24 +56,26 @@ export const getLinodeLishToken = (linodeId: number) =>
 
 /**
  * getLinodeVolumes
- * 
+ *
  * Returns a paginated list of Block Storage volumes attached to the
  * specified Linode.
- * 
+ *
  * @param linodeId { number } The id of the Linode.
  */
-export const getLinodeVolumes = (linodeId: number) =>
+export const getLinodeVolumes = (linodeId: number, params: any = {}, filter: any = {}) =>
   Request<Page<Linode.Volume>>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/volumes`),
     setMethod('GET'),
+    setXFilter(filter),
+    setParams(params),
   )
     .then(response => response.data);
 
 /**
  * getLinodes
- * 
+ *
  * Returns a paginated list of Linodes on your account.
- * 
+ *
  * @param linodeId { number } The id of the Linode.
  */
 export const getLinodes = (params?: any, filter?: any) =>
@@ -87,12 +89,12 @@ export const getLinodes = (params?: any, filter?: any) =>
 
 /**
  * createLinode
- * 
+ *
  * Create a new Linode. The authenticating user must have the
  * add_linodes grant in order to use this endpoint.
- * 
+ *
  * @param data { object } Options for type, region, etc.
- * 
+ *
  * @returns the newly created Linode object.
  */
 export const createLinode = (data: CreateLinodeRequest) =>
@@ -105,9 +107,9 @@ export const createLinode = (data: CreateLinodeRequest) =>
 
 /**
  * updateLinode
- * 
+ *
  * Generates a token which can be used to authenticate with LISH.
- * 
+ *
  * @param linodeId { number } The id of the Linode to be updated.
  * @param values { object } the fields of the Linode object to be updated.
  * Fields not included in this parameter will be left unchanged.
@@ -122,9 +124,9 @@ export const updateLinode = (linodeId: number, values: Partial<Linode>) =>
 
 /**
  * deleteLinode
- * 
+ *
  * Delete the specified Linode instance.
- * 
+ *
  * @param linodeId { number } The id of the Linode to be deleted.
  */
 export const deleteLinode = (linodeId: number) =>

--- a/src/services/volumes/volumes.schema.ts
+++ b/src/services/volumes/volumes.schema.ts
@@ -3,7 +3,7 @@ import { number, object, string } from 'yup';
 export const CreateVolumeSchema = object({
   region: string()
     .when('linode_id', {
-      is: (id) => Boolean(id),
+      is: (id) => id === undefined,
       then: string().required("Must provide a region or a Linode ID."),
     }),
   linode_id: number(),


### PR DESCRIPTION
## Purpose
We duplicated a significant amount of code between VolumesLanding and LinodesVolume, both were features that displayed a paginated table of Volumes and provided means by which a user could start creation. 

To DRY things up a bit, I've updated the configured request in VolumesLanding to update a few things based on existence of the linodeId React Router match param.
- Request is updated to request the Linode's volumes, rather than all volumes
- Region is hidden if the linodeId is found.
- Attachment is hidden if the linodeId is found.


## Notes
I intend to remove the LinodeVolumes and ancillary components once everything is reviewed and styled. 