### PR TITLE
Update e2e:modified script

### DIFF
--- a/scripts/e2e-modified.sh
+++ b/scripts/e2e-modified.sh
@@ -4,6 +4,5 @@ if [[ -z $GET_ORIGIN ]]; then
 fi  
 set -- $GET_ORIGIN
 ORIGIN=$1
-echo $ORIGIN
 git fetch $ORIGIN
 yarn e2e --spec=$(git diff --name-only $ORIGIN/develop | egrep 'e2e/specs/.*\/*spec.js' | tr '\n' ',' | sed 's/.$//')

--- a/scripts/e2e-modified.sh
+++ b/scripts/e2e-modified.sh
@@ -2,4 +2,4 @@ GET_ORIGIN=$(git remote -v | grep git@github.com:linode/manager.git)
 set -- $GET_ORIGIN
 ORIGIN=$1
 git fetch $ORIGIN
-yarn e2e --spec=$(git diff --name-only $ORIGIN/develop | egrep 'e2e/specs/.*\/*spec.js' | tr '\n' ',' | sed 's/.$//')
+yarn e2e --spec=$(git diff --name-only $ORIGIN develop | egrep 'e2e/specs/.*\/*spec.js' | tr '\n' ',' | sed 's/.$//')

--- a/scripts/e2e-modified.sh
+++ b/scripts/e2e-modified.sh
@@ -1,5 +1,9 @@
 GET_ORIGIN=$(git remote -v | grep git@github.com:linode/manager.git)
+if [[ -z $GET_ORIGIN ]]; then 
+  GET_ORIGIN=$(git remote -v | grep https://github.com/linode/manager)
+fi  
 set -- $GET_ORIGIN
 ORIGIN=$1
+echo $ORIGIN
 git fetch $ORIGIN
-yarn e2e --spec=$(git diff --name-only $ORIGIN develop | egrep 'e2e/specs/.*\/*spec.js' | tr '\n' ',' | sed 's/.$//')
+yarn e2e --spec=$(git diff --name-only $ORIGIN/develop | egrep 'e2e/specs/.*\/*spec.js' | tr '\n' ',' | sed 's/.$//')


### PR DESCRIPTION
When running `yarn e2e:modified` locally, I received an error `fatal: ambiguous argument '/develop': unknown revision or path not in the working tree.`. As a result, all e2e tests would run rather than the new ones being tested in a given PR.

Changing `/develop` to `develop` fixes this, but I have no idea why, or why it was just me in the first place.