### PR TITLE
M3-1875 Create volume for Linode

### DIFF
--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -356,7 +356,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           copy="Add storage to your Linodes using the resilient Volumes service for $0.10/GiB per month."
           icon={VolumesIcon}
           buttonProps={{
-            onClick: this.props.openForCreating,
+            onClick: this.openCreateVolumeDrawer,
             children: 'Create a Volume',
           }}
         />
@@ -412,7 +412,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                 onEdit={this.handleEdit}
                 onResize={this.handleResize}
                 onClone={this.handleClone}
-                attached={Boolean(volume.linodeLabel)}
+                attached={Boolean(volume.linode_id)}
                 onAttach={this.handleAttach}
                 onDetach={this.handleDetach}
                 poweredOff={volume.linodeStatus === 'offline'}
@@ -434,7 +434,10 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   }
 
   openCreateVolumeDrawer = (e: any) => {
-    this.props.openForCreating();
+    const { linodeId } = this.props.match.params;
+    const maybeLinodeId = linodeId ? Number(linodeId) : undefined;
+    this.props.openForCreating(maybeLinodeId);
+
     e.preventDefault();
   }
 
@@ -495,7 +498,7 @@ const connected = connect(undefined, mapDispatchToProps);
 const documented = setDocs(VolumesLanding.docs);
 
 const updatedRequest = (ownProps: RouteProps, params: any, filters: any) => {
-  const linodeId = path<string>(['match','params', 'linodeId'], ownProps);
+  const linodeId = path<string>(['match', 'params', 'linodeId'], ownProps);
 
   const req: (params: any, filter: any) => Promise<Linode.ResourcePage<Linode.Volume>>
     = linodeId
@@ -563,9 +566,9 @@ const withEvents = WithEvents();
 const styled = withStyles(styles);
 
 export default compose(
-    connected,
-    documented,
-    paginated,
-    styled,
-    withEvents
-  )(VolumesLanding);
+  connected,
+  documented,
+  paginated,
+  styled,
+  withEvents
+)(VolumesLanding);

--- a/src/features/linodes/LinodesDetail/HeaderSections/TabsAndStatusBarPanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/TabsAndStatusBarPanel.tsx
@@ -5,6 +5,7 @@ import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import { linodeInTransition } from 'src/features/linodes/transitions';
+import VolumesLanding from 'src/features/Volumes/VolumesLanding';
 import LinodeBackup from '../LinodeBackup';
 import LinodeNetworking from '../LinodeNetworking';
 import LinodeRebuild from '../LinodeRebuild';
@@ -13,7 +14,6 @@ import LinodeResize from '../LinodeResize';
 import LinodeSettings from '../LinodeSettings';
 import LinodeSummary from '../LinodeSummary';
 import LinodeBusyStatus from '../LinodeSummary/LinodeBusyStatus';
-import LinodeVolumes from '../LinodeVolumes';
 
 type ClassNames = 'root';
 
@@ -74,14 +74,14 @@ const TabsAndStatusBarPanel: React.StatelessComponent<CombinedProps> = (props) =
         </Tabs>
       </AppBar>
       <Switch>
-        <Route exact path={`${url}/summary`} component={LinodeSummary} />
-        <Route exact path={`${url}/volumes`} component={LinodeVolumes} />
-        <Route exact path={`${url}/networking`} component={LinodeNetworking} />
-        <Route exact path={`${url}/resize`} component={LinodeResize} />
-        <Route exact path={`${url}/rescue`} component={LinodeRescue} />
-        <Route exact path={`${url}/rebuild`} component={LinodeRebuild} />
-        <Route exact path={`${url}/backup`} component={LinodeBackup} />
-        <Route exact path={`${url}/settings`} component={LinodeSettings} />
+        <Route exact path={`/linodes/:linodeId/summary`} component={LinodeSummary} />
+        <Route exact path={`/linodes/:linodeId/volumes`} component={VolumesLanding} />
+        <Route exact path={`/linodes/:linodeId/networking`} component={LinodeNetworking} />
+        <Route exact path={`/linodes/:linodeId/resize`} component={LinodeResize} />
+        <Route exact path={`/linodes/:linodeId/rescue`} component={LinodeRescue} />
+        <Route exact path={`/linodes/:linodeId/rebuild`} component={LinodeRebuild} />
+        <Route exact path={`/linodes/:linodeId/backup`} component={LinodeBackup} />
+        <Route exact path={`/linodes/:linodeId/settings`} component={LinodeSettings} />
         {/* 404 */}
         <Redirect to={`${url}/summary`} />
       </Switch>

--- a/src/services/linodes/linodes.ts
+++ b/src/services/linodes/linodes.ts
@@ -30,9 +30,9 @@ export interface CreateLinodeRequest {
 
 /**
  * getLinode
- * 
+ *
  * View details for a single Linode.
- * 
+ *
  * @param linodeId { number } The id of the Linode to retrieve.
  */
 export const getLinode = (linodeId: number) =>
@@ -43,9 +43,9 @@ export const getLinode = (linodeId: number) =>
 
 /**
  * getLinodeLishToken
- * 
+ *
  * Generates a token which can be used to authenticate with LISH.
- * 
+ *
  * @param linodeId { number } The id of the Linode.
  */
 export const getLinodeLishToken = (linodeId: number) =>
@@ -56,24 +56,26 @@ export const getLinodeLishToken = (linodeId: number) =>
 
 /**
  * getLinodeVolumes
- * 
+ *
  * Returns a paginated list of Block Storage volumes attached to the
  * specified Linode.
- * 
+ *
  * @param linodeId { number } The id of the Linode.
  */
-export const getLinodeVolumes = (linodeId: number) =>
+export const getLinodeVolumes = (linodeId: number, params: any = {}, filter: any = {}) =>
   Request<Page<Linode.Volume>>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/volumes`),
     setMethod('GET'),
+    setXFilter(filter),
+    setParams(params),
   )
     .then(response => response.data);
 
 /**
  * getLinodes
- * 
+ *
  * Returns a paginated list of Linodes on your account.
- * 
+ *
  * @param linodeId { number } The id of the Linode.
  */
 export const getLinodes = (params?: any, filter?: any) =>
@@ -87,12 +89,12 @@ export const getLinodes = (params?: any, filter?: any) =>
 
 /**
  * createLinode
- * 
+ *
  * Create a new Linode. The authenticating user must have the
  * add_linodes grant in order to use this endpoint.
- * 
+ *
  * @param data { object } Options for type, region, etc.
- * 
+ *
  * @returns the newly created Linode object.
  */
 export const createLinode = (data: CreateLinodeRequest) =>
@@ -105,9 +107,9 @@ export const createLinode = (data: CreateLinodeRequest) =>
 
 /**
  * updateLinode
- * 
+ *
  * Generates a token which can be used to authenticate with LISH.
- * 
+ *
  * @param linodeId { number } The id of the Linode to be updated.
  * @param values { object } the fields of the Linode object to be updated.
  * Fields not included in this parameter will be left unchanged.
@@ -122,9 +124,9 @@ export const updateLinode = (linodeId: number, values: Partial<Linode>) =>
 
 /**
  * deleteLinode
- * 
+ *
  * Delete the specified Linode instance.
- * 
+ *
  * @param linodeId { number } The id of the Linode to be deleted.
  */
 export const deleteLinode = (linodeId: number) =>

--- a/src/services/volumes/volumes.schema.ts
+++ b/src/services/volumes/volumes.schema.ts
@@ -3,7 +3,7 @@ import { number, object, string } from 'yup';
 export const CreateVolumeSchema = object({
   region: string()
     .when('linode_id', {
-      is: (id) => Boolean(id),
+      is: (id) => id === undefined,
       then: string().required("Must provide a region or a Linode ID."),
     }),
   linode_id: number(),

--- a/src/store/reducers/volumeDrawer.ts
+++ b/src/store/reducers/volumeDrawer.ts
@@ -3,6 +3,7 @@ import { modes } from 'src/features/Volumes/VolumeDrawer';
 
 const CLOSE = '@@manager/volumeDrawer/CLOSE';
 const CREATING = '@@manager/volumeDrawer/CREATING';
+const CREATING_FOR_LINODE = '@@manager/volumeDrawer/CREATING_FOR_LINODE';
 const EDITING = '@@manager/volumeDrawer/EDITING';
 const RESIZING = '@@manager/volumeDrawer/RESIZING';
 const CLONING = '@@manager/volumeDrawer/CLONING';
@@ -19,11 +20,24 @@ interface Creating extends Action {
   type: typeof CREATING;
 }
 
-export const openForCreating = (): Creating => {
-  return ({
-    type: CREATING,
-  });
-};
+interface CreatingForLinode extends Action {
+  type: typeof CREATING_FOR_LINODE;
+  linodeId: number;
+}
+
+export const openForCreating: (linodeId?: number) => Creating | CreatingForLinode =
+  (linodeId?: number) => {
+    if (linodeId) {
+      return ({
+        type: CREATING_FOR_LINODE,
+        linodeId,
+      })
+    }
+
+    return ({
+      type: CREATING,
+    });
+  };
 
 interface Editing extends Action {
   type: typeof EDITING;
@@ -112,10 +126,11 @@ export const defaultState = {
 
 type ActionTypes =
   Close
-| Creating
-| Editing
-| Resizing
-| Cloning;
+  | Creating
+  | CreatingForLinode
+  | Editing
+  | Resizing
+  | Cloning;
 
 export const volumeDrawer = (state = defaultState, action: ActionTypes) => {
   switch (action.type) {
@@ -124,11 +139,20 @@ export const volumeDrawer = (state = defaultState, action: ActionTypes) => {
         ...state,
         mode: modes.CLOSED,
       };
+
     case CREATING:
       return {
         ...defaultState,
         mode: modes.CREATING,
       };
+
+    case CREATING_FOR_LINODE:
+      return {
+        ...defaultState,
+        mode: modes.CREATING_FOR_LINODE,
+        linodeId: action.linodeId,
+      };
+
     case EDITING:
       return {
         ...defaultState,
@@ -139,6 +163,7 @@ export const volumeDrawer = (state = defaultState, action: ActionTypes) => {
         linodeLabel: action.linodeLabel,
         mode: modes.EDITING,
       };
+
     case RESIZING:
       return {
         ...defaultState,
@@ -149,6 +174,7 @@ export const volumeDrawer = (state = defaultState, action: ActionTypes) => {
         linodeLabel: action.linodeLabel,
         mode: modes.RESIZING,
       };
+
     case CLONING:
       return {
         ...defaultState,
@@ -158,6 +184,7 @@ export const volumeDrawer = (state = defaultState, action: ActionTypes) => {
         region: action.region,
         mode: modes.CLONING,
       };
+
     default:
       return state;
   }


### PR DESCRIPTION
## Purpose
Use the global drawer for creation of a volume and immediate attachment to a Linode.

## Notes
This is _only_ creation. The next PR will add the attach to Linode flow back.