### PR TITLE
change: M3-1998 Display Empty Row for Domain Records types with no records

### DIFF
--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -15,6 +15,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import { deleteDomainRecord } from 'src/services/domains';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import ActionMenu from './DomainRecordActionMenu';
@@ -581,7 +582,9 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                     </TableHead>
                     <TableBody>
                       {
-                        type.data.map((data, idx) => {
+                        type.data.length === 0
+                        ? <TableRowEmptyState colSpan={type.columns.length}/>
+                        : type.data.map((data, idx) => {
                           return (
                             <TableRow key={idx} data-qa-record-row={type.title}>
                               {type.columns.length > 0


### PR DESCRIPTION
## Description

Adds an empty state row if the domain record type has no domain records to display

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

To test:

1. Have a domain record type with no record
2. See "no items to display."
3. 🙏 