### PR TITLE
M3-1889 tests for auto backup enrollment M3-1789 and M3-1793 

### DIFF
--- a/e2e/config/custom-commands.js
+++ b/e2e/config/custom-commands.js
@@ -11,7 +11,8 @@ const {
     getMyStackScripts,
     removeStackScript,
     getUserProfile,
-    updateUserProfile
+    updateUserProfile,
+    updateGlobalSettings
 } = require('../setup/setup');
 
 const {
@@ -196,6 +197,11 @@ exports.browserCommands = () => {
 
     browser.addCommand('updateUserProfile', function async(token,profileData) {
         return updateUserProfile(token,profileData)
+            .then(res => res);
+    });
+
+    browser.addCommand('updateGlobalSettings', function async(token, settingsData) {
+        return putGlobalSetting(token,settingsData)
             .then(res => res);
     });
 }

--- a/e2e/config/custom-commands.js
+++ b/e2e/config/custom-commands.js
@@ -12,7 +12,7 @@ const {
     removeStackScript,
     getUserProfile,
     updateUserProfile,
-    updateGlobalSettings
+    putGlobalSetting
 } = require('../setup/setup');
 
 const {

--- a/e2e/config/custom-commands.js
+++ b/e2e/config/custom-commands.js
@@ -12,7 +12,8 @@ const {
     removeStackScript,
     getUserProfile,
     updateUserProfile,
-    putGlobalSetting
+    putGlobalSetting,
+    getGlobalSettings
 } = require('../setup/setup');
 
 const {
@@ -202,6 +203,11 @@ exports.browserCommands = () => {
 
     browser.addCommand('updateGlobalSettings', function async(token, settingsData) {
         return putGlobalSetting(token,settingsData)
+            .then(res => res);
+    });
+
+    browser.addCommand('getGlobalSettings', function async(token) {
+        return getGlobalSettings(token)
             .then(res => res);
     });
 }

--- a/e2e/pageobjects/account/global-settings.page.js
+++ b/e2e/pageobjects/account/global-settings.page.js
@@ -3,15 +3,15 @@ const { constants } = require('../../constants');
 import Page from '../page';
 
 class GlobalSettings extends Page {
-  get enrollInNewLinodesAutoBackupsToggle() { return $('[heading="Backup Auto Enrollment"] [data-qa-toggle]'); }
-  get networkHelperToggle() { return $('[heading="Network Helper"] [data-qa-toggle]'); }
-  get panelLinkSelector() { return '[data-qa-grid-item] p a'; }
-  get backupPricingPage() { return $$(this.panelLinkSelector)[0]; }
-  get openEnableBackupsForAllLinodesDrawer() { return $$(this.panelLinkSelector)[1]; }
+  get enrollInNewLinodesAutoBackupsToggle() { return $('[data-qa-toggle-auto-backup]'); }
+  get networkHelperToggle() { return $('[data-qa-toggle-network-helper]'); }
+  get backupPricingPage() { return $('[data-qa-backups-price]'); }
+  get enableBackupsForAllLinodesDrawer() { return $('[data-qa-backups-drawer]'); }
 
   baseElementsDisplay(){
       this.enrollInNewLinodesAutoBackupsToggle.waitForVisible(constants.wait.normal);
       this.networkHelperToggle.waitForVisible(constants.wait.normal);
+      this.backupPricingPage.waitForVisible(constants.wait.normal);
   }
 }
 

--- a/e2e/pageobjects/account/global-settings.page.js
+++ b/e2e/pageobjects/account/global-settings.page.js
@@ -1,0 +1,18 @@
+const { constants } = require('../../constants');
+
+import Page from '../page';
+
+class GlobalSettings extends Page {
+  get enrollInNewLinodesAutoBackupsToggle() { return $('[heading="Backup Auto Enrollment"] [data-qa-toggle]'); }
+  get networkHelperToggle() { return $('[heading="Network Helper"] [data-qa-toggle]'); }
+  get panelLinkSelector() { return '[data-qa-grid-item] p a'; }
+  get backupPricingPage() { return $$(this.panelLinkSelector)[0]; }
+  get openEnableBackupsForAllLinodesDrawer() { return $$(this.panelLinkSelector)[1]; }
+
+  baseElementsDisplay(){
+      this.enrollInNewLinodesAutoBackupsToggle.waitForVisible(constants.wait.normal);
+      this.networkHelperToggle.waitForVisible(constants.wait.normal);
+  }
+}
+
+export default new GlobalSettings();

--- a/e2e/pageobjects/account/global-settings.page.js
+++ b/e2e/pageobjects/account/global-settings.page.js
@@ -6,7 +6,7 @@ class GlobalSettings extends Page {
   get enrollInNewLinodesAutoBackupsToggle() { return $('[data-qa-toggle-auto-backup]'); }
   get networkHelperToggle() { return $('[data-qa-toggle-network-helper]'); }
   get backupPricingPage() { return $('[data-qa-backups-price]'); }
-  get enableBackupsForAllLinodesDrawer() { return $('[data-qa-backups-drawer]'); }
+  get enableBackupsForAllLinodesDrawer() { return $(this.enableAllBackups.selector); }
 
   baseElementsDisplay(){
       this.enrollInNewLinodesAutoBackupsToggle.waitForVisible(constants.wait.normal);

--- a/e2e/pageobjects/configure-linode.js
+++ b/e2e/pageobjects/configure-linode.js
@@ -63,6 +63,8 @@ class ConfigureLinode extends Page {
 
     get addonsHeader() { return $('[data-qa-add-ons]'); }
     get addons() { return $$('[data-qa-add-ons] [data-qa-checked]');  }
+    get backupsCheckBox() { return $('[data-qa-check-backups]'); }
+    get privateIpCheckbox() { return $('[data-qa-check-private-ip]'); }
 
     get orderSummary() { return $('[data-qa-order-summary]'); }
     get total() { return $('[data-qa-total-price]'); }

--- a/e2e/pageobjects/dashboard.page.js
+++ b/e2e/pageobjects/dashboard.page.js
@@ -1,7 +1,6 @@
 const { constants } = require('../constants');
 
 import Page from './page';
-import EnableAllBackupsDrawer from './enable-all-backups-drawer';
 
 export class Dashboard extends Page {
     get header() { return $('[data-qa-dashboard-header]'); }

--- a/e2e/pageobjects/dashboard.page.js
+++ b/e2e/pageobjects/dashboard.page.js
@@ -1,6 +1,7 @@
 const { constants } = require('../constants');
 
 import Page from './page';
+import EnableAllBackupsDrawer from './enable-all-backups-drawer';
 
 export class Dashboard extends Page {
     get header() { return $('[data-qa-dashboard-header]'); }
@@ -36,7 +37,8 @@ export class Dashboard extends Page {
     get readMore() { return $('[data-qa-read-more]'); }
     get autoBackupEnrollmentCTA() { return $('[data-qa-account-link]'); }
     get backupExistingLinodes() { return $('[data-qa-backup-existing]'); }
-    
+    get backupExistingMessage() { return $('[data-qa-linodes-message]'); }
+
     baseElemsDisplay() {
         this.header.waitForVisible(constants.wait.normal);
 
@@ -44,6 +46,7 @@ export class Dashboard extends Page {
         expect(this.volumesCard.isVisible()).toBe(true);
         expect(this.nodebalancerCard.isVisible()).toBe(true);
         expect(this.domainsCard.isVisible()).toBe(true);
+        this.blogCard.waitForVisible(constants.wait.normal);
         expect(this.blogCard.isVisible()).toBe(true);
         expect(this.readMore.isVisible()).toBe(true);
     }

--- a/e2e/pageobjects/dashboard.page.js
+++ b/e2e/pageobjects/dashboard.page.js
@@ -36,7 +36,7 @@ export class Dashboard extends Page {
 
     get readMore() { return $('[data-qa-read-more]'); }
     get autoBackupEnrollmentCTA() { return $('[data-qa-account-link]'); }
-    get backupExistingLinodes() { return $('[data-qa-backup-existing]'); }
+    get backupExistingLinodes() { return $(this.enableAllBackups.selector); }
     get backupExistingMessage() { return $('[data-qa-linodes-message]'); }
 
     baseElemsDisplay() {

--- a/e2e/pageobjects/dashboard.page.js
+++ b/e2e/pageobjects/dashboard.page.js
@@ -4,7 +4,7 @@ import Page from './page';
 
 export class Dashboard extends Page {
     get header() { return $('[data-qa-dashboard-header]'); }
-    
+
     get linodesCard() { return $('[data-qa-card="Linodes"]'); }
     get linodes() { return $('[data-qa-linode]'); }
     get linodePlan() { return $('[data-qa-linode-plan]'); }
@@ -14,7 +14,7 @@ export class Dashboard extends Page {
     get volumes() { return $$('[data-qa-volume]'); }
     get volumeRegion() { return $('[data-qa-volume-region]'); }
     get volumeStatus() { return $('[data-qa-volume-status]'); }
-    
+
     get nodebalancerCard() { return $('[data-qa-card="NodeBalancers"]'); }
     get nodebalancers() { return $$('[data-qa-node]'); }
     get nodeHostname() { return $('[data-qa-node-hostname]'); }
@@ -34,10 +34,12 @@ export class Dashboard extends Page {
     get postDescription() { return $('[data-qa-post-desc]'); }
 
     get readMore() { return $('[data-qa-read-more]'); }
-
+    get autoBackupEnrollmentCTA() { return $('[data-qa-account-link]'); }
+    get backupExistingLinodes() { return $('[data-qa-backup-existing]'); }
+    
     baseElemsDisplay() {
         this.header.waitForVisible(constants.wait.normal);
-        
+
         expect(this.linodesCard.isVisible()).toBe(true);
         expect(this.volumesCard.isVisible()).toBe(true);
         expect(this.nodebalancerCard.isVisible()).toBe(true);

--- a/e2e/pageobjects/enable-all-backups-drawer.js
+++ b/e2e/pageobjects/enable-all-backups-drawer.js
@@ -7,6 +7,7 @@ class EnableAllBackupsDrawer extends Page {
     get linodeLabel() { return $$(`${this.linodeTableBase} [data-qa-linode-label]`); }
     get linodePlan() { return $$(`${this.linodeTableBase} [data-qa-linode-plan]`); }
     get linodeType() { return $$(`${this.linodeTableBase} [data-qa-linode-plan]`); }
+    get enableAutoBackupsToggle() { return $(`${this.drawerBase.selector} ${this.toggleOption.selector}`)}
     get backupPricingPage() { return $('[data-qa-backups-price]'); }
     get countLinodesToBackup() { return $('[data-qa-backup-count]'); }
 

--- a/e2e/pageobjects/enable-all-backups-drawer.js
+++ b/e2e/pageobjects/enable-all-backups-drawer.js
@@ -1,0 +1,28 @@
+const { constants } = require('../constants');
+import Page from './page';
+
+class EnableAllBackupsDrawer extends Page {
+    get linodeTableBase() { return '[data-qa-linodes]'; }
+    get linodesTable() { return $$(this.linodeTableBase); }
+    get linodeLabel() { return $$(`${this.linodeTableBase} [data-qa-linode-label]`); }
+    get linodePlan() { return $$(`${this.linodeTableBase} [data-qa-linode-plan]`); }
+    get linodeType() { return $$(`${this.linodeTableBase} [data-qa-linode-plan]`); }
+    get backupPricingPage() { return $('[data-qa-backups-price]'); }
+    get countLinodesToBackup() { return $('[data-qa-backup-count]'); }
+
+    enableAllBackupsDrawerDisplays(notAutoBackupEnabled) {
+        this.drawerBase.waitForVisible(constants.wait.normal);
+        this.countLinodesToBackup.waitForVisible(constants.wait.normal);
+        browser.waitUntil(() => {
+            return this.linodesTable.length > 0;
+        },constants.wait.normal);
+        if(notAutoBackupEnabled) {
+            this.toggleOption.waitForVisible(constants.wait.normal);
+            this.backupPricingPage.waitForVisible(constants.wait.normal);
+        }
+        this.submitButton.waitForVisible(constants.wait.normal);
+        this.cancelButton.waitForVisible(constants.wait.normal);
+    }
+}
+
+export default new EnableAllBackupsDrawer();

--- a/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
@@ -31,8 +31,8 @@ export class VolumeDetail extends Page {
     get cloneLabel() { return $('[data-qa-clone-from] input'); }
     get copyToolTips() { return $$('[data-qa-copy-tooltip]'); }
     get configHelpMessages() { return $$('[data-qa-config-help-msg]'); }
-    get volumePrice() { return $('[qa-data-price]'); }
-    get volumePriceBillingInterval() { return $('[qa-data-billing-interval]'); }
+    get volumePrice() { return $(this.drawerPrice.selector); }
+    get volumePriceBillingInterval() { return $(this.drawerBillingInterval.selector); }
 
     volAttachedToLinode(linodeLabel) {
         browser.waitUntil(function() {

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -43,6 +43,7 @@ export default class Page {
     get drawerBase() { return $('[data-qa-drawer]'); }
     get drawerPrice() { return $('[qa-data-price]'); }
     get drawerBillingInterval() { return $('[qa-data-billing-interval]'); }
+    get enableAllBackups() { return $('[data-qa-backup-existing]'); }
 
     // Breadcrumb Component
     get breadcrumbEditableText() { return $('[data-qa-editable-text]'); }

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -39,6 +39,10 @@ export default class Page {
     get popoverMsg() { return $('[role="tooltip"]'); }
     get submitButton () { return $('[data-qa-submit]'); }
     get cancelButton() { return $('[data-qa-cancel]'); }
+    get linearProgress() { return $('[data-qa-linear-progress]'); }
+    get drawerBase() { return $('[data-qa-drawer]'); }
+    get drawerPrice() { return $('[qa-data-price]'); }
+    get drawerBillingInterval() { return $('[qa-data-billing-interval]'); }
 
     // Breadcrumb Component
     get breadcrumbEditableText() { return $('[data-qa-editable-text]'); }

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -136,8 +136,6 @@ exports.createLinode = (token, password, linodeLabel, tags) => {
             linodeConfig['tags'] = tags;
         }
 
-        console.log(linodeConfig);
-
         return getAxiosInstance(token).post(linodesEndpoint, linodeConfig)
             .then(response => {
                 resolve(response.data);
@@ -404,9 +402,23 @@ exports.updateUserProfile = (token, profileData) => {
 exports.putGlobalSetting = (token, settingsData) => {
     return new Promise((resolve, reject) => {
         const endpoint = '/account/settings';
-        console.log(settingsData);
+
         return getAxiosInstance(token)
             .put(endpoint,settingsData)
+            .then(response => resolve(response.data))
+            .catch(error => {
+                console.error("Error", error);
+                reject(error);
+            });
+    });
+}
+
+exports.getGlobalSettings = (token) => {
+    return new Promise((resolve, reject) => {
+        const endpoint = '/account/settings';
+
+        return getAxiosInstance(token)
+            .get(endpoint)
             .then(response => resolve(response.data))
             .catch(error => {
                 console.error("Error", error);

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -136,6 +136,8 @@ exports.createLinode = (token, password, linodeLabel, tags) => {
             linodeConfig['tags'] = tags;
         }
 
+        console.log(linodeConfig);
+
         return getAxiosInstance(token).post(linodesEndpoint, linodeConfig)
             .then(response => {
                 resolve(response.data);
@@ -399,10 +401,10 @@ exports.updateUserProfile = (token, profileData) => {
     });
 }
 
-exports.updateGlobalSettings = (token, settingsData) => {
+exports.putGlobalSetting = (token, settingsData) => {
     return new Promise((resolve, reject) => {
         const endpoint = '/account/settings';
-
+        console.log(settingsData);
         return getAxiosInstance(token)
             .put(endpoint,settingsData)
             .then(response => resolve(response.data))

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -125,7 +125,7 @@ exports.createLinode = (token, password, linodeLabel, tags) => {
             image: 'linode/debian9',
             region: 'us-east',
             root_pass: password,
-            type: 'g6-standard-1'
+            type: 'g6-nanode-1'
         }
 
         if (linodeLabel !== false) {
@@ -391,6 +391,20 @@ exports.updateUserProfile = (token, profileData) => {
 
         return getAxiosInstance(token)
             .put(endpoint,profileData)
+            .then(response => resolve(response.data))
+            .catch(error => {
+                console.error("Error", error);
+                reject(error);
+            });
+    });
+}
+
+exports.updateGlobalSettings = (token, settingsData) => {
+    return new Promise((resolve, reject) => {
+        const endpoint = '/account/settings';
+
+        return getAxiosInstance(token)
+            .put(endpoint,settingsData)
             .then(response => resolve(response.data))
             .catch(error => {
                 console.error("Error", error);

--- a/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
+++ b/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
@@ -90,7 +90,7 @@ describe('Backup Auto Enrollment Suite', () => {
         EnableAllBackupsDrawer.drawerBase.waitForVisible(constants.wait.normal,true);
     });
 
-    it('Enable backup auto enrollment toggel', () => {
+    it('Enable backup auto enrollment toggle', () => {
         GlobalSettings.enrollInNewLinodesAutoBackupsToggle.click();
         browser.waitUntil(() => {
             return GlobalSettings.enrollInNewLinodesAutoBackupsToggle.getAttribute('data-qa-toggle') === 'true';

--- a/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
+++ b/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
@@ -2,21 +2,31 @@ const { constants } = require('../../constants');
 import {
     apiCreateLinode,
     updateGlobalSettings,
-    timestamp
+    timestamp,
+    retrieveGlobalSettings
 } from '../../utils/common';
 import Dashboard from '../../pageobjects/dashboard.page';
 import GlobalSettings from '../../pageobjects/account/global-settings.page';
 import ListLinodes from '../../pageobjects/list-linodes';
+import EnableAllBackupsDrawer from '../../pageobjects/enable-all-backups-drawer';
 
 describe('Backup Auto Enrollment Suite', () => {
-    const disableAutoEnrollment = { backups_enabled: false };
+    const disableAutoEnrollment = { 'backups_enabled': false };
     const linodeLabel = `TestLinode${timestamp()}`;
 
+    const checkBackupPricingPageLink = () => {
+        browser.debug();
+        browser.waitUntil(() => {
+            return browser.windowHandles().value.length === 2;
+        }, constants.wait.normal);
+        browser.switchTab();
+        expect(browser.getTitle()).toEqual('Protect Your Data with Backups - Linode');
+        browser.close();
+    }
+
     beforeAll(() => {
-        const settins = updateGlobalSettings(disableAutoEnrollment);
-        console.log(settings);
-        const linode = apiCreateLinode(linodeLabel);
-        console.log(linode);
+        updateGlobalSettings(disableAutoEnrollment);
+        apiCreateLinode(linodeLabel);
         browser.url(constants.routes.dashboard);
     });
 
@@ -24,9 +34,60 @@ describe('Backup Auto Enrollment Suite', () => {
         updateGlobalSettings(disableAutoEnrollment);
     });
 
-    it('Enable backups for existing and backup auto enrollment CTA should display on dashboard', () => {
+    it('Enable backups for existing linodes and backup auto enrollment CTA should display on dashboard', () => {
         Dashboard.baseElemsDisplay();
         expect(Dashboard.autoBackupEnrollmentCTA.isVisible()).toBe(true);
         expect(Dashboard.backupExistingLinodes.isVisible()).toBe(true);
+    });
+
+    it('Enable backups for existing linodes card should display the number of linodes that are not yet backedup', () => {
+        expect(Dashboard.backupExistingMessage.isVisible()).toBe(true);
+        const notBackedUpCount = Dashboard.backupExistingMessage.getText().replace( /\D/g, '');
+        expect(notBackedUpCount).toEqual('1');
+    });
+
+    it('Enable all backups drawer opens when the backup existing linodes link is selected', () => {
+        Dashboard.backupExistingLinodes.click();
+        EnableAllBackupsDrawer.enableAllBackupsDrawerDisplays(true);
+        expect(EnableAllBackupsDrawer.drawerTitle.getText()).toEqual('Enable All Backups');
+    });
+
+    it('Enable all backups drawer contains an external link to the backup pricing page', () => {
+        EnableAllBackupsDrawer.backupPricingPage.click();
+        checkBackupPricingPageLink();
+        EnableAllBackupsDrawer.enableAllBackupsDrawerDisplays(true);
+    });
+
+    it('Enable all backups drawer displays the count of linodes to be backed up in message and linodes to be backedup', () => {
+        expect(EnableAllBackupsDrawer.countLinodesToBackup.getText()).toEqual('1');
+        expect(EnableAllBackupsDrawer.linodeLabel[0].getText()).toEqual(linodeLabel);
+        EnableAllBackupsDrawer.drawerClose.click();
+        EnableAllBackupsDrawer.drawerBase.waitForVisible(constants.wait.normal,true);
+    });
+
+    it('Backup auto enrollment CTA should link to globabl settings page', () => {
+        Dashboard.autoBackupEnrollmentCTA.click();
+        GlobalSettings.baseElementsDisplay();
+    });
+
+    it('The gloabal settings page contains an external link to the backups pricing page', () => {
+        GlobalSettings.backupPricingPage.click();
+        checkBackupPricingPageLink();
+        GlobalSettings.baseElementsDisplay();
+    });
+
+    it('The enable all backups drawer can be opened from the global settings page if auto backups is not enabled and there are linodes not backed up', () => {
+        GlobalSettings.enableBackupsForAllLinodesDrawer.click();
+        EnableAllBackupsDrawer.enableAllBackupsDrawerDisplays(true);
+        EnableAllBackupsDrawer.drawerClose.click();
+        EnableAllBackupsDrawer.drawerBase.waitForVisible(constants.wait.normal,true);
+    });
+
+    it('Enable backup auto enrollment toggel', () => {
+        GlobalSettings.enrollInNewLinodesAutoBackupsToggle.click();
+        browser.waitUntil(() => {
+            return GlobalSettings.enrollInNewLinodesAutoBackupsToggle.getAttribute('data-qa-toggle') === 'true';
+        }, constants.wait.normal);
+        expect(browser.get)
     });
 });

--- a/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
+++ b/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
@@ -65,7 +65,7 @@ describe('Backup Auto Enrollment Suite', () => {
         EnableAllBackupsDrawer.enableAllBackupsDrawerDisplays(true);
     });
 
-    it('Enable all backups drawer displays the count of linodes to be backed up in message and linodes to be backedup', () => {
+    it('Enable all backups drawer displays the count of linodes to be backed up in message and linodes to be backed up', () => {
         expect(EnableAllBackupsDrawer.countLinodesToBackup.getText()).toEqual('1');
         expect(EnableAllBackupsDrawer.linodeLabel[0].getText()).toEqual(linodeLabel);
         EnableAllBackupsDrawer.drawerClose.click();
@@ -77,7 +77,7 @@ describe('Backup Auto Enrollment Suite', () => {
         GlobalSettings.baseElementsDisplay();
     });
 
-    it('The gloabal settings page contains an external link to the backups pricing page', () => {
+    it('The global settings page contains an external link to the backups pricing page', () => {
         GlobalSettings.backupPricingPage.click();
         checkBackupPricingPageLink();
         GlobalSettings.baseElementsDisplay();
@@ -99,9 +99,7 @@ describe('Backup Auto Enrollment Suite', () => {
     });
 
     it('Backups should be enabled when creating a new linode and checkbox', () => {
-        GlobalSettings.globalCreate.click();
-        GlobalSettings.addLinodeMenu.waitForVisible(constants.wait.normal);
-        GlobalSettings.addLinodeMenu.click();
+        GlobalSettings.selectGlobalCreateItem('Linode');
         ConfigureLinode.baseDisplay();
         ConfigureLinode.backupsCheckBox.waitForVisible(constants.wait.normal);
         expect(ConfigureLinode.backupsCheckBox.getAttribute('data-qa-check-backups')).toEqual('auto backup enabled');

--- a/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
+++ b/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
@@ -20,8 +20,8 @@ describe('Backup Auto Enrollment Suite', () => {
     const checkBackupPricingPageLink = () => {
         const start = new Date().getTime();
         browser.waitUntil(() => {
-            //wait 5 seconds for page load
-            return browser.getTabIds().length === 2 && (new Date().getTime() - start) > 5000;
+            //wait 3 seconds for page load
+            return browser.getTabIds().length === 2 && (new Date().getTime() - start) > 3000;
         }, constants.wait.normal);
         const tabs = browser.getTabIds();
         const manager = tabs[0];
@@ -135,7 +135,7 @@ describe('Backup Auto Enrollment Suite', () => {
         Backups.baseElemsDisplay(false);
     });
 
-    it('BEnable backups for existing linodes CTA should no longer display on dashboard there are no linodes to backup', () => {
+    it('Enable backups for existing linodes CTA should no longer display on dashboard there are no linodes to backup', () => {
         browser.url(constants.routes.dashboard);
         Dashboard.baseElemsDisplay();
         expect(Dashboard.backupExistingLinodes.isVisible()).toBe(false);

--- a/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
+++ b/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
@@ -135,7 +135,7 @@ describe('Backup Auto Enrollment Suite', () => {
         Backups.baseElemsDisplay(false);
     });
 
-    it('Enable backups for existing linodes CTA should no longer display on dashboard there are no linodes to backup', () => {
+    it('Enable backups for existing linodes CTA should no longer display on dashboard if there are no linodes to backup', () => {
         browser.url(constants.routes.dashboard);
         Dashboard.baseElemsDisplay();
         expect(Dashboard.backupExistingLinodes.isVisible()).toBe(false);

--- a/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
+++ b/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
@@ -1,0 +1,32 @@
+const { constants } = require('../../constants');
+import {
+    apiCreateLinode,
+    updateGlobalSetting,
+    timestamp
+} from '../../utils/common';
+import Dashboard from '../../pageobjects/dashboard.page';
+import GlobalSettings from '../../pageobjects/account/global-settings.page';
+import ListLinodes from '../../pageobjects/list-linodes';
+
+describe('Backup Auto Enrollment Suite', () => {
+    const enableBackupsData = { backups_enabled: false };
+    const linodeLabel = `TestLinode${timestamp()}`;
+
+    beforeAll(() => {
+      const settings = updateGlobalSetting(enableBackupsData);
+      console.log(settings);
+      const linode = apiCreateLinode(linodeLabel);
+      console.log(linode);
+      browser.url(constants.routes.dashboard);
+    });
+
+    afterAll(() => {
+        updateGlobalSettings(enableBackupsData);
+    });
+
+    it('Enable backups for existing and backup auto enrollment CTA should display on dashboard', () => {
+        Dashboard.baseElemsDisplay();
+        expect(Dashboard.autoBackupEnrollmentCTA.isVisible()).toBe(true);
+        expect(Dashboard.backupExistingLinodes.isVisible()).toBe(true);
+    });
+});

--- a/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
+++ b/e2e/specs/globalsettings/auto-backup-enrollment.spec.js
@@ -1,7 +1,7 @@
 const { constants } = require('../../constants');
 import {
     apiCreateLinode,
-    updateGlobalSetting,
+    updateGlobalSettings,
     timestamp
 } from '../../utils/common';
 import Dashboard from '../../pageobjects/dashboard.page';
@@ -9,19 +9,19 @@ import GlobalSettings from '../../pageobjects/account/global-settings.page';
 import ListLinodes from '../../pageobjects/list-linodes';
 
 describe('Backup Auto Enrollment Suite', () => {
-    const enableBackupsData = { backups_enabled: false };
+    const disableAutoEnrollment = { backups_enabled: false };
     const linodeLabel = `TestLinode${timestamp()}`;
 
     beforeAll(() => {
-      const settings = updateGlobalSetting(enableBackupsData);
-      console.log(settings);
-      const linode = apiCreateLinode(linodeLabel);
-      console.log(linode);
-      browser.url(constants.routes.dashboard);
+        const settins = updateGlobalSettings(disableAutoEnrollment);
+        console.log(settings);
+        const linode = apiCreateLinode(linodeLabel);
+        console.log(linode);
+        browser.url(constants.routes.dashboard);
     });
 
     afterAll(() => {
-        updateGlobalSettings(enableBackupsData);
+        updateGlobalSettings(disableAutoEnrollment);
     });
 
     it('Enable backups for existing and backup auto enrollment CTA should display on dashboard', () => {

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -146,5 +146,11 @@ export const updateProfile = (profileDate) => {
 export const updateGlobalSettings = (settingsData) => {
     const token = readToken(browser.options.testUser);
     const settings = browser.updateGlobalSettings(token,settingsData);
-    return profile;
+    return settings;
+}
+
+export const retrieveGlobalSettings = () => {
+    const token = readToken(browser.options.testUser);
+    const settings = browser.getGlobalSettings(token);
+    return settings;
 }

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -8,8 +8,7 @@ const {
     getPublicKeys,
     removePublicKey,
     updateUserProfile,
-    getUserProfile,
-    updateGlobalSettings
+    getUserProfile
 } = require('../setup/setup');
 
 import ConfigureLinode from '../pageobjects/configure-linode';
@@ -144,7 +143,7 @@ export const updateProfile = (profileDate) => {
     return profile;
 }
 
-export const updateGlobalSetting = (settingsData) => {
+export const updateGlobalSettings = (settingsData) => {
     const token = readToken(browser.options.testUser);
     const settings = browser.updateGlobalSettings(token,settingsData);
     return profile;

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -8,7 +8,8 @@ const {
     getPublicKeys,
     removePublicKey,
     updateUserProfile,
-    getUserProfile
+    getUserProfile,
+    updateGlobalSettings
 } = require('../setup/setup');
 
 import ConfigureLinode from '../pageobjects/configure-linode';
@@ -140,5 +141,11 @@ export const getProfile = () => {
 export const updateProfile = (profileDate) => {
     const token = readToken(browser.options.testUser);
     const profile = browser.updateUserProfile(token,profileDate);
+    return profile;
+}
+
+export const updateGlobalSetting = (settingsData) => {
+    const token = readToken(browser.options.testUser);
+    const settings = browser.updateGlobalSettings(token,settingsData);
     return profile;
 }

--- a/e2e/utils/config-utils.js
+++ b/e2e/utils/config-utils.js
@@ -67,6 +67,7 @@ exports.login = (username, password, credFilePath) => {
         }
     }
 
+    browser.debug();
     if (browser.isExisting('.Modal')) {
         browser.click('.btn-primary');
     }

--- a/e2e/utils/config-utils.js
+++ b/e2e/utils/config-utils.js
@@ -67,7 +67,6 @@ exports.login = (username, password, credFilePath) => {
         }
     }
 
-    browser.debug();
     if (browser.isExisting('.Modal')) {
         browser.click('.btn-primary');
     }

--- a/scripts/e2e-modified.sh
+++ b/scripts/e2e-modified.sh
@@ -1,9 +1,8 @@
 GET_ORIGIN=$(git remote -v | grep git@github.com:linode/manager.git)
 if [[ -z $GET_ORIGIN ]]; then
-  GET_ORIGIN=$(git remote -v | grep https://github.com/linode/manager.git)
+  GET_ORIGIN=$(git remote -v | grep https://github.com/linode/manager)
 fi
 set -- $GET_ORIGIN
 ORIGIN=$1
-echo $ORIGIN
 git fetch $ORIGIN
 yarn e2e --spec=$(git diff --name-only $ORIGIN/develop | egrep 'e2e/specs/.*\/*spec.js' | tr '\n' ',' | sed 's/.$//')

--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -61,7 +61,7 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
               This controls whether Linode Backups are enabled, by default, for all Linodes when
               they are initially created. For each Linode with Backups enabled, your account will
               be billed the additional hourly rate noted on the
-              <a href="https://linode.com/backups" target="_blank">{` Backups pricing page`}
+              <a data-qa-backups-price href="https://linode.com/backups" target="_blank">{` Backups pricing page`}
                 <OpenInNew className={classes.icon} />
               </a>.
             </Typography>
@@ -74,6 +74,7 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
                   <Toggle
                     onChange={onChange}
                     checked={backups_enabled}
+                    data-qa-toggle-auto-backup
                   />
                 }
                 label={backups_enabled
@@ -87,7 +88,7 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
             <Grid item>
               <Typography variant="body1" className={classes.footnote}>
                 {`For existing Linodes without backups, `}
-                <a className={classes.link} onClick={openBackupsDrawer}>enable now</a>.
+                <a data-qa-backups-drawer className={classes.link} onClick={openBackupsDrawer}>enable now</a>.
               </Typography>
             </Grid>
           }

--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -88,7 +88,7 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
             <Grid item>
               <Typography variant="body1" className={classes.footnote}>
                 {`For existing Linodes without backups, `}
-                <a data-qa-backups-drawer className={classes.link} onClick={openBackupsDrawer}>enable now</a>.
+                <a data-qa-backup-existing className={classes.link} onClick={openBackupsDrawer}>enable now</a>.
               </Typography>
             </Grid>
           }

--- a/src/features/Account/NetworkHelper.tsx
+++ b/src/features/Account/NetworkHelper.tsx
@@ -65,6 +65,7 @@ const NetworkHelper: React.StatelessComponent<CombinedProps> = (props) => {
                   <Toggle
                     onChange={onChange}
                     checked={networkHelperEnabled}
+                    data-qa-toggle-network-helper
                   />
                 }
                 label={networkHelperEnabled

--- a/src/features/Backups/AutoEnroll.tsx
+++ b/src/features/Backups/AutoEnroll.tsx
@@ -76,7 +76,7 @@ export const AutoEnroll: React.StatelessComponent<CombinedProps> = (props) => {
                     `Enroll all future Linodes in backups. Your account will be billed
                     the additional hourly rate noted on the `
                   }
-                  <a href="https://www.linode.com/backups"
+                  <a data-qa-backups-price href="https://www.linode.com/backups"
                     target="_blank"
                   >
                     Backups pricing page <OpenInNew className={classes.icon} />.

--- a/src/features/Backups/BackupDrawer.tsx
+++ b/src/features/Backups/BackupDrawer.tsx
@@ -132,7 +132,7 @@ export class BackupDrawer extends React.Component<CombinedProps, {}> {
             <Typography variant="body1">
               Three backup slots are executed and rotated automatically: a daily backup,
               a 2-7 day old backup, and an 8-14 day old backup. Confirm to add backups
-              to <strong>{linodeCount}</strong> {linodeCount > 1 ? 'Linodes' : 'Linode'}.
+              to <strong data-qa-backup-count >{linodeCount}</strong> {linodeCount > 1 ? 'Linodes' : 'Linode'}.
             </Typography>
           </Grid>
           {enableErrors && !isEmpty(enableErrors) &&

--- a/src/features/Backups/BackupLinodes.tsx
+++ b/src/features/Backups/BackupLinodes.tsx
@@ -43,7 +43,7 @@ export const BackupLinodes: React.StatelessComponent<CombinedProps> = (props) =>
         const error = pathOr('', ['linodeError', 'reason'], linode);
         return <React.Fragment key={idx}>
           <TableRow data-qa-linodes >
-            <TableCell parentColumn="Label">
+            <TableCell data-qa-linode-label parentColumn="Label">
               <Typography variant="body1" >
                 {linode.label}
               </Typography>
@@ -54,8 +54,8 @@ export const BackupLinodes: React.StatelessComponent<CombinedProps> = (props) =>
               }
             </TableCell>
 
-            <TableCell parentColumn="Plan" >{getLabel(linode.typeInfo)}</TableCell>
-            <TableCell parentColumn="Price" >{`${displayPrice(getPrice(linode.typeInfo))}/mo`}</TableCell>
+            <TableCell data-qa-linode-plan parentColumn="Plan" >{getLabel(linode.typeInfo)}</TableCell>
+            <TableCell data-qa-backup-price parentColumn="Price" >{`${displayPrice(getPrice(linode.typeInfo))}/mo`}</TableCell>
           </TableRow>
         </React.Fragment>
       })}

--- a/src/features/Backups/BackupsCTA.tsx
+++ b/src/features/Backups/BackupsCTA.tsx
@@ -47,7 +47,7 @@ const BackupsCTA: React.StatelessComponent<CombinedProps> = (props) => {
           </Typography>
         </Grid>
         <Grid item>
-          <Button type="primary" className={classes.button} onClick={openBackupsDrawer}>Enable Now</Button>
+          <Button data-qa-backup-existing type="primary" className={classes.button} onClick={openBackupsDrawer}>Enable Now</Button>
         </Grid>
       </Grid>
 

--- a/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -110,6 +110,7 @@ class AddonsPanel extends React.Component<CombinedProps> {
                     checked={accountBackups || this.props.backups}
                     onChange={changeBackups}
                     disabled={accountBackups}
+                    data-qa-check-backups={accountBackups ? 'auto backup enabled' : 'auto backup disabled'}
                   />
                 }
                 label="Backups"
@@ -143,6 +144,7 @@ class AddonsPanel extends React.Component<CombinedProps> {
                   <CheckBox
                     checked={this.props.privateIP}
                     onChange={() => changePrivateIP()}
+                    data-qa-check-private-ip
                   />
                 }
                 label="Private IP (Free!)"


### PR DESCRIPTION
**Purpose**
Added tests for the auto enroll in backups for future linode global setting, dashboard backup CTA, linodes backup CTA, and enroll existing linode for backups features.

**To Test**
`yarn && yarn start` new shell `yarn selenium` new shell `yarn e2e:modified`