### PR TITLE
Bug-fix: stats input checking

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -214,7 +214,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
   renderCPUChart = () => {
     const { rangeSelection, stats } = this.state;
     const { classes } = this.props;
-    const data = pathOr([[]], ['data','cpu'], stats);
+    const data = pathOr([], ['data','cpu'], stats);
 
     const metrics = getMetrics(data);
     const format = formatPercentage;
@@ -262,17 +262,17 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     const { rangeSelection, stats } = this.state;
 
     const v4Data = {
-      publicIn: pathOr([[]], ['data','netv4','in'], stats),
-      publicOut: pathOr([[]], ['data','netv4','out'], stats),
-      privateIn: pathOr([[]], ['data','netv4','private_in'], stats),
-      privateOut: pathOr([[]], ['data','netv4','private_out'], stats)
+      publicIn: pathOr([], ['data','netv4','in'], stats),
+      publicOut: pathOr([], ['data','netv4','out'], stats),
+      privateIn: pathOr([], ['data','netv4','private_in'], stats),
+      privateOut: pathOr([], ['data','netv4','private_out'], stats)
     };
 
     // Need these to calculate Total Traffic
     const v6Data = {
-      publicIn: pathOr([[]], ['data','netv6','in'], stats),
-      publicOut: pathOr([[]], ['data','netv6','out'], stats),
-      privateIn: pathOr([[]], ['data','netv6','private_in'], stats),
+      publicIn: pathOr([], ['data','netv6','in'], stats),
+      publicOut: pathOr([], ['data','netv6','out'], stats),
+      privateIn: pathOr([], ['data','netv6','private_in'], stats),
     };
 
     const format = formatBitsPerSecond;
@@ -384,10 +384,10 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     const { rangeSelection, stats } = this.state;
 
     const data = {
-      publicIn: pathOr([[]], ['data','netv6','in'], stats),
-      publicOut: pathOr([[]], ['data','netv6','out'], stats),
-      privateIn: pathOr([[]], ['data','netv6','private_in'], stats),
-      privateOut: pathOr([[]], ['data','netv6','private_out'], stats)
+      publicIn: pathOr([], ['data','netv6','in'], stats),
+      publicOut: pathOr([], ['data','netv6','out'], stats),
+      privateIn: pathOr([], ['data','netv6','private_in'], stats),
+      privateOut: pathOr([], ['data','netv6','private_out'], stats)
     };
 
     const format = formatBitsPerSecond;
@@ -492,8 +492,8 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     const { rangeSelection, stats } = this.state;
 
     const data = {
-      io: pathOr([[]], ['data','io','io'], stats),
-      swap: pathOr([[]], ['data','io','swap'], stats)
+      io: pathOr([], ['data','io','io'], stats),
+      swap: pathOr([], ['data','io','swap'], stats)
     };
 
     const format = formatNumber;

--- a/src/utilities/statMetrics.test.ts
+++ b/src/utilities/statMetrics.test.ts
@@ -41,6 +41,20 @@ describe('Stat Metrics', () => {
     expect(metrics.last).toBe(0);
     expect(getMetrics([...data, [0, 8]]).last).toBe(8);
   });
+
+  it('does not crash with unexpected inputs', () => {
+    const emptyResponse = { max: 0, average: 0, last: 0, total: 0, length: 0 };
+    expect(getMetrics([])).toEqual(emptyResponse);
+    expect(getMetrics(undefined as any)).toEqual(emptyResponse);
+    expect(getMetrics(null as any)).toEqual(emptyResponse);
+    expect(getMetrics(12 as any)).toEqual(emptyResponse);
+    expect(getMetrics('hello' as any)).toEqual(emptyResponse);
+    expect(getMetrics({} as any)).toEqual(emptyResponse);
+    expect(getMetrics([[], []] as any)).toEqual({average: 0, last: 0, length: 2, max: 0, total: 0});
+    expect(getMetrics([[], ['hello']] as any)).toEqual({average: 0, last: 0, length: 2, max: 0, total: 0});
+    expect(getMetrics([[], ['hello', 3]] as any)).toEqual({average: 1.5, last: 3, length: 2, max: 3, total: 3});
+    expect(getMetrics([[3, 'hello'], ['hello', 3]] as any)).toEqual({average: 1.5, last: 3, length: 2, max: 3, total: 3});
+  });
 });
 
 describe('total traffic', () => {

--- a/src/utilities/statMetrics.ts
+++ b/src/utilities/statMetrics.ts
@@ -1,5 +1,3 @@
-import { isEmpty } from 'ramda';
-
 export interface Metrics {
   max: number;
   average: number;
@@ -14,7 +12,7 @@ export interface Metrics {
 export const getMetrics = (data: number[][]): Metrics => {
 
   // If there's no data
-  if (isEmpty(data[0])) {
+  if (!data || !Array.isArray(data) || data.length < 1) {
     return { max: 0, average: 0, last: 0, total: 0, length: 0 };
   }
 
@@ -23,6 +21,7 @@ export const getMetrics = (data: number[][]): Metrics => {
 
   // The data is large, so we get everything we need in one iteration
   data.forEach(([_, value]: number[], idx): void => {
+    if (!value || isNaN(value)) { return; }
 
     if (value > max) {
       max = value;
@@ -38,7 +37,7 @@ export const getMetrics = (data: number[][]): Metrics => {
     ? sum/length
     : 0;
 
-  const last = data[length-1][1];
+  const last = data[length-1][1] || 0;
 
   return { max, average, last, total: sum, length};
 }


### PR DESCRIPTION
## Description

There is a bug in production causing stats to crash in circumstances in which the API returns an empty array on `stats.data.cpu`, etc. This issue is addressed by rigorously checking input on the `getMetrics` function.

## Type of Change
- bug-fix

