### PR TITLE
M3 1769 Dismiss domain create drawer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { RegionsProvider, WithRegionsContext } from 'src/context/regions';
 import { TypesProvider, WithTypesContext } from 'src/context/types';
 import { events$ } from 'src/events';
 import BackupDrawer from 'src/features/Backups';
+import DomainCreateDrawer from 'src/features/Domains/DomainCreateDrawer';
 import Footer from 'src/features/Footer';
 import TheApplicationIsOnFire from 'src/features/TheApplicationIsOnFire';
 import ToastNotifications from 'src/features/ToastNotifications';
@@ -376,6 +377,7 @@ export class App extends React.Component<CombinedProps, State> {
                     onClose={this.closeWelcomeBanner}
                     data-qa-beta-notice />
                   <ToastNotifications />
+                  <DomainCreateDrawer />
                   <VolumeDrawer />
                   <BackupDrawer />
                 </div>

--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -337,17 +337,17 @@ const mapDispatchToProps = (dispatch: Dispatch<any>) => bindActionCreators(
 );
 
 interface StateProps {
-  domain: string;
-  cloneId: number;
   mode: typeof CLONING | typeof CREATING;
   open: boolean;
+  domain?: string;
+  cloneId?: number;
 }
 
 const mapStateToProps = (state: ApplicationState) => ({
-  domain: path(['domainDrawer', 'domain'], state),
-  cloneId: path(['domainDrawer', 'cloneId'], state),
   mode: path(['domainDrawer', 'mode'], state),
   open: path(['domainDrawer', 'open'], state),
+  domain: path(['domainDrawer', 'domain'], state),
+  cloneId: path(['domainDrawer', 'cloneId'], state),
 });
 
 const connected = connect(mapStateToProps, mapDispatchToProps);

--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -210,7 +210,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
     soa_email: 'SOA Email',
   };
 
-  reset = () => {
+  resetInternalState = () => {
     if (this.mounted) {
       this.setState({ ...this.defaultState });
     }
@@ -299,7 +299,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
   }
 
   closeDrawer = () => {
-    this.reset();
+    this.resetInternalState();
     this.props.resetDrawer();
   }
 

--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -344,8 +344,8 @@ interface StateProps {
 }
 
 const mapStateToProps = (state: ApplicationState) => ({
-  mode: path(['domainDrawer', 'mode'], state),
-  open: path(['domainDrawer', 'open'], state),
+  mode: pathOr(CREATING, ['domainDrawer', 'mode'], state),
+  open: pathOr(false, ['domainDrawer', 'open'], state),
   domain: path(['domainDrawer', 'domain'], state),
   cloneId: path(['domainDrawer', 'cloneId'], state),
 });

--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -352,7 +352,7 @@ const mapStateToProps = (state: ApplicationState) => ({
 
 const connected = connect(mapStateToProps, mapDispatchToProps);
 
-export default compose(
+export default compose<any, any, any, any>(
   styled,
   connected,
   withRouter

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -1,6 +1,6 @@
 import { compose } from 'ramda';
 import * as React from 'react';
-import { connect, Dispatch, MapStateToProps } from 'react-redux';
+import { connect, Dispatch } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import DomainIcon from 'src/assets/addnewmenu/domain.svg';

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -141,8 +141,10 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
 
   handleSuccess = (domain: Linode.Domain) => {
     if (domain.id) {
-      this.props.history.push(`/domains/${domain.id}`);
-      return;
+      this.setState({ createDrawer: { open: false, mode: 'create' }}, () => {
+        this.props.history.push(`/domains/${domain.id}`);
+        return;
+      });
     }
     this.props.request();
   }

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -287,7 +287,7 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
           copy="Adding a new domain is easy. Click below to add a domain."
           icon={DomainIcon}
           buttonProps={{
-            onClick: () => this.props.openForCreating(),
+            onClick: this.props.openForCreating,
             children: 'Add a Domain',
           }}
         />

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -135,7 +135,9 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
 
   onDomainSuccess = (domain:Linode.Domain) => {
     const id = domain.id ? domain.id : '';
-    this.props.history.push(`/domains/${id}`);
+    this.setState({ domainDrawerOpen: false }, () => {
+      this.props.history.push(`/domains/${id}`);
+    });
   }
 
   render() {

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -1,9 +1,10 @@
 import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUp from '@material-ui/icons/KeyboardArrowUp';
 import * as React from 'react';
-import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
+import { connect } from 'react-redux';
+import { Dispatch } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { compose } from 'redux';
+import { bindActionCreators, compose } from 'redux';
 import DomainIcon from 'src/assets/addnewmenu/domain.svg';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import NodebalancerIcon from 'src/assets/addnewmenu/nodebalancer.svg';
@@ -11,9 +12,8 @@ import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import Button from 'src/components/core/Button';
 import Menu from 'src/components/core/Menu';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
-import DomainCreateDrawer from 'src/features/Domains/DomainCreateDrawer';
-import { handleClose, handleOpen } from 'src/store/reducers/domainDrawer';
-import { openForCreating } from 'src/store/reducers/volumeDrawer';
+import { openForCreating as openDomainDrawerForCreating } from 'src/store/reducers/domainDrawer';
+import { openForCreating as openVolumeDrawerForCreating } from 'src/store/reducers/volumeDrawer';
 import AddNewMenuItem, { MenuItem } from './AddNewMenuItem';
 
 type CSSClasses = 'wrapper'
@@ -56,14 +56,14 @@ const styles: StyleRulesCallback = (theme) => ({
 });
 
 interface Props {
-  openForCreating: typeof openForCreating;
+  openVolumeDrawerForCreating: typeof openVolumeDrawerForCreating;
 }
 
 interface State {
   anchorEl?: HTMLElement;
 }
 
-type CombinedProps = Props & WithStyles<CSSClasses> & RouteComponentProps<{}> & DispatchProps & StateProps;
+type CombinedProps = Props & WithStyles<CSSClasses> & RouteComponentProps<{}> & DispatchProps;
 
 const styled = withStyles(styles);
 
@@ -86,7 +86,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
     {
       title: 'Volume',
       onClick: (e) => {
-        this.props.openForCreating();
+        this.props.openVolumeDrawerForCreating();
         this.handleClose();
         e.preventDefault();
       },
@@ -106,7 +106,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
     {
       title: 'Domain',
       onClick: (e) => {
-        this.props.actions.openDomainDrawer();
+        this.props.openDomainDrawerForCreating();
         this.handleClose();
         e.preventDefault();
       },
@@ -123,17 +123,9 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
     this.setState({ anchorEl: undefined });
   }
 
-  onDomainSuccess = (domain:Linode.Domain) => {
-    const id = domain.id ? domain.id : '';
-    this.props.actions.closeDomainDrawer();
-    this.props.history.push(`/domains/${id}`);
-    return;
-  }
-
   render() {
     const { anchorEl } = this.state;
-    const { classes, domainDrawerOpen } = this.props;
-    const { closeDomainDrawer } = this.props.actions;
+    const { classes } = this.props;
     const itemsLen = this.items.length;
 
     return (
@@ -173,12 +165,6 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
               {...i}
             />)}
         </Menu>
-        <DomainCreateDrawer
-          open={domainDrawerOpen}
-          onClose={closeDomainDrawer}
-          onSuccess={this.onDomainSuccess}
-          mode="create"
-        />
       </div>
 
     );
@@ -188,29 +174,16 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
 export const styledComponent = styled(AddNewMenu);
 
 interface DispatchProps {
-  actions: {
-    closeDomainDrawer: () => void;
-    openDomainDrawer: () => void;
-  },
+  openDomainDrawerForCreating: () => void;
+  openVolumeDrawerForCreating: () => void;
 }
 
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch, ownProps) => {
-  return {
-    actions: {
-      closeDomainDrawer: () => dispatch(handleClose()),
-      openDomainDrawer: () => dispatch(handleOpen()),
-    }
-  };
-};
-interface StateProps {
-  domainDrawerOpen: boolean;
-}
+const mapDispatchToProps = (dispatch: Dispatch<any>) => bindActionCreators(
+  { openDomainDrawerForCreating, openVolumeDrawerForCreating },
+  dispatch,
+);
 
-const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (state, ownProps) => ({
-  domainDrawerOpen: state.domainDrawer.open
-});
-
-const connected = connect(mapStateToProps, mapDispatchToProps);
+const connected = connect(undefined, mapDispatchToProps);
 
 export default compose(
   connected,

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -1,8 +1,7 @@
 import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUp from '@material-ui/icons/KeyboardArrowUp';
 import * as React from 'react';
-import { connect } from 'react-redux';
-import { Dispatch } from 'react-redux';
+import { connect, Dispatch } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { bindActionCreators, compose } from 'redux';
 import DomainIcon from 'src/assets/addnewmenu/domain.svg';

--- a/src/store/ApplicationState.d.ts
+++ b/src/store/ApplicationState.d.ts
@@ -10,6 +10,7 @@ declare interface ApplicationState {
   features: FeaturesState;
   volumeDrawer: VolumeDrawerState;
   notifications: RequestableData<Linode.Notification[]>;
+  domainDrawer: DomainDrawerState;
 }
 
 declare interface AuthState {
@@ -40,6 +41,10 @@ declare interface BackupDrawerState extends RequestableData<Linode.Linode[]> {
   autoEnroll: boolean;
   autoEnrollError?: string;
   enrolling: boolean;
+}
+
+declare interface DomainDrawerState {
+  open: boolean;
 }
 
 declare interface RequestableData<D> {

--- a/src/store/ApplicationState.d.ts
+++ b/src/store/ApplicationState.d.ts
@@ -45,6 +45,9 @@ declare interface BackupDrawerState extends RequestableData<Linode.Linode[]> {
 
 declare interface DomainDrawerState {
   open: boolean;
+  mode: string;
+  cloneId?: number;
+  domain?: string;
 }
 
 declare interface RequestableData<D> {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -21,7 +21,6 @@ const defaultState: ApplicationState = {
   volumeDrawer: defaultVolumeDrawerState,
   notifications: defaultNotificationState,
   domainDrawer: defaultDomainDrawerState
-
 };
 
 const reduxDevTools = (window as any).__REDUX_DEVTOOLS_EXTENSION__;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,6 +4,7 @@ import thunk from 'redux-thunk';
 import authentication, { defaultState as defaultAuthenticationState } from './reducers/authentication';
 import backups, { defaultState as defaultBackupState } from './reducers/backupDrawer';
 import documentation, { defaultState as defaultDocumentationState } from './reducers/documentation';
+import domainDrawer, { defaultState as defaultDomainDrawerState } from './reducers/domainDrawer';
 import features, { defaultState as defaultFeaturesState } from './reducers/features';
 import notifications, { DEFAULT_STATE as defaultNotificationState } from './reducers/notifications';
 import resources, { defaultState as defaultResourcesState } from './reducers/resources';
@@ -19,6 +20,8 @@ const defaultState: ApplicationState = {
   sidebar: defaultSidebarState,
   volumeDrawer: defaultVolumeDrawerState,
   notifications: defaultNotificationState,
+  domainDrawer: defaultDomainDrawerState
+
 };
 
 const reduxDevTools = (window as any).__REDUX_DEVTOOLS_EXTENSION__;
@@ -32,6 +35,7 @@ const reducers = combineReducers<ApplicationState>({
   sidebar,
   volumeDrawer,
   notifications,
+  domainDrawer
 });
 
 const enhancers = compose(

--- a/src/store/reducers/domainDrawer.test.ts
+++ b/src/store/reducers/domainDrawer.test.ts
@@ -1,0 +1,14 @@
+import reducer, { defaultState, handleClose, handleOpen } from './domainDrawer';
+
+describe('domainDrawer reducer', () => {
+
+  it('should handle OPEN', () => {
+    const newState = reducer(defaultState, handleOpen());
+    expect(newState).toHaveProperty('open', true);
+  });
+
+  it('should handle CLOSE', () => {
+    const newState = reducer(defaultState, handleClose());
+    expect(newState).toHaveProperty('open', false);
+  });
+});

--- a/src/store/reducers/domainDrawer.test.ts
+++ b/src/store/reducers/domainDrawer.test.ts
@@ -1,14 +1,37 @@
-import reducer, { defaultState, handleClose, handleOpen } from './domainDrawer';
+import reducer, {
+  CLONING,
+  closeDrawer,
+  CREATING,
+  defaultState,
+  openForCloning,
+  openForCreating,
+} from './domainDrawer';
 
 describe('domainDrawer reducer', () => {
-
-  it('should handle OPEN', () => {
-    const newState = reducer(defaultState, handleOpen());
+  it('should be OPEN when opening for creating', () => {
+    const newState = reducer(defaultState, openForCreating());
     expect(newState).toHaveProperty('open', true);
+    expect(newState.mode).toBe(CREATING);
+  });
+
+  it('should be OPEN when opening for cloning', () => {
+    const newState = reducer(defaultState, openForCloning());
+    expect(newState).toHaveProperty('open', true);
+    expect(newState.mode).toBe(CLONING);
+  });
+
+  it('should accept domain when cloning', () => {
+    const newState = reducer(defaultState, openForCloning('my-domain', 1234));
+    expect(newState.domain).toBe('my-domain');
+  });
+
+  it('should accept cloneId when cloning', () => {
+    const newState = reducer(defaultState, openForCloning('my-domain', 1234));
+    expect(newState.cloneId).toBe(1234);
   });
 
   it('should handle CLOSE', () => {
-    const newState = reducer(defaultState, handleClose());
+    const newState = reducer(defaultState, closeDrawer());
     expect(newState).toHaveProperty('open', false);
   });
 });

--- a/src/store/reducers/domainDrawer.ts
+++ b/src/store/reducers/domainDrawer.ts
@@ -1,0 +1,36 @@
+// ACTIONS
+export const OPEN = '@manager/domains/OPEN'
+export const CLOSE = '@manager/domains/CLOSE'
+
+type State = DomainDrawerState;
+
+interface Action {
+  type: string;
+  error?: Error;
+  data?: any;
+}
+
+type ActionCreator = (...args: any[]) => Action;
+
+// ACTION CREATORS
+export const handleOpen: ActionCreator = () => ({ type: OPEN });
+export const handleClose: ActionCreator = () => ({ type: CLOSE });
+
+// DEFAULT STATE
+export const defaultState: State = {
+  open: false,
+};
+
+export default (state: State = defaultState, action: Action) => {
+  switch (action.type) {
+    case OPEN:
+      return { ...state, lastUpdated: Date.now(), open: true,
+        error: undefined, enableErrors: [], autoEnrollError: undefined, autoEnroll: false };
+
+    case CLOSE:
+      return { ...state, lastUpdated: Date.now(), open: false, };
+
+    default:
+      return state;
+  }
+};

--- a/src/store/reducers/domainDrawer.ts
+++ b/src/store/reducers/domainDrawer.ts
@@ -1,34 +1,76 @@
+import { Action } from 'redux';
+
 // ACTIONS
 export const OPEN = '@manager/domains/OPEN'
 export const CLOSE = '@manager/domains/CLOSE'
+export const CREATING = '@manager/domains/CREATING';
+export const CLONING = '@manager/domains/CLONING';
+export const RESET = '@manager/domains/RESET';
 
 type State = DomainDrawerState;
 
-interface Action {
-  type: string;
-  error?: Error;
-  data?: any;
+interface Creating extends Action {
+  type: typeof CREATING;
+}
+interface Cloning extends Action {
+  type: typeof CLONING;
+  cloneId: number;
+  domain: string;
+}
+
+interface Close extends Action {
+  type: typeof CLOSE;
+}
+
+interface Reset extends Action {
+  type: typeof RESET;
 }
 
 type ActionCreator = (...args: any[]) => Action;
 
 // ACTION CREATORS
-export const handleOpen: ActionCreator = () => ({ type: OPEN });
-export const handleClose: ActionCreator = () => ({ type: CLOSE });
+export const openForCreating: ActionCreator = (): Creating => ({ type: CREATING });
+export const openForCloning: ActionCreator = (
+  domain: string,
+  cloneId: number
+  ): Cloning => ({
+    type: CLONING,
+    domain,
+    cloneId
+  });
+export const closeDrawer: ActionCreator = (): Close => ({ type: CLOSE });
+export const resetDrawer: ActionCreator = (): Reset => ({ type: RESET });
 
 // DEFAULT STATE
 export const defaultState: State = {
   open: false,
+  mode: CREATING
 };
 
-export default (state: State = defaultState, action: Action) => {
+type ActionTypes =
+  Creating
+| Cloning
+| Close
+| Reset
+
+export default (state: State = defaultState, action: ActionTypes) => {
   switch (action.type) {
-    case OPEN:
-      return { ...state, lastUpdated: Date.now(), open: true,
-        error: undefined, enableErrors: [], autoEnrollError: undefined, autoEnroll: false };
+    case CREATING:
+      return { mode: CREATING, open: true }
+
+    case CLONING:
+      return {
+        open: true,
+        mode: CLONING,
+        domain: action.domain,
+        cloneId: action.cloneId
+      }
 
     case CLOSE:
-      return { ...state, lastUpdated: Date.now(), open: false, };
+      return { ...state, open: false, };
+
+    case RESET:
+      return defaultState;
 
     default:
       return state;


### PR DESCRIPTION
## Purpose

This PR makes is so that `DomainCreateDrawer` closes upon success (after creating or cloning a domain). 

## Why so many changes?
Making this change was challenging because we navigate to `DomainDetails` upon success. BUT at the same time, we also need to close the drawer. 

We currently have two instances of `DomainCreateDrawer`. The one mounted on `AddNewMenu` plays nicely with this change, because that component is top-level, i.e. the routing change didn't affect it.

But the drawer mounted on `DomainsLanding` doesn't work with this change, because once the routing changed happens, _the drawer isn't mounted anymore._ This means that it simply disappears, which looks very choppy.

## Solution
My proposal is to have ONE `DomainCreateDrawer` which is at the App level (similar to `VolumeDrawer`). This means routing changes won't affect it. 

My hope is that in addition to smoothing out the transition, this is better to maintain.

## Notes
As this is my first foray using Redux in this codebase, feel free to especially rip this one apart.