### PR TITLE
M3-2234 0% Disk Space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Added a column for tags.
 - Account tab for StackScripts, lists all scripts created on the account the user has permissions to read/write.
   - If an account user does not have access to StackScripts, then a message indicating the user does not have the proper permissions will display.
+- Trusted Device table in My Profile> Password & Authentication> New section titled Trusted Devices.
+  - Lists devices that have been active on the account for the past 30 days, device name and browser used.
+  - Ability to untrust/delete a trusted device.
 
 ### Changed:
 - Explicitly check for errors before setting local storage.
@@ -54,6 +57,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Hide radio buttons on edit disk drawer.
 - Display notice on successful deletion of a user.
 - Submission of the enable back ups for all Linodes drawer caused duplicate listings of Linodes.
+- Display Scratch Code when enabling TFA
 
 ## [0.44.1] - 2019.01.10
 ### Fixed:

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskSpace.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskSpace.test.tsx
@@ -48,4 +48,23 @@ describe('LinodeDiskSpace', () => {
       component.setProps({ totalDiskSpace: undefined })
       expect(component.children().length).toBeFalsy()
     });
+
+  describe('percentages', () => {
+    it('should return 0% if no disk space is used', () => {
+      component.setProps({ disks: [], totalDiskSpace: 27000 })
+      expect(component.find('[data-qa-disk-used-percentage]').text()).toBe('0%')
+    });
+    
+    it('should return < 1% if used percentage is between 0 and 1', () => {
+      component.setProps({ disks, totalDiskSpace: 10000000 })
+      expect(component.find('[data-qa-disk-used-percentage]').text()).toBe('< 1%')
+    });
+    
+    it('should return percentage if usedPercentage is above 1', () => {
+      component.setProps({ disks, totalDiskSpace: 25600 })
+      expect(component.find('[data-qa-disk-used-percentage]').text()).toBe('100%')
+      component.setProps({ disks, totalDiskSpace: 27000 })      
+      expect(component.find('[data-qa-disk-used-percentage]').text()).toBe('94%')
+    });
+  });
 });

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskSpace.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskSpace.tsx
@@ -66,7 +66,7 @@ export class LinodeDiskSpace extends React.PureComponent<CombinedProps> {
     const freeDiskSpace = totalDiskSpace - usedDiskSpace;
 
     const usedPercentage = (usedDiskSpace / totalDiskSpace) * 100;
-    const formattedPercentage = (usedPercentage < 1)
+    const formattedPercentage = (usedPercentage < 1 && usedPercentage !== 0)
       ? '< 1'
       : Math.floor(usedPercentage);
 
@@ -81,7 +81,7 @@ export class LinodeDiskSpace extends React.PureComponent<CombinedProps> {
           value={usedDiskSpace}
         />
         <Typography className={classes.text}>
-          <strong>{formattedPercentage}%</strong> of your {totalDiskSpace}MB is allocated towards
+          <strong data-qa-disk-used-percentage>{formattedPercentage}%</strong> of your {totalDiskSpace}MB is allocated towards
           <strong> {disks.length}</strong> disk {disks.length === 1 ? 'image' : 'images'}.
         </Typography>
         <Divider className={classes.divider} />


### PR DESCRIPTION
## Description

Previously, we weren't telling the user they had 0% disk space used if it was at 0%. We were instead saying it was < 1%.

Now anything between 0 and 1 will display < 1%

## Type of Change
- Non breaking change ('update', 'change')