### PR TITLE
M3-1904: add search by tag for NodeBalancers

### DIFF
--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -309,13 +309,20 @@ class SearchBar extends React.Component<CombinedProps, State> {
 
     if (this.state.nodebalancers) {
       const nodebalancersByLabel = this.state.nodebalancers.filter(
-        nodebal => nodebal.label.toLowerCase().includes(queryLower),
+        nodebal => {
+          const matchingTags = this.getMatchingTags(nodebal.tags || [], queryLower); // with temporary fallback while NodeBalancers don't have tags
+          const bool = or(
+            nodebal.label.toLowerCase().includes(queryLower),
+            matchingTags.length > 0
+          )
+          return bool;
+        }
       );
       searchResults.push(...(nodebalancersByLabel.map(nodebal => ({
         label: nodebal.label,
         value: nodebal.id,
         data: {
-          tags: [],
+          tags: nodebal.tags || [], // temporary fallback while NodeBalancers don't have tags
           description: nodebal.hostname,
           Icon: NodebalIcon,
           path: `/nodebalancers/${nodebal.id}`,


### PR DESCRIPTION
Adds searching by tag for NodeBalancers.
Uses temporary fallback with an empty array while we don't get that from the API.