### PR TITLE
M3-1583 Add sorting by label to Linode landing table view.

### DIFF
--- a/src/components/Pagey/Pagey.ts
+++ b/src/components/Pagey/Pagey.ts
@@ -23,6 +23,13 @@ export type PaginatedRequest<T = {}> = (
   f?: FilterParams,
 ) => Promise<Linode.ResourcePage<T>>;
 
+
+export type HandleOrderChange = (key: string, order?: Order) => void;
+
+export type Order = 'asc' | 'desc';
+
+export type OrderBy = undefined | string;
+
 interface State<T={}> {
   count: number;
   error?: Error;
@@ -31,8 +38,8 @@ interface State<T={}> {
   pages?: number;
   pageSize: number;
   data?: T[];
-  orderBy?: string;
-  order: 'asc' | 'desc';
+  orderBy?: OrderBy;
+  order: Order;
   filter: any;
   searching: boolean;
 }
@@ -41,7 +48,7 @@ export interface PaginationProps<T> extends State<T> {
   handlePageChange: (v: number, showSpinner?: boolean) => void;
   handlePageSizeChange: (v: number) => void;
   request: <U={}>(update?: (v: T[]) => U) => Promise<void>;
-  handleOrderChange: (key: string, order?: 'asc' | 'desc') => void;
+  handleOrderChange: HandleOrderChange;
   handleSearch: (newFilter: any) => void;
   onDelete: () => void;
 }
@@ -68,11 +75,11 @@ export default (requestFn: PaginatedRequest) => (Component: React.ComponentType<
        * Basically, if we're on page 2 and the user deletes the last entity
        * on the page, send the user back to the previous page, AKA the max number
        * of pages.
-       * 
+       *
        * This solves the issue where the user deletes the last entity
        * on a page and then sees an empty state instead of going to the
        * last page available
-       * 
+       *
        * Please note that if the deletion of an entity is instant and not
        * initiated by the completetion of an event, we need to check that
        * the data.length === 1 because we're not calling this.request() to update
@@ -122,7 +129,7 @@ export default (requestFn: PaginatedRequest) => (Component: React.ComponentType<
       this.setState({ page }, () => { this.request() })
     };
 
-    public handleOrderChange = (orderBy: string, order: 'asc' | 'desc' = 'asc') => {
+    public handleOrderChange = (orderBy: string, order: Order = 'asc') => {
       this.setState({ orderBy, order, page: 1 }, () => this.request());
     };
 

--- a/src/components/Pagey/index.ts
+++ b/src/components/Pagey/index.ts
@@ -1,1 +1,1 @@
-export { default, PaginationProps } from './Pagey';
+export { default, PaginationProps, HandleOrderChange, Order, OrderBy } from './Pagey';

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -243,6 +243,9 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
         images={images}
         openConfigDrawer={this.openConfigDrawer}
         toggleConfirmation={this.toggleDialog}
+        order={this.props.order}
+        orderBy={this.props.orderBy}
+        handleOrderChange={this.props.handleOrderChange}
       />
     )
   }

--- a/src/features/linodes/LinodesLanding/LinodesViewWrapper.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesViewWrapper.tsx
@@ -3,112 +3,138 @@ import Paper from 'src/components/core/Paper';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Grid from 'src/components/Grid';
+import { PaginationProps } from 'src/components/Pagey';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
+import TableSortCell from 'src/components/TableSortCell';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 import { safeGetImageLabel } from 'src/utilities/safeGetImageLabel';
 import LinodeCard from './LinodeCard';
 import LinodeRow from './LinodeRow/LinodeRow';
 
-interface Props {
-  view: 'grid' | 'list';
+type PaginatedLinodes = PaginationProps<Linode.Linode>;
+interface ViewProps {
   linodes: Linode.EnhancedLinode[];
   images: Linode.Image[];
   openConfigDrawer: (c: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
-  toggleConfirmation: (bootOption: Linode.BootAction,
-    linodeId: number, linodeLabel: string) => void;
+  toggleConfirmation: (bootOption: Linode.BootAction, linodeId: number, linodeLabel: string) => void;
+  handleOrderChange: PaginatedLinodes['handleOrderChange'];
+  order: PaginatedLinodes['order'];
+  orderBy?: PaginatedLinodes['orderBy'];
 }
 
-class LinodesViewWrapper extends React.Component<Props, {}> {
-  renderCards = () => {
-    const { linodes, images, openConfigDrawer, toggleConfirmation } = this.props;
+const CardView: React.StatelessComponent<ViewProps> = (props) => {
+  const { linodes, images, openConfigDrawer, toggleConfirmation } = props;
 
-    return (
-      <Grid container>
-        {linodes.map(linode =>
-          <LinodeCard
-            key={linode.id}
-            linodeId={linode.id}
-            linodeStatus={linode.status}
-            linodeIpv4={linode.ipv4}
-            linodeIpv6={linode.ipv6}
-            linodeRegion={linode.region}
-            linodeType={linode.type}
-            linodeNotification={linode.notification}
-            linodeLabel={linode.label}
-            linodeBackups={linode.backups}
-            linodeTags={linode.tags}
-            linodeRecentEvent={linode.recentEvent}
-            imageLabel={safeGetImageLabel(images, linode.image)}
-            openConfigDrawer={openConfigDrawer}
-            linodeSpecDisk={linode.specs.disk}
-            linodeSpecMemory={linode.specs.memory}
-            linodeSpecVcpus={linode.specs.vcpus}
-            linodeSpecTransfer={linode.specs.transfer}
-            toggleConfirmation={toggleConfirmation}
-          />,
-        )}
-      </Grid>
-    )
-  }
+  return (
+    <Grid container>
+      {linodes.map(linode =>
+        <LinodeCard
+          key={linode.id}
+          linodeId={linode.id}
+          linodeStatus={linode.status}
+          linodeIpv4={linode.ipv4}
+          linodeIpv6={linode.ipv6}
+          linodeRegion={linode.region}
+          linodeType={linode.type}
+          linodeNotification={linode.notification}
+          linodeLabel={linode.label}
+          linodeBackups={linode.backups}
+          linodeTags={linode.tags}
+          linodeRecentEvent={linode.recentEvent}
+          imageLabel={safeGetImageLabel(images, linode.image)}
+          openConfigDrawer={openConfigDrawer}
+          linodeSpecDisk={linode.specs.disk}
+          linodeSpecMemory={linode.specs.memory}
+          linodeSpecVcpus={linode.specs.vcpus}
+          linodeSpecTransfer={linode.specs.transfer}
+          toggleConfirmation={toggleConfirmation}
+        />,
+      )}
+    </Grid>
+  )
+};
 
-  renderRows = () => {
-    const { linodes, openConfigDrawer, toggleConfirmation } = this.props;
+const RowView: React.StatelessComponent<ViewProps> = (props) => {
+  const {
+    handleOrderChange,
+    linodes,
+    openConfigDrawer,
+    order,
+    orderBy,
+    toggleConfirmation,
+  } = props;
 
-    return (
-      <Paper>
-        <Grid container className="my0">
-          <Grid item xs={12} className="py0">
-            <Table arial-label="List of Linodes">
-              <TableHead data-qa-table-head>
-                <TableRow>
-                  <TableCell>Linode</TableCell>
-                  <TableCell>Plan</TableCell>
-                  <TableCell noWrap>Last Backup</TableCell>
-                  <TableCell>IP Addresses</TableCell>
-                  <TableCell>Region</TableCell>
-                  <TableCell />
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {linodes.map(linode =>
-                  <LinodeRow
-                    key={linode.id}
-                    linodeId={linode.id}
-                    linodeType={linode.type}
-                    linodeStatus={linode.status}
-                    linodeIpv4={linode.ipv4}
-                    linodeIpv6={linode.ipv6}
-                    linodeRegion={linode.region}
-                    linodeNotification={linode.notification}
-                    linodeLabel={linode.label}
-                    linodeBackups={linode.backups}
-                    linodeTags={linode.tags}
-                    linodeRecentEvent={linode.recentEvent}
-                    openConfigDrawer={openConfigDrawer}
-                    toggleConfirmation={toggleConfirmation}
-                    mostRecentBackup={linode.mostRecentBackup}
-                  />,
-                )}
-              </TableBody>
-            </Table>
-          </Grid>
+  const isActive = (label: string) => label === orderBy;
+
+  return (
+    <Paper>
+      <Grid container className="my0">
+        <Grid item xs={12} className="py0">
+          <Table arial-label="List of Linodes">
+            <TableHead data-qa-table-head>
+              <TableRow>
+                <TableSortCell
+                  label='label'
+                  direction={order}
+                  active={isActive('label')}
+                  handleClick={handleOrderChange}
+                >
+                  Linode
+                </TableSortCell>
+                <TableCell>Plan</TableCell>
+                <TableCell noWrap>Last Backup</TableCell>
+                <TableCell>IP Addresses</TableCell>
+                <TableCell>Region</TableCell>
+                {/** @todo Enable sorting by region once ARB-1014 is resolved. */}
+                {/* <TableSortCell
+                  label='region'
+                  direction={order}
+                  active={isActive('region')}
+                  handleClick={handleOrderChange}
+                >
+                  Region
+                </TableSortCell> */}
+                <TableCell />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {linodes.map(linode =>
+                <LinodeRow
+                  key={linode.id}
+                  linodeId={linode.id}
+                  linodeType={linode.type}
+                  linodeStatus={linode.status}
+                  linodeIpv4={linode.ipv4}
+                  linodeIpv6={linode.ipv6}
+                  linodeRegion={linode.region}
+                  linodeNotification={linode.notification}
+                  linodeLabel={linode.label}
+                  linodeBackups={linode.backups}
+                  linodeTags={linode.tags}
+                  linodeRecentEvent={linode.recentEvent}
+                  openConfigDrawer={openConfigDrawer}
+                  toggleConfirmation={toggleConfirmation}
+                  mostRecentBackup={linode.mostRecentBackup}
+                />,
+              )}
+            </TableBody>
+          </Table>
         </Grid>
-      </Paper>
-    )
-  }
+      </Grid>
+    </Paper>
+  );
+};
+interface Props extends ViewProps {
+  view: 'grid' | 'list';
+}
 
-  render() {
-    const { view } = this.props;
-    return (
-      <React.Fragment>
-        {(view === 'grid')
-          ? this.renderCards()
-          : this.renderRows()}
-      </React.Fragment>
-    );
-  }
+const LinodesViewWrapper: React.StatelessComponent<Props> = (props) => {
+  const { view, ...rest } = props;
+  const Component = view === 'grid' ? CardView : RowView;
+
+  return <Component {...rest} />
 };
 
 export default LinodesViewWrapper;


### PR DESCRIPTION
add: Enable sorting of the Linodes landing table by Linode labels.

## Note
Story for adding ordering by region M3-1989 was found to be blocked.