### PR TITLE
M3-2109 M3-2110 Move Images into Redux

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -31,11 +31,11 @@ it('renders without crashing', () => {
             userId={123456}
             profileLoading={false}
             actions={{
-              getAccountSettings: jest.fn(),
-              getProfile: jest.fn(),
-              getNotifications: jest.fn(),
               requestDomains: jest.fn(),
               requestLinodes: jest.fn(),
+              requestNotifications: jest.fn(),
+              requestProfile: jest.fn(),
+              requestSettings: jest.fn(),
               requestTypes: jest.fn(),
             }}
             documentation={[]}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -32,6 +32,7 @@ it('renders without crashing', () => {
             profileLoading={false}
             actions={{
               requestDomains: jest.fn(),
+              requestImages: jest.fn(),
               requestLinodes: jest.fn(),
               requestNotifications: jest.fn(),
               requestProfile: jest.fn(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { getRegions } from 'src/services/misc';
 import { requestNotifications } from 'src/store/reducers/notifications';
 import { requestAccountSettings } from 'src/store/reducers/resources/accountSettings';
 import { async as domainsAsync } from 'src/store/reducers/resources/domains';
+import { async as imagesAsync } from 'src/store/reducers/resources/images';
 import { async as linodesAsync } from 'src/store/reducers/resources/linodes';
 import { requestProfile } from 'src/store/reducers/resources/profile';
 import { async as typesAsync } from 'src/store/reducers/resources/types';
@@ -220,6 +221,7 @@ export class App extends React.Component<CombinedProps, State> {
     const { actions } = this.props;
 
     actions.requestDomains();
+    actions.requestImages();
     actions.requestLinodes();
     actions.requestNotifications();
     actions.requestProfile();
@@ -372,6 +374,7 @@ const themeDataAttr = () => {
 interface DispatchProps {
   actions: {
     requestDomains: () => void;
+    requestImages: () => void;
     requestLinodes: () => void;
     requestNotifications: () => void;
     requestProfile: () => void;
@@ -384,6 +387,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (dispatch, 
   return {
     actions: {
       requestDomains: () => dispatch(domainsAsync.requestDomains()),
+      requestImages: () => dispatch(imagesAsync.requestImages()),
       requestLinodes: () => dispatch(linodesAsync.requestLinodes()),
       requestNotifications: () => dispatch(requestNotifications()),
       requestProfile: () => dispatch(requestProfile()),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,11 +217,14 @@ export class App extends React.Component<CombinedProps, State> {
   }
 
   componentDidMount() {
-    const { getAccountSettings, getNotifications, getProfile, requestDomains, requestLinodes, requestTypes } = this.props.actions;
+    const { actions } = this.props;
 
-    requestDomains();
-    requestLinodes();
-    requestTypes();
+    actions.requestDomains();
+    actions.requestLinodes();
+    actions.requestNotifications();
+    actions.requestProfile();
+    actions.requestSettings();
+    actions.requestTypes();
 
     /*
      * We want to listen for migration events side-wide
@@ -254,10 +257,6 @@ export class App extends React.Component<CombinedProps, State> {
     if (notifications.welcome.get() === 'open') {
       this.setState({ welcomeBanner: true });
     }
-
-    getProfile();
-    getNotifications();
-    getAccountSettings();
 
     this.state.regionsContext.request();
   }
@@ -372,11 +371,11 @@ const themeDataAttr = () => {
 
 interface DispatchProps {
   actions: {
-    getProfile: () => void;
-    getNotifications: () => void;
-    getAccountSettings: () => void;
     requestDomains: () => void;
     requestLinodes: () => void;
+    requestNotifications: () => void;
+    requestProfile: () => void;
+    requestSettings: () => void;
     requestTypes: () => void;
   },
 }
@@ -384,11 +383,11 @@ interface DispatchProps {
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (dispatch, ownProps) => {
   return {
     actions: {
-      getProfile: () => dispatch(requestProfile()),
-      getNotifications: () => dispatch(requestNotifications()),
-      getAccountSettings: () => dispatch(requestAccountSettings()),
       requestDomains: () => dispatch(domainsAsync.requestDomains()),
       requestLinodes: () => dispatch(linodesAsync.requestLinodes()),
+      requestNotifications: () => dispatch(requestNotifications()),
+      requestProfile: () => dispatch(requestProfile()),
+      requestSettings: () => dispatch(requestAccountSettings()),
       requestTypes: () => dispatch(typesAsync.requestTypes()),
     }
   };

--- a/src/store/ApplicationState.d.ts
+++ b/src/store/ApplicationState.d.ts
@@ -13,6 +13,13 @@ declare interface ApplicationState {
       lastUpdated: number;
       error?: Linode.ApiFieldError[];
     },
+    images: {
+      results: string[];
+      entities: Linode.Image[];
+      loading: boolean;
+      lastUpdated: number;
+      error?: Linode.ApiFieldError[];
+    },
     linodes: {
       results: number[];
       entities: Linode.Linode[];

--- a/src/store/reducers/resources/images.ts
+++ b/src/store/reducers/resources/images.ts
@@ -1,0 +1,97 @@
+import { Reducer } from "redux";
+import { ThunkAction } from "redux-thunk";
+import { getImages } from "src/services/images";
+import { getAll } from "src/utilities/getAll";
+import actionCreatorFactory, { isType } from 'typescript-fsa';
+
+
+
+/**
+ * State
+ */
+type State = ApplicationState['__resources']['images'];
+
+export const defaultState: State = {
+  entities: [],
+  results: [],
+  error: undefined,
+  loading: true,
+  lastUpdated: 0,
+};
+
+
+
+/**
+ * Actions
+ */
+const actionCreator = actionCreatorFactory(`@@manager/images`);
+
+const getImagesRequest = actionCreator(`request`)
+
+const getImagesSuccess = actionCreator<Linode.Image[]>(`success`)
+
+const getImagesFailure = actionCreator<Linode.ApiFieldError[]>(`fail`)
+
+export const actions = {};
+
+
+
+/**
+ * Reducer
+ */
+const reducer: Reducer<State> = (state = defaultState, action) => {
+
+  if (isType(action, getImagesRequest)) {
+    return {
+      ...state,
+      loading: true,
+    };
+  }
+
+  if (isType(action, getImagesSuccess)) {
+    const { payload } = action;
+
+    return {
+      ...state,
+      loading: false,
+      lastUpdated: Date.now(),
+      entities: payload,
+      results: payload.map(t => t.id)
+    };
+  }
+
+  if (isType(action, getImagesFailure)) {
+    const { payload } = action;
+
+    return {
+      ...state,
+      loading: false,
+      error: payload,
+    };
+  }
+
+  return state;
+};
+
+
+
+/**
+ * Async
+ */
+const requestImages = (): ThunkAction<Promise<Linode.Image[]>, State, undefined> => (dispatch) => {
+  const getAllImages = getAll<Linode.Image>(getImages);
+
+  return getAllImages()
+    .then(({ data }) => {
+      dispatch(getImagesSuccess(data))
+      return data;
+    })
+    .catch((err) => {
+      dispatch(getImagesFailure(err))
+      return err;
+    })
+};
+
+export const async = { requestImages };
+
+export default reducer;

--- a/src/store/reducers/resources/index.ts
+++ b/src/store/reducers/resources/index.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from "redux";
 import accountSettings, { DEFAULT_STATE as defaultAccountSettingsState } from './accountSettings';
 import domains, { defaultState as defaultDomainsState } from './domains';
+import images, { defaultState as defaultImagesState } from './images';
 import linodes, { defaultState as defaultLinodesState } from './linodes';
 import profile, { DEFAULT_STATE as defaultProfileState } from './profile';
 import types, { defaultState as defaultTypesState } from './types';
@@ -12,6 +13,7 @@ export const defaultState = {
   domains: defaultDomainsState,
   linodes: defaultLinodesState,
   types: defaultTypesState,
+  images: defaultImagesState,
 }
 
-export default combineReducers({ accountSettings, profile, domains, linodes, types });
+export default combineReducers({ accountSettings, profile, domains, linodes, types, images });


### PR DESCRIPTION
## Description
The start of M3-2109. Adding the basics of the reducer and state. Additionally requests images on app initialization.

## Note to Reviewers
- Load application.
- Verify a `getAll` request was sent for images.
- Verify Redux store now contains images at `state.__resources.images`.
