### PR TITLE
M3-1875 Create volume for Linode.

### DIFF
--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -356,7 +356,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           copy="Add storage to your Linodes using the resilient Volumes service for $0.10/GiB per month."
           icon={VolumesIcon}
           buttonProps={{
-            onClick: this.props.openForCreating,
+            onClick: this.openCreateVolumeDrawer,
             children: 'Create a Volume',
           }}
         />
@@ -434,7 +434,10 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   }
 
   openCreateVolumeDrawer = (e: any) => {
-    this.props.openForCreating();
+    const { linodeId } = this.props.match.params;
+    const maybeLinodeId = linodeId ? Number(linodeId) : undefined;
+    this.props.openForCreating(maybeLinodeId);
+
     e.preventDefault();
   }
 
@@ -495,7 +498,7 @@ const connected = connect(undefined, mapDispatchToProps);
 const documented = setDocs(VolumesLanding.docs);
 
 const updatedRequest = (ownProps: RouteProps, params: any, filters: any) => {
-  const linodeId = path<string>(['match','params', 'linodeId'], ownProps);
+  const linodeId = path<string>(['match', 'params', 'linodeId'], ownProps);
 
   const req: (params: any, filter: any) => Promise<Linode.ResourcePage<Linode.Volume>>
     = linodeId
@@ -563,9 +566,9 @@ const withEvents = WithEvents();
 const styled = withStyles(styles);
 
 export default compose(
-    connected,
-    documented,
-    paginated,
-    styled,
-    withEvents
-  )(VolumesLanding);
+  connected,
+  documented,
+  paginated,
+  styled,
+  withEvents
+)(VolumesLanding);

--- a/src/store/reducers/volumeDrawer.ts
+++ b/src/store/reducers/volumeDrawer.ts
@@ -3,6 +3,7 @@ import { modes } from 'src/features/Volumes/VolumeDrawer';
 
 const CLOSE = '@@manager/volumeDrawer/CLOSE';
 const CREATING = '@@manager/volumeDrawer/CREATING';
+const CREATING_FOR_LINODE = '@@manager/volumeDrawer/CREATING_FOR_LINODE';
 const EDITING = '@@manager/volumeDrawer/EDITING';
 const RESIZING = '@@manager/volumeDrawer/RESIZING';
 const CLONING = '@@manager/volumeDrawer/CLONING';
@@ -19,11 +20,24 @@ interface Creating extends Action {
   type: typeof CREATING;
 }
 
-export const openForCreating = (): Creating => {
-  return ({
-    type: CREATING,
-  });
-};
+interface CreatingForLinode extends Action {
+  type: typeof CREATING_FOR_LINODE;
+  linodeId: number;
+}
+
+export const openForCreating: (linodeId?: number) => Creating | CreatingForLinode =
+  (linodeId?: number) => {
+    if (linodeId) {
+      return ({
+        type: CREATING_FOR_LINODE,
+        linodeId,
+      })
+    }
+
+    return ({
+      type: CREATING,
+    });
+  };
 
 interface Editing extends Action {
   type: typeof EDITING;
@@ -112,10 +126,11 @@ export const defaultState = {
 
 type ActionTypes =
   Close
-| Creating
-| Editing
-| Resizing
-| Cloning;
+  | Creating
+  | CreatingForLinode
+  | Editing
+  | Resizing
+  | Cloning;
 
 export const volumeDrawer = (state = defaultState, action: ActionTypes) => {
   switch (action.type) {
@@ -124,11 +139,20 @@ export const volumeDrawer = (state = defaultState, action: ActionTypes) => {
         ...state,
         mode: modes.CLOSED,
       };
+
     case CREATING:
       return {
         ...defaultState,
         mode: modes.CREATING,
       };
+
+    case CREATING_FOR_LINODE:
+      return {
+        ...defaultState,
+        mode: modes.CREATING_FOR_LINODE,
+        linodeId: action.linodeId,
+      };
+
     case EDITING:
       return {
         ...defaultState,
@@ -139,6 +163,7 @@ export const volumeDrawer = (state = defaultState, action: ActionTypes) => {
         linodeLabel: action.linodeLabel,
         mode: modes.EDITING,
       };
+
     case RESIZING:
       return {
         ...defaultState,
@@ -149,6 +174,7 @@ export const volumeDrawer = (state = defaultState, action: ActionTypes) => {
         linodeLabel: action.linodeLabel,
         mode: modes.RESIZING,
       };
+
     case CLONING:
       return {
         ...defaultState,
@@ -158,6 +184,7 @@ export const volumeDrawer = (state = defaultState, action: ActionTypes) => {
         region: action.region,
         mode: modes.CLONING,
       };
+
     default:
       return state;
   }


### PR DESCRIPTION
## Purpose
Use the global drawer for creation of a volume and immediate attachment to a Linode.

## Notes
This is _only_ creation. The next PR will add the attach to Linode flow back.

## Goldplatting
I'll be submitting a final clean-up PR to bring this component in-line with our current patterns at the end of the review. If anything jumps out, let me know so I can include it in the final.