### PR TITLE
M3-2225 Fix: Update results in Redux store when upserting a Linode

### DIFF
--- a/src/store/linodes/linodes.reducer.ts
+++ b/src/store/linodes/linodes.reducer.ts
@@ -53,10 +53,13 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   if (isType(action, upsertLinode)) {
     const { payload } = action;
     const { entities } = state;
+    // @todo check for unnecessary state rendering
+    const newEntities = updateOrAdd(payload, entities);
 
     return {
       ...state,
-      entities: updateOrAdd(payload, entities)
+      entities: newEntities,
+      results: newEntities.map(linode => linode.id)
     }
   }
 

--- a/src/store/linodes/linodes.reducer.ts
+++ b/src/store/linodes/linodes.reducer.ts
@@ -59,7 +59,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     return {
       ...state,
       entities: newEntities,
-      results: newEntities.map(linode => linode.id)
+      results: resultsFromPayload(newEntities)
     }
   }
 


### PR DESCRIPTION
## Description

When a user had 0 Linodes, a new Linode would not appear on Linodes Landing.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')


## Note to Reviewers

`results` was not being updated by `upsertLinode`, so the value (which ListLinodes was checking) stayed at 0 in this case.