### PR TITLE
M3-2011	Fix Yup errors

### DIFF
--- a/src/services/index.test.ts
+++ b/src/services/index.test.ts
@@ -16,7 +16,7 @@ describe('services', () => {
 
         return Request(setData(data, schema))
           .catch((response) => {
-            expect(response.response.data.errors).toEqual([{
+            expect(response).toEqual([{
               field: 'region',
               reason: `A region is required.`,
             }]);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -112,10 +112,7 @@ const reduceRequestConfig = (...fns: Function[]) => fns.reduceRight((result, fn)
 export default <T>(...fns: Function[]): Promise<T> => {
   const config = reduceRequestConfig(...fns);
   if (config.validationErrors) {
-    return Promise.reject({
-      config: omit(['validationErrors'], config),
-      response: { data: { errors: config.validationErrors } },
-    });
+    return Promise.reject(config.validationErrors);
   }
 
   return Axios(config)
@@ -126,7 +123,7 @@ export default <T>(...fns: Function[]): Promise<T> => {
         ['response', 'data', 'errors'],
         error
     );
-      throw defaultError;
+      return Promise.reject(defaultError);
     }) // Same with error messages. This way all errors are in Linode.ApiError[] format.
 
   /*

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,7 +5,6 @@ import {
   isNil,
   lensPath,
   not,
-  omit,
   pathOr,
   set,
   when,
@@ -221,10 +220,7 @@ export const CancellableRequest = <T>(...fns: Function[]): CancellableRequest<T>
   if (config.validationErrors) {
     return {
       cancel: () => null,
-      request: () => Promise.reject({
-        config: omit(['validationErrors'], config),
-        response: { data: { errors: config.validationErrors } },
-      }),
+      request: () => Promise.reject(config.validationErrors)
     };
   }
 
@@ -232,6 +228,14 @@ export const CancellableRequest = <T>(...fns: Function[]): CancellableRequest<T>
     cancel: source.cancel,
     request: () => Axios({ ...config, cancelToken: source.token })
       .then(response => response.data)
+      .catch(error => {
+        const defaultError = pathOr(
+          [],
+          ['response', 'data', 'errors'],
+          error
+      );
+        return Promise.reject(defaultError);
+      })
   }
 
 };


### PR DESCRIPTION
Previous PR forgot to adjust format of Yup validation errors.
Since all handlers are now expecting a list of Linode.ApiFieldError[],
that's what Yup should return as well.

## To test
1. Make a change that will trigger Yup validation but not Formik. For example, create a disk but leave the label input blank.
2. Observe: no network request should be made, the app should not crash, and a Yup validation error should be displayed.

Changed:
- Axios post-validation logic updated to return `config.validationErrors` rather than a full response object on rejection.