### PR TITLE
M3-2115 disk drawer images redux

### DIFF
--- a/src/containers/withImages.container.ts
+++ b/src/containers/withImages.container.ts
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux';
+
+export default <TInner extends {}, TOutter extends {}>(
+  mapImagesToProps: (ownProps: TOutter, images?: Linode.Image[]) => TInner,
+) => connect((state: ApplicationState, ownProps: TOutter) => {
+  const images = state.__resources.images.entities;
+
+  return mapImagesToProps(ownProps, images);
+});

--- a/src/containers/withImages.container.ts
+++ b/src/containers/withImages.container.ts
@@ -1,9 +1,16 @@
 import { connect } from 'react-redux';
 
+const isEmpty = (error?: Linode.ApiFieldError[]) => {
+  return error && error.length > 0;
+}
+
 export default <TInner extends {}, TOutter extends {}>(
-  mapImagesToProps: (ownProps: TOutter, images?: Linode.Image[]) => TInner,
+  mapImagesToProps: (ownProps: TOutter, images: Linode.Image[], imagesLoading: boolean, imageError?: string ) => TInner,
 ) => connect((state: ApplicationState, ownProps: TOutter) => {
   const images = state.__resources.images.entities;
+  const imagesLoading = state.__resources.images.loading;
+  const { error } = state.__resources.images;
+  const imageError = isEmpty(error) ? error![0].reason : undefined; // @todo use updated error handling utils after they're merged
 
-  return mapImagesToProps(ownProps, images);
+  return mapImagesToProps(ownProps, images, imagesLoading, imageError);
 });

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.test.tsx
@@ -25,7 +25,9 @@ const props = {
   onResetImageMode: jest.fn(),
   label: "This drawer",
   filesystem: "ext4",
-  size: 50
+  size: 50,
+  imagesLoading: false,
+  imageError: undefined
 }
 
 const component = shallow(<LinodeDiskDrawer {...props} />)

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
@@ -43,6 +43,8 @@ interface EditableFields {
 
 interface WithImages {
   images?: Linode.Image[];
+  imagesLoading: boolean;
+  imageError?: string;
 }
 
 interface Props extends EditableFields {
@@ -65,7 +67,6 @@ interface State {
   hasErrorFor?: (v: string) => any,
   initialSize: number;
   selectedMode: diskMode;
-  imageError?: string;
 }
 
 type CombinedProps = Props & WithImages & WithStyles<ClassNames>;
@@ -205,6 +206,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
       open,
       mode,
       images,
+      imageError,
       onSubmit,
       submitting,
       onClose,
@@ -212,7 +214,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
       password,
       userSSHKeys,
     } = this.props;
-    const { imageError, selectedMode } = this.state;
+    const { selectedMode } = this.state;
 
     const generalError = this.getErrors('none');
     const passwordError = this.getErrors('root_pass');
@@ -264,7 +266,8 @@ const styled = withStyles(styles);
 
 const enhanced = compose<CombinedProps, Props>(
   styled,
-  withImages((ownProps, images) => ({ ...ownProps, images })),
+  withImages((ownProps, images, imagesLoading, imageError) =>
+    ({ ...ownProps, images, imagesLoading, imageError })),
 )(LinodeDiskDrawer);
 
 export default enhanced;

--- a/src/store/reducers/resources/images.ts
+++ b/src/store/reducers/resources/images.ts
@@ -1,3 +1,4 @@
+import { pathOr } from 'ramda';
 import { Reducer } from "redux";
 import { ThunkAction } from "redux-thunk";
 import { getImages } from "src/services/images";
@@ -87,7 +88,12 @@ const requestImages = (): ThunkAction<Promise<Linode.Image[]>, State, undefined>
       return data;
     })
     .catch((err) => {
-      dispatch(getImagesFailure(err))
+      const ApiError = pathOr(
+        [{ reason: "There was an error retrieving your Images."}],
+        ['response', 'data', 'errors'],
+        err
+      )
+      dispatch(getImagesFailure(ApiError))
       return err;
     })
 };


### PR DESCRIPTION
Added
- withImages container

Changed
- LinodeDiskDrawer now gets its images from Redux rather than by going through the API.