### PR TITLE
M3-1983 Update: Respond to community_like events, display in menu

### DIFF
--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -28,6 +28,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   community_question_reply: {
     notification: e => `There has been a reply to your thread "${e.entity!.label}".`,
   },
+  community_like: {
+    notification: e => e.entity!.label
+  },
   credit_card_updated: {
     notification: e => `Credit card information has been updated.`,
   },

--- a/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -119,6 +119,9 @@ const createClickHandlerForNotification = (
           return (e: React.MouseEvent<HTMLElement>) => onClick(`/nodebalancers/${id}/summary`);
       }
 
+    case 'community_like':
+      return () => { window.open(entity!.url, '_blank') };
+
     default:
       return;
   }


### PR DESCRIPTION
## Description

"Likes" on Community questions and answers have been filtered out by our display logic, with an "Unknown API Event Received" logged to the console. This is now changed so that these events are displayed in the Events Menu (top right of navbar).

## Note to Reviewers

A `community_like` event looks like this, if you would prefer to mock it with Charles:

```
        {
            "read": false,
            "status": "notification",
            "percent_complete": null,
            "seen": false,
            "id": 12345678,
            "username": "awesomeuser",
            "rate": null,
            "time_remaining": null,
            "created": "2018-12-20T17:15:03",
            "action": "community_like",
            "entity": {
                "type": "community_like",
                "label": "1 user liked your answer to: How do I boot a Linode?",
                "url": "https://linode.com/community/questions/17461#answer-67625",
                "id": 34567
            }
        },
``` 
