### PR TITLE
Fix Handling of Null StackScript Images

### DIFF
--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -129,7 +129,8 @@ const listStackScript = () => (s: Linode.StackScript.Response) => (
 * the slug to the display name
 */
 const stripImageName = (images: string[]) => {
-  return images.map((image: string) => {
+  return images.map((image: string | null) => {
+    if (!image) { return '' }
     return image.replace('linode/', '');
   });
 };

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptsSection.tsx
@@ -129,10 +129,10 @@ const listStackScript = () => (s: Linode.StackScript.Response) => (
 * the slug to the display name
 */
 const stripImageName = (images: string[]) => {
-  return images.map((image: string | null) => {
-    if (!image) { return '' }
-    return image.replace('linode/', '');
-  });
+  return images
+    /** fixes freak edge-case where the API is returning null in the array of images */
+    .filter((eachImage: string | null) => !!eachImage)
+    .map((filteredImage: string) => filteredImage.replace('linode/', ''))
 };
 
 const styled = withStyles(styles);

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -304,7 +304,8 @@ export class StackScriptForm extends React.Component<CombinedProps> {
 * @TODO Deprecate once we have a reliable way of mapping
 * the slug to the display name
 */
-const stripImageName = (image: string) => {
+const stripImageName = (image: string | null) => {
+  if (!image) { return '' }
   return image.replace('linode/', '');
 };
 

--- a/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -304,8 +304,7 @@ export class StackScriptForm extends React.Component<CombinedProps> {
 * @TODO Deprecate once we have a reliable way of mapping
 * the slug to the display name
 */
-const stripImageName = (image: string | null) => {
-  if (!image) { return '' }
+const stripImageName = (image: string) => {
   return image.replace('linode/', '');
 };
 


### PR DESCRIPTION
## Description

Fixes issue where app would crash if a StackScript has an array of images in which one element is `null`

This is a super-edge case and probably isn't affecting most people, since we're already filtering out StackScripts that have solely deprecated images

## Type of Change
- Bug fix

## Notes

Not really sure how a stackscript can end up with a `null` image but....

<img width="687" alt="screen shot 2018-12-18 at 12 16 30 pm" src="https://user-images.githubusercontent.com/7387001/50172739-b5979800-02c3-11e9-92f9-1203ddc91ed6.png">
