### PR TITLE
change group import CTA logic

### DIFF
--- a/src/features/Account/ImportGroupsAsTags.tsx
+++ b/src/features/Account/ImportGroupsAsTags.tsx
@@ -31,7 +31,7 @@ export const ImportGroupsAsTags: React.StatelessComponent<CombinedProps> = (prop
         You now have the ability to import your Display Groups from Classic Manager as tags and they will be associated with your Domains and Linodes. This will give you the ability to organize and view your Linodes by tags. <strong>Your existing tags will not be affected.</strong>
       </Typography>
       <Button type="primary" onClick={openDrawer} data-qa-open-group-import-drawer>
-        Import Display Groups Now
+        Import Display Groups
       </Button>
     </ExpansionPanel>
   );

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -10,7 +10,8 @@ import Grid from 'src/components/Grid';
 import TagImportDrawer from 'src/features/TagImport';
 import { handleOpen } from 'src/store/reducers/backupDrawer';
 import { openGroupDrawer } from 'src/store/reducers/tagImportDrawer';
-import getEntitiesWithGroupsToImport, { GroupedEntitiesForImport } from 'src/store/selectors/getEntitiesWithGroupsToImport';
+import getEntitiesWithGroupsToImport, { emptyGroupedEntities, GroupedEntitiesForImport } from 'src/store/selectors/getEntitiesWithGroupsToImport';
+import shouldDisplayGroupImport from 'src/utilities/shouldDisplayGroupImportCTA';
 import { storage } from 'src/utilities/storage';
 import BackupsDashboardCard from './BackupsDashboardCard';
 import BlogDashboardCard from './BlogDashboardCard';
@@ -20,7 +21,6 @@ import LinodesDashboardCard from './LinodesDashboardCard';
 import NodeBalancersDashboardCard from './NodeBalancersDashboardCard';
 import TransferDashboardCard from './TransferDashboardCard';
 import VolumesDashboardCard from './VolumesDashboardCard';
-
 
 type ClassNames = 'root';
 
@@ -44,15 +44,6 @@ interface DispatchProps {
 }
 
 type CombinedProps = StateProps & DispatchProps & WithStyles<ClassNames> & WithTheme;
-
-const shouldDisplayGroupImportCTA = (groupedEntities: GroupedEntitiesForImport) => {
-  const userHasDisabledCTA = storage.hideGroupImportCTA.get();
-  const { linodes, domains } = groupedEntities;
-  return (
-    !userHasDisabledCTA &&
-    (linodes.length > 0 || domains.length > 0)
-  )
-}
 
 export const Dashboard: React.StatelessComponent<CombinedProps> = (props) => {
   const {
@@ -86,7 +77,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = (props) => {
               openBackupDrawer={openBackupDrawer}
             />
           }
-          {shouldDisplayGroupImportCTA(entitiesWithGroupsToImport) &&
+          {!storage.hideGroupImportCTA.get() && shouldDisplayGroupImport(entitiesWithGroupsToImport) &&
             <ImportGroupsCard
               theme={props.theme.name}
               openImportDrawer={openImportDrawer}
@@ -106,7 +97,10 @@ const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (stat
   linodesWithoutBackups: state.__resources.linodes.entities.filter(l => !l.backups.enabled),
   managed: pathOr(false, ['__resources', 'accountSettings', 'data', 'managed'], state),
   backupError: pathOr(false, ['backups', 'error'], state),
-  entitiesWithGroupsToImport: getEntitiesWithGroupsToImport(state), // <-- Memoized selector
+  entitiesWithGroupsToImport: (
+    (!storage.hideGroupImportCTA.get() || !storage.hasImportedGroups.get())
+      ? getEntitiesWithGroupsToImport(state)
+      : emptyGroupedEntities),
 });
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (dispatch, ownProps) => {

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -98,7 +98,7 @@ const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (stat
   managed: pathOr(false, ['__resources', 'accountSettings', 'data', 'managed'], state),
   backupError: pathOr(false, ['backups', 'error'], state),
   entitiesWithGroupsToImport: (
-    (!storage.hideGroupImportCTA.get() || !storage.hasImportedGroups.get())
+    (!storage.hideGroupImportCTA.get() && !storage.hasImportedGroups.get())
       ? getEntitiesWithGroupsToImport(state)
       : emptyGroupedEntities),
 });

--- a/src/features/TagImport/TagImportDrawer.tsx
+++ b/src/features/TagImport/TagImportDrawer.tsx
@@ -19,12 +19,14 @@ import {
 } from 'src/store/reducers/tagImportDrawer'
 import getEntitiesWithGroupsToImport,
   {
+    emptyGroupedEntities,
     GroupedEntitiesForImport,
     GroupImportProps,
   } from 'src/store/selectors/getEntitiesWithGroupsToImport';
 
 
 import { sortAlphabetically } from 'src/utilities/sort-by';
+import { storage } from 'src/utilities/storage';
 import DisplayGroupList from './DisplayGroupList';
 
 type ClassNames = 'root';
@@ -134,7 +136,10 @@ const mapStateToProps = (state: ApplicationState, ownProps: CombinedProps) => {
     loading: pathOr(false, ['tagImportDrawer', 'loading'], state),
     errors: pathOr([], ['tagImportDrawer', 'errors'], state),
     success: pathOr(false, ['tagImportDrawer', 'success'], state),
-    entitiesWithGroupsToImport: getEntitiesWithGroupsToImport(state),
+    entitiesWithGroupsToImport: (
+      !storage.hasImportedGroups.get()
+        ? getEntitiesWithGroupsToImport(state)
+        : emptyGroupedEntities),
   });
 };
 

--- a/src/store/reducers/tagImportDrawer.ts
+++ b/src/store/reducers/tagImportDrawer.ts
@@ -7,7 +7,8 @@ import actionCreatorFactory from 'typescript-fsa';
 import { updateDomain } from 'src/services/domains';
 import { updateLinode } from 'src/services/linodes';
 import getEntitiesWithGroupsToImport,
-  { GroupImportProps } from 'src/store/selectors/getEntitiesWithGroupsToImport';
+{ GroupImportProps } from 'src/store/selectors/getEntitiesWithGroupsToImport';
+import { storage } from 'src/utilities/storage';
 
 const actionCreator = actionCreatorFactory(`@@manager/tagImportDrawer`);
 
@@ -206,6 +207,7 @@ export const addTagsToEntities: ImportGroupsAsTagsThunk = () => (dispatch: Dispa
     dispatch,
     handleAccumulatedResponsesAndErrors,
   )
+    .then(() => storage.hasImportedGroups.set())
     .catch(() => dispatch(
       // Errors from individual requests will be accumulated and passed to .then(); hitting
       // this block indicates something went wrong with .reduce() or .join().

--- a/src/store/selectors/getEntitiesWithGroupsToImport.tsx
+++ b/src/store/selectors/getEntitiesWithGroupsToImport.tsx
@@ -12,6 +12,11 @@ export interface GroupImportProps {
   tags: string[];
 }
 
+export const emptyGroupedEntities = {
+  linodes: [],
+  domains: []
+};
+
 // Linodes and Domains are the only entities with Display Groups.
 type GroupedEntity = Linode.Linode | Linode.Domain;
 

--- a/src/utilities/shouldDisplayGroupImportCTA.ts
+++ b/src/utilities/shouldDisplayGroupImportCTA.ts
@@ -1,0 +1,8 @@
+import { GroupedEntitiesForImport } from 'src/store/selectors/getEntitiesWithGroupsToImport';
+
+const shouldDisplayGroupImport = (groupedEntities: GroupedEntitiesForImport) => {
+  const { linodes, domains } = groupedEntities;
+  return (linodes.length > 0 || domains.length > 0);
+}
+
+export default shouldDisplayGroupImport;

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -26,6 +26,7 @@ const BETA_NOTIFICATION = 'BetaNotification';
 const LINODE_VIEW = 'linodesViewStyle';
 const GROUP_LINODES = 'GROUP_LINODES';
 const HIDE_DISPLAY_GROUPS_CTA = 'importDisplayGroupsCTA';
+const HAS_IMPORTED_GROUPS = 'hasImportedGroups';
 
 type Theme = 'dark' | 'light';
 type Beta = 'open' | 'closed';
@@ -64,6 +65,10 @@ export const storage = {
   hideGroupImportCTA: {
     get: (): 'true' | 'false' =>  getStorage(HIDE_DISPLAY_GROUPS_CTA),
     set: () => setStorage(HIDE_DISPLAY_GROUPS_CTA, 'true')
+  },
+  hasImportedGroups: {
+    get: (): 'true' | 'false' =>  getStorage(HAS_IMPORTED_GROUPS),
+    set: () => setStorage(HAS_IMPORTED_GROUPS, 'true')
   }
 }
 


### PR DESCRIPTION
## Description

The logic for displaying the Group Import CTA on the DASHBOARD is as follows:

- IF the user has never imported groups before
- AND the user hasn’t dismissed the CTA
- AND the user has groups to import 
- THEN we display the CTA 

The logic for displaying the Group Import setting in GLOBAL SETTINGS is as follows:

- IF the user has never imported groups before
- AND the user has groups to import
- THEN we display the setting
 

## Type of Change
- change
