### PR TITLE
fix: Display notice on successful deletion of a user.

### DIFF
--- a/src/features/Users/UserProfile.tsx
+++ b/src/features/Users/UserProfile.tsx
@@ -1,7 +1,9 @@
+import { InjectedNotistackProps, withSnackbar } from 'notistack';
 import { path } from 'ramda';
 import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
@@ -60,7 +62,12 @@ interface State {
   userDeleteError: boolean;
 }
 
-type CombinedProps = Props & StateProps & WithStyles<ClassNames> & RouteComponentProps<{}>;
+type CombinedProps =
+  & Props
+  & InjectedNotistackProps
+  & StateProps
+  & WithStyles<ClassNames>
+  & RouteComponentProps<{}>;
 
 class UserProfile extends React.Component<CombinedProps> {
   state: State = {
@@ -89,7 +96,7 @@ class UserProfile extends React.Component<CombinedProps> {
       success,
       errors
     } = this.props;
-    const hasErrorFor = getAPIErrorsFor({ username: "Username" }, errors,)
+    const hasErrorFor = getAPIErrorsFor({ username: "Username" }, errors)
     const generalError = hasErrorFor('none');
     return (
       <Paper className={classes.root}>
@@ -148,6 +155,7 @@ class UserProfile extends React.Component<CombinedProps> {
     });
     deleteUser(username)
       .then(() => {
+        this.props.enqueueSnackbar(`${username} has been deleted successfully.`, { variant: 'success' });
         push(`/account/users`, { deletedUsername: username });
       })
       .catch(() => {
@@ -249,4 +257,11 @@ export const connected = connect(mapStateToProps);
 
 const styled = withStyles(styles);
 
-export default styled(withRouter(connected(UserProfile)));
+const enhanced = compose<CombinedProps, Props>(
+  styled,
+  withRouter,
+  connected,
+  withSnackbar,
+);
+
+export default enhanced(UserProfile);

--- a/src/features/Users/UsersLanding.tsx
+++ b/src/features/Users/UsersLanding.tsx
@@ -154,7 +154,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
     deleteUser(username)
       .then(() => {
         this.props.onDelete();
-        this.props.enqueueSnackbar(`${username} has been deleted successfully.`, { variant: 'info' })
+        this.props.enqueueSnackbar(`${username} has been deleted successfully.`, { variant: 'success' });
       })
       .catch(() => {
         this.setState({
@@ -322,7 +322,7 @@ const paginated = Pagey((ownProps, params, filters) => getUsers(params, filters)
     )
       .then((updatedUsers) => ({ page, pages, results, data: updatedUsers }))));
 
-export default compose<{}, CombinedProps>(
+export default compose<CombinedProps, {}>(
   withRouter,
   setDocs(UsersLanding.docs),
   styled,

--- a/src/features/Users/UsersLanding.tsx
+++ b/src/features/Users/UsersLanding.tsx
@@ -1,8 +1,9 @@
 import { map as mapPromise } from 'bluebird';
 import * as memoize from 'memoizee';
-import { compose } from 'ramda';
+import { InjectedNotistackProps, withSnackbar } from 'notistack';
 import * as React from 'react';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import { compose } from 'recompose';
 import UserIcon from 'src/assets/icons/user.svg';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
@@ -84,12 +85,12 @@ interface State {
   newUsername?: string;
   deleteConfirmDialogOpen: boolean;
   toDeleteUsername?: string;
-  deletedUsername?: string;
   userDeleteError?: boolean;
 }
 
 type CombinedProps =
-  WithStyles<ClassNames>
+  & WithStyles<ClassNames>
+  & InjectedNotistackProps
   & PaginationProps<Linode.User>
   & RouteComponentProps<{}>;
 
@@ -124,15 +125,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
   ];
 
   componentDidMount() {
-    const { location: { state: locationState } } = this.props;
     this.props.request();
-    // this.setUserAvatars()
-
-    if (locationState && locationState.deletedUsername) {
-      this.setState({
-        deletedUsername: locationState.deletedUsername,
-      })
-    }
   }
 
   addUser = () => {
@@ -154,7 +147,6 @@ class UsersLanding extends React.Component<CombinedProps, State> {
   onDeleteConfirm = (username: string) => {
     this.setState({
       newUsername: undefined,
-      deletedUsername: undefined,
       userDeleteError: false,
       deleteConfirmDialogOpen: false,
     });
@@ -162,6 +154,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
     deleteUser(username)
       .then(() => {
         this.props.onDelete();
+        this.props.enqueueSnackbar(`${username} has been deleted successfully.`, { variant: 'info' })
       })
       .catch(() => {
         this.setState({
@@ -227,7 +220,6 @@ class UsersLanding extends React.Component<CombinedProps, State> {
       newUsername,
       toDeleteUsername,
       deleteConfirmDialogOpen,
-      deletedUsername,
       userDeleteError
     } = this.state;
 
@@ -254,16 +246,9 @@ class UsersLanding extends React.Component<CombinedProps, State> {
         {newUsername &&
           <Notice success text={`User ${newUsername} created successfully`} />
         }
-        {deletedUsername &&
-          <Notice
-            style={{ marginTop: newUsername ? 16 : 0 }}
-            success
-            text={`User ${deletedUsername} deleted successfully`}
-          />
-        }
         {userDeleteError &&
           <Notice
-            style={{ marginTop: (newUsername || deletedUsername) ? 16 : 0 }}
+            style={{ marginTop: newUsername ? 16 : 0 }}
             error
             text={`Error when deleting user, please try again later`}
           />
@@ -337,9 +322,10 @@ const paginated = Pagey((ownProps, params, filters) => getUsers(params, filters)
     )
       .then((updatedUsers) => ({ page, pages, results, data: updatedUsers }))));
 
-export default compose<any, any, any, any, any>(
+export default compose<{}, CombinedProps>(
   withRouter,
   setDocs(UsersLanding.docs),
   styled,
-  paginated
+  paginated,
+  withSnackbar,
 )(UsersLanding);


### PR DESCRIPTION
## Description
The notice of a successful deletion was inadvertently deleted during the pagination refactor. This adds a notice back in, in the form of a toast for better user experience.

## Type of Change
- Bug fix.

## Note to Reviewers
Delete a user, see a toast. Enjoy.