### PR TITLE
M3-2073 update: Make cta dismissable

### DIFF
--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -10,6 +10,7 @@ import TagImportDrawer from 'src/features/TagImport';
 import { handleOpen } from 'src/store/reducers/backupDrawer';
 import { openGroupDrawer } from 'src/store/reducers/tagImportDrawer';
 import getEntitiesWithGroupsToImport, { GroupedEntitiesForImport } from 'src/store/selectors/getEntitiesWithGroupsToImport';
+import { storage } from 'src/utilities/storage';
 
 import BackupsDashboardCard from './BackupsDashboardCard';
 import BlogDashboardCard from './BlogDashboardCard';
@@ -43,6 +44,15 @@ interface DispatchProps {
 
 type CombinedProps = StateProps & DispatchProps & WithStyles<ClassNames>;
 
+const shouldDisplayGroupImportCTA = (groupedEntities: GroupedEntitiesForImport) => {
+  const userHasDisabledCTA = storage.hideGroupImportCTA.get();
+  return (
+    !userHasDisabledCTA &&
+    groupedEntities.linodes.length >= 0 // &&
+    // groupedEntities.domains.length >= 0
+  )
+}
+
 export const Dashboard: React.StatelessComponent<CombinedProps> = (props) => {
   const {
     accountBackups,
@@ -52,12 +62,6 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = (props) => {
     managed,
     entitiesWithGroupsToImport
   } = props;
-
-  // Display the CTA if there is at least 1 group to import
-  const hasGroupsToImport =
-    entitiesWithGroupsToImport.linodes.length >= 1
-    // @todo: Uncomment when domain support is added
-    // && entitiesWithGroupsToImport.domains.length >= 1
 
   return (
     <React.Fragment>
@@ -81,9 +85,10 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = (props) => {
               openBackupDrawer={openBackupDrawer}
             />
           }
-          {hasGroupsToImport &&
+          {shouldDisplayGroupImportCTA(entitiesWithGroupsToImport) &&
             <ImportGroupsCard
               openImportDrawer={openImportDrawer}
+              dismiss={storage.hideGroupImportCTA.set}
             />
           }
           <BlogDashboardCard />

--- a/src/features/Dashboard/GroupImportCard/GroupImportCard.test.tsx
+++ b/src/features/Dashboard/GroupImportCard/GroupImportCard.test.tsx
@@ -30,7 +30,7 @@ describe('GroupImportCard', () => {
   it('renders a header', () => {
     const header = wrapper.find('[data-qa-group-cta-header]');
     expect(header).toHaveLength(1);
-    expect(header.children().text()).toBe('Import Your Display Group to Tags')
+    expect(header.children().text()).toBe('Import Your Display Groups to Tags')
   });
 
   it('renders body text', () => {

--- a/src/features/Dashboard/GroupImportCard/GroupImportCard.test.tsx
+++ b/src/features/Dashboard/GroupImportCard/GroupImportCard.test.tsx
@@ -4,6 +4,8 @@ import { GroupImportCard } from './GroupImportCard';
 
 describe('GroupImportCard', () => {
   const mockFn = jest.fn();
+  const dismiss = jest.fn();
+  const hide = jest.fn();
   const wrapper = shallow(
     <GroupImportCard
       classes={{
@@ -11,9 +13,13 @@ describe('GroupImportCard', () => {
         header: '',
         section: '',
         title: '',
-        button: ''
+        button: '',
+        icon: '',
       }}
       openImportDrawer={mockFn}
+      dismiss={dismiss}
+      hide={hide}
+      hidden={false}
     />
   );
 
@@ -38,6 +44,11 @@ describe('GroupImportCard', () => {
 
   it('executes function on button click', () => {
     wrapper.find('WithStyles(wrappedButton)').simulate('click');
-    expect(mockFn.mock.calls.length).toEqual(1);
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+  it('calls hide and dismiss when the close button is clicked', () => {
+    wrapper.find('[data-qa-dismiss-cta]').simulate('click', { preventDefault: jest.fn() });
+    expect(dismiss).toHaveBeenCalledTimes(1);
+    expect(hide).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/Dashboard/GroupImportCard/GroupImportCard.tsx
+++ b/src/features/Dashboard/GroupImportCard/GroupImportCard.tsx
@@ -81,7 +81,7 @@ export const GroupImportCard: React.StatelessComponent<CombinedProps> = (props) 
         <Grid container direction="row" justify="center" alignItems="center">
           <Grid item xs={11}>
             <Typography className={classes.header} variant="h1" data-qa-group-cta-header>
-              Import Your Display Group to Tags
+              Import Your Display Groups to Tags
             </Typography>
           </Grid>
           <Grid item xs={1}>

--- a/src/features/Dashboard/GroupImportCard/GroupImportCard.tsx
+++ b/src/features/Dashboard/GroupImportCard/GroupImportCard.tsx
@@ -1,16 +1,21 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
+import { compose, onlyUpdateForKeys, withStateHandlers } from 'recompose';
+
+import Close from '@material-ui/icons/Close';
 import Button from 'src/components/Button';
 import Paper from 'src/components/core/Paper';
 import { StyleRulesCallback, Theme, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
 import DashboardCard from '../DashboardCard';
 
 type ClassNames = 'root'
 | 'header'
 | 'section'
 | 'title'
-| 'button';
+| 'button'
+| 'icon';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
@@ -34,18 +39,37 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   },
   button: {
     marginTop: '18px'
+  },
+  icon: {
+    cursor: 'pointer',
+    float: 'right',
+    border: 'none',
+    backgroundColor: 'transparent',
   }
 });
 
 interface Props {
   openImportDrawer: () => void;
+  dismiss: () => void;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+interface HandlerProps {
+  hide: () => void;
+  hidden: boolean;
+}
+
+type CombinedProps = Props & HandlerProps & WithStyles<ClassNames>;
 
 export const GroupImportCard: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, openImportDrawer } = props;
+  const { classes, dismiss, hide, hidden, openImportDrawer } = props;
 
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    hide();
+    dismiss();
+  } // @todo needs to be memoized
+
+  if (hidden) { return null; }
   return (
     <DashboardCard>
       <Paper className={classNames(
@@ -54,9 +78,22 @@ export const GroupImportCard: React.StatelessComponent<CombinedProps> = (props) 
           [classes.title]: true
         }
       )}>
-        <Typography className={classes.header} variant="h1" data-qa-group-cta-header>
-          Import Your Display Group to Tags
-        </Typography>
+        <Grid container direction="row" justify="center" alignItems="center">
+          <Grid item xs={11}>
+            <Typography className={classes.header} variant="h1" data-qa-group-cta-header>
+              Import Your Display Group to Tags
+            </Typography>
+          </Grid>
+          <Grid item xs={1}>
+            <button
+              className={classes.icon}
+              onClick={handleClick}
+              data-qa-dismiss-cta
+            >
+              <Close />
+            </button>
+          </Grid>
+        </Grid>
       </Paper>
       <Paper className={classes.section}>
         <Typography variant="body1" data-qa-group-cta-body>
@@ -80,4 +117,13 @@ GroupImportCard.displayName = "ImportGroupsCard";
 
 const styled = withStyles(styles);
 
-export default styled(GroupImportCard);
+const enhanced = compose<CombinedProps, Props>(
+  styled,
+  withStateHandlers({ hidden: false },
+    {
+      hide: () => () => ({ hidden: true })
+    }),
+  onlyUpdateForKeys(['hidden'])
+)(GroupImportCard)
+
+export default enhanced;

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -25,6 +25,7 @@ const THEME = 'themeChoice';
 const BETA_NOTIFICATION = 'BetaNotification';
 const LINODE_VIEW = 'linodesViewStyle';
 const GROUP_LINODES = 'GROUP_LINODES';
+const HIDE_DISPLAY_GROUPS_CTA = 'importDisplayGroupsCTA';
 
 type Theme = 'dark' | 'light';
 type Beta = 'open' | 'closed';
@@ -60,6 +61,10 @@ export const storage = {
     ) =>
       Cookies.set('loginCloudManager', v, options),
   },
+  hideGroupImportCTA: {
+    get: (): 'true' | 'false' =>  getStorage(HIDE_DISPLAY_GROUPS_CTA),
+    set: () => setStorage(HIDE_DISPLAY_GROUPS_CTA, 'true')
+  }
 }
 
 export const { theme, notifications, views } = storage;


### PR DESCRIPTION
## Description

Users who don't want to be prompted to import their groups as tags can click on a close button on the dashboard CTA. This will hide the CTA, and save their choice to local storage so it won't display (on that browser) again.

## Note to Reviewers

1. Have at least one Linode with a display group (and no matching tag)
2. Visit the dashboard and observe that the CTA is displayed.
3. Click the X on the CTA
4. The CTA should be hidden
5. In the Application tab in devtools, you should also see that `importDisplayGroupsCTA` is set to 'true'.