### PR TITLE
Added tests for import groups as tags, and group linodes by tags

### DIFF
--- a/e2e/config/custom-commands.js
+++ b/e2e/config/custom-commands.js
@@ -75,8 +75,8 @@ exports.browserCommands = () => {
         return token;
     });
 
-    browser.addCommand('createLinode', function async(token, password, linodeLabel=false, tags=[], type=undefined, region=undefined) {
-        return createLinode(token, password, linodeLabel, tags, type, region)
+    browser.addCommand('createLinode', function async(token, password, linodeLabel=false, tags=[], type, region, group) {
+        return createLinode(token, password, linodeLabel, tags, type, region, group)
             .then(res => res)
             .catch(err => err);
     });

--- a/e2e/pageobjects/dashboard.page.js
+++ b/e2e/pageobjects/dashboard.page.js
@@ -37,6 +37,8 @@ export class Dashboard extends Page {
     get autoBackupEnrollmentCTA() { return $('[data-qa-account-link]'); }
     get backupExistingLinodes() { return $(this.enableAllBackups.selector); }
     get backupExistingMessage() { return $('[data-qa-linodes-message]'); }
+    get importGroupsAsTagsCta() { return $('[data-qa-group-cta-body]'); }
+    get dismissGroupCTA() { return $('[data-qa-dismiss-cta]'); }
 
     baseElemsDisplay() {
         this.header.waitForVisible(constants.wait.normal);

--- a/e2e/pageobjects/import-groups-as-tags-drawer.page.js
+++ b/e2e/pageobjects/import-groups-as-tags-drawer.page.js
@@ -1,0 +1,20 @@
+const { constants } = require('../constants');
+import Page from './page';
+
+class ImportGroupsAsTagsDrawer extends Page {
+    get linodeGroupList() { return $('[data-qa-linode-group-list]'); }
+    get linodeGroups() { return $$('[data-qa-display-group-item]'); }
+    get domainGroupList() { return $('[data-qa-domain-group-list]'); }
+    get domainGroups() { return $$('[data-qa-domain-group-item]'); }
+    get importMessage() { return $('[data-qa-group-body]')}
+
+    drawerDisplays(){
+        this.drawerBase.waitForVisible(constants.wait.normal);
+        this.submitButton.waitForVisible(constants.wait.normal);
+        this.linodeGroupList.waitForVisible(constants.wait.normal);
+        this.domainGroupList.waitForVisible(constants.wait.normal);
+        expect(this.drawerTitle.getText()).toBe('Import Display Groups as Tags');
+    }
+}
+
+export default new ImportGroupsAsTagsDrawer();

--- a/e2e/pageobjects/list-linodes.js
+++ b/e2e/pageobjects/list-linodes.js
@@ -24,6 +24,11 @@ export class ListLinodes extends Page {
     get gridToggle() { return $('[data-qa-view="grid"]'); }
     get status() { return $('[data-qa-status]') }
     get tableHead() { return $('[data-qa-table-head]'); }
+    get tagHeaderSelector() { return 'data-qa-tag-header'; }
+    get tagHeaders() { return $$(`[${this.tagHeaderSelector}]`); }
+    get groupByTagsToggle() { return $$('span').find(it => it.getText().includes('Group by Tag')).$('..'); }
+    get linodeSortAttribute() { return 'data-qa-sort-label'; }
+    get sortLinodesByLabel() { return $(`[${this.linodeSortAttribute}]`); }
 
     // Action Menu Items
     get powerOffMenu() { return $('[data-qa-action-menu-item="Power Off"]'); }
@@ -53,6 +58,21 @@ export class ListLinodes extends Page {
 
     getLinodeSelector(linode){
         return `[data-qa-linode="${linode}"]`;
+    }
+
+    getLinodeTags(linode){
+        return $(this.getLinodeSelector(linode)).$$(this.tag.selector)
+            .map(tag => tag.getText());
+    }
+
+    tagHeader(tag){
+        return $(`[${this.tagHeaderSelector}=${tag}]`);
+    }
+
+    getLinodesInTagsGroup(tag){
+        const attribute = this.linodeElem.selector.substr(1).slice(0, -1);
+        return this.tagHeader(tag).$$(this.linodeElem.selector)
+            .map(linode => linode.getAttribute(attribute));
     }
 
     navigateToDetail(linode) {

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -47,9 +47,7 @@ export default class Page {
     get enableAllBackups() { return $('[data-qa-backup-existing]'); }
     get basicSelect() { return '[data-qa-select]'; }
     get pageTitle() { return $('[data-qa-title]'); }
-
-
-    // Breadcrumb Component
+    get openImportDrawerButton() { return $('[data-qa-open-import-drawer-button]'); }
     get breadcrumbEditableText() { return $('[data-qa-editable-text]'); }
     get breadcrumbStaticText() { return $('[data-qa-label-title]'); }
     get breadcrumbBackLink() { return $('[data-qa-link]'); }

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -115,7 +115,7 @@ exports.removeAllLinodes = token => {
     });
 }
 
-exports.createLinode = (token, password, linodeLabel, tags, type, region) => {
+exports.createLinode = (token, password, linodeLabel, tags, type, region, group) => {
     return new Promise((resolve, reject) => {
         const linodesEndpoint = '/linode/instances';
 
@@ -134,6 +134,10 @@ exports.createLinode = (token, password, linodeLabel, tags, type, region) => {
 
         if (!isEmpty(tags)) {
             linodeConfig['tags'] = tags;
+        }
+
+        if(group) {
+            linodeConfig['group'] = group;
         }
 
         return getAxiosInstance(token).post(linodesEndpoint, linodeConfig)

--- a/e2e/specs/tagmanagement/group-by-tags-linode.spec.js
+++ b/e2e/specs/tagmanagement/group-by-tags-linode.spec.js
@@ -1,0 +1,127 @@
+const { constants } = require('../../constants');
+import {
+    timestamp,
+    apiCreateMultipleLinodes,
+    apiDeleteAllLinodes,
+    getLocalStorageValue,
+} from '../../utils/common';
+import ListLinodes from '../../pageobjects/list-linodes';
+
+describe('Group Linodes by Tags - Suite', () => {
+
+    const tags = [`a${timestamp()}`,`b${timestamp()}`,`c${timestamp()}`];
+    let linodes = [];
+
+    const generateTagGroups = () => {
+        tags.forEach((tag) => {
+            const lin = {
+                linodeLabel: `A${tag}${timestamp()}`,
+                tags: [tag]
+            }
+            const lin1 = {
+                linodeLabel: `B${tag}${timestamp()}`,
+                tags: [tag]
+            }
+            linodes.push(lin);
+            linodes.push(lin1);
+        });
+    }
+
+    const checkGroupedByTags = () => {
+        tags.forEach((tag) => {
+            const expectedLinodes = linodes.filter(linode => linode.tags[0] === tag)
+                .map(filteredLinode => filteredLinode.linodeLabel);
+            const displayedGroup = ListLinodes.getLinodesInTagsGroup(tag);
+            expect(displayedGroup.sort()).toEqual(expectedLinodes.sort());
+        });
+    }
+
+    const checkSortOrder = () => {
+        const ascOrDesc = ListLinodes.sortLinodesByLabel.getAttribute(ListLinodes.linodeSortAttribute);
+        tags.forEach((tag) => {
+            const linodesInGroup = ListLinodes.getLinodesInTagsGroup(tag);
+            ascOrDesc === 'asc' ? expect(linodesInGroup).toEqual(linodesInGroup.sort().reverse()) :
+              expect(linodesInGroup).toEqual(linodesInGroup.sort())
+        });
+    }
+
+    const tagGroupsInAlphabeticalOrder = () => {
+        const tagHeaders = ListLinodes.tagHeaders
+            .map(header => header.getAttribute(ListLinodes.tagHeaderSelector));
+        expect(tagHeaders).toEqual(tags.sort());
+    }
+
+    beforeAll(() => {
+        generateTagGroups();
+        apiCreateMultipleLinodes(linodes);
+        browser.pause(1000);
+    });
+
+    afterAll(() => {
+        apiDeleteAllLinodes();
+    });
+
+    it('Group by tag toggle is present and off by default', () => {
+        expect(ListLinodes.groupByTagsToggle.isVisible()).toBe(true);
+        expect(ListLinodes.tagHeaders.length).toBe(0);
+    });
+
+    it('Group linodes by tags', () => {
+        ListLinodes.groupByTagsToggle.click();
+        browser.waitUntil(() => {
+            return ListLinodes.tagHeaders.length > 0;
+        },constants.wait.normal);
+    });
+
+    describe('Grouped Linodes - List View', () => {
+
+        it('Linodes are groupped by tags', () => {
+            checkGroupedByTags();
+        });
+
+        it('Tag groups are displayed in alphabetical order', () => {
+            tagGroupsInAlphabeticalOrder();
+        });
+
+        it('Linodes are sortable within tag groups', () => {
+            expect(ListLinodes.sortLinodesByLabel.isVisible()).toBe(true);
+            [1,2].forEach((iterator) => {
+                ListLinodes.sortLinodesByLabel.$('svg').click();
+                browser.pause(500);
+                checkSortOrder();
+            });
+        });
+
+    });
+
+    describe('Grouped Linodes - Grid View', () => {
+
+        beforeAll(() => {
+            ListLinodes.switchView('grid');
+            browser.waitUntil(() => {
+                return browser.getUrl().includes('?view=grid')
+            });
+        })
+
+        it('Linodes are groupped by tags', () => {
+            checkGroupedByTags();
+        });
+
+        it('Tag groups are displayed in alphabetical order', () => {
+            tagGroupsInAlphabeticalOrder();
+        });
+
+    });
+
+    it('Ungroup Linodes', () => {
+        ListLinodes.groupByTagsToggle.click();
+        browser.waitUntil(() => {
+          return ListLinodes.tagHeaders.length === 0;
+        },constants.wait.normal);
+        ListLinodes.switchView('list');
+        browser.waitUntil(() => {
+            return browser.getUrl().includes('?view=list')
+        });
+        expect(ListLinodes.tagHeaders.length).toBe(0);
+    });
+});

--- a/e2e/specs/tagmanagement/group-by-tags-linode.spec.js
+++ b/e2e/specs/tagmanagement/group-by-tags-linode.spec.js
@@ -9,7 +9,7 @@ import ListLinodes from '../../pageobjects/list-linodes';
 
 describe('Group Linodes by Tags - Suite', () => {
 
-    const tags = [`a${timestamp()}`,`b${timestamp()}`,`c${timestamp()}`];
+    const tags = [`b${timestamp()}`,`a${timestamp()}`,`c${timestamp()}`];
     let linodes = [];
 
     const generateTagGroups = () => {

--- a/e2e/specs/tagmanagement/import-groups-as-tags-linodes.spec.js
+++ b/e2e/specs/tagmanagement/import-groups-as-tags-linodes.spec.js
@@ -1,0 +1,79 @@
+const { constants } = require('../../constants');
+import {
+    timestamp,
+    apiCreateMultipleLinodes,
+    apiDeleteAllLinodes,
+    getLocalStorageValue,
+} from '../../utils/common';
+import Dashboard from '../../pageobjects/dashboard.page';
+import ListLinodes from '../../pageobjects/list-linodes';
+import GlobalSettings from '../../pageobjects/account/global-settings.page';
+import ImportGroupsAsTagsDrawer from '../../pageobjects/import-groups-as-tags-drawer.page';
+
+describe('Import Display Groups as Tags - Linodes Suite', () => {
+    const linode = {
+        linodeLabel: `AutoLinode${timestamp()}`,
+        group: `group${timestamp()}`
+    }
+    const linode1 = {
+        linodeLabel: `AutoLinode1${timestamp()}`,
+        group: `group1${timestamp()}`
+    }
+    const importMessage = 'You now have the ability to import your Display Groups from Classic Manager as tags and they will be associated with your Domains and Linodes. This will give you the ability to organize and view your Linodes by tags. Your existing tags will not be affected.';
+
+    beforeAll(() => {
+        apiCreateMultipleLinodes([linode,linode1]);
+        browser.url(constants.routes.dashboard);
+    });
+
+    afterAll(() => {
+        apiDeleteAllLinodes();
+    });
+
+    it('Import Groups as Tags CTA is displayed on Dashboard', () => {
+        Dashboard.baseElemsDisplay();
+        expect(Dashboard.openImportDrawerButton.isVisible()).toBe(true);
+        expect(Dashboard.importGroupsAsTagsCta.getText()).toEqual(importMessage);
+    });
+
+    it('Clicking the import groups as tags buttons opens the import drawer', () => {
+        Dashboard.openImportDrawerButton.click();
+        ImportGroupsAsTagsDrawer.drawerDisplays();
+        expect(ImportGroupsAsTagsDrawer.importMessage.getText()).toEqual(importMessage);
+        const groupsToImport = ImportGroupsAsTagsDrawer.linodeGroups
+            .map(group => group.getText().replace('- ',''));
+        expect(groupsToImport.sort()).toEqual([linode.group,linode1.group].sort());
+        ImportGroupsAsTagsDrawer.drawerClose.click();
+        Dashboard.drawerBase.waitForVisible(constants.wait.normal, true);
+    });
+
+    it('Dismiss group CTA, verify local storage', () => {
+        Dashboard.dismissGroupCTA.click();
+        Dashboard.importGroupsAsTagsCta.waitForVisible(constants.wait.normal, true);
+        expect(Dashboard.openImportDrawerButton.isVisible()).toBe(false);
+        expect(getLocalStorageValue('importDisplayGroupsCTA')).toBe('true');
+    });
+
+    it('Import display groups button is displayed on Global Settings page', () => {
+        browser.url(constants.routes.account.globalSettings);
+        GlobalSettings.baseElementsDisplay();
+        expect(GlobalSettings.openImportDrawerButton.isVisible()).toBe(true);
+    });
+
+    it('Import display groups as tags, verify local storage', () => {
+        GlobalSettings.openImportDrawerButton.click();
+        ImportGroupsAsTagsDrawer.drawerDisplays();
+        ImportGroupsAsTagsDrawer.submitButton.click();
+        GlobalSettings.drawerBase.waitForVisible(constants.wait.long);
+        GlobalSettings.toastDisplays('Your display groups have been imported successfully.');
+        expect(getLocalStorageValue('hasImportedGroups')).to('true');
+    });
+
+    it('Verify groups are imported as tags', () => {
+        browser.url(constants.routes.linodes);
+        [linode,linode1].forEach((linode) => {
+            $(ListLinodes.getLinodeSelector(linode.linodeLabel)).waitForVisible(constants.wait.noraml);
+            expect(ListLinodes.getLinodeTags(linode.linodeLabel)).toEqual([linode.group.toLowerCase()]);
+        });
+    });
+});

--- a/e2e/specs/tagmanagement/import-groups-as-tags-linodes.spec.js
+++ b/e2e/specs/tagmanagement/import-groups-as-tags-linodes.spec.js
@@ -66,7 +66,7 @@ describe('Import Display Groups as Tags - Linodes Suite', () => {
         ImportGroupsAsTagsDrawer.submitButton.click();
         GlobalSettings.drawerBase.waitForVisible(constants.wait.long);
         GlobalSettings.toastDisplays('Your display groups have been imported successfully.');
-        expect(getLocalStorageValue('hasImportedGroups')).to('true');
+        expect(getLocalStorageValue('hasImportedGroups')).toBe('true');
     });
 
     it('Verify groups are imported as tags', () => {

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -55,10 +55,10 @@ export const createLinodeIfNone = () => {
     }
 }
 
-export const apiCreateLinode = (linodeLabel=false, privateIp=false, tags=[], type=undefined, region=undefined) => {
+export const apiCreateLinode = (linodeLabel=false, privateIp=false, tags=[], type, region, group) => {
     const token = readToken(browser.options.testUser);
     const newLinodePass = crypto.randomBytes(20).toString('hex');
-    const linode = browser.createLinode(token, newLinodePass, linodeLabel, tags, type, region);
+    const linode = browser.createLinode(token, newLinodePass, linodeLabel, tags, type, region, group);
 
     browser.url(constants.routes.linodes);
     browser.waitForVisible('[data-qa-add-new-menu-button]', constants.wait.normal);
@@ -76,7 +76,7 @@ export const apiCreateLinode = (linodeLabel=false, privateIp=false, tags=[], typ
 
     arrayOfLinodeCreateObj.forEach((linodeObj) => {
         const newLinodePass = crypto.randomBytes(20).toString('hex');
-        const linode = browser.createLinode(token, newLinodePass, linodeObj.linodeLabel, linodeObj.tags, linodeObj.type, linodeObj.region);
+        const linode = browser.createLinode(token, newLinodePass, linodeObj.linodeLabel, linodeObj.tags, linodeObj.type, linodeObj.region,linodeObj.group);
         linodes.push(linode);
     });
 
@@ -218,4 +218,9 @@ export const getDistrobutionLabel = (distrobutionTags) => {
         distrobutionLabel.push(distroDetails.label);
     });
     return distrobutionLabel;
+}
+
+export const getLocalStorageValue = (key) => {
+    console.log(browser.localStorage('GET', key));
+    return browser.localStorage('GET', key).value;
 }

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -221,6 +221,5 @@ export const getDistrobutionLabel = (distrobutionTags) => {
 }
 
 export const getLocalStorageValue = (key) => {
-    console.log(browser.localStorage('GET', key));
     return browser.localStorage('GET', key).value;
 }

--- a/src/features/Account/ImportGroupsAsTags.test.tsx
+++ b/src/features/Account/ImportGroupsAsTags.test.tsx
@@ -18,7 +18,7 @@ describe('Component', () => {
     expect(component).toBeDefined();
   });
   it('should open the tag import drawer on click', () => {
-    component.find('[data-qa-open-group-import-drawer]').simulate('click');
+    component.find('[data-qa-open-import-drawer-button]').simulate('click');
     expect(props.openDrawer).toHaveBeenCalled();
   });
 });

--- a/src/features/Account/ImportGroupsAsTags.tsx
+++ b/src/features/Account/ImportGroupsAsTags.tsx
@@ -30,7 +30,7 @@ export const ImportGroupsAsTags: React.StatelessComponent<CombinedProps> = (prop
       <Typography variant="body1" className={classes.helperText}>
         You now have the ability to import your Display Groups from Classic Manager as tags and they will be associated with your Domains and Linodes. This will give you the ability to organize and view your Linodes by tags. <strong>Your existing tags will not be affected.</strong>
       </Typography>
-      <Button type="primary" onClick={openDrawer} data-qa-open-group-import-drawer>
+      <Button type="primary" onClick={openDrawer} data-qa-open-import-drawer-button>
         Import Display Groups
       </Button>
     </ExpansionPanel>

--- a/src/features/TagImport/TagImportDrawer.tsx
+++ b/src/features/TagImport/TagImportDrawer.tsx
@@ -85,7 +85,7 @@ export const TagImportDrawer: React.StatelessComponent<CombinedProps> = (props) 
       >
         <Grid container direction={'column'} >
           <Grid item>
-            <Typography variant="body1">
+            <Typography variant="body1" data-qa-group-body>
               You now have the ability to import your Display Groups from Classic Manager as tags and they will be associated with your Domains and Linodes. This will give you the ability to organize and view your Linodes by tags. <strong>Your existing tags will not be affected.</strong>
             </Typography>
           </Grid>

--- a/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -81,7 +81,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<CombinedProps> = (props) =
       <>
         {orderedGroupedLinodes.map(([tag, linodes]) => {
           return (
-            <div key={tag} className={classes.tagGridRow}>
+            <div key={tag} className={classes.tagGridRow} data-qa-tag-header={tag}>
               <Grid container>
                 <Grid item xs={12}>
                   <div className={classes.tagHeaderOuter}>
@@ -137,7 +137,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<CombinedProps> = (props) =
                   const finalProps = { ...rest, data: paginatedData, pageSize, page, handlePageSizeChange, handlePageChange, handleOrderChange, order, orderBy, };
                   return (
                     <React.Fragment>
-                      <TableBody className={classes.groupContainer}>
+                      <TableBody className={classes.groupContainer} data-qa-tag-header={tag}>
                         <TableRow className={classes.tagHeaderRow}>
                           <TableCell colSpan={7}><Typography variant="h2" component="h3" className={classes.tagHeader}>{tag}</Typography></TableCell>
                         </TableRow>

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -251,7 +251,9 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                 <Toggle
                   className={(this.props.groupByTags ? ' checked' : ' unchecked')}
                   onChange={this.props.toggleGroupByTag}
-                  checked={this.props.groupByTags} />
+                  checked={this.props.groupByTags}
+                  data-qa-tags-toggle={this.props.groupByTags}
+                  />
               }
               label="Group by Tag:"
             />

--- a/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -18,6 +18,7 @@ const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = 
           direction={order}
           active={isActive('label')}
           handleClick={handleOrderChange}
+          data-qa-sort-label={order}
         >
           Linode
         </TableSortCell>
@@ -29,6 +30,7 @@ const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = 
           direction={order}
           active={isActive('region')}
           handleClick={handleOrderChange}
+          data-qa-sort-region={order}
         >
           Region
         </TableSortCell>


### PR DESCRIPTION
## Description
**Test 1:**
- Create linodes with display group
- Verify import groups as tags CTA displays on dashboard
- Open import drawer verify expected elements and group display
- Dismiss drawer, verify flag in local storage
- Navigate to account global settings, verify import groups as tags button displays
- Import groups, verify flag in local storage
- Navigate to linode landing page, verify tags applied

**Test 2:** 
- Create 3 groups with 2 linodes
- Group by tag in list view
- Verify linodes are grouped properly
- Sort linodes asc desc verify group sorting logic
- Verify group by tags in grid view
- Ungroup verify linode listing
 
## Type of Change
- Test

## Note to Reviewers
`yarn && yarn start` new shell `yarn selenium` new shell `yarn e2e:modified`
