### PR TITLE
M3-2195 Fix community events, make all clickable.

### DIFF
--- a/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -119,6 +119,9 @@ const createClickHandlerForNotification = (
           return (e: React.MouseEvent<HTMLElement>) => onClick(`/nodebalancers/${id}/summary`);
       }
 
+    case 'community_question':
+      return () => { window.open(entity!.url, '_blank') };
+
     case 'community_like':
       return () => { window.open(entity!.url, '_blank') };
 


### PR DESCRIPTION
## Description

Replies and mentions on Community Questions and Answers generate events that haven't been clickable. This is changed so that these events are clickable and take you to the appropriate url.

## Note to Reviewers

You should be able to see the clickable events by using two users:
Create a question for user 1.
Reply to the question as user 2.
Check notifications as user 1.
Click community question event.
You should be directed to the question.

This will also work for mentioned users.