### PR TITLE
M3-1869 Tags going off screen in search bar

### DIFF
--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -149,6 +149,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   suggestionTitle: {
     fontSize: '1rem',
     color: theme.palette.text.primary,
+    wordBreak: 'break-all',
   },
   suggestionDescription: {
     color: theme.color.headline,
@@ -162,7 +163,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   tagContainer: {
     display: 'flex',
-    justifyContent: 'center',
+    flexWrap: 'wrap',
+    paddingRight: 8,
+    justifyContent: 'flex-end',
     alignItems: 'center',
     '& > div': {
       margin: '2px',

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -125,14 +125,16 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   suggestionRoot: {
     cursor: 'pointer',
-    display: 'flex',
     width: 'calc(100% + 2px)',
     alignItems: 'space-between',
     justifyContent: 'space-between',
     borderBottom: `1px solid ${theme.palette.divider}`,
+    [theme.breakpoints.up('md')]: {
+     display: 'flex',
+    },
     '&:last-child': {
       borderBottom: 0,
-    }
+    },
   },
   highlight: {
     color: theme.palette.primary.main,


### PR DESCRIPTION
Tags on search will wrap now, along with a few other adjustments:
<img width="767" alt="screen shot 2018-11-28 at 3 27 59 pm" src="https://user-images.githubusercontent.com/2565527/49180314-47922d80-f322-11e8-9239-e85abc02e916.png"> 

