### PR TITLE
M3-1948 Scroll regression on personal access token modal

### DIFF
--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -58,6 +58,7 @@ const styles: StyleRulesCallback = (theme) => {
       fontFamily: 'LatoWebBold',
       fontSize: '1rem',
       lineHeight: 1.2,
+      wordBreak: 'break-all',
     },
     error: {
       borderLeft: `5px solid ${status.errorDark}`,

--- a/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/src/features/Profile/APITokens/APITokenTable.tsx
@@ -492,7 +492,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
             {`Your personal access token has been created.
               Store this secret. It won't be shown again.`}
           </Typography>
-          <Notice typeProps={{ variant: 'body1' }} warning text={this.state.token && this.state.token.value!} />
+          <Notice spacingTop={8} typeProps={{ variant: 'body1' }} warning text={this.state.token && this.state.token.value!} />
         </ConfirmationDialog>
       </React.Fragment>
     );

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -299,7 +299,7 @@ const themeDefaults: ThemeOptions = {
         padding: '11px 26px 13px',
         transition: 'border 225ms ease-in-out, color 225ms ease-in-out',
         '&:hover, &:focus': {
-          backgroundColor: 'transparent',
+          backgroundColor: 'transparent !important',
           color: primaryColors.light,
           borderColor: primaryColors.light,
         },


### PR DESCRIPTION
Adding word break to notice component text so that long, unbreakable strings will wrap to next line and the notice containers aren't overflowed/scrollable.

<img width="608" alt="screen shot 2018-11-30 at 2 07 42 pm" src="https://user-images.githubusercontent.com/2565527/49312270-a803a500-f4b1-11e8-8780-3a9227553ca9.png">
