### PR TITLE
M3-2106 change: error handling

### DIFF
--- a/src/features/Account/GlobalSettings.tsx
+++ b/src/features/Account/GlobalSettings.tsx
@@ -11,6 +11,7 @@ import { handleOpen } from 'src/store/reducers/backupDrawer';
 import { updateAccountSettings } from 'src/store/reducers/resources/accountSettings';
 import { openGroupDrawer } from 'src/store/reducers/tagImportDrawer';
 import getEntitiesWithGroupsToImport, { emptyGroupedEntities, GroupedEntitiesForImport } from 'src/store/selectors/getEntitiesWithGroupsToImport';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import shouldDisplayGroupImport from 'src/utilities/shouldDisplayGroupImportCTA';
 import { storage } from 'src/utilities/storage';
 import AutoBackups from './AutoBackups';
@@ -59,10 +60,9 @@ class GlobalSettings extends React.Component<CombinedProps, {}> {
     if (!errors) {
       return;
     }
-    const errorText = pathOr(
-      "There was an error updating your account settings.",
-      ['response', 'data', 'errors', 0, 'reason'],
-      errors
+    const errorText = getErrorStringOrDefault(
+      errors,
+      "There was an error updating your account settings."
     );
 
     return this.props.enqueueSnackbar(errorText, {

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -1,5 +1,5 @@
 import * as classNames from 'classnames';
-import { compose, pathOr } from 'ramda';
+import { compose } from 'ramda';
 import * as React from 'react';
 import scriptLoader from 'react-async-script-loader';
 import * as ReactDOM from 'react-dom';
@@ -19,7 +19,9 @@ import Radio from 'src/components/Radio';
 import TextField from 'src/components/TextField';
 import { withAccount } from 'src/features/Billing/context';
 import { executePaypalPayment, makePayment, stagePaypalPayment } from 'src/services/account';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+
 
 type ClassNames = 'root'
   | 'positive'
@@ -185,11 +187,10 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
           success: true,
         })
       })
-      .catch((error) => {
+      .catch((errorResponse) => {
         this.setState({
           submitting: false,
-          errors: pathOr([{ reason: 'Unable to make a payment at this time.' }],
-            ['response', 'data', 'errors'], error),
+          errors: getAPIErrorOrDefault(errorResponse, 'Unable to make a payment at this time.')
         })
       })
   };
@@ -228,13 +229,12 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
           successMessage: ''
         })
       })
-      .catch((error) => {
+      .catch((errorResponse) => {
         this.setState({
           isExecutingPaypalPayment: false,
           dialogOpen: false,
           usd: '',
-          errors: pathOr([{ reason: 'Unable to make a payment at this time.' }],
-            ['response', 'data', 'errors'], error),
+          errors: getAPIErrorOrDefault(errorResponse, 'Unable to make a payment at this time.')
         })
       });
   }
@@ -290,11 +290,10 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
         })
         return response.payment_id;
       })
-      .catch((error) => {
+      .catch((errorResponse) => {
         this.setState({
           submitting: false,
-          errors: pathOr([{ reason: 'Unable to make a payment at this time.' }],
-            ['response', 'data', 'errors'], error),
+          errors: getAPIErrorOrDefault(errorResponse, 'Unable to make a payment at this time.')
         });
         return;
       })
@@ -533,7 +532,7 @@ export const isAllowedUSDAmount = (usd: number) => {
 }
 
 export const shouldEnablePaypalButton = (value: number | undefined) => {
-  /** 
+  /**
    * paypal button should be disabled if there is either
    * no value entered or it's below $5 or over $500 as per APIv4 requirements
    */

--- a/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -1,5 +1,5 @@
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
-import { compose, pathOr } from 'ramda';
+import { compose } from 'ramda';
 import * as React from 'react';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import Paper from 'src/components/core/Paper';
@@ -17,6 +17,7 @@ import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 import { getInvoice, getInvoiceItems } from 'src/services/account';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 type ClassNames = 'root' | 'backButton' | 'titleWrapper';
 
@@ -67,9 +68,9 @@ class InvoiceDetail extends React.Component<CombinedProps, State> {
         items,
       })
     })
-      .catch((error) => {
+      .catch((errorResponse) => {
         this.setState({
-          errors: pathOr([{ reason: 'Unable to retrieve invoice details. ' }], ['response', 'data', 'errors'], error),
+          errors: getAPIErrorOrDefault(errorResponse, 'Unable to retrieve invoice details. '),
         })
       });
   };

--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -23,6 +23,7 @@ import {
   CREATING,
   resetDrawer
 } from 'src/store/reducers/domainDrawer';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
@@ -256,7 +257,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
         if (!this.mounted) { return; }
         this.setState({
           submitting: false,
-          errors: pathOr([], ['response', 'data', 'errors'], err),
+          errors: getAPIErrorOrDefault(err),
         }, () => {
           scrollErrorIntoView();
         });
@@ -286,7 +287,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
         if (!this.mounted) { return; }
         this.setState({
           submitting: false,
-          errors: pathOr([], ['response', 'data', 'errors'], err),
+          errors: getAPIErrorOrDefault(err),
         }, () => {
           scrollErrorIntoView();
         });

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -1,4 +1,4 @@
-import { compose, equals, pathOr } from 'ramda';
+import { compose, equals } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -13,6 +13,7 @@ import DiskSelect from 'src/features/linodes/DiskSelect';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
 import { createImage, updateImage } from 'src/services/images';
 import { getLinodeDisks, getLinodes } from 'src/services/linodes';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 
 type ClassNames = 'root'
@@ -153,9 +154,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
             if(!this.mounted){ return; }
 
             this.setState({
-              errors: pathOr([
-                { reason: 'Unable to edit image' }],
-                ['response', 'data', 'errors'], errorResponse),
+              errors: getAPIErrorOrDefault(errorResponse, 'Unable to edit image')
             });
           });
         return;
@@ -177,11 +176,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
             if(!this.mounted){ return; }
 
             this.setState({
-              errors: pathOr(
-                'There was an error creating the image.',
-                ['response', 'data', 'errors'],
-                errorResponse
-              ),
+              errors: getAPIErrorOrDefault(errorResponse, 'There was an error creating the image.')
             });
           })
         return;

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -1,5 +1,4 @@
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -29,6 +28,7 @@ import TableCell from 'src/components/TableCell';
 import { Images } from 'src/documentation';
 import { events$ } from 'src/events';
 import { deleteImage, getImages } from 'src/services/images';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import ImageRow from './ImageRow';
 import ImagesDrawer from './ImagesDrawer';
 
@@ -217,8 +217,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
         });
       })
       .catch((err) => {
-        const errors: Linode.ApiFieldError[] = pathOr([], ['response', 'data', 'errors'], err);
-        const error: string = errors.length > 0 ? errors[0].reason : "There was an error deleting the image."
+        const error = getErrorStringOrDefault(err, "There was an error deleting the image.");
         this.setState({ removeDialog: { ...removeDialog, error } });
       })
   }

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -32,6 +32,7 @@ import TextField from 'src/components/TextField';
 import { events$, resetEventsPolling } from 'src/events';
 import { linodeInTransition as isLinodeInTransition } from 'src/features/linodes/transitions';
 import { cancelBackups, enableBackups, getLinodeBackups, getType, takeSnapshot } from 'src/services/linodes';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { withLinode } from '../context';
@@ -245,7 +246,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
         resetEventsPolling();
       })
       .catch((errorResponse) => {
-        pathOr([], ['response', 'data', 'errors'], errorResponse)
+        getAPIErrorOrDefault(errorResponse)
           .forEach((err: Linode.ApiFieldError) => enqueueSnackbar(err.reason, {
             variant: 'error'
           }));
@@ -266,11 +267,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
         resetEventsPolling();
       })
       .catch((errorResponse) => {
-        pathOr(
-          [{ reason: 'There was an error disabling backups' }],
-          ['response', 'data', 'errors'],
-          errorResponse
-        )
+        getAPIErrorOrDefault(errorResponse, 'There was an error disabling backups')
           /**  @todo move this error to the actual modal */
           .forEach((err: Linode.ApiFieldError) => enqueueSnackbar(err.reason, {
             variant: 'error'
@@ -292,10 +289,9 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
         resetEventsPolling();
       })
       .catch((errorResponse) => {
-        pathOr(
-          [{ reason: 'There was an error taking a snapshot' }],
-          ['response', 'data', 'errors'],
-          errorResponse
+        getAPIErrorOrDefault(
+          errorResponse,
+          'There was an error taking a snapshot',
         )
           .forEach((err: Linode.ApiFieldError) => enqueueSnackbar(err.reason, {
             variant: 'error'
@@ -317,7 +313,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
         this.setState({
           settingsForm: {
             ...settingsForm,
-            errors: path(['response', 'data', 'errors'], err),
+            errors: getAPIErrorOrDefault(err),
           },
         }, () => {
           scrollErrorIntoView();

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -9,7 +9,7 @@ import { pathOr } from 'ramda';
        ? [{ 'reason': defaultError, field }]
        : [{ 'reason': defaultError }]
 
-      return errorResponse.length === 0 ? _defaultError : errorResponse
+      return pathOr(_defaultError, ['response', 'data', 'errors'], errorResponse);
    }
 
   export const getErrorStringOrDefault = (

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -1,7 +1,8 @@
+import { AxiosError } from 'axios';
 import { pathOr } from 'ramda';
 
   export const getAPIErrorOrDefault = (
-     errorResponse: Linode.ApiFieldError[],
+     errorResponse: Linode.ApiFieldError[] | AxiosError,
      defaultError: string = "An unexpected error occurred.",
      field?: string,
    ): Linode.ApiFieldError[] => {

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -1,0 +1,20 @@
+import { pathOr } from 'ramda';
+
+  export const getAPIErrorOrDefault = (
+     errorResponse: Linode.ApiFieldError[],
+     defaultError: string = "An unexpected error occurred.",
+     field?: string,
+   ): Linode.ApiFieldError[] => {
+     const _defaultError = field
+       ? [{ 'reason': defaultError, field }]
+       : [{ 'reason': defaultError }]
+
+      return errorResponse.length === 0 ? _defaultError : errorResponse
+   }
+
+  export const getErrorStringOrDefault = (
+     errors: Linode.ApiFieldError[],
+     defaultError: string = "An unexpected error occurred."
+   ): string => {
+   return pathOr<string>(defaultError, [0, 'reason'], errors);
+ }


### PR DESCRIPTION
## Description

Rebuilding my previous error-handling POC, this time in more manageable chunks.

This should not change the app's behavior in any way (except that errors are being set in ImagesDrawer correctly).

There are two basic API error handling patterns used in .catch blocks in the app:
1. `Linode.APIFieldError[]`: Use pathOr to get the API error response from the Axios response, or a default error if that doesn't exist.
2. `string`: Use pathOr or some other method to get the reason for the first error in the array, or a default. This pattern is not ideal, but it's widespread.

This abstracts these patterns to two functions in `src/utilities/errorUtils`

Why?
1. Fixes a few error bugs (see ImagesDrawer)
2. Consistency
3. Single concern: since Services will be a separate module, it doesn't make sense for individual components to be dealing with Axios responses (as opposed to actual API responses)
4. Easy refactoring: if we ever change our error patterns (Fetch instead of Axios, handling errors in interceptors, whatever), we'd have to change every instance of `pathOr('response', 'data', 'errors'....` throughout the app.
5. Hopefully will save some typing in the long run
