### PR TITLE
M3-1770 Domains in Redux

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -34,6 +34,7 @@ it('renders without crashing', () => {
               getAccountSettings: jest.fn(),
               getProfile: jest.fn(),
               getNotifications: jest.fn(),
+              requestDomains: jest.fn(),
               requestLinodes: jest.fn(),
               requestTypes: jest.fn(),
             }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
 import { getRegions } from 'src/services/misc';
 import { requestNotifications } from 'src/store/reducers/notifications';
 import { requestAccountSettings } from 'src/store/reducers/resources/accountSettings';
+import { async as domainsAsync } from 'src/store/reducers/resources/domains';
 import { async as linodesAsync } from 'src/store/reducers/resources/linodes';
 import { requestProfile } from 'src/store/reducers/resources/profile';
 import { async as typesAsync } from 'src/store/reducers/resources/types';
@@ -216,8 +217,9 @@ export class App extends React.Component<CombinedProps, State> {
   }
 
   componentDidMount() {
-    const { getAccountSettings, getNotifications, getProfile, requestLinodes, requestTypes } = this.props.actions;
+    const { getAccountSettings, getNotifications, getProfile, requestDomains, requestLinodes, requestTypes } = this.props.actions;
 
+    requestDomains();
     requestLinodes();
     requestTypes();
 
@@ -373,6 +375,7 @@ interface DispatchProps {
     getProfile: () => void;
     getNotifications: () => void;
     getAccountSettings: () => void;
+    requestDomains: () => void;
     requestLinodes: () => void;
     requestTypes: () => void;
   },
@@ -384,6 +387,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (dispatch, 
       getProfile: () => dispatch(requestProfile()),
       getNotifications: () => dispatch(requestNotifications()),
       getAccountSettings: () => dispatch(requestAccountSettings()),
+      requestDomains: () => dispatch(domainsAsync.requestDomains()),
       requestLinodes: () => dispatch(linodesAsync.requestLinodes()),
       requestTypes: () => dispatch(typesAsync.requestTypes()),
     }

--- a/src/features/Dashboard/Dashboard.test.tsx
+++ b/src/features/Dashboard/Dashboard.test.tsx
@@ -12,9 +12,7 @@ const props = {
   linodesWithoutBackups: [],
   managed: false,
   backupError: undefined,
-  entitiesWithGroupsToImport: { linodes: [] },
-  // @todo: uncomment when support for domains is added
-  // entitiesWithGroupsToImport: { linodes: [], domains: [] },
+  entitiesWithGroupsToImport: { linodes: [], domains: [] },
   classes: { root: ''}
 }
 

--- a/src/features/TagImport/TagImportDrawer.test.tsx
+++ b/src/features/TagImport/TagImportDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { linodes } from 'src/__data__/groupImports';
+import { domains, linodes } from 'src/__data__/groupImports';
 
 import { getGroupImportList, TagImportDrawer } from './TagImportDrawer'
 
@@ -14,7 +14,7 @@ const props = {
   errors: [],
   loading: false,
   success: false,
-  entitiesWithGroupsToImport: { linodes },
+  entitiesWithGroupsToImport: { domains, linodes },
   onPresentSnackbar: jest.fn(),
   enqueueSnackbar: jest.fn(),
   classes: { root: ''}

--- a/src/services/domains/domains.ts
+++ b/src/services/domains/domains.ts
@@ -1,4 +1,6 @@
 import { API_ROOT } from 'src/constants';
+import store from 'src/store';
+import { actions } from 'src/store/reducers/resources/domains';
 
 import Request,
 {
@@ -64,7 +66,11 @@ export const updateDomain = (domainId: number, data: Partial<Linode.Domain>) =>
     setMethod('PUT'),
     setData(data, updateDomainSchema),
   )
-    .then(response => response.data);
+    .then(response => response.data)
+    .then(domain => {
+      store.dispatch(actions.updateDomain(domain));
+      return domain;
+    })
 
 /**
  * Deletes a Domain from Linode's DNS Manager. The Domain will be removed from Linode's nameservers shortly after this

--- a/src/services/domains/domains.ts
+++ b/src/services/domains/domains.ts
@@ -52,7 +52,11 @@ export const createDomain = (data: Partial<Linode.Domain>) =>
     setURL(`${API_ROOT}/domains`),
     setMethod('POST'),
   )
-    .then(response => response.data);
+    .then(response => response.data)
+    .then(domain => {
+      store.dispatch(actions.addDomain(domain));
+      return domain;
+    });
 
 /**
  * Update information about a Domain in Linode's DNS Manager.
@@ -83,7 +87,10 @@ export const deleteDomain = (domainID: number) =>
     setURL(`${API_ROOT}/domains/${domainID}`),
     setMethod('DELETE'),
   )
-    .then(response => response.data);
+    .then(response => {
+      store.dispatch(actions.deleteDomain(domainID));
+      return response.data;
+    });
 
 /**
  * Clones a Domain.

--- a/src/store/ApplicationState.d.ts
+++ b/src/store/ApplicationState.d.ts
@@ -20,6 +20,13 @@ declare interface ApplicationState {
       lastUpdated: number;
       error?: Linode.ApiFieldError[];
     },
+    domains: {
+      results: number[];
+      entities: Linode.Domain[];
+      loading: boolean;
+      lastUpdated: number;
+      error?: Linode.ApiFieldError[];
+    },
   },
   authentication: AuthState;
   backups: BackupDrawerState;

--- a/src/store/reducers/resources/domains.ts
+++ b/src/store/reducers/resources/domains.ts
@@ -53,15 +53,21 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       ...state,
       entities: entitiesFromPayload(payload),
       results: resultsFromPayload(payload),
-      lastUpdate: Date.now(),
+      lastUpdated: Date.now(),
       loading: false,
     };
   }
 
   if (isType(action, getDomainsFailure)) {
-    return {
+
+    // This could be an Axios error (network) or API error
+    const error = action.payload instanceof Error ?
+      [{ reason: 'Network error' }]
+      : action.payload;
+
+      return {
       ...state,
-      error: action.payload,
+      error,
       loading: false,
     };
   }

--- a/src/store/reducers/resources/domains.ts
+++ b/src/store/reducers/resources/domains.ts
@@ -1,7 +1,8 @@
-import { Dispatch, Reducer } from "redux";
+import { pathOr } from 'ramda';
+import { Dispatch, Reducer } from 'redux';
 import { ThunkAction } from 'redux-thunk';
-import { getDomain, getDomains } from "src/services/domains";
-import { getAll } from "src/utilities/getAll";
+import { getDomain, getDomains } from 'src/services/domains';
+import { getAll } from 'src/utilities/getAll';
 import actionCreatorFactory, { isType } from 'typescript-fsa';
 
 /**
@@ -59,15 +60,10 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   }
 
   if (isType(action, getDomainsFailure)) {
-
-    // This could be an Axios error (network) or API error
-    const error = action.payload instanceof Error ?
-      [{ reason: 'Network error' }]
-      : action.payload;
-
-      return {
+    const { payload } = action;
+    return {
       ...state,
-      error,
+      error: payload,
       loading: false,
     };
   }
@@ -119,7 +115,9 @@ const requestDomains = () => (dispatch: Dispatch<State>) => {
       return domains;
     })
     .catch((err) => {
-      dispatch(getDomainsFailure(err));
+      const defaultError = [{ reason: 'An unexpected error has occurred.' }];
+      const errors = pathOr(defaultError, ['response', 'data', 'errors'], err);
+      dispatch(getDomainsFailure(errors));
     });
 };
 

--- a/src/store/reducers/resources/domains.ts
+++ b/src/store/reducers/resources/domains.ts
@@ -1,7 +1,5 @@
-// import * as Bluebird from 'bluebird';
 import { Dispatch, Reducer } from "redux";
 import { ThunkAction } from 'redux-thunk';
-// import requestMostRecentBackupForLinode from 'src/features/linodes/LinodesLanding/requestMostRecentBackupForLinode';
 import { getDomain, getDomains } from "src/services/domains";
 import { getAll } from "src/utilities/getAll";
 import actionCreatorFactory, { isType } from 'typescript-fsa';
@@ -110,7 +108,6 @@ const requestDomains = () => (dispatch: Dispatch<State>) => {
   dispatch(getDomainsRequest());
 
   return getAll<Linode.Domain>(getDomains)()
-    // .then(getBackupsForLinodes)
     .then((domains) => {
       dispatch(getDomainsSuccess(domains.data));
       return domains;
@@ -120,15 +117,12 @@ const requestDomains = () => (dispatch: Dispatch<State>) => {
     });
 };
 
-// const getBackupsForLinodes = ({ data }: { data: Linode.Linode[] }) => Bluebird.map(data, requestMostRecentBackupForLinode);
-
 type RequestDomainForStoreThunk = (id: number) => ThunkAction<void, ApplicationState, undefined>;
 const requestDomainForStore: RequestDomainForStoreThunk = (id) => (dispatch, getState) => {
   const { results } = getState().__resources.domains;
 
   getDomain(id)
     .then(response => response)
-    // .then(requestMostRecentBackupForLinode)
     .then(domain => {
       if (results.includes(id)) {
         return dispatch(updateDomain(domain));

--- a/src/store/reducers/resources/domains.ts
+++ b/src/store/reducers/resources/domains.ts
@@ -1,0 +1,155 @@
+// import * as Bluebird from 'bluebird';
+import { Dispatch, Reducer } from "redux";
+import { ThunkAction } from 'redux-thunk';
+// import requestMostRecentBackupForLinode from 'src/features/linodes/LinodesLanding/requestMostRecentBackupForLinode';
+import { getDomain, getDomains } from "src/services/domains";
+import { getAll } from "src/utilities/getAll";
+import actionCreatorFactory, { isType } from 'typescript-fsa';
+
+/**
+ * State
+ */
+type State = ApplicationState['__resources']['domains'];
+
+export const defaultState: State = {
+  results: [],
+  entities: [],
+  loading: true,
+  lastUpdated: 0,
+  error: undefined,
+};
+
+/**
+ * Actions
+ */
+export const actionCreator = actionCreatorFactory(`@@manager/domains`);
+
+const getDomainsRequest = actionCreator('request');
+
+const getDomainsSuccess = actionCreator<Linode.Domain[]>('success');
+
+const getDomainsFailure = actionCreator<Linode.ApiFieldError[]>('fail');
+
+const addDomain = actionCreator<Linode.Domain>('add');
+
+const updateDomain = actionCreator<Linode.Domain>('update');
+
+const deleteDomain = actionCreator<number>('delete');
+
+export const actions = { addDomain, updateDomain, deleteDomain, };
+
+/**
+ * Reducer
+ */
+const reducer: Reducer<State> = (state = defaultState, action) => {
+  if (isType(action, getDomainsRequest)) {
+    return {
+      ...state,
+      loading: true,
+    };
+  }
+
+  if (isType(action, getDomainsSuccess)) {
+    const { payload } = action;
+    return {
+      ...state,
+      entities: entitiesFromPayload(payload),
+      results: resultsFromPayload(payload),
+      lastUpdate: Date.now(),
+      loading: false,
+    };
+  }
+
+  if (isType(action, getDomainsFailure)) {
+    return {
+      ...state,
+      error: action.payload,
+      loading: false,
+    };
+  }
+
+  if (isType(action, updateDomain)) {
+    const { payload } = action;
+    return {
+      ...state,
+      entities: state.entities.map((domain) => domain.id === payload.id ? payload : domain),
+    }
+  }
+
+  if (isType(action, deleteDomain)) {
+    const { payload } = action;
+    const { entities, results } = state;
+
+    return {
+      ...state,
+      entities: entities.filter((domain) => domain.id !== payload),
+      results: results.filter((id) => id !== payload),
+    }
+  }
+
+  if (isType(action, addDomain)) {
+    const { payload } = action;
+    const { entities, results } = state;
+    return {
+      ...state,
+      entities: [...entities, payload],
+      results: [...results, payload.id],
+    }
+  }
+
+  return state
+};
+
+export default reducer;
+
+/**
+ * Async
+ */
+const requestDomains = () => (dispatch: Dispatch<State>) => {
+
+  dispatch(getDomainsRequest());
+
+  return getAll<Linode.Domain>(getDomains)()
+    // .then(getBackupsForLinodes)
+    .then((domains) => {
+      dispatch(getDomainsSuccess(domains.data));
+      return domains;
+    })
+    .catch((err) => {
+      dispatch(getDomainsFailure(err));
+    });
+};
+
+// const getBackupsForLinodes = ({ data }: { data: Linode.Linode[] }) => Bluebird.map(data, requestMostRecentBackupForLinode);
+
+type RequestDomainForStoreThunk = (id: number) => ThunkAction<void, ApplicationState, undefined>;
+const requestDomainForStore: RequestDomainForStoreThunk = (id) => (dispatch, getState) => {
+  const { results } = getState().__resources.domains;
+
+  getDomain(id)
+    .then(response => response)
+    // .then(requestMostRecentBackupForLinode)
+    .then(domain => {
+      if (results.includes(id)) {
+        return dispatch(updateDomain(domain));
+      }
+      return dispatch(addDomain(domain))
+    })
+
+};
+
+export const async = { requestDomains, requestDomainForStore }
+
+/**
+ * Helpers
+ */
+const entitiesFromPayload = (domains: Linode.Domain[]) => {
+  /** transform as necessary */
+  return domains.map(i => i);
+}
+
+const resultsFromPayload = (domains: Linode.Domain[]) => {
+  return domains.map(l => l.id);
+}
+
+export const helpers = {};

--- a/src/store/reducers/resources/index.ts
+++ b/src/store/reducers/resources/index.ts
@@ -1,5 +1,6 @@
 import { combineReducers } from "redux";
 import accountSettings, { DEFAULT_STATE as defaultAccountSettingsState } from './accountSettings';
+import domains, { defaultState as defaultDomainsState } from './domains';
 import linodes, { defaultState as defaultLinodesState } from './linodes';
 import profile, { DEFAULT_STATE as defaultProfileState } from './profile';
 import types, { defaultState as defaultTypesState } from './types';
@@ -8,8 +9,9 @@ import types, { defaultState as defaultTypesState } from './types';
 export const defaultState = {
   accountSettings: defaultAccountSettingsState,
   profile: defaultProfileState,
+  domains: defaultDomainsState,
   linodes: defaultLinodesState,
   types: defaultTypesState,
 }
 
-export default combineReducers({ accountSettings, profile, linodes, types });
+export default combineReducers({ accountSettings, profile, domains, linodes, types });

--- a/src/store/reducers/resources/linodes.ts
+++ b/src/store/reducers/resources/linodes.ts
@@ -58,15 +58,21 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       ...state,
       entities: entitiesFromPayload(payload),
       results: resultsFromPayload(payload),
-      lastUpdate: Date.now(),
+      lastUpdated: Date.now(),
       loading: false,
     };
   }
 
   if (isType(action, getLinodesFailure)) {
+
+    // This could be an Axios error (network) or API error
+    const error = action.payload instanceof Error ?
+      [{ reason: 'Network error' }]
+      : action.payload;
+
     return {
       ...state,
-      error: action.payload,
+      error,
       loading: false,
     };
   }

--- a/src/store/selectors/getEntitiesWithGroupsToImport.test.tsx
+++ b/src/store/selectors/getEntitiesWithGroupsToImport.test.tsx
@@ -1,11 +1,10 @@
-import { linodes } from 'src/__data__';
+import { domains, linodes } from 'src/__data__';
 import { entitiesWithGroupsToImport } from './getEntitiesWithGroupsToImport';
 
 const state = {
   __resources: {
     linodes: { entities: linodes },
-    // @todo: Uncomment when domain support is added
-    // domains  { entities: domains}
+    domains: { entities: domains }
   }
 };
 
@@ -34,24 +33,23 @@ describe('Entities that have groups to import', () => {
     });
   });
 
-  // @todo: Uncomment when domain support is added
-  // describe('domains', () => {
-  //   it('returns an object with a "domains" property', () => {
-  //     expect(entities.domains).toBeDefined();
-  //     expect(entities.domains).toBeInstanceOf(Array);
-  //   });
+  describe('domains', () => {
+    it('returns an object with a "domains" property', () => {
+      expect(entities.domains).toBeDefined();
+      expect(entities.domains).toBeInstanceOf(Array);
+    });
 
-  //   it('each element in "domains" array has group', () => {
-  //     entities.domains.forEach(linode => {
-  //       expect(linode.group).toBeDefined();
-  //       expect(linode.group).not.toEqual('');
-  //     });
-  //   });
+    it('each element in "domains" array has group', () => {
+      entities.domains.forEach(linode => {
+        expect(linode.group).toBeDefined();
+        expect(linode.group).not.toEqual('');
+      });
+    });
 
-  //   it('each element in "domains" array has group that is NOT a tag', () => {
-  //     entities.domains.forEach(linode => {
-  //       expect(linode.tags.indexOf(linode.group!)).toBe(-1);
-  //     });
-  //   });
-  // });
+    it('each element in "domains" array has group that is NOT a tag', () => {
+      entities.domains.forEach(linode => {
+        expect(linode.tags.indexOf(linode.group!)).toBe(-1);
+      });
+    });
+  });
 });

--- a/src/store/selectors/getEntitiesWithGroupsToImport.tsx
+++ b/src/store/selectors/getEntitiesWithGroupsToImport.tsx
@@ -3,8 +3,7 @@ import { createSelector } from 'reselect';
 
 export interface GroupedEntitiesForImport {
   linodes: GroupImportProps[];
-  // @todo: Uncomment when domain support is added
-  // domains: GroupImportProps[];
+  domains: GroupImportProps[];
 }
 export interface GroupImportProps {
   id: number;
@@ -35,35 +34,19 @@ export const extractProps = (entity: GroupedEntity) => ({
 
 
 const linodeSelector = (state: ApplicationState) => state.__resources.linodes.entities;
-
-// @todo: Uncomment when domain support is added
-// const domainSelector = (state: ApplicationState) => state.__resources.domains.entities
+const domainSelector = (state: ApplicationState) => state.__resources.domains.entities
 
 // Selector that returns Linodes and Domains that have a GROUP without
 // corresponding TAG.
 export const entitiesWithGroupsToImport =
-  createSelector<ApplicationState, Linode.Linode[], GroupedEntitiesForImport>(
-    linodeSelector,
-    (linodes) => {
+  createSelector<ApplicationState, Linode.Linode[], Linode.Domain[], GroupedEntitiesForImport>(
+    linodeSelector, domainSelector,
+    (linodes, domains) => {
       return {
         linodes: linodes.filter(uniqueGroup).map(extractProps),
-        // @todo: Uncomment when domain support is added
-        // domains: domains.filter(tagsIncludeGroup).map(extractProps)
+        domains: domains.filter(uniqueGroup).map(extractProps)
       }
     }
   );
-
-// @todo: Use this version of the selector when domain support is added
-// export const entitiesWithGroupsToImport =
-//   createSelector<ApplicationState, Linode.Linode[], Linode.Domain[], GroupedEntitiesForImport>(
-//     linodeSelector, domainSelector,
-//     (linodes, domains) => {
-//       return {
-//         linodes: linodes.filter(tagsIncludeGroup).map(extractProps),
-//         // @todo: Uncomment when domain support is added
-//         // domains: domains.filter(tagsIncludeGroup).map(extractProps)
-//       }
-//     }
-//   );
 
 export default entitiesWithGroupsToImport;


### PR DESCRIPTION
## Description

This PR caches Domains in Redux upon application load. Create/Update/Delete Domain events update the Redux store as well.

## To test:

Load the application normally. If you have domains on your account, you should see them in the Redux store (use Redux dev-tools). Try updating, creating, and deleting domains, and you should see actions happening in Redux.

## Notes:

We should figure out a solution for using the methods in `src/store/reducers/resources/domains` with other types of entities. I basically copied over `./linodes` and had to make only minimal changes. A more generic solution would be ideal.