### PR TITLE
M3-1800 Display resize instructions on form submission.

### DIFF
--- a/src/features/Volumes/VolumeDrawer/ResizeVolumeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/ResizeVolumeForm.tsx
@@ -20,12 +20,14 @@ interface Props {
   onClose: () => void;
   volumeSize: number;
   volumeId: number;
+  volumeLabel: string;
+  onSuccess: (volumeLabel: string, message?: string) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const ResizeVolumeForm: React.StatelessComponent<CombinedProps> = (props) => {
-  const { volumeId, volumeSize, onClose } = props;
+  const { volumeId, volumeSize, onClose, volumeLabel, onSuccess } = props;
   const initialValues = { size: volumeSize };
   const validationSchema = ResizeVolumeSchema(volumeSize);
 
@@ -38,9 +40,10 @@ const ResizeVolumeForm: React.StatelessComponent<CombinedProps> = (props) => {
 
         resizeVolume(volumeId, { size: Number(values.size) })
           .then(response => {
-            onClose();
-            resetForm();
+            resetForm(initialValues);
+            setSubmitting(false);
             resetEventsPolling();
+            onSuccess(volumeLabel, `Volume scheduled to be resized.`);
           })
           .catch(errorResponse => {
             const defaultMessage = `Unable to resize this volume at this time. Please try again later.`;

--- a/src/features/Volumes/VolumeDrawer/ResizeVolumesInstruction.tsx
+++ b/src/features/Volumes/VolumeDrawer/ResizeVolumesInstruction.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import CopyableTextField from '../CopyableTextField';
+import NoticePanel from './NoticePanel';
+
+type ClassNames = 'root'
+  | 'copySection'
+  | 'copyField';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {},
+  copySection: {
+    marginTop: theme.spacing.unit * 2,
+  },
+  copyField: {
+    marginTop: theme.spacing.unit,
+  },
+});
+
+interface Props {
+  volumeLabel: string;
+  onClose: () => void;
+  message?: string;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const ResizeVolumeInstructions: React.StatelessComponent<CombinedProps> = (props) => {
+  const { classes, message, onClose, volumeLabel } = props;
+
+  return (
+    <React.Fragment>
+
+      {message && <NoticePanel success={message} />}
+
+      <div className={classes.copySection}>
+        <Typography variant="body1">After the volume resize is complete, you'll need to restart your Linode for the changes to take effect.</Typography>
+        <Typography variant="body1">Once your Linode has restarted, make sure the volume is unmounted for safety:</Typography>
+        <CopyableTextField className={classes.copyField} value={`umount /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`} />
+      </div>
+
+      <div className={classes.copySection}>
+        <Typography variant="body1">Assuming you have an ext2, ext3, or ext4 partition, first run a file system check, then resize it to fill the new volume size:</Typography>
+        <CopyableTextField className={classes.copyField} value={`e2fsck -f /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`} />
+        <CopyableTextField className={classes.copyField} value={`resize2fs /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`} />
+      </div>
+
+      <div className={classes.copySection}>
+        <Typography variant="body1">Now mount it back onto the filesystem:</Typography>
+        <CopyableTextField className={classes.copyField} value={`mount /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel} /mnt/${volumeLabel}`} />
+      </div>
+      <ActionsPanel>
+        <Button onClick={onClose} type="primary">Close</Button>
+      </ActionsPanel>
+    </React.Fragment>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(ResizeVolumeInstructions);

--- a/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
@@ -1,23 +1,25 @@
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import Drawer from 'src/components/Drawer';
-import { close, openForConfig } from 'src/store/reducers/volumeDrawer';
+import { close, openForConfig, viewResizeInstructions } from 'src/store/reducers/volumeDrawer';
 import AttachVolumeToLinodeForm from './AttachVolumeToLinodeForm';
 import CloneVolumeForm from './CloneVolumeForm';
 import CreateVolumeForLinodeForm from './CreateVolumeForLinodeForm';
 import CreateVolumeForm from './CreateVolumeForm';
 import EditVolumeForm from './EditVolumeForm';
 import ResizeVolumeForm from './ResizeVolumeForm';
+import ResizeVolumesInstruction from './ResizeVolumesInstruction';
 import VolumeConfigForm from './VolumeConfigForm';
 
 export const modes = {
-  CLOSED: 'closed',
-  CREATING: 'creating',
-  CREATING_FOR_LINODE: 'creating_for_linode',
-  RESIZING: 'resizing',
-  CLONING: 'cloning',
-  EDITING: 'editing',
   ATTACHING: 'attaching',
+  CLONING: 'cloning',
+  CLOSED: 'closed',
+  CREATING_FOR_LINODE: 'creating_for_linode',
+  CREATING: 'creating',
+  EDITING: 'editing',
+  RESIZING: 'resizing',
+  VIEW_RESIZE_INSTRUCTIONS: 'viewing_resize_instructions',
   VIEWING_CONFIG: 'viewing_config',
 };
 
@@ -59,8 +61,18 @@ class VolumeDrawer extends React.PureComponent<CombinedProps> {
           />
         }
         {
-          mode === modes.RESIZING && volumeId !== undefined && volumeSize !== undefined &&
-          <ResizeVolumeForm volumeId={volumeId} volumeSize={volumeSize} onClose={actions.closeDrawer} />
+          mode === modes.RESIZING
+          && volumeId !== undefined
+          && volumeSize !== undefined
+          && volumeLabel !== undefined
+          &&
+          <ResizeVolumeForm
+            volumeId={volumeId}
+            volumeSize={volumeSize}
+            onClose={actions.closeDrawer}
+            volumeLabel={volumeLabel}
+            onSuccess={actions.openForResizeInstructions}
+          />
         }
         {
           mode === modes.CLONING && volumeId !== undefined
@@ -115,6 +127,16 @@ class VolumeDrawer extends React.PureComponent<CombinedProps> {
             onClose={actions.closeDrawer}
           />
         }
+        {
+          mode === modes.VIEW_RESIZE_INSTRUCTIONS
+          && volumeLabel !== undefined
+          &&
+          <ResizeVolumesInstruction
+            volumeLabel={volumeLabel}
+            message={message}
+            onClose={actions.closeDrawer}
+          />
+        }
       </Drawer>
     );
   }
@@ -124,6 +146,7 @@ interface DispatchProps {
   actions: {
     closeDrawer: () => void;
     openForConfig: (volumeLabel: string, volumePath: string, message?: string) => void;
+    openForResizeInstructions: (volumeLabel: string, message?: string) => void;
   }
 }
 
@@ -131,6 +154,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch) => 
   actions: {
     closeDrawer: () => dispatch(close()),
     openForConfig: (volumeLabel: string, volumePath: string, message?: string) => dispatch(openForConfig(volumeLabel, volumePath, message)),
+    openForResizeInstructions: (volumeLabel: string, message?: string) => dispatch(viewResizeInstructions({ volumeLabel, message })),
   },
 });
 
@@ -187,7 +211,7 @@ const titleFromState = (state: ApplicationState['volumeDrawer']) => {
 
   switch (mode) {
     case modes.CREATING:
-    return `Create a Volume`;
+      return `Create a Volume`;
 
     case modes.CREATING_FOR_LINODE:
       return `Create a volume for ${linodeLabel}`
@@ -206,6 +230,9 @@ const titleFromState = (state: ApplicationState['volumeDrawer']) => {
 
     case modes.VIEWING_CONFIG:
       return `Volume Configuration`;
+
+      case modes.VIEW_RESIZE_INSTRUCTIONS:
+      return `Resizing Instructions`;
 
     default:
       return '';


### PR DESCRIPTION
## Purpose
Provide instructions for users after submitting a request to resize a volume.

# Gold Plating
I updated the openForCreating to use `typescript-fsa`. I was going to update the entire reducer, but I wanted to keep the PR relatively small.