### PR TITLE
(For Release) M3-2221 Tags in LinodeRow should be clickable

### DIFF
--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -50,7 +50,7 @@ class TableRow extends React.Component<CombinedProps> {
   rowClick = (e: any, target: string | onClickFn ) =>  {
     const body = document.body as any;
     // Inherit the ROW click unless the element is a <button> or an <a> or is contained within them
-    const isButton = e.target.tagName === 'BUTTON' || e.target.closest('button');
+    const isButton = e.target.tagName === 'BUTTON' || e.target.closest('button') || document.querySelector('[role="button"]');
     const isAnchor = e.target.tagName === 'A' || e.target.closest('a');
 
     if (

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -50,7 +50,7 @@ class TableRow extends React.Component<CombinedProps> {
   rowClick = (e: any, target: string | onClickFn ) =>  {
     const body = document.body as any;
     // Inherit the ROW click unless the element is a <button> or an <a> or is contained within them
-    const isButton = e.target.tagName === 'BUTTON' || e.target.closest('button') || document.querySelector('[role="button"]');
+    const isButton = e.target.tagName === 'BUTTON' || e.target.closest('button');
     const isAnchor = e.target.tagName === 'A' || e.target.closest('a');
 
     if (

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -137,9 +137,8 @@ class Tag extends React.Component<CombinedProps, {}> {
       classes={{ label: classes.label, deletable: classes[colorVariant!]}}
       onClick={this.handleClick}
       data-qa-tag={this.props.label}
-      component="div"
+      component="button"
       clickable
-      role="button"
     />;
   }
 };

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -137,7 +137,7 @@ class Tag extends React.Component<CombinedProps, {}> {
       classes={{ label: classes.label, deletable: classes[colorVariant!]}}
       onClick={this.handleClick}
       data-qa-tag={this.props.label}
-      component="button"
+      component={"button" as "div"}
       clickable
     />;
   }


### PR DESCRIPTION
## Description

Making tags in LinodeRow click to search results rather than to the linode details page. This will impact tags globally.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

When reviewing the linode row, ensure the entire row is still clickable to linode details, actions still occur from the linode landing, and that the tags go to search results. Please also review other places where tags are implemented, such as the search results dropdown, linode details, etc.
