### PR TITLE
M3-1871 Improve Tags styling

### DIFF
--- a/src/components/EnhancedSelect/components/MultiValue.tsx
+++ b/src/components/EnhancedSelect/components/MultiValue.tsx
@@ -32,6 +32,8 @@ class MultiValue extends React.PureComponent<CombinedProps> {
           tabIndex={-1}
           label={children}
           onDelete={this.onDelete}
+          component="div"
+          role="term"
         />
     );
   }

--- a/src/components/ShowMore/ShowMore.test.tsx
+++ b/src/components/ShowMore/ShowMore.test.tsx
@@ -22,7 +22,7 @@ describe('ShowMore', () => {
   });
 
   it('should render a chip with items.length', () => {
-    const chipText = wrapper.find('Chip div span').text();
+    const chipText = wrapper.find('Chip button span').text();
     expect(chipText).toBe('+2');
   });
 });

--- a/src/components/ShowMore/ShowMore.tsx
+++ b/src/components/ShowMore/ShowMore.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import Chip, { ChipProps } from 'src/components/core/Chip';
 import Popover from 'src/components/core/Popover';
@@ -7,15 +8,13 @@ type CSSClasses =  'chip' | 'label' | 'popover';
 
 const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   chip: {
-    top: -2,
     position: 'relative',
     marginLeft: theme.spacing.unit / 2,
-    paddingLeft: theme.spacing.unit / 2,
-    paddingRight: theme.spacing.unit / 2,
+    paddingLeft: 2,
+    paddingRight: 2,
     backgroundColor: theme.bg.lightBlue,
     fontWeight: 500,
     lineHeight: 1,
-    fontSize: '.9rem',
     '&:hover, &.active': {
       backgroundColor: theme.palette.primary.main,
       color: 'white',
@@ -28,13 +27,12 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   label: {
     paddingLeft: 6,
     paddingRight: 6,
-    fontSize: '.75rem',
   },
   popover: {
     minWidth: 'auto',
     maxWidth: 400,
     overflow: 'visible',
-    padding: theme.spacing.unit * 2,
+    padding: theme.spacing.unit,
     [theme.breakpoints.down('xs')]: {
       maxWidth: 285,
     },
@@ -50,20 +48,18 @@ interface Props<T> {
 class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
   state = {
     anchorEl: undefined,
-    classes: this.props.classes.chip,
   };
 
   handleClick = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault();
     this.setState({
       anchorEl: event.currentTarget,
-      classes: this.props.classes.chip + ' active',
     });
   }
 
   handleClose = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault();
-    this.setState({ anchorEl: undefined, classes: this.props.classes.chip });
+    this.setState({ anchorEl: undefined });
   }
 
   render() {
@@ -73,12 +69,20 @@ class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
     return (
       <React.Fragment>
         <Chip
-          className={this.state.classes}
+          className={classNames(
+            {
+              [classes.chip]: true,
+              'active': anchorEl,
+            },
+            'chip',
+          )}
           label={`+${items.length}`}
           classes={{ label: classes.label }}
           onClick={this.handleClick}
           {...chipProps}
           data-qa-show-more-chip
+          component="button"
+          clickable
         />
         <Popover
           classes={{ paper: classes.popover }}
@@ -87,11 +91,11 @@ class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
           onClose={this.handleClose}
           anchorOrigin={{
             vertical: 28,
-            horizontal: 'right',
+            horizontal: 'left',
           }}
           transformOrigin={{
             vertical: 'top',
-            horizontal: 'right',
+            horizontal: 'left',
           }}
         >
           {render(items)}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -112,6 +112,8 @@ class Tag extends React.Component<PropsWithStyles, {}> {
       deleteIcon={this.props.deleteIcon || <Close />}
       classes={{ label: classes.label, deletable: classes[colorVariant!]}}
       data-qa-tag={this.props.label}
+      component="div"
+      role="term"
     />;
   }
 };

--- a/src/components/Tags/Tags.tsx
+++ b/src/components/Tags/Tags.tsx
@@ -15,18 +15,11 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => {
   return ({
     root: {},
     tag: {
-      marginTop: theme.spacing.unit / 2,
-      marginRight: theme.spacing.unit,
-      padding: theme.spacing.unit / 2,
       backgroundColor: theme.color.grey2,
       color: theme.palette.text.primary,
       fontFamily: 'LatoWeb',
       '&:focus': {
         backgroundColor: theme.color.grey2,
-      },
-      '& > span': {
-        position: 'relative',
-        top: -2,
       },
     },
   });

--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -60,7 +60,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
       width: 34,
       height: 34,
     },
-    padding:0
+    padding: 0
   },
   label: {
     marginBottom: theme.spacing.unit,
@@ -83,7 +83,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   status: {
     marginLeft: theme.spacing.unit,
-    padding: theme.spacing.unit,
     color: theme.color.white,
   },
   open: {
@@ -329,7 +328,10 @@ export class SupportTicketDetail extends React.Component<CombinedProps,State> {
               [classes.open]: ticket.status === 'open' || ticket.status === 'new',
               [classes.closed]: ticket.status === 'closed',
             })}
-            label={ticket.status} />
+              label={ticket.status}
+              component="div"
+              role="term"
+            />
           </Grid>
         </Grid>
 

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -28,6 +28,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   },
   root: {
     marginBottom: theme.spacing.unit / 2,
+    width: '100%',
     '&:last-child': {
       marginBottom: 0,
     },

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -25,7 +25,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   tagWrapper: {
     marginTop: theme.spacing.unit / 2,
     marginLeft: theme.spacing.unit * 4,
-    '& [class*="MuiChip"]': {
+    '& .chip': {
       cursor: 'pointer',
     },
   },

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -333,9 +333,20 @@ const themeDefaults: ThemeOptions = {
     MuiChip: {
       root: {
         backgroundColor: '#f4f4f4',
-        height: 24,
+        height: 20,
+        display: 'inline-flex',
+        alignItems: 'center',
         borderRadius: 4,
+        marginTop: 2,
+        marginBottom: 2,
+        marginRight: 4,
+        paddingLeft: 2,
+        paddingRight: 2,
         color: '#555',
+        fontSize: '.8rem',
+        '&:last-child': {
+          marginRight: 0
+        },
         '&:hover': {
           '& $deleteIcon': {
             color: primaryColors.text,
@@ -345,8 +356,8 @@ const themeDefaults: ThemeOptions = {
       label: {
         paddingLeft: 4,
         paddingRight: 4,
-        fontSize: '.9rem',
         position: 'relative',
+        top: -1,
       },
       deleteIcon: {
         color: '#aaa',


### PR DESCRIPTION
This PR covers few stories related to the display of tags through the app:

- Show More tag wrapping
- Show more popup placement
- Chip markup (changed from button to div unless clickable)
- Chip padding and font-size
- Styling error on theme switch with Show More button