### PR TITLE
M3-1567 Change: Default image Debian 9

### DIFF
--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
@@ -58,7 +58,7 @@ describe('FromImageContent', () => {
       classes={{ root: '', main: '', sidebar: '' }}
       {...mockProps}
       images={[{
-        id: 'linode/ubuntu18.10',
+        id: 'linode/debian9',
         label: '',
         description: null,
         created: '',
@@ -72,8 +72,8 @@ describe('FromImageContent', () => {
     />,
   );
 
-  it('should default to Ubuntu 18.10 as the selected image', () => {
-    expect(componentWithImages.state().selectedImageID).toBe('linode/ubuntu18.10');
+  it('should default to Debian 9 as the selected image', () => {
+    expect(componentWithImages.state().selectedImageID).toBe('linode/debian9');
   });
 
   it('should set selectedImageID to null when initial state (from history or default) is not in images', () => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -24,7 +24,7 @@ import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
 import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
 import { renderBackupsDisplaySection } from './utils';
 
-const DEFAULT_IMAGE = 'linode/ubuntu18.10';
+const DEFAULT_IMAGE = 'linode/debian9';
 
 type ClassNames = 'root' | 'main' | 'sidebar';
 


### PR DESCRIPTION
Change default image for Linode Creation _from_ Ubuntu 18.10 _to_ Debian 9.