### PR TITLE
M3-1939 Add analytics to GetAllEntities()

### DIFF
--- a/src/components/StackScript/StackScript.tsx
+++ b/src/components/StackScript/StackScript.tsx
@@ -7,7 +7,7 @@ import ScriptCode from 'src/components/ScriptCode';
 import { getImages } from 'src/services/images';
 import { getAll } from 'src/utilities/getAll';
 
-const getAllImages = getAll(getImages);
+const getAllImages = getAll<Linode.Image>(getImages);
 
 type CSSClasses = 'root' | 'deployments' | 'author' | 'description' | 'scriptHeading' | 'descriptionText';
 
@@ -62,8 +62,8 @@ export class StackScript extends React.Component<PropsWithStyles, {}> {
   componentDidMount() {
     const { data: { images } } = this.props;
 
-    getAllImages().then(allImages => {
-      const imagesList = allImages.filter((image: Linode.Image)  => images.indexOf(image.id) !== -1)
+    getAllImages().then(({ data: allImages }) => {
+      const imagesList = allImages.filter((image: Linode.Image) => images.indexOf(image.id) !== -1)
       this.setState({ imagesList });
     });
   }

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -460,7 +460,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
         </Grid>
         <Grid item>
           <ActionsPanel>
-            <Button onClick={this.onSubmit}  type="primary">Submit</Button>
+            <Button onClick={this.onSubmit} type="primary">Submit</Button>
             <Button
               type="secondary"
               className="cancel"
@@ -480,7 +480,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     const { linodeId, linodeRegion } = this.props;
     /** Get all volumes for usage in the block device assignment. */
     getAllVolumes()
-      .then((volumes) => volumes.reduce((result: Linode.Volume[], volume: Linode.Volume) => {
+      .then(({ data: volumes }) => volumes.reduce((result: Linode.Volume[], volume: Linode.Volume) => {
         /**
          * This is a combination of filter and map. Filter out irrelevant volumes, and update
          * volumes with the special _id property.
@@ -503,7 +503,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
 
     /** Get all Linode disks for usage in the block device assignment. */
     getAllLinodeDisks(linodeId)
-      .then(disks => disks.map((disk:Linode.Disk) => ({ ...disk, _id: `disk-${disk.id}` })))
+      .then(disks => disks.map((disk: Linode.Disk) => ({ ...disk, _id: `disk-${disk.id}` })))
       .then(disks => this.setState({ availableDevices: { ...this.state.availableDevices, disks } }))
       .catch(console.error);
   }
@@ -613,7 +613,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     this.setState({ loading: { ...this.state.loading, kernels: true } });
 
     return getAllKernels({}, { [linodeHypervisor]: true })
-      .then((kernels) => {
+      .then(({ data: kernels }) => {
         this.setState({
           kernels,
           loading: { ...this.state.loading, kernels: false },

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -90,8 +90,8 @@ interface State {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const getAllKernels = getAll(getLinodeKernels);
-const getAllVolumes = getAll(getVolumes);
+const getAllKernels = getAll<Linode.Kernel>(getLinodeKernels);
+const getAllVolumes = getAll<Linode.Volume>(getVolumes);
 const getAllLinodeDisks = getAllFromEntity(getLinodeDisks);
 
 class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
@@ -497,7 +497,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
 
         return result;
       }, []))
-      .then(volumes => this.setState({ availableDevices: { ...this.state.availableDevices, volumes } }))
+      .then((volumes: ExtendedVolume[]) =>
+        this.setState({ availableDevices: { ...this.state.availableDevices, volumes } }))
       .catch(console.error);
 
     /** Get all Linode disks for usage in the block device assignment. */

--- a/src/utilities/analytics.ts
+++ b/src/utilities/analytics.ts
@@ -4,6 +4,7 @@ interface AnalyticsEvent {
   category: string,
   action: string,
   label?: string,
+  value?: number,
 }
 
 /*


### PR DESCRIPTION
### Purpose

Log to Google analytics how many entities we are requesting when we make a network request for all entities

### Notes
* return API `results` meta data in the `getAll()` response
* Filtering out public images from the imageCount because there's no reason to include them in the total count
* Split the analytics tracking into buckets (i.e 1-10, 11-20, 21-50, etc)
* Also sent the actual number requested to analytics
* Typed the response of `getAll()`
   * Typescript compiler was complaining about the rest parameter `...results` being typed as `any`, even though the linter thought otherwise. Not sure if this is a TS bug or I'm just doing something wrong.

### To test
1. Ensure the `REACT_APP_GA_ID` is in your `.env` file. Let me know if you need the ID for manager.dev.linode.com
2. Run the app and search for something in the search box so that a network request happens to get all entities
3. Head over to Google Analytics on the manager.dev.linode.com project and view all events in real time. You should see your search come in