### PR TITLE
M3-1792 Select placeholders display

### DIFF
--- a/src/features/linodes/DiskSelect/DiskSelect.tsx
+++ b/src/features/linodes/DiskSelect/DiskSelect.tsx
@@ -45,7 +45,7 @@ const DiskSelect: React.StatelessComponent<CombinedProps> = (props) => {
         select
         data-qa-disk-select
       >
-        <MenuItem value="none" disabled>Select a Disk</MenuItem>
+        <MenuItem value="none" disabled className="placeholder">Select a Disk</MenuItem>
         {
           props.disks && props.disks.map((disk) => {
             return (

--- a/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -43,7 +43,7 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = (props) => {
             select
             data-qa-linode-select
         >
-        <MenuItem value="none" disabled>Select a Linode</MenuItem>
+        <MenuItem value="none" disabled className="placeholder">Select a Linode</MenuItem>
         {
             props.linodes && props.linodes.map((l) => {
             return <MenuItem key={l[0]} value={l[0]} data-qa-linode-menu-item={l[1]}>{l[1]}</MenuItem>;

--- a/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -151,7 +151,7 @@ export class RestoreToLinodeDrawer extends React.Component<CombinedProps, State>
             inputProps={{ name: 'linode', id: 'linode' }}
             error={Boolean(linodeError)}
           >
-            <MenuItem value="none" disabled>Select a Linode</MenuItem>
+            <MenuItem value="none" disabled className="placeholder">Select a Linode</MenuItem>
             {
               linodes && linodes.map((l) => {
                 return <MenuItem key={l[0]} value={l[0]}>{l[1]}</MenuItem>;

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -193,7 +193,7 @@ class LinodeRebuild extends React.Component<CombinedProps, State> {
                 inputProps={{ name: 'image-select', id: 'image-select' }}
                 data-qa-rebuild-image
               >
-                <MenuItem value={'select'} disabled>
+                <MenuItem value={'select'} disabled className="placeholder">
                   Select an Image
                 </MenuItem>
                 {

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -307,7 +307,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               errorText={errorFor('kernel')}
               errorGroup="linode-config-drawer"
             >
-              <MenuItem value="none" disabled><em>Select a Kernel</em></MenuItem>
+              <MenuItem value="none" disabled className="placeholder"><em>Select a Kernel</em></MenuItem>
               {
                 kernels.map(eachKernel =>
                   <MenuItem

--- a/src/features/linodes/LinodesDetail/LinodeVolumes/VolumeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeVolumes/VolumeDrawer.tsx
@@ -211,7 +211,7 @@ class VolumeDrawer extends React.Component<CombinedProps, State> {
         value={this.props.selectedVolume || 'none'}
         errorText={getAPIErrorFor(jawn, this.props.errors)('volume')}
       >
-        <MenuItem value="none">Select a Volume</MenuItem>
+        <MenuItem value="none" className="placeholder">Select a Volume</MenuItem>
         {
           this.state.attachableVolumes && this.state.attachableVolumes.map((volume) => (
             <MenuItem key={volume.id} value={volume.id}>{volume.label}</MenuItem>

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -698,6 +698,9 @@ const themeDefaults: ThemeOptions = {
         '& em': {
           fontStyle: 'normal !important',
         },
+        '&.placeholder': {
+          display: 'none'
+        }
       },
       selected: {
         backgroundColor: 'white !important',


### PR DESCRIPTION
I added a class to hide the placeholder in the drop down menu once and once a selection is made it won't reappear. I only targeted selects that need a required value. This is more of a hack as the placeholder are currently not well supported. See: https://github.com/mui-org/material-ui/issues/8813