### PR TITLE
M3-2223 Fix: Adjust filtering logic in updateMultipleLinodes

### DIFF
--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -78,8 +78,8 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = (props) => {
                   />
                 }
                 label={backups_enabled
-                  ? "Enabled (Auto Enroll All New Linodes in Backups)"
-                  : "Disabled (Don't Enroll New Linodes in Backups Automatically)"
+                  ? "Enabled (Auto enroll all new Linodes in Backups)"
+                  : "Disabled (Don't enroll new Linodes in Backups automatically)"
                 }
               />
             </Grid>

--- a/src/store/linodes/linodes.reducer.ts
+++ b/src/store/linodes/linodes.reducer.ts
@@ -21,7 +21,6 @@ export const defaultState: State = {
  * Reducer
  */
 const reducer: Reducer<State> = (state = defaultState, action) => {
-
   if (isType(action, linodesRequest.started)) {
     return {
       ...state,
@@ -67,7 +66,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       entities: [
         ...state.entities
           .filter(eachEntity => {
-            return payload.some(eachLinode => {
+            return !payload.some(eachLinode => {
               return eachLinode.id === eachEntity.id
             })
           }),

--- a/src/store/linodes/linodes.reducer.ts
+++ b/src/store/linodes/linodes.reducer.ts
@@ -61,6 +61,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
   if (isType(action, updateMultipleLinodes)) {
     const { payload } = action; /** list of successfully updated Linodes */
+    if (payload && payload.length === 0) { return state; }
     return {
       ...state,
       entities: [

--- a/src/store/reducers/backupDrawer.ts
+++ b/src/store/reducers/backupDrawer.ts
@@ -182,7 +182,8 @@ export default reducer;
 export const gatherResponsesAndErrors = (accumulator: Accumulator, linode: Linode.Linode) => {
   return enableBackups(linode.id).then(() => ({
     ...accumulator,
-    success: [...accumulator.success, linode]
+    // This is accurate, since a 200 from the API means that backups were enabled.
+    success: [...accumulator.success, {...linode, backups: { ...linode.backups, enabled: true }}]
   }))
     .catch((error) => {
       const reason = pathOr('Backups could not be enabled for this Linode.',
@@ -215,8 +216,6 @@ export const enableAllBackups: EnableAllBackupsThunk = () => (dispatch, getState
       else {
         dispatch(handleEnableSuccess(response.success));
       }
-      /** @todo */
-      // dispatch(requestLinodesWithoutBackups());
       dispatch(updateMultipleLinodes(response.success));
     })
     .catch(() => dispatch(
@@ -230,11 +229,19 @@ export const enableAllBackups: EnableAllBackupsThunk = () => (dispatch, getState
 */
 type EnableAutoEnrollThunk = () => ThunkAction<void, ApplicationState, undefined>;
 export const enableAutoEnroll: EnableAutoEnrollThunk = () => (dispatch, getState) => {
-  const { backups } = getState();
-  const backups_enabled = Boolean(backups.autoEnroll);
+  const state = getState();
+  const { backups } = state;
+  const hasBackupsEnabled = pathOr(false,
+    ['__resources', 'accountSettings', 'data', 'backups_enabled'], state);
+  const shouldEnableBackups = Boolean(backups.autoEnroll);
+
+  /** If the selected toggle setting matches the setting already on the user's account,
+   * don't bother the API.
+   */
+  if (hasBackupsEnabled === shouldEnableBackups) { dispatch(enableAllBackups()); return; }
 
   dispatch(handleAutoEnroll());
-  updateAccountSettings({ backups_enabled })
+  updateAccountSettings({ backups_enabled: shouldEnableBackups })
     .then((response) => {
       dispatch(handleAutoEnrollSuccess());
       dispatch(enableAllBackups());


### PR DESCRIPTION
## Description

Addresses 3 unrelated issues:

1. UpdateMultipleLinodes Redux action had buggy filtering logic.
2. backupsCTA was not being hidden on success
3. API was being called regardless of whether the user had toggled "enable backups" in the drawer

Please check as many possible combinations of actions/failures in the backups drawer as possible.

## Note to Reviewers

To test:

1. Turn backups on and off for one Linode (and have other Linodes on your account)
2. Open the backupsCTA and enable backups for existing Linodes
3: Observe: on develop, all Linodes disappear (or doubles, depending on the initial state). The behavior should be as expected on this branch.

1. Have at least one Linode that needs backups (and none that will error, e.g. have cancelled backups within the past 24 hours)
2. Open the drawer and enable backups.
3. Observe: On develop, the drawer will close but the CTA will not disappear; this branch should be correct.

1. Make sure your Auto Enroll backups setting (in account/settings/global) is off
2. Open the backups CTA
3. Leave the auto-enroll toggle off and submit the form
4. Observe: in the network tab, no request to settings is made