### PR TITLE
M3-1515 Create a unified volumes table- Styling Updates

### DIFF
--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -44,6 +44,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   button: {
     height: 26,
     width: 26,
+    padding: 0,
     '& svg': {
       fontSize: '28px',
     },

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -40,12 +40,32 @@ type ClassNames = 'root'
   | 'labelCol'
   | 'attachmentCol'
   | 'sizeCol'
-  | 'pathCol';
+  | 'pathCol'
+  | 'volumesWrapper'
+  | 'linodeVolumesWrapper';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
   title: {
     marginBottom: theme.spacing.unit * 2,
+  },
+  // styles for /volumes table
+  volumesWrapper: {
+  },
+  // styles for linodes/id/volumes table
+  linodeVolumesWrapper: {
+    '& $labelCol': {
+      width: '20%',
+      minWidth: 200,
+    },
+    '& $sizeCol': {
+      width: '15%',
+      minWidth: 100,
+    },
+    '& $pathCol': {
+      width: '55%',
+      minWidth: 350,
+    },
   },
   labelCol: {
     width: '15%',
@@ -275,7 +295,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           </Grid>
         </Grid>
         <Paper>
-          <Table aria-label="List of Volumes">
+          <Table aria-label="List of Volumes" className={isVolumesLanding ? classes.volumesWrapper : classes.linodeVolumesWrapper}>
             <TableHead>
               <TableRow>
                 <TableCell className={classes.labelCol}>Label</TableCell>


### PR DESCRIPTION
Updated the styling based on view, so the columns will be wider on `linodes/id/volumes` view than they are on `/volumes` (as they presently are today). I also updated the action menu padding, it was inheriting a new MUI style that was messing up alignment throughout the app.