### PR TITLE
M3-1710 Fix search results query bug

### DIFF
--- a/src/features/Help/SupportSearchLanding/SupportSearchLanding.test.tsx
+++ b/src/features/Help/SupportSearchLanding/SupportSearchLanding.test.tsx
@@ -1,0 +1,63 @@
+import { shallow } from 'enzyme';
+import { assocPath } from 'ramda';
+import * as React from 'react';
+
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import Typography from 'src/components/core/Typography';
+import { SupportSearchLanding } from './SupportSearchLanding';
+
+const classes = {
+  root: '',
+  backButton: '',
+  searchBar: '',
+  searchBoxInner: '',
+  searchHeading: '',
+  searchField: '',
+  searchIcon: '',
+}
+
+const props = {
+  classes,
+  searchAlgolia: jest.fn(),
+  searchResults: [],
+  searchEnabled: true,
+  ...reactRouterProps,
+}
+
+
+const propsWithMultiWordURLQuery = assocPath(['location', 'search'],'?query=search%20two%20words', props);
+const component = shallow(<SupportSearchLanding {...props} />);
+// Query is read on mount so we have to mount twice.
+const component2 = shallow(<SupportSearchLanding {...propsWithMultiWordURLQuery} />)
+
+describe('Component', () => {
+  it('should render', () => {
+    expect(component).toBeDefined();
+  });
+  it("should set the query from the URL param to state", () => {
+    expect(component.state().query).toMatch('search');
+  });
+  it("should read multi-word queries correctly", () => {
+    expect(component2.state().query).toMatch("search two words");
+  });
+  it("should display the query text in the header", () => {
+    expect(component.containsMatchingElement(
+      <Typography variant="h1" >
+        Search results for "search"
+      </Typography>
+    )).toBeTruthy();
+  });
+  it("should display generic text if no query is provided", () => {
+    component.setState({ query: '' });
+    expect(component.containsMatchingElement(
+      <Typography variant="h1" >
+        Search
+      </Typography>
+    )).toBeTruthy();
+    expect(component.containsMatchingElement(
+      <Typography variant="h1" >
+        Search results for
+      </Typography>
+    )).toBeFalsy();
+  });
+});

--- a/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -11,7 +11,7 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { COMMUNITY_SEARCH_URL, DOCS_SEARCH_URL } from 'src/constants';
-import { parseQueryParams } from 'src/utilities/queryParams';
+import { getQueryParam } from 'src/utilities/queryParams';
 import withSearch, { AlgoliaState as AlgoliaProps } from '../SearchHOC';
 import DocumentationResults, { SearchResult } from './DocumentationResults';
 import HelpResources from './HelpResources';
@@ -83,8 +83,7 @@ class SupportSearchLanding extends React.Component<CombinedProps, State> {
   }
 
   searchFromParams() {
-    const queryFromParams = parseQueryParams(this.props.location.search)['?query'];
-    const query = queryFromParams ? decodeURIComponent(queryFromParams) : '';
+    const query = getQueryParam(this.props.location.search, 'query');
     this.setState({ query });
     this.props.searchAlgolia(query);
   }

--- a/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -72,7 +72,7 @@ interface State {
 
 type CombinedProps = AlgoliaProps & WithStyles<ClassNames> & RouteComponentProps<{}>;
 
-class SupportSearchLanding extends React.Component<CombinedProps, State> {
+export class SupportSearchLanding extends React.Component<CombinedProps, State> {
   searchIndex:any = null;
   state: State = {
     query: '',


### PR DESCRIPTION
# Cloud Manager Pull Request Template

## Description

Update SupportSearchLanding.tsx to use updated query-parsing helper methods.

## Type of Change
- Bug fix

changed:
- Use `getQueryParam` in SupportSearchLanding
- Add component unit tests

## Note to Reviewers

The original bug noted in the ticket was fixed as a side effect of #4172 but that change also broke the logic for reading params into state in the support search landing page.