### PR TITLE
M3-1916 Make clickable row UX more consistent

### DIFF
--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -42,18 +42,26 @@ interface Props {
   htmlFor?: string;
 }
 
+
 type CombinedProps = Props & _TableRowProps & RouteComponentProps<{}> & WithStyles<ClassNames>;
 
 class TableRow extends React.Component<CombinedProps> {
 
   rowClick = (e: any, target: string | onClickFn ) =>  {
-    if (e.target.tagName === 'TD') {
-      e.stopPropagation();
-      if (typeof(target) === 'string') {
-        this.props.history.push(target);
+    const body = document.body as any;
+
+    // if no modal is open
+    if (body.getAttribute('style') !== null && body.getAttribute('style').indexOf('overflow: hidden') !== 0) {
+      // Inherit the ROW click unless the element is a <button> or an <a> or is contained within them
+      if (e.target.tagName !== 'BUTTON' && !e.target.closest('button')
+          && e.target.tagName !== 'A' && !e.target.closest('a')) {
+          e.stopPropagation();
+          if (typeof(target) === 'string') {
+            this.props.history.push(target);
+          }
       }
+      if (typeof(target) === 'function') { target(e) };
     }
-    if (typeof(target) === 'function') { target(e) };
   }
 
   render() {

--- a/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -148,7 +148,7 @@ class AddonsPanel extends React.Component<CombinedProps> {
                     data-qa-check-private-ip
                   />
                 }
-                label="Private IP (Free!)"
+                label="Private IP"
               />
             </Grid>
           </Grid>


### PR DESCRIPTION
We had reports of user experience inconsistencies for this component. clicking in some areas of the rows that were not CTAs would **not** trigger the row click. 

This PR fixes that as well as making sure sure that clicking on regular text triggers the row click while stopping propagation `<a>` and `<button>` tags and their children