### PR TITLE
M3-2004 Tag as Buttons styles refactor

### DIFF
--- a/src/components/CircleProgress/CircleProgress.tsx
+++ b/src/components/CircleProgress/CircleProgress.tsx
@@ -9,6 +9,7 @@ type CSSClasses = 'root'
 | 'topWrapper'
 | 'noTopMargin'
 | 'mini'
+| 'tag'
 | 'hasValueInside'
 | 'green'
 | 'valueInside';
@@ -60,6 +61,13 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   mini: {
     padding: theme.spacing.unit * 1.3,
   },
+  tag: {
+    width: '12px !important',
+    height: '12px !important',
+    padding: 0,
+    marginLeft: 4,
+    marginRight: 4,
+  },
   valueInside: {
     position: 'absolute',
     marginTop: theme.spacing.unit / 2,
@@ -87,6 +95,7 @@ interface Props extends CircularProgressProps {
   className?: string;
   noInner?: boolean;
   mini?: boolean;
+  tag?: boolean;
   children?: JSX.Element;
   green?: boolean;
 }
@@ -96,7 +105,7 @@ type CombinedProps = Props & WithStyles<CSSClasses>;
 const circleProgressComponent: React.StatelessComponent<CombinedProps> = (props) => {
   const variant = typeof props.value === 'number' ? 'static' : 'indeterminate';
   const value = typeof props.value === 'number' ? props.value : 0;
-  const { children, classes, noTopMargin, green, ...rest } = props;
+  const { children, classes, noTopMargin, green, mini, tag, ...rest } = props;
 
   const outerClasses = {
     [classes.root]: true,
@@ -110,7 +119,7 @@ const circleProgressComponent: React.StatelessComponent<CombinedProps> = (props)
   }
 
   return (
-    (!props.mini)
+    (!mini)
       ? <div className={classNames({
         [classes.root]: true,
         [classes.noTopMargin]: noTopMargin,
@@ -139,7 +148,10 @@ const circleProgressComponent: React.StatelessComponent<CombinedProps> = (props)
         />
       </div>
       : <CircularProgress
-          className={classes.mini}
+          className={classNames({
+            [classes.mini]: true,
+            [classes.tag]: tag,
+          })}
           data-qa-circle-progress
         />
   );

--- a/src/components/CircleProgress/CircleProgress.tsx
+++ b/src/components/CircleProgress/CircleProgress.tsx
@@ -67,6 +67,9 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     padding: 0,
     marginLeft: 4,
     marginRight: 4,
+    '& circle': {
+      stroke: 'white',
+    },
   },
   valueInside: {
     position: 'absolute',

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -219,6 +219,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   selectedMenuItem: {
     ...theme.animateCircleIcon,
     backgroundColor: `${theme.bg.main} !important`,
+    '& .tag': {
+      backgroundColor: theme.bg.lightBlue,
+      color: theme.palette.text.primary,
+      '&:hover': {
+        backgroundColor: theme.palette.primary.main,
+        color: 'white'
+      }
+    }
   },
 });
 

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -67,9 +67,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     '& .react-select__input': {
       width: '100%',
       color: theme.palette.text.primary,
-      '& input': {
-        width: '100% !important',
-      },
     },
     '& .react-select__menu': {
       margin: '-1px 0 0 0',
@@ -109,31 +106,36 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     },
     '& .react-select__multi-value': {
       borderRadius: 4,
-      backgroundColor: theme.bg.main,
+      backgroundColor: theme.bg.lightBlue,
       alignItems: 'center',
-      padding: '2px 2px 3px',
-      '& svg': {
-        color: 'white',
-      },
+      
     },
     '& .react-select__multi-value__label': {
       color: theme.palette.text.primary,
-      fontSize: '100%',
-      backgroundColor: theme.bg.main,
+      fontSize: '.8rem',
+      height: 20,
+      marginTop: 2,
+      marginBottom: 2,
+      marginRight: 4,
+      paddingLeft: 6,
+      paddingRight: 0,
     },
     '& .react-select__multi-value__remove': {
-      backgroundColor: theme.palette.primary.main,
+      backgroundColor: 'transparent',
       borderRadius: '50%',
-      width: 18,
-      height: 18,
-      padding: 0,
+      padding: 2,
       marginLeft: 4,
       marginRight: 4,
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
+      '& svg': {
+        color: theme.palette.text.primary,
+        width: 12,
+        height: 12,
+      },
       '&:hover': {
-        backgroundColor: theme.palette.primary.light,
+        backgroundColor: theme.palette.primary.main,
         '& svg': {
           color: 'white',
         },

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -95,6 +95,7 @@ export interface Props extends ChipProps {
   label: string;
   colorVariant?: Variants;
   asSuggestion?: boolean;
+  closeMenu?: any;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<CSSClasses>;
@@ -108,6 +109,7 @@ class Tag extends React.Component<CombinedProps, {}> {
     e.preventDefault();
     if (this.props.asSuggestion) {
       e.stopPropagation();
+      this.props.closeMenu();
     }
     const { history, label } = this.props;
     history.push(`/search/?query=${label}`);
@@ -120,6 +122,7 @@ class Tag extends React.Component<CombinedProps, {}> {
       className,
       history, location, staticContext, match, // Don't pass route props to the Chip component
       asSuggestion,
+      closeMenu,
       ...chipProps
     } = this.props;
 

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -117,6 +117,7 @@ class Tag extends React.Component<CombinedProps, {}> {
       classes,
       className,
       history, location, staticContext, match, // Don't pass route props to the Chip component
+      asSuggestion,
       ...chipProps
     } = this.props;
 

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -25,59 +25,60 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => {
     root: {},
     white: {
       backgroundColor: theme.color.white,
-      '&:focus': {
+      '&:hover': {
         backgroundColor: theme.color.white,
       },
     },
     gray: {
       backgroundColor: '#939598',
       color: 'white',
-      '&:focus': {
+      '&:hover': {
         backgroundColor: '#939598',
       },
     },
     lightGray: {
       backgroundColor: '#C9CACB',
       color: 'white',
-      '&:focus': {
+      '&:hover': {
         backgroundColor: '#C9CACB',
       },
     },
     blue: {
       backgroundColor: theme.palette.primary.main,
       color: 'white',
-      '&:focus': {
+      '&:hover': {
         backgroundColor: theme.palette.primary.main,
       },
     },
     lightBlue: {
       backgroundColor: theme.bg.lightBlue,
-      '&:focus': {
-        backgroundColor: theme.bg.lightBlue,
+      '&:hover': {
+        backgroundColor: theme.palette.primary.main,
+        color: 'white'
       },
     },
     green: {
       backgroundColor: '#61CD7B',
       color: 'white',
-      '&:focus': {
+      '&:hover': {
         backgroundColor: '#61CD7B',
       },
     },
     lightGreen: {
       backgroundColor: '#DFF3E7',
-      '&:focus': {
+      '&:hover': {
         backgroundColor: '#DFF3E7',
       },
     },
     yellow: {
       backgroundColor: '#F8D147',
-      '&:focus': {
+      '&:hover': {
         backgroundColor: '#F8D147',
       },
     },
     lightYellow: {
       backgroundColor: '#FCF4DD',
-      '&:focus': {
+      '&:hover': {
         backgroundColor: '#FCF4DD',
       },
     },
@@ -123,7 +124,7 @@ class Tag extends React.Component<CombinedProps, {}> {
       onClick={this.handleClick}
       data-qa-tag={this.props.label}
       component="button"
-      role="term"
+      role="button"
     />;
   }
 };

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,3 +1,4 @@
+import IconButton from '@material-ui/core/IconButton';
 import Close from '@material-ui/icons/Close';
 import * as classNames from 'classnames';
 import * as React from 'react';
@@ -5,6 +6,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import Chip, { ChipProps } from 'src/components/core/Chip';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
+
 
 type Variants =
   'white'
@@ -128,11 +130,12 @@ class Tag extends React.Component<CombinedProps, {}> {
         [classes[colorVariant!]]: true,
         [classes.root]: true,
       })}
-      deleteIcon={this.props.deleteIcon || <Close />}
+      deleteIcon={<IconButton data-qa-delete-tag className="deleteButton"><Close /></IconButton>}
       classes={{ label: classes.label, deletable: classes[colorVariant!]}}
       onClick={this.handleClick}
       data-qa-tag={this.props.label}
-      component="button"
+      component="div"
+      clickable
       role="button"
     />;
   }

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -56,6 +56,10 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => {
         backgroundColor: theme.palette.primary.main,
         color: 'white'
       },
+      '&:focus': {
+        backgroundColor: theme.bg.lightBlue,
+        color: theme.color.black,
+      }
     },
     green: {
       backgroundColor: '#61CD7B',
@@ -88,6 +92,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => {
 export interface Props extends ChipProps {
   label: string;
   colorVariant?: Variants;
+  asSuggestion?: boolean;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}> & WithStyles<CSSClasses>;
@@ -99,6 +104,9 @@ class Tag extends React.Component<CombinedProps, {}> {
 
   handleClick = (e: React.MouseEvent<any>) => {
     e.preventDefault();
+    if (this.props.asSuggestion) {
+      e.stopPropagation();
+    }
     const { history, label } = this.props;
     history.push(`/search/?query=${label}`);
   }

--- a/src/components/Tags/Tags.tsx
+++ b/src/components/Tags/Tags.tsx
@@ -16,12 +16,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => {
   return ({
     root: {},
     tag: {
-      backgroundColor: theme.color.grey2,
       color: theme.palette.text.primary,
       fontFamily: 'LatoWeb',
-      '&:focus': {
-        backgroundColor: theme.color.grey2,
-      },
     },
   });
 };
@@ -39,6 +35,7 @@ export class Tags extends React.Component<CombinedProps, {}> {
           key={eachTag}
           clickable={clickable}
           component="button"
+          colorVariant="lightBlue"
         />
       )
     })

--- a/src/components/TagsPanel/TagsPanel.tsx
+++ b/src/components/TagsPanel/TagsPanel.tsx
@@ -33,6 +33,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     position: 'relative',
     top: theme.spacing.unit,
     marginRight: theme.spacing.unit,
+    [theme.breakpoints.down('xs')]: {
+      marginRight: 16,
+    }
   },
   addButton: {
     marginTop: theme.spacing.unit / 2,

--- a/src/components/TagsPanel/TagsPanel.tsx
+++ b/src/components/TagsPanel/TagsPanel.tsx
@@ -33,16 +33,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     position: 'relative',
     top: theme.spacing.unit,
     marginRight: theme.spacing.unit,
-    padding: theme.spacing.unit / 2,
-    backgroundColor: theme.color.grey2,
-    color: theme.palette.text.primary,
-    '& > span': {
-      position: 'relative',
-      top: -2,
-    },
-    '&:focus': {
-      backgroundColor: theme.color.grey2,
-    },
   },
   addButton: {
     marginTop: theme.spacing.unit / 2,

--- a/src/components/TagsPanel/TagsPanelItem.tsx
+++ b/src/components/TagsPanel/TagsPanelItem.tsx
@@ -35,7 +35,7 @@ class TagsPanelItem extends React.Component<CombinedProps, {}> {
   renderIcon = () => {
     return (!this.props.loading)
       ? <Close data-qa-delete-tag />
-      : <CircleProgress mini />
+      : <CircleProgress mini tag />
   }
 
   render() {
@@ -43,9 +43,10 @@ class TagsPanelItem extends React.Component<CombinedProps, {}> {
     return (
       <Tag
         {...restOfProps}
-        clickable
         deleteIcon={this.renderIcon()}
         onDelete={this.handleDelete}
+        component="button"
+        colorVariant="lightBlue"
       />
     );
   }

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -140,6 +140,7 @@ interface State {
   [resource: string]: any;
   options: Item[];
   searchResults: SearchResults;
+  menuOpen: boolean;
 }
 
 type CombinedProps = TypesContextProps
@@ -181,6 +182,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
     searchActive: false,
     resultsLoading: false,
     options: [],
+    menuOpen: false,
     searchResults: {...emptyResults}
   };
 
@@ -272,15 +274,22 @@ class SearchBar extends React.Component<CombinedProps, State> {
   toggleSearch = () => {
     this.setState({
       searchActive: !this.state.searchActive,
+      menuOpen: !this.state.menuOpen,
     });
   }
 
   onClose = () => {
-    this.setState({ searchActive: false })
+    this.setState({
+      searchActive: false,
+      menuOpen: false,
+    })
   }
 
   onOpen = () => {
-    this.setState({ searchActive: true });
+    this.setState({
+      searchActive: true,
+      menuOpen: true,
+    });
   }
 
   onSelect = (item: Item) => {
@@ -307,7 +316,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
 
   render() {
     const { classes } = this.props;
-    const { searchActive, searchText, options, resultsLoading } = this.state;
+    const { searchActive, searchText, options, resultsLoading, menuOpen } = this.state;
     const defaultOption = {
       label: `View search results page for "${searchText}"`,
       value: 'redirect',
@@ -361,6 +370,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
             onMenuClose={this.onClose}
             onMenuOpen={this.onOpen}
             value={false}
+            menuIsOpen={menuOpen}
           />
           <IconButton
             color="inherit"

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -361,7 +361,6 @@ class SearchBar extends React.Component<CombinedProps, State> {
             onMenuClose={this.onClose}
             onMenuOpen={this.onOpen}
             value={false}
-            menuIsOpen={true}
           />
           <IconButton
             color="inherit"

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -361,6 +361,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
             onMenuClose={this.onClose}
             onMenuOpen={this.onOpen}
             value={false}
+            menuIsOpen={true}
           />
           <IconButton
             color="inherit"

--- a/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
+++ b/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
@@ -43,7 +43,9 @@ class SearchSuggestion extends React.Component<CombinedProps> {
         key={`tag-${tag}`}
         label={tag}
         clickable
-        colorVariant={selected ? 'blue' : 'lightGray'}
+        colorVariant={selected ? 'blue' : 'lightBlue'}
+        component="button"
+        asSuggestion
       />
     );
   }

--- a/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
+++ b/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
@@ -45,7 +45,7 @@ class SearchSuggestion extends React.Component<CombinedProps> {
         clickable
         colorVariant={selected ? 'blue' : 'lightBlue'}
         component="button"
-        asSuggestion
+        asSuggestion={true}
         className="tag"
       />
     );

--- a/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
+++ b/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
@@ -47,6 +47,7 @@ class SearchSuggestion extends React.Component<CombinedProps> {
         component="button"
         asSuggestion={true}
         className="tag"
+        closeMenu={this.props.selectProps.onMenuClose}
       />
     );
   }

--- a/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
+++ b/src/features/TopMenu/SearchBar/SearchSuggestion.tsx
@@ -46,6 +46,7 @@ class SearchSuggestion extends React.Component<CombinedProps> {
         colorVariant={selected ? 'blue' : 'lightBlue'}
         component="button"
         asSuggestion
+        className="tag"
       />
     );
   }

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -25,9 +25,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   tagWrapper: {
     marginTop: theme.spacing.unit / 2,
     marginLeft: theme.spacing.unit * 4,
-    '& .chip': {
-      cursor: 'pointer',
-    },
   },
 });
 

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -379,7 +379,7 @@ const themeDefaults: ThemeOptions = {
         marginRight: 4,
         paddingLeft: 2,
         paddingRight: 2,
-        color: '#555',
+        color: primaryColors.text,
         fontSize: '.8rem',
         '&:last-child': {
           marginRight: 0

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -393,6 +393,9 @@ const themeDefaults: ThemeOptions = {
             },
           },
         },
+        '&:focus': {
+          outline: '1px dotted #999',
+        }
       },
       label: {
         paddingLeft: 4,

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -70,6 +70,7 @@ const primaryColors = {
   headline: '#32363C',
   divider: '#f4f4f4',
   offBlack: '#444',
+  white: '#fff',
 }
 
 const iconCircleAnimation = {
@@ -385,7 +386,11 @@ const themeDefaults: ThemeOptions = {
         },
         '&:hover': {
           '& $deleteIcon': {
-            color: primaryColors.text,
+            color: primaryColors.white,
+            '&:hover': {
+              color: primaryColors.main,
+              backgroundColor: primaryColors.white,
+            },
           },
         },
       },
@@ -396,11 +401,12 @@ const themeDefaults: ThemeOptions = {
         top: -1,
       },
       deleteIcon: {
-        color: '#aaa',
-        width: 20,
-        height: 20,
-        marginLeft: 2,
-        marginRight: 2,
+        color: primaryColors.text,
+        width: 12,
+        height: 12,
+        marginLeft: 4,
+        marginRight: 4,
+        borderRadius: '50%',
       },
     },
     MuiCircularProgress: {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -404,12 +404,26 @@ const themeDefaults: ThemeOptions = {
         top: -1,
       },
       deleteIcon: {
-        color: primaryColors.text,
-        width: 12,
-        height: 12,
+        padding: 2,
         marginLeft: 4,
-        marginRight: 4,
-        borderRadius: '50%',
+        marginRight: 2,
+        color: primaryColors.text,
+        '& svg': {
+          width: 12,
+          height: 12,
+          borderRadius: '50%',
+        },
+        [breakpoints.down('xs')]: {
+          marginLeft: 8,
+          marginRight: -8,
+          color: 'white !important',
+          '& svg': {
+            width: 22,
+            height: 22,
+            borderRadius: '50%',
+            backgroundColor: primaryColors.main,
+          },
+        },
       },
     },
     MuiCircularProgress: {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -56,7 +56,7 @@ export const dark = createTheme({
     offWhite: '#111111',
     offWhiteDT: '#444', // better handing for dark theme
     navy: '#32363C',
-    lightBlue: '#444',
+    lightBlue: '#222',
     white: '#32363C',
     pureWhite: '#000',
     tableHeader: 'rgba(0, 0, 0, 0.15)',
@@ -220,20 +220,14 @@ export const dark = createTheme({
         backgroundColor: 'rgba(0, 0, 0, 0.2)',
       },
     },
+    MuiChip: {
+      root: {
+        color: primaryColors.text,
+      }
+    },
     MuiCardActions: {
       root: {
         backgroundColor: 'rgba(0, 0, 0, 0.2) !important',
-      },
-    },
-    MuiChip: {
-      root: {
-        backgroundColor: 'rgba(0, 0, 0, 0.2)',
-        color: '#fff',
-        '&:hover': {
-          '& $deleteIcon': {
-            color: '#fff',
-          },
-        },
       },
     },
     MuiDialog: {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -15,6 +15,7 @@ const primaryColors = {
   headline: '#f4f4f4',
   divider: '#222222',
   offBlack: '#fff',
+  white: '#222',
 }
 
 const iconCircleAnimation = {


### PR DESCRIPTION
This PR attempt to re-styles tags properly now that they are buttons. The goal was to achieve consistency across components and theme choice:

- check tags within tables (linodes, volumes for instance) and interact with them
- check their styling and behavior in enhanced selects (create a volume for instance)
- check their styles and behaviors on create and delete (linode detail)
- check all the above in both light and dark themes
