### PR TITLE
M3-1945 Search bar: sprint review feedback

### DIFF
--- a/src/features/Search/HiddenResults.test.tsx
+++ b/src/features/Search/HiddenResults.test.tsx
@@ -30,7 +30,7 @@ describe("Hidden results component", () => {
   });
   it("should have a Show More button", () => {
     expect(component.containsMatchingElement(
-      <Button type="primary">Show More</Button>
+      <Button type="primary">Show All</Button>
     ));
   });
   it("should show hidden results when showMore is true", () => {

--- a/src/features/Search/HiddenResults.tsx
+++ b/src/features/Search/HiddenResults.tsx
@@ -42,7 +42,7 @@ export const HiddenResults: React.StatelessComponent<CombinedProps> = (props) =>
           className={classes.button}
           data-qa-show-more-toggle
         >
-          {showMore ? "Show Less" : "Show More"}
+          {showMore ? "Show Less" : "Show All"}
         </Button>
     </React.Fragment>
   );

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -316,7 +316,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
       }
     }
 
-    const finalOptions = isEmpty(options) ? [] : [...options, defaultOption];
+    const finalOptions = isEmpty(options) ? [] : [defaultOption, ...options];
 
     return (
       <React.Fragment>


### PR DESCRIPTION
* Link to results page is first option in results dropdown,
rather than last
* Change Show More to Show All on results page HiddenResults buttons