### PR TITLE
M3-1983 Add break-word support as a prop for notices

### DIFF
--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -19,6 +19,7 @@ type ClassNames = 'root'
   | 'success'
   | 'successList'
   | 'flag'
+  | 'breakWords'
   | 'icon';
 
 const styles: StyleRulesCallback = (theme) => {
@@ -39,9 +40,6 @@ const styles: StyleRulesCallback = (theme) => {
       maxWidth: '100%',
       display: 'flex',
       alignItems: 'center',
-      '& p': {
-        wordWrap: 'break-word',
-      },
       '& + .notice': {
         marginTop: `${theme.spacing.unit}px !important`,
       },
@@ -53,12 +51,16 @@ const styles: StyleRulesCallback = (theme) => {
     inner: {
       width: '100%',
     },
+    breakWords: {
+      '& $noticeText': {
+        wordBreak: 'break-all',
+      },
+    },
     noticeText: {
       color: theme.palette.text.primary,
       fontFamily: 'LatoWebBold',
       fontSize: '1rem',
       lineHeight: 1.2,
-      wordBreak: 'break-all',
     },
     error: {
       borderLeft: `5px solid ${status.errorDark}`,
@@ -115,6 +117,7 @@ interface Props extends GridProps {
   notificationList?: boolean;
   spacingTop?: 0 | 8 | 16 | 24;
   spacingBottom?: 0 | 8 | 16 | 24;
+  breakWords?: boolean;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
@@ -127,6 +130,7 @@ const Notice: React.StatelessComponent<CombinedProps> = (props) => {
     important,
     text,
     error,
+    breakWords,
     errorGroup,
     warning,
     success,
@@ -169,6 +173,7 @@ const Notice: React.StatelessComponent<CombinedProps> = (props) => {
         [classes.root]: true,
         [classes.important]: important,
         [errorScrollClassName]: error,
+        [classes.breakWords]: breakWords,
         [classes.error]: error && !notificationList,
         [classes.errorList]: error && notificationList,
         [classes.success]: success && !notificationList,

--- a/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -177,13 +177,14 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
       <Table
         aria-label="Personnal Acccess Token Permissions"
         className={classes.permsTable}
+        spacingTop={24}
       >
         <TableHead>
           <TableRow>
-            <TableCell padding="checkbox" data-qa-perm-access>Access</TableCell>
-            <TableCell padding="checkbox" data-qa-perm-none>None</TableCell>
-            <TableCell padding="checkbox" data-qa-perm-read>Read Only</TableCell>
-            <TableCell padding="checkbox" data-qa-perm-rw>Read/Write</TableCell>
+            <TableCell data-qa-perm-access>Access</TableCell>
+            <TableCell data-qa-perm-none>None</TableCell>
+            <TableCell data-qa-perm-read>Read Only</TableCell>
+            <TableCell data-qa-perm-rw>Read/Write</TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/src/features/Profile/APITokens/APITokenTable.tsx
@@ -492,7 +492,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
             {`Your personal access token has been created.
               Store this secret. It won't be shown again.`}
           </Typography>
-          <Notice spacingTop={8} typeProps={{ variant: 'body1' }} warning text={this.state.token && this.state.token.value!} />
+          <Notice spacingTop={16} typeProps={{ variant: 'body1' }} warning text={this.state.token && this.state.token.value!} breakWords />
         </ConfirmationDialog>
       </React.Fragment>
     );


### PR DESCRIPTION
We have a default word break on the notices for just one edge cases. we needed to add that as a prop and add it only when necessary (Personal Access Tokens modal key)