### PR TITLE
Compose for running automation against specific environments

### DIFF
--- a/ci-environment-test.yml
+++ b/ci-environment-test.yml
@@ -13,20 +13,6 @@ services:
       - SCREEN_WIDTH=1600
     depends_on:
       - selenium
-  manager-local:
-    environment:
-      - HTTPS=true
-      - REACT_APP_APP_ROOT=${REACT_APP_APP_ROOT}
-      - REACT_APP_LOGIN_ROOT=${REACT_APP_LOGIN_ROOT}
-      - REACT_APP_CLIENT_ID=${REACT_APP_CLIENT_ID}
-      - REACT_APP_API_ROOT=${REACT_APP_API_ROOT}
-      - REACT_APP_TEST_ENVIRONMENT=true
-    build:
-      context: .
-      dockerfile: Dockerfile
-    entrypoint: ["/src/scripts/start_manager.sh"]
-    depends_on:
-      - chrome
   manager-e2e:
     environment:
       - DOCKER=true
@@ -43,6 +29,6 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./e2e/test-results:/src/e2e/test-results
-    entrypoint: ["./scripts/wait-for-it.sh", "-t", "250", "-s", "manager-local:3000", "--", "yarn","e2e", "--log"]
+    entrypoint: ["./scripts/wait-for-it.sh", "-t", "250", "-s", "selenium:4444", "--", "yarn","e2e", "--log"]
     depends_on:
-      - manager-local
+      - chrome

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -125,7 +125,7 @@ exports.config = {
     // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
     // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
     // gets prepended directly.
-    baseUrl: process.env.DOCKER ? 'https://manager-local:3000' : process.env.REACT_APP_APP_ROOT,
+    baseUrl: process.env.REACT_APP_APP_ROOT,
     //
     // Default timeout for all waitFor* commands.
     waitforTimeout: process.env.DOCKER || process.env.BROWSERSTACK_USERNAME ? 30000 : 10000,


### PR DESCRIPTION
Maintain the integration-test.yml to still run manager UI in a docker container with most recent changes, added ci-environment-test.yml to just have selenium and test runner container, then switch test job to linodemanager-e2e-v2.