### PR TITLE
M3-2026 Change: show IP copy buttons on hover

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -66,7 +66,7 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = (props) => {
               <strong>IP:</strong>
             </Typography>
             <div className={classes.IPgrouping} data-qa-ip>
-              <IPAddress ips={[nodeBalancer.ipv4]} copyRight />
+              <IPAddress ips={[nodeBalancer.ipv4]} copyRight showMore />
               {nodeBalancer.ipv6 && <IPAddress ips={[nodeBalancer.ipv6]} copyRight />}
             </div>
           </div>

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -358,8 +358,8 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
           </TableCell>
           <TableCell parentColumn="IP Addresses" data-qa-nodebalancer-ips>
             <div className={classes.ipsWrapper}>
-              <IPAddress ips={[nodeBalancer.ipv4]} copyRight />
-              {nodeBalancer.ipv6 && <IPAddress ips={[nodeBalancer.ipv6]} copyRight />}
+              <IPAddress ips={[nodeBalancer.ipv4]} copyRight showMore />
+              {nodeBalancer.ipv6 && <IPAddress ips={[nodeBalancer.ipv6]} copyRight showMore />}
             </div>
           </TableCell>
           <TableCell parentColumn="Region" data-qa-region>

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingSummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingSummaryPanel.tsx
@@ -127,13 +127,13 @@ export default restyled(connected(LinodeNetworkingSummaryPanel)) as React.Compon
 
 const renderIPv4DNSResolvers = () => () => (
   <div style={{ display: 'flex', alignItems: "center" }}>
-    <IPAddress ips={ipv4DNSResolvers} copyRight />
+    <IPAddress ips={ipv4DNSResolvers} copyRight showMore />
   </div>
 )
 
 const renderIPv6DNSResolvers = () => () => (
   <div style={{ display: 'flex', alignItems: "center" }}>
-    <IPAddress ips={ipv6DNSResolvers} copyRight />
+    <IPAddress ips={ipv6DNSResolvers} copyRight showMore />
   </div>
 )
 

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -116,12 +116,12 @@ class SummaryPanel extends React.Component<CombinedProps> {
           </Grid>
           <Grid item xs={12} sm={6} lg={4}>
             <div className={classes.section}>
-              <IPAddress ips={linode.ipv4} copyRight />
+              <IPAddress ips={linode.ipv4} copyRight showMore />
             </div>
             {
               linode.ipv6 &&
               <div className={classes.section}>
-                <IPAddress ips={[linode.ipv6]} copyRight />
+                <IPAddress ips={[linode.ipv6]} copyRight showMore />
               </div>
             }
           </Grid>

--- a/src/features/linodes/LinodesLanding/IPAddress.test.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.test.tsx
@@ -32,6 +32,7 @@ describe('IPAddress', () => {
       <LinodeThemeWrapper>
         <IPAddress
           ips={['8.8.8.8', '8.8.4.4']}
+          showMore
         />
       </LinodeThemeWrapper>,
     );

--- a/src/features/linodes/LinodesLanding/IPAddress.test.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.test.tsx
@@ -1,45 +1,58 @@
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
-
-import IPAddress, { sortIPAddress } from './IPAddress';
+import { IPAddress, sortIPAddress } from './IPAddress';
 
 const publicIP = '8.8.8.8';
 const publicIP2 = '45.45.45.45';
 const privateIP = '192.168.220.103';
 const privateIP2 = '192.168.220.102';
 
+const classes = {
+  root: '',
+  left: '',
+  right: '',
+  icon: '',
+  row: '',
+  ip: '',
+  ipLink: '',
+  hide: 'hide'
+}
+
+const component = shallow(<IPAddress classes={classes} ips={['8.8.8.8', '8.8.4.4']}  />)
+
 describe('IPAddress', () => {
   it('should render without error and display and IP address', () => {
-    const result = mount(
-      <LinodeThemeWrapper>
-        <IPAddress
-          ips={['8.8.8.8']}
-        />
-      </LinodeThemeWrapper>,
-    );
-
-    const rendered = result.find('IPAddress');
-    const ipText = result.find('.ip').text();
+    const rendered = component.find('[data-qa-ip-main]');
+    const ipText = rendered.text();
 
     expect(rendered).toHaveLength(1);
     expect(ipText).toBe('8.8.8.8');
   });
 
-  it('should render ShowMore with props.items = IPs', () => {
-    const result = mount(
-      <LinodeThemeWrapper>
-        <IPAddress
-          ips={['8.8.8.8', '8.8.4.4']}
-          showMore
-        />
-      </LinodeThemeWrapper>,
-    );
-    const showmore = result.find('ShowMore');
+  it("should not display ShowMore button unless the showMore prop is passed", () => {
+    expect(component.find('[data-qa-ip-more]')).toHaveLength(0);
+  });
 
+  it('should render ShowMore with props.items = IPs', () => {
+    component.setProps({ showMore: true });
+    const showmore = component.find('[data-qa-ip-more]');
     expect(showmore.exists()).toBe(true);
     expect(showmore.prop('items')).toEqual(['8.8.4.4']);
+  });
+
+  it("should show the copy icon if copyRight is true", () => {
+    expect(component.find('[data-qa-copy-ip]')).toHaveLength(0);
+    component.setProps({ copyRight: true });
+    expect(component.find('[data-qa-copy-ip]')).toHaveLength(1);
+  });
+
+  it("should render the copyIcon, but not show it, if copyRight is true and showCopyOnHover is true", () => {
+    expect(component.find('.hide')).toHaveLength(0);
+    component.setProps({ copyRight: true, showCopyOnHover: true });
+    const copy = component.find('[data-qa-copy-ip]');
+    expect(copy).toHaveLength(1);
+    expect(component.find('.hide')).toHaveLength(1);
   });
 
   describe("IP address sorting", () => {

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -69,7 +69,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
 
   },
   show: {
-    opacity: 0, // Hide until the component is hovered,
+    opacity: 0, // Hide until the component is hovered, when props.showCopyOnHover is true
     transition: theme.transitions.create(['opacity']),
   }
 });
@@ -77,6 +77,8 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
 interface Props {
   ips: string[];
   copyRight?: boolean;
+  showCopyOnHover?: boolean;
+  showMore?: boolean;
 }
 
 const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
@@ -106,10 +108,10 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
   }
 
   renderCopyIcon = (ip: string) => {
-    const { classes, copyRight } = this.props;
+    const { classes, copyRight, showCopyOnHover } = this.props;
 
     return (
-      <div className={`${classes.ipLink} ${classes.show}`} data-qa-copy-ip>
+      <div className={`${classes.ipLink} ${showCopyOnHover ? classes.show : ''}`} data-qa-copy-ip>
         <CopyTooltip
           text={ip}
           className={`${classes.icon} ${copyRight ? classes.right : classes.left}`}
@@ -129,7 +131,7 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
   }
 
   render() {
-    const { classes, ips, copyRight } = this.props;
+    const { classes, ips, copyRight, showMore } = this.props;
 
     const formattedIPS = ips
       .map(ip => ip.replace('/64', ''))
@@ -138,15 +140,13 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     return (
       <div className={`dif ${classes.root}`}>
         { this.renderIP(formattedIPS[0], copyRight) }
-        <span className={classes.show}>
         {
-          formattedIPS.length > 1 && <ShowMore
+          formattedIPS.length > 1 && showMore && <ShowMore
             items={tail(formattedIPS)}
             render={(ipsAsArray: string[]) => {
               return ipsAsArray.map((ip, idx) => this.renderIP(ip.replace('/64', ''), copyRight, idx));
             }} />
         }
-        </span>
       </div>
     );
   }

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -34,7 +34,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
       marginBottom: 0,
     },
     '&:hover': {
-      '& $show': {
+      '& $hide': {
         opacity: 1
       }
     }

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -71,6 +71,9 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   hide: {
     opacity: 0, // Hide until the component is hovered, when props.showCopyOnHover is true
     transition: theme.transitions.create(['opacity']),
+    '&:focus': {
+      opacity: 1
+    }
   }
 });
 
@@ -111,10 +114,10 @@ export class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     const { classes, copyRight, showCopyOnHover } = this.props;
 
     return (
-      <div className={`${classes.ipLink} ${showCopyOnHover ? classes.hide : ''}`} data-qa-copy-ip>
+      <div className={`${classes.ipLink}`} data-qa-copy-ip>
         <CopyTooltip
           text={ip}
-          className={`${classes.icon} ${copyRight ? classes.right : classes.left}`}
+          className={`${classes.icon} ${showCopyOnHover ? classes.hide : ''} ${copyRight ? classes.right : classes.left}`}
         />
       </div>
     );

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -138,6 +138,7 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     return (
       <div className={`dif ${classes.root}`}>
         { this.renderIP(formattedIPS[0], copyRight) }
+        <span className={classes.show}>
         {
           formattedIPS.length > 1 && <ShowMore
             items={tail(formattedIPS)}
@@ -145,6 +146,7 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
               return ipsAsArray.map((ip, idx) => this.renderIP(ip.replace('/64', ''), copyRight, idx));
             }} />
         }
+        </span>
       </div>
     );
   }

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -11,7 +11,8 @@ type CSSClasses =  'root'
 | 'icon'
 | 'row'
 | 'ip'
-| 'ipLink';
+| 'ipLink'
+| 'show';
 
 const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   '@keyframes popUp': {
@@ -32,6 +33,11 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     '&:last-child': {
       marginBottom: 0,
     },
+    '&:hover': {
+      '& $show': {
+        opacity: 1
+      }
+    }
   },
   row: {
     display: 'flex',
@@ -60,7 +66,12 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     display: 'inline-block',
     width: 28,
     transition: theme.transitions.create(['color']),
+
   },
+  show: {
+    opacity: 0, // Hide until the component is hovered,
+    transition: theme.transitions.create(['opacity']),
+  }
 });
 
 interface Props {
@@ -98,7 +109,7 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     const { classes, copyRight } = this.props;
 
     return (
-      <div className={classes.ipLink} data-qa-copy-ip>
+      <div className={`${classes.ipLink} ${classes.show}`} data-qa-copy-ip>
         <CopyTooltip
           text={ip}
           className={`${classes.icon} ${copyRight ? classes.right : classes.left}`}

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -12,7 +12,7 @@ type CSSClasses =  'root'
 | 'row'
 | 'ip'
 | 'ipLink'
-| 'show';
+| 'hide';
 
 const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   '@keyframes popUp': {
@@ -68,7 +68,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     transition: theme.transitions.create(['color']),
 
   },
-  show: {
+  hide: {
     opacity: 0, // Hide until the component is hovered, when props.showCopyOnHover is true
     transition: theme.transitions.create(['opacity']),
   }
@@ -86,7 +86,7 @@ const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\
 export const sortIPAddress = (ip1: string, ip2: string) =>
   ((privateIPRegex.test(ip1) ? 1 : -1) - (privateIPRegex.test(ip2) ? 1 : -1));
 
-class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
+export class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
   state = {
     copied: false,
   };
@@ -111,7 +111,7 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     const { classes, copyRight, showCopyOnHover } = this.props;
 
     return (
-      <div className={`${classes.ipLink} ${showCopyOnHover ? classes.show : ''}`} data-qa-copy-ip>
+      <div className={`${classes.ipLink} ${showCopyOnHover ? classes.hide : ''}`} data-qa-copy-ip>
         <CopyTooltip
           text={ip}
           className={`${classes.icon} ${copyRight ? classes.right : classes.left}`}
@@ -124,7 +124,7 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     const { classes } = this.props;
     return (
       <div key={key} className={classes.row}>
-        <div className={`${classes.ip} ${'ip'}`}>{ip}</div>
+        <div className={`${classes.ip} ${'ip'}`} data-qa-ip-main>{ip}</div>
         {copyRight && this.renderCopyIcon(ip)}
       </div>
     );
@@ -145,7 +145,9 @@ class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
             items={tail(formattedIPS)}
             render={(ipsAsArray: string[]) => {
               return ipsAsArray.map((ip, idx) => this.renderIP(ip.replace('/64', ''), copyRight, idx));
-            }} />
+            }}
+            data-qa-ip-more
+          />
         }
       </div>
     );

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -140,8 +140,8 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
               <RegionIndicator region={linodeRegion} />
             </div>
             <div className={classes.cardSection} data-qa-ips>
-              <IPAddress ips={linodeIpv4} copyRight />
-              <IPAddress ips={[linodeIpv6]} copyRight />
+              <IPAddress ips={linodeIpv4} copyRight showMore />
+              <IPAddress ips={[linodeIpv6]} copyRight showMore />
             </div>
             <div className={classes.cardSection} data-qa-image>
               {imageLabel}

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -97,8 +97,8 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
         <LinodeRowBackupCell linodeId={linodeId} mostRecentBackup={mostRecentBackup} />
         <TableCell parentColumn="IP Addresses" className={classes.ipCell} data-qa-ips>
           <div className={classes.ipCellWrapper}>
-            <IPAddress ips={linodeIpv4} copyRight />
-            <IPAddress ips={[linodeIpv6]} copyRight />
+            <IPAddress ips={linodeIpv4} copyRight showCopyOnHover />
+            <IPAddress ips={[linodeIpv6]} copyRight showCopyOnHover />
           </div>
         </TableCell>
         <TableCell parentColumn="Region" className={classes.regionCell} data-qa-region>

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
@@ -50,7 +50,7 @@ const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
             interactive={true}
           >
             <div className={classes.wrapper}>
-              <a className={classes.tagLink}>{tags.length}</a>
+              <a href="javascript:;" className={classes.tagLink}>{tags.length}</a>
             </div>
           </Tooltip>
         : <Typography>0</Typography>

--- a/src/features/linodes/LinodesLanding/OverflowIPs.tsx
+++ b/src/features/linodes/LinodesLanding/OverflowIPs.tsx
@@ -65,7 +65,7 @@ class OverflowIPs extends React.Component<Props & WithStyles<CSSClasses> > {
         >
           {ips.map(ip =>
             <div key={ip}>
-              <IPAddress  ips={[ip]}/>
+              <IPAddress ips={[ip]}/>
             </div>,
           )}
         </Popover>

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1043,16 +1043,16 @@ const themeDefaults: ThemeOptions = {
         transition: 'color 225ms ease-in-out',
         '&:hover': {
           color: primaryColors.main,
+        },
+        '&:focus': {
+          outline: '1px dotted #999',
         }
       },
       active: {
         color: primaryColors.main,
-        '&:focus': {
-          outline: '1px dotted #999',
-          '&:hover': {
-            color: primaryColors.main,
-          }
-        },
+        '&:hover': {
+          color: primaryColors.main,
+        }
       },
       icon: {
         opacity: 1,


### PR DESCRIPTION
## Description

Addresses M3-1914 and M3-2026; on LinodeLanding list view (and nowhere else), the copy IP address icons are hidden by default, and only appear when the IP address is hovered over.

Also on list view (and nowhere else), the `+1` button to view additional IP addresses is hidden.

Added two props (`showCopyOnHover` and `showMore`) to specify this behavior.
## Type of Change
- Non breaking change ('update', 'change')

## Notes

- Added unit tests for the new logic
- Updated existing tests to use `shallow` instead of `mount`