### PR TITLE
M3-1569 Change: Default label name during Linode creation

### DIFF
--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.test.tsx
@@ -27,6 +27,9 @@ const mockProps = {
   },
   enqueueSnackbar: jest.fn(),
   onPresentSnackbar: jest.fn(),
+  customLabel: '',
+  updateCustomLabel: jest.fn(),
+  getLabel: jest.fn()
 };
 
 const mockPropsWithNotice = {
@@ -55,6 +58,9 @@ const mockPropsWithNotice = {
   },
   enqueueSnackbar: jest.fn(),
   onPresentSnackbar: jest.fn(),
+  customLabel: '',
+  updateCustomLabel: jest.fn(),
+  getLabel: jest.fn()
 };
 
 describe('FromBackupsContent', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -299,11 +299,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
       ? selectedBackup.label
       : 'auto'; // automatic backups have a label of 'null', so use a custom string for these
 
-    return getLabel(
-      selectedLinode.label,
-      backup,
-      'backup'
-    );
+    return getLabel(selectedLinode.label, backup, 'backup');
   }
 
   render() {
@@ -459,12 +455,11 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
 }
 
 const styled = withStyles(styles);
-const withLabels = WithLabelGenerator({}); // @todo: find better name
 
 const enhanced = compose<CombinedProps, Props>(
   styled,
   withSnackbar,
-  withLabels
+  WithLabelGenerator
 );
 
 export default enhanced(FromBackupsContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -1,8 +1,9 @@
 import * as Promise from 'bluebird';
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { compose, pathOr } from 'ramda';
+import { compose as ramdaCompose, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
+import { compose } from 'recompose';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import CheckoutBar from 'src/components/CheckoutBar';
 import CircleProgress from 'src/components/CircleProgress';
@@ -19,10 +20,12 @@ import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import getLinodeInfo from 'src/utilities/getLinodeInfo';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { aggregateBackups } from '../../LinodesDetail/LinodeBackup';
 import AddonsPanel from '../AddonsPanel';
 import SelectBackupPanel from '../SelectBackupPanel';
 import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
+import WithLabelGenerator, { LabelProps } from '../withLabelGenerator';
 import { renderBackupsDisplaySection } from './utils';
 
 type ClassNames = 'root' | 'main' | 'sidebar';
@@ -81,6 +84,7 @@ interface State {
 type CombinedProps =
   & Props
   & InjectedNotistackProps
+  & LabelProps
   & WithStyles<ClassNames>;
 
 interface Notice {
@@ -212,7 +216,6 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     const {
       selectedRegionID,
       selectedTypeID,
-      label,
       backups,
       privateIP,
       selectedBackupID,
@@ -220,6 +223,8 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     } = this.state;
 
     this.setState({ isMakingRequest: true });
+
+    const label = this.label();
 
     createLinode({
       region: selectedRegionID,
@@ -275,12 +280,34 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     }
   }
 
+  // Generate a default label name with a selected Linode and/or Backup name IF they are selected
+  label = () => {
+    const { linodesWithBackups, selectedBackupID, selectedLinodeID } = this.state;
+    const { getLabel } = this.props;
+
+    const selectedLinode = linodesWithBackups && linodesWithBackups.find(l => l.id === selectedLinodeID);
+
+    if (!selectedLinode) { return getLabel(); }
+
+    const selectedBackup = aggregateBackups(selectedLinode.currentBackups).find(b => b.id === selectedBackupID);
+
+    if (!selectedBackup) {
+      return getLabel({ image: selectedLinode.label });
+    }
+
+    const backup = selectedBackup.type !== 'auto'
+      ? selectedBackup.label
+      : 'auto'; // automatic backups have a label of 'null', so use a custom string for these
+
+    return getLabel({ image: selectedLinode.label, backup });
+  }
+
   render() {
     const { errors, selectedBackupID, selectedDiskSize, selectedLinodeID, tags,
-      selectedTypeID, selectedRegionID, label, backups, linodesWithBackups, privateIP,
+      selectedTypeID, selectedRegionID, backups, linodesWithBackups, privateIP,
     selectedBackupInfo, isMakingRequest } = this.state;
     const { accountBackups, extendLinodes, getBackupsMonthlyPrice, classes,
-       notice, types, getRegionInfo, getTypeInfo } = this.props;
+       notice, types, getRegionInfo, getTypeInfo, updateCustomLabel } = this.props;
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
 
@@ -291,6 +318,8 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     const typeInfo = getTypeInfo(selectedTypeID);
 
     const hasBackups = backups || accountBackups;
+
+    const label = this.label();
 
     return (
       <React.Fragment>
@@ -318,7 +347,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
         }
         <SelectLinodePanel
           error={hasErrorFor('linode_id')}
-          linodes={compose(
+          linodes={ramdaCompose(
             (linodes: Linode.LinodeWithBackups[]) => extendLinodes(linodes),
             filterLinodesWithBackups,
           )(linodesWithBackups!)}
@@ -350,7 +379,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
           labelFieldProps={{
             label: 'Linode Label',
             value: label || '',
-            onChange: this.handleSelectLabel,
+            onChange: updateCustomLabel,
             errorText: hasErrorFor('label'),
           }}
           tagsInputProps={{
@@ -426,5 +455,12 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
 }
 
 const styled = withStyles(styles);
+const withLabels = WithLabelGenerator({}); // @todo: find better name
 
-export default styled(withSnackbar(FromBackupsContent));
+const enhanced = compose<CombinedProps, Props>(
+  styled,
+  withSnackbar,
+  withLabels
+);
+
+export default enhanced(FromBackupsContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -25,7 +25,7 @@ import AddonsPanel from '../AddonsPanel';
 import SelectBackupPanel from '../SelectBackupPanel';
 import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
-import WithLabelGenerator, { LabelProps } from '../withLabelGenerator';
+import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
 import { renderBackupsDisplaySection } from './utils';
 
 type ClassNames = 'root' | 'main' | 'sidebar';
@@ -459,7 +459,7 @@ const styled = withStyles(styles);
 const enhanced = compose<CombinedProps, Props>(
   styled,
   withSnackbar,
-  WithLabelGenerator
+  withLabelGenerator
 );
 
 export default enhanced(FromBackupsContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -292,14 +292,18 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     const selectedBackup = aggregateBackups(selectedLinode.currentBackups).find(b => b.id === selectedBackupID);
 
     if (!selectedBackup) {
-      return getLabel({ image: selectedLinode.label });
+      return getLabel(selectedLinode.label, 'backup');
     }
 
     const backup = selectedBackup.type !== 'auto'
       ? selectedBackup.label
       : 'auto'; // automatic backups have a label of 'null', so use a custom string for these
 
-    return getLabel({ image: selectedLinode.label, backup });
+    return getLabel(
+      selectedLinode.label,
+      backup,
+      'backup'
+    );
   }
 
   render() {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
@@ -26,6 +26,9 @@ const mockProps = {
   },
   enqueueSnackbar: jest.fn(),
   onPresentSnackbar: jest.fn(),
+  updateCustomLabel: jest.fn(),
+  getLabel: jest.fn(),
+  customLabel: ''
 };
 
 describe('FromImageContent', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -366,13 +366,12 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
 
 const styled = withStyles(styles);
-const withLabels = WithLabelGenerator({}); // @todo: find better name
 
 const enhanced = compose<CombinedProps, Props>(
   styled,
   withSnackbar,
   userSSHKeyHoc,
-  withLabels
+  WithLabelGenerator
 );
 
 export default enhanced(FromImageContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -19,6 +19,7 @@ import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
+import deriveDefaultLabel from '../deriveDefaultLabel';
 import SelectImagePanel from '../SelectImagePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
 import { renderBackupsDisplaySection } from './utils';
@@ -64,6 +65,7 @@ interface State {
   privateIP: boolean;
   password: string | null;
   isMakingRequest: boolean;
+  hasUserTypedCustomLabel: boolean;
   initTab?: number;
   tags: Tag[];
 }
@@ -100,6 +102,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
     privateIP: false,
     isMakingRequest: false,
     initTab: pathOr(null, ['history', 'location', 'state', 'initTab'], this.props),
+    hasUserTypedCustomLabel: false,
     tags: [],
   };
 
@@ -118,7 +121,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
   }
 
   handleTypeLabel = (e: any) => {
-    this.setState({ label: e.target.value });
+    this.setState({ label: e.target.value, hasUserTypedCustomLabel: true });
   }
 
   handleChangeTags = (selected: Tag[]) => {
@@ -195,6 +198,19 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
       });
   }
 
+  getLabel = () => {
+    const { hasUserTypedCustomLabel, label, selectedImageID, selectedRegionID, selectedTypeID } = this.state;
+
+    // If a user has typed in the 'label' input field, don't derive a default label name
+    if (hasUserTypedCustomLabel) { return label; }
+
+    const defaultLabel = deriveDefaultLabel(selectedImageID, selectedRegionID, selectedTypeID);
+
+    // TODO: add increment logic here
+
+    return defaultLabel;
+  }
+
   componentWillUnmount() {
     this.mounted = false;
   }
@@ -204,7 +220,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { errors, backups, privateIP, label, selectedImageID, tags,
+    const { errors, backups, privateIP, selectedImageID, tags,
       selectedRegionID, selectedTypeID, password, isMakingRequest, initTab } = this.state;
 
 
@@ -222,6 +238,9 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
     const typeInfo = getTypeInfo(selectedTypeID);
 
     const hasBackups = backups || accountBackups;
+
+    const label = this.getLabel();
+
 
     return (
       <React.Fragment>

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -149,12 +149,14 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
   }
 
   label = () => {
-    const { selectedImageID, selectedRegionID } = this.state;
-    const { getLabel } = this.props;
+    const { selectedImageID, selectedRegionID } = this.state;;
+    const { getLabel, images } = this.props;
 
-    return getLabel({
-      image: selectedImageID, region: selectedRegionID
-    });
+    // We'd prefer to use image 'vendor' instead of 'id'
+    const selectedImage = images.find(img => img.id === selectedImageID);
+    const image = selectedImage && selectedImage.vendor;
+
+    return getLabel({ image, region: selectedRegionID });
   }
 
   createNewLinode = () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -148,13 +148,21 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
     };
   }
 
+  label = () => {
+    const { selectedImageID, selectedRegionID, selectedTypeID } = this.state;
+    const { getLabel } = this.props;
+
+    return getLabel({
+      image: selectedImageID, region: selectedRegionID, type: selectedTypeID
+    });
+  }
+
   createNewLinode = () => {
     const { history, userSSHKeys } = this.props;
     const {
       selectedImageID,
       selectedRegionID,
       selectedTypeID,
-      label,
       password,
       backups,
       privateIP,
@@ -162,6 +170,8 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
     } = this.state;
 
     this.setState({ isMakingRequest: true });
+
+    const label = this.label();
 
     createLinode({
       region: selectedRegionID,
@@ -213,7 +223,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
 
     const { accountBackups, classes, notice, types, regions, images, getBackupsMonthlyPrice,
-      getLabel, getRegionInfo, getTypeInfo, updateCustomLabel, userSSHKeys } = this.props;
+      getRegionInfo, getTypeInfo, updateCustomLabel, userSSHKeys } = this.props;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
@@ -227,9 +237,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
     const hasBackups = backups || accountBackups;
 
-    const label = getLabel({
-      image: selectedImageID, region: selectedRegionID, type: selectedTypeID
-    });
+    const label = this.label();
 
     return (
       <React.Fragment>

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -199,19 +199,6 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
       });
   }
 
-  // getLabel = () => {
-  //   const { hasUserTypedCustomLabel, label, selectedImageID, selectedRegionID, selectedTypeID } = this.state;
-
-  //   // If a user has typed in the 'label' input field, don't derive a default label name
-  //   if (hasUserTypedCustomLabel) { return label; }
-
-  //   const defaultLabel = deriveDefaultLabel(selectedImageID, selectedRegionID, selectedTypeID);
-
-  //   // TODO: add increment logic here
-
-  //   return defaultLabel;
-  // }
-
   componentWillUnmount() {
     this.mounted = false;
   }

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -152,11 +152,15 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
     const { selectedImageID, selectedRegionID } = this.state;;
     const { getLabel, images } = this.props;
 
-    // We'd prefer to use image 'vendor' instead of 'id'
     const selectedImage = images.find(img => img.id === selectedImageID);
-    const image = selectedImage && selectedImage.vendor;
 
-    return getLabel({ image, region: selectedRegionID });
+    // Use 'vendor' if it's a public image, otherwise use label (because 'vendor') will be null
+    const image = selectedImage && (selectedImage.is_public
+      ? selectedImage.vendor
+      : selectedImage.label);
+
+
+    return getLabel(image, selectedRegionID);
   }
 
   createNewLinode = () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -21,7 +21,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
 import SelectImagePanel from '../SelectImagePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
-import WithLabelGenerator, { LabelProps } from '../withLabelGenerator';
+import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
 import { renderBackupsDisplaySection } from './utils';
 
 type ClassNames = 'root' | 'main' | 'sidebar';
@@ -65,7 +65,6 @@ interface State {
   privateIP: boolean;
   password: string | null;
   isMakingRequest: boolean;
-  hasUserTypedCustomLabel: boolean;
   initTab?: number;
   tags: Tag[];
 }
@@ -103,7 +102,6 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
     privateIP: false,
     isMakingRequest: false,
     initTab: pathOr(null, ['history', 'location', 'state', 'initTab'], this.props),
-    hasUserTypedCustomLabel: false,
     tags: [],
   };
 
@@ -119,10 +117,6 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
   handleSelectPlan = (id: string) => {
     this.setState({ selectedTypeID: id });
-  }
-
-  handleTypeLabel = (e: any) => {
-    this.props.updateCustomLabel(e);
   }
 
   handleChangeTags = (selected: Tag[]) => {
@@ -154,7 +148,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
     const selectedImage = images.find(img => img.id === selectedImageID);
 
-    // Use 'vendor' if it's a public image, otherwise use label (because 'vendor') will be null
+    // Use 'vendor' if it's a public image, otherwise use label (because 'vendor' will be null)
     const image = selectedImage && (selectedImage.is_public
       ? selectedImage.vendor
       : selectedImage.label);
@@ -371,7 +365,7 @@ const enhanced = compose<CombinedProps, Props>(
   styled,
   withSnackbar,
   userSSHKeyHoc,
-  WithLabelGenerator
+  withLabelGenerator
 );
 
 export default enhanced(FromImageContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -149,11 +149,11 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
   }
 
   label = () => {
-    const { selectedImageID, selectedRegionID, selectedTypeID } = this.state;
+    const { selectedImageID, selectedRegionID } = this.state;
     const { getLabel } = this.props;
 
     return getLabel({
-      image: selectedImageID, region: selectedRegionID, type: selectedTypeID
+      image: selectedImageID, region: selectedRegionID
     });
   }
 

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.test.tsx
@@ -18,6 +18,9 @@ const mockProps = {
   enqueueSnackbar: jest.fn(),
   onPresentSnackbar: jest.fn(),
   upsertLinode: jest.fn(),
+  updateCustomLabel: jest.fn(),
+  getLabel: jest.fn(),
+  customLabel: ''
 };
 
 describe('FromImageContent', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -205,11 +205,7 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
     const selectedLinode = linodes.find(l => l.id === selectedLinodeID);
     const linodeLabel = selectedLinode && selectedLinode.label;
 
-    return getLabel(
-      linodeLabel,
-      'clone',
-      selectedRegionID ,
-    );
+    return getLabel(linodeLabel, 'clone', selectedRegionID);
   }
 
   render() {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -23,7 +23,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
 import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
-import WithLabelGenerator, { LabelProps } from '../withLabelGenerator';
+import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
 import { renderBackupsDisplaySection } from './utils';
 
 type ClassNames = 'root' | 'main' | 'sidebar';
@@ -352,13 +352,12 @@ interface WithUpsertLinode {
 const WithUpsertLinode = connect(undefined, { upsertLinode });
 
 const styled = withStyles(styles);
-const withLabels = WithLabelGenerator({}); // @todo: find better name
 
 const enhanced = compose<CombinedProps, Props>(
   WithUpsertLinode,
   styled,
   withSnackbar,
-  withLabels
+  withLabelGenerator
 );
 
 export default enhanced(FromLinodeContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -124,10 +124,6 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
     this.setState({ selectedTypeID: id });
   }
 
-  handleTypeLabel = (e: any) => {
-    this.setState({ label: e.target.value });
-  }
-
   handleChangeTags = (selected: Tag[]) => {
     this.setState({ tags: selected })
   }

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -28,6 +28,7 @@ const mockProps = {
   },
   updateCustomLabel: jest.fn(),
   getLabel: jest.fn(),
+  linodes: [],
   customLabel: ''
 };
 

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.test.tsx
@@ -25,7 +25,10 @@ const mockProps = {
       createTag: jest.fn(),
       getLinodeTagList: jest.fn(),
     }
-  }
+  },
+  updateCustomLabel: jest.fn(),
+  getLabel: jest.fn(),
+  customLabel: ''
 };
 
 describe('FromImageContent', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -529,13 +529,12 @@ export class FromStackScriptContent extends React.Component<CombinedProps, State
 }
 
 const styled = withStyles(styles);
-const withLabels = WithLabelGenerator({}); // @todo: find better name
 
 const enhanced = compose<CombinedProps, Props>(
   styled,
   withSnackbar,
   userSSHKeyHoc,
-  withLabels
+  WithLabelGenerator
 );
 
 export default enhanced(FromStackScriptContent) as any;

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -26,7 +26,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
 import SelectImagePanel from '../SelectImagePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
-import WithLabelGenerator, { LabelProps } from '../withLabelGenerator';
+import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
 import { renderBackupsDisplaySection } from './utils';
 
 type ClassNames = 'root'
@@ -534,7 +534,7 @@ const enhanced = compose<CombinedProps, Props>(
   styled,
   withSnackbar,
   userSSHKeyHoc,
-  WithLabelGenerator
+  withLabelGenerator
 );
 
 export default enhanced(FromStackScriptContent) as any;

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.test.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.test.tsx
@@ -1,4 +1,4 @@
-import { deriveDefaultLabel } from './deriveDefaultLabel';
+import { deriveDefaultLabel, ensureSingleDashesAndUnderscores } from './deriveDefaultLabel';
 
 describe('create label name', () => {
   it('creates label name with image, region, type', () => {
@@ -9,5 +9,29 @@ describe('create label name', () => {
     expect(deriveDefaultLabel('ubuntu', 'newark')).toBe('ubuntu-newark');
     expect(deriveDefaultLabel('1gb')).toBe('1gb');
     expect(deriveDefaultLabel('ubuntu', 'newark')).toBe('ubuntu-newark');
+  });
+
+  it('clamps length when necessary', () => {
+    expect(deriveDefaultLabel('really-long-linode-label', 'newark')).toBe('really-long-li-newark')
+    expect(deriveDefaultLabel('really-long-linode-label', 'us-east-another-region')).toBe('really-long-li-us-east-anothe')
+  });
+
+  it('ensures no double dashes or underscores are present', () => {
+    expect(deriveDefaultLabel('really-long-l-inode-label', 'us-east-another-region')).toBe('really-long-l-us-east-anothe')
+    expect(deriveDefaultLabel('this-is__impossible', 'us-west')).toBe('this-is_impos-us-west')
+  });
+});
+
+describe('ensure single dashes and underscores', () => {
+  it('doesn\'t allow double dashes', () => {
+    expect(ensureSingleDashesAndUnderscores('hello--world')).toBe('hello-world');
+    expect(ensureSingleDashesAndUnderscores('--hello-world')).toBe('-hello-world');
+    expect(ensureSingleDashesAndUnderscores('hello-world--')).toBe('hello-world-');
+  });
+
+  it('doesn\'t allow double dashes', () => {
+    expect(ensureSingleDashesAndUnderscores('hello__world')).toBe('hello_world');
+    expect(ensureSingleDashesAndUnderscores('_hello__world')).toBe('_hello_world');
+    expect(ensureSingleDashesAndUnderscores('hello__world_')).toBe('hello_world_');
   });
 });

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.test.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.test.tsx
@@ -1,0 +1,13 @@
+import { deriveDefaultLabel } from './deriveDefaultLabel';
+
+describe('create label name', () => {
+  it('creates label name with image, region, type', () => {
+    expect(deriveDefaultLabel('ubuntu', 'newark', '1gb')).toBe('ubuntu-newark-1gb');
+  });
+
+  it('works without all params', () => {
+    expect(deriveDefaultLabel('ubuntu', null, '1gb')).toBe('ubuntu-1gb');
+    expect(deriveDefaultLabel(null, null, '1gb')).toBe('1gb');
+    expect(deriveDefaultLabel('ubuntu', 'newark', null)).toBe('ubuntu-newark');
+  });
+});

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.test.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.test.tsx
@@ -12,13 +12,15 @@ describe('create label name', () => {
   });
 
   it('clamps length when necessary', () => {
-    expect(deriveDefaultLabel('really-long-linode-label', 'newark')).toBe('really-long-li-newark')
-    expect(deriveDefaultLabel('really-long-linode-label', 'us-east-another-region')).toBe('really-long-li-us-east-anothe')
+    expect(deriveDefaultLabel('really-long-linode-label', 'newark')).toBe('really-long-l-newark')
+    expect(deriveDefaultLabel('really-long-linode-label', 'us-east-another-region')).toBe('really-long-l-us-east-anoth')
+    expect(deriveDefaultLabel('123456789', '10', '11', '12131415')).toBe('123456789-10-11-12131415')
+    expect(deriveDefaultLabel('123456789', '10', '11', '12131415161718192021')).toBe('123456-10-11-121314')
   });
 
   it('ensures no double dashes or underscores are present', () => {
-    expect(deriveDefaultLabel('really-long-l-inode-label', 'us-east-another-region')).toBe('really-long-l-us-east-anothe')
-    expect(deriveDefaultLabel('this-is__impossible', 'us-west')).toBe('this-is_impos-us-west')
+    expect(deriveDefaultLabel('really-long-l-inode-label', 'us-east-another-region')).toBe('really-long-l-us-east-anoth')
+    expect(deriveDefaultLabel('this-is__impossible', 'us-west')).toBe('this-is_impossible-us-west')
   });
 });
 

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.test.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.test.tsx
@@ -1,17 +1,13 @@
-import { deriveDefaultLabel, LabelOptions } from './deriveDefaultLabel';
+import { deriveDefaultLabel } from './deriveDefaultLabel';
 
 describe('create label name', () => {
   it('creates label name with image, region, type', () => {
-    const options: LabelOptions = { image: 'ubuntu', region: 'newark', type: '1gb' };
-    expect(deriveDefaultLabel(options)).toBe('ubuntu-newark-1gb');
+    expect(deriveDefaultLabel('ubuntu', 'newark', '1gb')).toBe('ubuntu-newark-1gb');
   });
 
   it('works without all params', () => {
-    let options: LabelOptions = { image: 'ubuntu', region: 'newark' };
-    expect(deriveDefaultLabel(options)).toBe('ubuntu-newark');
-    options = { type: '1gb' };
-    expect(deriveDefaultLabel(options)).toBe('1gb');
-    options = { image: 'ubuntu', region: 'newark' };
-    expect(deriveDefaultLabel(options)).toBe('ubuntu-newark');
+    expect(deriveDefaultLabel('ubuntu', 'newark')).toBe('ubuntu-newark');
+    expect(deriveDefaultLabel('1gb')).toBe('1gb');
+    expect(deriveDefaultLabel('ubuntu', 'newark')).toBe('ubuntu-newark');
   });
 });

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.test.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.test.tsx
@@ -1,13 +1,17 @@
-import { deriveDefaultLabel } from './deriveDefaultLabel';
+import { deriveDefaultLabel, LabelOptions } from './deriveDefaultLabel';
 
 describe('create label name', () => {
   it('creates label name with image, region, type', () => {
-    expect(deriveDefaultLabel('ubuntu', 'newark', '1gb')).toBe('ubuntu-newark-1gb');
+    const options: LabelOptions = { image: 'ubuntu', region: 'newark', type: '1gb' };
+    expect(deriveDefaultLabel(options)).toBe('ubuntu-newark-1gb');
   });
 
   it('works without all params', () => {
-    expect(deriveDefaultLabel('ubuntu', null, '1gb')).toBe('ubuntu-1gb');
-    expect(deriveDefaultLabel(null, null, '1gb')).toBe('1gb');
-    expect(deriveDefaultLabel('ubuntu', 'newark', null)).toBe('ubuntu-newark');
+    let options: LabelOptions = { image: 'ubuntu', region: 'newark' };
+    expect(deriveDefaultLabel(options)).toBe('ubuntu-newark');
+    options = { type: '1gb' };
+    expect(deriveDefaultLabel(options)).toBe('1gb');
+    options = { image: 'ubuntu', region: 'newark' };
+    expect(deriveDefaultLabel(options)).toBe('ubuntu-newark');
   });
 });

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
@@ -1,6 +1,7 @@
 import { compose, filter, join, map } from 'ramda';
 
-const API_MAX_LABEL_LENGTH = 32;
+// Set this at 29, so we can leave room for zero-padding if needed
+const MAX_LABEL_LENGTH = 29;
 
 export type LabelArgTypes = string | null | undefined;
 
@@ -10,14 +11,14 @@ export const deriveDefaultLabel = (...args: LabelArgTypes[]): string => {
   const filtered = filter(Boolean)(args);
 
   // Max string length of each param. If we have to cut down the string because it's over
-  // the API limit, we cut each param down, rather
-  const maxLength = Math.floor(API_MAX_LABEL_LENGTH / filtered.length);
+  // the API limit, we chop each param, rather than chopping the string as a whole
+  const maxLength = Math.floor(MAX_LABEL_LENGTH / filtered.length);
 
   return compose(
     ensureSingleDashesAndUnderscores,
     join('-'),
     map((s: string) => {
-      return s.replace(/[^a-zA-Z0-9-_]/g, '')
+      return s.replace(/[^a-zA-Z0-9-_]/g, '') // Only alpha-numeric chars, dashes, and underscores allowed by the API
         .slice(0, maxLength)
         .toLowerCase()
     }),
@@ -25,7 +26,6 @@ export const deriveDefaultLabel = (...args: LabelArgTypes[]): string => {
 }
 
 export default deriveDefaultLabel;
-
 
 // The API doesn't allow double dashes or underscores. Just in case joining the param
 // sections of the derived label name results in this, we need to do one final 'replace';

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
@@ -1,9 +1,10 @@
-import { compose, filter, join } from 'ramda';
+import { compose, filter, join, map } from 'ramda';
 
 export interface LabelOptions {
   image?: string | null;
   region?: string | null;
   type?: string | null;
+  backup?: string | null;
   stackScript?: string | null;
 }
 
@@ -16,8 +17,15 @@ export const deriveDefaultLabel = (options: LabelOptions): string => {
 
   return compose(
     join('-'),
+    stripChars,
     filter(Boolean) // Some params might be null or undefined, so filter those out
   )(values);
 }
 
 export default deriveDefaultLabel;
+
+export const stripChars =
+ map<string, string>(value =>
+    value
+      .replace('linode/', '') // Image IDS
+  );

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
@@ -1,4 +1,5 @@
 import { compose, filter, join } from 'ramda';
+
 export interface LabelOptions {
   image?: string | null;
   region?: string | null;

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
@@ -9,23 +9,18 @@ export interface LabelOptions {
 }
 
 export const deriveDefaultLabel = (options: LabelOptions): string => {
-  const { image, region, type, stackScript } = options;
+  const { image, backup, region, type, stackScript } = options;
 
   // TODO: map to custom ID abbreviations
 
-  const values = [image, region, type, stackScript];
+  const values = [image, backup, region, type, stackScript];
 
   return compose(
     join('-'),
-    stripChars,
+    map<string, string>(s => s.toLowerCase()),
+    // @todo: clamp to prevent going over char limit
     filter(Boolean) // Some params might be null or undefined, so filter those out
   )(values);
 }
 
 export default deriveDefaultLabel;
-
-export const stripChars =
- map<string, string>(value =>
-    value
-      .replace('linode/', '') // Image IDS
-  );

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
@@ -1,11 +1,22 @@
-export const deriveDefaultLabel = (
-  imageID: string | null,
-  regionID: string | null,
-  typeID: string | null ): string => {
-
-    // TODO: map to custom ID abbreviations
-
-    // Some params might be null, so filter those out
-    return [imageID, regionID, typeID].filter(Boolean).join('-');
+import { compose, filter, join } from 'ramda';
+export interface LabelOptions {
+  image?: string | null;
+  region?: string | null;
+  type?: string | null;
+  stackScript?: string | null;
 }
+
+export const deriveDefaultLabel = (options: LabelOptions): string => {
+  const { image, region, type, stackScript } = options;
+
+  // TODO: map to custom ID abbreviations
+
+  const values = [image, region, type, stackScript];
+
+  return compose(
+    join('-'),
+    filter(Boolean) // Some params might be null or undefined, so filter those out
+  )(values);
+}
+
 export default deriveDefaultLabel;

--- a/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
+++ b/src/features/linodes/LinodesCreate/deriveDefaultLabel.tsx
@@ -1,0 +1,11 @@
+export const deriveDefaultLabel = (
+  imageID: string | null,
+  regionID: string | null,
+  typeID: string | null ): string => {
+
+    // TODO: map to custom ID abbreviations
+
+    // Some params might be null, so filter those out
+    return [imageID, regionID, typeID].filter(Boolean).join('-');
+}
+export default deriveDefaultLabel;

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
@@ -1,9 +1,9 @@
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as React from 'react';
 import store from 'src/store';
-import { dedupeLabel, LabelProps, pad, WithLabelGenerator } from './withLabelGenerator';
+import { dedupeLabel, LabelProps, pad, withLabelGenerator } from './withLabelGenerator';
 
-const RawComponent = WithLabelGenerator(() => <div/>);
+const RawComponent = withLabelGenerator(() => <div/>);
 
 describe('withLabelGenerator HOC', () => {
   let wrapper: ShallowWrapper<LabelProps, {}>;

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
@@ -1,35 +1,56 @@
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as React from 'react';
-import { LabelProps, WithLabelGenerator } from './withLabelGenerator';
+import store from 'src/store';
+import { dedupeLabel, LabelProps, pad, WithLabelGenerator } from './withLabelGenerator';
 
-const withLabels = WithLabelGenerator({});
-const RawComponent = withLabels(React.Component);
+const RawComponent = WithLabelGenerator(() => <div/>);
 
 describe('withLabelGenerator HOC', () => {
-  let wrapper: ShallowWrapper<LabelProps>
+  let wrapper: ShallowWrapper<LabelProps, {}>;
+  let nestedComponent: ShallowWrapper<LabelProps, {}>;
   beforeEach(() => {
-    wrapper = shallow(<RawComponent />);
+    wrapper = shallow(<RawComponent />, { context: { store } });
+    nestedComponent = wrapper.dive()
+
   });
 
   it('returns label', () => {
-    expect(wrapper.props().getLabel()).toBe('');
+    expect(nestedComponent.props().getLabel()).toBe('');
   });
 
   it('updates custom label', () => {
-    wrapper.props().updateCustomLabel({ target: { value: '' } });
-    expect(wrapper.props().customLabel).toBe('');
-    wrapper.props().updateCustomLabel({ target: { value: 'hello world' } });
-    expect(wrapper.props().customLabel).toBe('hello world');
+    nestedComponent.props().updateCustomLabel({ target: { value: '' } });
+    expect(nestedComponent.props().customLabel).toBe('');
+    nestedComponent.props().updateCustomLabel({ target: { value: 'hello world' } });
+    expect(nestedComponent.props().customLabel).toBe('hello world');
   });
 
   it('returns custom label after custom label has been altered', () => {
-    expect(wrapper.props().getLabel('ubuntu')).toBe('ubuntu');
-    wrapper.props().updateCustomLabel({ target: { value: 'hello world' } });
-    expect(wrapper.props().getLabel('ubuntu')).toBe('hello world');
+    expect(nestedComponent.props().getLabel('ubuntu')).toBe('ubuntu');
+    nestedComponent.props().updateCustomLabel({ target: { value: 'hello world' } });
+    expect(nestedComponent.props().getLabel('ubuntu')).toBe('hello world');
   });
 
   it('returns custom label if not given args', () => {
-    expect(wrapper.props().getLabel()).toBe('');
+    expect(nestedComponent.props().getLabel()).toBe('');
   });
-
 });
+
+describe('pad', () => {
+  it('pads with the specified character', () => {
+    expect(pad(9, 3)).toBe('009')
+    expect(pad(9, 3, '+')).toBe('++9')
+    expect(pad(9, 2)).toBe('09')
+    expect(pad(9, 1)).toBe('9')
+    expect(pad(19, 5)).toBe('00019')
+  })
+});
+
+describe('dedupe label', () => {
+  it('adds an incrementor', () => {
+    expect(dedupeLabel('my-label', ['my-label'])).toBe('my-label001');
+    expect(dedupeLabel('my-label', ['my-label001'])).toBe('my-label');
+    expect(dedupeLabel('my-label', ['my-label', 'my-label-002'])).toBe('my-label001');
+    expect(dedupeLabel('my-label', ['my-label', 'my-label001', 'my-label003'])).toBe('my-label002');
+  });
+})

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
@@ -1,0 +1,35 @@
+import { shallow, ShallowWrapper } from 'enzyme';
+import * as React from 'react';
+import { LabelProps, WithLabelGenerator } from './withLabelGenerator';
+
+const withLabels = WithLabelGenerator({});
+const RawComponent = withLabels(React.Component);
+
+describe('withLabelGenerator HOC', () => {
+  let wrapper: ShallowWrapper<LabelProps>
+  beforeEach(() => {
+    wrapper = shallow(<RawComponent />);
+  });
+
+  it('returns label', () => {
+    expect(wrapper.props().getLabel()).toBe('');
+  });
+
+  it('updates custom label', () => {
+    wrapper.props().updateCustomLabel({ target: { value: '' } });
+    expect(wrapper.props().customLabel).toBe('');
+    wrapper.props().updateCustomLabel({ target: { value: 'hello world' } });
+    expect(wrapper.props().customLabel).toBe('hello world');
+  });
+
+  it('returns custom label after custom label has been altered', () => {
+    expect(wrapper.props().getLabel({ image: 'ubuntu' })).toBe('ubuntu');
+    wrapper.props().updateCustomLabel({ target: { value: 'hello world' } });
+    expect(wrapper.props().getLabel({ image: 'ubuntu' })).toBe('hello world');
+  });
+
+  it('returns custom label if not given args', () => {
+    expect(wrapper.props().getLabel()).toBe('');
+  });
+
+});

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
@@ -23,9 +23,9 @@ describe('withLabelGenerator HOC', () => {
   });
 
   it('returns custom label after custom label has been altered', () => {
-    expect(wrapper.props().getLabel({ image: 'ubuntu' })).toBe('ubuntu');
+    expect(wrapper.props().getLabel('ubuntu')).toBe('ubuntu');
     wrapper.props().updateCustomLabel({ target: { value: 'hello world' } });
-    expect(wrapper.props().getLabel({ image: 'ubuntu' })).toBe('hello world');
+    expect(wrapper.props().getLabel('ubuntu')).toBe('hello world');
   });
 
   it('returns custom label if not given args', () => {

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
@@ -48,9 +48,9 @@ describe('pad', () => {
 
 describe('dedupe label', () => {
   it('adds an incrementor', () => {
-    expect(dedupeLabel('my-label', ['my-label'])).toBe('my-label001');
-    expect(dedupeLabel('my-label', ['my-label001'])).toBe('my-label');
-    expect(dedupeLabel('my-label', ['my-label', 'my-label-002'])).toBe('my-label001');
-    expect(dedupeLabel('my-label', ['my-label', 'my-label001', 'my-label003'])).toBe('my-label002');
+    expect(dedupeLabel('my-label', ['my-label'])).toBe('my-label-001');
+    expect(dedupeLabel('my-label', ['my-label-001'])).toBe('my-label');
+    expect(dedupeLabel('my-label', ['my-label', 'my-label-002'])).toBe('my-label-001');
+    expect(dedupeLabel('my-label', ['my-label', 'my-label-001', 'my-label003'])).toBe('my-label-002');
   });
 })

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.test.tsx
@@ -1,7 +1,7 @@
 import { shallow, ShallowWrapper } from 'enzyme';
 import * as React from 'react';
 import store from 'src/store';
-import { dedupeLabel, LabelProps, pad, withLabelGenerator } from './withLabelGenerator';
+import { dedupeLabel, LabelProps, withLabelGenerator } from './withLabelGenerator';
 
 const RawComponent = withLabelGenerator(() => <div/>);
 
@@ -34,16 +34,6 @@ describe('withLabelGenerator HOC', () => {
   it('returns custom label if not given args', () => {
     expect(nestedComponent.props().getLabel()).toBe('');
   });
-});
-
-describe('pad', () => {
-  it('pads with the specified character', () => {
-    expect(pad(9, 3)).toBe('009')
-    expect(pad(9, 3, '+')).toBe('++9')
-    expect(pad(9, 2)).toBe('09')
-    expect(pad(9, 1)).toBe('9')
-    expect(pad(19, 5)).toBe('00019')
-  })
 });
 
 describe('dedupe label', () => {

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
@@ -92,9 +92,3 @@ export const dedupeLabel = (label: string, existingLabels: string[]): string => 
   }
   return dedupedLabel;
 }
-
-// Adds padding to the specified width. pad(7, 3) --> '007
-export const pad = (n: number, width: number, padChar = '0'): string => {
-  const s = n + '';
-  return s.length >= width ? s : new Array(width - s.length + 1).join(padChar) + s;
-}

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
@@ -83,7 +83,7 @@ export const dedupeLabel = (label: string, existingLabels: string[]): string => 
   const matchingLabels = existingLabels.filter(l => l.startsWith(label));
 
   while (matchingLabels.find(l => l === dedupedLabel)) {
-    dedupedLabel = label + pad(i, ZERO_PAD_WIDTH);
+    dedupedLabel = label + '-' + i.toString().padStart(ZERO_PAD_WIDTH, '0');
     i++;
 
     // EDGE CASE: if a user has 999 iterations of the same name (arch-us-east-001, arch-us-east-002, ...)

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { deriveDefaultLabel, LabelOptions } from './deriveDefaultLabel';
+// import { connect } from 'redux';
+
+export interface LabelProps {
+  updateCustomLabel: (e: any) => void;
+  getLabel: (args: Partial<LabelOptions>) => string;
+}
+
+export interface LabelState {
+  customLabel: string;
+  hasUserTypedCustomLabel: boolean;
+}
+
+// @todo: do we actually need options?
+const WithLabelGenerator = (options: any /* @todo: type */) => (Component: React.ComponentType<any>) => {
+  class WrappedComponent extends React.PureComponent<{}, LabelState> {
+    state: LabelState = {
+      customLabel: '',
+      hasUserTypedCustomLabel: false
+    }
+
+    updateCustomLabel = (e: any) => {
+      this.setState({ customLabel: e.target.value, hasUserTypedCustomLabel: true });
+    }
+
+    getLabel = (args: Partial<LabelOptions>) => {
+      const { hasUserTypedCustomLabel, customLabel } = this.state;
+
+      // If a user has typed in the 'label' input field, don't derive a default label name
+      if (hasUserTypedCustomLabel) { return customLabel; }
+
+      const defaultLabel = deriveDefaultLabel(args);
+
+      // TODO: add increment logic here
+
+      return defaultLabel;
+    }
+
+    render() {
+      return React.createElement(Component, {
+        updateCustomLabel: this.updateCustomLabel,
+        getLabel: this.getLabel,
+        ...this.props,
+        ...this.state
+      })
+    }
+  }
+  return WrappedComponent;
+}
+
+// @todo: will need to connect to redux to check for existing labels (will increment if there are existing)
+export default WithLabelGenerator;

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
-import { deriveDefaultLabel, LabelOptions } from './deriveDefaultLabel';
+;import * as React from 'react';
+import { deriveDefaultLabel, LabelArgTypes } from './deriveDefaultLabel';
 // import { connect } from 'redux';
 
 export interface LabelProps {
   customLabel: string;
   updateCustomLabel: (e: any) => void;
-  getLabel: (args?: Partial<LabelOptions>) => string;
+  getLabel: (...args: any[]) => string;
 }
 
 export interface LabelState {
@@ -25,13 +25,16 @@ export const WithLabelGenerator = (options: any /* @todo: type */) => (Component
       this.setState({ customLabel: e.target.value, hasUserTypedCustomLabel: true });
     }
 
-    getLabel = (args?: Partial<LabelOptions>) => {
+    getLabel = (...args: LabelArgTypes[]) => {
       const { hasUserTypedCustomLabel, customLabel } = this.state;
 
       // If a user has typed in the 'label' input field, don't derive a default label name
       if (hasUserTypedCustomLabel || !args) { return customLabel; }
 
-      const defaultLabel = deriveDefaultLabel(args);
+      const defaultLabel = deriveDefaultLabel(...args);
+
+      // In case the derived label doesn't match API requirements
+      if (!testAPIRequirements(defaultLabel)) { return customLabel; }
 
       // TODO: add increment logic here
 
@@ -52,3 +55,8 @@ export const WithLabelGenerator = (options: any /* @todo: type */) => (Component
 
 // @todo: will need to connect to redux to check for existing labels (will increment if there are existing)
 export default WithLabelGenerator;
+
+const testAPIRequirements = (label: string) => {
+  const linodeLabelRegExp = /^[a-zA-Z]((?!--|__)[a-zA-Z0-9-_])+$/;
+  return linodeLabelRegExp.test(label);
+}

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
@@ -13,7 +13,13 @@ export interface LabelState {
   hasUserTypedCustomLabel: boolean;
 }
 
-export const WithLabelGenerator = (Component: React.ComponentType<any>) => {
+// This HOC gives a component the ability to:
+//  1) Derive a default label name based on given params, e.g. props.getLabel('image-name', 'region-name')
+//  2) Keep track of custom input state. If a user has typed into an input field, we don't want to derive label
+//     names anymore, even if additional selections are made, because once they've touched the label input field,
+//     they may have given it a custom name, which we don't want to erase.
+//
+export const withLabelGenerator = (Component: React.ComponentType<any>) => {
   class WrappedComponent extends React.PureComponent<any, LabelState> {
     state: LabelState = {
       customLabel: '',
@@ -34,7 +40,7 @@ export const WithLabelGenerator = (Component: React.ComponentType<any>) => {
 
       const dedupedLabel = dedupeLabel(defaultLabel, this.props.linodeLabels);
 
-      // In case the derived label doesn't match API requirements
+      // Final failsafe: in case the derived label doesn't match API requirements
       if (!testAPIRequirements(dedupedLabel)) { return customLabel; }
 
       return dedupedLabel;
@@ -52,19 +58,22 @@ export const WithLabelGenerator = (Component: React.ComponentType<any>) => {
   return connected(WrappedComponent);
 }
 
+// Connect to Redux state, so that we have access to existing Linode Labels (we may need to dedupe).
 const connected = connect((state: ApplicationState) => ({
   linodeLabels: state.__resources.linodes.entities.map(l => l.label)
 }));
 
+// Regex taken from API documentation.
 const testAPIRequirements = (label: string) => {
   const linodeLabelRegExp = /^[a-zA-Z]((?!--|__)[a-zA-Z0-9-_])+$/;
   return linodeLabelRegExp.test(label) && label.length <= 32;
 }
 
-export default WithLabelGenerator;
-
+export default withLabelGenerator;
 
 // Utilities
+
+// Searches 'existingLabels' and appends a zero-padded incrementer to the original label
 export const dedupeLabel = (label: string, existingLabels: string[]): string => {
   const ZERO_PAD_WIDTH = 3;
 
@@ -76,10 +85,15 @@ export const dedupeLabel = (label: string, existingLabels: string[]): string => 
   while (matchingLabels.find(l => l === dedupedLabel)) {
     dedupedLabel = label + pad(i, ZERO_PAD_WIDTH);
     i++;
+
+    // EDGE CASE: if a user has 999 iterations of the same name (arch-us-east-001, arch-us-east-002, ...)
+    // just return the original label. They'll get an API error.
+    if (i === 999) { return label; }
   }
   return dedupedLabel;
 }
 
+// Adds padding to the specified width. pad(7, 3) --> '007
 export const pad = (n: number, width: number, padChar = '0'): string => {
   const s = n + '';
   return s.length >= width ? s : new Array(width - s.length + 1).join(padChar) + s;

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
@@ -3,8 +3,9 @@ import { deriveDefaultLabel, LabelOptions } from './deriveDefaultLabel';
 // import { connect } from 'redux';
 
 export interface LabelProps {
+  customLabel: string;
   updateCustomLabel: (e: any) => void;
-  getLabel: (args: Partial<LabelOptions>) => string;
+  getLabel: (args?: Partial<LabelOptions>) => string;
 }
 
 export interface LabelState {
@@ -13,7 +14,7 @@ export interface LabelState {
 }
 
 // @todo: do we actually need options?
-const WithLabelGenerator = (options: any /* @todo: type */) => (Component: React.ComponentType<any>) => {
+export const WithLabelGenerator = (options: any /* @todo: type */) => (Component: React.ComponentType<any>) => {
   class WrappedComponent extends React.PureComponent<{}, LabelState> {
     state: LabelState = {
       customLabel: '',
@@ -24,11 +25,11 @@ const WithLabelGenerator = (options: any /* @todo: type */) => (Component: React
       this.setState({ customLabel: e.target.value, hasUserTypedCustomLabel: true });
     }
 
-    getLabel = (args: Partial<LabelOptions>) => {
+    getLabel = (args?: Partial<LabelOptions>) => {
       const { hasUserTypedCustomLabel, customLabel } = this.state;
 
       // If a user has typed in the 'label' input field, don't derive a default label name
-      if (hasUserTypedCustomLabel) { return customLabel; }
+      if (hasUserTypedCustomLabel || !args) { return customLabel; }
 
       const defaultLabel = deriveDefaultLabel(args);
 


### PR DESCRIPTION
## Description

Adds a default label name during Linode creation flow. The default name is derived from the Image, Region, Linode, Backup, or StackScript, depending on which creation flow you are going through.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

- Once you type in the "Linode Label" input field, the default label name will stop being derived, even if additional selections are made.
- Label name sections (image, region, etc.) may be individually shortened, if the label name is longer than the API limit of 32 characters.

### To Test:

- Try creating a Linode from each possible flow.
- Try creating Linodes that would yield the same default name (e.g. `arch-us-west`).

**New HOC:** `withLabelGenerator`. I chose this approach because this functionality needed to be shared across several components (`FromImageContent`, `FromBackupsContent`, etc.) 
