### PR TITLE
M3-2006 Edit SOA drawer loading button styling bug

### DIFF
--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -511,6 +511,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     const buttonProps: ButtonProps = {
       type: submitting ? 'secondary' : 'primary',
       disabled: submitting,
+      loading: submitting,
       className: classNames({ loading: submitting }),
       onClick: isDomain
         ? this.onDomainEdit


### PR DESCRIPTION
Essentially the loading styles/prop weren't passing to the internal elements of the button component for the domain record drawer and so the loading icon never appeared. I did a quick search for other places we might be setting up buttons in this way but if you know of others we should review, please call it out here.

See ticket for additional details.