### PR TITLE
M3-2229 Update: Remove Documentation Sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,11 @@ import { path } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { Redirect, Route, RouteProps, Switch } from 'react-router-dom';
-import { Sticky, StickyContainer, StickyProps } from 'react-sticky';
 import { Action, compose } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { Subscription } from 'rxjs/Subscription';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import DefaultLoader from 'src/components/DefaultLoader';
-import DocsSidebar from 'src/components/DocsSidebar';
 import { DocumentTitleSegment, withDocumentTitleProvider } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import NotFound from 'src/components/NotFound';
@@ -245,13 +243,10 @@ export class App extends React.Component<CombinedProps, State> {
     const { menuOpen, hasError } = this.state;
     const {
       classes,
-      documentation,
       toggleTheme,
       profileLoading,
-      profileError,
+      profileError
     } = this.props;
-
-    const hasDoc = documentation.length > 0;
 
     if (profileError || hasError) {
       return <TheApplicationIsOnFire />;
@@ -270,39 +265,30 @@ export class App extends React.Component<CombinedProps, State> {
                 <main className={classes.content}>
                   <TopMenu openSideMenu={this.openMenu} />
                   <div className={classes.wrapper} id="main-content">
-                    <StickyContainer>
-                      <Grid container spacing={0} className={classes.grid}>
-                        <Grid item className={`${classes.switchWrapper} ${hasDoc ? 'mlMain' : ''}`}>
-                          <Switch>
-                            <Route path="/linodes" component={LinodesRoutes} />
-                            <Route path="/volumes" component={Volumes} />
-                            <Route path="/nodebalancers" component={NodeBalancers} />
-                            <Route path="/domains" component={Domains} />
-                            <Route exact path="/managed" component={Managed} />
-                            <Route exact path="/longview" component={Longview} />
-                            <Route exact path="/images" component={Images} />
-                            <Route path="/stackscripts" component={StackScripts} />
-                            <Route path="/account" component={Account} />
-                            <Route exact path="/support/tickets" component={SupportTickets} />
-                            <Route path="/support/tickets/:ticketId" component={SupportTicketDetail} />
-                            <Route path="/profile" component={Profile} />
-                            <Route exact path="/support" component={Help} />
-                            <Route exact path="/support/search/" component={SupportSearchLanding} />
-                            <Route path="/dashboard" component={Dashboard} />
-                            <Route path="/search" component={SearchLanding} />
-                            <Redirect exact from="/" to="/dashboard" />
-                            <Route component={NotFound} />
-                          </Switch>
-                        </Grid>
-                        {hasDoc &&
-                          <Grid className='mlSidebar'>
-                            <Sticky topOffset={-24} disableCompensation>
-                              {(props: StickyProps) => (<DocsSidebar docs={documentation} {...props} />)}
-                            </Sticky>
-                          </Grid>
-                        }
+                    <Grid container spacing={0} className={classes.grid}>
+                      <Grid item className={classes.switchWrapper}>
+                        <Switch>
+                          <Route path="/linodes" component={LinodesRoutes} />
+                          <Route path="/volumes" component={Volumes} />
+                          <Route path="/nodebalancers" component={NodeBalancers} />
+                          <Route path="/domains" component={Domains} />
+                          <Route exact path="/managed" component={Managed} />
+                          <Route exact path="/longview" component={Longview} />
+                          <Route exact path="/images" component={Images} />
+                          <Route path="/stackscripts" component={StackScripts} />
+                          <Route path="/account" component={Account} />
+                          <Route exact path="/support/tickets" component={SupportTickets} />
+                          <Route path="/support/tickets/:ticketId" component={SupportTicketDetail} />
+                          <Route path="/profile" component={Profile} />
+                          <Route exact path="/support" component={Help} />
+                          <Route exact path="/support/search/" component={SupportSearchLanding} />
+                          <Route path="/dashboard" component={Dashboard} />
+                          <Route path="/search" component={SearchLanding} />
+                          <Redirect exact from="/" to="/dashboard" />
+                          <Route component={NotFound} />
+                        </Switch>
                       </Grid>
-                    </StickyContainer>
+                    </Grid>
                   </div>
 
                 </main>
@@ -389,5 +375,5 @@ export default compose(
   connected,
   styled,
   withDocumentTitleProvider,
-  withSnackbar
+  withSnackbar,
 )(App);

--- a/src/components/DocsSidebar/DocsSidebar.tsx
+++ b/src/components/DocsSidebar/DocsSidebar.tsx
@@ -1,10 +1,8 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
 import { StickyProps } from 'react-sticky';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
-import { BackupsCTA } from 'src/features/Backups';
 import DocComponent, { Doc } from './DocComponent';
 
 type ClassNames = 'root'
@@ -36,12 +34,12 @@ interface Props {
   isSticky?: boolean;
 }
 
-type CombinedProps = Props & BackupCTAProps & StickyProps & WithStyles<ClassNames>;
+type CombinedProps = Props & StickyProps & WithStyles<ClassNames>;
 
 const styled = withStyles(styles);
 
 const DocsSidebar: React.StatelessComponent<CombinedProps> = (props) =>  {
-  const { backupsCTA, classes, docs, style, isSticky } = props;
+  const { classes, docs, style, isSticky } = props;
 
   if (docs.length === 0) {
     return null;
@@ -57,11 +55,6 @@ const DocsSidebar: React.StatelessComponent<CombinedProps> = (props) =>  {
 
   return (
     <Grid container item style={stickyStyles} className={classes.root}>
-      {backupsCTA &&
-        <Grid item className={classes.gridItem}>
-          <BackupsCTA />
-        </Grid>
-      }
       <Grid item className={classes.gridItem}>
       <Typography
         role="header"
@@ -79,12 +72,4 @@ const DocsSidebar: React.StatelessComponent<CombinedProps> = (props) =>  {
   );
 }
 
-interface BackupCTAProps {
-  backupsCTA: boolean;
-}
-
-const connected = connect((state: ApplicationState, ownProps) => ({
-  backupsCTA: state.__resources.linodes.entities.filter(l => !l.backups.enabled).length > 0
-}));
-
-export default connected(styled(DocsSidebar));
+export default styled(DocsSidebar);

--- a/src/components/IconTextLink/IconTextLink.tsx
+++ b/src/components/IconTextLink/IconTextLink.tsx
@@ -19,7 +19,7 @@ const styles: StyleRulesCallback<CSSClasses> = (theme) => ({
     padding: 12,
     color: theme.palette.primary.main,
     transition: theme.transitions.create(['color']),
-    margin: '0 -12px 7px 0',
+    margin: '0 -12px 2px 0',
     minHeight: 'auto',
     '&:hover': {
       color: theme.palette.primary.light,

--- a/src/containers/withBackupCTA.container.ts
+++ b/src/containers/withBackupCTA.container.ts
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux';
+
+export interface BackupCTAProps {
+  backupsCTA: boolean;
+}
+
+export default connect((state: ApplicationState, ownProps) => ({
+  backupsCTA: state.__resources.linodes.entities.filter(l => !l.backups.enabled).length > 0
+}));

--- a/src/features/Backups/BackupsCTA.tsx
+++ b/src/features/Backups/BackupsCTA.tsx
@@ -10,16 +10,22 @@ import { handleOpen } from 'src/store/backupDrawer';
 import { MapState } from 'src/store/types';
 
 type ClassNames = 'root'
+  | 'container'
   | 'button';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
     padding: theme.spacing.unit * 2,
-    margin: `${theme.spacing.unit}px ${theme.spacing.unit}px ${theme.spacing.unit * 3}px 0`,
+    margin: `${theme.spacing.unit}px 0 ${theme.spacing.unit * 3}px 0`,
     [theme.breakpoints.down('md')]: {
       marginTop: -theme.spacing.unit,
       width: '100%',
     },
+  },
+  container: {
+    [theme.breakpoints.down('md')]: {
+      alignItems: 'center'
+    }
   },
   button: {
     marginTop: theme.spacing.unit,
@@ -36,7 +42,7 @@ const BackupsCTA: React.StatelessComponent<CombinedProps> = (props) => {
 
   return (
     <Paper className={classes.root} >
-      <Grid container direction="column">
+      <Grid container direction="column" className={classes.container}>
         <Grid item>
           <Typography variant="h2">
             Back Up Your Data

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -59,7 +59,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   },
   tagGroup: {
     flexDirection: 'row-reverse',
-    marginBottom: theme.spacing.unit -2,
+    marginBottom: theme.spacing.unit + 2,
   }
 });
 
@@ -196,13 +196,13 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Domains" />
-        <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }} >
+        <Grid container justify="space-between" alignItems="flex-end" >
           <Grid item className={classes.titleWrapper}>
             <Typography role="header" variant="h1" data-qa-title className={classes.title}>
               Domains
             </Typography>
           </Grid>
-          <Grid item>
+          <Grid item className="p0">
             <FormControlLabel
               className={classes.tagGroup}
               control={
@@ -216,13 +216,13 @@ class DomainsLanding extends React.Component<CombinedProps, State> {
           </Grid>
           <Grid item>
             <Grid container alignItems="flex-end" style={{ width: 'auto' }}>
-              <Grid item>
+              <Grid item className="pt0">
                 <AddNewLink
                   onClick={this.openImportZoneDrawer}
                   label="Import a Zone"
                 />
               </Grid>
-              <Grid item>
+              <Grid item className="pt0">
                 <AddNewLink
                   onClick={this.props.openForCreating}
                   label="Add a Domain"

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -253,7 +253,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Images" />
-        <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }} updateFor={[]}>
+        <Grid container justify="space-between" alignItems="flex-end" updateFor={[]}>
           <Grid item>
             <Typography variant="h1" data-qa-title className={classes.title}>
               Images
@@ -261,7 +261,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
           </Grid>
           <Grid item>
             <Grid container alignItems="flex-end">
-              <Grid item>
+              <Grid item className="pt0">
                 <AddNewLink
                   onClick={this.openForCreate}
                   label="Add an Image"

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -201,12 +201,12 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
       <React.Fragment>
         <DocumentTitleSegment segment="NodeBalancers" />
         <Grid container justify="space-between" alignItems="flex-end">
-          <Grid item className="pt0">
+          <Grid item>
             <Typography role="header" variant="h1" className={classes.title} data-qa-title >
               NodeBalancers
             </Typography>
           </Grid>
-          <Grid item className="pt0">
+          <Grid item>
             <Grid container alignItems="flex-end">
               <Grid item className="pt0">
                 <AddNewLink

--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -200,15 +200,15 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="NodeBalancers" />
-        <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }}>
-          <Grid item>
+        <Grid container justify="space-between" alignItems="flex-end">
+          <Grid item className="pt0">
             <Typography role="header" variant="h1" className={classes.title} data-qa-title >
               NodeBalancers
             </Typography>
           </Grid>
-          <Grid item>
+          <Grid item className="pt0">
             <Grid container alignItems="flex-end">
-              <Grid item>
+              <Grid item className="pt0">
                 <AddNewLink
                   onClick={() => history.push('/nodebalancers/create')}
                   label="Add a NodeBalancer"

--- a/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/src/features/StackScripts/StackScriptsLanding.tsx
@@ -47,7 +47,7 @@ export class StackScriptsLanding extends React.Component<CombinedProps, {}> {
         {!!history.location.state && !!history.location.state.successMessage &&
           <Notice success text={history.location.state.successMessage} />
         }
-        <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }}>
+        <Grid container justify="space-between" alignItems="flex-end">
           <Grid item>
             <Typography role="header" variant="h1" className={classes.title} data-qa-title >
               StackScripts
@@ -55,7 +55,7 @@ export class StackScriptsLanding extends React.Component<CombinedProps, {}> {
           </Grid>
           <Grid item>
             <Grid container alignItems="flex-end">
-              <Grid item>
+              <Grid item className="pt0">
                 <AddNewLink
                   onClick={this.goToCreateStackScript}
                   label="Create New StackScript"

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -255,15 +255,15 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Volumes" />
-        <Grid container justify="space-between" alignItems="flex-end" style={{ marginTop: 8 }}>
-          <Grid item>
+        <Grid container justify="space-between" alignItems="flex-end">
+          <Grid item className="pt0">
             <Typography role="header" variant="h1" className={classes.title} data-qa-title >
               Volumes
             </Typography>
           </Grid>
-          <Grid item>
+          <Grid item className="pt0">
             <Grid container alignItems="flex-end">
-              <Grid item>
+              <Grid item className="pt0">
                 <AddNewLink
                   onClick={this.openCreateVolumeDrawer}
                   label="Create a Volume"

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -256,12 +256,12 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <DocumentTitleSegment segment="Volumes" />
         <Grid container justify="space-between" alignItems="flex-end">
-          <Grid item className="pt0">
+          <Grid item>
             <Typography role="header" variant="h1" className={classes.title} data-qa-title >
               Volumes
             </Typography>
           </Grid>
-          <Grid item className="pt0">
+          <Grid item>
             <Grid container alignItems="flex-end">
               <Grid item className="pt0">
                 <AddNewLink

--- a/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
@@ -30,6 +30,7 @@ describe('ListLinodes', () => {
             onPresentSnackbar={jest.fn()}
             setDocs={setDocs}
             toggleGroupByTag={jest.fn()}
+            backupsCTA={false}
           />
         </StaticRouter>
       </LinodeThemeWrapper>,
@@ -57,6 +58,7 @@ describe('ListLinodes', () => {
             onPresentSnackbar={jest.fn()}
             setDocs={setDocs}
             toggleGroupByTag={jest.fn()}
+            backupsCTA={false}
           />
         </StaticRouter>
       </LinodeThemeWrapper>,
@@ -88,6 +90,7 @@ describe('ListLinodes', () => {
             onPresentSnackbar={jest.fn()}
             setDocs={setDocs}
             toggleGroupByTag={jest.fn()}
+            backupsCTA={false}
           />
         </StaticRouter>
       </LinodeThemeWrapper>,

--- a/src/index.css
+++ b/src/index.css
@@ -200,7 +200,8 @@ a.black:not(.nu):active {
 }
 .mlSidebar {
   width: 100%;
-  flex-basis: 100%
+  flex-basis: 100%;
+  margin-top: 24px !important;
 }
 @media (min-width: 1280px) {
   .mlMain {
@@ -210,7 +211,8 @@ a.black:not(.nu):active {
   .mlSidebar {
     max-width: 21.2%;
     max-width: 21.2%;
-    padding-left: 24px !important;
+    padding-left: 16px !important;
+    margin-top: 0 !important;
   }
 }
 .p0 {
@@ -226,6 +228,9 @@ a.black:not(.nu):active {
 .py0 {
   padding-top: 0 !important;
   padding-bottom: 0 !important;
+}
+.pt0 {
+  padding-top: 0 !important;
 }
 .mx0 {
   margin-left: 0 !important;


### PR DESCRIPTION
## Remove Documentation Sidebar

This PR removes the doc sidebar globally AND places the backups CTA on the linodes landing page ONLY. Therefore i had to modify the App file, create a container for the backupsCTA and use that on the /linodes landing. This means I have to do some modification to the layout in several places. Since I was there I also lessened the top padding for all the landing pages so we eliminate the previous white space.

## Type of Change
- Non breaking change

## Note to Reviewers

All landing pages should be tested for layout update and making sure the CTA is gone. The /linodes
landing page should be tested with both the CTA and without