### PR TITLE
M3-1902 Improve button accessibility

### DIFF
--- a/src/components/AccessPanel/AccessPanel.tsx
+++ b/src/components/AccessPanel/AccessPanel.tsx
@@ -145,7 +145,7 @@ class AccessPanel extends React.Component<CombinedProps> {
                   </TableCell>
                   <TableCell className={classes.cellUser}>
                     <div className={classes.userWrapper}>
-                      <img src={gravatarUrl} className={classes.gravatar} />
+                      <img src={gravatarUrl} className={classes.gravatar} alt={username} />
                       {username}
                     </div>
                   </TableCell>

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -133,7 +133,7 @@ class ActionMenu extends React.Component<CombinedProps, State> {
           open={Boolean(anchorEl)}
           onClose={this.handleClose}
         >
-          <MenuItem key="placeholder" className={classes.hidden} />
+          <MenuItem key="placeholder" aria-hidden className={classes.hidden} />
           {(actions as Action[]).map((a, idx) =>
             <MenuItem
               key={idx}

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -222,6 +222,7 @@ export class EditableText extends React.Component<FinalProps, State> {
                   className={`${classes.button} ${classes.editIcon}`}
                   onClick={this.toggleEditing}
                   data-qa-edit-button
+                  aria-label={`Edit ${labelText}`}
                 >
                   <Edit className={`${classes.icon} ${classes.edit}`}/>
                 </Button>

--- a/src/components/PrimaryNav/ThemeToggle.tsx
+++ b/src/components/PrimaryNav/ThemeToggle.tsx
@@ -61,6 +61,7 @@ export const ThemeToggle: React.StatelessComponent<CombinedProps> = (props) => {
           [classes.toggle]: true,
           [themeName]: true,
         })}
+        aria-label="Switch Theme"
       />
       <span
         className={classNames({

--- a/src/features/Support/ExpandableTicketPanel.tsx
+++ b/src/features/Support/ExpandableTicketPanel.tsx
@@ -269,7 +269,7 @@ export class ExpandableTicketPanel extends React.Component<CombinedProps, State>
 
     return (url !== 'not found')
       ? <div className={classes.userWrapper}>
-          <img src={url} className={classes.leftIcon} />
+          <img src={url} className={classes.leftIcon} alt="Gravatar" />
         </div>
       : <div className={classes.userWrapper}>
           <UserIcon className={classes.leftIcon} />

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -10,17 +10,19 @@ import NodebalancerIcon from 'src/assets/addnewmenu/nodebalancer.svg';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import Button from 'src/components/Button';
 import Menu from 'src/components/core/Menu';
+import MenuItem from 'src/components/core/MenuItem';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import { openForCreating as openDomainDrawerForCreating } from 'src/store/reducers/domainDrawer';
 import { openForCreating as openVolumeDrawerForCreating } from 'src/store/reducers/volumeDrawer';
-import AddNewMenuItem, { MenuItem } from './AddNewMenuItem';
+import AddNewMenuItem, { MenuItems } from './AddNewMenuItem';
 
 type CSSClasses = 'wrapper'
   | 'menu'
   | 'button'
   | 'caret'
   | 'mobileCreate'
-  | 'mobileButton';
+  | 'mobileButton'
+  | 'hidden';
 
 const styles: StyleRulesCallback = (theme) => ({
   wrapper: {
@@ -52,6 +54,10 @@ const styles: StyleRulesCallback = (theme) => ({
     width: 32,
     height: 32,
   },
+  hidden: {
+    height: 0,
+    padding: 0,
+  },
 });
 
 interface Props {
@@ -71,7 +77,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
     anchorEl: undefined,
   };
 
-  items: MenuItem[] = [
+  items: MenuItems[] = [
     {
       title: 'Linode',
       onClick: (e) => {
@@ -131,12 +137,10 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
       <div className={classes.wrapper}>
         <Button
           type="primary"
-          aria-owns={anchorEl ? 'add-new-menu' : undefined}
-          aria-expanded={anchorEl ? true : undefined}
-          aria-haspopup="true"
           onClick={this.handleClick}
           className={classes.button}
           data-qa-add-new-menu-button
+          aria-label="Linode Create"
         >
           Create {
             anchorEl
@@ -155,6 +159,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
           transformOrigin={{ vertical: 'top', horizontal: 'left' }}
           className={classes.menu}
         >
+          <MenuItem key="placeholder" aria-hidden className={classes.hidden} />
           {this.items.map((i, idx) =>
             <AddNewMenuItem
               key={idx}

--- a/src/features/TopMenu/AddNewMenu/AddNewMenuItem.test.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenuItem.test.tsx
@@ -22,23 +22,6 @@ describe('AddNewMenuItem', () => {
      );
   });
 
-  it('should render a divider if not the last item', () => {
-    const result = mount(
-      <LinodeThemeWrapper>
-        <AddNewMenuItem
-          index={1}
-          count={1}
-          title="shenanigans"
-          body="These be the stories of shennanigans."
-          ItemIcon={LinodeIcon}
-          onClick={jest.fn()}
-        />
-      </LinodeThemeWrapper>,
-    );
-
-    expect(result.find('WithStyles(Divider)')).toHaveLength(1);
-  });
-
   it('should not render a divider if not the last item', () => {
     const result = mount(
       <LinodeThemeWrapper>

--- a/src/features/TopMenu/AddNewMenu/AddNewMenuItem.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenuItem.tsx
@@ -1,7 +1,8 @@
+import MenuItem from '@material-ui/core/MenuItem';
 import * as React from 'react';
-import Divider from 'src/components/core/Divider';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+
 
 type CSSClasses = 'root'
 | 'content'
@@ -20,8 +21,8 @@ const styles: StyleRulesCallback = (theme) => ({
     paddingRight: theme.spacing.unit * 2,
     paddingTop: theme.spacing.unit * 2,
     paddingBottom: theme.spacing.unit * 2,
+    borderBottom: `1px solid ${theme.palette.divider}`,
     maxWidth: '350px',
-    cursor: 'pointer',
     display: 'flex',
     alignItems: 'center',
     transition: 'background-color .2s ease-in-out',
@@ -31,7 +32,7 @@ const styles: StyleRulesCallback = (theme) => ({
     '& .outerCircle': {
       stroke: theme.bg.main,
     },
-    '&:hover': {
+    '&:hover, &:focus': {
       ...theme.animateCircleIcon,
       backgroundColor: theme.bg.offWhiteDT,
     },
@@ -58,14 +59,14 @@ const styles: StyleRulesCallback = (theme) => ({
   },
 });
 
-export interface MenuItem {
+export interface MenuItems {
   title: string;
   onClick: (e: React.MouseEvent<HTMLElement>) => void;
   body: string;
   ItemIcon: React.ComponentClass<any>;
 }
 
-interface Props extends MenuItem {
+interface Props extends MenuItems {
   index: number;
   count: number;
 }
@@ -78,31 +79,30 @@ type PropsWithStyles = Props & WithStyles<CSSClasses>;
 
 class AddNewMenuItem extends React.Component<PropsWithStyles, State> {
   render() {
-    const { classes, title, onClick, body, ItemIcon, index, count } = this.props;
+    const { classes, title, onClick, body, ItemIcon } = this.props;
 
     return (
       <React.Fragment>
-        <li onClick={onClick} className={classes.root} data-qa-add-new-menu={title}>
+        <MenuItem
+          onClick={onClick}
+          className={classes.root}
+          data-qa-add-new-menu={title}
+          button
+          component="li"
+          aria-label={`Create ${title}`}
+        >
           <div className={classes.iconWrapper}>
             <ItemIcon />
           </div>
           <div className={classes.content}>
             <Typography role="header" variant="h3">
-              <a
-                href="javascript:void(0)"
-                onClick={onClick}
-                title={title}
-                className={classes.titleLink}
-              >
-                {title}
-              </a>
+              {title}
             </Typography>
             <Typography variant="body1" className={classes.body}>
               {body}
             </Typography>
           </div>
-        </li>
-        {index + 1 !== count && <Divider />}
+        </MenuItem>
       </React.Fragment>
     );
   }

--- a/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
@@ -90,6 +90,7 @@ const UserEventsButton: React.StatelessComponent<CombinedProps> = ({
       onClick={onClick}
       className={`${classes.root} ${className}`}
       disabled={disabled}
+      aria-label="User Events"
     >
       <NotificationIcon className={classes.icon} />
       {count && count > 0

--- a/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -192,6 +192,7 @@ export class UserMenu extends React.Component<CombinedProps, State> {
             onClick={this.handleMenu}
             className={` ${classes.button} ${anchorEl && 'active'}`}
             data-qa-user-menu
+            aria-label="User Menu"
           >
             {username &&
               <React.Fragment>
@@ -217,7 +218,7 @@ export class UserMenu extends React.Component<CombinedProps, State> {
             onClose={this.handleClose}
             className={classes.menu}
           >
-            <MenuItem key="placeholder" className={classes.hidden} />
+            <MenuItem key="placeholder" aria-hidden className={classes.hidden} />
             {menuLinks.map(menuLink => this.renderMenuLink(menuLink))}
           </Menu>
         </Hidden>

--- a/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -158,7 +158,7 @@ export class UserMenu extends React.Component<CombinedProps, State> {
     if (!gravatarUrl) { return null; }
     return (gravatarUrl !== 'not found'
       ? <div className={classes.userWrapper}>
-        <img src={gravatarUrl} className={classes.leftIcon} />
+        <img src={gravatarUrl} className={classes.leftIcon} alt="Gravatar" />
       </div>
       : <div className={classes.userWrapper}>
         <UserIcon className={classes.leftIcon} />

--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationsButton.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationsButton.tsx
@@ -76,6 +76,7 @@ const userNotificationButton: React.StatelessComponent<CombinedProps> = ({
     <IconButton
       onClick={onClick}
       className={`${classes.root} ${className}`}
+      aria-label="User Notifications"
     >
       <div className={
         classNames({

--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationsMenu.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationsMenu.tsx
@@ -142,7 +142,7 @@ class UserNotificationsMenu extends React.Component<CombinedProps, State> {
           className={classes.root}
           PaperProps={{ className: classes.dropDown }}
         >
-          <MenuItem key="placeholder" className={classes.hidden} tabIndex={1} />
+          <MenuItem key="placeholder" aria-hidden className={classes.hidden} tabIndex={1} />
           <UserNotificationsList notifications={notifications} closeMenu={this.closeMenu} />
         </Menu>
         <GDPRNotification open={this.state.privacyPolicyModalOpen} onClose={this.closePrivacyPolicyModal} />

--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -214,7 +214,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
           anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
           transformOrigin={{ vertical: -10, horizontal: 'right' }}
         >
-          <MenuItem key="placeholder" className={classes.hidden} />
+          <MenuItem key="placeholder" aria-hidden className={classes.hidden} />
           <MenuItem
             onClick={this.toggleRebootDialog}
             className={classes.menuItem}


### PR DESCRIPTION
A few high level buttons were missing proper aria description. This PR improves the screen reader experience for all top menu items:

- create new menu (screen reading was stuck and tabulation was off)
- user menu button
- user events button
- user notifications button
- theme switch button (although not a button)