### PR TITLE
M3-2089 Fix: disk drawer

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.test.tsx
@@ -1,0 +1,56 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { LinodeDiskDrawer, modes } from './LinodeDiskDrawer';
+
+const classes = {
+  root: '',
+  section: '',
+  divider: ''
+}
+const props = {
+  classes,
+  mode: 'create' as any,
+  selectedMode: modes.EMPTY,
+  maximumSize: 100,
+  open: true,
+  submitting: false,
+  onClose: jest.fn(),
+  onSubmit: jest.fn(),
+  onLabelChange: jest.fn(),
+  onImageChange: jest.fn(),
+  onFilesystemChange: jest.fn(),
+  onSizeChange: jest.fn(),
+  onPasswordChange: jest.fn(),
+  onResetImageMode: jest.fn(),
+  label: "This drawer",
+  filesystem: "ext4",
+  size: 50
+}
+
+const component = shallow(<LinodeDiskDrawer {...props} />)
+
+describe("Component", () => {
+  it("should render", () => {
+    expect(component).toBeDefined();
+  });
+  it("should display the mode toggle when creating", () => {
+    expect(component.find('[data-qa-mode-toggle]')).toHaveLength(1);
+  });
+  it("should not display the mode toggle when resizing", () => {
+    component.setProps({ mode: 'resize' as any})
+    expect(component.find('[data-qa-mode-toggle]')).toHaveLength(0);
+  });
+  it("should not display the mode toggle when renaming", () => {
+    component.setProps({ mode: 'rename' as any})
+    expect(component.find('[data-qa-mode-toggle]')).toHaveLength(0);
+  });
+  it("should call the submit handler when Submit is clicked", () => {
+    component.find('[data-qa-disk-submit]').simulate('click');
+    expect(props.onSubmit).toHaveBeenCalledTimes(1);
+  });
+  it("should call the cancel handler when Cancel is clicked", () => {
+    component.find('[data-qa-disk-cancel]').simulate('click');
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
@@ -66,7 +66,7 @@ interface State {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const modes = {
+export const modes = {
   EMPTY: 'create_empty' as diskMode,
   IMAGE: 'from_image' as diskMode,
 }
@@ -84,7 +84,13 @@ const modeList: Mode<diskMode>[] = [
   }
 ]
 
-class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
+const submitLabelMap = {
+  'create': 'Add',
+  'rename': 'Rename',
+  'resize': 'Resize'
+}
+
+export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
   state: State = {
     hasErrorFor: (v) => null,
     initialSize: this.props.size,
@@ -229,7 +235,7 @@ class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
       <Drawer title={LinodeDiskDrawer.getTitle(mode)} open={open} onClose={onClose}>
         <Grid container direction="row">
           {mode === 'create' &&
-            <Grid item>
+            <Grid item data-qa-mode-toggle>
               <ModeSelect modes={modeList} selected={selectedMode} onChange={this.onModeChange} />
             </Grid>
           }
@@ -254,8 +260,10 @@ class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
           </Grid>
           <Grid item className={classes.section}>
             <ActionsPanel>
-              <Button onClick={onSubmit} type="primary" loading={submitting}>Submit</Button>
-              <Button onClick={onClose} type="secondary" className="cancel">
+              <Button onClick={onSubmit} type="primary" loading={submitting} data-qa-disk-submit>
+                {submitLabelMap[mode]}
+              </Button>
+              <Button onClick={onClose} type="secondary" className="cancel" data-qa-disk-cancel>
                 Cancel
               </Button>
             </ActionsPanel>

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
@@ -228,9 +228,11 @@ class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
     return (
       <Drawer title={LinodeDiskDrawer.getTitle(mode)} open={open} onClose={onClose}>
         <Grid container direction="row">
-          <Grid item>
-            <ModeSelect modes={modeList} selected={selectedMode} onChange={this.onModeChange} />
-          </Grid>
+          {mode === 'create' &&
+            <Grid item>
+              <ModeSelect modes={modeList} selected={selectedMode} onChange={this.onModeChange} />
+            </Grid>
+          }
           <Grid item xs={12}>
             {generalError && <Notice error spacingBottom={8} errorGroup="linode-disk-drawer" text={generalError} />}
           </Grid>

--- a/src/utilities/capitalize.ts
+++ b/src/utilities/capitalize.ts
@@ -1,4 +1,4 @@
-const capitalize = (s:string) => {
+export const capitalize = (s:string) => {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 


### PR DESCRIPTION
## Description

The mode toggle was being displayed in the disk drawer when renaming or resizing, which is confusing because you can't change the image once a disk has been created.

## Type of Change
- Bug fix

## Note to Reviewers

Also changed the names of the confirmation buttons so we don't use Submit