### PR TITLE
M3-2213 Fix: Parse timestamps in UTC

### DIFF
--- a/src/store/reducers/events.test.ts
+++ b/src/store/reducers/events.test.ts
@@ -1,3 +1,5 @@
+import * as moment from 'moment';
+
 import reducer, {
   actions,
   addToEvents,
@@ -60,7 +62,7 @@ describe('events', () => {
         });
 
         it('should update the mostRecentEventTime', () => {
-          expect(state).toHaveProperty('mostRecentEventTime', new Date('2018-12-03T22:34:09').getTime())
+          expect(state).toHaveProperty('mostRecentEventTime', moment.utc('2018-12-03T22:34:09').valueOf())
         });
 
         it('should update the countUnseenEvents', () => {
@@ -145,11 +147,12 @@ describe('events', () => {
       it('should return the most recent event time', () => {
         expect(
           mostRecentCreated(new Date(`1970-01-01T00:00:00`).getTime(), { created: `2018-12-03T22:37:20` })
-        ).toBe(new Date(`2018-12-03T22:37:20`).getTime());
+        ).toBe(moment.utc(`2018-12-03T22:37:20`).valueOf());
 
+        const recentTime = moment.utc(`2018-12-03T23:37:20`).valueOf();
         expect(
-          mostRecentCreated(new Date(`2018-12-03T23:37:20`).getTime(), { created: `2018-12-03T22:37:20` })
-        ).toBe(new Date(`2018-12-03T23:37:20`).getTime());
+          mostRecentCreated(recentTime, { created: `2018-12-03T22:37:20` })
+        ).toBe(recentTime);
 
       });
     });

--- a/src/store/reducers/events.ts
+++ b/src/store/reducers/events.ts
@@ -143,7 +143,7 @@ export const updateEvents = compose(
  *
  */
 export const mostRecentCreated = (latestTime: number, current: Pick<Event, 'created'>) => {
-  const time = new Date(current.created).getTime();
+  const time: number = moment.utc(current.created).valueOf(); // Unix time (milliseconds)
   return latestTime > time ? latestTime : time;
 };
 
@@ -208,7 +208,7 @@ const getEvents: () => ThunkAction<Promise<Event[]>, ApplicationState, undefined
     const { mostRecentEventTime, inProgressEvents } = getState().events;
 
     const filters = generatePollingFilter(
-      moment(mostRecentEventTime).format(dateFormat),
+      moment.utc(mostRecentEventTime).format(dateFormat),
       Object.keys(inProgressEvents),
     );
 


### PR DESCRIPTION
## Description

Timestamps from the API (which are UTC, but do not include offset) were being parsed in local time. This resulted in differences between browsers, which resulted in extraneous event notifications in Safari.


## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Easily verify by checking the behavior when creating volumes (w/ different browsers.)