### PR TITLE
M3-1979 Remove size helper text from create volume form

### DIFF
--- a/src/features/Volumes/VolumeDrawer/SizeField.tsx
+++ b/src/features/Volumes/VolumeDrawer/SizeField.tsx
@@ -24,7 +24,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 const SizeField: React.StatelessComponent<CombinedProps> = ({ error, onBlur, onChange, value, name, resize }) => {
   const helperText = resize
     ? `This volume can range from ${resize} GiB to ${MAX_VOLUME_SIZE} GiB in size.`
-    : `A single volume can range from 10 GiB to ${MAX_VOLUME_SIZE} GiB in size.`;
+    : undefined;
 
   return (<TextField
     data-qa-size


### PR DESCRIPTION
Remove redundant form helper text for volume size when creating a volume. Helper text will still appear on the resize volume drawer (as it includes a reminder that volumes can't be sized down).

changed
- Remove helper text from size field when creating a Volume