### PR TITLE
M3-2093 Add Display Scratch Code After 2FA is Enabled

### DIFF
--- a/src/features/Profile/AuthenticationSettings/TwoFactor/DiableTwoFactorDialog.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/DiableTwoFactorDialog.tsx
@@ -1,0 +1,134 @@
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles,
+} from '@material-ui/core/styles';
+import { pathOr } from 'ramda';
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import { disableTwoFactor } from 'src/services/profile';
+
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+import { Props as LoadingAndErrorProps, withLoadingAndError }
+  from 'src/components/withLoadingAndError';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {},
+});
+
+interface Props {
+  open: boolean;
+  closeDialog: () => void;
+  onSuccess: () => void;
+}
+
+type CombinedProps = Props
+  & LoadingAndErrorProps
+  & WithStyles<ClassNames>;
+
+class TrustedDevicesDialog extends React.PureComponent<CombinedProps, {}> {
+  handleCloseDialog = () => {
+    this.props.clearLoadingAndErrors();
+    this.props.closeDialog();
+  }
+
+  handleDisableTFA = (deviceId: number) => {
+    const {
+      setLoadingAndClearErrors,
+      clearLoadingAndErrors,
+      setErrorAndClearLoading,
+      closeDialog
+    } = this.props;
+    setLoadingAndClearErrors();
+    disableTwoFactor()
+      .then(() => {
+        clearLoadingAndErrors();
+        closeDialog();
+        this.props.onSuccess();
+      })
+      .catch(e => {
+        const defaultError = 'There was an error disabling TFA.';
+        const errorString = pathOr(defaultError, ['response', 'data', 'errors', 0, 'reason'], e);
+        setErrorAndClearLoading(errorString)
+      })
+  }
+  render() {
+    const {
+      open,
+      closeDialog,
+      error,
+      loading,
+    } = this.props;
+
+    return (
+      <ConfirmationDialog
+        open={open}
+        title={`Disable Two-Factor Authentication`}
+        onClose={closeDialog}
+        error={error}
+        actions={
+          <DialogActions
+            closeDialog={this.handleCloseDialog}
+            loading={loading}
+            handleDelete={this.handleDisableTFA}
+          />
+        }
+      >
+        <Typography>
+          Are you sure you want to disable two-factor authentication?
+        </Typography>
+      </ConfirmationDialog>
+    );
+  }
+}
+
+const styled = withStyles(styles);
+
+export default compose<CombinedProps, Props>(
+  styled,
+  withLoadingAndError
+)(TrustedDevicesDialog);
+
+interface ActionsProps {
+  closeDialog: () => void;
+  loading: boolean;
+  handleDelete: (deviceId?: number) => void;
+  deviceId?: number;
+}
+
+class DialogActions extends React.PureComponent<ActionsProps, {}> {
+  handleSubmit = () => {
+    const { handleDelete, deviceId } = this.props;
+    return handleDelete(deviceId)
+  }
+  render() {
+
+    return (
+      <ActionsPanel>
+        <Button
+          onClick={this.props.closeDialog}
+          type="cancel"
+          data-qa-cancel
+        >
+          Cancel
+      </Button>
+        <Button
+          type="secondary"
+          destructive
+          loading={this.props.loading}
+          onClick={this.handleSubmit}
+          data-qa-submit
+        >
+          Disable Two-factor Authenitcation
+      </Button>
+      </ActionsPanel>
+
+    )
+  }
+}

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/DisableTwoFactorDialog.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/DisableTwoFactorDialog.tsx
@@ -32,7 +32,7 @@ type CombinedProps = Props
   & LoadingAndErrorProps
   & WithStyles<ClassNames>;
 
-class TrustedDevicesDialog extends React.PureComponent<CombinedProps, {}> {
+class DisableTwoFactorDialog extends React.PureComponent<CombinedProps, {}> {
   handleCloseDialog = () => {
     this.props.clearLoadingAndErrors();
     this.props.closeDialog();
@@ -76,7 +76,7 @@ class TrustedDevicesDialog extends React.PureComponent<CombinedProps, {}> {
           <DialogActions
             closeDialog={this.handleCloseDialog}
             loading={loading}
-            handleDelete={this.handleDisableTFA}
+            handleDisable={this.handleDisableTFA}
           />
         }
       >
@@ -93,19 +93,19 @@ const styled = withStyles(styles);
 export default compose<CombinedProps, Props>(
   styled,
   withLoadingAndError
-)(TrustedDevicesDialog);
+)(DisableTwoFactorDialog);
 
 interface ActionsProps {
   closeDialog: () => void;
   loading: boolean;
-  handleDelete: (deviceId?: number) => void;
+  handleDisable: (deviceId?: number) => void;
   deviceId?: number;
 }
 
 class DialogActions extends React.PureComponent<ActionsProps, {}> {
   handleSubmit = () => {
-    const { handleDelete, deviceId } = this.props;
-    return handleDelete(deviceId)
+    const { handleDisable, deviceId } = this.props;
+    return handleDisable(deviceId)
   }
   render() {
 

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
@@ -27,6 +27,8 @@ interface Props {
   username: string;
   twoFactorConfirmed: boolean;
   onSuccess: () => void;
+  dialogOpen: boolean;
+  toggleDialog: () => void;
 }
 
 interface State {

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
@@ -26,8 +26,7 @@ interface Props {
   secret: string;
   username: string;
   twoFactorConfirmed: boolean;
-  onSuccess: () => void;
-  dialogOpen: boolean;
+  onSuccess: (scratchCode: string) => void;
   toggleDialog: () => void;
 }
 
@@ -76,7 +75,9 @@ export class EnableTwoFactorForm extends React.Component<CombinedProps, State> {
           submitting: false,
           token: '',
         });
-        this.props.onSuccess();
+        this.props.onSuccess(response.scratch);
+        /** toggle the scratch code dialog */
+        this.props.toggleDialog();
       })
       .catch((error) => {
         if (!this.mounted) { return; }

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/ScratchCodeDialog.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/ScratchCodeDialog.tsx
@@ -16,6 +16,7 @@ class TrustedDevicesDialog extends React.PureComponent<Props, {}> {
     const {
       open,
       closeDialog,
+      scratchCode
     } = this.props;
 
     return (
@@ -30,7 +31,17 @@ class TrustedDevicesDialog extends React.PureComponent<Props, {}> {
         }
       >
         <Typography>
-          {`Her is your scratch code dummy`}
+          {`Here is your scratch code. Please note that you can only use this code once.
+          This is the only time it will appear. Be sure to make a note of it and keep it
+          secure:`}
+        </Typography>
+        <Typography
+          style={{
+            marginTop: '16px'
+          }}
+          variant="h5"
+        >
+          {scratchCode}
         </Typography>
       </ConfirmationDialog>
     );

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/ScratchCodeDialog.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/ScratchCodeDialog.tsx
@@ -11,7 +11,7 @@ interface Props {
   scratchCode: string;
 }
 
-class TrustedDevicesDialog extends React.PureComponent<Props, {}> {
+class ScratchCodeDialog extends React.PureComponent<Props, {}> {
   render() {
     const {
       open,
@@ -31,9 +31,10 @@ class TrustedDevicesDialog extends React.PureComponent<Props, {}> {
         }
       >
         <Typography>
-          {`Here is your scratch code. Please note that you can only use this code once.
-          This is the only time it will appear. Be sure to make a note of it and keep it
-          secure:`}
+          {`This scratch code can be used in place of two-factor authentication in the event
+          you cannot access your two-factor authentication device. It is limited to a one-time
+          use. Be sure to make a note of it and keep it secure, as this is the only time it
+          will appear:`}
         </Typography>
         <Typography
           style={{
@@ -48,7 +49,7 @@ class TrustedDevicesDialog extends React.PureComponent<Props, {}> {
   }
 }
 
-export default TrustedDevicesDialog;
+export default ScratchCodeDialog;
 
 interface ActionsProps {
   closeDialog: () => void;

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/ScratchCodeDialog.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/ScratchCodeDialog.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+
+interface Props {
+  open: boolean;
+  closeDialog: () => void;
+  scratchCode: string;
+}
+
+class TrustedDevicesDialog extends React.PureComponent<Props, {}> {
+  render() {
+    const {
+      open,
+      closeDialog,
+    } = this.props;
+
+    return (
+      <ConfirmationDialog
+        open={open}
+        title={`Scratch Code`}
+        onClose={closeDialog}
+        actions={
+          <DialogActions
+            closeDialog={this.props.closeDialog}
+          />
+        }
+      >
+        <Typography>
+          {`Her is your scratch code dummy`}
+        </Typography>
+      </ConfirmationDialog>
+    );
+  }
+}
+
+export default TrustedDevicesDialog;
+
+interface ActionsProps {
+  closeDialog: () => void;
+}
+
+class DialogActions extends React.PureComponent<ActionsProps, {}> {
+  render() {
+    return (
+      <ActionsPanel>
+        <Button
+          type="secondary"
+          onClick={this.props.closeDialog}
+          data-qa-submit>
+          Got it
+     </Button>
+      </ActionsPanel>
+    )
+  }
+}

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -1,7 +1,8 @@
 import SettingsBackupRestore from '@material-ui/icons/SettingsBackupRestore';
-import { compose, path, pathOr } from 'ramda';
+import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
+import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
@@ -12,6 +13,7 @@ import { StyleRulesCallback, WithStyles, withStyles } from 'src/components/core/
 import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
 import Toggle from 'src/components/Toggle';
+import ToggleState from 'src/components/ToggleState';
 import { disableTwoFactor, getTFAToken } from 'src/services/profile';
 import { handleUpdate } from 'src/store/reducers/resources/profile';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
@@ -55,6 +57,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 
 interface Props {
   clearState: () => void;
+  twoFactor?: boolean;
+  username?: string;
+  updateProfile: (profile: Partial<Linode.Profile>) => void;
 }
 
 interface ConfirmDisable {
@@ -305,13 +310,19 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
             </div>
           }
           {twoFactorEnabled && showQRCode && username && twoFactorConfirmed !== undefined &&
-            <EnableTwoFactorForm
-              secret={secret}
-              username={username}
-              loading={loading}
-              onSuccess={this.confirmToken}
-              twoFactorConfirmed={twoFactorConfirmed}
-            />
+            <ToggleState>
+              {({ open: dialogOpen, toggle: toggleDialog }) => (
+                <EnableTwoFactorForm
+                  secret={secret}
+                  username={username}
+                  loading={loading}
+                  onSuccess={this.confirmToken}
+                  twoFactorConfirmed={twoFactorConfirmed}
+                  toggleDialog={toggleDialog}
+                  dialogOpen={dialogOpen}
+                />
+              )}
+            </ToggleState>
           }
         </Paper>
         <ConfirmationDialog
@@ -358,6 +369,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (dispatch, 
 
 const connected = connect(mapStateToProps, mapDispatchToProps);
 
-const enhanced = compose<any, any, any>(styled, connected);
-
-export default enhanced(TwoFactor);
+export default compose<CombinedProps, Props>(
+  styled,
+  connected
+)(TwoFactor);

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -3,9 +3,7 @@ import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { compose } from 'recompose';
-import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
-import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import FormControl from 'src/components/core/FormControl';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import Paper from 'src/components/core/Paper';
@@ -14,11 +12,15 @@ import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
 import Toggle from 'src/components/Toggle';
 import ToggleState from 'src/components/ToggleState';
-import { disableTwoFactor, getTFAToken } from 'src/services/profile';
+import { getTFAToken } from 'src/services/profile';
 import { handleUpdate } from 'src/store/reducers/resources/profile';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import EnableTwoFactorForm from './EnableTwoFactorForm';
+
+import ScratchDialog from './ScratchCodeDialog';
+
+import DiableTwoFactorDialog from './DiableTwoFactorDialog';
 
 type ClassNames = 'root'
   | 'container'
@@ -77,6 +79,7 @@ interface State {
   success?: string;
   twoFactorEnabled?: boolean;
   twoFactorConfirmed?: boolean;
+  scratchCode: string;
 }
 
 type CombinedProps = Props & StateProps & DispatchProps & WithStyles<ClassNames>;
@@ -95,7 +98,8 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
       open: false,
       error: undefined,
       submitting: false,
-    }
+    },
+    scratchCode: ''
   }
 
   /*
@@ -127,7 +131,7 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
     });
   }
 
-  confirmToken = () => {
+  confirmToken = (scratchCode: string) => {
     this.props.actions.updateProfile({
       ...this.props.profile,
       two_factor_auth: true,
@@ -137,64 +141,20 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
       showQRCode: false,
       twoFactorEnabled: true,
       twoFactorConfirmed: true,
+      scratchCode
     })
   }
 
-  disableTFA = () => {
-    disableTwoFactor()
-      .then((response) => {
-        this.props.actions.updateProfile({
-          ...this.props.profile,
-          two_factor_auth: false,
-        });
-        this.setState({
-          success: "Two-factor authentication has been disabled.",
-          twoFactorEnabled: false,
-          twoFactorConfirmed: false,
-          disableDialog: {
-            error: undefined,
-            open: false,
-            success: undefined,
-            submitting: false,
-          }
-        });
-      })
-      .catch((error) => {
-        const fallbackError = [{ reason: 'There was an error disabling TFA.' }];
-        const disableError = pathOr(fallbackError, ['response', 'data', 'errors'], error);
-        this.setState({
-          twoFactorEnabled: true,
-          disableDialog: {
-            error: disableError[0].reason,
-            submitting: false,
-            open: true,
-            success: undefined,
-          }
-        });
-      })
-  }
-
-  getActions = () => {
-    return (
-      <ActionsPanel>
-        <Button
-          onClick={this.closeDisableDialog}
-          type="cancel"
-          data-qa-cancel
-        >
-          Cancel
-        </Button>
-        <Button
-          type="secondary"
-          destructive
-          loading={this.state.disableDialog.submitting}
-          onClick={this.disableTFA}
-          data-qa-submit
-        >
-          Disable Two-factor Authenitcation
-        </Button>
-      </ActionsPanel>
-    )
+  disableTFASuccess = () => {
+    this.props.actions.updateProfile({
+      ...this.props.profile,
+      two_factor_auth: false,
+    })
+    this.setState({
+      success: 'Two-factor authentication has been disabled.',
+      twoFactorEnabled: false,
+      twoFactorConfirmed: false,
+    })
   }
 
   getToken = () => {
@@ -223,25 +183,16 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
     this.setState({ showQRCode: !this.state.showQRCode });
   }
 
-  toggleTwoFactorEnabled = () => {
+  toggleTwoFactorEnabled = (toggleEnabled: boolean) => {
     this.setState({ errors: undefined, success: undefined });
-    const { twoFactorEnabled, twoFactorConfirmed } = this.state;
-    const toggle = !twoFactorEnabled;
-    if (toggle) {
-      // Enable TFA. Ask the API for a TFA secret.
-      this.setState({ twoFactorEnabled: true, loading: true, showQRCode: true, });
+    /** if we're turning TFA on, ask the API for a TFA secret */
+    if (toggleEnabled) {
       this.getToken();
-    } else {
-      // If TFA isn't active on the account,
-      // there's nothing to do here; just flip the toggle.
-      if (!twoFactorConfirmed) {
-        this.setState({ twoFactorEnabled: false })
-        return;
-      }
-      // Deactivate TFA.
-      // This is destructive (sort of), so
-      // open a confirmation dialog.
-      this.openDisableDialog();
+      return this.setState({
+        twoFactorEnabled: true,
+        loading: true,
+        showQRCode: true,
+      });
     }
   }
 
@@ -252,91 +203,89 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
     const generalError = hasErrorFor('none');
 
     return (
-      <React.Fragment>
-        <Paper className={classes.root}>
-          {success && <Notice success text={success} />}
-          {generalError && <Notice error text={generalError} />}
-          <Typography
-            role="header"
-            variant="h2"
-            className={classes.title}
-            data-qa-title
-          >
-            Two-Factor Authentication (TFA)
-          </Typography>
-          <FormControl fullWidth>
-            <FormControlLabel
-              label={twoFactorEnabled ? "Enabled" : "Disabled"}
-              control={
-                <Toggle
-                  checked={twoFactorEnabled}
-                  onChange={this.toggleTwoFactorEnabled}
-                  data-qa-toggle-tfa={twoFactorEnabled}
+      <ToggleState>
+        {({ open: disable2FAOpen, toggle: toggleDisable2FA }) => (
+          <ToggleState>
+            {({ open: scratchDialogOpen, toggle: toggleScratchDialog }) => (
+              <React.Fragment>
+                <Paper className={classes.root}>
+                  {success && <Notice success text={success} />}
+                  {generalError && <Notice error text={generalError} />}
+                  <Typography
+                    role="header"
+                    variant="h2"
+                    className={classes.title}
+                    data-qa-title
+                  >
+                    Two-Factor Authentication (TFA)
+                  </Typography>
+                  {typeof twoFactorConfirmed !== 'undefined' &&
+                    <TwoFactorToggle
+                      twoFactorEnabled={twoFactorEnabled || false}
+                      onChange={this.toggleTwoFactorEnabled}
+                      toggleDisableDialog={toggleDisable2FA}
+                      twoFactorConfirmed={twoFactorConfirmed}
+                    />
+                  }
+                  <Typography
+                    variant="body1"
+                    data-qa-copy
+                  >
+                    Two-factor authentication increases the security of your Linode account by requiring two different
+                    forms of authentication to log in: your account password and a security token. You can set up a
+                    third party app such as Authy or Google Authenticator to generate these tokens for you.
+                  </Typography>
+                  {twoFactorEnabled &&
+                    <div className={classes.container}>
+                      {showQRCode
+                        ? <Button
+                          type="secondary"
+                          className={classes.visibility}
+                          onClick={this.toggleHidden}
+                          destructive
+                          data-qa-hide-show-code
+                        >
+                          <SettingsBackupRestore />
+                          <span className={classes.showHideText}>Hide QR Code</span>
+                        </Button>
+                        : <Button
+                          type="secondary"
+                          className={classes.visibility}
+                          onClick={this.toggleHidden}
+                          data-qa-hide-show-code
+                        >
+                          <SettingsBackupRestore />
+                          <span className={classes.showHideText}>{twoFactorConfirmed ? "Reset two-factor authentication" : "Show QR Code"}</span>
+                        </Button>
+                      }
+                    </div>
+                  }
+                  {twoFactorEnabled && showQRCode && username && twoFactorConfirmed !== undefined &&
+                    <EnableTwoFactorForm
+                      secret={secret}
+                      username={username}
+                      loading={loading}
+                      onSuccess={this.confirmToken}
+                      twoFactorConfirmed={twoFactorConfirmed}
+                      toggleDialog={toggleScratchDialog}
+                    />
+                  }
+                </Paper>
+                <ScratchDialog
+                  open={scratchDialogOpen}
+                  closeDialog={toggleScratchDialog}
+                  scratchCode={this.state.scratchCode}
                 />
-              }
-            />
-          </FormControl>
-          <Typography
-            variant="body1"
-            data-qa-copy
-          >
-            Two-factor authentication increases the security of your Linode account by requiring two different
-            forms of authentication to log in: your account password and a security token. You can set up a
-            third party app such as Authy or Google Authenticator to generate these tokens for you.
-          </Typography>
-          {twoFactorEnabled &&
-            <div className={classes.container}>
-              {showQRCode
-                ? <Button
-                  type="secondary"
-                  className={classes.visibility}
-                  onClick={this.toggleHidden}
-                  destructive
-                  data-qa-hide-show-code
-                >
-                  <SettingsBackupRestore />
-                  <span className={classes.showHideText}>Hide QR Code</span>
-                </Button>
-                : <Button
-                  type="secondary"
-                  className={classes.visibility}
-                  onClick={this.toggleHidden}
-                  data-qa-hide-show-code
-                >
-                  <SettingsBackupRestore />
-                  <span className={classes.showHideText}>{twoFactorConfirmed ? "Reset two-factor authentication" : "Show QR Code"}</span>
-                </Button>
-              }
-            </div>
-          }
-          {twoFactorEnabled && showQRCode && username && twoFactorConfirmed !== undefined &&
-            <ToggleState>
-              {({ open: dialogOpen, toggle: toggleDialog }) => (
-                <EnableTwoFactorForm
-                  secret={secret}
-                  username={username}
-                  loading={loading}
-                  onSuccess={this.confirmToken}
-                  twoFactorConfirmed={twoFactorConfirmed}
-                  toggleDialog={toggleDialog}
-                  dialogOpen={dialogOpen}
+                <DiableTwoFactorDialog
+                  onSuccess={this.disableTFASuccess}
+                  open={disable2FAOpen}
+                  closeDialog={toggleDisable2FA}
                 />
-              )}
-            </ToggleState>
-          }
-        </Paper>
-        <ConfirmationDialog
-          open={this.state.disableDialog.open}
-          title="Disable Two-Factor Authentication"
-          onClose={this.closeDisableDialog}
-          actions={this.getActions}
-        >
-          {this.state.disableDialog.error &&
-            <Notice error text={this.state.disableDialog.error} />
-          }
-          <Typography>Are you sure you want to disable two-factor authentication?</Typography>
-        </ConfirmationDialog>
-      </React.Fragment>
+              </React.Fragment>
+            )}
+          </ToggleState>
+        )}
+      </ToggleState>
     )
   }
 }
@@ -373,3 +322,43 @@ export default compose<CombinedProps, Props>(
   styled,
   connected
 )(TwoFactor);
+
+interface ToggleProps {
+  toggleDisableDialog: () => void;
+  onChange: (value: boolean) => void;
+  twoFactorEnabled: boolean;
+  twoFactorConfirmed: boolean;
+}
+
+class TwoFactorToggle extends React.PureComponent<ToggleProps, {}> {
+  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { twoFactorConfirmed, onChange } = this.props;
+    const enabled = e.currentTarget.checked;
+    onChange(enabled);
+    /** 
+     * only open the disable dialog if 2FA has been turned on and we're flipping the toggle off 
+     */
+    if (!enabled && twoFactorConfirmed) {
+      this.props.toggleDisableDialog();
+    }
+  }
+
+  render() {
+    const { twoFactorEnabled } = this.props;
+
+    return (
+      <FormControl fullWidth>
+        <FormControlLabel
+          label={twoFactorEnabled ? "Enabled" : "Disabled"}
+          control={
+            <Toggle
+              checked={twoFactorEnabled}
+              onChange={this.handleChange}
+              data-qa-toggle-tfa={twoFactorEnabled}
+            />
+          }
+        />
+      </FormControl>
+    )
+  }
+}

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -20,7 +20,7 @@ import EnableTwoFactorForm from './EnableTwoFactorForm';
 
 import ScratchDialog from './ScratchCodeDialog';
 
-import DiableTwoFactorDialog from './DiableTwoFactorDialog';
+import DisableTwoFactorDialog from './DisableTwoFactorDialog';
 
 type ClassNames = 'root'
   | 'container'
@@ -159,28 +159,30 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
 
   getToken = () => {
     this.setState({ loading: true });
-    getTFAToken()
+    return getTFAToken()
       .then((response) => {
-        this.setState({ secret: response.data.secret, loading: false })
+        this.setState({ secret: response.data.secret, loading: false, errors: undefined })
       })
       .catch((error) => {
         const fallbackError = [{ reason: 'There was an error retrieving your secret key. Please try again.' }];
         this.setState({
           errors: pathOr(fallbackError, ['response', 'data', 'errors'], error),
           loading: false,
-          twoFactorEnabled: false,
         }, () => {
           scrollErrorIntoView();
         });
+        return Promise.reject('Error');
       });
   }
 
   toggleHidden = () => {
     const { showQRCode } = this.state;
     if (!showQRCode) {
-      this.getToken();
+      return this.getToken()
+      .then(response => this.setState({showQRCode: !showQRCode}))
+      .catch(err => err)
     }
-    this.setState({ showQRCode: !this.state.showQRCode });
+    return this.setState({ showQRCode: !this.state.showQRCode });
   }
 
   toggleTwoFactorEnabled = (toggleEnabled: boolean) => {
@@ -276,7 +278,7 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
                   closeDialog={toggleScratchDialog}
                   scratchCode={this.state.scratchCode}
                 />
-                <DiableTwoFactorDialog
+                <DisableTwoFactorDialog
                   onSuccess={this.disableTFASuccess}
                   open={disable2FAOpen}
                   closeDialog={toggleDisable2FA}

--- a/src/services/profile/twoFactor.ts
+++ b/src/services/profile/twoFactor.ts
@@ -50,8 +50,9 @@ export const disableTwoFactor = () =>
  * being locked out of your Account.
  */
 export const confirmTwoFactor = (tfa_code: string) =>
-  Request<string>(
+  Request<{ scratch: string }>(
     setMethod('POST'),
     setURL(`${API_ROOT}/profile/tfa-enable-confirm`),
     setData({ tfa_code })
   )
+    .then(response => response.data)


### PR DESCRIPTION
## Description

Display a scratch code after a user has enabled 2FA

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

#### Changed
* Abstracted DisableTFA Dialog to it's own component
   * it also now leverages the ToggleState component
* Fixed typings for the return payload of `/profile/tfa-enable-confirm`

#### Added
* Scratch code dialog, which leverages ToggleState


Todo
- [x] Wrap all dialogs in ToggleState
- [x] pass down scratch code to dialog