### PR TITLE
M3-2113 M3-2123 Source images and Linodes from Redux

### DIFF
--- a/src/containers/withLinodes.container.ts
+++ b/src/containers/withLinodes.container.ts
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+
+type MapProps<TOutter, TInner> = (
+  ownProps: TOutter,
+  linodes: Linode.Linode[],
+  loading: boolean,
+  error?: Linode.ApiFieldError[],
+) => TInner;
+
+export default <TInner extends {}, TOutter extends {}>(mapToProps: MapProps<TOutter, TInner>,
+) => connect((state: ApplicationState, ownProps: TOutter) => {
+  const { loading, error, entities } = state.__resources.linodes;
+
+  return mapToProps(ownProps, entities, loading, error);
+});
+

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -326,11 +326,11 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
   render() {
     const { selectedTab } = this.state;
 
-    const { classes, regionsLoading } = this.props;
+    const { classes, regionsLoading, imagesLoading } = this.props;
 
     const tabRender = this.tabs[selectedTab].render;
 
-    if (regionsLoading) { return <CircleProgress />; }
+    if (regionsLoading || imagesLoading) { return <CircleProgress />; }
 
     return (
       <StickyContainer>

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { StickyContainer } from 'react-sticky';
+import { compose as composeComponent } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
 import AppBar from 'src/components/core/AppBar';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
@@ -11,13 +12,12 @@ import Tabs from 'src/components/core/Tabs';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
-import PromiseLoader from 'src/components/PromiseLoader';
 import { ExtendedRegion } from 'src/components/SelectRegionPanel';
 import { dcDisplayNames } from 'src/constants';
+import withImages from 'src/containers/withImages.container';
+import withLinodes from 'src/containers/withLinodes.container';
 import { withRegions } from 'src/context/regions';
 import { displayType, typeLabelDetails } from 'src/features/linodes/presentation';
-import { getImages } from 'src/services/images';
-import { getLinodes } from 'src/services/linodes';
 import { parseQueryParams } from 'src/utilities/queryParams';
 import { ExtendedLinode } from './SelectLinodePanel';
 import { ExtendedType } from './SelectPlanPanel';
@@ -51,16 +51,12 @@ interface RegionsContextProps {
   regionsLoading: boolean;
 }
 
-interface PreloadedProps {
-  images: { response: Linode.Image[] };
-  linodes: { response: Linode.LinodeWithBackups[] };
-}
-
 type CombinedProps =
+  & WithImagesProps
+  & WithLinodesProps
   & WithTypesProps
   & RegionsContextProps
   & WithStyles<ClassNames>
-  & PreloadedProps
   & StateProps
   & RouteComponentProps<{}>;
 
@@ -80,18 +76,6 @@ interface QueryStringOptions {
   stackScriptID: string;
   stackScriptUsername: string;
 }
-
-const preloaded = PromiseLoader<{}>({
-  linodes: () => getLinodes()
-    /*
-     * @todo: We're only allowing the user to select from their first 100
-     * Linodes
-     */
-    .then(response => response.data || []),
-
-  images: () => getImages()
-    .then(response => response.data || []),
-});
 
 const formatLinodeSubheading = (typeInfo: string, imageInfo: string) => {
   const subheading = imageInfo
@@ -157,7 +141,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
   setSelectedRegionByLinodeID(linodeID: number): void {
     const selectedLinode = filter(
       (linode: Linode.LinodeWithBackups) => linode.id === linodeID,
-      this.props.linodes.response
+      this.props.linodesData
     );
     if (selectedLinode.length > 0) {
       this.setState({ selectedRegionIDFromLinode: selectedLinode[0].region });
@@ -178,7 +162,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
   }
 
   extendLinodes = (linodes: Linode.Linode[]): ExtendedLinode[] => {
-    const images = this.props.images.response || [];
+    const images = this.props.imagesData || [];
     const types = this.props.typesData || [];
     return linodes.map(linode =>
       compose<Linode.Linode, Partial<ExtendedLinode>, Partial<ExtendedLinode>>(
@@ -204,7 +188,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
           <FromImageContent
             getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
             regions={this.props.regionsData}
-            images={this.props.images.response}
+            images={this.props.imagesData}
             types={this.props.typesData}
             getTypeInfo={this.getTypeInfo}
             getRegionInfo={this.getRegionInfo}
@@ -230,7 +214,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
             selectedBackupFromQuery={this.state.selectedBackupIDFromQueryString}
             selectedLinodeFromQuery={this.state.selectedLinodeIDFromQueryString}
             selectedRegionIDFromLinode={this.state.selectedRegionIDFromLinode}
-            linodes={this.props.linodes.response}
+            linodes={this.props.linodesData}
             types={this.props.typesData}
             extendLinodes={this.extendLinodes}
             getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
@@ -255,7 +239,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
             getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
             regions={this.props.regionsData}
             types={this.props.typesData}
-            linodes={this.props.linodes.response}
+            linodes={this.props.linodesData}
             extendLinodes={this.extendLinodes}
             getTypeInfo={this.getTypeInfo}
             getRegionInfo={this.getRegionInfo}
@@ -272,7 +256,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
           <FromStackScriptContent
             getBackupsMonthlyPrice={this.getBackupsMonthlyPrice}
             regions={this.props.regionsData}
-            images={this.props.images.response}
+            images={this.props.imagesData}
             types={this.props.typesData}
             getTypeInfo={this.getTypeInfo}
             getRegionInfo={this.getRegionInfo}
@@ -436,8 +420,31 @@ const connected = connect(mapStateToProps);
 
 const styled = withStyles(styles);
 
-export default compose(
-  preloaded,
+interface WithImagesProps {
+  imagesData: Linode.Image[]
+  imagesLoading: boolean;
+  imagesError?: string;
+}
+
+interface WithLinodesProps {
+  linodesData: Linode.Linode[]
+  linodesLoading: boolean;
+  linodesError?: Linode.ApiFieldError[];
+}
+
+export default composeComponent<CombinedProps, {}>(
+  withImages((ownProps, imagesData, imagesLoading, imagesError) => ({
+    ...ownProps,
+    imagesData,
+    imagesLoading,
+    imagesError,
+  })),
+  withLinodes((ownProps, linodesData, linodesLoading, linodesError) => ({
+    ...ownProps,
+    linodesData,
+    linodesLoading,
+    linodesError,
+  })),
   regionsContext,
   withTypes,
   styled,

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -10,7 +10,6 @@ import 'rxjs/add/operator/debounce';
 import 'rxjs/add/operator/filter';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
-
 import CircleProgress from 'src/components/CircleProgress';
 import ErrorState from 'src/components/ErrorState';
 import NotFound from 'src/components/NotFound';
@@ -19,19 +18,11 @@ import { reportException } from 'src/exceptionReporting';
 import LinodeConfigSelectionDrawer from 'src/features/LinodeConfigSelectionDrawer';
 import { newLinodeEvents } from 'src/features/linodes/events';
 import { Requestable } from 'src/requestableContext';
-import { getImage } from 'src/services/images';
-import {
-  getLinode,
-  getLinodeConfigs,
-  getType,
-  startMutation,
-  updateLinode,
-} from 'src/services/linodes';
+import { getLinode, getLinodeConfigs, getType, startMutation, updateLinode } from 'src/services/linodes';
 import { _getLinodeDisks } from 'src/store/reducers/features/linodeDetail/disks';
 import { _getLinodeVolumes } from 'src/store/reducers/features/linodeDetail/volumes';
 import haveAnyBeenModified from 'src/utilities/haveAnyBeenModified';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-
 import { ConfigsProvider, LinodeProvider } from './context';
 import LinodeDetailErrorBoundary from './LinodeDetailErrorBoundary';
 import LinodesDetailHeader from './LinodesDetailHeader';
@@ -63,7 +54,6 @@ interface MutateDrawer {
 interface State {
   context: {
     configs: Requestable<Linode.Config[]>;
-    image: Requestable<Linode.Image>;
     linode: Requestable<Linode.Linode>;
   };
   configDrawer: ConfigDrawerState;
@@ -82,7 +72,6 @@ type CombinedProps = DispatchProps & RouteProps & InjectedNotistackProps;
 
 const labelInputLens = lensPath(['labelInput']);
 const configsLens = lensPath(['context', 'configs']);
-const imageLens = lensPath(['context', 'image']);
 const linodeLens = lensPath(['context', 'linode']);
 
 const L = {
@@ -92,13 +81,6 @@ const L = {
     errors: compose(configsLens, lensPath(['errors'])) as Lens,
     lastUpdated: compose(configsLens, lensPath(['lastUpdated'])) as Lens,
     loading: compose(configsLens, lensPath(['loading'])) as Lens,
-  },
-  image: {
-    data: compose(imageLens, lensPath(['data'])) as Lens,
-    errors: compose(imageLens, lensPath(['errors'])) as Lens,
-    image: imageLens,
-    lastUpdated: compose(imageLens, lensPath(['lastUpdated'])) as Lens,
-    loading: compose(imageLens, lensPath(['loading'])) as Lens,
   },
   labelInput: {
     errorText: compose(labelInputLens, lensPath(['errorText'])) as Lens,
@@ -163,49 +145,6 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
 
           this.composeState(
             set(L.configs.data, updater(configs)),
-          );
-        },
-      },
-      image: {
-        lastUpdated: 0,
-        loading: true,
-        request: (image: string) => {
-
-          if (!image) {
-            const i: Partial<Linode.Image> = { id: 'unknown', label: 'Unknown Image', type: 'Unknown', vendor: 'unknown' };
-            this.composeState(
-              set(L.image.lastUpdated, Date.now()),
-              set(L.image.data, i),
-            );
-
-            return Promise.resolve();
-          }
-
-          this.setState(set(L.image.loading, true));
-
-          return getImage(image)
-            .then((data) => {
-              this.composeState(
-                set(L.image.loading, false),
-                set(L.image.data, data),
-                set(L.image.lastUpdated, Date.now()),
-              );
-              return data;
-            })
-            .catch((r) => {
-              this.composeState(
-                set(L.image.lastUpdated, Date.now()),
-                set(L.image.loading, false),
-                set(L.image.errors, r)
-              );
-            });
-        },
-        update: (updater) => {
-          const { data: image } = this.state.context.image;
-          if (!image) { return }
-
-          this.composeState(
-            set(L.image.data, updater(image)),
           );
         },
       },
@@ -334,7 +273,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
   componentDidMount() {
     this.mounted = true;
 
-    const { context: { configs, image, linode } } = this.state;
+    const { context: { configs, linode } } = this.state;
     const mountTime = moment().subtract(5, 'seconds');
     const { actions, match: { params: { linodeId } } } = this.props;
 
@@ -352,11 +291,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
         configs.request();
         actions.getLinodeDisks();
         actions.getLinodeVolumes();
-        linode.request(linodeEvent)
-          .then((l) => {
-            if (l) { image.request(l.image) }
-          })
-          .catch(console.error);
+        linode.request(linodeEvent);
       });
 
     /** Get events which are related to volumes and this Linode */
@@ -376,11 +311,7 @@ class LinodeDetail extends React.Component<CombinedProps, State> {
 
     configs.request();
     actions.getLinodeVolumes();
-    linode.request()
-      .then((l) => {
-        if (l) { image.request(l.image) }
-      })
-      .catch(console.error);
+    linode.request();
   }
 
   openConfigDrawer = (configs: Linode.Config[], action: (id: number) => void) => {

--- a/src/features/linodes/LinodesLanding/CardView.tsx
+++ b/src/features/linodes/LinodesLanding/CardView.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import Grid from 'src/components/Grid';
 import { PaginationProps } from 'src/components/Paginate';
+import withImages from 'src/containers/withImages.container';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 import { safeGetImageLabel } from 'src/utilities/safeGetImageLabel';
 import LinodeCard from './LinodeCard';
@@ -14,11 +15,12 @@ interface Props {
 }
 
 type CombinedProps =
+  & WithImagesProps
   & PaginationProps
   & Props;
 
 const CardView: React.StatelessComponent<CombinedProps> = (props) => {
-  const { data, images, openConfigDrawer, toggleConfirmation } = props;
+  const { data, imagesData, openConfigDrawer, toggleConfirmation } = props;
 
   return (
     <Grid container>
@@ -34,7 +36,7 @@ const CardView: React.StatelessComponent<CombinedProps> = (props) => {
           linodeLabel={linode.label}
           linodeBackups={linode.backups}
           linodeTags={linode.tags}
-          imageLabel={safeGetImageLabel(images, linode.image)}
+          imageLabel={safeGetImageLabel(imagesData, linode.image)}
           openConfigDrawer={openConfigDrawer}
           linodeSpecDisk={linode.specs.disk}
           linodeSpecMemory={linode.specs.memory}
@@ -47,4 +49,6 @@ const CardView: React.StatelessComponent<CombinedProps> = (props) => {
   )
 };
 
-export default CardView;
+interface WithImagesProps { imagesData: Linode.Image[] }
+
+export default withImages((ownProps, imagesData) => ({ ...ownProps, imagesData }))(CardView);

--- a/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -52,7 +52,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 });
 
 interface Props {
-  images: Linode.Image[];
   openConfigDrawer: (c: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
   toggleConfirmation: (bootOption: Linode.BootAction, linodeId: number, linodeLabel: string) => void;
   display: 'grid' | 'list';

--- a/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -8,7 +8,6 @@ import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSe
 import TableWrapper from './TableWrapper';
 
 interface Props {
-  images: Linode.Image[];
   openConfigDrawer: (c: Linode.Config[], action: LinodeConfigSelectionDrawerCallback) => void;
   toggleConfirmation: (bootOption: Linode.BootAction, linodeId: number, linodeLabel: string) => void;
   display: 'grid' | 'list';

--- a/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
@@ -15,6 +15,8 @@ describe('ListLinodes', () => {
       <LinodeThemeWrapper>
         <StaticRouter location="/" context={{}}>
           <RoutedListLinodes
+            imagesLoading={false}
+            imagesError={undefined}
             linodesData={[]}
             width={'lg'}
             classes={classes}
@@ -40,6 +42,8 @@ describe('ListLinodes', () => {
       <LinodeThemeWrapper>
         <StaticRouter location="/" context={{}}>
           <RoutedListLinodes
+            imagesLoading={false}
+            imagesError={undefined}
             linodesData={[]}
             width={'lg'}
             classes={classes}
@@ -69,6 +73,8 @@ describe('ListLinodes', () => {
       <LinodeThemeWrapper>
         <StaticRouter location="/" context={{}}>
           <RoutedListLinodes
+            imagesLoading={false}
+            imagesError={undefined}
             linodesData={[]}
             width={'lg'}
             classes={classes}


### PR DESCRIPTION
## Description
- Updated LinodesCreate to source images and Linodes from Redux.
- Update LinodesLanding to source images from Redux.
- Complete removal of ImagesContext from LinodesDeatil.

## Type of Change
- Non breaking change

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers
- Create a Linode.
- Verify no additional requests made to `/images`.