### PR TITLE
M3-1948 Scroll regression on personal access token modal

### DIFF
--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -58,6 +58,7 @@ const styles: StyleRulesCallback = (theme) => {
       fontFamily: 'LatoWebBold',
       fontSize: '1rem',
       lineHeight: 1.2,
+      wordBreak: 'break-all',
     },
     error: {
       borderLeft: `5px solid ${status.errorDark}`,


### PR DESCRIPTION
Adding word break to notice component text so that long, unbreakable strings will wrap to next line and the notice containers aren't overflowed/scrollable. 

<img width="608" alt="screen shot 2018-11-30 at 2 07 42 pm" src="https://user-images.githubusercontent.com/2565527/49309974-fe211a00-f4aa-11e8-9f4f-82acd6a00455.png">
