### PR TITLE
M3-2118 M3-2117 Source images information from Redux for LinodesDetail, LinodeSummary, and SummaryPanel

### DIFF
--- a/src/containers/withImage.container.ts
+++ b/src/containers/withImage.container.ts
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+
+export default <TInner extends {}, TOutter extends {}>(
+  propsSelector: (ownProps: TOutter) => null | string,
+  mapImageToProps: (ownProps: TOutter, image?: Linode.Image) => TInner,
+) => connect((state: ApplicationState, ownProps: TOutter) => {
+  const imageId = propsSelector(ownProps);
+
+  if (!imageId) {
+    return { image: null };
+  }
+
+  const image = state.__resources.images.entities.find((i) => i.id === imageId);
+
+  return mapImageToProps(ownProps, image);
+});

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -11,7 +11,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
 import Select from 'src/components/Select';
-import { withImage, withLinode } from 'src/features/linodes/LinodesDetail/context';
+import { withLinode } from 'src/features/linodes/LinodesDetail/context';
 import { displayType, typeLabelLong } from 'src/features/linodes/presentation';
 import { getLinodeStats, getLinodeStatsByDate } from 'src/services/linodes';
 import { setUpCharts } from 'src/utilities/charts';
@@ -82,7 +82,6 @@ interface LinodeContextProps {
   linodeCreated: string;
   linodeId: number;
   linodeData: Linode.Linode;
-  imageData: Linode.Image;
   volumesData: Linode.Volume[];
 }
 
@@ -552,7 +551,6 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
   render() {
     const {
       linodeData: linode,
-      imageData: image,
       volumesData: volumes,
       classes,
       typesData,
@@ -581,7 +579,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment={`${linode.label} - Summary`} />
-        <SummaryPanel linode={linode} image={image} volumes={volumes} typesLongLabel={longLabel} />
+        <SummaryPanel linode={linode} volumes={volumes} typesLongLabel={longLabel} linodeImageId={linode.image} />
 
         <React.Fragment>
           <div className={classes.graphControls}>
@@ -637,14 +635,9 @@ const styled = withStyles(styles);
 const linodeContext = withLinode((context) => ({
   linodeCreated: context.data!.created,
   linodeId: context.data!.id,
-
-  linodeData: context.data, /** @todo get rid of this */
+  /** @todo get rid of this */
+  linodeData: context.data,
 }));
-
-const imageContext = withImage((context) => ({
-  imageData: context.data!,
-}))
-
 
 interface WithTypesProps {
   typesData: Linode.LinodeType[];
@@ -658,18 +651,17 @@ interface StateProps {
   volumesData?: Linode.Volume[]
 }
 
-const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (state, ownProps) => ({
+const withVolumesData: MapStateToProps<StateProps, {}, ApplicationState> = (state, ownProps) => ({
   volumesData: state.features.linodeDetail.volumes.data,
 });
 
-const connected = connect(mapStateToProps);
+const connected = connect(withVolumesData);
 
 const enhanced = compose(
   connected,
   styled,
   withTypes,
   linodeContext,
-  imageContext,
 );
 
 export default enhanced(LinodeSummary);

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -32,7 +32,7 @@ import { _getLinodeVolumes } from 'src/store/reducers/features/linodeDetail/volu
 import haveAnyBeenModified from 'src/utilities/haveAnyBeenModified';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
-import { ConfigsProvider, ImageProvider, LinodeProvider } from './context';
+import { ConfigsProvider, LinodeProvider } from './context';
 import LinodeDetailErrorBoundary from './LinodeDetailErrorBoundary';
 import LinodesDetailHeader from './LinodesDetailHeader';
 import MutateDrawer from './MutateDrawer';
@@ -561,7 +561,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <ConfigsProvider value={this.state.context.configs}>
           <React.Fragment>
-            <ImageProvider value={this.state.context.image}>
+            <>
               <LinodeProvider value={this.state.context.linode}>
                 <React.Fragment>
                   <LinodesDetailHeader
@@ -614,7 +614,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
                   }
                 </React.Fragment>
               </LinodeProvider>
-            </ImageProvider>
+            </>
           </React.Fragment>
         </ConfigsProvider>
       </React.Fragment>

--- a/src/features/linodes/LinodesDetail/context.tsx
+++ b/src/features/linodes/LinodesDetail/context.tsx
@@ -19,7 +19,3 @@ export const withLinode = createHOCForConsumer<Linode.Linode>(linodeContext.Cons
 export const LinodeProvider = linodeContext.Provider;
 export const LinodeConsumer = linodeContext.Consumer;
 
-const imageContext = React.createContext<Requestable<Linode.Image>>({...initialState});
-export const withImage = createHOCForConsumer<Linode.Image>(imageContext.Consumer, 'WithImage');
-export const ImageProvider = imageContext.Provider;
-export const ImageConsumer = imageContext.Consumer;


### PR DESCRIPTION
## Description
- Deleted imagesContext.
- Updated LinodesDetail, LinodeSummary, and SummaryPanel.
- Created a new container. Going to try to pursue this pattern.

## Type of Change
- Non-breaking change.

## Note to Reviewers
- Visit the detail page for any Linode.
- Preferably one with an image, one with a null image, and one with an old image.
- Verify the image text is visible in the summary panel.