### PR TITLE
M3-929 As an account owner, I want to see a print-friendly version of my invoice

### DIFF
--- a/src/features/Footer/Footer.tsx
+++ b/src/features/Footer/Footer.tsx
@@ -45,28 +45,30 @@ export class Footer extends React.PureComponent<CombinedProps> {
     const { classes } = this.props;
 
     return (
-      <Grid container spacing={32} className={classes.container}>
-        <Grid item className={classes.version}>
-          {this.renderVersion(classes.link)}
+      <footer>
+        <Grid container spacing={32} className={classes.container}>
+          <Grid item className={classes.version}>
+            {this.renderVersion(classes.link)}
+          </Grid>
+          <Grid item>
+            <a
+              className={classes.link}
+              href="https://developers.linode.com"
+              target="_blank"
+            >
+              API Reference
+            </a>
+          </Grid>
+          <Grid item style={{ paddingLeft: 0 }}>
+            <a
+              className={classes.link}
+              href="mailto:feedback@linode.com"
+            >
+              Provide Feedback
+            </a>
+          </Grid>
         </Grid>
-        <Grid item>
-          <a
-            className={classes.link}
-            href="https://developers.linode.com"
-            target="_blank"
-          >
-            API Reference
-          </a>
-        </Grid>
-        <Grid item style={{ paddingLeft: 0 }}>
-          <a
-            className={classes.link}
-            href="mailto:feedback@linode.com"
-          >
-            Provide Feedback
-          </a>
-        </Grid>
-      </Grid>
+      </footer>
     );
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -74,9 +74,11 @@ body {
     color: #000 !important;
   }
 
-  /* td > span:first-child {
-    display: none;
-  } */
+  @media (max-width: 959px) {
+    td > span:first-child {
+      display: none;
+    }
+  }
   
   td > span:last-child {
     text-align: left;

--- a/src/index.css
+++ b/src/index.css
@@ -25,8 +25,63 @@ body {
 }
 
 @media print {
+  /** Setting margins */       
+  @page { margin: 1cm }
+
   body {
-    background-color: #fff;
+    font: 13pt Georgia, "Times New Roman", Times, serif;
+    line-height: 1.3;
+    background: #fff !important;
+    color: #000 !important;
+  }
+
+  #root {
+    width: 100%; 
+    margin: 0; 
+    float: none;
+  }
+
+  header,
+  footer,
+  svg {
+    display: none !important;
+  }
+
+  h1 {
+    font-size: 24pt;
+    color: #000 !important;
+  }
+  
+  h2, h3, h4 {
+    font-size: 14pt;
+    margin-top: 25px;
+    color: #000 !important;
+  }
+
+  thead {
+    display: table-header-group !important;
+  }
+
+  tr {
+    display: table-row !important;
+  }
+
+  tbody > tr > td {
+    display: table-cell !important;
+    min-height: auto;
+    padding: 5px !important;
+    border-bottom: 1px solid #f4f4f4 !important;
+    color: #000 !important;
+  }
+
+  /* td > span:first-child {
+    display: none;
+  } */
+  
+  td > span:last-child {
+    text-align: left;
+    word-break: normal;
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
## Description

Updating our print styles to include rules specific to elements on the invoice page so printable invoices will resemble how they are in classic manager.

Todo:
- [ ] hiding breakpoint-specific elements
- [ ] adding invoice/remit addresses + styling for them
- [ ] logo addition?

## Note to Reviewers

There are 2 ways to test this, one way is to command + p to pull up print preview window, another would be to inspect- in the elements tab, go to the 3 circles/more options icon:
<img width="390" alt="screen shot 2018-12-20 at 12 42 15 pm" src="https://user-images.githubusercontent.com/2565527/50301708-0c34db80-0456-11e9-8412-d1840695a859.png">
Under 'rendering' select, from the 'emulating css media' select, choose print media:
<img width="790" alt="screen shot 2018-12-20 at 12 42 32 pm" src="https://user-images.githubusercontent.com/2565527/50301721-135be980-0456-11e9-98bc-623e3dabc1de.png">

Emulator does have a few discrepancies compared to the print preview, but it's much easier to view/inspect.
