### PR TITLE
M3-2044 Feature: import groups global settings

### DIFF
--- a/src/features/Account/GlobalSettings.tsx
+++ b/src/features/Account/GlobalSettings.tsx
@@ -6,9 +6,13 @@ import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from 'src/components/core/styles';
 import ErrorState from 'src/components/ErrorState';
+import TagImportDrawer from 'src/features/TagImport';
 import { handleOpen } from 'src/store/reducers/backupDrawer';
 import { updateAccountSettings } from 'src/store/reducers/resources/accountSettings';
+import { openGroupDrawer } from 'src/store/reducers/tagImportDrawer';
+import getEntitiesWithGroupsToImport, { GroupedEntitiesForImport } from 'src/store/selectors/getEntitiesWithGroupsToImport';
 import AutoBackups from './AutoBackups';
+import ImportGroupsAsTags from './ImportGroupsAsTags';
 import NetworkHelper from './NetworkHelper';
 
 type ClassNames = 'root';
@@ -24,11 +28,13 @@ interface StateProps {
   linodesWithoutBackups: Linode.Linode[];
   updateError?: Linode.ApiFieldError[];
   networkHelperEnabled: boolean;
+  entitiesWithGroupsToImport: GroupedEntitiesForImport;
 }
 
 interface DispatchProps {
   actions: {
     updateAccount: (data: Partial<Linode.AccountSettings>) => void;
+    openImportDrawer: () => void;
     openBackupsDrawer: () => void;
   }
 }
@@ -64,14 +70,21 @@ class GlobalSettings extends React.Component<CombinedProps, {}> {
 
   render() {
     const {
-      actions: { openBackupsDrawer },
+      actions: { openBackupsDrawer, openImportDrawer },
       backups_enabled,
       networkHelperEnabled,
       error,
       loading,
       linodesWithoutBackups,
-      updateError
+      updateError,
+      entitiesWithGroupsToImport,
     } = this.props;
+
+    // Only show the import groups option if the user has groups available to import
+    const hasGroupsToImport =
+    entitiesWithGroupsToImport.linodes.length >= 1
+    // @todo: Uncomment when domain support is added
+    // && entitiesWithGroupsToImport.domains.length >= 1
 
     if (loading) { return <CircleProgress /> }
     if (error) { return <ErrorState errorText={"There was an error retrieving your account data."} /> }
@@ -90,6 +103,12 @@ class GlobalSettings extends React.Component<CombinedProps, {}> {
           onChange={this.toggleNetworkHelper}
           networkHelperEnabled={networkHelperEnabled}
         />
+        {hasGroupsToImport &&
+          <ImportGroupsAsTags
+            openDrawer={openImportDrawer}
+          />
+        }
+        <TagImportDrawer />
       </React.Fragment>
     )
   }
@@ -101,14 +120,16 @@ const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (stat
   error: path(['__resources', 'accountSettings', 'error'], state),
   updateError: path(['__resources', 'accountSettings', 'updateError'], state),
   linodesWithoutBackups: state.__resources.linodes.entities.filter(l => !l.backups.enabled),
-  networkHelperEnabled: pathOr(false, ['__resources', 'accountSettings', 'data', 'network_helper'], state)
+  networkHelperEnabled: pathOr(false, ['__resources', 'accountSettings', 'data', 'network_helper'], state),
+  entitiesWithGroupsToImport: getEntitiesWithGroupsToImport(state),
 });
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch, ownProps) => {
   return {
     actions: {
       updateAccount: (data: Partial<Linode.AccountSettings>) => dispatch(updateAccountSettings(data)),
-      openBackupsDrawer: () => dispatch(handleOpen())
+      openBackupsDrawer: () => dispatch(handleOpen()),
+      openImportDrawer: () => dispatch(openGroupDrawer())
     }
   };
 };

--- a/src/features/Account/ImportGroupsAsTags.test.tsx
+++ b/src/features/Account/ImportGroupsAsTags.test.tsx
@@ -1,0 +1,24 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { ImportGroupsAsTags } from './ImportGroupsAsTags';
+
+const classes = { root: '', helperText: ''};
+
+const props = {
+  classes,
+  openDrawer: jest.fn(),
+}
+
+const component = shallow(
+  <ImportGroupsAsTags {...props} />
+)
+
+describe('Component', () => {
+  it('should render', () => {
+    expect(component).toBeDefined();
+  });
+  it('should open the tag import drawer on click', () => {
+    component.find('[data-qa-open-group-import-drawer]').simulate('click');
+    expect(props.openDrawer).toHaveBeenCalled();
+  });
+});

--- a/src/features/Account/ImportGroupsAsTags.tsx
+++ b/src/features/Account/ImportGroupsAsTags.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import Button from 'src/components/Button';
+import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import ExpansionPanel from 'src/components/ExpansionPanel';
+
+type ClassNames = 'root' | 'helperText';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {
+
+  },
+  helperText: {
+    marginBottom: theme.spacing.unit * 2,
+  }
+});
+
+interface Props {
+  openDrawer: () => void;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const ImportGroupsAsTags: React.StatelessComponent<CombinedProps> = (props) => {
+  const { classes, openDrawer } = props;
+  return (
+    <ExpansionPanel
+      className={classes.root}
+      defaultExpanded={true}
+      heading={"Import Display Groups"}
+    >
+      <Typography variant="body1" className={classes.helperText}>
+        Import Display Groups from Classic Manager and convert them to tags.
+        Your existing tags will not be affected.
+      </Typography>
+      <Button type="primary" onClick={openDrawer}>
+        Import Display Groups
+      </Button>
+    </ExpansionPanel>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(ImportGroupsAsTags);

--- a/src/features/Account/ImportGroupsAsTags.tsx
+++ b/src/features/Account/ImportGroupsAsTags.tsx
@@ -7,9 +7,7 @@ import ExpansionPanel from 'src/components/ExpansionPanel';
 type ClassNames = 'root' | 'helperText';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
-  root: {
-
-  },
+  root: {},
   helperText: {
     marginBottom: theme.spacing.unit * 2,
   }
@@ -21,7 +19,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ImportGroupsAsTags: React.StatelessComponent<CombinedProps> = (props) => {
+export const ImportGroupsAsTags: React.StatelessComponent<CombinedProps> = (props) => {
   const { classes, openDrawer } = props;
   return (
     <ExpansionPanel
@@ -33,7 +31,7 @@ const ImportGroupsAsTags: React.StatelessComponent<CombinedProps> = (props) => {
         Import Display Groups from Classic Manager and convert them to tags.
         Your existing tags will not be affected.
       </Typography>
-      <Button type="primary" onClick={openDrawer}>
+      <Button type="primary" onClick={openDrawer} data-qa-open-group-import-drawer>
         Import Display Groups
       </Button>
     </ExpansionPanel>


### PR DESCRIPTION
## Description

For users that have dismissed the CTA on the Dashboard inviting them to import their CF manager display groups as tags, the import drawer will also be available from account/settings.

## Note to Reviewers

This is a lot of expansion panels that no one will ever collapse. We'll probably be asked to replace them with Papers at some point