### PR TITLE
M3-1567 Change: Set default image in "Create from Image" flow

### DIFF
--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
@@ -49,6 +49,10 @@ describe('FromImageContent', () => {
     />,
   );
 
+  it('should default to Ubuntu 18.10 as the selected image', () => {
+    expect(component.state().selectedImageID).toBe('linode/ubuntu18.10');
+  });
+
   it('should render a notice when passed a Notice prop', () => {
     expect(componentWithNotice.find('WithStyles(Notice)')).toHaveLength(1);
   });

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
@@ -49,8 +49,32 @@ describe('FromImageContent', () => {
     />,
   );
 
+  const componentWithImages = shallow(
+    <FromImageContent
+      handleDisablePasswordField={jest.fn()}
+      classes={{ root: '', main: '', sidebar: '' }}
+      {...mockProps}
+      images={[{
+        id: 'linode/ubuntu18.10',
+        label: '',
+        description: null,
+        created: '',
+        type: '',
+        is_public: true,
+        size: 1,
+        created_by: null,
+        vendor: null,
+        deprecated: false }
+      ]}
+    />,
+  );
+
   it('should default to Ubuntu 18.10 as the selected image', () => {
-    expect(component.state().selectedImageID).toBe('linode/ubuntu18.10');
+    expect(componentWithImages.state().selectedImageID).toBe('linode/ubuntu18.10');
+  });
+
+  it('should set selectedImageID to null when initial state (from history or default) is not in images', () => {
+    expect(component.state().selectedImageID).toBe(null);
   });
 
   it('should render a notice when passed a Notice prop', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -23,6 +23,8 @@ import SelectImagePanel from '../SelectImagePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
 import { renderBackupsDisplaySection } from './utils';
 
+const DEFAULT_IMAGE = 'linode/ubuntu18.10';
+
 type ClassNames = 'root' | 'main' | 'sidebar';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
@@ -91,7 +93,7 @@ type CombinedProps =
 
 export class FromImageContent extends React.Component<CombinedProps, State> {
   state: State = {
-    selectedImageID: pathOr(null, ['history', 'location', 'state', 'selectedImageId'], this.props),
+    selectedImageID: pathOr(DEFAULT_IMAGE, ['history', 'location', 'state', 'selectedImageId'], this.props),
     selectedTypeID: null,
     selectedRegionID: null,
     password: '',
@@ -106,7 +108,10 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
   mounted: boolean = false;
 
   handleSelectImage = (id: string) => {
-    this.setState({ selectedImageID: id });
+    // Allow for deselecting an image
+    id === this.state.selectedImageID
+      ? this.setState({ selectedImageID: null })
+      : this.setState({ selectedImageID: id });
   }
 
   handleSelectRegion = (id: string) => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -1,5 +1,5 @@
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { pathOr } from 'ramda';
+import { find, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
@@ -206,6 +206,10 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     this.mounted = true;
+
+    if (!find((image) => image.id === this.state.selectedImageID, this.props.images)) {
+      this.setState({ selectedImageID: null });
+    }
   }
 
   render() {


### PR DESCRIPTION
## Description

This PR also allows deselecting of images, so that image-less Linodes can still be created.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

The default is Ubuntu 18.10, which is hard-coded at the top of `FromImageContent.tsx`. 
