### PR TITLE
M3-2029 Update styles for sortable headers

### DIFF
--- a/src/assets/icons/sort.svg
+++ b/src/assets/icons/sort.svg
@@ -1,0 +1,4 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M11 7h-6l3-4z"></path>
+  <path fill="currentColor" d="M5 9h6l-3 4z"></path>
+</svg>

--- a/src/assets/icons/sortUp.svg
+++ b/src/assets/icons/sortUp.svg
@@ -1,0 +1,3 @@
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M11 7h-6l3-4z"></path>
+</svg>

--- a/src/components/CircleProgress/CircleProgress.tsx
+++ b/src/components/CircleProgress/CircleProgress.tsx
@@ -10,6 +10,7 @@ type CSSClasses = 'root'
 | 'noTopMargin'
 | 'mini'
 | 'tag'
+| 'sort'
 | 'hasValueInside'
 | 'green'
 | 'valueInside';
@@ -71,6 +72,15 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
       stroke: 'white',
     },
   },
+  sort: {
+    width: '14px !important',
+    height: '14px !important',
+    padding: 0,
+    position: 'relative',
+    top: 4,
+    marginLeft: 8,
+    marginRight: 4,
+  },
   valueInside: {
     position: 'absolute',
     marginTop: theme.spacing.unit / 2,
@@ -99,6 +109,7 @@ interface Props extends CircularProgressProps {
   noInner?: boolean;
   mini?: boolean;
   tag?: boolean;
+  sort?: boolean;
   children?: JSX.Element;
   green?: boolean;
 }
@@ -108,7 +119,7 @@ type CombinedProps = Props & WithStyles<CSSClasses>;
 const circleProgressComponent: React.StatelessComponent<CombinedProps> = (props) => {
   const variant = typeof props.value === 'number' ? 'static' : 'indeterminate';
   const value = typeof props.value === 'number' ? props.value : 0;
-  const { children, classes, noTopMargin, green, mini, tag, ...rest } = props;
+  const { children, classes, noTopMargin, green, mini, tag, sort, ...rest } = props;
 
   const outerClasses = {
     [classes.root]: true,
@@ -154,6 +165,7 @@ const circleProgressComponent: React.StatelessComponent<CombinedProps> = (props)
           className={classNames({
             [classes.mini]: true,
             [classes.tag]: tag,
+            [classes.sort]: sort,
           })}
           data-qa-circle-progress
         />

--- a/src/components/Pagey/Pagey.ts
+++ b/src/components/Pagey/Pagey.ts
@@ -103,7 +103,6 @@ export default (requestFn: PaginatedRequest) => (Component: React.ComponentType<
       if (this.state.orderBy) {
         filters['+order_by'] = this.state.orderBy;
         filters['+order'] = this.state.order;
-        this.state.isSorting = false;
       }
       return requestFn(this.props, { page: this.state.page, page_size: this.state.pageSize }, filters)
         .then((response) => {
@@ -114,6 +113,7 @@ export default (requestFn: PaginatedRequest) => (Component: React.ComponentType<
             data: map ? map(response.data) : response.data,
             loading: false,
             error: undefined,
+            isSorting: false,
           });
         })
         .catch((response) => {

--- a/src/components/Pagey/Pagey.ts
+++ b/src/components/Pagey/Pagey.ts
@@ -34,6 +34,7 @@ interface State<T={}> {
   count: number;
   error?: Error;
   loading: boolean;
+  isSorting?: boolean;
   page: number;
   pages?: number;
   pageSize: number;
@@ -60,6 +61,7 @@ export default (requestFn: PaginatedRequest) => (Component: React.ComponentType<
     state: State = {
       count: 0,
       loading: true,
+      isSorting: false,
       page: 1,
       pageSize: 25,
       error: undefined,
@@ -101,6 +103,7 @@ export default (requestFn: PaginatedRequest) => (Component: React.ComponentType<
       if (this.state.orderBy) {
         filters['+order_by'] = this.state.orderBy;
         filters['+order'] = this.state.order;
+        this.state.isSorting = false;
       }
       return requestFn(this.props, { page: this.state.page, page_size: this.state.pageSize }, filters)
         .then((response) => {
@@ -129,8 +132,8 @@ export default (requestFn: PaginatedRequest) => (Component: React.ComponentType<
       this.setState({ page }, () => { this.request() })
     };
 
-    public handleOrderChange = (orderBy: string, order: Order = 'asc') => {
-      this.setState({ orderBy, order, page: 1 }, () => this.request());
+    public handleOrderChange = (orderBy: string, order: Order = 'asc', isSorting: boolean) => {
+      this.setState({ orderBy, order, page: 1, isSorting: true }, () => this.request());
     };
 
     public handleSearch = (filter: any) => {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -10,6 +10,12 @@ type ClassNames = 'root'
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {
     overflowX: 'auto',
+    '& tbody': {
+      transition: [theme.transitions.create('opacity')]
+    },
+    '& tbody.sorting': {
+      opacity: .5,
+    }
   },
   responsive: {
     [theme.breakpoints.down('sm')]: {

--- a/src/components/TableSortCell/TableSortCell.tsx
+++ b/src/components/TableSortCell/TableSortCell.tsx
@@ -1,16 +1,27 @@
 import * as React from 'react';
+import CircleProgress from 'src/components/CircleProgress';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import TableCell, { TableCellProps } from 'src/components/core/TableCell';
 import TableSortLabel from 'src/components/core/TableSortLabel';
 
-type ClassNames = 'root';
+import Sort from 'src/assets/icons/sort.svg';
+import SortUp from 'src/assets/icons/sortUp.svg';
+
+type ClassNames = 'root'
+  | 'intialIcon';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
-  root: {}
+  root: {
+    color: theme.palette.text.primary,
+  },
+  intialIcon: {
+    margin: '2px 0 0 4px'
+  }
 });
 
 interface Props extends TableCellProps {
   active: boolean;
+  isLoading?: boolean;
   label: string;
   direction: 'asc' | 'desc';
   handleClick: (key: string, order?: 'asc' | 'desc') => void;
@@ -29,7 +40,7 @@ class TableSortCell extends React.PureComponent<CombinedProps, {}> {
   }
 
   render() {
-    const { classes, children, direction, label, active, handleClick, ...rest } = this.props;
+    const { classes, children, direction, label, active, handleClick, isLoading, ...rest } = this.props;
 
     return (
       <TableCell {...rest}>
@@ -37,9 +48,14 @@ class TableSortCell extends React.PureComponent<CombinedProps, {}> {
           active={active}
           direction={direction}
           onClick={this.handleClick}
+          className={classes.root}
+          IconComponent={SortUp}
+          hideSortIcon={true}
         >
           {children}
+          {!active && <Sort className={classes.intialIcon} /> }
         </TableSortLabel>
+        {isLoading && <CircleProgress mini sort />}
       </TableCell>
     );
   }

--- a/src/features/StackScripts/SelectStackScriptPanel/PanelContent/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/PanelContent/StackScriptTableHead.tsx
@@ -24,8 +24,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     minWidth: 200,
   },
   deploys: {
-    width: '10%',
-    minWidth: 100,
+    width: '15%',
+    minWidth: 140,
   },
   revisions: {
     width: '15%',

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -246,6 +246,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
         order={this.props.order}
         orderBy={this.props.orderBy}
         handleOrderChange={this.props.handleOrderChange}
+        isSorting={this.props.isSorting}
       />
     )
   }

--- a/src/features/linodes/LinodesLanding/LinodesViewWrapper.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesViewWrapper.tsx
@@ -22,6 +22,7 @@ interface ViewProps {
   handleOrderChange: PaginatedLinodes['handleOrderChange'];
   order: PaginatedLinodes['order'];
   orderBy?: PaginatedLinodes['orderBy'];
+  isSorting?: PaginatedLinodes['isSorting'];
 }
 
 const CardView: React.StatelessComponent<ViewProps> = (props) => {
@@ -63,6 +64,7 @@ const RowView: React.StatelessComponent<ViewProps> = (props) => {
     openConfigDrawer,
     order,
     orderBy,
+    isSorting,
     toggleConfirmation,
   } = props;
 
@@ -80,6 +82,7 @@ const RowView: React.StatelessComponent<ViewProps> = (props) => {
                   direction={order}
                   active={isActive('label')}
                   handleClick={handleOrderChange}
+                  isLoading={isSorting}
                 >
                   Linode
                 </TableSortCell>
@@ -99,7 +102,7 @@ const RowView: React.StatelessComponent<ViewProps> = (props) => {
                 <TableCell />
               </TableRow>
             </TableHead>
-            <TableBody>
+            <TableBody className={isSorting ? 'sorting' : ''}>
               {linodes.map(linode =>
                 <LinodeRow
                   key={linode.id}

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1038,14 +1038,24 @@ const themeDefaults: ThemeOptions = {
     MuiTableSortLabel: {
       root: {
         fontSize: '.9rem',
-        color: '#111',
+        transition: 'color 225ms ease-in-out',
+        '&:hover': {
+          color: primaryColors.main,
+        }
       },
       active: {
         color: primaryColors.main,
         '&:focus': {
-          color: primaryColors.main,
+          outline: '1px dotted #999',
+          '&:hover': {
+            color: primaryColors.main,
+          }
         },
       },
+      icon: {
+        opacity: 1,
+        marginTop: 2
+      }
     },
     MuiTooltip: {
       popper: {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -563,7 +563,6 @@ export const dark = createTheme({
     },
     MuiTableSortLabel: {
       root: {
-        color: '#fff',
         textDecoration: 'underline',
       },
     },


### PR DESCRIPTION
# Update styles for sortable headers

## Description

Now that we are starting implementing sortable headers more on the APP, the pattern has been polished and we needed new styles. In addition to the new UI kit styles, I passed a new 'isSorting' prop in pagey in order to add visual indicators while the sorting is happening.

This can be tested on the main linode list view

## Type of Change
- Non breaking change
