### PR TITLE
Update docs links to Cloud Manager versions.

### DIFF
--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -2,13 +2,13 @@
  * The docs in this file are intended for reuse throughout the app by means of the setDocs function.
  * In a component that will use the Docs sidebar, import as many of the objects below as needed, then
  * pass them as an array to the setDocs method. The usual pattern is:
- * 
+ *
  * import { Domains } from 'src/documentation';
- * 
+ *
  * ...
- * 
+ *
  * static docs = [ Domains ]
- * 
+ *
  * compose(
  *  ...
  *  setDocs(Domains.docs)
@@ -90,7 +90,7 @@ export const LISH: Linode.Doc = {
 
 export const LinodeGettingStarted: Linode.Doc = {
   title: 'Getting Started with Linode',
-  src: 'https://linode.com/docs/getting-started/',
+  src: 'https://linode.com/docs/getting-started-new-manager/',
   body: `This guide will help you set up your first Linode.`,
 }
 

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -85,7 +85,7 @@ class DomainDetail extends React.Component<CombinedProps, State> {
   static docs: Linode.Doc[] = [
     {
       title: 'DNS Manager Overview',
-      src: 'https://www.linode.com/docs/networking/dns/dns-manager-overview/',
+      src: 'https://linode.com/docs/platform/manager/dns-manager-new-manager/#add-records',
       body: `The DNS Manager is a comprehensive DNS management interface available within the
       Linode Manager that allows you to add DNS records for all of your domain names. This guide
       covers the use of Linode’s DNS Manager and basic domain zone setup. For an introduction to

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -144,12 +144,12 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
   static docs: Linode.Doc[] = [
     {
       title: 'Getting Started with NodeBalancers',
-      src: 'https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/',
+      src: 'https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers-new-manager/',
       body: `Using a NodeBalancer to begin managing a simple web application`,
     },
     {
       title: 'NodeBalancer Reference Guide',
-      src: 'https://www.linode.com/docs/platform/nodebalancer/nodebalancer-reference-guide/',
+      src: 'https://www.linode.com/docs/platform/nodebalancer/nodebalancer-reference-guide-new-manager/',
       body: `NodeBalancer Reference Guide`,
     },
   ];

--- a/src/features/Users/UsersLanding.tsx
+++ b/src/features/Users/UsersLanding.tsx
@@ -102,7 +102,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
   static docs: Linode.Doc[] = [
     {
       title: 'Accounts and Password',
-      src: 'https://www.linode.com/docs/platform/accounts-and-passwords/',
+      src: 'https://www.linode.com/docs/platform/manager/accounts-and-passwords-new-manager/',
       body: `Maintaining your user Linode Manager accounts, passwords, and
       contact information is just as important as administering your Linode.
       This guide shows you how to control access to the Linode Manager,
@@ -112,7 +112,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
     },
     {
       title: 'Linode Manager Security Controls',
-      src: 'https://www.linode.com/docs/security/linode-manager-security-controls/',
+      src: 'https://www.linode.com/docs/security/linode-manager-security-controls-new-manager/',
       body: `The Linode Manager is the gateway to all of your Linode products
       and services, and you should take steps to protect it from unauthorized
       access. This guide documents several of Linode Manager’s features that


### PR DESCRIPTION
Updated following files to point to Cloud Manager version of guides:
- `src/documentation.ts`
- `src/features/Domains/DomainDetail.tsx`
- `src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx`
- `src/features/Users/UsersLanding.tsx`