### PR TITLE
M3-1804 Add Total Traffic to stats

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -268,17 +268,19 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     const v6Data = {
       publicIn: pathOr([[]], ['data','netv6','in'], stats),
       publicOut: pathOr([[]], ['data','netv6','out'], stats),
+      privateIn: pathOr([[]], ['data','netv6','private_in'], stats),
     };
 
     const format = formatBitsPerSecond;
-
-    const netv4InMetrics = getMetrics(v4Data.publicIn);
-    const netv4OutMetrics = getMetrics(v4Data.publicOut);
 
     // @todo refactor this component so that these calcs don't need to be done
     // again when we render the v6 chart
     const netv6InMetrics = getMetrics(v6Data.publicIn);
     const netv6OutMetrics = getMetrics(v6Data.publicOut);
+    const netv6PrivateInMetrics = getMetrics(v6Data.privateIn);
+
+    const netv4InMetrics = getMetrics(v4Data.publicIn);
+    const netv4OutMetrics = getMetrics(v4Data.publicOut);
 
     const totalTraffic: TotalTrafficProps = map(formatBytes, getTotalTraffic(
       netv4InMetrics.total,
@@ -329,13 +331,17 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                   {
                     legendTitle: 'Private IPv4 Outbound',
                     legendColor: 'yellow',
-                    data: getMetrics(v4Data.privateOut), // <-- Include 0
+                    // We include 0 as possibility for LAST and use the length
+                    // of V6 privateIn to calculate average... no idea why
+                    data: getMetrics(v4Data.privateOut, true, netv6PrivateInMetrics.length),
                     format
                   },
                   {
                     legendTitle: 'Private IPv4 Inbound',
                     legendColor: 'red',
-                    data: getMetrics(v4Data.privateIn), // <-- Include 0
+                    // We include 0 as possibility for LAST and use the length
+                    // of V6 privateIn to calculate average... no idea why
+                    data: getMetrics(v4Data.privateIn, true, netv6PrivateInMetrics.length),
                     format
                   }
                 ]}

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -332,13 +332,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
               <MetricsDisplay
                 rows={[
                   {
-                    legendTitle: 'Private IPv4 Outbound',
+                    legendTitle: 'Private Outbound',
                     legendColor: 'yellow',
                     data: getMetrics(v4Data.privateOut),
                     format
                   },
                   {
-                    legendTitle: 'Private IPv4 Inbound',
+                    legendTitle: 'Private Inbound',
                     legendColor: 'red',
                     data: getMetrics(v4Data.privateIn),
                     format
@@ -350,13 +350,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
               <MetricsDisplay
                 rows={[
                   {
-                    legendTitle: 'Public IPv4 Outbound',
+                    legendTitle: 'Public Outbound',
                     legendColor: 'green',
                     data: netv4OutMetrics,
                     format
                   },
                   {
-                    legendTitle: 'Public IPv4 Inbound',
+                    legendTitle: 'Public Inbound',
                     legendColor: 'blue',
                     data: netv4InMetrics,
                     format
@@ -440,13 +440,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
               <MetricsDisplay
                 rows={[
                   {
-                    legendTitle: 'Private IPv6 Outbound',
+                    legendTitle: 'Private Outbound',
                     legendColor: 'yellow',
                     data: getMetrics(data.privateOut),
                     format
                   },
                   {
-                    legendTitle: 'Private IPv6 Inbound',
+                    legendTitle: 'Private Inbound',
                     legendColor: 'red',
                     data: getMetrics(data.privateIn),
                     format
@@ -458,13 +458,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
               <MetricsDisplay
                 rows={[
                   {
-                    legendTitle: 'Public IPv6 Outbound',
+                    legendTitle: 'Public Outbound',
                     legendColor: 'green',
                     data: publicOutMetrics,
                     format
                   },
                   {
-                    legendTitle: 'Public IPv6 Inbound',
+                    legendTitle: 'Public Inbound',
                     legendColor: 'blue',
                     data: publicInMetrics,
                     format
@@ -509,12 +509,12 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
             showToday={rangeSelection === '24'}
             data={[
               {
-                borderColor: '#d01e1e',
+                borderColor: '#ffd100',
                 data: data.io,
                 label: 'Disk I/O',
               },
               {
-                borderColor: '#ffd100',
+                borderColor: '#d01e1e',
                 data: data.swap,
                 label: 'Swap I/O',
               },
@@ -528,7 +528,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 rows={[
                   {
                     legendTitle: 'I/O Rate',
-                    legendColor: 'red',
+                    legendColor: 'yellow',
                     data: getMetrics(data.io),
                     format
                   }
@@ -540,7 +540,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 rows={[
                   {
                     legendTitle: 'Swap Rate',
-                    legendColor: 'yellow',
+                    legendColor: 'red',
                     data: getMetrics(data.swap),
                     format
                   }

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -257,21 +257,35 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     const { classes } = this.props;
     const { rangeSelection, stats } = this.state;
 
-    const data = {
+    const v4Data = {
       publicIn: pathOr([[]], ['data','netv4','in'], stats),
       publicOut: pathOr([[]], ['data','netv4','out'], stats),
       privateIn: pathOr([[]], ['data','netv4','private_in'], stats),
       privateOut: pathOr([[]], ['data','netv4','private_out'], stats)
     };
 
+    // Need these to calculate Total Traffic
+    const v6Data = {
+      publicIn: pathOr([[]], ['data','netv6','in'], stats),
+      publicOut: pathOr([[]], ['data','netv6','out'], stats),
+    };
+
     const format = formatBitsPerSecond;
 
-    const publicInMetrics = getMetrics(data.publicIn);
-    const publicOutMetrics = getMetrics(data.publicOut);
+    const netv4InMetrics = getMetrics(v4Data.publicIn);
+    const netv4OutMetrics = getMetrics(v4Data.publicOut);
+
+    // @todo refactor this component so that these calcs don't need to be done
+    // again when we render the v6 chart
+    const netv6InMetrics = getMetrics(v6Data.publicIn);
+    const netv6OutMetrics = getMetrics(v6Data.publicOut);
 
     const totalTraffic: TotalTrafficProps = map(formatBytes, getTotalTraffic(
-      publicInMetrics.average,
-      publicOutMetrics.average
+      netv4InMetrics.total,
+      netv4OutMetrics.total,
+      v4Data.publicIn.length,
+      netv6InMetrics.total,
+      netv6OutMetrics.total,
     ));
 
     return (
@@ -286,22 +300,22 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
             data={[
               {
                 borderColor: '#3683dc',
-                data: data.publicIn,
+                data: v4Data.publicIn,
                 label: 'Public Traffic In',
               },
               {
                 borderColor: '#01b159',
-                data: data.publicOut,
+                data: v4Data.publicOut,
                 label: 'Public Traffic Out',
               },
               {
                 borderColor: '#d01e1e',
-                data: data.privateIn,
+                data: v4Data.privateIn,
                 label: 'Private Traffic In',
               },
               {
                 borderColor: '#ffd100',
-                data: data.privateOut,
+                data: v4Data.privateOut,
                 label: 'Private Traffic Out',
               },
             ]}
@@ -315,13 +329,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                   {
                     legendTitle: 'Private IPv4 Outbound',
                     legendColor: 'yellow',
-                    data: getMetrics(data.privateOut, true), // <-- Include 0
+                    data: getMetrics(v4Data.privateOut), // <-- Include 0
                     format
                   },
                   {
                     legendTitle: 'Private IPv4 Inbound',
                     legendColor: 'red',
-                    data: getMetrics(data.privateIn, true), // <-- Include 0
+                    data: getMetrics(v4Data.privateIn), // <-- Include 0
                     format
                   }
                 ]}
@@ -333,13 +347,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                   {
                     legendTitle: 'Public IPv4 Outbound',
                     legendColor: 'green',
-                    data: publicOutMetrics,
+                    data: netv4OutMetrics,
                     format
                   },
                   {
                     legendTitle: 'Public IPv4 Inbound',
                     legendColor: 'blue',
-                    data: publicInMetrics,
+                    data: netv4InMetrics,
                     format
                   }
                 ]}
@@ -377,8 +391,10 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     const publicOutMetrics = getMetrics(data.publicOut, true); // <-- Include 0
 
     const totalTraffic: TotalTrafficProps = map(formatBytes, getTotalTraffic(
-      publicInMetrics.average,
-      publicOutMetrics.average
+      publicInMetrics.total,
+      publicOutMetrics.total,
+      publicInMetrics.length
+
     ));
 
     return (

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -28,7 +28,8 @@ type ClassNames = 'chart'
   | 'leftLegend'
   | 'bottomLegend'
   | 'graphTitle'
-  | 'graphControls';
+  | 'graphControls'
+  | 'totalTraffic';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => {
   return {
@@ -71,6 +72,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => {
       margin: `${theme.spacing.unit * 2}px 0`,
       display: 'flex',
       alignItems: 'center',
+    },
+    totalTraffic: {
+      margin: '12px',
     }
   };
 };
@@ -277,7 +281,6 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     // again when we render the v6 chart
     const netv6InMetrics = getMetrics(v6Data.publicIn);
     const netv6OutMetrics = getMetrics(v6Data.publicOut);
-    const netv6PrivateInMetrics = getMetrics(v6Data.privateIn);
 
     const netv4InMetrics = getMetrics(v4Data.publicIn);
     const netv4OutMetrics = getMetrics(v4Data.publicOut);
@@ -331,17 +334,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                   {
                     legendTitle: 'Private IPv4 Outbound',
                     legendColor: 'yellow',
-                    // We include 0 as possibility for LAST and use the length
-                    // of V6 privateIn to calculate average... no idea why
-                    data: getMetrics(v4Data.privateOut, true, netv6PrivateInMetrics.length),
+                    data: getMetrics(v4Data.privateOut),
                     format
                   },
                   {
                     legendTitle: 'Private IPv4 Inbound',
                     legendColor: 'red',
-                    // We include 0 as possibility for LAST and use the length
-                    // of V6 privateIn to calculate average... no idea why
-                    data: getMetrics(v4Data.privateIn, true, netv6PrivateInMetrics.length),
+                    data: getMetrics(v4Data.privateIn),
                     format
                   }
                 ]}
@@ -366,7 +365,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
               />
             </Grid>
             {rangeSelection === '24' &&
-              <Grid item xs={12} lg={6}>
+              <Grid item xs={12} lg={6} className={classes.totalTraffic}>
                 <TotalTraffic
                   inTraffic={totalTraffic.inTraffic}
                   outTraffic={totalTraffic.outTraffic}
@@ -393,14 +392,13 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
     const format = formatBitsPerSecond;
 
-    const publicInMetrics = getMetrics(data.publicIn, true); // <-- Include 0
-    const publicOutMetrics = getMetrics(data.publicOut, true); // <-- Include 0
+    const publicInMetrics = getMetrics(data.publicIn);
+    const publicOutMetrics = getMetrics(data.publicOut);
 
     const totalTraffic: TotalTrafficProps = map(formatBytes, getTotalTraffic(
       publicInMetrics.total,
       publicOutMetrics.total,
       publicInMetrics.length
-
     ));
 
     return (

--- a/src/features/linodes/LinodesDetail/LinodeSummary/MetricsDisplay.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/MetricsDisplay.test.tsx
@@ -1,14 +1,12 @@
 import { shallow } from 'enzyme';
-import { compose } from 'ramda';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
-import { appendPercentSign, formatNumber } from 'src/utilities/statMetrics';
+import { formatPercentage } from 'src/utilities/statMetrics';
 import { metricsBySection, MetricsDisplay } from './MetricsDisplay';
 
 
 describe('CPUMetrics', () => {
-  const mockMetrics = { max: 10, average: 5.5, last: 7.75, total: 40 };
-  const format = compose(appendPercentSign, formatNumber);
+  const mockMetrics = { max: 10, average: 5.5, last: 7.75, total: 40, length: 3 };
 
   const wrapper = shallow(
     <MetricsDisplay
@@ -18,7 +16,7 @@ describe('CPUMetrics', () => {
           legendTitle: 'Legend Title',
           legendColor: 'blue',
           data: mockMetrics,
-          format
+          format: formatPercentage
         }
       ]}
     />
@@ -57,13 +55,13 @@ describe('CPUMetrics', () => {
         legendTitle: 'Legend Title 1',
         legendColor: 'blue',
         data: mockMetrics,
-        format
+        format: formatPercentage
       },
       {
         legendTitle: 'Legend Title 2',
         legendColor: 'red',
         data: { max: 80, average: 90, last: 100, total: 110 },
-        format
+        format: formatPercentage
       }
     ]});
     expect(wrapper.find('[data-qa-legend-title]')).toHaveLength(2);
@@ -71,7 +69,7 @@ describe('CPUMetrics', () => {
 });
 
 describe('metrics by section', () => {
-  const metrics = { max: 10, average: 5, last: 8, total: 80 };
+  const metrics = { max: 10, average: 5, last: 8, total: 80, length: 10 };
   expect(metricsBySection(metrics)).toHaveLength(3);
   expect(metricsBySection(metrics)).toBeInstanceOf(Array);
   expect(metricsBySection(metrics)[0]).toEqual(metrics.max);

--- a/src/features/linodes/LinodesDetail/LinodeSummary/TotalTraffic.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/TotalTraffic.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = () => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+});
+
+export interface TotalTrafficProps {
+  inTraffic: string;
+  outTraffic: string;
+  combinedTraffic: string;
+}
+
+type CombinedProps = TotalTrafficProps & WithStyles<ClassNames>
+
+export const TotalTraffic = (props: CombinedProps) => {
+  const { classes, inTraffic, outTraffic, combinedTraffic } = props;
+  return (
+    <div className={classes.root}>
+      <Typography variant="subtitle2">
+        Total Traffic
+      </Typography>
+      <Typography>In: {inTraffic}</Typography>
+      <Typography>Out: {outTraffic}</Typography>
+      <Typography>Combined: {combinedTraffic}</Typography>
+    </div>
+  );
+}
+
+const styled = withStyles(styles);
+
+export default styled(TotalTraffic);

--- a/src/features/linodes/LinodesDetail/LinodeSummary/TotalTraffic.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/TotalTraffic.tsx
@@ -2,13 +2,16 @@ import * as React from 'react';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 
-type ClassNames = 'root';
+type ClassNames = 'root' | 'text';
 
-const styles: StyleRulesCallback<ClassNames> = () => ({
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center'
+  },
+  text: {
+    color: theme.color.black,
   },
 });
 
@@ -24,12 +27,12 @@ export const TotalTraffic = (props: CombinedProps) => {
   const { classes, inTraffic, outTraffic, combinedTraffic } = props;
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle2">
+      <Typography variant="body2" className={classes.text}>
         Total Traffic
       </Typography>
-      <Typography>In: {inTraffic}</Typography>
-      <Typography>Out: {outTraffic}</Typography>
-      <Typography>Combined: {combinedTraffic}</Typography>
+      <Typography variant="body2" className={classes.text}>In: {inTraffic}</Typography>
+      <Typography variant="body2" className={classes.text}>Out: {outTraffic}</Typography>
+      <Typography variant="body2" className={classes.text}>Combined: {combinedTraffic}</Typography>
     </div>
   );
 }

--- a/src/utilities/statMetrics.test.ts
+++ b/src/utilities/statMetrics.test.ts
@@ -30,27 +30,16 @@ describe('Stat Metrics', () => {
   });
 
   it('returns average', () => {
-    expect(metrics.average).toBe(1.008);
+    expect(metrics.average).toBe(0.63);
     expect(getMetrics([[0, 0]]).average).toBe(0);
     expect(getMetrics([[0, 0], [0, 0]]).average).toBe(0);
-    expect(getMetrics([[0, 0], [0, 1]]).average).toBe(1);
-    expect(getMetrics([[0, 0], [0, 100], [0, 100]]).average).toBe(100);
+    expect(getMetrics([[0, 0], [0, 1]]).average).toBe(0.5);
+    expect(getMetrics([[0, 0], [0, 3], [0, 12]]).average).toBe(5);
   });
 
   it('returns last', () => {
-    expect(metrics.last).toBe(1.2);
-    let newData = [...data, [0, 0]];
-    expect(getMetrics(newData).last).toBe(1.2);
-    newData = [...data, [0, 50]];
-    expect(getMetrics(newData).last).toBe(50);
-  });
-
-  it('includes 0 in calculations when passed second arg', () => {
-    const metricsWithZero = getMetrics(data, true);
-    expect(metricsWithZero.max).toBe(2.98);
-    expect(metricsWithZero.average).toBe(0.63);
-    expect(metricsWithZero.last).toBe(0);
-
+    expect(metrics.last).toBe(0);
+    expect(getMetrics([...data, [0, 8]]).last).toBe(8);
   });
 });
 

--- a/src/utilities/statMetrics.test.ts
+++ b/src/utilities/statMetrics.test.ts
@@ -56,10 +56,10 @@ describe('Stat Metrics', () => {
 
 describe('total traffic', () => {
   it('returns total traffic given the average', () => {
-    const totalTraffic = getTotalTraffic(1, 2);
-    expect(totalTraffic.inTraffic).toBe(10800);
-    expect(totalTraffic.outTraffic).toBe(21600);
-    expect(totalTraffic.combinedTraffic).toBe(32400);
+    const totalTraffic = getTotalTraffic(1, 2, 2);
+    expect(totalTraffic.inTraffic).toBe(5400);
+    expect(totalTraffic.outTraffic).toBe(10800);
+    expect(totalTraffic.combinedTraffic).toBe(16200);
     expect(totalTraffic.combinedTraffic).toEqual(totalTraffic.inTraffic + totalTraffic.outTraffic);
   });
 });
@@ -110,9 +110,9 @@ describe('format number', () => {
 
 describe('formatting', () => {
   it('formatPercent adds percent sign', () => {
-    expect(formatPercentage(12)).toBe('12.00 %');
-    expect(formatPercentage(0)).toBe('0.00 %');
-    expect(formatPercentage(123456789)).toBe('123456789.00 %');
+    expect(formatPercentage(12)).toBe('12.00%');
+    expect(formatPercentage(0)).toBe('0.00%');
+    expect(formatPercentage(123456789)).toBe('123456789.00%');
   });
   it('formatBitsPerSecond adds unit', () => {
     expect(formatBitsPerSecond(12)).toBe('12.00 b/s');

--- a/src/utilities/statMetrics.test.ts
+++ b/src/utilities/statMetrics.test.ts
@@ -1,4 +1,12 @@
-import { appendBitrateUnit, appendPercentSign, formatNumber, getMetrics } from './statMetrics';
+import {
+  formatBitsPerSecond,
+  formatBytes,
+  formatMagnitude,
+  formatNumber,
+  formatPercentage,
+  getMetrics,
+  getTotalTraffic
+} from './statMetrics';
 
 const data = [
   [0, 0.12],
@@ -36,27 +44,54 @@ describe('Stat Metrics', () => {
     newData = [...data, [0, 50]];
     expect(getMetrics(newData).last).toBe(50);
   });
+
+  it('includes 0 in calculations when passed second arg', () => {
+    const metricsWithZero = getMetrics(data, true);
+    expect(metricsWithZero.max).toBe(2.98);
+    expect(metricsWithZero.average).toBe(0.63);
+    expect(metricsWithZero.last).toBe(0);
+
+  });
 });
 
-describe('add unit', () => {
-  it('returns bit/s if less than 1000', () => {
-    expect(appendBitrateUnit('612.12')).toBe('612.12 bit/s');
-    expect(appendBitrateUnit('1024')).not.toBe('1000.24 bit/s');
+describe('total traffic', () => {
+  it('returns total traffic given the average', () => {
+    const totalTraffic = getTotalTraffic(1, 2);
+    expect(totalTraffic.inTraffic).toBe(10800);
+    expect(totalTraffic.outTraffic).toBe(21600);
+    expect(totalTraffic.combinedTraffic).toBe(32400);
+    expect(totalTraffic.combinedTraffic).toEqual(totalTraffic.inTraffic + totalTraffic.outTraffic);
+  });
+});
+
+describe('format magnitude', () => {
+  it('doesn\'t add magnitude when 1 < X < 999', () => {
+    expect(formatMagnitude('612.12', 'b/s')).toBe('612.12 b/s');
+    expect(formatMagnitude(1, 'b/s')).toBe('1.00 b/s');
+    expect(formatMagnitude(99, 'b/s')).toBe('99.00 b/s');
+    expect(formatMagnitude(99.09, 'b/s')).toBe('99.09 b/s');
   });
 
-  it('converts to Kbit/s if 1000 or greater', () => {
-    expect(appendBitrateUnit('6211.21')).toBe('6.21 Kbit/s');
-    expect(appendBitrateUnit('1000')).toBe('1.00 Kbit/s');
+  it('milli', () => {
+    expect(formatMagnitude('0.021', 'b/s')).toBe('21.00 mb/s');
+    expect(formatMagnitude('0.001', 'b/s')).toBe('1.00 mb/s');
+    expect(formatMagnitude('0.999', 'b/s')).toBe('999.00 mb/s');
   });
 
-  it('converts to Mbit/s if 1000 * 1000 or greater', () => {
-    expect(appendBitrateUnit('62232111.21')).toBe('62.23 Mbit/s');
-    expect(appendBitrateUnit('1000000')).toBe('1.00 Mbit/s');
+  it('kilo', () => {
+    expect(formatMagnitude('6211.21', 'b/s')).toBe('6.21 kb/s');
+    expect(formatMagnitude('1000', 'b/s')).toBe('1.00 kb/s');
+    expect(formatMagnitude('555555', 'b/s')).toBe('555.55 kb/s');
   });
 
-  it('converts to Gbit/s if 1000 * 1000 * 1000 or greater', () => {
-    expect(appendBitrateUnit('62331232111.21')).toBe('62.33 Gbit/s');
-    expect(appendBitrateUnit('1000000000')).toBe('1.00 Gbit/s');
+  it('mega', () => {
+    expect(formatMagnitude('62232111.21', 'b/s')).toBe('62.23 Mb/s');
+    expect(formatMagnitude('1000000', 'b/s')).toBe('1.00 Mb/s');
+  });
+
+  it('giga', () => {
+    expect(formatMagnitude('62331232111.21', 'b/s')).toBe('62.33 Gb/s');
+    expect(formatMagnitude('1000000000', 'b/s')).toBe('1.00 Gb/s');
   });
 });
 
@@ -71,12 +106,22 @@ describe('format number', () => {
     expect(formatNumber(99.999)).toBe('100.00');
     expect(formatNumber(99.7)).toBe('99.70');
   });
+});
 
-  it('with percentage', () => {
-    expect(appendPercentSign('2')).toBe('2%');
-    expect(appendPercentSign('223')).toBe('223%');
-    expect(appendPercentSign('22.32')).toBe('22.32%');
-    expect(appendPercentSign('')).toBe('%');
-    expect(appendPercentSign('  ')).toBe('  %');
+describe('formatting', () => {
+  it('formatPercent adds percent sign', () => {
+    expect(formatPercentage(12)).toBe('12.00 %');
+    expect(formatPercentage(0)).toBe('0.00 %');
+    expect(formatPercentage(123456789)).toBe('123456789.00 %');
+  });
+  it('formatBitsPerSecond adds unit', () => {
+    expect(formatBitsPerSecond(12)).toBe('12.00 b/s');
+    expect(formatBitsPerSecond(0)).toBe('0.00 b/s');
+    expect(formatBitsPerSecond(123456789)).toBe('123.46 Mb/s');
+  });
+  it('formatBytes adds unit', () => {
+    expect(formatBytes(12)).toBe('12.00 B');
+    expect(formatBytes(0)).toBe('0.00 B');
+    expect(formatBytes(123456789)).toBe('123.46 MB');
   });
 });

--- a/src/utilities/statMetrics.ts
+++ b/src/utilities/statMetrics.ts
@@ -13,7 +13,11 @@ export interface Metrics {
 // value. We ignore values of 0 IF the second param is passed in. This needs
 // to be optional because there are certain metrics in Classic Manager that
 // behave this way.
-export const getMetrics = (data: number[][], includeZero?: boolean): Metrics => {
+//
+// The hacky "customLength" param comes from the need to divide the sum
+// of private_in/out on NetV4 by NetV6 to get the average for netV6
+// private_in/out. I have no idea why.
+export const getMetrics = (data: number[][], includeZero?: boolean, customLength?: number): Metrics => {
 
   // If there's no data
   if (isEmpty(data[0])) {
@@ -42,9 +46,11 @@ export const getMetrics = (data: number[][], includeZero?: boolean): Metrics => 
     length++;
   });
 
+  const lengthToDivideBy = customLength || length;
+
   // Safeguard against dividing by 0
-  const average = length > 0
-    ? sum/length
+  const average = lengthToDivideBy > 0
+    ? sum/lengthToDivideBy
     : 0;
 
   return { max, average, last, total: sum, length};

--- a/src/utilities/statMetrics.ts
+++ b/src/utilities/statMetrics.ts
@@ -17,7 +17,7 @@ export interface Metrics {
 // The hacky "customLength" param comes from the need to divide the sum
 // of private_in/out on NetV4 by NetV6 to get the average for netV6
 // private_in/out. I have no idea why.
-export const getMetrics = (data: number[][], includeZero?: boolean, customLength?: number): Metrics => {
+export const getMetrics = (data: number[][]): Metrics => {
 
   // If there's no data
   if (isEmpty(data[0])) {
@@ -27,31 +27,24 @@ export const getMetrics = (data: number[][], includeZero?: boolean, customLength
   let max = 0;
   let sum = 0
   let length = 0; // Number of non-zero elements
-  let last = 0; // Last non-zero element
 
   // The data is large, so we get everything we need in one iteration
   data.forEach(([_, value]: number[], idx): void => {
-
-    // Ignore '0' values
-    if (!includeZero && value === 0) {
-      return;
-    }
 
     if (value > max) {
       max = value;
     }
 
-    last = value;
     sum += value;
     length++;
   });
 
-  const lengthToDivideBy = customLength || length;
-
   // Safeguard against dividing by 0
-  const average = lengthToDivideBy > 0
-    ? sum/lengthToDivideBy
+  const average = length > 0
+    ? sum/length
     : 0;
+
+  const last = data[data.length-1][1];
 
   return { max, average, last, total: sum, length};
 }

--- a/src/utilities/statMetrics.ts
+++ b/src/utilities/statMetrics.ts
@@ -10,13 +10,7 @@ export interface Metrics {
 
 // Returns max, average, and last for RDD data from the API, which has this
 // shape: [ [n1, n2], ... ], where n1 is unix-time in milliseconds and n2 is the
-// value. We ignore values of 0 IF the second param is passed in. This needs
-// to be optional because there are certain metrics in Classic Manager that
-// behave this way.
-//
-// The hacky "customLength" param comes from the need to divide the sum
-// of private_in/out on NetV4 by NetV6 to get the average for netV6
-// private_in/out. I have no idea why.
+// value.
 export const getMetrics = (data: number[][]): Metrics => {
 
   // If there's no data
@@ -26,7 +20,6 @@ export const getMetrics = (data: number[][]): Metrics => {
 
   let max = 0;
   let sum = 0
-  let length = 0; // Number of non-zero elements
 
   // The data is large, so we get everything we need in one iteration
   data.forEach(([_, value]: number[], idx): void => {
@@ -36,15 +29,16 @@ export const getMetrics = (data: number[][]): Metrics => {
     }
 
     sum += value;
-    length++;
   });
+
+  const length = data.length;
 
   // Safeguard against dividing by 0
   const average = length > 0
     ? sum/length
     : 0;
 
-  const last = data[data.length-1][1];
+  const last = data[length-1][1];
 
   return { max, average, last, total: sum, length};
 }

--- a/src/utilities/statMetrics.ts
+++ b/src/utilities/statMetrics.ts
@@ -1,4 +1,5 @@
 import { isEmpty } from 'ramda';
+
 export interface Metrics {
   max: number;
   average: number;
@@ -8,8 +9,10 @@ export interface Metrics {
 
 // Returns max, average, and last for RDD data from the API, which has this
 // shape: [ [n1, n2], ... ], where n1 is unix-time in milliseconds and n2 is the
-// value. We ignore values of 0.
-export const getMetrics = (data: number[][]): Metrics => {
+// value. We ignore values of 0 IF the second param is passed in. This needs
+// to be optional because there are certain metrics in Classic Manager that
+// behave this way.
+export const getMetrics = (data: number[][], includeZero?: boolean): Metrics => {
 
   // If there's no data
   if (isEmpty(data[0])) {
@@ -22,10 +25,10 @@ export const getMetrics = (data: number[][]): Metrics => {
   let last = 0; // Last non-zero element
 
   // The data is large, so we get everything we need in one iteration
-  data.forEach(([timestamp, value]: number[], idx): void => {
+  data.forEach(([_, value]: number[], idx): void => {
 
     // Ignore '0' values
-    if (value === 0) {
+    if (!includeZero && value === 0) {
       return;
     }
 
@@ -48,30 +51,61 @@ export const getMetrics = (data: number[][]): Metrics => {
 
 export const formatNumber = (n: number): string => n.toFixed(2);
 
-export const appendPercentSign = (value: string) => value + '%';
+// Applies SI Magnitude prefix.
+// 1400 --> "1.40 K"
+// 1400000 --> "1.40 M"
+// 1400000000 --> "1.40 G"
+export const formatMagnitude = (value: number | string, unit: string) => {
+  const num = Number(value);
 
-// Appends a "friendly" unit of measurement – bit/s, Kbit/s, Mbit/s, Gbit/s
-// Will make appropriate division, e.g. appendFriendlyBitrateUnit(1000) --> 1.00 Kbit/s
-export const appendBitrateUnit = (valueInBits: string | number) => {
-  const num = Number(valueInBits);
+  const ranges = [
+    { divider: 1e9 , suffix: 'G' },
+    { divider: 1e6 , suffix: 'M' },
+    { divider: 1e3 , suffix: 'k' },
+    { divider: 1 , suffix: '' },
+    { divider: 1e-3 , suffix: 'm' },
+  ];
 
-  const Kbit = 1000;
-  const Mbit = 1000 * Kbit;
-  const Gbit = 1000 * Mbit;
+  let finalNum;
+  let magnitude;
 
-  let divisor = 1;
-  let unit = 'bit/s';
+  // Use Array.prototype.some, because we might need to break this loop early.
+  ranges.some(range => {
+    if (num >= range.divider) {
+      finalNum = num / range.divider
+      magnitude = range.suffix;
+      return true;
+    }
+    return false;
+  });
 
-  if (num >= Gbit) {
-    divisor = Gbit;
-    unit = 'Gbit/s';
-  } else if (num >= Mbit) {
-    divisor = Mbit;
-    unit = 'Mbit/s';
-  } else if (num >= Kbit) {
-    divisor = Kbit;
-    unit = 'Kbit/s';
+  return finalNum
+    ? `${formatNumber(finalNum)} ${magnitude}${unit}`
+    : `${formatNumber(num)} ${unit}`;
+}
+
+export const formatPercentage = (value: number) => formatNumber(value) + ' %';
+export const formatBitsPerSecond = (value: number) => formatMagnitude(value, 'b/s');
+export const formatBytes = (value: number) => formatMagnitude(value, 'B');
+
+export const getTraffic = (averageInBits: number): number => {
+  const averageInBytes = averageInBits / 8;
+  const averageBytesOverDay = averageInBytes * (60 * 60 * 24) // 86400 seconds in 24 hours
+  return averageBytesOverDay;
+}
+
+export interface TotalTrafficResults {
+  inTraffic: number;
+  outTraffic: number;
+  combinedTraffic: number;
+}
+export const getTotalTraffic = (inBits: number, outBits: number): TotalTrafficResults => {
+  const inTraffic = getTraffic(inBits);
+  const outTraffic = getTraffic(outBits);
+
+  return {
+    inTraffic,
+    outTraffic,
+    combinedTraffic: inTraffic + outTraffic
   }
-
-  return formatNumber(num/divisor) + ' ' + unit;
 }

--- a/src/utilities/statMetrics.ts
+++ b/src/utilities/statMetrics.ts
@@ -5,6 +5,7 @@ export interface Metrics {
   average: number;
   last: number;
   total: number;
+  length: number;
 }
 
 // Returns max, average, and last for RDD data from the API, which has this
@@ -16,7 +17,7 @@ export const getMetrics = (data: number[][], includeZero?: boolean): Metrics => 
 
   // If there's no data
   if (isEmpty(data[0])) {
-    return { max: 0, average: 0, last: 0, total: 0 };
+    return { max: 0, average: 0, last: 0, total: 0, length: 0 };
   }
 
   let max = 0;
@@ -46,7 +47,7 @@ export const getMetrics = (data: number[][], includeZero?: boolean): Metrics => 
     ? sum/length
     : 0;
 
-  return { max, average, last, total: sum };
+  return { max, average, last, total: sum, length};
 }
 
 export const formatNumber = (n: number): string => n.toFixed(2);
@@ -84,7 +85,7 @@ export const formatMagnitude = (value: number | string, unit: string) => {
     : `${formatNumber(num)} ${unit}`;
 }
 
-export const formatPercentage = (value: number) => formatNumber(value) + ' %';
+export const formatPercentage = (value: number) => formatNumber(value) + '%';
 export const formatBitsPerSecond = (value: number) => formatMagnitude(value, 'b/s');
 export const formatBytes = (value: number) => formatMagnitude(value, 'B');
 
@@ -99,9 +100,26 @@ export interface TotalTrafficResults {
   outTraffic: number;
   combinedTraffic: number;
 }
-export const getTotalTraffic = (inBits: number, outBits: number): TotalTrafficResults => {
-  const inTraffic = getTraffic(inBits);
-  const outTraffic = getTraffic(outBits);
+export const getTotalTraffic = (
+  inBits: number,
+  outBits: number,
+  length: number,
+  inBitsV6?: number,
+  outBitsV6?: number
+): TotalTrafficResults => {
+  if (inBitsV6) {
+    inBits += inBitsV6;
+  }
+
+  if (outBitsV6) {
+    outBits += outBitsV6;
+  }
+
+  const averageIn = inBits/length;
+  const averageOut = outBits/length;
+
+  const inTraffic = getTraffic(averageIn);
+  const outTraffic = getTraffic(averageOut);
 
   return {
     inTraffic,


### PR DESCRIPTION
This PR adds "Total Traffic" under Linode graphs.

It also changes the way AVERAGE and LAST are calculated. Previously, AVERAGE did NOT take in to account zero values, and LAST was the last non-zero value. 

#### Stil To do:

- [ ] Style `<TotalTraffic />`
- [ ] Add tests for `<TotalTraffic />`