### PR TITLE
M3-2168, M3-2169, M3-2170: add entities icons to tables

### DIFF
--- a/src/features/Domains/DomainTableRow.tsx
+++ b/src/features/Domains/DomainTableRow.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import DomainIcon from 'src/assets/addnewmenu/domain.svg';
 import { StyleRulesCallback, WithStyles, withStyles } from 'src/components/core/styles';
+import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import Tags from 'src/components/Tags';
@@ -8,6 +10,7 @@ import ActionMenu from './DomainActionMenu';
 
 type ClassNames =
   | 'domain'
+  | 'icon'
   | 'tagWrapper'
   | 'domainRow';
 
@@ -18,6 +21,18 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   domainRow: {
     height: 75,
     backgroundColor: theme.bg.white,
+  },
+  icon: {
+    position: 'relative',
+    top: 3,
+    width: 40,
+    height: 40,
+    '& .circle': {
+      fill: theme.bg.offWhiteDT,
+    },
+    '& .outerCircle': {
+      stroke: theme.bg.main,
+    },
   },
   tagWrapper: {
     marginTop: theme.spacing.unit / 2,
@@ -51,10 +66,17 @@ const DomainsTableRow: React.StatelessComponent<CombinedProps> = (props) => {
     >
       <TableCell parentColumn="Domain" data-qa-domain-label>
         <Link to={`/domains/${id}`}>
-          {domain}
-          <div className={classes.tagWrapper}>
-            <Tags tags={tags} />
-          </div>
+          <Grid container wrap="nowrap" alignItems="center">
+            <Grid item className="py0">
+              <DomainIcon className={classes.icon}/>
+            </Grid>
+            <Grid item>
+              {domain}
+              <div className={classes.tagWrapper}>
+                <Tags tags={tags} />
+              </div>
+            </Grid>
+          </Grid>
         </Link>
       </TableCell>
       <TableCell parentColumn="Type" data-qa-domain-type>{type}</TableCell>

--- a/src/features/Domains/ListDomains.tsx
+++ b/src/features/Domains/ListDomains.tsx
@@ -11,10 +11,13 @@ import TableRow from 'src/components/TableRow';
 import TableSortCell from 'src/components/TableSortCell';
 import DomainTableRow from 'src/features/Domains/DomainTableRow';
 
-type ClassNames = 'root';
+type ClassNames = 'root' | 'label';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
+  label: {
+    paddingLeft: 65
+  }
 });
 
 interface Props {
@@ -30,7 +33,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 const ListDomains: React.StatelessComponent<CombinedProps> = (props) => {
   const {
-    data, orderBy, order, handleOrderChange,
+    data, orderBy, order, handleOrderChange, classes
   } = props;
   return (
     <Paginate data={data} pageSize={25}>
@@ -46,6 +49,7 @@ const ListDomains: React.StatelessComponent<CombinedProps> = (props) => {
                     direction={order}
                     handleClick={handleOrderChange}
                     data-qa-domain-name-header={order}
+                    className={classes.label}
                   >
                     Domain
                 </TableSortCell>

--- a/src/features/Domains/SortableTableHead.tsx
+++ b/src/features/Domains/SortableTableHead.tsx
@@ -1,24 +1,57 @@
 import * as React from 'react';
+import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import TableHead from 'src/components/core/TableHead';
 import { OrderByProps } from 'src/components/OrderBy';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableSortCell from 'src/components/TableSortCell';
 
-const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = (props) => {
-  const { order, orderBy, handleOrderChange } = props;
+type ClassNames = 'root' | 'label';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {
+  },
+  label: {
+    paddingLeft: 65,
+  }
+});
+
+type combinedProps = Omit<OrderByProps, 'data'> & WithStyles<ClassNames>;
+
+
+const SortableTableHead: React.StatelessComponent<combinedProps> = (props) => {
+  const { order, orderBy, handleOrderChange, classes } = props;
 
   const isActive = (label: string) => label === orderBy;
 
   return (
     <TableHead data-qa-table-head={order}>
       <TableRow>
-        <TableSortCell label='domain' direction={order} active={isActive('domain')} handleClick={handleOrderChange} data-qa-sort-domain={order}>Domain</TableSortCell>
-        <TableSortCell label='type' direction={order} active={isActive('type')} handleClick={handleOrderChange} data-qa-sort-type={order}>Type</TableSortCell>
+        <TableSortCell
+          label='domain'
+          direction={order}
+          active={isActive('domain')}
+          handleClick={handleOrderChange}
+          data-qa-sort-domain={order}
+          className={classes.label}
+        >
+          Domain
+        </TableSortCell>
+        <TableSortCell
+          label='type'
+          direction={order}
+          active={isActive('type')}
+          handleClick={handleOrderChange}
+          data-qa-sort-type={order}
+        >
+          Type
+        </TableSortCell>
         <TableCell />
       </TableRow>
     </TableHead>
   );
 };
 
-export default SortableTableHead;
+const styled = withStyles(styles);
+
+export default styled(SortableTableHead);

--- a/src/features/NodeBalancers/NodeBalancersLanding.test.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.test.tsx
@@ -21,6 +21,7 @@ describe.skip('NodeBalancers', () => {
             root: '',
             title: '',
             nameCell: '',
+            icon: '',
             nodeStatus: '',
             transferred: '',
             ports: '',

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -37,6 +37,7 @@ type ClassNames = 'root'
   | 'title'
   | 'nodeStatus'
   | 'nameCell'
+  | 'icon'
   | 'nodeStatus'
   | 'transferred'
   | 'ports'
@@ -52,6 +53,19 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   nameCell: {
     width: '15%',
     minWidth: 150,
+    paddingLeft: 65,
+  },
+  icon: {
+    position: 'relative',
+    top: 3,
+    width: 40,
+    height: 40,
+    '& .circle': {
+      fill: theme.bg.offWhiteDT,
+    },
+    '& .outerCircle': {
+      stroke: theme.bg.main,
+    },
   },
   nodeStatus: {
     width: '10%',
@@ -339,10 +353,17 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
         >
           <TableCell parentColumn="Name" data-qa-nodebalancer-label>
             <Link to={`/nodebalancers/${nodeBalancer.id}`}>
-              {nodeBalancer.label}
-              <div className={classes.tagWrapper}>
-                <Tags tags={nodeBalancer.tags} />
-              </div>
+              <Grid container wrap="nowrap" alignItems="center">
+                <Grid item className="py0">
+                  <NodeBalancer className={classes.icon}/>
+                </Grid>
+                <Grid item>
+                  {nodeBalancer.label}
+                  <div className={classes.tagWrapper}>
+                    <Tags tags={nodeBalancer.tags} />
+                  </div>
+                </Grid>
+              </Grid>
             </Link>
           </TableCell>
           <TableCell parentColumn="Node Status" data-qa-node-status>

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -51,7 +51,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     marginBottom: theme.spacing.unit * 2,
   },
   nameCell: {
-    width: '15%',
+    width: '20%',
     minWidth: 150,
     paddingLeft: 65,
   },

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -40,6 +40,7 @@ import WithEvents from './WithEvents';
 type ClassNames = 'root'
   | 'title'
   | 'labelCol'
+  | 'icon'
   | 'attachmentCol'
   | 'sizeCol'
   | 'pathCol'
@@ -47,7 +48,6 @@ type ClassNames = 'root'
   | 'linodeVolumesWrapper';
 
   type TagClassNames = 'tagWrapper';
-
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
@@ -75,6 +75,19 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   labelCol: {
     width: '15%',
     minWidth: 150,
+    paddingLeft: 65,
+  },
+  icon: {
+    position: 'relative',
+    top: 3,
+    width: 40,
+    height: 40,
+    '& .circle': {
+      fill: theme.bg.offWhiteDT,
+    },
+    '& .outerCircle': {
+      stroke: theme.bg.main,
+    },
   },
   attachmentCol: {
     width: '15%',
@@ -382,6 +395,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   };
 
   renderData = (volumes: ExtendedVolume[]) => {
+    const { classes } = this.props;
     const isVolumesLanding = this.props.match.params.linodeId === undefined;
 
     return volumes.map((volume) => {
@@ -400,8 +414,15 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
         ? (
           <TableRow key={volume.id} data-qa-volume-loading className="fade-in-table">
             <TableCell data-qa-volume-cell-label={label}>
-              {label}
-              <RenderTags tags={volume.tags} />
+              <Grid container wrap="nowrap" alignItems="center">
+                <Grid item className="py0">
+                  <VolumesIcon className={classes.icon}/>
+                </Grid>
+                <Grid item>
+                  {label}
+                  <RenderTags tags={volume.tags} />
+                </Grid>
+              </Grid>
             </TableCell>
             <TableCell colSpan={5}>
               <LinearProgress value={progressFromEvent(volume.recentEvent)} />
@@ -411,8 +432,15 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
         : (
           <TableRow key={volume.id} data-qa-volume-cell={volume.id} className="fade-in-table">
             <TableCell parentColumn="Label" data-qa-volume-cell-label={volume.label}>
-              {volume.label}
-              <RenderTags tags={volume.tags} />
+              <Grid container wrap="nowrap" alignItems="center">
+                <Grid item className="py0">
+                  <VolumesIcon className={classes.icon} />
+                </Grid>
+                <Grid item>
+                  {volume.label}
+                  <RenderTags tags={volume.tags} />
+                </Grid>
+              </Grid>
             </TableCell>
             {isVolumesLanding && <TableCell parentColumn="Region" data-qa-volume-region>{region}</TableCell>}
             <TableCell parentColumn="Size" data-qa-volume-size>{size} GiB</TableCell>

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -73,7 +73,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     },
   },
   labelCol: {
-    width: '15%',
+    width: '25%',
     minWidth: 150,
     paddingLeft: 65,
   },

--- a/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -1,12 +1,24 @@
 import * as React from 'react';
+import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import TableHead from 'src/components/core/TableHead';
 import { OrderByProps } from 'src/components/OrderBy';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableSortCell from 'src/components/TableSortCell';
 
-const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = (props) => {
-  const { order, orderBy, handleOrderChange } = props;
+type ClassNames = 'root' | 'label';
+
+const styles: StyleRulesCallback<ClassNames> = (theme) => ({
+  root: {},
+  label: {
+    paddingLeft: 65
+  }
+});
+
+type combinedProps = Omit<OrderByProps, 'data'> & WithStyles<ClassNames>;
+
+const SortableTableHead: React.StatelessComponent<combinedProps> = (props) => {
+  const { order, orderBy, handleOrderChange, classes } = props;
 
   const isActive = (label: string) => label === orderBy;
 
@@ -19,6 +31,7 @@ const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = 
           active={isActive('label')}
           handleClick={handleOrderChange}
           data-qa-sort-label={order}
+          className={classes.label}
         >
           Linode
         </TableSortCell>
@@ -47,4 +60,6 @@ const SortableTableHead: React.StatelessComponent<Omit<OrderByProps, 'data'>> = 
   );
 };
 
-export default SortableTableHead;
+const styled = withStyles(styles);
+
+export default styled(SortableTableHead);


### PR DESCRIPTION
## Description

Uses similar pattern to add icons to all tables where it was missing: NodeBalancers, Volumes, Domains.

## Type of Change
- Add icon to NodeBalancers table
- Add icon to Volumes table
- Add icon to Domains table
- Fix spacing in Linodes table
