### PR TITLE
M3-2060 change: plan to tags column

### DIFF
--- a/src/components/OrderBy.test.ts
+++ b/src/components/OrderBy.test.ts
@@ -1,0 +1,60 @@
+import { sort } from 'ramda';
+import { sortData } from './OrderBy';
+
+const a =
+  {
+    name: 'april',
+    hobbies: ['this', 'that', 'the other'],
+    age: 43
+  }
+
+const b =
+  {
+    name: 'may',
+    hobbies: [],
+    age: 23
+  }
+
+const c =
+  {
+    name: 'june',
+    hobbies: ['traditional Irish bowling'],
+    age: 53
+  }
+
+const d =
+  {
+    name: 'july',
+    hobbies: ['one','two','three'],
+    age: 53
+  }
+
+const e =
+  {
+    name: 'august',
+    hobbies: ['traditional Irish bowling'],
+    age: 53
+  }
+
+describe("OrderBy", () => {
+  describe("sortData function", () => {
+    const data = [a, b, c, d, e];
+    it("should sort by string", () => {
+      const order = sortData('name', 'asc');
+      expect(sort(order, data)).toEqual([a, e, d, c, b]);
+    });
+    it("should handle the selected order (asc or desc)", () => {
+      const order = sortData('name', 'desc');
+      expect(sort(order, data)).toEqual([b, c, d, e, a]);
+    });
+    it("should sort by number", () => {
+      const order = sortData('age', 'asc');
+      expect(sort(order, data)).toEqual([b, a, c, d, e]);
+    });
+    it("should sort by array length", () => {
+      const order = sortData('hobbies', 'asc');
+      expect(sort(order, data)).toEqual([b, c, e, a, d]);
+    });
+  });
+})
+

--- a/src/components/OrderBy.ts
+++ b/src/components/OrderBy.ts
@@ -21,7 +21,7 @@ interface Props {
   orderBy?: string;
 }
 
-const sortData = curry((orderBy: string, order: Order, obj1: any, obj2: any) => {
+export const sortData = curry((orderBy: string, order: Order, obj1: any, obj2: any) => {
   /* If the column we're sorting on is an array (e.g. 'tags', which is string[]),
   *  we want to sort by the length of the array. Otherwise, do a simple comparison.
   */

--- a/src/components/OrderBy.ts
+++ b/src/components/OrderBy.ts
@@ -1,11 +1,22 @@
-import { compose, prop, reverse, sortBy, when } from 'ramda';
+import { compose, cond, length, path, prop, reverse, sortBy, when } from 'ramda';
 import * as React from 'react';
 import { Order } from 'src/components/Pagey';
+import { isArray as _isArray } from 'util';
+
+const isArray = (arr: any[], columnName: string) => {
+  const targetColumn = path([columnName], arr[0]);
+  return _isArray(targetColumn);
+}
 
 const orderList: <T>(order: Order, orderBy: keyof T) => (list: T[]) => T[] = (order, orderBy) => (list) => {
+  console.log(orderBy);
+  const orderedField = prop(orderBy as string);
   return compose<any, any, any>(
     when(() => order === 'desc', reverse),
-    sortBy(prop(orderBy as string)), /** I spent a long, long time trying to type this. */
+    cond([
+      [(a) => isArray(a, orderBy as string), sortBy(compose(length, orderedField))], // If the field to sort is an array (e.g. tags)
+      [() => true, sortBy(orderedField), /** I spent a long, long time trying to type this. */]
+    ]),
   )(list);
 };
 

--- a/src/components/ShowMore/ShowMore.test.tsx
+++ b/src/components/ShowMore/ShowMore.test.tsx
@@ -1,20 +1,26 @@
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
+import Chip from 'src/components/core/Chip';
+import { ShowMore } from './ShowMore';
 
-import ShowMore from './ShowMore';
+const mockRender = jest.fn();
+const classes = {
+  chip: '', label: '', popover: '', link: ''
+}
+
+const props = {
+  classes,
+  items: ['a', 'b'],
+  render: mockRender
+}
 
 describe('ShowMore', () => {
-  const mockRender = jest.fn();
 
-  const wrapper = mount(
-    <LinodeThemeWrapper>
+  const wrapper = shallow(
       <ShowMore
-        items={['a', 'b']}
-        render={mockRender}
+        {...props}
       />
-    </LinodeThemeWrapper>,
   );
 
   it('should call provided render function with items.', () => {
@@ -22,7 +28,12 @@ describe('ShowMore', () => {
   });
 
   it('should render a chip with items.length', () => {
-    const chipText = wrapper.find('Chip button span').text();
-    expect(chipText).toBe('+2');
+    expect(wrapper.containsMatchingElement(<Chip label="+2" />)).toBeTruthy();
+  });
+
+  it('should render a link instead of a chip if asLink is true', () => {
+    wrapper.setProps({ asLink: true });
+    expect(wrapper.find('[data-qa-show-more-chip]')).toHaveLength(0);
+    expect(wrapper.find('[data-qa-show-more-link]')).toHaveLength(1);
   });
 });

--- a/src/components/ShowMore/ShowMore.test.tsx
+++ b/src/components/ShowMore/ShowMore.test.tsx
@@ -30,10 +30,4 @@ describe('ShowMore', () => {
   it('should render a chip with items.length', () => {
     expect(wrapper.containsMatchingElement(<Chip label="+2" />)).toBeTruthy();
   });
-
-  it('should render a link instead of a chip if asLink is true', () => {
-    wrapper.setProps({ asLink: true });
-    expect(wrapper.find('[data-qa-show-more-chip]')).toHaveLength(0);
-    expect(wrapper.find('[data-qa-show-more-link]')).toHaveLength(1);
-  });
 });

--- a/src/components/ShowMore/ShowMore.tsx
+++ b/src/components/ShowMore/ShowMore.tsx
@@ -81,7 +81,7 @@ export class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasse
         {asLink
           ?
             <a
-              aria-label="Expand Tags"
+              aria-label="Expand"
               className={classes.link}
               onClick={this.handleClick}
               data-qa-show-more-link

--- a/src/components/ShowMore/ShowMore.tsx
+++ b/src/components/ShowMore/ShowMore.tsx
@@ -52,7 +52,7 @@ interface Props<T> {
   asLink?: boolean;
 }
 
-class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
+export class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
   state = {
     anchorEl: undefined,
   };

--- a/src/components/ShowMore/ShowMore.tsx
+++ b/src/components/ShowMore/ShowMore.tsx
@@ -33,6 +33,9 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   },
   link: {
     color: `${theme.color.blueDTwhite} !important`,
+    '&:hover' : {
+      textDecoration: 'underline',
+    }
   },
   popover: {
     minWidth: 'auto',

--- a/src/components/ShowMore/ShowMore.tsx
+++ b/src/components/ShowMore/ShowMore.tsx
@@ -52,7 +52,6 @@ interface Props<T> {
   items: T[];
   render: (items: T[]) => any;
   chipProps?: ChipProps;
-  asLink?: boolean;
 }
 
 export class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
@@ -73,39 +72,27 @@ export class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasse
   }
 
   render() {
-    const { asLink, classes, render, items, chipProps } = this.props;
+    const { classes, render, items, chipProps } = this.props;
     const { anchorEl } = this.state;
 
     return (
       <React.Fragment>
-        {asLink
-          ?
-            <a
-              aria-label="Expand"
-              className={classes.link}
-              onClick={this.handleClick}
-              data-qa-show-more-link
-            >
-              {items.length}
-            </a>
-          :
-            <Chip
-              className={classNames(
-                {
-                  [classes.chip]: true,
-                  'active': anchorEl,
-                },
-                'chip',
-              )}
-              label={`+${items.length}`}
-              classes={{ label: classes.label }}
-              onClick={this.handleClick}
-              {...chipProps}
-              data-qa-show-more-chip
-              component="button"
-              clickable
-            />
-        }
+        <Chip
+          className={classNames(
+            {
+              [classes.chip]: true,
+              'active': anchorEl,
+            },
+            'chip',
+          )}
+          label={`+${items.length}`}
+          classes={{ label: classes.label }}
+          onClick={this.handleClick}
+          {...chipProps}
+          data-qa-show-more-chip
+          component="button"
+          clickable
+        />
 
         <Popover
           classes={{ paper: classes.popover }}

--- a/src/components/ShowMore/ShowMore.tsx
+++ b/src/components/ShowMore/ShowMore.tsx
@@ -4,7 +4,10 @@ import Chip, { ChipProps } from 'src/components/core/Chip';
 import Popover from 'src/components/core/Popover';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 
-type CSSClasses =  'chip' | 'label' | 'popover';
+type CSSClasses =  'chip'
+  | 'label'
+  | 'popover'
+  | 'link';
 
 const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   chip: {
@@ -28,6 +31,9 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     paddingLeft: 6,
     paddingRight: 6,
   },
+  link: {
+    color: `${theme.color.blueDTwhite} !important`,
+  },
   popover: {
     minWidth: 'auto',
     maxWidth: 400,
@@ -43,6 +49,7 @@ interface Props<T> {
   items: T[];
   render: (items: T[]) => any;
   chipProps?: ChipProps;
+  asLink?: boolean;
 }
 
 class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
@@ -63,27 +70,40 @@ class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
   }
 
   render() {
-    const { classes, render, items, chipProps } = this.props;
+    const { asLink, classes, render, items, chipProps } = this.props;
     const { anchorEl } = this.state;
 
     return (
       <React.Fragment>
-        <Chip
-          className={classNames(
-            {
-              [classes.chip]: true,
-              'active': anchorEl,
-            },
-            'chip',
-          )}
-          label={`+${items.length}`}
-          classes={{ label: classes.label }}
-          onClick={this.handleClick}
-          {...chipProps}
-          data-qa-show-more-chip
-          component="button"
-          clickable
-        />
+        {asLink
+          ?
+            <a
+              aria-label="Expand Tags"
+              className={classes.link}
+              onClick={this.handleClick}
+              data-qa-show-more-link
+            >
+              {items.length}
+            </a>
+          :
+            <Chip
+              className={classNames(
+                {
+                  [classes.chip]: true,
+                  'active': anchorEl,
+                },
+                'chip',
+              )}
+              label={`+${items.length}`}
+              classes={{ label: classes.label }}
+              onClick={this.handleClick}
+              {...chipProps}
+              data-qa-show-more-chip
+              component="button"
+              clickable
+            />
+        }
+
         <Popover
           classes={{ paper: classes.popover }}
           anchorEl={anchorEl}

--- a/src/features/Search/utils.ts
+++ b/src/features/Search/utils.ts
@@ -5,7 +5,8 @@ import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import NodebalIcon from 'src/assets/addnewmenu/nodebalancer.svg';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import { Item } from 'src/components/EnhancedSelect/Select';
-import { displayType, typeLabelLong } from 'src/features/linodes/presentation';
+import { displayType } from 'src/features/linodes/presentation';
+import getLinodeDescription from 'src/utilities/getLinodeDescription';
 
 export interface SearchResults {
   linodes: Item[];
@@ -55,7 +56,7 @@ export const searchLinodes = (
     value: linode.id,
     data: {
       tags: getMatchingTags(linode.tags, query),
-      description: linodeDescription(
+      description: getLinodeDescription(
         displayType(linode.type, typesData),
         linode.specs.memory,
         linode.specs.disk,
@@ -141,21 +142,6 @@ export const searchImages = (images: Linode.Image[], query: string) =>
       created: image.created,
     }
   }));
-
-  export const linodeDescription = (
-    typeLabel: string,
-    memory: number,
-    disk: number,
-    vcpus: number,
-    imageId: string,
-    images: Linode.Image[]
-  ) => {
-    const image = (images && images.find((img:Linode.Image) => img.id === imageId))
-      || { label: 'Unknown Image' };
-    const imageDesc = image.label;
-    const typeDesc = typeLabelLong(typeLabel, memory, disk, vcpus);
-    return `${imageDesc}, ${typeDesc}`;
-  }
 
   export const searchAll = (
     _linodes: Linode.Linode[],

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import Flag from 'src/assets/icons/flag.svg';
 import Tooltip from 'src/components/core/Tooltip';
-import Typography from 'src/components/core/Typography';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
@@ -18,6 +17,7 @@ import styled, { StyleProps } from './LinodeRow.style';
 import LinodeRowBackupCell from './LinodeRowBackupCell';
 import LinodeRowHeadCell from './LinodeRowHeadCell';
 import LinodeRowLoading from './LinodeRowLoading';
+import LinodeRowTagCell from './LinodeRowTagCell';
 
 interface Props {
   linodeBackups: Linode.LinodeBackups;
@@ -58,7 +58,7 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
     mutationAvailable,
     openConfigDrawer,
     toggleConfirmation,
-    displayType,
+    // displayType, @todo use for M3-2059
     recentEvent,
   } = props;
   const loading = linodeInTransition(linodeStatus, recentEvent);
@@ -86,9 +86,7 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
         arial-label={linodeLabel}
       >
         {!loading && headCell}
-        <TableCell parentColumn="Plan" className={classes.planCell}>
-          <Typography variant="body1">{displayType}</Typography>
-        </TableCell>
+        <LinodeRowTagCell tags={linodeTags} />
         <LinodeRowBackupCell linodeId={linodeId} mostRecentBackup={mostRecentBackup} />
         <TableCell parentColumn="IP Addresses" className={classes.ipCell} data-qa-ips>
           <div className={classes.ipCellWrapper}>

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
@@ -11,7 +11,7 @@ import Tooltip from 'src/components/core/Tooltip';
 type ClassNames =
   | 'root'
   | 'tagLink'
-  | 'wrapper'
+  | 'wrapper';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
@@ -16,8 +16,9 @@ type ClassNames =
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {
     width: '15%',
-    height: '100%',
+    height: '20px !important',
     paddingTop: '0 !important',
+    paddingBottom: '0 !important',
     [theme.breakpoints.down('sm')]: {
       width: '100%'
     },
@@ -26,9 +27,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     color: `${theme.color.blueDTwhite} !important`,
   },
   wrapper: {
-    width: '100% !important',
-    height: '100% !important',
-  }
+    width: '50% !important',
+    height: '20px !important',
+  },
 });
 
 interface Props {
@@ -62,9 +63,7 @@ const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
             </div>
           </Tooltip>
         : <Typography>0</Typography>
-
       }
-
     </TableCell>
   )
 };

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
@@ -57,6 +57,7 @@ const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
             onOpen={open}
             onClose={close}
             open={isOpen}
+            interactive={true}
           >
             <div className={classes.wrapper}>
               <a className={classes.tagLink}>{tags.length}</a>

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
@@ -1,37 +1,33 @@
 import * as React from 'react';
+import { compose, withStateHandlers } from 'recompose';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import ShowMore from 'src/components/ShowMore';
 import TableCell from 'src/components/TableCell';
-import Tag from 'src/components/Tag';
+
+import LinodeRowTags from './LinodeRowTags';
+
+import Tooltip from 'src/components/core/Tooltip';
 
 type ClassNames =
-  'icon'
-  | 'noBackupText'
   | 'root'
+  | 'tagLink'
   | 'wrapper'
-  | 'backupLink';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
-  icon: {
-    fontSize: 18,
-    fill: theme.color.grey1,
-  },
-  noBackupText: {
-    marginRight: '8px',
-  },
   root: {
     width: '15%',
+    height: '100%',
+    paddingTop: '0 !important',
     [theme.breakpoints.down('sm')]: {
       width: '100%'
     },
   },
-  wrapper: {
-    display: 'flex',
-    alignContent: 'center',
+  tagLink: {
+    color: `${theme.color.blueDTwhite} !important`,
   },
-  backupLink: {
-    display: 'flex'
+  wrapper: {
+    width: '100% !important',
+    height: '100% !important',
   }
 });
 
@@ -39,24 +35,32 @@ interface Props {
   tags: string[];
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+interface HandlerProps {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
 
-const renderTags = (tags: string[]) =>
-  tags.map((tag, idx) => <Tag key={`linode-row-tag-item-${idx}`} colorVariant='lightBlue' label={tag} />)
+type CombinedProps = Props & HandlerProps & WithStyles<ClassNames>;
 
 const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, tags } = props;
+  const { classes, close, isOpen, open, tags } = props;
 
   return (
     <TableCell parentColumn="Tags" className={classes.root}>
       {tags.length > 0
-        ? <ShowMore
-            items={tags}
-            render={renderTags}
-            asLink
+        ? <Tooltip
+            title={<LinodeRowTags tags={tags} />}
+            placement="bottom-start"
+            leaveDelay={50}
+            onOpen={open}
+            onClose={close}
+            open={isOpen}
           >
-            <a>{tags.length}</a>
-          </ShowMore>
+            <div className={classes.wrapper}>
+              <a className={classes.tagLink}>{tags.length}</a>
+            </div>
+          </Tooltip>
         : <Typography>0</Typography>
 
       }
@@ -67,4 +71,15 @@ const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
 
 const styled = withStyles(styles);
 
-export default styled(LinodeRowTagCell);
+const handlers = withStateHandlers({ isOpen: false },
+  {
+    open: () => () => ({ isOpen: true }),
+    close: () => () => ({ isOpen: false })
+  });
+
+const enhanced = compose<CombinedProps, Props>(
+  styled,
+  handlers,
+)(LinodeRowTagCell);
+
+export default enhanced;

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { compose, withStateHandlers } from 'recompose';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import TableCell from 'src/components/TableCell';
@@ -36,16 +35,10 @@ interface Props {
   tags: string[];
 }
 
-interface HandlerProps {
-  isOpen: boolean;
-  open: () => void;
-  close: () => void;
-}
-
-type CombinedProps = Props & HandlerProps & WithStyles<ClassNames>;
+type CombinedProps = Props & WithStyles<ClassNames>;
 
 const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, close, isOpen, open, tags } = props;
+  const { classes, tags } = props;
 
   return (
     <TableCell parentColumn="Tags" className={classes.root}>
@@ -54,9 +47,6 @@ const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
             title={<LinodeRowTags tags={tags} />}
             placement="bottom-start"
             leaveDelay={50}
-            onOpen={open}
-            onClose={close}
-            open={isOpen}
             interactive={true}
           >
             <div className={classes.wrapper}>
@@ -71,15 +61,4 @@ const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
 
 const styled = withStyles(styles);
 
-const handlers = withStateHandlers({ isOpen: false },
-  {
-    open: () => () => ({ isOpen: true }),
-    close: () => () => ({ isOpen: false })
-  });
-
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  handlers,
-)(LinodeRowTagCell);
-
-export default enhanced;
+export default styled(LinodeRowTagCell);

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import ShowMore from 'src/components/ShowMore';
+import TableCell from 'src/components/TableCell';
+import Tag from 'src/components/Tag';
+
+type ClassNames =
+  'icon'
+  | 'noBackupText'
+  | 'root'
+  | 'wrapper'
+  | 'backupLink';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  icon: {
+    fontSize: 18,
+    fill: theme.color.grey1,
+  },
+  noBackupText: {
+    marginRight: '8px',
+  },
+  root: {
+    width: '15%',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%'
+    },
+  },
+  wrapper: {
+    display: 'flex',
+    alignContent: 'center',
+  },
+  backupLink: {
+    display: 'flex'
+  }
+});
+
+interface Props {
+  tags: string[];
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const renderTags = (tags: string[]) =>
+  tags.map((tag, idx) => <Tag key={`linode-row-tag-item-${idx}`} colorVariant='lightBlue' label={tag} />)
+
+const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
+  const { classes, tags } = props;
+
+  return (
+    <TableCell parentColumn="Tags" className={classes.root}>
+      {tags.length > 0
+        ? <ShowMore
+            items={tags}
+            render={renderTags}
+            asLink
+          >
+            <a>{tags.length}</a>
+          </ShowMore>
+        : <Typography>0</Typography>
+
+      }
+
+    </TableCell>
+  )
+};
+
+const styled = withStyles(styles);
+
+export default styled(LinodeRowTagCell);

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTags.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTags.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
+
+import Paper from 'src/components/core/Paper';
+import Tag from 'src/components/Tag';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {},
+});
+
+interface Props {
+  tags: string[];
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const LinodeRowTags: React.StatelessComponent<CombinedProps> = (props) => {
+  const { tags } = props;
+  return (
+    <Paper>
+      {tags.map((tag, idx) =>
+        <Tag
+          key={`linode-row-tag-item-${idx}`}
+          colorVariant='lightBlue'
+          label={tag}
+        />
+      )}
+    </Paper>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(LinodeRowTags);

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTags.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTags.tsx
@@ -7,7 +7,9 @@ import Tag from 'src/components/Tag';
 type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
-  root: {},
+  root: {
+    backgroundColor: 'transparent',
+  },
 });
 
 interface Props {
@@ -17,9 +19,9 @@ interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const LinodeRowTags: React.StatelessComponent<CombinedProps> = (props) => {
-  const { tags } = props;
+  const { tags, classes } = props;
   return (
-    <Paper>
+    <Paper className={classes.root}>
       {tags.map((tag, idx) =>
         <Tag
           key={`linode-row-tag-item-${idx}`}

--- a/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -21,7 +21,14 @@ const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = 
         >
           Linode
         </TableSortCell>
-        <TableCell>Tags</TableCell>
+        <TableSortCell
+          label='tags'
+          direction={order}
+          active={isActive('tags')}
+          handleClick={handleOrderChange}
+        >
+          Tags
+        </TableSortCell>
         <TableCell noWrap>Last Backup</TableCell>
         <TableCell>IP Addresses</TableCell>
         <TableSortCell

--- a/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -21,7 +21,7 @@ const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = 
         >
           Linode
         </TableSortCell>
-        <TableCell>Plan</TableCell>
+        <TableCell>Tags</TableCell>
         <TableCell noWrap>Last Backup</TableCell>
         <TableCell>IP Addresses</TableCell>
         <TableSortCell

--- a/src/utilities/getLinodeDescription.ts
+++ b/src/utilities/getLinodeDescription.ts
@@ -1,0 +1,18 @@
+import { typeLabelLong } from 'src/features/linodes/presentation';
+
+export const linodeDescription = (
+  typeLabel: string,
+  memory: number,
+  disk: number,
+  vcpus: number,
+  imageId: string,
+  images: Linode.Image[]
+) => {
+  const image = (images && images.find((img:Linode.Image) => img.id === imageId))
+    || { label: 'Unknown Image' };
+  const imageDesc = image.label;
+  const typeDesc = typeLabelLong(typeLabel, memory, disk, vcpus);
+  return `${imageDesc}, ${typeDesc}`;
+}
+
+export default linodeDescription;


### PR DESCRIPTION
## Description

Replace "Plan" column in Linode Row with a "Tags" column. Tags are still displayed in the header cell, this will be addressed by M3-2059.

## Note to Reviewers

- Added `asLink` prop to the ShowMore component to handle this use case
- Changed sorting logic in OrderBy.tsx to allow sorting by length of array

