### PR TITLE
bug: M3-2098 explicitly check for errors before setting local storage

### DIFF
--- a/src/store/reducers/tagImportDrawer.ts
+++ b/src/store/reducers/tagImportDrawer.ts
@@ -193,6 +193,7 @@ const handleAccumulatedResponsesAndErrors = (
     else {
       dispatch(handleSuccess());
     }
+    return totalErrors;
     // @todo do we need to update entities in store here? Seems to be currently handled with post-request events
     // in services
 }
@@ -207,7 +208,11 @@ export const addTagsToEntities: ImportGroupsAsTagsThunk = () => (dispatch: Dispa
     dispatch,
     handleAccumulatedResponsesAndErrors,
   )
-    .then(() => storage.hasImportedGroups.set())
+    .then((totalErrors: TagError[]) => {
+      if (isEmpty(totalErrors)) {
+        storage.hasImportedGroups.set()
+      }
+    })
     .catch(() => dispatch(
       // Errors from individual requests will be accumulated and passed to .then(); hitting
       // this block indicates something went wrong with .reduce() or .join().


### PR DESCRIPTION
## Description

Fixes a bug where Local Storage was still set if there were errors during group import.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

1) Have Linodes with groups to import. 
2) Click the "Import Display Groups" CTA button.
3) Enable request blocking.
4) Click "Import Display Groups Now"
5) Check Local Storage. 
6) **Observe:** You will NOT see the `hasImportedGroups` key.
