### PR TITLE
M3-1888 Report counts of successes and failures for backups

### DIFF
--- a/src/features/Backups/BackupDrawer.test.tsx
+++ b/src/features/Backups/BackupDrawer.test.tsx
@@ -61,6 +61,7 @@ const props = {
   enrolling: false,
   autoEnroll: false,
   autoEnrollError: undefined,
+  updatedCount: 0,
 }
 
 const component = shallow(
@@ -126,6 +127,12 @@ describe("BackupDrawer component", () => {
       expect(component.find('WithStyles(Notice)')).toHaveLength(0);
       component.setProps({ enableErrors: [error]});
       expect(component.find('WithStyles(Notice)')).toHaveLength(1);
+    });
+    it("should include the number of failures and successes in the Notice", () => {
+      component.setProps({ enableErrors: [error], updatedCount: 2 });
+      const _props = component.find('WithStyles(Notice)').props() as any;
+      expect(_props.children).toMatch('1 Linode failed');
+      expect(_props.children).toMatch('2 Linodes')
     });
     it("should call enrollAutoBackups on submit", () => {
       const button = component.find('[data-qa-submit]');

--- a/src/store/ApplicationState.d.ts
+++ b/src/store/ApplicationState.d.ts
@@ -48,6 +48,7 @@ declare interface BackupDrawerState extends RequestableData<Linode.Linode[]> {
   enabling: boolean;
   enableErrors: BackupError[];
   enableSuccess: boolean;
+  updatedCount: number;
   autoEnroll: boolean;
   autoEnrollError?: string;
   enrolling: boolean;

--- a/src/store/reducers/backupDrawer.test.ts
+++ b/src/store/reducers/backupDrawer.test.ts
@@ -1,5 +1,3 @@
-import * as Bluebird from 'bluebird';
-
 import backups, * as B from './backupDrawer';
 
 import { linode1, linode2 } from 'src/__data__/linodes';
@@ -8,7 +6,6 @@ import { mockAPIFieldErrors } from 'src/services/';
 const error: BackupError = { linodeId: 123456, reason: 'Error'};
 const apiError = mockAPIFieldErrors([]);
 const linodes = [linode1, linode2];
-const linodeIds = linodes.map(linode => linode.id);
 
 const mockFn = jest.fn();
 jest.mock('axios', () => ({
@@ -31,6 +28,7 @@ describe("Redux backups", () => {
         expect(newState).toHaveProperty('error', undefined);
         expect(newState).toHaveProperty('enableErrors', []);
         expect(newState).toHaveProperty('autoEnrollError', undefined);
+        expect(newState).toHaveProperty('updatedCount', 0);
     });
     it("should handle CLOSE", () => {
       const newState = backups(
@@ -63,12 +61,13 @@ describe("Redux backups", () => {
       );
       expect(newState).toHaveProperty('enabling', false);
       expect(newState).toHaveProperty('enableSuccess', true);
+      expect(newState).toHaveProperty('updatedCount', 1);
       expect(newState.data).not.toContain(linode1);
     });
     it("should handle ENABLE_ERROR", () => {
       const newState = backups(
         {...B.defaultState, enabling: true },
-        B.handleEnableError([error])
+        B.handleEnableError({errors: [error], success: [1,2,3]})
       );
       expect(newState).toHaveProperty('enabling', false);
       expect(newState.enableErrors).toEqual([error]);
@@ -117,20 +116,6 @@ describe("Redux backups", () => {
         B.handleAutoEnrollError('Error')
       )
       expect(newState).toHaveProperty('autoEnrollError', 'Error')
-    });
-  });
-  describe("magic error reducer", () => {
-    // Triggers a Jasmine error that we still need to work out
-    it.skip("should provide a list of errors and linode ids", async () => {
-      const initialValue = { success: [], errors: []};
-      const accumulator = await Bluebird.reduce(linodeIds, B.gatherResponsesAndErrors, initialValue);
-      expect(accumulator).toEqual({
-        success: [1],
-        errors: [{
-          linodeId: linode2.id,
-          reason: "Backups could not be enabled for this Linode."
-        }]
-      });
     });
   });
 });


### PR DESCRIPTION
## Purpose

Generic error message Notice when some backups had failed and others succeeded was confusing. This PR adds a more detailed message indicating how many Linodes had backups enabled successfully, and how many failed. Individual error message for each failed Linode are unchanged.

Changed
- Track number of updated Linodes in backupDrawer reducer
- Include number of successes and failures in error and success messaging in BackupDrawer.

## Notes

The text wrapping within the Notice is on Alban's radar, should be fixed soon.

![screen shot 2018-12-04 at 4 05 24 pm](https://user-images.githubusercontent.com/1624067/49472966-c5e94680-f7de-11e8-9a4e-c1f9bf5b62dc.png)
