### PR TITLE
M3-2258: fix tab opening, add download invoice link

### DIFF
--- a/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesPanel.tsx
+++ b/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesPanel.tsx
@@ -1,7 +1,6 @@
 import { compose } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
@@ -157,7 +156,7 @@ class RecentInvoicesPanel extends React.Component<CombinedProps, State> {
     return (
       <TableRow key={`invoice-${item.id}`} rowLink={`/account/billing/invoices/${item.id}`} data-qa-invoice>
         <TableCell parentColumn="Date Created" data-qa-invoice-date><DateTimeDisplay value={item.date}/></TableCell>
-        <TableCell parentColumn="Description" data-qa-invoice-desc={item.id}><Link to={`/account/billing/invoices/${item.id}`}>Invoice #{item.id}</Link></TableCell>
+        <TableCell parentColumn="Description" data-qa-invoice-desc={item.id}>Invoice #{item.id}</TableCell>
         <TableCell parentColumn="Amount" data-qa-invoice-amount>${item.total}</TableCell>
         <TableCell>
           {account.data && <a href="#" onClick={e => this.printInvoice(e, account.data as Linode.Account, item)}>Download PDF</a>}

--- a/src/features/Billing/BillingPanels/RecentPaymentsPanel/RecentPaymentsPanel.tsx
+++ b/src/features/Billing/BillingPanels/RecentPaymentsPanel/RecentPaymentsPanel.tsx
@@ -144,7 +144,7 @@ class RecentPaymentsPanel extends React.Component<CombinedProps, State> {
         <TableCell parentColumn="Description">Payment #{item.id}</TableCell>
         <TableCell parentColumn="Amount">${item.usd}</TableCell>
         <TableCell>
-          {account.data && <a href="#" target="_blank" onClick={() => this.printPayment(account.data as Linode.Account, item)}>Download PDF</a>}
+          {account.data && <a href="#" onClick={() => this.printPayment(account.data as Linode.Account, item)}>Download PDF</a>}
           {pdfGenerationError.itemId === item.id && <Notice error={true} text="Failed generating PDF." />}
         </TableCell>
       </TableRow>

--- a/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -30,7 +30,7 @@ const formatDescription = (desc: string) => {
   }, '');
 }
 
-const addLeftHeader = (doc: jsPDF, page: number, pages: number, date: string | null) => {
+const addLeftHeader = (doc: jsPDF, page: number, pages: number, date: string | null, type: string) => {
   const addLine = (text: string, fontSize = 9) => {
     doc.text(text, leftPadding, currentLine, { charSpace: 0.75 });
     currentLine += fontSize;
@@ -43,7 +43,7 @@ const addLeftHeader = (doc: jsPDF, page: number, pages: number, date: string | n
 
   addLine(`Page ${page} of ${pages}`);
   if (date) {
-    addLine(`Invoice Date: ${date}`);
+    addLine(`${type} Date: ${date}`);
   }
 
   doc.setFontStyle('bold');
@@ -192,7 +192,7 @@ export const printInvoice = (account: Linode.Account, invoice: Linode.Invoice, i
     // Create a separate page for each set of invoice items
     itemsChunks.forEach((itemsChunk, index) => {
       doc.addImage(LinodeLogo, 'JPEG', 150, 5, 120, 50);
-      addLeftHeader(doc, index + 1, itemsChunks.length, date);
+      addLeftHeader(doc, index + 1, itemsChunks.length, date, 'Invoice');
       addRightHeader(doc, account);
       addTitle(doc, `Invoice: #${invoiceId}`);
       addTable(itemsChunk);
@@ -263,7 +263,7 @@ export const printPayment = (account: Linode.Account, payment: Linode.Payment) =
     };
 
     doc.addImage(LinodeLogo, 'JPEG', 150, 5, 120, 50);
-    addLeftHeader(doc, 1, 1, date);
+    addLeftHeader(doc, 1, 1, date, 'Payment');
     addRightHeader(doc, account);
     addTitle(doc, `Receipt for Payment #${paymentId}`);
     addTable();

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1053,7 +1053,7 @@ const themeDefaults: ThemeOptions = {
       },
       hover: {
         cursor: 'pointer',
-        '& a': {
+        '& a.secondaryLink': {
           color: primaryColors.offBlack,
           fontFamily: 'LatoWebBold',
         },


### PR DESCRIPTION
## Description

## Type of Change
- Fix 'Payment' word in Payments PDF
- Fix unnecessary tab opening
- Add 'Download PDF' link to invoice table on account page

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

@alioso can you help with styling 'Download PDF' on invoices table on account page, please? It is not highlighted as a link in Payments table
