### PR TITLE
M3-1742 Refresh volumes list on volume_clone event.

### DIFF
--- a/src/features/Volumes/WithEvents.tsx
+++ b/src/features/Volumes/WithEvents.tsx
@@ -61,7 +61,7 @@ export default () => (WrappedComponent: React.ComponentType<any>) => {
           }
 
           /** if our volume finished provisioning, refresh the list of Volumes */
-          if (['volume_create', 'volume_attach'].includes(event.action)) {
+          if (['volume_create', 'volume_attach', 'volume_clone'].includes(event.action)) {
             return this.props.request();
           }
 


### PR DESCRIPTION
## Purpose
It was found that the volumes landing was not being updated after a volume clone requests completed.