### PR TITLE
M3-1988 Tag links

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,13 +1,16 @@
 import { withKnobs } from '@storybook/addon-knobs';
 import { addDecorator, configure } from '@storybook/react';
+import StoryRouter from 'storybook-react-router';
 import '../.storybook/storybook.css';
 import '../public/fonts/fonts.css';
 import '../src/index.css';
 import ThemeDecorator from '../src/utilities/storybookDecorators';
 
+
 /** Global decorators */
 addDecorator(ThemeDecorator);
 addDecorator(withKnobs);
+addDecorator(StoryRouter());
 
 // automatically import all files ending in *.stories.js
 const req = require.context('../src/components', true, /.stories.tsx?$/);

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "mountebank": "^1.14.1",
     "otplib": "^10.0.1",
     "selenium-standalone": "^6.13.0",
+    "storybook-react-router": "^1.0.2",
     "svgr": "^1.9.0",
     "tslint-config-airbnb": "^5.6.0",
     "tslint-config-prettier": "^1.13.0",

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -2,7 +2,6 @@ import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 
-
 import Tag from './Tag';
 
 storiesOf('Tags', module)

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,6 +1,8 @@
 import Close from '@material-ui/icons/Close';
 import * as classNames from 'classnames';
 import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { compose } from 'recompose';
 import Chip, { ChipProps } from 'src/components/core/Chip';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 
@@ -87,18 +89,24 @@ export interface Props extends ChipProps {
   colorVariant?: Variants;
 }
 
-type PropsWithStyles = Props & WithStyles<CSSClasses>;
+type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<CSSClasses>;
 
-class Tag extends React.Component<PropsWithStyles, {}> {
+class Tag extends React.Component<CombinedProps, {}> {
   static defaultProps = {
     colorVariant: 'gray' as Variants,
   };
+
+  handleClick = () => {
+    const { history, label } = this.props;
+    history.push(`/search/?query=${label}`);
+  }
 
   render() {
     const {
       colorVariant,
       classes,
       className,
+      history, location, staticContext, match, // Don't pass route props to the Chip component
       ...chipProps
     } = this.props;
 
@@ -111,6 +119,7 @@ class Tag extends React.Component<PropsWithStyles, {}> {
       })}
       deleteIcon={this.props.deleteIcon || <Close />}
       classes={{ label: classes.label, deletable: classes[colorVariant!]}}
+      onClick={this.handleClick}
       data-qa-tag={this.props.label}
       component="div"
       role="term"
@@ -120,4 +129,9 @@ class Tag extends React.Component<PropsWithStyles, {}> {
 
 const styled = withStyles(styles);
 
-export default styled(Tag);
+const enhanced = compose<CombinedProps, Props>(
+  styled,
+  withRouter,
+)(Tag)
+
+export default enhanced;

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -96,7 +96,8 @@ class Tag extends React.Component<CombinedProps, {}> {
     colorVariant: 'gray' as Variants,
   };
 
-  handleClick = () => {
+  handleClick = (e: React.MouseEvent<any>) => {
+    e.preventDefault();
     const { history, label } = this.props;
     history.push(`/search/?query=${label}`);
   }
@@ -121,7 +122,7 @@ class Tag extends React.Component<CombinedProps, {}> {
       classes={{ label: classes.label, deletable: classes[colorVariant!]}}
       onClick={this.handleClick}
       data-qa-tag={this.props.label}
-      component="div"
+      component="button"
       role="term"
     />;
   }

--- a/src/components/Tags/Tags.tsx
+++ b/src/components/Tags/Tags.tsx
@@ -6,6 +6,7 @@ import Tag from 'src/components/Tag';
 
 export interface Props {
   tags: string[];
+  clickable?: boolean;
 }
 
 type ClassNames = 'root'
@@ -29,14 +30,15 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 export class Tags extends React.Component<CombinedProps, {}> {
   renderTags = (tags: string[]) => {
-    const { classes } = this.props;
+    const { classes, clickable } = this.props;
     return tags.map(eachTag => {
       return (
         <Tag
           className={classes.tag}
           label={eachTag}
           key={eachTag}
-          clickable={false}
+          clickable={clickable}
+          component="button"
         />
       )
     })

--- a/src/components/TagsPanel/TagsPanelItem.tsx
+++ b/src/components/TagsPanel/TagsPanelItem.tsx
@@ -43,6 +43,7 @@ class TagsPanelItem extends React.Component<CombinedProps, {}> {
     return (
       <Tag
         {...restOfProps}
+        clickable
         deleteIcon={this.renderIcon()}
         onDelete={this.handleDelete}
       />

--- a/src/features/Search/ResultRow.tsx
+++ b/src/features/Search/ResultRow.tsx
@@ -39,6 +39,16 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     paddingBottom: '0 !important',
     width: '100%',
     cursor: 'pointer',
+    '&:hover': {
+      '& $rowContent': {
+        background: theme.bg.tableHeader,
+        '&:before': {
+          backgroundColor: theme.palette.primary.main,
+        }
+      }
+    },
+  },
+  description: {
   },
   label: {
     wordBreak: 'break-all',
@@ -68,14 +78,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     },
   },
   regionCell: {
-    width: '100%', 
+    width: '100%',
     [theme.breakpoints.up('md')]: {
       width: '15%',
       padding: 4,
     },
   },
   createdCell: {
-    width: '100%', 
+    width: '100%',
     [theme.breakpoints.up('md')]: {
       width: '20%',
       padding: 4,

--- a/src/features/StackScripts/LandingPanel/Table/TableRows/TableRows.test.tsx
+++ b/src/features/StackScripts/LandingPanel/Table/TableRows/TableRows.test.tsx
@@ -31,9 +31,6 @@ beforeAll(() => {
 
 describe('StackScript Table Rows', () => {
   it('should render 2 rows', () => {
-
-    // console.log(component.debug());
-
     expect(component.find('WithStyles(withRouter(TableRow))')).toHaveLength(2)
   });
 
@@ -41,14 +38,14 @@ describe('StackScript Table Rows', () => {
     const firstRow = component
       .find('WithStyles(WrappedTableCell)[parentColumn="Compatible Images"]')
       .first();
-    expect(firstRow.find('WithStyles(Tag)')).toHaveLength(3);
+    expect(firstRow.find('WithStyles(withRouter(Tag))')).toHaveLength(3);
   });
 
   it('the second row should render 3 tags and a "Show More" button', () => {
     const secondRow = component
       .find('WithStyles(WrappedTableCell)[parentColumn="Compatible Images"]')
       .at(1);
-    expect(secondRow.find('WithStyles(Tag)')).toHaveLength(3);
+    expect(secondRow.find('WithStyles(withRouter(Tag))')).toHaveLength(3);
     expect(secondRow.find('WithStyles(ShowMore)')).toHaveLength(1)
   });
 

--- a/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
+++ b/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
@@ -42,6 +42,7 @@ class SearchSuggestion extends React.Component<CombinedProps> {
       <Tag
         key={`tag-${tag}`}
         label={tag}
+        clickable
         colorVariant={selected ? 'blue' : 'lightGray'}
       />
     );

--- a/src/storybook.d.ts
+++ b/src/storybook.d.ts
@@ -1,0 +1,1 @@
+declare module 'storybook-react-router';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12421,6 +12421,13 @@ stealthy-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
+storybook-react-router@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/storybook-react-router/-/storybook-react-router-1.0.2.tgz#8c53a809b343d41002c3373e53ef4a642a2b34ce"
+  integrity sha512-+dV0wMO8DW3oUaUykoQJKC11uugwgwZRHsXksmO6bRo36CDoJPGFjfnT8LAkDpT1E9FaDZ668xOhJ+7Ml0qUDQ==
+  dependencies:
+    prop-types "^15.6.1"
+
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"


### PR DESCRIPTION
added:
- storybook-router-react added as a dev dependency (allows using a router decorator
so that stories for components with Router don't break)

changed:
- Tag is now a routable component
- Make tags clickable in Tags.tsx and SearchSuggestion.tsx
- Update tests
- When clicked, a Tag will link to the search results page for its label
(i.e. /search/?query=tag-name)