### PR TITLE
change: M3-XXX Add Render Guard to Contact Info/Config Forms

### DIFF
--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -2,9 +2,11 @@ import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import * as classNames from 'classnames';
 import { equals } from 'ramda';
 import * as React from 'react';
+import { compose } from 'recompose';
 import { StyleRulesCallback, withStyles, WithStyles, WithTheme } from 'src/components/core/styles';
 import TextField, { TextFieldProps } from 'src/components/core/TextField';
 import HelpIcon from 'src/components/HelpIcon';
+import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard' 
 
 type ClassNames = 'root'
   | 'helpWrapper'
@@ -138,4 +140,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default styled(LinodeTextField);
+export default compose<CombinedProps, Props & RenderGuardProps>(
+  styled,
+  RenderGuard
+)(LinodeTextField);

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -6,7 +6,6 @@ import { compose } from 'recompose';
 import { StyleRulesCallback, withStyles, WithStyles, WithTheme } from 'src/components/core/styles';
 import TextField, { TextFieldProps } from 'src/components/core/TextField';
 import HelpIcon from 'src/components/HelpIcon';
-import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard' 
 
 type ClassNames = 'root'
   | 'helpWrapper'
@@ -112,7 +111,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
             disableUnderline: true,
             className: classNames('input', { [classes.expand]: expand, }, className),
             ...finalProps.InputProps,
-            }
+          }
           }
           SelectProps={{
             IconComponent: KeyboardArrowDown,
@@ -127,7 +126,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
           className={classNames({
             [classes.helpWrapperTextField]: Boolean(tooltipText),
           },
-          className,
+            className,
           )}
         >
           {this.props.children}
@@ -140,7 +139,6 @@ class LinodeTextField extends React.Component<CombinedProps> {
 
 const styled = withStyles(styles, { withTheme: true });
 
-export default compose<CombinedProps, Props & RenderGuardProps>(
+export default compose<CombinedProps, Props>(
   styled,
-  RenderGuard
 )(LinodeTextField);

--- a/src/components/core/FormControl.ts
+++ b/src/components/core/FormControl.ts
@@ -1,6 +1,7 @@
 import FormControl, { FormControlProps as _FormControlProps } from '@material-ui/core/FormControl';
+import RenderGuard from 'src/components/RenderGuard';
 
 /* tslint:disable-next-line:no-empty-interface */
-export interface FormControlProps extends _FormControlProps {}
+export interface FormControlProps extends _FormControlProps { }
 
-export default FormControl;
+export default RenderGuard(FormControl);

--- a/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -135,7 +135,7 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
         {generalError && <Grid item xs={12}><Notice error text={generalError} /></Grid>}
         {success && <Grid item xs={12}><Notice success text={success} /></Grid>}
 
-        <Grid item xs={12}>
+        <Grid item xs={12} updateFor={[fields.company, hasErrorFor('company')]}>
           <Grid container>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -149,7 +149,7 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           </Grid>
         </Grid>
 
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} updateFor={[fields.email, hasErrorFor('email')]}>
           <TextField
             label="Email"
             type="email"
@@ -160,7 +160,7 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           />
         </Grid>
 
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} updateFor={[fields.phone, hasErrorFor('phone')]}>
           <TextField
             label="Phone Number"
             type="tel"
@@ -171,7 +171,7 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           />
         </Grid>
 
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} updateFor={[fields.first_name, hasErrorFor('first_name')]}>
           <TextField
             label="First Name"
             value={defaultTo(account.first_name, fields.first_name)}
@@ -181,7 +181,7 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           />
         </Grid>
 
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} updateFor={[fields.last_name, hasErrorFor('last_name')]}>
           <TextField
             label="Last Name"
             value={defaultTo(account.last_name, fields.last_name)}
@@ -191,7 +191,7 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           />
         </Grid>
 
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} updateFor={[fields.address_1, hasErrorFor('address_1')]}>
           <TextField
             label="Address"
             value={defaultTo(account.address_1, fields.address_1)}
@@ -201,7 +201,7 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           />
         </Grid>
 
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} updateFor={[fields.address_2, hasErrorFor('address2')]}>
           <TextField
             label="Address 2"
             value={defaultTo(account.address_2, fields.address_2)}
@@ -211,7 +211,7 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           />
         </Grid>
 
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} updateFor={[fields.city, hasErrorFor('city')]}>
           <TextField
             label="City"
             value={defaultTo(account.city, fields.city)}
@@ -221,7 +221,16 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           />
         </Grid>
 
-        <Grid item xs={12} sm={6}>
+        <Grid
+          item
+          xs={12}
+          sm={6}
+          updateFor={[
+            fields.state,
+            fields.zip,
+            hasErrorFor('state'),
+            hasErrorFor('zip')
+          ]}>
           <Grid container className={classes.stateZip}>
             <Grid item xs={12} sm={7}>
               <TextField
@@ -244,7 +253,7 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           </Grid>
         </Grid>
 
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} updateFor={[fields.country, hasErrorFor('country')]}>
           <TextField
             label="Country"
             value={defaultTo(account.country, fields.country)}
@@ -257,7 +266,7 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           </TextField>
         </Grid>
 
-        <Grid item xs={12} sm={6}>
+        <Grid item xs={12} sm={6} updateFor={[fields.tax_id, hasErrorFor('tax_id')]}>
           <TextField
             label="Tax ID"
             value={defaultTo(account.tax_id, fields.tax_id)}
@@ -626,10 +635,11 @@ class UpdateContactInformationPanel extends React.Component<CombinedProps, State
           * overwrite the previous values for expiration/last 4 digits
           * with null, so we need to manually set them here.
           */
-          return {...existingAccount,
-                  ...updatedAccount,
-                  credit_card: existingAccount.credit_card
-                 }
+          return {
+            ...existingAccount,
+            ...updatedAccount,
+            credit_card: existingAccount.credit_card
+          }
         });
 
         this.setState({

--- a/src/features/Support/AttachFileListItem.tsx
+++ b/src/features/Support/AttachFileListItem.tsx
@@ -65,6 +65,10 @@ type CombinedProps = Props & HandlerProps & WithStyles<ClassNames>;
 export const AttachFileListItem: React.StatelessComponent<CombinedProps> = (props) => {
   const { classes, file, inlineDisplay, onClick } = props;
   if (file.uploaded) { return null; }
+  const err = (file.errors && file.errors.length)
+    ? file.errors[0].reason
+    : undefined;
+
   return (
     <React.Fragment>
       <Grid container className={classes.attachmentsContainer}>
@@ -72,7 +76,7 @@ export const AttachFileListItem: React.StatelessComponent<CombinedProps> = (prop
           <TextField
             className={classes.attachmentField}
             value={file.name}
-            errorText={file.errors && file.errors.length && file.errors[0].reason}
+            errorText={err}
             InputProps={{
               startAdornment:
               <InputAdornment position="end">

--- a/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -400,7 +400,6 @@ class SupportTicketDrawer extends React.Component<CombinedProps, State> {
           label="What is this regarding?"
           value={ticket.entity_type}
           onChange={this.handleEntityTypeChange}
-          errorText={false}
           data-qa-ticket-entity-type
         >
           <MenuItem key={'none'} value={'none'}>Choose a Product</MenuItem>

--- a/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
@@ -50,39 +50,41 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = (props) => {
     <React.Fragment>
       {
         slots.map((slot, idx) => {
-          return counter < idx ? null : <FormControl key={slot} fullWidth>
-            <InputLabel
-              htmlFor={`rescueDevice_${slot}`}
-              disableAnimation
-              shrink={true}
-            >
-              /dev/{slot}
-            </InputLabel>
-            <Select
-              fullWidth
-              value={getSelected(slot) || 'none'}
-              onChange={e => onChange(slot, e.target.value)}
-              inputProps={{ name: `rescueDevice_${slot}`, id: `rescueDevice_${slot}` }}
-            >
-              <MenuItem value="none">None</MenuItem>
-              {
-                Object
-                  .entries(devices)
-                  .map(([type, items]) => [
-                    <MenuItem
-                      className="selectHeader"
-                      disabled
-                      key={type}
-                      data-qa-type={titlecase(type)}
-                    >
-                      {titlecase(type)}
-                    </MenuItem>,
-                    ...(items as any[]).map(({ _id, label }) =>
-                      <MenuItem key={_id} value={_id} data-qa-option={label}>{label}</MenuItem>),
-                  ])
-              }
-            </Select>
-          </FormControl>;
+          return counter < idx
+            ? null
+            : <FormControl updateFor={[getSelected(slot)]} key={slot} fullWidth>
+              <InputLabel
+                htmlFor={`rescueDevice_${slot}`}
+                disableAnimation
+                shrink={true}
+              >
+                /dev/{slot}
+              </InputLabel>
+              <Select
+                fullWidth
+                value={getSelected(slot) || 'none'}
+                onChange={e => onChange(slot, e.target.value)}
+                inputProps={{ name: `rescueDevice_${slot}`, id: `rescueDevice_${slot}` }}
+              >
+                <MenuItem value="none">None</MenuItem>
+                {
+                  Object
+                    .entries(devices)
+                    .map(([type, items]) => [
+                      <MenuItem
+                        className="selectHeader"
+                        disabled
+                        key={type}
+                        data-qa-type={titlecase(type)}
+                      >
+                        {titlecase(type)}
+                      </MenuItem>,
+                      ...(items as any[]).map(({ _id, label }) =>
+                        <MenuItem key={_id} value={_id} data-qa-option={label}>{label}</MenuItem>),
+                    ])
+                }
+              </Select>
+            </FormControl>;
         })
       }
       {rescue && <FormControl fullWidth>

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -249,7 +249,17 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         {generalError && <Notice error errorGroup="linode-config-drawer" text={generalError} />}
-        <Grid item xs={12} className={classes.section}>
+        <Grid
+          item
+          xs={12}
+          className={classes.section}
+          updateFor={[
+            errorFor('label'),
+            errorFor('comments'),
+            label,
+            comments
+          ]}
+        >
           <Typography role="header" variant="h3">Label and Comments</Typography>
           <TextField
             label="Label"
@@ -258,6 +268,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             onChange={this.handleChangeLabel}
             errorText={errorFor('label')}
             errorGroup="linode-config-drawer"
+            updateFor={[label, errorFor('label')]}
           />
 
           <TextField
@@ -268,12 +279,13 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             rows={3}
             errorText={errorFor('comments')}
             errorGroup="linode-config-drawer"
+            updateFor={[comments, errorFor('comments')]}
           />
         </Grid>
 
         <Divider className={classes.divider} />
 
-        <Grid item xs={12} className={classes.section}>
+        <Grid item xs={12} className={classes.section} updateFor={[virt_mode]}>
           <Typography role="header" variant="h3">Virtual Machine</Typography>
           <FormControl component="fieldset">
             <FormLabel
@@ -296,7 +308,17 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
 
         <Divider className={classes.divider} />
 
-        <Grid item xs={12} className={classes.section}>
+        <Grid
+          item xs={12}
+          className={classes.section}
+          updateFor={[
+            kernel,
+            errorFor('kernel'),
+            run_level,
+            memory_limit,
+            errorFor('memory_limit')
+          ]}
+        >
           <Typography role="header" variant="h3">Boot Settings</Typography>
           {kernels &&
             <TextField
@@ -306,6 +328,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               onChange={this.handleChangeKernel}
               errorText={errorFor('kernel')}
               errorGroup="linode-config-drawer"
+              updateFor={[kernel, errorFor('kernel')]}
             >
               <MenuItem value="none" disabled><em>Select a Kernel</em></MenuItem>
               {
@@ -320,7 +343,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               }
             </TextField>}
 
-          <FormControl fullWidth component="fieldset">
+          <FormControl updateFor={[run_level]} fullWidth component="fieldset">
             <FormLabel
               htmlFor="run_level"
               component="label"
@@ -346,6 +369,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             onChange={this.handleMemoryLimitChange}
             helperText={`Max: ${maxMemory}`}
             errorText={errorFor('memory_limit')}
+            updateFor={[memory_limit, errorFor('memory_limit')]}
           />
         </Grid>
 
@@ -404,7 +428,17 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
 
         <Grid item xs={12} className={classes.section}>
           <Typography role="header" variant="h3">Filesystem/Boot Helpers</Typography>
-          <FormControl fullWidth component="fieldset">
+          <FormControl
+            updateFor={[
+              helpers.distro,
+              helpers.updatedb_disabled,
+              helpers.modules_dep,
+              helpers.devtmpfs_automount,
+              helpers.network
+            ]}
+            fullWidth
+            component="fieldset"
+          >
             <FormGroup>
               <FormControlLabel
                 label="Distro Helper"

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -268,7 +268,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             onChange={this.handleChangeLabel}
             errorText={errorFor('label')}
             errorGroup="linode-config-drawer"
-            updateFor={[label, errorFor('label')]}
           />
 
           <TextField
@@ -279,7 +278,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             rows={3}
             errorText={errorFor('comments')}
             errorGroup="linode-config-drawer"
-            updateFor={[comments, errorFor('comments')]}
           />
         </Grid>
 
@@ -328,7 +326,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               onChange={this.handleChangeKernel}
               errorText={errorFor('kernel')}
               errorGroup="linode-config-drawer"
-              updateFor={[kernel, errorFor('kernel')]}
             >
               <MenuItem value="none" disabled><em>Select a Kernel</em></MenuItem>
               {
@@ -369,7 +366,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             onChange={this.handleMemoryLimitChange}
             helperText={`Max: ${maxMemory}`}
             errorText={errorFor('memory_limit')}
-            updateFor={[memory_limit, errorFor('memory_limit')]}
           />
         </Grid>
 


### PR DESCRIPTION
## Description

The contact info and advanced config drawer forms were slow and gross, so I added some RenderGuard logic to make them a little better.

Some of the performance hit is from MUI and still appears to not be 100% performant even with this new logic

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Use chrome dev tools to audit the user interaction times between the develop branch and this branch. You can simple type into the fields to see the difference