### PR TITLE
M3-2051: capitalize linode progress bar text

### DIFF
--- a/src/features/linodes/transitions.test.ts
+++ b/src/features/linodes/transitions.test.ts
@@ -1,0 +1,39 @@
+import { transitionText } from './transitions';
+
+describe('transitionText helper', () => {
+  it('should remove "linode" from the event and capitalize it', () => {
+    expect(transitionText('loading', {
+      id: 123,
+      action: 'linode_snapshot',
+      created: '2012-12-12',
+      entity: null,
+      percent_complete: null,
+      rate: null,
+      read: true,
+      seen: true,
+      status: 'started',
+      time_remaining: null,
+      username: 'linode'
+    })).toEqual('Snapshot');
+  });
+
+  it('should use status if an event is missing and capitalize it', () => {
+    expect(transitionText('loading')).toEqual('Loading');
+  });
+
+  it('should use status if an event is not a transition event and capitalize it', () => {
+    expect(transitionText('optimus', {
+      id: 123,
+      action: 'linode_addip',
+      created: '2012-12-12',
+      entity: null,
+      percent_complete: null,
+      rate: null,
+      read: true,
+      seen: true,
+      status: 'started',
+      time_remaining: null,
+      username: 'linode'
+    })).toEqual('Optimus');
+  });
+});

--- a/src/features/linodes/transitions.ts
+++ b/src/features/linodes/transitions.ts
@@ -29,8 +29,11 @@ export const linodeInTransition = (status: string, recentEvent?: Linode.Event): 
 }
 
 export const transitionText = (status: string, recentEvent?: Linode.Event): string => {
+  let event;
   if (recentEvent && transitionAction.includes(recentEvent.action)) {
-    return recentEvent.action.replace('linode_', '').replace('_', ' ');
+    event = recentEvent.action.replace('linode_', '').replace('_', ' ');
+  } else {
+    event = status.replace('_', ' ');
   }
-  return status.replace('_', ' ');
+  return event.charAt(0).toUpperCase() + event.slice(1);
 }

--- a/src/features/linodes/transitions.ts
+++ b/src/features/linodes/transitions.ts
@@ -1,3 +1,5 @@
+import { capitalizeAllWords } from 'src/utilities/capitalize';
+
 export const transitionStatus = [
   'booting',
   'shutting_down',
@@ -35,5 +37,5 @@ export const transitionText = (status: string, recentEvent?: Linode.Event): stri
   } else {
     event = status.replace('_', ' ');
   }
-  return event.charAt(0).toUpperCase() + event.slice(1);
+  return capitalizeAllWords(event);
 }

--- a/src/utilities/capitalize.test.ts
+++ b/src/utilities/capitalize.test.ts
@@ -1,0 +1,15 @@
+import capitalize, {capitalizeAllWords} from './capitalize';
+
+describe('capitalize', () => {
+  it('should return capitalized string', () => {
+    expect(capitalize('hello world')).toBe('Hello world');
+  });
+});
+
+describe('capitalize', () => {
+  it('should return string with all words capitalized', () => {
+    expect(capitalizeAllWords('hello world')).toBe('Hello World');
+  });
+});
+
+  

--- a/src/utilities/capitalize.ts
+++ b/src/utilities/capitalize.ts
@@ -1,3 +1,9 @@
-export default (s:string) => {
-    return s.charAt(0).toUpperCase() + s.slice(1);
+const capitalize = (s:string) => {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export default capitalize;
+
+export const capitalizeAllWords = (s:string) => {
+  return s.split(' ').map(capitalize).join(' ');
 }


### PR DESCRIPTION
# M3-2051: capitalize linode progress bar text

## Description

Updates transitionText method to ensure it returns a capitalized version of the event.

## Type of Change
- Fix linode progress bar transition text casing