### PR TITLE
M3-1985 Fix NodeBalancer Tag Error

### DIFF
--- a/src/components/TagsPanel/TagsPanel.tsx
+++ b/src/components/TagsPanel/TagsPanel.tsx
@@ -249,12 +249,12 @@ class TagsPanel extends React.Component<CombinedProps, State> {
         })
       })
       .catch(e => {
-        const APIErrors = pathOr(
+        const tagError = pathOr(
           'Error while creating tag',
-          ['response', 'data', 'errors'],
+          ['response', 'data', 'errors', 0, 'reason'],
           e);
         // display the first error in the array or a generic one
-        this.setState({ tagError: APIErrors[0].reason || 'Error while creating tag' })
+        this.setState({ tagError })
       })
   }
 

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -125,12 +125,9 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
   updateTags = (tags: string[]) => {
     const { nodeBalancer } = this.state;
     return updateNodeBalancer(nodeBalancer.id, { tags })
-    .then(() => {
-      this.setState({ nodeBalancer: { ...nodeBalancer, tags }, ApiError: undefined })
-    })
-    .catch(() => {
-      this.props.enqueueSnackbar("There was an error updating tags for this NodeBalancer.", { variant: 'error' });
-    });
+      .then(() => {
+        this.setState({ nodeBalancer: { ...nodeBalancer, tags }, ApiError: undefined })
+      })
   }
 
   cancelUpdate = () => {


### PR DESCRIPTION
### Purpose

Previously, NodeBalancer tag errors were appearing as toasts.

We remove the toast handler because the inline error is handled natively in the TagsPanel component

### Notes

There's an API issue currently that deals with tag error handling.

NodeBalancers and Volumes return this error format:

`nth is a duplicate tag ` which to the user looks like `Tag 1 is a duplicate tag`

while Linodes and Domains errors return 

`An entity may not have the same tag twice`

There is an API ticket open to resolve this. see ARB-1016 and ARB-1017