### PR TITLE
Update email notification setting label for clarity

### DIFF
--- a/src/features/Profile/Settings/Settings.tsx
+++ b/src/features/Profile/Settings/Settings.tsx
@@ -56,7 +56,7 @@ class ProfileSettings extends React.Component<CombinedProps, State> {
                 <Toggle onChange={this.toggle} checked={status} />
               }
               label={`
-                Email alerts if a Linode exceeds its configurated thresholds are ${status === true ? 'enabled' : 'disabled'}
+                Email alerts for account activity are ${status === true ? 'enabled' : 'disabled'}
               `}
               disabled={this.state.submitting}
             />


### PR DESCRIPTION
we send notifications for other things, e.g. events. this also matches up with the description from the API docs:

https://developers.linode.com/api/v4#operation/getProfile