### PR TITLE
M3-2038 remove created text

### DIFF
--- a/src/features/Search/ResultRow.tsx
+++ b/src/features/Search/ResultRow.tsx
@@ -180,7 +180,7 @@ export const ResultRow: React.StatelessComponent<CombinedProps> = (props) => {
         {result.data.created &&
           <React.Fragment>
             <Typography >
-              Created <DateTimeDisplay value={result.data.created} />
+              <DateTimeDisplay value={result.data.created} />
             </Typography>
           </React.Fragment>
         }


### PR DESCRIPTION
## Description

Remove redundant "created" text from search landing tables (as Created already occurs in table headers)

- Bug fix 
