### PR TITLE
M3-2179 - Added Domain tag management tests

### DIFF
--- a/e2e/config/custom-commands.js
+++ b/e2e/config/custom-commands.js
@@ -16,6 +16,7 @@ const {
     getGlobalSettings,
     createVolume,
     getLinodeImage,
+    createDomain,
 } = require('../setup/setup');
 
 const {
@@ -220,6 +221,11 @@ exports.browserCommands = () => {
 
     browser.addCommand('getLinodeImage', function async(token,imageId) {
         return getLinodeImage(token,imageId)
+            .then(res => res);
+    });
+
+    browser.addCommand('createDomain', function async(token,type,domain,tags,group) {
+        return createDomain(token,type,domain,tags,group)
             .then(res => res);
     });
 }

--- a/e2e/pageobjects/import-groups-as-tags-drawer.page.js
+++ b/e2e/pageobjects/import-groups-as-tags-drawer.page.js
@@ -3,9 +3,9 @@ import Page from './page';
 
 class ImportGroupsAsTagsDrawer extends Page {
     get linodeGroupList() { return $('[data-qa-linode-group-list]'); }
-    get linodeGroups() { return $$('[data-qa-display-group-item]'); }
+    get linodeGroups() { return $$('[data-qa-display-group-item="Linode"]'); }
     get domainGroupList() { return $('[data-qa-domain-group-list]'); }
-    get domainGroups() { return $$('[data-qa-domain-group-item]'); }
+    get domainGroups() { return $$('[data-qa-display-group-item="Domain"]'); }
     get importMessage() { return $('[data-qa-group-body]')}
 
     drawerDisplays(){

--- a/e2e/pageobjects/list-domains.page.js
+++ b/e2e/pageobjects/list-domains.page.js
@@ -11,16 +11,18 @@ class ListDomains extends Page {
     get domainNameHeader() { return $('[data-qa-domain-name-header]'); }
     get domainTypeHeader() { return $('[data-qa-domain-type-header]'); }
     get domainDrawer() { return $('[data-qa-drawer]'); }
-    get domains() { return $$('[data-qa-domain-cell]'); }
-    get domainElem() { return $('[data-qa-domain-cell]'); }
+    get domainAttribute() { return 'data-qa-domain-cell'; }
+    get domains() { return $$(`[${this.domainAttribute}]`); }
+    get domainElem() { return $(`[${this.domainAttribute}]`); }
     get label() { return $('[data-qa-domain-label]'); }
     get type() { return $('[data-qa-domain-type]'); }
-
     get createSoaEmail() { return $('[data-qa-soa-email]'); }
     get createDomainName() { return $('[data-qa-domain-name]'); }
     get cloneDomainName() { return $('[data-qa-clone-name]'); }
-    get cancel() { return $(this.cancelButton.selector); }
-    get submit() { return $(this.submitButton.selector); }
+    get cancel() { return this.cancelButton; }
+    get submit() { return this.submitButton; }
+    get domainSortAtttribute() { return 'data-qa-sort-domain'; }
+    get typeSortAttribure() { return 'data-qa-sort-type'; }
 
     baseElemsDisplay(placeholder) {
         if (placeholder) {
@@ -136,6 +138,33 @@ class ListDomains extends Page {
         this.submit.click();
         this.dialogTitle.waitForVisible(constants.wait.normal, true);
         domain.waitForVisible(constants.wait.normal, true);
+    }
+
+    domainRow(domain){
+        const selector = this.domainElem.selector.replace(']','');
+        return $(`${selector}="${domain}"`);
+    }
+
+    getDomainTags(domain){
+        this.domainRow(domain).waitForVisible(constants.wait.normal);
+        return this.domainRow(domain).$$(this.tag.selector)
+            .map(tag => tag.getText());
+    }
+
+    getDomainsInTagGroup(tag){
+        return this.tagHeader(tag).$$(this.domainElem.selector)
+            .map(domain => domain.getAttribute(this.domainAttribute));
+    }
+
+    sortTableByHeader(header){
+        const selector = header.toLowerCase() === 'domain' ?  this.domainSortAtttribute : this.typeSortAttribure;
+        const start = $(`[${selector}]`).getAttribute(selector);
+        $(`[${selector}]`).$('svg').click();
+        browser.pause(1000);
+        browser.waitUntil(() => {
+            return $(`[${selector}]`).getAttribute(selector) !== start;
+        }, constants.wait.normal);
+        return $(`[${selector}]`).getAttribute(selector);
     }
 }
 

--- a/e2e/pageobjects/list-linodes.js
+++ b/e2e/pageobjects/list-linodes.js
@@ -24,9 +24,6 @@ export class ListLinodes extends Page {
     get gridToggle() { return $('[data-qa-view="grid"]'); }
     get status() { return $('[data-qa-status]') }
     get tableHead() { return $('[data-qa-table-head]'); }
-    get tagHeaderSelector() { return 'data-qa-tag-header'; }
-    get tagHeaders() { return $$(`[${this.tagHeaderSelector}]`); }
-    get groupByTagsToggle() { return $$('span').find(it => it.getText().includes('Group by Tag')).$('..'); }
     get linodeSortAttribute() { return 'data-qa-sort-label'; }
     get sortLinodesByLabel() { return $(`[${this.linodeSortAttribute}]`); }
 
@@ -63,10 +60,6 @@ export class ListLinodes extends Page {
     getLinodeTags(linode){
         return $(this.getLinodeSelector(linode)).$$(this.tag.selector)
             .map(tag => tag.getText());
-    }
-
-    tagHeader(tag){
-        return $(`[${this.tagHeaderSelector}=${tag}]`);
     }
 
     getLinodesInTagsGroup(tag){

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -55,6 +55,9 @@ export default class Page {
     get breadcrumbEditButton() { return $('[data-qa-edit-button]'); }
     get breadcrumbSaveEdit() { return $('[data-qa-save-edit]'); }
     get breadcrumbCancelEdit() { return $('[data-qa-cancel-edit]'); }
+    get groupByTagsToggle() { return $$('span').find(it => it.getText().includes('Group by Tag')).$('..'); }
+    get tagHeaderSelector() { return 'data-qa-tag-header'; }
+    get tagHeaders() { return $$(`[${this.tagHeaderSelector}]`); }
     get enterKey() { return '\uE007'; }
     get upArrowKey() { return '\ue013'; }
 
@@ -249,5 +252,22 @@ export default class Page {
 
     addIcon(iconText){
         return $(`[data-qa-icon-text-link="${iconText}"]`);
+    }
+
+    tagHeader(tag){
+        return $(`[${this.tagHeaderSelector}=${tag}]`);
+    }
+
+    groupByTags(group){
+        this.groupByTagsToggle.click();
+        browser.waitUntil(() => {
+          return group ? this.tagHeaders.length > 0 : this.tagHeaders.length === 0;
+        },constants.wait.normal);
+    }
+
+    tagGroupsInAlphabeticalOrder(tags){
+        const tagHeaders = this.tagHeaders
+            .map(header => header.getAttribute(this.tagHeaderSelector));
+        expect(tagHeaders).toEqual(tags.sort());
     }
 }

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -249,6 +249,32 @@ exports.removeAllVolumes = token => {
     });
 }
 
+exports.createDomain = (token,type,domain,tags,group) => {
+    return new Promise((resolve, reject) => {
+        const endpoint = '/domains';
+        const domainConfig = {
+            type: type ? type : 'master',
+            domain: domain,
+            soa_email: 'fake@gmail.com'
+        }
+
+        if(group){
+            domainConfig['group'] = group;
+        }
+
+        if(tags){
+            domainConfig['tags'] = tags;
+        }
+
+        return getAxiosInstance(token).post(endpoint,domainConfig)
+            .then(response => resolve(response.data))
+            .catch(error => {
+                console.error('Error', error);
+                reject(error);
+            });
+    });
+}
+
 exports.getDomains = token => {
     return new Promise((resolve, reject) => {
         const endpoint = '/domains';

--- a/e2e/specs/tagmanagement/group-by-tags-linode.spec.js
+++ b/e2e/specs/tagmanagement/group-by-tags-linode.spec.js
@@ -67,10 +67,7 @@ describe('Group Linodes by Tags - Suite', () => {
     });
 
     it('Group linodes by tags', () => {
-        ListLinodes.groupByTagsToggle.click();
-        browser.waitUntil(() => {
-            return ListLinodes.tagHeaders.length > 0;
-        },constants.wait.normal);
+        ListLinodes.groupByTags(true);
     });
 
     describe('Grouped Linodes - List View', () => {
@@ -80,7 +77,7 @@ describe('Group Linodes by Tags - Suite', () => {
         });
 
         it('Tag groups are displayed in alphabetical order', () => {
-            tagGroupsInAlphabeticalOrder();
+            ListLinodes.tagGroupsInAlphabeticalOrder(tags);
         });
 
         it('Linodes are sortable within tag groups', () => {
@@ -108,16 +105,13 @@ describe('Group Linodes by Tags - Suite', () => {
         });
 
         it('Tag groups are displayed in alphabetical order', () => {
-            tagGroupsInAlphabeticalOrder();
+            ListLinodes.tagGroupsInAlphabeticalOrder(tags);
         });
 
     });
 
     it('Ungroup Linodes', () => {
-        ListLinodes.groupByTagsToggle.click();
-        browser.waitUntil(() => {
-          return ListLinodes.tagHeaders.length === 0;
-        },constants.wait.normal);
+        ListLinodes.groupByTags(false);
         ListLinodes.switchView('list');
         browser.waitUntil(() => {
             return browser.getUrl().includes('?view=list')

--- a/e2e/specs/tagmanagement/import-groups-and-group-by-tag-domains.spec.js
+++ b/e2e/specs/tagmanagement/import-groups-and-group-by-tag-domains.spec.js
@@ -1,0 +1,108 @@
+const { constants } = require('../../constants');
+import {
+    apiCreateDomains,
+    apiDeleteAllDomains,
+    timestamp,
+} from '../../utils/common';
+import Dashboard from '../../pageobjects/dashboard.page';
+import ImportGroupsAsTagsDrawer from '../../pageobjects/import-groups-as-tags-drawer.page';
+import ListDomains from '../../pageobjects/list-domains.page';
+
+describe('Domain Tag Management Suite', () => {
+
+    const groupsAsTags = [`a${timestamp().toLowerCase()}`, `b${timestamp().toLowerCase()}`];
+    let domains = [];
+
+    const generateDomainGroups = () => {
+        groupsAsTags.forEach(group => {
+            for(let i = 0; i < 3; i++){
+                const domain = {
+                    domain: `test${group}${i}.com`,
+                    group: group
+                }
+                domains.push(domain);
+            }
+        });
+    }
+
+    const domainsInGroup = (group) => {
+      return domains.filter(domain => domain.group === group)
+          .map(domain => domain.domain);
+    }
+
+    const checkSortOrder = () => {
+      const order = ListDomains.sortTableByHeader('Domains');
+      groupsAsTags.forEach((tag) => {
+          const expectedDomainsInGroup = domainsInGroup(tag);
+          const expectedOrder = order === 'asc' ? expectedDomainsInGroup.sort() : expectedDomainsInGroup.sort().reverse();
+          expect(ListDomains.getDomainsInTagGroup(tag)).toEqual(expectedOrder);
+      });
+    }
+
+    beforeAll(() => {
+        generateDomainGroups();
+        apiCreateDomains(domains);
+        browser.url(constants.routes.dashboard);
+        Dashboard.baseElemsDisplay();
+    });
+
+    afterAll(() => {
+        apiDeleteAllDomains();
+    });
+
+    describe('Import Domain Groups as Tags', function() {
+
+        it('Import domain groups as tags', () => {
+            Dashboard.openImportDrawerButton
+            Dashboard.openImportDrawerButton.click();
+            ImportGroupsAsTagsDrawer.drawerDisplays();
+            const groupsToImport = ImportGroupsAsTagsDrawer.domainGroups
+                .map(group => group.getText().replace('- ',''));
+            expect(groupsToImport.sort()).toEqual(groupsAsTags.sort());
+            ImportGroupsAsTagsDrawer.submitButton.click();
+            Dashboard.drawerBase.waitForVisible(constants.wait.minute,true);
+            Dashboard.toastDisplays('Your display groups have been imported successfully.');
+        });
+
+        it('Verify display groups are applied as tags to Domains', () => {
+            browser.url(constants.routes.domains);
+            ListDomains.baseElemsDisplay();
+            groupsAsTags.forEach((tag) => {
+                const domainsInGroup = domains.filter(domain => domain.group === tag);
+                domainsInGroup.forEach((domain) => {
+                    const domainTag = ListDomains.getDomainTags(domain.domain);
+                    expect(domainTag).toEqual([domain.group])
+                });
+            });
+        });
+    });
+
+    describe('Group Domains by Tag', () => {
+
+        it('Group Domain by Tag', () => {
+            expect(ListDomains.groupByTagsToggle.isVisible()).toBe(true);
+            ListDomains.groupByTags(true);
+        });
+
+        it('Domains are properly grouped', () => {
+            groupsAsTags.forEach((tag) => {
+                const expectedDomainsInGroup = domainsInGroup(tag);
+                expect(ListDomains.getDomainsInTagGroup(tag).sort()).toEqual(expectedDomainsInGroup.sort());
+            });
+        });
+
+        it('Tag Groups are displayed in alphabetical order', () => {
+            ListDomains.tagGroupsInAlphabeticalOrder(groupsAsTags);
+        });
+
+        it('Domains are sortable within tag groups', () => {
+            [1,2].forEach(i => checkSortOrder());
+        });
+
+        it('Domains can be ungrouped by tags', () => {
+            ListDomains.groupByTags(false);
+            expect(ListDomains.tagHeaders.length).toBe(0);
+        });
+    });
+
+});

--- a/e2e/specs/tagmanagement/import-groups-as-tags-linodes.spec.js
+++ b/e2e/specs/tagmanagement/import-groups-as-tags-linodes.spec.js
@@ -64,7 +64,7 @@ describe('Import Display Groups as Tags - Linodes Suite', () => {
         GlobalSettings.openImportDrawerButton.click();
         ImportGroupsAsTagsDrawer.drawerDisplays();
         ImportGroupsAsTagsDrawer.submitButton.click();
-        GlobalSettings.drawerBase.waitForVisible(constants.wait.long);
+        GlobalSettings.drawerBase.waitForVisible(constants.wait.long,true);
         GlobalSettings.toastDisplays('Your display groups have been imported successfully.');
         expect(getLocalStorageValue('hasImportedGroups')).toBe('true');
     });

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -223,3 +223,14 @@ export const getDistrobutionLabel = (distrobutionTags) => {
 export const getLocalStorageValue = (key) => {
     return browser.localStorage('GET', key).value;
 }
+
+export const apiCreateDomains = (domainObjArray) => {
+    const token = readToken(browser.options.testUser);
+    let domains = []
+    domainObjArray.forEach((domain) => {
+        const newDomain = browser.createDomain(token, domain.type,domain.domain,domain.tags,domain.group);
+        domains.push(newDomain);
+    });
+    browser.url(constants.routes.domains);
+    domainObjArray.forEach((domain) => browser.waitForVisible(`[data-qa-domain-cell="${domain.domain}"]`,constants.wait.normal));
+}

--- a/e2e/utils/config-utils.js
+++ b/e2e/utils/config-utils.js
@@ -31,7 +31,6 @@ exports.storeToken = (credFilePath, username) => {
 exports.readToken = (username) => {
     const credCollection = JSON.parse(readFileSync('./e2e/creds.js'));
     const currentUserCreds = credCollection.find(cred => cred.username === username);
-
     return currentUserCreds['token'];
 }
 

--- a/src/features/Domains/DomainTableRow.tsx
+++ b/src/features/Domains/DomainTableRow.tsx
@@ -44,7 +44,7 @@ const DomainsTableRow: React.StatelessComponent<CombinedProps> = (props) => {
   return (
     <TableRow
       key={id}
-      data-qa-domain-cell={id}
+      data-qa-domain-cell={domain}
       className={`${classes.domainRow} ${'fade-in-table'}`}
       rowLink={`/domains/${id}`}
     >

--- a/src/features/Domains/ListDomains.tsx
+++ b/src/features/Domains/ListDomains.tsx
@@ -45,12 +45,12 @@ const ListDomains: React.StatelessComponent<CombinedProps> = (props) => {
                     label="domain"
                     direction={order}
                     handleClick={handleOrderChange}
-                    data-qa-domain-name-header
+                    data-qa-domain-name-header={order}
                   >
                     Domain
                 </TableSortCell>
                   <TableSortCell
-                    data-qa-domain-type-header
+                    data-qa-domain-type-header={order}
                     active={orderBy === 'type'}
                     label="type"
                     direction={order}

--- a/src/features/Domains/ListGroupedDomains.tsx
+++ b/src/features/Domains/ListGroupedDomains.tsx
@@ -77,7 +77,7 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = (props) => {
 
                 return (
                   <React.Fragment>
-                    <TableBody className={classes.groupContainer}>
+                    <TableBody className={classes.groupContainer} data-qa-tag-header={tag}>
                       <TableRow className={classes.tagHeaderRow}>
                         <TableCell colSpan={7}>
                           <Typography variant="h2" component="h3" className={classes.tagHeader}>

--- a/src/features/Domains/SortableTableHead.tsx
+++ b/src/features/Domains/SortableTableHead.tsx
@@ -11,10 +11,10 @@ const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = 
   const isActive = (label: string) => label === orderBy;
 
   return (
-    <TableHead data-qa-table-head>
+    <TableHead data-qa-table-head={order}>
       <TableRow>
-        <TableSortCell label='domain' direction={order} active={isActive('domain')} handleClick={handleOrderChange}>Domain</TableSortCell>
-        <TableSortCell label='type' direction={order} active={isActive('type')} handleClick={handleOrderChange}>Type</TableSortCell>
+        <TableSortCell label='domain' direction={order} active={isActive('domain')} handleClick={handleOrderChange} data-qa-sort-domain={order}>Domain</TableSortCell>
+        <TableSortCell label='type' direction={order} active={isActive('type')} handleClick={handleOrderChange} data-qa-sort-type={order}>Type</TableSortCell>
         <TableCell />
       </TableRow>
     </TableHead>

--- a/src/features/TagImport/DisplayGroupList.tsx
+++ b/src/features/TagImport/DisplayGroupList.tsx
@@ -41,7 +41,7 @@ export const DisplayGroupList: React.StatelessComponent<CombinedProps> = (props)
           <Typography
             key={`${entity}-group-item-${idx}`}
             className={classes.groupItem}
-            data-qa-display-group-item
+            data-qa-display-group-item={entity}
           >
             - {group}
           </Typography>


### PR DESCRIPTION
## Description
**Test:**
- Create 6 domains and 2 display groups, 3 domains per group
- Import display group as tags CTA displays
- Import display group as tags drawer displays the correct groups
- Display groups are successfully imported as tags
- Domains can be grouped by tags on Domain landing page
- Tag headers displayed in alphabetical order on Domain landing page
- Domains are sortable within tag groups
- Domains can be ungrouped by tags

## Type of Change
- Integration Test

## Note to Reviewers
`yarn && yarn start` new shell `yarn selenium` new shell `yarn e2e --spec=e2e/specs/tagmanagement/import-groups-and-group-by-tag-domains.spec.js`