### PR TITLE
Feature/linode row

### DIFF
--- a/src/components/OrderBy.test.ts
+++ b/src/components/OrderBy.test.ts
@@ -1,0 +1,60 @@
+import { sort } from 'ramda';
+import { sortData } from './OrderBy';
+
+const a =
+  {
+    name: 'april',
+    hobbies: ['this', 'that', 'the other'],
+    age: 43
+  }
+
+const b =
+  {
+    name: 'may',
+    hobbies: [],
+    age: 23
+  }
+
+const c =
+  {
+    name: 'june',
+    hobbies: ['traditional Irish bowling'],
+    age: 53
+  }
+
+const d =
+  {
+    name: 'july',
+    hobbies: ['one','two','three'],
+    age: 53
+  }
+
+const e =
+  {
+    name: 'august',
+    hobbies: ['traditional Irish bowling'],
+    age: 53
+  }
+
+describe("OrderBy", () => {
+  describe("sortData function", () => {
+    const data = [a, b, c, d, e];
+    it("should sort by string", () => {
+      const order = sortData('name', 'asc');
+      expect(sort(order, data)).toEqual([a, e, d, c, b]);
+    });
+    it("should handle the selected order (asc or desc)", () => {
+      const order = sortData('name', 'desc');
+      expect(sort(order, data)).toEqual([b, c, d, e, a]);
+    });
+    it("should sort by number", () => {
+      const order = sortData('age', 'asc');
+      expect(sort(order, data)).toEqual([b, a, c, d, e]);
+    });
+    it("should sort by array length", () => {
+      const order = sortData('hobbies', 'asc');
+      expect(sort(order, data)).toEqual([b, c, e, a, d]);
+    });
+  });
+})
+

--- a/src/components/OrderBy.ts
+++ b/src/components/OrderBy.ts
@@ -1,18 +1,8 @@
-import { compose, prop, reverse, sortBy, toLower, when } from 'ramda';
+import { curry, pathOr, sort,  } from 'ramda';
 import * as React from 'react';
 import { Order } from 'src/components/Pagey';
+import { isArray } from 'util';
 
-const orderList: <T>(order: Order, orderBy: keyof T) => (list: T[]) => T[] = (order, orderBy) => (list) => {
-  return compose<any, any, any>(
-    when(() => order === 'desc', reverse),
-    sortBy(
-      compose(
-        when(v => typeof v === 'string', toLower),
-        prop(orderBy as string),
-      ),
-    ), /** I spent a long, long time trying to type this. */
-  )(list);
-};
 
 export interface OrderByProps extends State {
   handleOrderChange: (orderBy: string, order: Order) => void;
@@ -31,6 +21,30 @@ interface Props {
   orderBy?: string;
 }
 
+export const sortData = curry((orderBy: string, order: Order, obj1: any, obj2: any) => {
+  /* If the column we're sorting on is an array (e.g. 'tags', which is string[]),
+  *  we want to sort by the length of the array. Otherwise, do a simple comparison.
+  */
+
+  // Get target column for each object, and length if this is an array
+  let a = pathOr(0, [orderBy], obj1);
+  let b = pathOr(0, [orderBy], obj2);
+  if (isArray(a) && isArray(b)) {
+    a = a.length;
+    b = b.length;
+  }
+
+  // Sort
+  let result: number;
+  if (a > b) { result = 1; }
+  else if (a < b) { result = -1; }
+  else { result = 0; }
+
+  // Ascending or descending
+  // nb: thought this would be more efficient than sorting then conditionally reversing as a separate step
+  return order === 'asc' ? result : -result;
+});
+
 export default class OrderBy extends React.Component<Props, State> {
   state: State = {
     order: this.props.order || 'asc',
@@ -40,13 +54,14 @@ export default class OrderBy extends React.Component<Props, State> {
   handleOrderChange = (orderBy: string, order: Order) => this.setState({ orderBy, order });
 
   render() {
-    const order = orderList(this.state.order, this.state.orderBy);
+    const order = sortData(this.state.orderBy, this.state.order);
+    const sortedData = sort(order, this.props.data);
 
     const props = {
       ...this.props,
       ...this.state,
       handleOrderChange: this.handleOrderChange,
-      data: order(this.props.data),
+      data: sortedData,
       count: this.props.data.length,
     };
 

--- a/src/components/ShowMore/ShowMore.test.tsx
+++ b/src/components/ShowMore/ShowMore.test.tsx
@@ -1,20 +1,26 @@
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
+import Chip from 'src/components/core/Chip';
+import { ShowMore } from './ShowMore';
 
-import ShowMore from './ShowMore';
+const mockRender = jest.fn();
+const classes = {
+  chip: '', label: '', popover: '', link: ''
+}
+
+const props = {
+  classes,
+  items: ['a', 'b'],
+  render: mockRender
+}
 
 describe('ShowMore', () => {
-  const mockRender = jest.fn();
 
-  const wrapper = mount(
-    <LinodeThemeWrapper>
+  const wrapper = shallow(
       <ShowMore
-        items={['a', 'b']}
-        render={mockRender}
+        {...props}
       />
-    </LinodeThemeWrapper>,
   );
 
   it('should call provided render function with items.', () => {
@@ -22,7 +28,6 @@ describe('ShowMore', () => {
   });
 
   it('should render a chip with items.length', () => {
-    const chipText = wrapper.find('Chip button span').text();
-    expect(chipText).toBe('+2');
+    expect(wrapper.containsMatchingElement(<Chip label="+2" />)).toBeTruthy();
   });
 });

--- a/src/components/ShowMore/ShowMore.tsx
+++ b/src/components/ShowMore/ShowMore.tsx
@@ -4,7 +4,10 @@ import Chip, { ChipProps } from 'src/components/core/Chip';
 import Popover from 'src/components/core/Popover';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 
-type CSSClasses =  'chip' | 'label' | 'popover';
+type CSSClasses =  'chip'
+  | 'label'
+  | 'popover'
+  | 'link';
 
 const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   chip: {
@@ -28,6 +31,12 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     paddingLeft: 6,
     paddingRight: 6,
   },
+  link: {
+    color: `${theme.color.blueDTwhite} !important`,
+    '&:hover' : {
+      textDecoration: 'underline',
+    }
+  },
   popover: {
     minWidth: 'auto',
     maxWidth: 400,
@@ -45,7 +54,7 @@ interface Props<T> {
   chipProps?: ChipProps;
 }
 
-class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
+export class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
   state = {
     anchorEl: undefined,
   };
@@ -84,6 +93,7 @@ class ShowMore<T> extends React.Component<Props<T> & WithStyles<CSSClasses> > {
           component="button"
           clickable
         />
+
         <Popover
           classes={{ paper: classes.popover }}
           anchorEl={anchorEl}

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -49,21 +49,20 @@ class TableRow extends React.Component<CombinedProps> {
 
   rowClick = (e: any, target: string | onClickFn ) =>  {
     const body = document.body as any;
+    // Inherit the ROW click unless the element is a <button> or an <a> or is contained within them
+    const isButton = e.target.tagName === 'BUTTON' || e.target.closest('button');
+    const isAnchor = e.target.tagName === 'A' || e.target.closest('a');
 
-  // return if a modal is open
-  if (body.getAttribute('style') === null || body.getAttribute('style').indexOf('overflow: hidden') === 0) { return; }
-  // Inherit the ROW click unless the element is a <button> or an <a> or is contained within them
-  const isButton = e.target.tagName === 'BUTTON' || e.target.closest('button');
-  const isAnchor = e.target.tagName === 'A' || e.target.closest('a');
-  if (!isButton && !isAnchor) {
-    e.stopPropagation();
-    if (typeof(target) === 'string') {
-      this.props.history.push(target);
+    if (!isButton && !isAnchor) {
+      e.stopPropagation();
+      if (typeof(target) === 'string') {
+        this.props.history.push(target);
+        // return if a modal is open
+      } else if (body.getAttribute('style') !== null && body.getAttribute('style').indexOf('overflow: hidden') !== 0) { return; }
     }
+    if (typeof(target) === 'function') { target(e) };
   }
-  // @alioso should this be outside of the if statement above?
-  if (typeof(target) === 'function') { target(e) };
-  }
+
 
   render() {
     const { classes, className, rowLink, staticContext, ...rest } = this.props;

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -53,14 +53,20 @@ class TableRow extends React.Component<CombinedProps> {
     const isButton = e.target.tagName === 'BUTTON' || e.target.closest('button');
     const isAnchor = e.target.tagName === 'A' || e.target.closest('a');
 
-    if (!isButton && !isAnchor) {
-      e.stopPropagation();
-      if (typeof(target) === 'string') {
-        this.props.history.push(target);
-        // return if a modal is open
-      } else if (body.getAttribute('style') !== null && body.getAttribute('style').indexOf('overflow: hidden') !== 0) { return; }
+    if (
+      body.getAttribute('style') === null ||
+      body.getAttribute('style').indexOf('overflow: hidden') !== 0 ||
+      body.getAttribute('style') === ''
+    ){
+      if (!isButton && !isAnchor) {
+        e.stopPropagation();
+        if (typeof(target) === 'string') {
+          this.props.history.push(target);
+          // return if a modal is open
+        }
+      }
+      if (typeof(target) === 'function') { target(e) };
     }
-    if (typeof(target) === 'function') { target(e) };
   }
 
 

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -66,7 +66,7 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = (props) => {
               <strong>IP:</strong>
             </Typography>
             <div className={classes.IPgrouping} data-qa-ip>
-              <IPAddress ips={[nodeBalancer.ipv4]} copyRight />
+              <IPAddress ips={[nodeBalancer.ipv4]} copyRight showMore />
               {nodeBalancer.ipv6 && <IPAddress ips={[nodeBalancer.ipv6]} copyRight />}
             </div>
           </div>

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -358,8 +358,8 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
           </TableCell>
           <TableCell parentColumn="IP Addresses" data-qa-nodebalancer-ips>
             <div className={classes.ipsWrapper}>
-              <IPAddress ips={[nodeBalancer.ipv4]} copyRight />
-              {nodeBalancer.ipv6 && <IPAddress ips={[nodeBalancer.ipv6]} copyRight />}
+              <IPAddress ips={[nodeBalancer.ipv4]} copyRight showMore />
+              {nodeBalancer.ipv6 && <IPAddress ips={[nodeBalancer.ipv6]} copyRight showMore />}
             </div>
           </TableCell>
           <TableCell parentColumn="Region" data-qa-region>

--- a/src/features/Search/utils.ts
+++ b/src/features/Search/utils.ts
@@ -5,7 +5,8 @@ import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import NodebalIcon from 'src/assets/addnewmenu/nodebalancer.svg';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import { Item } from 'src/components/EnhancedSelect/Select';
-import { displayType, typeLabelLong } from 'src/features/linodes/presentation';
+import { displayType } from 'src/features/linodes/presentation';
+import getLinodeDescription from 'src/utilities/getLinodeDescription';
 
 export interface SearchResults {
   linodes: Item[];
@@ -55,7 +56,7 @@ export const searchLinodes = (
     value: linode.id,
     data: {
       tags: linode.tags,
-      description: linodeDescription(
+      description: getLinodeDescription(
         displayType(linode.type, typesData),
         linode.specs.memory,
         linode.specs.disk,
@@ -141,21 +142,6 @@ export const searchImages = (images: Linode.Image[], query: string) =>
       created: image.created,
     }
   }));
-
-  export const linodeDescription = (
-    typeLabel: string,
-    memory: number,
-    disk: number,
-    vcpus: number,
-    imageId: string,
-    images: Linode.Image[]
-  ) => {
-    const image = (images && images.find((img:Linode.Image) => img.id === imageId))
-      || { label: 'Unknown Image' };
-    const imageDesc = image.label;
-    const typeDesc = typeLabelLong(typeLabel, memory, disk, vcpus);
-    return `${imageDesc}, ${typeDesc}`;
-  }
 
   export const searchAll = (
     _linodes: Linode.Linode[],

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingSummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingSummaryPanel.tsx
@@ -127,13 +127,13 @@ export default restyled(connected(LinodeNetworkingSummaryPanel)) as React.Compon
 
 const renderIPv4DNSResolvers = () => () => (
   <div style={{ display: 'flex', alignItems: "center" }}>
-    <IPAddress ips={ipv4DNSResolvers} copyRight />
+    <IPAddress ips={ipv4DNSResolvers} copyRight showMore />
   </div>
 )
 
 const renderIPv6DNSResolvers = () => () => (
   <div style={{ display: 'flex', alignItems: "center" }}>
-    <IPAddress ips={ipv6DNSResolvers} copyRight />
+    <IPAddress ips={ipv6DNSResolvers} copyRight showMore />
   </div>
 )
 

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -116,12 +116,12 @@ class SummaryPanel extends React.Component<CombinedProps> {
           </Grid>
           <Grid item xs={12} sm={6} lg={4}>
             <div className={classes.section}>
-              <IPAddress ips={linode.ipv4} copyRight />
+              <IPAddress ips={linode.ipv4} copyRight showMore />
             </div>
             {
               linode.ipv6 &&
               <div className={classes.section}>
-                <IPAddress ips={[linode.ipv6]} copyRight />
+                <IPAddress ips={[linode.ipv6]} copyRight showMore />
               </div>
             }
           </Grid>

--- a/src/features/linodes/LinodesLanding/IPAddress.test.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.test.tsx
@@ -1,44 +1,58 @@
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
-
-import IPAddress, { sortIPAddress } from './IPAddress';
+import { IPAddress, sortIPAddress } from './IPAddress';
 
 const publicIP = '8.8.8.8';
 const publicIP2 = '45.45.45.45';
 const privateIP = '192.168.220.103';
 const privateIP2 = '192.168.220.102';
 
+const classes = {
+  root: '',
+  left: '',
+  right: '',
+  icon: '',
+  row: '',
+  ip: '',
+  ipLink: '',
+  hide: 'hide'
+}
+
+const component = shallow(<IPAddress classes={classes} ips={['8.8.8.8', '8.8.4.4']}  />)
+
 describe('IPAddress', () => {
   it('should render without error and display and IP address', () => {
-    const result = mount(
-      <LinodeThemeWrapper>
-        <IPAddress
-          ips={['8.8.8.8']}
-        />
-      </LinodeThemeWrapper>,
-    );
-
-    const rendered = result.find('IPAddress');
-    const ipText = result.find('.ip').text();
+    const rendered = component.find('[data-qa-ip-main]');
+    const ipText = rendered.text();
 
     expect(rendered).toHaveLength(1);
     expect(ipText).toBe('8.8.8.8');
   });
 
-  it('should render ShowMore with props.items = IPs', () => {
-    const result = mount(
-      <LinodeThemeWrapper>
-        <IPAddress
-          ips={['8.8.8.8', '8.8.4.4']}
-        />
-      </LinodeThemeWrapper>,
-    );
-    const showmore = result.find('ShowMore');
+  it("should not display ShowMore button unless the showMore prop is passed", () => {
+    expect(component.find('[data-qa-ip-more]')).toHaveLength(0);
+  });
 
+  it('should render ShowMore with props.items = IPs', () => {
+    component.setProps({ showMore: true });
+    const showmore = component.find('[data-qa-ip-more]');
     expect(showmore.exists()).toBe(true);
     expect(showmore.prop('items')).toEqual(['8.8.4.4']);
+  });
+
+  it("should show the copy icon if copyRight is true", () => {
+    expect(component.find('[data-qa-copy-ip]')).toHaveLength(0);
+    component.setProps({ copyRight: true });
+    expect(component.find('[data-qa-copy-ip]')).toHaveLength(1);
+  });
+
+  it("should render the copyIcon, but not show it, if copyRight is true and showCopyOnHover is true", () => {
+    expect(component.find('.hide')).toHaveLength(0);
+    component.setProps({ copyRight: true, showCopyOnHover: true });
+    const copy = component.find('[data-qa-copy-ip]');
+    expect(copy).toHaveLength(1);
+    expect(component.find('.hide')).toHaveLength(1);
   });
 
   describe("IP address sorting", () => {

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -36,6 +36,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
             })
             lishLaunch(linodeId);
             e.preventDefault();
+            e.stopPropagation();
           },
         },
         {
@@ -47,6 +48,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
             })
             push(`/linodes/${linodeId}/summary`);
             e.preventDefault();
+            e.stopPropagation();
           },
         },
         {
@@ -58,6 +60,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
             })
             push(`/linodes/${linodeId}/resize`);
             e.preventDefault();
+            e.stopPropagation();
           },
         },
         {
@@ -69,6 +72,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
             })
             push(`/linodes/${linodeId}/backup`);
             e.preventDefault();
+            e.stopPropagation();
           },
         },
         {
@@ -80,7 +84,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
             })
             push(`/linodes/${linodeId}/settings`);
             e.preventDefault();
-          },
+            e.stopPropagation();          },
         },
       ];
 
@@ -108,6 +112,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
                 action: 'Reboot Linode',
               })
               e.preventDefault();
+              e.stopPropagation();
               toggleConfirmation('reboot', linodeId, linodeLabel);
               closeMenu();
             },
@@ -119,6 +124,8 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
                 category: 'Linode Action Menu Item',
                 action: 'Power Off Linode',
               })
+              e.preventDefault();
+              e.stopPropagation();
               toggleConfirmation('power_down', linodeId, linodeLabel);
               closeMenu();
             },
@@ -139,6 +146,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
               state: { enableOnLoad: true }
             });
             e.preventDefault();
+            e.stopPropagation();
           },
         })
       }

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -140,8 +140,8 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
               <RegionIndicator region={linodeRegion} />
             </div>
             <div className={classes.cardSection} data-qa-ips>
-              <IPAddress ips={linodeIpv4} copyRight />
-              <IPAddress ips={[linodeIpv6]} copyRight />
+              <IPAddress ips={linodeIpv4} copyRight showMore />
+              <IPAddress ips={[linodeIpv6]} copyRight showMore />
             </div>
             <div className={classes.cardSection} data-qa-image>
               {imageLabel}

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
@@ -10,6 +10,9 @@ type ClassNames =
   | 'ipCellWrapper'
   | 'planCell'
   | 'regionCell'
+  | 'iconTableCell'
+  | 'icon'
+  | 'iconGridCell';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   actionCell: {
@@ -31,6 +34,29 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     '&:hover .backupIcon': {
       fill: theme.palette.primary.main,
     },
+  },
+  iconTableCell: {
+    [theme.breakpoints.up('md')]: {
+      width: '4%',
+      padding: 4,
+    },
+  },
+  icon: {
+    position: 'relative',
+    top: 1,
+    width: 40,
+    height: 40,
+    '& .circle': {
+      fill: theme.bg.offWhiteDT,
+    },
+    '& .outerCircle': {
+      stroke: theme.bg.main,
+    },
+  },
+  iconGridCell: {
+    display: 'flex',
+    alignItems: 'center',
+    padding: 4,
   },
   ipCell: {
     width: '25%',

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
@@ -30,7 +30,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     justifyContent: 'flex-end',
   },
   bodyRow: {
-    height: 77,
+    height: 'auto',
     '&:hover .backupIcon': {
       fill: theme.palette.primary.main,
     },

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
@@ -39,6 +39,14 @@ describe('LinodeRow', () => {
       enabled: false,
       schedule: { day: 'Friday', window: 'W0' },
     },
+    linodeImage: null,
+     linodeSpecs: {
+       memory: 0,
+       vcpus: 0,
+       disk: 0,
+       transfer: 0
+     },
+     imagesData: [],
     displayType: 'Some Fancy Name'
   };
 

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
@@ -13,6 +13,9 @@ describe('LinodeRow', () => {
     ipCellWrapper: '',
     planCell: '',
     regionCell: '',
+    iconTableCell: '',
+    icon: '',
+    iconGridCell: ''
   };
 
   const mockProps: CombinedProps = {

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import Flag from 'src/assets/icons/flag.svg';
 import Tooltip from 'src/components/core/Tooltip';
-import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
+import withImages from 'src/containers/withImages.container';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 import { linodeInTransition } from 'src/features/linodes/transitions';
+import getLinodeDescription from 'src/utilities/getLinodeDescription';
 import hasMutationAvailable, { HasMutationAvailable } from '../hasMutationAvailable';
 import IPAddress from '../IPAddress';
 import LinodeActionMenu from '../LinodeActionMenu';
@@ -24,10 +24,12 @@ import LinodeRowTagCell from './LinodeRowTagCell';
 interface Props {
   linodeBackups: Linode.LinodeBackups;
   linodeId: number;
+  linodeImage: string | null;
   linodeIpv4: string[];
   linodeIpv6: string;
   linodeLabel: string;
   linodeRegion: string;
+  linodeSpecs: Linode.LinodeSpecs;
   linodeStatus: Linode.LinodeStatus;
   linodeType: null | string;
   linodeTags: string[];
@@ -40,6 +42,7 @@ export type CombinedProps =
   & Props
   & HasMutationAvailable
   & WithDisplayType
+  & WithImagesProps
   & WithRecentEvent
   & WithNotifications
   & StyleProps
@@ -47,13 +50,21 @@ export type CombinedProps =
 export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
   const {
     classes,
+    displayType,
+    imagesData,
     linodeBackups,
     linodeId,
+    linodeImage,
     linodeIpv4,
     linodeIpv6,
     linodeLabel,
     linodeNotifications,
     linodeRegion,
+    linodeSpecs: {
+      memory,
+      disk,
+      vcpus,
+    },
     linodeStatus,
     linodeTags,
     mostRecentBackup,
@@ -65,12 +76,21 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
   } = props;
   const loading = linodeInTransition(linodeStatus, recentEvent);
 
+  const description = getLinodeDescription(
+    displayType,
+    memory,
+    disk,
+    vcpus,
+    linodeImage,
+    imagesData,
+    )
+
   const headCell = <LinodeRowHeadCell
     loading={loading}
+    linodeDescription={description}
     linodeId={linodeId}
     linodeRecentEvent={recentEvent}
     linodeLabel={linodeLabel}
-    linodeTags={linodeTags}
     linodeStatus={linodeStatus}
   />
 
@@ -87,12 +107,7 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
         rowLink={`/linodes/${linodeId}`}
         arial-label={linodeLabel}
       >
-        <TableCell className={classes.iconTableCell}>
-          <Grid item className={classes.iconGridCell}>
-            <LinodeIcon className={classes.icon} />
-          </Grid>
-        </TableCell>
-        {!loading && headCell}
+      {!loading && headCell}
         <LinodeRowTagCell tags={linodeTags} />
         <LinodeRowBackupCell linodeId={linodeId} mostRecentBackup={mostRecentBackup} />
         <TableCell parentColumn="IP Addresses" className={classes.ipCell} data-qa-ips>
@@ -126,10 +141,18 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
   );
 };
 
+interface WithImagesProps {
+  imagesData: Linode.Image[]
+}
+
 const enhanced = compose<CombinedProps, Props>(
   styled,
   withRecentEvent,
   withDisplayType,
+  withImages((ownProps, imagesData, imagesLoading) => ({
+    ...ownProps,
+    imagesData: imagesData.filter(i => i.is_public === true),
+  })),
   hasMutationAvailable,
   withNotifications,
 );

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import Flag from 'src/assets/icons/flag.svg';
 import Tooltip from 'src/components/core/Tooltip';
-import Typography from 'src/components/core/Typography';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
@@ -18,6 +17,7 @@ import styled, { StyleProps } from './LinodeRow.style';
 import LinodeRowBackupCell from './LinodeRowBackupCell';
 import LinodeRowHeadCell from './LinodeRowHeadCell';
 import LinodeRowLoading from './LinodeRowLoading';
+import LinodeRowTagCell from './LinodeRowTagCell';
 
 interface Props {
   linodeBackups: Linode.LinodeBackups;
@@ -58,7 +58,7 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
     mutationAvailable,
     openConfigDrawer,
     toggleConfirmation,
-    displayType,
+    // displayType, @todo use for M3-2059
     recentEvent,
   } = props;
   const loading = linodeInTransition(linodeStatus, recentEvent);
@@ -86,9 +86,7 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
         arial-label={linodeLabel}
       >
         {!loading && headCell}
-        <TableCell parentColumn="Plan" className={classes.planCell}>
-          <Typography variant="body1">{displayType}</Typography>
-        </TableCell>
+        <LinodeRowTagCell tags={linodeTags} />
         <LinodeRowBackupCell linodeId={linodeId} mostRecentBackup={mostRecentBackup} />
         <TableCell parentColumn="IP Addresses" className={classes.ipCell} data-qa-ips>
           <div className={classes.ipCellWrapper}>

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -112,8 +112,8 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
         <LinodeRowBackupCell linodeId={linodeId} mostRecentBackup={mostRecentBackup} />
         <TableCell parentColumn="IP Addresses" className={classes.ipCell} data-qa-ips>
           <div className={classes.ipCellWrapper}>
-            <IPAddress ips={linodeIpv4} copyRight />
-            <IPAddress ips={[linodeIpv6]} copyRight />
+            <IPAddress ips={linodeIpv4} copyRight showCopyOnHover />
+            <IPAddress ips={[linodeIpv6]} copyRight showCopyOnHover />
           </div>
         </TableCell>
         <TableCell parentColumn="Region" className={classes.regionCell} data-qa-region>

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { compose } from 'recompose';
+import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import Flag from 'src/assets/icons/flag.svg';
 import Tooltip from 'src/components/core/Tooltip';
+import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
@@ -79,12 +81,17 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = (props) => {
       </ LinodeRowLoading>}
       <TableRow
         key={linodeId}
-        className={`${classes.bodyRow}`}
+        className={classes.bodyRow}
         data-qa-loading
         data-qa-linode={linodeLabel}
         rowLink={`/linodes/${linodeId}`}
         arial-label={linodeLabel}
       >
+        <TableCell className={classes.iconTableCell}>
+          <Grid item className={classes.iconGridCell}>
+            <LinodeIcon className={classes.icon} />
+          </Grid>
+        </TableCell>
         {!loading && headCell}
         <LinodeRowTagCell tags={linodeTags} />
         <LinodeRowBackupCell linodeId={linodeId} mostRecentBackup={mostRecentBackup} />

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowBackupCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowBackupCell.tsx
@@ -11,7 +11,8 @@ type ClassNames =
   | 'noBackupText'
   | 'root'
   | 'wrapper'
-  | 'backupLink';
+  | 'backupLink'
+  | 'backupText';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   icon: {
@@ -33,6 +34,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   backupLink: {
     display: 'flex'
+  },
+  backupText: {
+    whiteSpace: 'nowrap'
   }
 });
 
@@ -51,7 +55,7 @@ const LinodeRowBackupCell: React.StatelessComponent<CombinedProps> = (props) => 
       {
         mostRecentBackup ?
           (
-            <Typography variant="body1">
+            <Typography variant="body1" className={classes.backupText}>
               <DateTimeDisplay value={mostRecentBackup} humanizeCutoff={"never"} />
             </Typography>
           )

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -1,13 +1,24 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
-import Tags from 'src/components/Tags';
 import { linodeInTransition, transitionText } from 'src/features/linodes/transitions';
 import LinodeStatusIndicator from '../LinodeStatusIndicator';
 
-type ClassNames = 'root' | 'link' | 'tagWrapper' | 'loadingStatus' | 'labelWrapper' | 'status' | 'labelRow';
+type ClassNames = 'root'
+ | 'link'
+ | 'loadingStatus'
+ | 'labelWrapper'
+ | 'linodeDescription'
+ | 'status'
+ | 'labelRow'
+ | 'icon'
+ | 'labelStatusWrapper'
+ | 'statusOuter'
+ | 'labelGridWrapper';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   link: {
@@ -18,12 +29,12 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     paddingTop: theme.spacing.unit / 4,
   },
   root: {
-    width: '30%',
+    width: '100%',
     '& h3': {
       transition: theme.transitions.create(['color']),
     },
-    [theme.breakpoints.down('sm')]: {
-      width: '100%'
+    [theme.breakpoints.up('xl')]: {
+      width: '35%'
     },
   },
   status: {
@@ -37,20 +48,46 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     flexFlow: 'row nowrap',
     alignItems: 'center',
   },
-  tagWrapper: {
-    marginTop: theme.spacing.unit / 2,
-  },
   loadingStatus: {
     marginBottom: theme.spacing.unit / 2,
+  },
+  linodeDescription: {
+    paddingTop: theme.spacing.unit / 2,
+  },
+  icon: {
+    position: 'relative',
+    top: 3,
+    width: 40,
+    height: 40,
+    '& .circle': {
+      fill: theme.bg.offWhiteDT,
+    },
+    '& .outerCircle': {
+      stroke: theme.bg.main,
+    },
+  },
+  labelStatusWrapper: {
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+  },
+  statusOuter: {
+    top: 0,
+    position: 'relative',
+    marginLeft: 4,
+    lineHeight: '0.8rem',
+  },
+  labelGridWrapper: {
+    padding: '0 4px !important',
   }
 });
 
 interface Props {
   loading: boolean;
+  linodeDescription: string;
   linodeId: number;
   linodeLabel: string;
   linodeStatus: Linode.LinodeStatus;
-  linodeTags: string[];
   linodeRecentEvent?: Linode.Event;
 }
 
@@ -59,10 +96,10 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = (props) => {
   const {
     classes,
+    linodeDescription,
     linodeId,
     linodeLabel,
     linodeStatus,
-    linodeTags,
     loading,
     linodeRecentEvent,
   } = props;
@@ -75,27 +112,34 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = (props) => {
       rowSpan={loading ? 2 : 1}
     >
       <Link to={`/linodes/${linodeId}`} className={classes.link}>
-        <div className={loading ? classes.labelWrapper : ''}>
-          {
-            linodeRecentEvent && linodeInTransition(linodeStatus, linodeRecentEvent) &&
-            <ProgressDisplay
-              className={classes.loadingStatus}
-              text={transitionText(linodeStatus, linodeRecentEvent)}
-              progress={linodeRecentEvent.percent_complete}
-            />
-          }
-          <div className={classes.labelRow}>
-            <Typography role="header" variant="h3" data-qa-label>
-              {linodeLabel}
-            </Typography>
-            <div className={classes.status} >
-              <LinodeStatusIndicator status={linodeStatus} />
+        <Grid container wrap="nowrap" alignItems="center">
+          <Grid item className="py0">
+            <LinodeIcon className={classes.icon}/>
+          </Grid>
+          <Grid item className={classes.labelGridWrapper}>
+            <div className={loading ? classes.labelWrapper : ''}>
+              {
+                linodeRecentEvent && linodeInTransition(linodeStatus, linodeRecentEvent) &&
+                <ProgressDisplay
+                  className={classes.loadingStatus}
+                  text={transitionText(linodeStatus, linodeRecentEvent)}
+                  progress={linodeRecentEvent.percent_complete}
+                />
+              }
+             <div className={classes.labelStatusWrapper}>
+               <Typography role="header" variant="h3" data-qa-label>
+                {linodeLabel}
+              </Typography>
+              <div className={classes.statusOuter}>
+                <LinodeStatusIndicator status={linodeStatus} />
+              </div>
             </div>
-          </div>
-        </div>
-        <div className={classes.tagWrapper}>
-          <Tags tags={linodeTags} />
-        </div>
+            <Typography className={classes.linodeDescription}>
+              {linodeDescription}
+            </Typography>
+            </div>
+          </Grid>
+        </Grid>
       </Link>
     </TableCell>
   );

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -78,7 +78,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     lineHeight: '0.8rem',
   },
   labelGridWrapper: {
-    padding: '0 4px !important',
+    paddingLeft: '4px !important',
+    paddingRight: '4px !important',
   }
 });
 

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import Tags from 'src/components/Tags';
 import { linodeInTransition, transitionText } from 'src/features/linodes/transitions';
 import LinodeStatusIndicator from '../LinodeStatusIndicator';
 
-type ClassNames = 'root' | 'link' | 'tagWrapper' | 'loadingStatus' | 'labelWrapper';
+type ClassNames = 'root' | 'link' | 'tagWrapper' | 'loadingStatus' | 'labelWrapper' | 'status' | 'labelRow';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   link: {
@@ -27,9 +26,19 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
       width: '100%'
     },
   },
+  status: {
+    marginLeft: theme.spacing.unit / 2,
+    position: 'relative',
+    top: 0,
+    lineHeight: '0.8rem',
+  },
+  labelRow: {
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+  },
   tagWrapper: {
     marginTop: theme.spacing.unit / 2,
-    marginLeft: theme.spacing.unit * 4,
   },
   loadingStatus: {
     marginBottom: theme.spacing.unit / 2,
@@ -66,26 +75,24 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = (props) => {
       rowSpan={loading ? 2 : 1}
     >
       <Link to={`/linodes/${linodeId}`} className={classes.link}>
-        <Grid container wrap="nowrap" alignItems="center">
-          <Grid item className="py0">
-            <LinodeStatusIndicator status={linodeStatus} />
-          </Grid>
-          <Grid item className="py0">
-            <div className={loading ? classes.labelWrapper : ''}>
-              {
-                linodeRecentEvent && linodeInTransition(linodeStatus, linodeRecentEvent) &&
-                <ProgressDisplay
-                  className={classes.loadingStatus}
-                  text={transitionText(linodeStatus, linodeRecentEvent)}
-                  progress={linodeRecentEvent.percent_complete}
-                />
-              }
-              <Typography role="header" variant="h3" data-qa-label>
-                {linodeLabel}
-              </Typography>
+        <div className={loading ? classes.labelWrapper : ''}>
+          {
+            linodeRecentEvent && linodeInTransition(linodeStatus, linodeRecentEvent) &&
+            <ProgressDisplay
+              className={classes.loadingStatus}
+              text={transitionText(linodeStatus, linodeRecentEvent)}
+              progress={linodeRecentEvent.percent_complete}
+            />
+          }
+          <div className={classes.labelRow}>
+            <Typography role="header" variant="h3" data-qa-label>
+              {linodeLabel}
+            </Typography>
+            <div className={classes.status} >
+              <LinodeStatusIndicator status={linodeStatus} />
             </div>
-          </Grid>
-        </Grid>
+          </div>
+        </div>
         <div className={classes.tagWrapper}>
           <Tags tags={linodeTags} />
         </div>

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowLoading.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowLoading.tsx
@@ -9,7 +9,7 @@ type ClassNames = 'bodyRow' | 'status' | 'bodyCell';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   bodyRow: {
-    height: 77,
+    height: 'auto',
   },
   bodyCell: {
     border: 0,

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
@@ -14,7 +14,7 @@ type ClassNames =
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {
-    width: '15%',
+    width: '8%',
     height: '20px !important',
     paddingTop: '0 !important',
     paddingBottom: '0 !important',
@@ -25,10 +25,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   tagLink: {
     color: `${theme.color.blueDTwhite} !important`,
   },
-  wrapper: {
-    width: '50% !important',
-    height: '20px !important',
-  },
+  wrapper: {},
 });
 
 interface Props {

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
@@ -47,7 +47,7 @@ const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
             interactive={true}
           >
             <div className={classes.wrapper}>
-              <a className={classes.tagLink}>{tags.length}</a>
+              <a href="javascript:;" className={classes.tagLink}>{tags.length}</a>
             </div>
           </Tooltip>
         : <Typography>0</Typography>

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTagCell.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import TableCell from 'src/components/TableCell';
+
+import LinodeRowTags from './LinodeRowTags';
+
+import Tooltip from 'src/components/core/Tooltip';
+
+type ClassNames =
+  | 'root'
+  | 'tagLink'
+  | 'wrapper';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {
+    width: '15%',
+    height: '20px !important',
+    paddingTop: '0 !important',
+    paddingBottom: '0 !important',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%'
+    },
+  },
+  tagLink: {
+    color: `${theme.color.blueDTwhite} !important`,
+  },
+  wrapper: {
+    width: '50% !important',
+    height: '20px !important',
+  },
+});
+
+interface Props {
+  tags: string[];
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const LinodeRowTagCell: React.StatelessComponent<CombinedProps> = (props) => {
+  const { classes, tags } = props;
+
+  return (
+    <TableCell parentColumn="Tags" className={classes.root}>
+      {tags.length > 0
+        ? <Tooltip
+            title={<LinodeRowTags tags={tags} />}
+            placement="bottom-start"
+            leaveDelay={50}
+            interactive={true}
+          >
+            <div className={classes.wrapper}>
+              <a className={classes.tagLink}>{tags.length}</a>
+            </div>
+          </Tooltip>
+        : <Typography>0</Typography>
+      }
+    </TableCell>
+  )
+};
+
+const styled = withStyles(styles);
+
+export default styled(LinodeRowTagCell);

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTags.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowTags.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
+
+import Paper from 'src/components/core/Paper';
+import Tag from 'src/components/Tag';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {
+    backgroundColor: 'transparent',
+  },
+});
+
+interface Props {
+  tags: string[];
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const LinodeRowTags: React.StatelessComponent<CombinedProps> = (props) => {
+  const { tags, classes } = props;
+  return (
+    <Paper className={classes.root}>
+      {tags.map((tag, idx) =>
+        <Tag
+          key={`linode-row-tag-item-${idx}`}
+          colorVariant='lightBlue'
+          label={tag}
+        />
+      )}
+    </Paper>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(LinodeRowTags);

--- a/src/features/linodes/LinodesLanding/LinodeStatusIndicator.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeStatusIndicator.tsx
@@ -25,7 +25,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
   },
   transition: {
     position: 'relative',
-    top: 4,
+    top: 1,
     left: -1,
     '& svg': {
       animation: 'rotate 2s linear infinite',

--- a/src/features/linodes/LinodesLanding/ListView.tsx
+++ b/src/features/linodes/LinodesLanding/ListView.tsx
@@ -24,12 +24,14 @@ export const ListView: React.StatelessComponent<CombinedProps> = (props) => {
           <LinodeRow
             key={`linode-row-${idx}`}
             linodeId={linode.id}
+            linodeImage={linode.image}
             linodeStatus={linode.status}
             linodeIpv4={linode.ipv4}
             linodeIpv6={linode.ipv6}
             linodeRegion={linode.region}
             linodeLabel={linode.label}
             linodeBackups={linode.backups}
+            linodeSpecs={linode.specs}
             linodeTags={linode.tags}
             openConfigDrawer={openConfigDrawer}
             toggleConfirmation={toggleConfirmation}

--- a/src/features/linodes/LinodesLanding/OverflowIPs.tsx
+++ b/src/features/linodes/LinodesLanding/OverflowIPs.tsx
@@ -65,7 +65,7 @@ class OverflowIPs extends React.Component<Props & WithStyles<CSSClasses> > {
         >
           {ips.map(ip =>
             <div key={ip}>
-              <IPAddress  ips={[ip]}/>
+              <IPAddress ips={[ip]}/>
             </div>,
           )}
         </Popover>

--- a/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -13,7 +13,6 @@ const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = 
   return (
     <TableHead data-qa-table-head>
       <TableRow>
-        <TableCell />
         <TableSortCell
           label='label'
           direction={order}

--- a/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -22,7 +22,14 @@ const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = 
         >
           Linode
         </TableSortCell>
-        <TableCell>Plan</TableCell>
+        <TableSortCell
+          label='tags'
+          direction={order}
+          active={isActive('tags')}
+          handleClick={handleOrderChange}
+        >
+          Tags
+        </TableSortCell>
         <TableCell noWrap>Last Backup</TableCell>
         <TableCell>IP Addresses</TableCell>
         <TableSortCell

--- a/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -13,6 +13,7 @@ const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = 
   return (
     <TableHead data-qa-table-head>
       <TableRow>
+        <TableCell />
         <TableSortCell
           label='label'
           direction={order}

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1043,16 +1043,16 @@ const themeDefaults: ThemeOptions = {
         transition: 'color 225ms ease-in-out',
         '&:hover': {
           color: primaryColors.main,
+        },
+        '&:focus': {
+          outline: '1px dotted #999',
         }
       },
       active: {
         color: primaryColors.main,
-        '&:focus': {
-          outline: '1px dotted #999',
-          '&:hover': {
-            color: primaryColors.main,
-          }
-        },
+        '&:hover': {
+          color: primaryColors.main,
+        }
       },
       icon: {
         opacity: 1,

--- a/src/utilities/getLinodeDescription.ts
+++ b/src/utilities/getLinodeDescription.ts
@@ -1,16 +1,15 @@
 import { typeLabelLong } from 'src/features/linodes/presentation';
+import { safeGetImageLabel } from 'src/utilities/safeGetImageLabel';
 
 export const linodeDescription = (
   typeLabel: string,
   memory: number,
   disk: number,
   vcpus: number,
-  imageId: string,
+  imageId: string | null,
   images: Linode.Image[]
 ) => {
-  const image = (images && images.find((img:Linode.Image) => img.id === imageId))
-    || { label: 'Unknown Image' };
-  const imageDesc = image.label;
+  const imageDesc = safeGetImageLabel(images, imageId);
   const typeDesc = typeLabelLong(typeLabel, memory, disk, vcpus);
   return `${imageDesc}, ${typeDesc}`;
 }

--- a/src/utilities/getLinodeDescription.ts
+++ b/src/utilities/getLinodeDescription.ts
@@ -1,0 +1,18 @@
+import { typeLabelLong } from 'src/features/linodes/presentation';
+
+export const linodeDescription = (
+  typeLabel: string,
+  memory: number,
+  disk: number,
+  vcpus: number,
+  imageId: string,
+  images: Linode.Image[]
+) => {
+  const image = (images && images.find((img:Linode.Image) => img.id === imageId))
+    || { label: 'Unknown Image' };
+  const imageDesc = image.label;
+  const typeDesc = typeLabelLong(typeLabel, memory, disk, vcpus);
+  return `${imageDesc}, ${typeDesc}`;
+}
+
+export default linodeDescription;


### PR DESCRIPTION
## Feature - Linode Row

Includes:

M3-2026: Hide +X IP addresses button on Linode Row, and show the copy icons on hover
M3-2059: Add Linode description text underneath Linode label
M3-2060: Add a Tags column to Linode row (replaces Plan)
M3-2055: Display Linode icon on Linode rows

Also fixes the clickable row issue and updates the logic in TableRow.tsx to determine if a modal is open.

## Type of Change
- Feature

## Note to Reviewers

