### PR TITLE
M3-2039 Fix breakpoint for larger mobile devices for stats & graphs

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -328,7 +328,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         </div>
         <div className={classes.bottomLegend}>
           <Grid container>
-            <Grid item xs={12} lg={6}>
+            <Grid item xs={12} sm={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -346,7 +346,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 ]}
               />
             </Grid>
-            <Grid item xs={12} lg={6}>
+            <Grid item xs={12} sm={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -367,7 +367,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           </Grid>
         </div>
         {rangeSelection === '24' &&
-          <Grid item xs={12} lg={6} className={classes.totalTraffic}>
+          <Grid item xs={12} sm={6} className={classes.totalTraffic}>
             <TotalTraffic
               inTraffic={totalTraffic.inTraffic}
               outTraffic={totalTraffic.outTraffic}
@@ -436,7 +436,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         </div>
         <div className={classes.bottomLegend}>
           <Grid container>
-            <Grid item xs={12} lg={6}>
+            <Grid item xs={12} sm={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -454,7 +454,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 ]}
               />
             </Grid>
-            <Grid item xs={12} lg={6}>
+            <Grid item xs={12} sm={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -475,7 +475,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           </Grid>
         </div>
         {rangeSelection === '24' &&
-          <Grid item xs={12} lg={6} className={classes.totalTraffic}>
+          <Grid item xs={12} sm={6} className={classes.totalTraffic}>
             <TotalTraffic
               inTraffic={totalTraffic.inTraffic}
               outTraffic={totalTraffic.outTraffic}
@@ -523,7 +523,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         </div>
         <div className={classes.bottomLegend}>
           <Grid container>
-            <Grid item xs={12} lg={6}>
+            <Grid item xs={12} sm={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -535,7 +535,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 ]}
               />
             </Grid>
-            <Grid item xs={12} lg={6}>
+            <Grid item xs={12} sm={6}>
               <MetricsDisplay
                 rows={[
                   {

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -239,7 +239,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         </div>
         <div className={classes.bottomLegend}>
           <Grid container>
-            <Grid item xs={12} lg={6}>
+            <Grid item xs={12} sm={6}>
               <MetricsDisplay
                 rows={[
                   {

--- a/src/features/linodes/LinodesDetail/LinodeSummary/MetricsDisplay.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/MetricsDisplay.tsx
@@ -24,6 +24,14 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
       border: 'none',
       backgroundColor: 'transparent',
     },
+    '& td:first-child': {
+      backgroundColor: 'transparent !important',
+    },
+    [theme.breakpoints.down('sm')]: {
+      '& td': {
+        justifyContent: 'normal',
+      },
+    },
   },
   tableHeadInner: {
     paddingBottom: 4,
@@ -49,7 +57,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     },
   },
   legend: {
-    [theme.breakpoints.up('sm')]: {
+    [theme.breakpoints.up('md')]: {
       width: '38%',
     },
     '& > div': {


### PR DESCRIPTION
# M3-2039 Fix breakpoint for larger mobile devices for stats & graphs

## Description

Fix for Stats & Graphs device views, label and data should be displayed closer together so they're not too far apart. Please review display at multiple breakpoints. 

## Type of Change
- Bug fix ('fix', 'repair', 'bug')