### PR TITLE
M3-2193 Update: Style new group domain by tag switch

### DIFF
--- a/src/features/Domains/DomainTableRow.tsx
+++ b/src/features/Domains/DomainTableRow.tsx
@@ -17,6 +17,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   domainRow: {
     height: 75,
+    backgroundColor: theme.bg.white,
   },
   tagWrapper: {
     marginTop: theme.spacing.unit / 2,

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -30,13 +30,18 @@ import { sendEvent } from 'src/utilities/analytics';
 import DomainZoneImportDrawer from './DomainZoneImportDrawer';
 
 type ClassNames = 'root'
+  | 'titleWrapper'
   | 'title'
   | 'domain'
   | 'tagWrapper'
-  | 'domainRow';
+  | 'domainRow'
+  | 'tagGroup';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
+  titleWrapper: {
+    flex: 1,
+  },
   title: {
     marginBottom: theme.spacing.unit * 2,
   },
@@ -52,6 +57,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
       cursor: 'pointer',
     },
   },
+  tagGroup: {
+    flexDirection: 'row-reverse',
+    marginBottom: theme.spacing.unit -2,
+  }
 });
 
 interface State {
@@ -186,21 +195,24 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <FormControlLabel
-          control={
-            <Toggle
-              className={(this.props.groupByTag ? ' checked' : ' unchecked')}
-              onChange={(e, checked) => this.props.toggleGroupByTag(checked)}
-              checked={this.props.groupByTag} />
-          }
-          label="Group by Tag:"
-        />
         <DocumentTitleSegment segment="Domains" />
         <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }} >
-          <Grid item>
+          <Grid item className={classes.titleWrapper}>
             <Typography role="header" variant="h1" data-qa-title className={classes.title}>
               Domains
-                    </Typography>
+            </Typography>
+          </Grid>
+          <Grid item>
+            <FormControlLabel
+              className={classes.tagGroup}
+              control={
+                <Toggle
+                  className={(this.props.groupByTag ? ' checked' : ' unchecked')}
+                  onChange={(e, checked) => this.props.toggleGroupByTag(checked)}
+                  checked={this.props.groupByTag} />
+                  }
+                  label="Group by Tag:"
+              />
           </Grid>
           <Grid item>
             <Grid container alignItems="flex-end" style={{ width: 'auto' }}>

--- a/src/features/Domains/DomainsTableWrapper.tsx
+++ b/src/features/Domains/DomainsTableWrapper.tsx
@@ -6,19 +6,22 @@ import { OrderByProps } from 'src/components/OrderBy';
 import Table from 'src/components/Table';
 import SortableTableHead from './SortableTableHead';
 
-type ClassNames = 'root';
+type ClassNames = 'root' | 'paperWrapper';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
+  paperWrapper: {
+    backgroundColor: 'transparent',
+  }
 });
 
 type CombinedProps = Omit<OrderByProps, 'data'> & WithStyles<ClassNames>;
 
 const DomainsTableWrapper: React.StatelessComponent<CombinedProps> = (props) => {
-  const { order, orderBy, handleOrderChange } = props;
+  const { order, orderBy, handleOrderChange, classes } = props;
 
   return (
-    <Paper>
+    <Paper className={classes.paperWrapper}>
       <Grid container className="my0">
         <Grid item xs={12} className="py0">
           <Table arial-label="List of Linodes">


### PR DESCRIPTION
## Style new group domain by tag switch

We do not have design to place the new switch for the group by domain landing page table. The best option is to use the same convention as the linode landing for now and place it inline with the other CTA and title

## Type of Change
- Non breaking change
