### PR TITLE
M3-2017 Paypal Client-Side Validation

### DIFF
--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.test.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.test.tsx
@@ -1,0 +1,25 @@
+import { isAllowedUSDAmount, shouldEnablePaypalButton } from './MakeAPaymentPanel';
+
+describe('Make a Payment Panel', () => {
+  it('should return false for invalid USD amount', () => {
+    expect(isAllowedUSDAmount(0)).toBeFalsy();
+    expect(isAllowedUSDAmount(501)).toBeFalsy();    
+  });
+
+  it('should return true for valid USD amount', () => {
+    expect(isAllowedUSDAmount(5)).toBeTruthy();
+    expect(isAllowedUSDAmount(455)).toBeTruthy();    
+  });
+
+  it('should disable paypal button when invalid USD amount or no input', () => {
+    expect(shouldEnablePaypalButton(undefined)).toBeFalsy();
+    expect(shouldEnablePaypalButton(1)).toBeFalsy();
+    expect(shouldEnablePaypalButton(501)).toBeFalsy();
+  });
+
+  it('should enable paypal button when valid USD amount', () => {
+    expect(shouldEnablePaypalButton(500)).toBeTruthy();
+    expect(shouldEnablePaypalButton(15)).toBeTruthy();
+    expect(shouldEnablePaypalButton(5)).toBeTruthy();
+  });
+});

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -155,14 +155,10 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
     * Luckily, the only thing the API validates is if the amount is over $5 USD
     */
 
-    const amountAsInt = parseInt(e.target.value, 10)
-    const isPaypal = this.state.type === 'PAYPAL';
-    if (isPaypal && isAllowedUSDAmount(amountAsInt)) {
-      this.setState({ paypalSubmitEnabled: true });
-    }
+    const amountAsInt = parseInt(e.target.value, 10);
 
-    if ((isPaypal && !e.target.value) || (isPaypal && !isAllowedUSDAmount(amountAsInt))) {
-      this.setState({ paypalSubmitEnabled: false });
+    if (this.state.type === 'PAYPAL') {
+      this.setState({ paypalSubmitEnabled: shouldEnablePaypalButton(amountAsInt) })
     }
 
     this.setState({ usd: e.target.value || '' });
@@ -418,7 +414,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
                 value={this.state.usd}
                 required
                 type="number"
-                placeholder={`1.00`}
+                placeholder={`5.00 minimum`}
               />
               {this.state.type === 'CREDIT_CARD' &&
                 <TextField
@@ -530,9 +526,17 @@ export default
     (enhanced(MakeAPaymentPanel));
 
 
-const isAllowedUSDAmount = (usd: number) => {
-  if (usd >= 5 && usd <= 500) {
-    return true;
+export const isAllowedUSDAmount = (usd: number) => {
+  return !!(usd >= 5 && usd <= 500);
+}
+
+export const shouldEnablePaypalButton = (value: number | undefined) => {
+  /** 
+   * paypal button should be disabled if there is either
+   * no value entered or it's below $5 or over $500 as per APIv4 requirements
+   */
+  if (!value || !isAllowedUSDAmount(value)) {
+    return false;
   }
-  return false;
+  return true;
 }

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -154,12 +154,14 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
     * the criteria isn't met
     * Luckily, the only thing the API validates is if the amount is over $5 USD
     */
+
     const amountAsInt = parseInt(e.target.value, 10)
-    if (this.state.type === 'PAYPAL' && amountAsInt >= 5) {
+    const isPaypal = this.state.type === 'PAYPAL';
+    if (isPaypal && isAllowedUSDAmount(amountAsInt)) {
       this.setState({ paypalSubmitEnabled: true });
     }
 
-    if (this.state.type === 'PAYPAL' && !e.target.value) {
+    if ((isPaypal && !e.target.value) || (isPaypal && !isAllowedUSDAmount(amountAsInt))) {
       this.setState({ paypalSubmitEnabled: false });
     }
 
@@ -288,7 +290,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
         this.setState({
           submitting: false,
           paymentID: response.payment_id
-         })
+        })
         return response.payment_id;
       })
       .catch((error) => {
@@ -314,7 +316,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
     this.setState({
       dialogOpen: true,
       payerID: data.payerID,
-     });
+    });
   }
 
   /*
@@ -359,35 +361,35 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
     const balanceDisplay = !accountLoading && balance !== false ? `$${Math.abs(balance).toFixed(2)}` : '';
     return (
       <React.Fragment>
-      <ExpansionPanel heading="Make a Payment" actions={this.renderActions}>
-        <Grid container>
-          {/* Current Balance */}
-          <Grid item xs={12}>
-            <Grid container>
-              <Grid item>
-                <Typography role="header" component={'span'} variant="h2">
+        <ExpansionPanel heading="Make a Payment" actions={this.renderActions}>
+          <Grid container>
+            {/* Current Balance */}
+            <Grid item xs={12}>
+              <Grid container>
+                <Grid item>
+                  <Typography role="header" component={'span'} variant="h2">
                     Current Balance:
                 </Typography>
-              </Grid>
-              <Grid item>
-                <Typography
-                  component={'span'}
-                  variant="h2"
-                  className={classNames({
-                    [classes.negative]: balance > 0,
-                    [classes.positive]: balance <= 0,
-                  })}
-                >
-                  {balanceDisplay}
-                  { balance < 0 && ` (credit)` }
-                </Typography>
+                </Grid>
+                <Grid item>
+                  <Typography
+                    component={'span'}
+                    variant="h2"
+                    className={classNames({
+                      [classes.negative]: balance > 0,
+                      [classes.positive]: balance <= 0,
+                    })}
+                  >
+                    {balanceDisplay}
+                    {balance < 0 && ` (credit)`}
+                  </Typography>
+                </Grid>
               </Grid>
             </Grid>
-          </Grid>
 
-          {/* Payment */}
-          <Grid item xs={12}>
-            {generalError && <Notice error text={generalError} />}
+            {/* Payment */}
+            <Grid item xs={12}>
+              {generalError && <Notice error text={generalError} />}
               {success &&
                 <Notice
                   success
@@ -396,41 +398,41 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
                     : `Payment successfully submitted.`}
                 />
               }
-            <RadioGroup
-              aria-label="payment type"
-              name="type"
-              value={this.state.type}
-              onChange={this.handleTypeChange}
-              row
-            >
-              <FormControlLabel value="CREDIT_CARD" label={`Credit Card ${lastFour}`} control={<Radio />} />
-              {
-                !!PaypalButton && this.state.paypalLoaded &&
-                <FormControlLabel value="PAYPAL" label="Paypal" control={<Radio />} />
-              }
-            </RadioGroup>
-            <TextField
-              errorText={hasErrorFor('usd')}
-              label="Amount to Charge"
-              onChange={this.handleUSDChange}
-              value={this.state.usd}
-              required
-              type="number"
-              placeholder={`1.00`}
-            />
-            {this.state.type === 'CREDIT_CARD' &&
+              <RadioGroup
+                aria-label="payment type"
+                name="type"
+                value={this.state.type}
+                onChange={this.handleTypeChange}
+                row
+              >
+                <FormControlLabel value="CREDIT_CARD" label={`Credit Card ${lastFour}`} control={<Radio />} />
+                {
+                  !!PaypalButton && this.state.paypalLoaded &&
+                  <FormControlLabel value="PAYPAL" label="Paypal" control={<Radio />} />
+                }
+              </RadioGroup>
               <TextField
-                errorText={hasErrorFor('CVV')}
-                label="CVV"
-                onChange={this.handleCVVChange}
-                value={this.state.CVV}
-                type="text"
-                placeholder={`000`}
+                errorText={hasErrorFor('usd')}
+                label="Amount to Charge"
+                onChange={this.handleUSDChange}
+                value={this.state.usd}
+                required
+                type="number"
+                placeholder={`1.00`}
               />
-            }
+              {this.state.type === 'CREDIT_CARD' &&
+                <TextField
+                  errorText={hasErrorFor('CVV')}
+                  label="CVV"
+                  onChange={this.handleCVVChange}
+                  value={this.state.CVV}
+                  type="text"
+                  placeholder={`000`}
+                />
+              }
+            </Grid>
           </Grid>
-        </Grid>
-      </ExpansionPanel>
+        </ExpansionPanel>
         <ConfirmationDialog
           open={this.state.dialogOpen}
           title={`Confirm Payment`}
@@ -463,7 +465,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
           <React.Fragment>
             {!paypalSubmitEnabled &&
               <Tooltip
-                title={'You need a minimum amount of $5.00 to enable the payment.'}
+                title={'Amount to charge must be between $5 and $500'}
                 data-qa-help-tooltip
                 enterTouchDelay={0}
                 leaveTouchDelay={5000}
@@ -472,25 +474,25 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
               </Tooltip>
             }
 
-              <div data-qa-paypal-button className={classNames(
-                {
-                  [classes.paypalButtonWrapper]: true,
-                  [classes.PaypalHidden]: !paypalSubmitEnabled,
-                }
-              )}>
-                <PaypalButton
-                  env={env}
-                  payment={this.payment}
-                  onAuthorize={this.onAuthorize}
-                  client={client}
-                  commit={false}
-                  onCancel={this.onCancel}
-                  style={{
-                    color: 'blue',
-                    shape: 'rect',
-                  }}
-                />
-              </div>
+            <div data-qa-paypal-button className={classNames(
+              {
+                [classes.paypalButtonWrapper]: true,
+                [classes.PaypalHidden]: !paypalSubmitEnabled,
+              }
+            )}>
+              <PaypalButton
+                env={env}
+                payment={this.payment}
+                onAuthorize={this.onAuthorize}
+                client={client}
+                commit={false}
+                onCancel={this.onCancel}
+                style={{
+                  color: 'blue',
+                  shape: 'rect',
+                }}
+              />
+            </div>
 
           </React.Fragment>
           : <Button
@@ -526,3 +528,11 @@ const enhanced = compose(styled, accountContext);
 export default
   scriptLoader('https://www.paypalobjects.com/api/checkout.v4.js')
     (enhanced(MakeAPaymentPanel));
+
+
+const isAllowedUSDAmount = (usd: number) => {
+  if (usd >= 5 && usd <= 500) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
### Purposes

Addresses sentry error `No value passed to payment`

Turns out some people were getting to Paypal with an invalid USD amount

e: ugh formatting...the only lines that changed were 157-166 and 533 onward