### PR TITLE
M3 2114 update: Add reduxed images to LinodeRebuild

### DIFF
--- a/src/containers/withImages.container.ts
+++ b/src/containers/withImages.container.ts
@@ -4,6 +4,12 @@ const isEmpty = (error?: Linode.ApiFieldError[]) => {
   return error && error.length > 0;
 }
 
+export interface WithImages {
+  images: Linode.Image[];
+  imagesLoading: boolean;
+  imageError?: string;
+}
+
 export default <TInner extends {}, TOutter extends {}>(
   mapImagesToProps: (ownProps: TOutter, images: Linode.Image[], imagesLoading: boolean, imageError?: string ) => TInner,
 ) => connect((state: ApplicationState, ownProps: TOutter) => {

--- a/src/features/Images/ImageSelect.tsx
+++ b/src/features/Images/ImageSelect.tsx
@@ -30,6 +30,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 interface Props {
   images: Linode.Image[];
   imageError?: string;
+  imageFieldError?: string;
   onSelect: (selected: Item<string>) => void;
 }
 
@@ -63,7 +64,7 @@ export class ImageSelect extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { classes, imageError, onSelect } = this.props;
+    const { classes, imageError, imageFieldError, onSelect } = this.props;
     const { renderedImages } = this.state;
     return (
       <React.Fragment>
@@ -72,7 +73,7 @@ export class ImageSelect extends React.Component<CombinedProps, State> {
             <Select
               id={'image-select'}
               isMulti={false}
-              errorText={imageError}
+              errorText={imageError || imageFieldError}
               disabled={Boolean(imageError)}
               onChange={onSelect}
               options={renderedImages as any}

--- a/src/features/Images/ImageSelect.tsx
+++ b/src/features/Images/ImageSelect.tsx
@@ -73,6 +73,7 @@ export class ImageSelect extends React.Component<CombinedProps, State> {
               id={'image-select'}
               isMulti={false}
               errorText={imageError}
+              disabled={Boolean(imageError)}
               onChange={onSelect}
               options={renderedImages as any}
               placeholder="Select an Image"

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -11,9 +11,7 @@ import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { Item } from 'src/components/EnhancedSelect/Select';
-import ErrorState from 'src/components/ErrorState';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
-import withImages, { WithImages } from 'src/containers/withImages.container';
 import { resetEventsPolling } from 'src/events';
 import userSSHKeyHoc from 'src/features/linodes/userSSHKeyHoc';
 import { rebuildLinode } from 'src/services/linodes';
@@ -67,7 +65,6 @@ interface State {
 type CombinedProps =
   & Props
   & ContextProps
-  & WithImages
   & WithStyles<ClassNames>
   & InjectedNotistackProps;
 
@@ -137,20 +134,11 @@ class LinodeRebuild extends React.Component<CombinedProps, State> {
   onPasswordChange = (value: string) => this.setState({ password: value });
 
   render() {
-    const { classes, images, imageError, linodeLabel, userSSHKeys } = this.props;
+    const { classes, linodeLabel, userSSHKeys } = this.props;
     const { errors } = this.state;
 
-    if (imageError) {
-      return (
-        <React.Fragment>
-          <DocumentTitleSegment segment={`${linodeLabel} - Rebuild`} />
-          <ErrorState errorText="There was an error retrieving images information." />
-        </React.Fragment>
-      );
-    }
-
     const getErrorFor = getAPIErrorFor({}, errors);
-    const imageFieldError = getErrorFor('image');
+    // const imageFieldError = getErrorFor('image'); @todo move out of render and use utility functions
     const passwordError = getErrorFor('password');
 
     return (
@@ -172,8 +160,6 @@ class LinodeRebuild extends React.Component<CombinedProps, State> {
             distribution. Rebuilding will destroy all data.
           </Typography>
           <ImageAndPassword
-            images={images}
-            imageError={imageFieldError}
             onImageChange={this.handleImageSelect}
             onPasswordChange={this.onPasswordChange}
             password={this.state.password || ''}
@@ -209,8 +195,6 @@ export default compose<CombinedProps, Props>(
   styled,
   userSSHKeyHoc,
   withSnackbar,
-  withImages((ownProps, images, imagesLoading, imageError) =>
-    ({ ...ownProps, images, imagesLoading, imageError })),
 )(LinodeRebuild);
 
 

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -78,7 +78,7 @@ class LinodeRebuild extends React.Component<CombinedProps, State> {
       this.setState({ selected: undefined });
       return;
     }
-    this.setState({ selected: selectedItem!.value });
+    this.setState({ selected: selectedItem!.value, errors: [] });
   }
 
   onSubmit = () => {
@@ -138,7 +138,7 @@ class LinodeRebuild extends React.Component<CombinedProps, State> {
     const { errors } = this.state;
 
     const getErrorFor = getAPIErrorFor({}, errors);
-    // const imageFieldError = getErrorFor('image'); @todo move out of render and use utility functions
+    const imageFieldError = getErrorFor('image'); // @todo move out of render and use utility functions
     const passwordError = getErrorFor('password');
 
     return (
@@ -160,6 +160,7 @@ class LinodeRebuild extends React.Component<CombinedProps, State> {
             distribution. Rebuilding will destroy all data.
           </Typography>
           <ImageAndPassword
+            imageFieldError={imageFieldError}
             onImageChange={this.handleImageSelect}
             onPasswordChange={this.onPasswordChange}
             password={this.state.password || ''}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.test.tsx
@@ -8,6 +8,8 @@ import { ImageAndPassword } from './ImageAndPassword';
 const props = {
   classes: { root: ''},
   images,
+  imagesLoading: false,
+  imageError: undefined,
   onImageChange: jest.fn(),
   password: '',
   onPasswordChange: jest.fn(),

--- a/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
@@ -4,6 +4,7 @@ import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/
 
 import AccessPanel, { UserSSHKeyObject } from 'src/components/AccessPanel';
 import { Item } from 'src/components/EnhancedSelect/Select';
+import withImages, { WithImages } from 'src/containers/withImages.container';
 import { ImageSelect } from 'src/features/Images';
 
 type ClassNames = 'root';
@@ -14,8 +15,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 
 
 interface Props {
-  images: Linode.Image[];
-  imageError?: string;
   onImageChange: (selected: Item<string>) => void;
 
   password: string;
@@ -25,7 +24,7 @@ interface Props {
   userSSHKeys: UserSSHKeyObject[];
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props & WithImages & WithStyles<ClassNames>;
 
 export const ImageAndPassword: React.StatelessComponent<CombinedProps> = (props) => {
   const {
@@ -42,7 +41,7 @@ export const ImageAndPassword: React.StatelessComponent<CombinedProps> = (props)
     <React.Fragment>
       <ImageSelect
         images={images}
-        imageError={imageError}
+        imageError={imageError} // @todo address image error from Redux vs. API error on form submit
         onSelect={onImageChange}
       />
       <AccessPanel
@@ -60,6 +59,8 @@ const styled = withStyles(styles);
 
 const enhanced = compose<CombinedProps, Props>(
   styled,
+  withImages((ownProps, images, imagesLoading, imageError) =>
+    ({ ...ownProps, images, imagesLoading, imageError })),
 )(ImageAndPassword);
 
 export default enhanced;

--- a/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
@@ -13,9 +13,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
 });
 
-
 interface Props {
   onImageChange: (selected: Item<string>) => void;
+  imageFieldError?: string;
 
   password: string;
   passwordError?: string;
@@ -30,6 +30,7 @@ export const ImageAndPassword: React.StatelessComponent<CombinedProps> = (props)
   const {
     images,
     imageError,
+    imageFieldError,
     onImageChange,
     onPasswordChange,
     password,
@@ -41,7 +42,8 @@ export const ImageAndPassword: React.StatelessComponent<CombinedProps> = (props)
     <React.Fragment>
       <ImageSelect
         images={images}
-        imageError={imageError} // @todo address image error from Redux vs. API error on form submit
+        imageError={imageError}
+        imageFieldError={imageFieldError}
         onSelect={onImageChange}
       />
       <AccessPanel

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.test.tsx
@@ -27,7 +27,8 @@ const props = {
   filesystem: "ext4",
   size: 50,
   imagesLoading: false,
-  imageError: undefined
+  imageError: undefined,
+  images: []
 }
 
 const component = shallow(<LinodeDiskDrawer {...props} />)

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.test.tsx
@@ -26,9 +26,6 @@ const props = {
   label: "This drawer",
   filesystem: "ext4",
   size: 50,
-  imagesLoading: false,
-  imageError: undefined,
-  images: []
 }
 
 const component = shallow(<LinodeDiskDrawer {...props} />)

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
@@ -209,6 +209,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
 
     const generalError = this.getErrors('none');
     const passwordError = this.getErrors('root_pass');
+    const imageFieldError = this.getErrors('image');
 
     return (
       <Drawer title={LinodeDiskDrawer.getTitle(mode)} open={open} onClose={onClose}>
@@ -227,6 +228,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
             {selectedMode === modes.IMAGE &&
               <ImageAndPassword
                 onImageChange={this.onImageChange}
+                imageFieldError={imageFieldError}
                 password={password || ''}
                 passwordError={passwordError}
                 onPasswordChange={this.props.onPasswordChange}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
@@ -14,7 +14,7 @@ import Grid from 'src/components/Grid';
 import ModeSelect, { Mode } from 'src/components/ModeSelect';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import withImages from 'src/containers/withImages.container';
+import withImages, { WithImages } from 'src/containers/withImages.container';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 
 import ImageAndPassword from './ImageAndPassword';
@@ -39,12 +39,6 @@ interface EditableFields {
   password?: string;
   passwordError?: string;
   userSSHKeys?: UserSSHKeyObject[];
-}
-
-interface WithImages {
-  images?: Linode.Image[];
-  imagesLoading: boolean;
-  imageError?: string;
 }
 
 interface Props extends EditableFields {
@@ -235,7 +229,7 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
             {selectedMode === modes.EMPTY && <this.filesystemField /> }
             {selectedMode === modes.IMAGE &&
               <ImageAndPassword
-                images={images || []}
+                images={images}
                 imageError={imageError}
                 onImageChange={this.onImageChange}
                 password={password || ''}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskDrawer.tsx
@@ -14,7 +14,6 @@ import Grid from 'src/components/Grid';
 import ModeSelect, { Mode } from 'src/components/ModeSelect';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import withImages, { WithImages } from 'src/containers/withImages.container';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 
 import ImageAndPassword from './ImageAndPassword';
@@ -63,7 +62,7 @@ interface State {
   selectedMode: diskMode;
 }
 
-type CombinedProps = Props & WithImages & WithStyles<ClassNames>;
+type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const modes = {
   EMPTY: 'create_empty' as diskMode,
@@ -199,8 +198,6 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
     const {
       open,
       mode,
-      images,
-      imageError,
       onSubmit,
       submitting,
       onClose,
@@ -229,8 +226,6 @@ export class LinodeDiskDrawer extends React.Component<CombinedProps, State> {
             {selectedMode === modes.EMPTY && <this.filesystemField /> }
             {selectedMode === modes.IMAGE &&
               <ImageAndPassword
-                images={images}
-                imageError={imageError}
                 onImageChange={this.onImageChange}
                 password={password || ''}
                 passwordError={passwordError}
@@ -260,8 +255,6 @@ const styled = withStyles(styles);
 
 const enhanced = compose<CombinedProps, Props>(
   styled,
-  withImages((ownProps, images, imagesLoading, imageError) =>
-    ({ ...ownProps, images, imagesLoading, imageError })),
 )(LinodeDiskDrawer);
 
 export default enhanced;


### PR DESCRIPTION
## Description

The image select in LinodeRebuild now gets its image data from the Redux cache.

## Note to Reviewers

- Used ImageAndPassword component so that withImages could be used in just one place (to handle rebuilding and disk creation).
- Updated error handling