### PR TITLE
M3-1901 Breadcrumb component on User Details

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,6 +1,7 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { StaticRouter } from 'react-router-dom';
+import UserIcon from 'src/assets/icons/user.svg';
 
 import ThemeDecorator from '../../utilities/storybookDecorators';
 import Breadcrumb from './Breadcrumb';
@@ -29,11 +30,13 @@ class InteractiveEditableBreadcrumb extends React.Component<Props, {}> {
           linkTo={this.state.linkTo}
           linkText={this.state.linkText}
           labelTitle={this.state.text}
+          labelOptions={{
+            linkTo: this.props.labelLink
+          }}
           onEditHandlers={{
             onEdit: this.onEdit,
             onCancel: this.onCancel
           }}
-          labelLink={this.props.labelLink}
         />
       </React.Fragment>
     )
@@ -60,7 +63,9 @@ storiesOf('Breadcrumb', module)
           linkTo="/linodes"
           linkText="Linodes"
           labelTitle="Static text"
-          labelLink="/summary"
+          labelOptions={{
+            linkTo: "/summary"
+          }}
         />
       </div>
     </StaticRouter>
@@ -71,7 +76,9 @@ storiesOf('Breadcrumb', module)
           linkTo="/linodes"
           linkText="Linodes"
           labelTitle="Static text"
-          labelSubtitle="A label subtitle"
+          labelOptions={{
+            subtitle: "A label subtitle"
+          }}
         />
       </div>
     </StaticRouter>
@@ -82,12 +89,34 @@ storiesOf('Breadcrumb', module)
           linkTo="/linodes"
           linkText="Linodes"
           labelTitle="Static text"
-          labelSubtitle="A label subtitle"
-          labelLink="/summary"
+          labelOptions={{
+            linkTo: "/summary",
+            subtitle: "A label subtitle"
+          }}
         />
       </div>
     </StaticRouter>
-  )).add('Editable text', () => (
+  )).add('Static text with user avatar', () => (
+    <StaticRouter location="/" context={{}}>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <Breadcrumb
+          linkTo="/linodes"
+          linkText="Linodes"
+          labelTitle="Static text"
+          labelOptions={{
+            prefixComponent: <UserIcon style={{
+              margin: '0 8px 0 -4px',
+              color: '#606469',
+              borderRadius: '50%',
+              width: '46px',
+              height: '46px',
+              animation: 'fadeIn 150ms linear forwards',
+            }} />
+          }}
+        />
+      </div>
+    </StaticRouter>
+)).add('Editable text', () => (
     <StaticRouter location="/" context={{}}>
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <InteractiveEditableBreadcrumb />

--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -10,7 +10,7 @@ describe('Breadcrumb component', () => {
       linkText="Linodes"
       labelTitle="MyTestLinode"
 
-      classes={{root: '', backButton: 'backButton', linkText: '', labelText: '', subtitleLinkText: ''}}
+      classes={{root: '', backButton: 'backButton', linkText: '', labelText: '', subtitleLinkText: '', prefixComponentWrapper: ''}}
     />
   );
 
@@ -25,6 +25,13 @@ describe('Breadcrumb component', () => {
 
   it('renders labelText without editable props', () => {
     expect(wrapper.find('[data-qa-labeltext]')).toHaveLength(1);
+  });
+
+  it('renders a prefixComponent wrapper', () => {
+    wrapper.setProps({
+      labelOptions: { prefixComponent: <React.Fragment /> }
+    })
+    expect(wrapper.find('[data-qa-prefixWrapper]')).toHaveLength(1);
   });
 
   it('renders editable text when given editable props', () => {

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -8,7 +8,7 @@ import Typography from 'src/components/core/Typography';
 import EditableText from 'src/components/EditableText';
 import LabelText from './LabelText';
 
-type ClassNames = 'root' | 'backButton' | 'linkText' | 'labelText' | 'subtitleLinkText';
+type ClassNames = 'root' | 'backButton' | 'linkText' | 'labelText' | 'subtitleLinkText' | 'prefixComponentWrapper';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
@@ -61,6 +61,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   labelText: {
     padding: '2px 10px'
+  },
+  prefixComponentWrapper: {
+    marginLeft: '14px',
+    '& svg': {
+      position: 'relative',
+      top: 2,
+      marginRight: '0',
+    }
   }
 });
 interface EditableProps {
@@ -68,21 +76,26 @@ interface EditableProps {
   onEdit: (value: string) => void;
   errorText?: string;
 }
+
+interface LabelProps {
+  linkTo?: string;
+  prefixComponent?: JSX.Element | null;
+  subtitle?: string;
+}
 export interface Props {
   // linkTo will be passed in to a <Link /> component, so we borrow the
   // LocationDescriptor interface from the history module
   linkTo: LocationDescriptor;
   linkText: string;
   labelTitle: string;
-  labelLink?: string;
-  labelSubtitle?: string;
+  labelOptions?: LabelProps;
   onEditHandlers?: EditableProps
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, linkTo, linkText, labelTitle } = props;
+  const { classes, linkTo, linkText, labelTitle, labelOptions, onEditHandlers } = props;
 
   return (
     <React.Fragment>
@@ -94,29 +107,38 @@ export const Breadcrumb: React.StatelessComponent<CombinedProps> = (props) => {
         <KeyboardArrowLeft />
         <Typography
           variant="subheading"
-          className={props.labelSubtitle ? classes.subtitleLinkText : classes.linkText}
+          className={(labelOptions && labelOptions.subtitle)
+            ? classes.subtitleLinkText
+            : classes.linkText}
           data-qa-link-text
         >
           {linkText}
         </Typography>
       </IconButton>
       </Link>
-      {props.onEditHandlers
+
+      {labelOptions && labelOptions.prefixComponent &&
+        <div className={classes.prefixComponentWrapper} data-qa-prefixWrapper>
+          {labelOptions.prefixComponent}
+        </div>
+      }
+
+      {onEditHandlers
         ?
         <EditableText
           role="header"
           typeVariant="h6"
           text={labelTitle}
-          errorText={props.onEditHandlers!.errorText}
-          onEdit={props.onEditHandlers!.onEdit}
-          onCancel={props.onEditHandlers!.onCancel}
-          labelLink={props.labelLink}
+          errorText={onEditHandlers.errorText}
+          onEdit={onEditHandlers.onEdit}
+          onCancel={onEditHandlers.onCancel}
+          labelLink={labelOptions && labelOptions.linkTo}
           data-qa-editable-text
         />
         : <LabelText
             title={props.labelTitle}
-            subtitle={props.labelSubtitle}
-            titleLink={props.labelLink}
+            subtitle={labelOptions && labelOptions.subtitle}
+            titleLink={labelOptions && labelOptions.linkTo}
             data-qa-labeltext
           />
       }

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -176,7 +176,7 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
               linkTo="/nodebalancers"
               linkText="NodeBalancers"
               labelTitle={nodeBalancerLabel}
-              labelLink={this.getLabelLink()}
+              labelOptions={{ linkTo: this.getLabelLink() }}
               onEditHandlers={{
                 onEdit: this.updateLabel,
                 onCancel: this.cancelUpdate,

--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -319,9 +319,11 @@ export class SupportTicketDetail extends React.Component<CombinedProps,State> {
               }}
               linkText="Support Tickets"
               labelTitle={`#${ticket.id}: ${ticket.summary}`}
-              labelSubtitle={
-                `${ticket.status === 'closed' ? 'Closed' : 'Last updated'} by ${ticket.updated_by} at ${formattedDate}`
-              }
+              labelOptions={{
+                subtitle: `${ticket.status === 'closed'
+                  ? 'Closed'
+                  : 'Last updated'} by ${ticket.updated_by} at ${formattedDate}`
+              }}
               data-qa-breadcrumb
             />
             <Chip className={classNames({

--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -1,15 +1,13 @@
-import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import { clone, compose, path as pathRamda, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { matchPath, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import UserIcon from 'src/assets/icons/user.svg';
+import Breadcrumb from 'src/components/Breadcrumb';
 import AppBar from 'src/components/core/AppBar';
-import IconButton from 'src/components/core/IconButton';
 import { StyleRulesCallback, WithStyles, withStyles } from 'src/components/core/styles';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
-import Typography from 'src/components/core/Typography';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
@@ -40,10 +38,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     animation: 'fadeIn 150ms linear forwards',
   },
   emptyImage: {
-    margin: '0 8px 0 -4px',
-    display: 'inline',
-    width: 46,
-    height: 46,
+    width: 42,
+    height: 49,
   },
   titleWrapper: {
     display: 'flex',
@@ -186,7 +182,7 @@ class UserDetail extends React.Component<CombinedProps> {
         })
 
         /**
-         * If the user we updated is the current user, we need to reflec that change at the global level.
+         * If the user we updated is the current user, we need to reflect that change at the global level.
          */
         if (profileUsername === originalUsername) {
           updateCurrentUser(user);
@@ -248,9 +244,15 @@ class UserDetail extends React.Component<CombinedProps> {
     if (error) {
       return (
         <React.Fragment>
-          <IconButton onClick={this.visitUsers} className={classes.backButton}>
-            <KeyboardArrowLeft />
-          </IconButton>
+          <Grid container justify="space-between">
+            <Grid item className={classes.titleWrapper}>
+              <Breadcrumb
+                linkTo="/account/users"
+                linkText="Users"
+                labelTitle={username || ''}
+              />
+            </Grid>
+          </Grid>
           <ErrorState
             errorText="There was an error retrieving the user data. Please reload and try again."
           />
@@ -258,26 +260,26 @@ class UserDetail extends React.Component<CombinedProps> {
       );
     }
 
+    const maybeGravatar = gravatarUrl === undefined
+      ? <div className={classes.emptyImage} />
+      : gravatarUrl === 'not found'
+        ? <UserIcon className={classes.avatar} />
+        : <img
+            alt={`user ${username}'s avatar`}
+            src={gravatarUrl}
+            className={classes.avatar}
+          />;
+
     return (
       <React.Fragment>
         <Grid container justify="space-between">
           <Grid item className={classes.titleWrapper}>
-            <IconButton onClick={this.visitUsers} className={classes.backButton} data-qa-back-button>
-              <KeyboardArrowLeft />
-            </IconButton>
-            {gravatarUrl === undefined
-              ? <div className={classes.emptyImage} />
-              : gravatarUrl === 'not found'
-                ? <UserIcon className={classes.avatar} />
-                : <img
-                  alt={`user ${username}'s avatar`}
-                  src={gravatarUrl}
-                  className={classes.avatar}
-                />
-            }
-            <Typography role="header" variant="headline" data-qa-user-detail-header>
-              {username}
-            </Typography>
+            <Breadcrumb
+              linkTo="/account/users"
+              linkText="Users"
+              labelTitle={username}
+              labelOptions={{ prefixComponent: maybeGravatar }}
+            />
           </Grid>
         </Grid>
         <AppBar position="static" color="default">

--- a/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
@@ -84,7 +84,7 @@ const LabelPowerAndConsolePanel: React.StatelessComponent<CombinedProps> = (prop
           linkTo="/linodes"
           linkText="Linodes"
           labelTitle={labelInput.label}
-          labelLink={getLabelLink()}
+          labelOptions={{ linkTo: getLabelLink() }}
           onEditHandlers={{
             onEdit: labelInput.onEdit,
             onCancel: labelInput.onCancel,


### PR DESCRIPTION
This PR adds the Breadcrumb component to UserDetails. This required changing the ever-evolving Breadcrumb component to accept a “label prefix component” which is rendered preceding the label. 

Further changes were made to the Breadcrumb API to keep it organized. The `labelSubtitle` and `labelLink` properties are moved to a new, optional `labelOptions` prop with the following shape: 

```
linkTo?: string;
prefixComponent?: JSX.Element | null;
subtitle?: string;
```

@alioso and @WilkinsKa1, it’d be great if one of you could have a look at this. I made a few styling adjustments so that the user icon comes in smoothly.