### PR TITLE
M3-1886 Add subject and user agent to "Provide Feedback" mailto link

### DIFF
--- a/src/features/Footer/Footer.tsx
+++ b/src/features/Footer/Footer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
+import createMailto from './createMailto';
 
 type CSSClasses = 'container'
   | 'link'
@@ -61,7 +62,7 @@ export class Footer extends React.PureComponent<CombinedProps> {
         <Grid item style={{ paddingLeft: 0 }}>
           <a
             className={classes.link}
-            href="mailto:feedback@linode.com"
+            href={createMailto(navigator.userAgent || '')}
           >
             Provide Feedback
           </a>

--- a/src/features/Footer/Footer.tsx
+++ b/src/features/Footer/Footer.tsx
@@ -62,7 +62,7 @@ export class Footer extends React.PureComponent<CombinedProps> {
         <Grid item style={{ paddingLeft: 0 }}>
           <a
             className={classes.link}
-            href={createMailto(navigator.userAgent || '')}
+            href={createMailto(window.navigator.userAgent || '')}
           >
             Provide Feedback
           </a>

--- a/src/features/Footer/createMailto.test.ts
+++ b/src/features/Footer/createMailto.test.ts
@@ -1,0 +1,35 @@
+import { parse } from 'qs';
+import createMailto from './createMailto';
+
+describe('mailto', () => {
+  const mailto = createMailto('my-user-agent');
+
+  it('is a mailto link', () => {
+    expect(mailto.startsWith('mailto:')).toBeTruthy();
+  });
+
+  it('includes correct recipient email address', () => {
+    const recipient = mailto.split('?')[0].split(':')[1];
+    expect(recipient).toBe('feedback@linode.com');
+  });
+
+  it('contains a subject', () => {
+    const queryString = parse(mailto.split('?')[1]);
+    expect(queryString).toHaveProperty('Subject');
+    expect(queryString.Subject).toBe('Cloud Manager User Feedback');
+  });
+
+  it('contains a body', () => {
+    const queryString = parse(mailto.split('?')[1]);
+    expect(queryString).toHaveProperty('Body');
+    expect(queryString.Body).toBe('\n\nmy-user-agent');
+  });
+
+  it('doesn\'t include body if user agent is bad input', () => {
+    expect(createMailto('')).toBe('mailto:feedback@linode.com?Subject=Cloud%20Manager%20User%20Feedback');
+    expect(createMailto(21 as any)).toBe('mailto:feedback@linode.com?Subject=Cloud%20Manager%20User%20Feedback');
+    expect(createMailto(true as any)).toBe('mailto:feedback@linode.com?Subject=Cloud%20Manager%20User%20Feedback');
+    expect(createMailto(undefined as any)).toBe('mailto:feedback@linode.com?Subject=Cloud%20Manager%20User%20Feedback');
+    expect(createMailto(null as any)).toBe('mailto:feedback@linode.com?Subject=Cloud%20Manager%20User%20Feedback');
+  });
+});

--- a/src/features/Footer/createMailto.test.ts
+++ b/src/features/Footer/createMailto.test.ts
@@ -15,14 +15,12 @@ describe('mailto', () => {
 
   it('contains a subject', () => {
     const queryString = parse(mailto.split('?')[1]);
-    expect(queryString).toHaveProperty('Subject');
-    expect(queryString.Subject).toBe('Cloud Manager User Feedback');
+    expect(queryString).toHaveProperty('Subject', 'Cloud Manager User Feedback');
   });
 
   it('contains a body', () => {
     const queryString = parse(mailto.split('?')[1]);
-    expect(queryString).toHaveProperty('Body');
-    expect(queryString.Body).toBe('\n\nmy-user-agent');
+    expect(queryString).toHaveProperty('Body', '\n\nmy-user-agent');
   });
 
   it('doesn\'t include body if user agent is bad input', () => {

--- a/src/features/Footer/createMailto.ts
+++ b/src/features/Footer/createMailto.ts
@@ -1,12 +1,23 @@
+const { VERSION } = process.env;
+
 const createMailto = (userAgent: string): string => {
   const recipient = 'feedback@linode.com';
   const subject = 'Cloud Manager User Feedback';
 
   let mailto = `mailto:${recipient}?Subject=${encodeURIComponent(subject)}`;
+  let body = '';
+
+  if (VERSION) {
+    body += `\nCloud Manager Version: ${VERSION}`;
+  }
 
   if (userAgent && typeof userAgent === 'string') {
-    const body = `\n\n${userAgent}`;
-    mailto += `&Body=${encodeURIComponent(body)}`;
+    body += `\n${userAgent}`;
+  }
+
+  if (body) {
+    const encodedBody = encodeURIComponent(`\n${body}`)
+    mailto += `&Body=${encodedBody}`;
   }
 
   return mailto;

--- a/src/features/Footer/createMailto.ts
+++ b/src/features/Footer/createMailto.ts
@@ -1,0 +1,15 @@
+const createMailto = (userAgent: string): string => {
+  const recipient = 'feedback@linode.com';
+  const subject = 'Cloud Manager User Feedback';
+
+  let mailto = `mailto:${recipient}?Subject=${encodeURIComponent(subject)}`;
+
+  if (userAgent && typeof userAgent === 'string') {
+    const body = `\n\n${userAgent}`;
+    mailto += `&Body=${encodeURIComponent(body)}`;
+  }
+
+  return mailto;
+};
+
+export default createMailto;

--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationsMenu.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationsMenu.tsx
@@ -65,7 +65,7 @@ const userAgentDetection = () => {
       return (
         <Typography>
           Your Web Browser (<strong>{b.name}</strong>) is not compatible with the Linode Manager.
-          Please update to <a href="https://www.microsoft.com/en-us/windows/microsoft-edge" target="_blank">Miscrosoft Edge</a> for more security,
+          Please update to <a href="https://www.microsoft.com/en-us/windows/microsoft-edge" target="_blank">Microsoft Edge</a> for more security,
           speed and the best experience on this site.
         </Typography>
       )


### PR DESCRIPTION
## Description

The subject added is "Cloud Manager User Feedback". 
The user agent is accessed directly from `window.navigator`.


## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Click the "Provide Feedback" link in the footer. Try different browsers and manually manipulating your user agent string with Chrome Dev Tools.