### PR TITLE
Fix: Editable Text cancelling upon event stream updating

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -16,6 +16,7 @@ class InteractiveEditableBreadcrumb extends React.Component<Props, {}> {
 
   onEdit = (value: string) => {
     this.setState({ text: value });
+    return Promise.resolve('hello world')
   }
 
   onCancel = () => {

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -73,7 +73,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 });
 interface EditableProps {
   onCancel: () => void;
-  onEdit: (value: string) => void;
+  onEdit: (value: string) => Promise<any>;
   errorText?: string;
 }
 

--- a/src/components/EditableText/EditableText.stories.tsx
+++ b/src/components/EditableText/EditableText.stories.tsx
@@ -18,6 +18,7 @@ class InteractiveEditableText extends React.Component {
 
   editText = (value: string) => {
     this.setState({ text: value });
+    return Promise.resolve('hello world')
   }
 
   cancelEdit = () => {

--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -165,10 +165,10 @@ export class EditableText extends React.Component<FinalProps, State> {
 
   finishEditing = () => {
     const { text } = this.state;
-    /** 
+    /**
      * if the entered text is different from the original text
      * provided, run the update callback
-     * 
+     *
      * only exit editing mode if promise resolved
      */
     if (text !== this.props.text) {

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -107,19 +107,21 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
 
   updateLabel = (label: string) => {
     const { nodeBalancer } = this.state;
-    updateNodeBalancer(nodeBalancer.id, { label })
-    .then(() => {
-      this.setState({ nodeBalancer: { ...nodeBalancer, label }, ApiError: undefined,
-        labelInput: label });
-    })
-    .catch((error) => {
-      this.setState(() => ({
-        ApiError: pathOr(defaultError, ['response', 'data', 'errors'], error),
-        labelInput: label,
-      }), () => {
-        scrollErrorIntoView();
+    return updateNodeBalancer(nodeBalancer.id, { label })
+      .then(() => {
+        this.setState({
+          nodeBalancer: { ...nodeBalancer, label }, ApiError: undefined,
+          labelInput: label
+        });
+      })
+      .catch((error) => {
+        this.setState(() => ({
+          ApiError: pathOr(defaultError, ['response', 'data', 'errors'], error),
+          labelInput: label,
+        }), () => {
+          scrollErrorIntoView();
+        });
       });
-    });
   }
 
   updateTags = (tags: string[]) => {

--- a/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/LabelPowerAndConsolePanel.tsx
@@ -53,7 +53,7 @@ interface LabelInput {
   label: string;
   errorText: string;
   onCancel: () => void;
-  onEdit: (value: string) => void;
+  onEdit: (value: string) => Promise<any>;
 }
 
 interface Props {

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -452,8 +452,8 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
     /** @todo figure out why this logic was here in the first place */
     // const { data: linode } = this.state.context.linode;
     // if (!linode) { return; }
-    
-    // this.setState({ labelInput: { label: linode.label, errorText: '' } });
+    const { labelInput } = this.state;
+    this.setState({ labelInput: { ...labelInput, errorText: '' } });
     // this.forceUpdate();
   }
 

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -428,9 +428,8 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
   // breaks the layout)
   updateLabel = (label: string) => {
     const { data: linode } = this.state.context.linode;
-    if (!linode) { return; }
-
-    updateLinode(linode.id, { label })
+    /** "!" is okay because linode being undefined is being handled by render() */
+    return updateLinode(linode!.id, { label })
       .then((linodeResponse) => {
         this.composeState(
           set(L.linode.data, linodeResponse),
@@ -441,18 +440,21 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       .catch((err) => {
         const errors: Linode.ApiFieldError[] = pathOr([], ['response', 'data', 'errors'], err);
         const errorStrings: string[] = errors.map(e => e.reason);
-        this.setState({ labelInput: { label, errorText: errorStrings[0] } }, () => {
+        /** "!" is okay because linode being undefined is being handled by render() */
+        this.setState({ labelInput: { label: linode!.label, errorText: errorStrings[0] } }, () => {
           scrollErrorIntoView();
         });
+        return Promise.reject(errorStrings[0])
       });
   }
 
   cancelUpdate = () => {
-    const { data: linode } = this.state.context.linode;
-    if (!linode) { return; }
-
-    this.setState({ labelInput: { label: linode.label, errorText: '' } });
-    this.forceUpdate();
+    /** @todo figure out why this logic was here in the first place */
+    // const { data: linode } = this.state.context.linode;
+    // if (!linode) { return; }
+    
+    // this.setState({ labelInput: { label: linode.label, errorText: '' } });
+    // this.forceUpdate();
   }
 
   openMutateDrawer = () => {

--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader.tsx
@@ -22,7 +22,7 @@ import { requestNotifications } from 'src/store/reducers/notifications';
 interface LabelInput {
   label: string;
   errorText: string;
-  onEdit: (label: string) => void;
+  onEdit: (label: string) => Promise<any>;
   onCancel: () => void;
 }
 
@@ -88,7 +88,7 @@ class LinodesDetailHeader extends React.Component<CombinedProps, State> {
   }
 
   editLabel = (value: string) => {
-    this.props.labelInput.onEdit(value)
+    return this.props.labelInput.onEdit(value)
   }
 
   handleUpdateTags = (tagsList: string[]) => {


### PR DESCRIPTION
## Description

Fixes an issue where the EditableText was getting cancelled out of edit mode if an event came down

## Type of Change
- fix

### To Test

1. Start an event (such as resizing a Linode)
2. Try to edit the text
3. Keep the edit text state open
4. Wait for a new event to come down
5. Observe - the field stays in edit mode

Now try doing step 1 then go to a different Linode Detail page and repeat steps 2-5