### PR TITLE
M3-2214 refactor search logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "mini-css-extract-plugin": "^0.5.0",
     "mountebank": "^1.14.1",
     "otplib": "^10.0.1",
+    "reselect-tools": "^0.0.7",
     "selenium-standalone": "^6.13.0",
     "storybook-react-router": "^1.0.2",
     "svgr": "^1.9.0",

--- a/src/__data__/resources.ts
+++ b/src/__data__/resources.ts
@@ -1,0 +1,41 @@
+import { domains, linodes } from 'src/__data__';
+
+export default {
+  linodes: {
+    loading: false,
+    lastUpdated: 0,
+    results: [linodes.map((linode: Linode.Linode) => linode.id)],
+    entities: linodes
+  },
+  volumes: {
+    loading: false,
+    lastUpdated: 0,
+    results: [],
+    entities: []
+  },
+  nodebalancers: {
+    loading: false,
+    lastUpdated: 0,
+    results: [],
+    entities: []
+  },
+  domains: {
+    loading: false,
+    lastUpdated: 0,
+    results: [domains.map((domain: Linode.Domain) => domain.id)],
+    entities: domains
+  },
+  images: {
+    loading: false,
+    lastUpdated: 0,
+    results: [],
+    entities: []
+  },
+  types: {
+    loading: false,
+    lastUpdated: 0,
+    results: [],
+    entities: []
+  },
+
+}

--- a/src/features/Search/ResultGroup.test.tsx
+++ b/src/features/Search/ResultGroup.test.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { searchbarResult1, searchbarResult2 } from 'src/__data__/searchResults';
 import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
-import TableRowLoading from 'src/components/TableRowLoading';
 
 import { ResultGroup } from './ResultGroup';
 
@@ -31,7 +30,6 @@ const emptyProps = {
   entity: 'linodes',
   classes,
   results: [],
-  loading: false,
   groupSize: 5,
   showMore: false,
   toggle: jest.fn(),
@@ -57,12 +55,6 @@ describe("ResultGroup component", () => {
   });
   it("should render its children", () => {
     expect(component.find('[data-qa-result-row-component]')).toHaveLength(5);
-  });
-  it("should render a loading spinner", () => {
-    component.setProps({ loading: true });
-    expect(component.containsMatchingElement(
-      <TableRowLoading colSpan={12} />
-    )).toBeTruthy();
   });
   describe("Hidden results", () => {
     it("should have a Show All button", () => {

--- a/src/features/Search/ResultGroup.tsx
+++ b/src/features/Search/ResultGroup.tsx
@@ -15,7 +15,6 @@ import Typography from 'src/components/core/Typography';
 import { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import Table from 'src/components/Table';
-import TableRowLoading from 'src/components/TableRowLoading';
 import capitalize from 'src/utilities/capitalize';
 
 import ResultRow from './ResultRow';
@@ -50,7 +49,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
 
 interface Props {
   entity: string;
-  loading: boolean;
   results: Item[];
   groupSize: number;
 }
@@ -62,7 +60,7 @@ interface HandlerProps {
 type CombinedProps = Props & HandlerProps & WithStyles<ClassNames>;
 
 export const ResultGroup: React.StatelessComponent<CombinedProps> = (props) => {
-  const { entity, classes, groupSize, loading, results, toggle, showMore } = props;
+  const { entity, classes, groupSize, results, toggle, showMore } = props;
 
   if (isEmpty(results)) { return null; }
 
@@ -87,7 +85,6 @@ export const ResultGroup: React.StatelessComponent<CombinedProps> = (props) => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {loading && <TableRowLoading  colSpan={12} />}
             {initial.map((result, idx: number) =>
               <ResultRow key={idx} result={result} data-qa-result-row-component/>)
             }

--- a/src/features/Search/SearchLanding.test.tsx
+++ b/src/features/Search/SearchLanding.test.tsx
@@ -3,6 +3,7 @@ import { assocPath } from 'ramda';
 import * as React from 'react';
 
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import { searchbarResult1 } from 'src/__data__/searchResults';
 import Typography from 'src/components/core/Typography';
 
 import { SearchLanding } from './SearchLanding';
@@ -14,8 +15,10 @@ const classes = {
 }
 
 const props = {
-  typesData: [],
   classes,
+  entities: emptyResults,
+  searchResults: emptyResults,
+  search: jest.fn(),
   ...reactRouterProps,
 }
 
@@ -26,6 +29,16 @@ const component = shallow(
 describe('Component', () => {
   it('should render', () => {
     expect(component).toBeDefined();
+  });
+  it("should search on mount", () => {
+    const newProps = assocPath(['location','search'], '?query=search', props);
+    shallow(<SearchLanding {...newProps} />);
+    expect(props.search).toHaveBeenCalledWith('search');
+  });
+  it("should search when the entity list (from Redux) changes", () => {
+    jest.resetAllMocks();
+    component.setProps({ entities: {...emptyResults, linodes: [searchbarResult1] }});
+    expect(props.search).toHaveBeenCalledTimes(1);
   });
   it("should show an error state", () => {
     expect(component.find('[data-qa-error-state]')).toHaveLength(0);

--- a/src/features/Search/SearchLanding.test.tsx
+++ b/src/features/Search/SearchLanding.test.tsx
@@ -20,6 +20,13 @@ const props = {
   entitiesLoading: false,
   searchResults: emptyResults,
   search: jest.fn(),
+  errors: {
+    hasErrors: false,
+    linodes: false,
+    domains: false,
+    nodebalancers: false,
+    images: false,
+  },
   ...reactRouterProps,
 }
 

--- a/src/features/Search/SearchLanding.test.tsx
+++ b/src/features/Search/SearchLanding.test.tsx
@@ -17,6 +17,7 @@ const classes = {
 const props = {
   classes,
   entities: emptyResults,
+  entitiesLoading: false,
   searchResults: emptyResults,
   search: jest.fn(),
   ...reactRouterProps,
@@ -35,15 +36,15 @@ describe('Component', () => {
     shallow(<SearchLanding {...newProps} />);
     expect(props.search).toHaveBeenCalledWith('search');
   });
+  it("should show a loading state", () => {
+    component.setProps({ entitiesLoading: true });
+    expect(component.find('[data-qa-search-loading]')).toHaveLength(1);
+    component.setProps({ entitiesLoading: false });
+  });
   it("should search when the entity list (from Redux) changes", () => {
     jest.resetAllMocks();
     component.setProps({ entities: {...emptyResults, linodes: [searchbarResult1] }});
     expect(props.search).toHaveBeenCalledTimes(1);
-  });
-  it("should show an error state", () => {
-    expect(component.find('[data-qa-error-state]')).toHaveLength(0);
-    component.setState({ error: true });
-    expect(component.find('[data-qa-error-state]')).toHaveLength(1);
   });
   it("should show an empty state", () => {
     component.setState({ error: false, results: emptyResults, loading: false });

--- a/src/features/Search/SearchLanding.tsx
+++ b/src/features/Search/SearchLanding.tsx
@@ -7,8 +7,10 @@ import CircleProgress from 'src/components/CircleProgress';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
 import Placeholder from 'src/components/Placeholder';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
+import { ErrorObject } from 'src/store/selectors/entitiesErrors';
 import { getQueryParam } from 'src/utilities/queryParams';
 
 import ResultGroup from './ResultGroup';
@@ -42,6 +44,17 @@ type CombinedProps =
   & RouteComponentProps<{}>
   & WithStyles<ClassNames>;
 
+const getErrorMessage = (errors: ErrorObject): string => {
+  const errorString: string[] = [];
+  if (errors.linodes) { errorString.push('Linodes'); }
+  if (errors.domains) { errorString.push('Domains'); }
+  if (errors.volumes) { errorString.push('Volumes'); }
+  if (errors.nodebalancers) { errorString.push('NodeBalancers'); }
+  if (errors.images) { errorString.push('Images'); }
+  const joined = errorString.join(', ');
+  return `Could not retrieve search results for: ${joined}`;
+}
+
 export class SearchLanding extends React.Component<CombinedProps, State> {
   mounted: boolean = false;
 
@@ -67,7 +80,7 @@ export class SearchLanding extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { classes, entitiesLoading, searchResults } = this.props;
+    const { classes, entitiesLoading, errors, searchResults } = this.props;
     const { query } = this.state;
 
     const resultsEmpty = equals(searchResults, emptyResults);
@@ -78,6 +91,11 @@ export class SearchLanding extends React.Component<CombinedProps, State> {
             Search Results { query && `for "${query}"` }
           </Typography>
         </Grid>
+        {errors.hasErrors &&
+          <Grid item>
+            <Notice error text={getErrorMessage(errors)} />
+          </Grid>
+        }
         {entitiesLoading &&
           <Grid item data-qa-search-loading>
             <CircleProgress />

--- a/src/features/Search/SearchLanding.tsx
+++ b/src/features/Search/SearchLanding.tsx
@@ -102,7 +102,7 @@ export class SearchLanding extends React.Component<CombinedProps, State> {
           </Grid>
         }
         {
-          resultsEmpty &&
+          resultsEmpty && !entitiesLoading &&
           <Grid item data-qa-empty-state>
             <Placeholder
               title="No results"

--- a/src/features/Search/SearchLanding.tsx
+++ b/src/features/Search/SearchLanding.tsx
@@ -3,9 +3,9 @@ import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 
+import CircleProgress from 'src/components/CircleProgress';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import Placeholder from 'src/components/Placeholder';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
@@ -35,8 +35,6 @@ const displayMap = {
 
 interface State {
   query: string;
-  loading: boolean;
-  error: boolean;
 }
 
 type CombinedProps =
@@ -49,8 +47,6 @@ export class SearchLanding extends React.Component<CombinedProps, State> {
 
   state: State = {
     query: getQueryParam(this.props.location.search, 'query'),
-    error: false,
-    loading: false,
   };
 
   componentDidMount() {
@@ -71,8 +67,8 @@ export class SearchLanding extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { classes, searchResults } = this.props;
-    const { query, error, loading } = this.state;
+    const { classes, entitiesLoading, searchResults } = this.props;
+    const { query } = this.state;
 
     const resultsEmpty = equals(searchResults, emptyResults);
     return (
@@ -82,13 +78,13 @@ export class SearchLanding extends React.Component<CombinedProps, State> {
             Search Results { query && `for "${query}"` }
           </Typography>
         </Grid>
-        {error &&
-          <Grid item data-qa-error-state>
-            <ErrorState errorText={"There was an error retrieving your search results."} />
+        {entitiesLoading &&
+          <Grid item data-qa-search-loading>
+            <CircleProgress />
           </Grid>
         }
         {
-          !loading && resultsEmpty &&
+          resultsEmpty &&
           <Grid item data-qa-empty-state>
             <Placeholder
               title="No results"
@@ -96,17 +92,19 @@ export class SearchLanding extends React.Component<CombinedProps, State> {
             />
           </Grid>
         }
-        <Grid item>
+        {!entitiesLoading &&
+          <Grid item>
           {Object.keys(searchResults).map((entityType, idx: number) =>
             <ResultGroup
               key={idx}
               entity={displayMap[entityType]}
               results={searchResults[entityType]}
-              loading={loading}
               groupSize={100}
             />
           )}
         </Grid>
+        }
+
       </Grid>
     );
   }

--- a/src/features/Search/withStoreSearch.tsx
+++ b/src/features/Search/withStoreSearch.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { compose, withStateHandlers } from 'recompose';
 
 import { emptyResults, filterMatched } from 'src/features/Search/utils';
+import entitiesErrors, { ErrorObject } from 'src/store/selectors/entitiesErrors';
 import entitiesLoading from 'src/store/selectors/entitiesLoading';
 import getSearchEntities, { SearchResults } from 'src/store/selectors/getSearchEntities';
 
@@ -14,6 +15,7 @@ export interface SearchProps extends HandlerProps {
   entities: SearchResults;
   entitiesLoading: boolean;
   searchResults: SearchResults;
+  errors: ErrorObject;
 }
 
 export const search = (entities: SearchResults, inputValue:string ): SearchResults => {
@@ -47,7 +49,8 @@ export default () => (Component: React.ComponentType<any>) => {
     (state: ApplicationState) => {
       return {
         entities: getSearchEntities(state.__resources),
-        entitiesLoading: entitiesLoading(state.__resources)
+        entitiesLoading: entitiesLoading(state.__resources),
+        errors: entitiesErrors(state.__resources)
       }
     }
   );

--- a/src/features/Search/withStoreSearch.tsx
+++ b/src/features/Search/withStoreSearch.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { compose, withStateHandlers } from 'recompose';
+
+import { emptyResults, filterMatched } from 'src/features/Search/utils';
+import getSearchEntities, { SearchResults } from 'src/store/selectors/getSearchEntities';
+
+
+interface HandlerProps {
+  search: (query: string) => SearchResults;
+}
+export interface SearchProps extends HandlerProps {
+  entities: SearchResults;
+  searchResults: SearchResults;
+}
+
+export const search = (entities: SearchResults, inputValue:string ): SearchResults => {
+  if (!inputValue || inputValue === '') {
+    return entities; // could also return empty results, but this matches existing pattern.
+  }
+  const {
+    linodes,
+    volumes,
+    domains,
+    nodebalancers,
+    images
+  } = entities;
+  return {
+    linodes: linodes.filter((linode) => filterMatched(inputValue, linode.label, linode.data.tags)),
+    volumes: volumes.filter((volume) => filterMatched(inputValue, volume.label, volume.data.tags)),
+    domains: domains.filter((domain) => filterMatched(inputValue, domain.label, domain.data.tags)),
+    images: images.filter((image) => filterMatched(inputValue, image.label, image.data.tags)),
+    nodebalancers: nodebalancers.filter((nodebal) => filterMatched(inputValue, nodebal.label, nodebal.data.tags)),
+  }
+}
+
+export default () => (Component: React.ComponentType<any>) => {
+  const WrappedComponent: React.StatelessComponent<SearchProps> = (props) => {
+      return React.createElement(Component, {
+        ...props,
+      });
+    }
+
+  const connected = connect(
+    (state: ApplicationState) => {
+      return {
+        entities: getSearchEntities(state),
+      }
+    }
+  );
+
+  return compose<SearchProps, {}>(
+    connected,
+    withStateHandlers<any, any, any>({ searchResults: emptyResults },
+      {
+        search: (_, props: SearchProps) => (query: string) => ({ searchResults: search(props.entities, query)  })
+      })
+  )(WrappedComponent);
+}

--- a/src/features/Search/withStoreSearch.tsx
+++ b/src/features/Search/withStoreSearch.tsx
@@ -44,7 +44,7 @@ export default () => (Component: React.ComponentType<any>) => {
   const connected = connect(
     (state: ApplicationState) => {
       return {
-        entities: getSearchEntities(state),
+        entities: getSearchEntities(state.__resources),
       }
     }
   );

--- a/src/features/Search/withStoreSearch.tsx
+++ b/src/features/Search/withStoreSearch.tsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { compose, withStateHandlers } from 'recompose';
 
 import { emptyResults, filterMatched } from 'src/features/Search/utils';
+import entitiesLoading from 'src/store/selectors/entitiesLoading';
 import getSearchEntities, { SearchResults } from 'src/store/selectors/getSearchEntities';
 
 
@@ -11,6 +12,7 @@ interface HandlerProps {
 }
 export interface SearchProps extends HandlerProps {
   entities: SearchResults;
+  entitiesLoading: boolean;
   searchResults: SearchResults;
 }
 
@@ -45,6 +47,7 @@ export default () => (Component: React.ComponentType<any>) => {
     (state: ApplicationState) => {
       return {
         entities: getSearchEntities(state.__resources),
+        entitiesLoading: entitiesLoading(state.__resources)
       }
     }
   );

--- a/src/store/domains/domains.actions.ts
+++ b/src/store/domains/domains.actions.ts
@@ -1,6 +1,6 @@
-import { pathOr } from 'ramda';
 import { Dispatch } from 'redux';
 import { getDomain, getDomains } from 'src/services/domains';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
 import actionCreatorFactory from 'typescript-fsa';
 import { ThunkActionCreator } from '../types';
@@ -33,8 +33,7 @@ export const requestDomains = () => (dispatch: Dispatch<any>) => {
       return domains;
     })
     .catch((err) => {
-      const defaultError = [{ reason: 'An unexpected error has occurred.' }];
-      const errors = pathOr(defaultError, ['response', 'data', 'errors'], err);
+      const errors = getAPIErrorOrDefault(err, 'There was an error retrieving your Domains.');
       dispatch(getDomainsFailure(errors));
     });
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -23,7 +23,10 @@ import combineEventsMiddleware from './middleware/combineEventsMiddleware';
 import imageEvents from './middleware/imageEvents';
 import notifications, { defaultState as notificationsDefaultState } from './notification/notification.reducer';
 
+import { initReselectDevtools } from './selectors';
+
 const reduxDevTools = (window as any).__REDUX_DEVTOOLS_EXTENSION__;
+initReselectDevtools();
 
 /**
  * Default State

--- a/src/store/linodes/linodes.actions.ts
+++ b/src/store/linodes/linodes.actions.ts
@@ -1,6 +1,7 @@
 import * as Bluebird from 'bluebird';
 import requestMostRecentBackupForLinode from 'src/features/linodes/LinodesLanding/requestMostRecentBackupForLinode';
 import { getLinode, getLinodes } from "src/services/linodes";
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from "src/utilities/getAll";
 import actionCreatorFactory from 'typescript-fsa';
 import { ThunkActionCreator } from '../types';
@@ -30,7 +31,7 @@ export const requestLinodes: ThunkActionCreator<Promise<Linode.Linode[]>> = () =
       return result;
     })
     .catch((err) => {
-      dispatch(linodesRequest.failed(err));
+      dispatch(linodesRequest.failed({ error: getAPIErrorOrDefault(err, 'There was an error retrieving your Linodes.')}));
       return err;
     });
 };

--- a/src/store/selectors/entitiesErrors.ts
+++ b/src/store/selectors/entitiesErrors.ts
@@ -1,0 +1,39 @@
+import { createSelector } from 'reselect';
+
+type State = ApplicationState['__resources'];
+
+export interface ErrorObject {
+  hasErrors: boolean;
+  linodes: boolean;
+  volumes: boolean;
+  domains: boolean;
+  images: boolean;
+  nodebalancers: boolean;
+}
+
+export const linodesErrorSelector = (state: State) => Boolean(state.linodes.error && state.linodes.error.length > 0)
+export const volumesErrorSelector = (state: State) => false //  Boolean(state.volumes.error && state.volumes.error.length > 0)
+export const nodeBalsErrorSelector = (state: State) => false //  Boolean(state.nodebalancers.error && state.nodebalancers.error.length > 0)
+export const domainsErrorSelector = (state: State) =>  Boolean(state.domains.error && state.domains.error.length > 0)
+export const imagesErrorSelector = (state: State) =>  Boolean(state.images.error && state.images.error.length > 0)
+export const typesErrorSelector = (state: State) =>  Boolean(state.types.error && state.types.error.length > 0)
+
+export default createSelector
+  <State,
+  boolean,
+  boolean,
+  boolean,
+  boolean,
+  boolean,
+  ErrorObject>
+  (
+  linodesErrorSelector, volumesErrorSelector, nodeBalsErrorSelector, domainsErrorSelector, imagesErrorSelector,
+  (linodes, volumes, nodebalancers, domains, images) => ({
+    linodes,
+    volumes,
+    nodebalancers,
+    domains,
+    images,
+    hasErrors: (linodes || volumes || nodebalancers || domains || images)
+  })
+)

--- a/src/store/selectors/entitiesLoading.test.ts
+++ b/src/store/selectors/entitiesLoading.test.ts
@@ -1,0 +1,20 @@
+import { assocPath } from 'ramda';
+import resources from 'src/__data__/resources';
+
+import entitiesLoading from './entitiesLoading';
+
+describe("Entities loading selector", () => {
+  it("should return true if any entity type is still loading", () => {
+    const _resources = assocPath(['linodes', 'loading'], true, resources);
+    expect(entitiesLoading(_resources as any)).toBeTruthy();
+  });
+  it("should return false if all entities are finished loading", () => {
+    expect(entitiesLoading(resources as any)).toBeFalsy();
+  });
+  it("should return false on entity updates (after initial load)", () => {
+    let _resources = assocPath(['linodes'], {loading: true, lastUpdated: 1} ,resources);
+    expect(entitiesLoading(_resources as any)).toBeFalsy();
+    _resources = assocPath(['linodes'], {loading: true, lastUpdated: new Date()} ,resources);
+    expect(entitiesLoading(_resources as any)).toBeFalsy();
+  });
+})

--- a/src/store/selectors/entitiesLoading.ts
+++ b/src/store/selectors/entitiesLoading.ts
@@ -2,23 +2,38 @@ import { createSelector } from 'reselect';
 
 type State = ApplicationState['__resources'];
 
+interface Resource<T> {
+  results: string[] | number[];
+  entities: T;
+  loading: boolean;
+  lastUpdated: number;
+  error?: Linode.ApiFieldError[];
+}
+
+const emptyResource = {
+  results: [],
+  entities: [],
+  loading: false,
+  lastUpdated: 0
+}
+
 export const linodesSelector = (state: State) => state.linodes
-export const volumesSelector = (state: State) => ({loading: false, lastUpdated: 0}) // state.volumes.loading
-export const nodeBalsSelector = (state: State) => ({loading: false, lastUpdated: 0}) // state.nodebalancers.loading
+export const volumesSelector = (state: State) => emptyResource // state.volumes
+export const nodeBalsSelector = (state: State) => emptyResource // state.nodebalancers
 export const domainsSelector = (state: State) => state.domains
 export const imagesSelector = (state: State) => state.images
 export const typesSelector = (state: State) => state.types
 
-const isInitialLoad = (e: RequestableData<any>) => e.loading && e.lastUpdated === 0;
+const isInitialLoad = (e: Resource<any>) => e.loading && e.lastUpdated === 0;
 
 export default createSelector
   <State,
-  RequestableData<Linode.Linode[]>,
-  RequestableData<Linode.Volume[]>,
-  RequestableData<Linode.NodeBalancer[][]>,
-  RequestableData<Linode.Domain[]>,
-  RequestableData<Linode.Image[]>,
-  RequestableData<Linode.LinodeType[]>,
+  Resource<Linode.Linode[]>,
+  Resource<Linode.Volume[]>,
+  Resource<Linode.NodeBalancer[][]>,
+  Resource<Linode.Domain[]>,
+  Resource<Linode.Image[]>,
+  Resource<Linode.LinodeType[]>,
   boolean>
   (
     linodesSelector, volumesSelector, nodeBalsSelector, domainsSelector, imagesSelector, typesSelector,
@@ -26,7 +41,7 @@ export default createSelector
       const entities = [linodes, volumes, nodebalancers, domains, images, types];
       const l = entities.length;
       for (let i = 0; i < l; i++) {
-        if (isInitialLoad(entities[l])) { return true; }
+        if (isInitialLoad(entities[i])) { return true; }
       }
       return false;
     }

--- a/src/store/selectors/entitiesLoading.tsx
+++ b/src/store/selectors/entitiesLoading.tsx
@@ -1,0 +1,16 @@
+import { createSelector } from 'reselect';
+
+type State = ApplicationState['__resources'];
+
+export const linodesLoadingSelector = (state: State) => state.linodes.loading
+export const volumesLoadingSelector = (state: State) => false // state.volumes.loading
+export const nodeBalsLoadingSelector = (state: State) => false // state.nodebalancers.loading
+export const domainsLoadingSelector = (state: State) => state.domains.loading
+export const imagesLoadingSelector = (state: State) => state.images.loading
+export const typesLoadingSelector = (state: State) => state.types.loading
+
+export default createSelector<State, boolean, boolean, boolean, boolean, boolean, boolean, boolean>(
+  linodesLoadingSelector, volumesLoadingSelector, nodeBalsLoadingSelector, domainsLoadingSelector, imagesLoadingSelector, typesLoadingSelector,
+  (linodes, volumes, nodebalancers, domains, images, types) =>
+    (linodes || volumes || nodebalancers || domains || images || types)
+)

--- a/src/store/selectors/entitiesLoading.tsx
+++ b/src/store/selectors/entitiesLoading.tsx
@@ -2,15 +2,32 @@ import { createSelector } from 'reselect';
 
 type State = ApplicationState['__resources'];
 
-export const linodesLoadingSelector = (state: State) => state.linodes.loading
-export const volumesLoadingSelector = (state: State) => false // state.volumes.loading
-export const nodeBalsLoadingSelector = (state: State) => false // state.nodebalancers.loading
-export const domainsLoadingSelector = (state: State) => state.domains.loading
-export const imagesLoadingSelector = (state: State) => state.images.loading
-export const typesLoadingSelector = (state: State) => state.types.loading
+export const linodesSelector = (state: State) => state.linodes
+export const volumesSelector = (state: State) => ({loading: false, lastUpdated: 0}) // state.volumes.loading
+export const nodeBalsSelector = (state: State) => ({loading: false, lastUpdated: 0}) // state.nodebalancers.loading
+export const domainsSelector = (state: State) => state.domains
+export const imagesSelector = (state: State) => state.images
+export const typesSelector = (state: State) => state.types
 
-export default createSelector<State, boolean, boolean, boolean, boolean, boolean, boolean, boolean>(
-  linodesLoadingSelector, volumesLoadingSelector, nodeBalsLoadingSelector, domainsLoadingSelector, imagesLoadingSelector, typesLoadingSelector,
-  (linodes, volumes, nodebalancers, domains, images, types) =>
-    (linodes || volumes || nodebalancers || domains || images || types)
+const isInitialLoad = (e: RequestableData<any>) => e.loading && e.lastUpdated === 0;
+
+export default createSelector
+  <State,
+  RequestableData<Linode.Linode[]>,
+  RequestableData<Linode.Volume[]>,
+  RequestableData<Linode.NodeBalancer[][]>,
+  RequestableData<Linode.Domain[]>,
+  RequestableData<Linode.Image[]>,
+  RequestableData<Linode.LinodeType[]>,
+  boolean>
+  (
+    linodesSelector, volumesSelector, nodeBalsSelector, domainsSelector, imagesSelector, typesSelector,
+    (linodes, volumes, nodebalancers, domains, images, types) => {
+      const entities = [linodes, volumes, nodebalancers, domains, images, types];
+      const l = entities.length;
+      for (let i = 0; i < l; i++) {
+        if (isInitialLoad(entities[l])) { return true; }
+      }
+      return false;
+    }
 )

--- a/src/store/selectors/getSearchEntities.ts
+++ b/src/store/selectors/getSearchEntities.ts
@@ -11,6 +11,8 @@ export interface SearchResults {
   images: Item[];
 }
 
+type State = ApplicationState['__resources'];
+
 const formatLinode = (linode: Linode.Linode, types: Linode.LinodeType[], images: Linode.Image[]): Item =>
   ({
     label: linode.label,
@@ -91,15 +93,15 @@ const nodeBalToItem = (nodebal: Linode.NodeBalancer) => ({
   }
 });
 
-const linodeSelector = (state: ApplicationState) => state.__resources.linodes.entities;
-const volumeSelector = (state: ApplicationState) => [] // state.__resources.volumes.entities;
-const nodebalSelector = (state: ApplicationState) => [] // state.__resources.nodebalancers;
-const imageSelector = (state: ApplicationState) => state.__resources.images.entities;
-const domainSelector = (state: ApplicationState) => state.__resources.domains.entities;
-const typesSelector = (state: ApplicationState) => state.__resources.types.entities;
+const linodeSelector = (state: State) => state.linodes.entities;
+const volumeSelector = (state: State) => [] // state.volumes.entities;
+const nodebalSelector = (state: State) => [] // state.nodebalancers;
+const imageSelector = (state: State) => state.images.entities;
+const domainSelector = (state: State) => state.domains.entities;
+const typesSelector = (state: State) => state.types.entities;
 
 export default createSelector
-  <ApplicationState,
+  <State,
   Linode.Linode[],
   Linode.Volume[],
   Linode.Image[],

--- a/src/store/selectors/getSearchEntities.ts
+++ b/src/store/selectors/getSearchEntities.ts
@@ -27,7 +27,7 @@ const formatLinode = (linode: Linode.Linode, types: Linode.LinodeType[], images:
       ),
       icon: 'LinodeIcon',
       path: `/linodes/${linode.id}`,
-      searchText: '',
+      searchText: '', // @todo update this, either here or in the consumer. Probably in the consumer.
       created: linode.created,
       region: linode.region,
       status: linode.status,

--- a/src/store/selectors/getSearchEntitites.test.ts
+++ b/src/store/selectors/getSearchEntitites.test.ts
@@ -1,0 +1,39 @@
+import { assocPath } from 'ramda';
+
+import { domains, images, linodes, types } from 'src/__data__';
+
+
+import getSearchEntities from './getSearchEntities';
+
+describe("getSearchEntities selector", () => {
+  const mockState: any = {
+      linodes: { entities: linodes },
+      domains: { entities: domains},
+      images: { entities: images },
+      types: { entities: types },
+  }
+  it("should return an array of Items for each entity type", () => {
+    const results = getSearchEntities(mockState);
+    expect(results.linodes).toBeInstanceOf(Array);
+    expect(results.volumes).toBeInstanceOf(Array);
+    expect(results.domains).toBeInstanceOf(Array);
+    expect(results.images).toBeInstanceOf(Array);
+    expect(results.nodebalancers).toBeInstanceOf(Array);
+  });
+  it("should not recompute objects if the list of entities does not change.", () => {
+    getSearchEntities.resetRecomputations();
+    getSearchEntities(mockState);
+    expect(getSearchEntities.recomputations()).toEqual(0);
+  });
+  it("should recompute objects if the list of entities changes.", () => {
+    getSearchEntities.resetRecomputations();
+    getSearchEntities({...mockState, linodes: { entities: []}});
+    expect(getSearchEntities.recomputations()).toEqual(1);
+  });
+  it("should recompute if an entry in entities is updated", () => {
+    getSearchEntities.resetRecomputations();
+    const updatedLinodes = assocPath([0, 'label'],'newlabel', linodes);
+    getSearchEntities({...mockState, linodes: { entities: updatedLinodes }});
+    expect(getSearchEntities.recomputations()).toEqual(1);
+  });
+});

--- a/src/store/selectors/index.ts
+++ b/src/store/selectors/index.ts
@@ -1,0 +1,25 @@
+import { registerSelectors } from 'reselect-tools';
+
+import entitiesLoading from './entitiesLoading';
+import getEntitiesWithGroupsToImport from './getEntitiesWithGroupsToImport';
+import getSearchEntities from './getSearchEntities';
+import inProgressEventForLinode from './inProgressEventForLinode';
+import inProgressEvents from './inProgressEvents';
+import recentEventForLinode from './recentEventForLinode';
+
+
+/** Note: We could simplify this boilerplate if we had a rule that each selector file
+ * could contain only one export (the selector itself).
+ */
+
+ export const initReselectDevtools = () => {
+  registerSelectors({
+    entitiesLoading,
+    getEntitiesWithGroupsToImport,
+    getSearchEntities,
+    inProgressEventForLinode,
+    inProgressEvents,
+    recentEventForLinode,
+  });
+ }
+

--- a/src/store/selectors/reselect-tools.d.ts
+++ b/src/store/selectors/reselect-tools.d.ts
@@ -1,0 +1,1 @@
+declare module 'reselect-tools';

--- a/yarn.lock
+++ b/yarn.lock
@@ -11689,7 +11689,14 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-reselect@^4.0.0:
+reselect-tools@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/reselect-tools/-/reselect-tools-0.0.7.tgz#bff19df422ebebd1a7c322262db94a554f6b44ed"
+  integrity sha512-+RGguS8ph21y04l6YwQwL+VfJ/c0qyZKCkhCd5ZwbNJ/lklsJml3CIim+uaG/t+7jYZQcwDW4bk5+VzTeuzwtw==
+  dependencies:
+    reselect "4.0.0"
+
+reselect@4.0.0, reselect@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==


### PR DESCRIPTION
## Description

Add a new HOC, withStoreSearch, that provides wrapped components with:

- searchResults: { linodes: Item[], etc. }
- search: (query) => SearchResults;
- combinedResults: Item[]
Also adds the Reselect dev tools as a dev dependency; you will need to add the extension to Chrome if you'd like to make use of the tools.

## Notes to Reviewers

Sorry this got big!

- NodeBalancers and Volumes are stubbed out, as they aren't yet available through Redux
- Fixed loading and error state for search landing, so please test using network throttling/request blocking (error message should show exactly which entity types didn't load, so if you block Linodes and Domains you should see both listed)
- Added logic to search bar and search landing
- Fixed error handling in linode.reducer, the API error was not getting through to state.
