### PR TITLE
M3-2027 Linode "Busy" icon invisible on Dark Theme Dashboard

### DIFF
--- a/src/features/linodes/LinodesLanding/LinodeStatusIndicator.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeStatusIndicator.tsx
@@ -29,6 +29,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     left: -1,
     '& svg': {
       animation: 'rotate 2s linear infinite',
+      fill: theme.color.offBlack,
     },
   },
   green: {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -156,6 +156,7 @@ const themeDefaults: ThemeOptions = {
     grey3: '#ccc',
     white: '#fff',
     black: '#222',
+    offBlack: primaryColors.offBlack,
     boxShadow: '#ddd',
     focusBorder: '#999',
     absWhite: '#fff',

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -75,6 +75,7 @@ export const dark = createTheme({
     grey3: '#999',
     white: '#32363C',
     black: '#fff',
+    offBlack: primaryColors.offBlack,
     boxShadow: '#222',
     focusBorder: '#999',
     absWhite: '#000',


### PR DESCRIPTION
# M3-2027 Update Linode "Busy" icon invisible on Dark Theme Dashboard

## Description

Updated linode 'busy' icon color to be visible for dark theme.