### PR TITLE
M3-1827: update IP sorting function to cover equal items

### DIFF
--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -117,7 +117,7 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
     const formattedIPS = ips
       .map(ip => ip.replace('/64', ''))
-      .sort(ip => !!ip.match(privateIPRegex) ? 1 : -1);
+      .sort((ip1, ip2) => ((privateIPRegex.test(ip1) ? 1 : -1) - (privateIPRegex.test(ip2) ? 1 : -1)));
 
     return (
       <div className={`dif ${classes.root}`}>


### PR DESCRIPTION
Covers all three sorting cases: items are equal in rank, either of items has higher rank