### PR TITLE
M3-2248: remove unnecessary label

### DIFF
--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -146,7 +146,6 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = (props) => {
 
   return (
     <TableCell
-      parentColumn="Linode"
       className={classes.root}
       rowSpan={loading ? 2 : 1}
     >


### PR DESCRIPTION
## Description

`parentColumn` prop is used for responsive tables. Linode table is a different type and we don't have to display label for the mobile view (it switches to cards for linodes landing)

## Type of Change
- Fix unnecessary Linode label on mobile view for Dashboard page

