### PR TITLE
M3-1818 Display network usage as a percentage

### DIFF
--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.test.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.test.tsx
@@ -9,8 +9,11 @@ describe("TransferDashboardCard component", () => {
       expect(renderPercentageString(0.01)).toEqual('<1%');
     });
     it("should not display decimals", () => {
-      expect(renderPercentageString(78.9743)).toEqual('79%');
+      expect(renderPercentageString(78.9743)).toEqual('78%');
       expect(renderPercentageString(1.0000001)).toEqual('1%');
+    });
+    it("should not round up to 100% for large values", () => {
+      expect(renderPercentageString(99.99)).toEqual('99%');
     });
   });
 });

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.test.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.test.tsx
@@ -1,0 +1,12 @@
+import { renderPercentageString } from './TransferDashboardCard';
+
+describe("TransferDashboardCard component", () => {
+  describe("renderPercentageString function", () => {
+    it("should render a percentage", () => {
+      expect(renderPercentageString(25)).toEqual('25%');
+    });
+    it("should use a < sign for small percentages", () => {
+      expect(renderPercentageString(0.01)).toEqual('<1%');
+    });
+  });
+});

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.test.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.test.tsx
@@ -8,5 +8,9 @@ describe("TransferDashboardCard component", () => {
     it("should use a < sign for small percentages", () => {
       expect(renderPercentageString(0.01)).toEqual('<1%');
     });
+    it("should not display decimals", () => {
+      expect(renderPercentageString(78.9743)).toEqual('79%');
+      expect(renderPercentageString(1.0000001)).toEqual('1%');
+    });
   });
 });

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -81,7 +81,7 @@ type CombinedProps = WithStyles<ClassNames>;
 
 export const renderPercentageString = (percentage: number) => {
   if (percentage < 1) { return "<1%"; }
-  else { return `${percentage}%`; }
+  else { return `${percentage.toFixed(0)}%`; }
 }
 class TransferDashboardCard extends React.Component<CombinedProps, State> {
   state: State = {

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -78,6 +78,11 @@ interface State {
 
 type CombinedProps = WithStyles<ClassNames>;
 
+
+export const renderPercentageString = (percentage: number) => {
+  if (percentage < 1) { return "<1%"; }
+  else { return `${percentage}%`; }
+}
 class TransferDashboardCard extends React.Component<CombinedProps, State> {
   state: State = {
     loading: true,
@@ -111,7 +116,7 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
       return null;
     }
 
-    const poolUsagePct = ((used / quota) * 100) < 1 ? 1 : (used / quota) * 100;
+    const poolUsagePct = ((used / quota) * 100);
 
     return (
       <DashboardCard className={classes.card}>
@@ -129,7 +134,7 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
                 variant="static"
                 noTopMargin
                 green
-                value={poolUsagePct}
+                value={Math.ceil(poolUsagePct)}
                 className={classes.poolUsageProgress}
               >
                 <span className={classes.circleChildren}>
@@ -137,7 +142,7 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
                     className={classes.used}
                     data-qa-transfer-used
                   >
-                    {used}
+                    {renderPercentageString(poolUsagePct)}
                   </Typography>
                   <Typography
                     variant="caption"

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -80,7 +80,7 @@ type CombinedProps = WithStyles<ClassNames>;
 
 
 export const renderPercentageString = (percentage: number) =>
-  percentage < 1 ? "<1%" : `${percentage.toFixed(0)}%`;
+  percentage < 1 ? "<1%" : `${Math.floor(percentage)}%`;
 class TransferDashboardCard extends React.Component<CombinedProps, State> {
   state: State = {
     loading: true,

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -79,10 +79,8 @@ interface State {
 type CombinedProps = WithStyles<ClassNames>;
 
 
-export const renderPercentageString = (percentage: number) => {
-  if (percentage < 1) { return "<1%"; }
-  else { return `${percentage.toFixed(0)}%`; }
-}
+export const renderPercentageString = (percentage: number) =>
+  percentage < 1 ? "<1%" : `${percentage.toFixed(0)}%`;
 class TransferDashboardCard extends React.Component<CombinedProps, State> {
   state: State = {
     loading: true,


### PR DESCRIPTION
## Purpose

On the Dashboard, replace the displayed bandwidth usage value with a percentage.
For values less than 1%, use a less-than sign