### PR TITLE
M3-853 Update: Ctrl-click enabled navigation patterns

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -4,7 +4,7 @@ import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { PrimaryNav } from './PrimaryNav';
 
 const findLinkIn = (w: ShallowWrapper) => (s: string) => {
-  return w.find(`WithStyles(ListItem)[data-qa-nav-item="${s}"]`);
+  return w.find(`[data-qa-nav-item="${s}"]`);
 };
 const mockClasses = {
   active: '',

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -60,18 +60,18 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     padding: '10px 0 8px 12px',
   },
   listItem: {
-    borderBottomColor: 'rgba(0, 0, 0, 0.12)',
     borderLeft: '6px solid transparent',
     transition: theme.transitions.create(['background-color', 'border-left-color']),
-    flexShrink: 0,
     padding: '10px 30px 10px 24px',
     '&:hover': {
-      borderLeftColor: 'rgba(0, 0, 0, 0.1)',
+      backgroundColor: 'rgba(0, 0, 0, 0.1)',
       '& $linkItem': {
         color: 'white',
       },
     },
     '&:focus, &:active': {
+      backgroundColor: 'rgba(0, 0, 0, 0.1)',
+      outline: 0,
       '& $linkItem': {
         color: 'white',
         zIndex: 2,
@@ -269,29 +269,29 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     const { classes } = this.props;
 
     return (
-      <ListItem
-        key={primaryLink.display}
-        button
-        divider={!isLast}
-        component="li"
-        role="menuitem"
-        focusRipple={true}
-        onClick={() => this.navigate(primaryLink.href)}
-        className={`
-          ${classes.listItem}
-          ${this.linkIsActive(primaryLink.href) && classes.active}
-        `}
-        data-qa-nav-item={primaryLink.key}
-      >
-        <ListItemText
-          primary={primaryLink.display}
-          disableTypography={true}
-          className={`
-            ${classes.linkItem}
-            ${this.linkIsActive(primaryLink.href) && classes.activeLink}
-          `}
-        />
-      </ListItem>
+      <React.Fragment key={primaryLink.key}>
+        <Link
+          role="menuitem"
+          to={primaryLink.href}
+          href="javascript:void(0)"
+          onClick={this.props.closeMenu}
+          data-qa-nav-item={primaryLink.key}
+          className={classNames({
+            [classes.listItem]: true,
+            [classes.active]: this.linkIsActive(primaryLink.href)
+          })}
+        >
+          <ListItemText
+            primary={primaryLink.display}
+            disableTypography={true}
+            className={classNames({
+              [classes.linkItem]: true,
+              [classes.active]: this.linkIsActive(primaryLink.href)
+            })}
+          />
+        </Link>
+        <Divider className={classes.divider} />
+      </React.Fragment>
     );
   }
 
@@ -309,7 +309,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
           direction="column"
           wrap="nowrap"
           spacing={0}
-          component="ul"
+          component="nav"
           role="menu"
         >
           <Grid item>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -224,7 +224,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     // }
 
     if (hasAccountAccess) {
-      primaryLinks.push({ display: 'Account', href: '/account', key: 'account' });
+      primaryLinks.push({ display: 'Account', href: '/account/billing', key: 'account' });
     }
 
     primaryLinks.push({ display: 'Get Help', href: '/support', key: 'support' });
@@ -258,7 +258,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
   }
 
   goToProfile = () => {
-    this.navigate('/profile');
+    this.navigate('/profile/display');
   }
 
   logOut = () => {
@@ -336,7 +336,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
                 className={classNames({
                   [classes.listItem]: true,
                   [classes.collapsible]: true,
-                  [classes.active]: this.linkIsActive('/profile') === true,
+                  [classes.active]: this.linkIsActive('/profile/display') === true,
                 })}
               >
                 <ListItemText
@@ -345,7 +345,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
                     [classes.linkItem]: true,
                     [classes.activeLink]:
                       expandedMenus.support
-                      || this.linkIsActive('/profile') === true,
+                      || this.linkIsActive('/profile/display') === true,
                   })}
                 >
                   My Profile

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -286,7 +286,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
             disableTypography={true}
             className={classNames({
               [classes.linkItem]: true,
-              [classes.active]: this.linkIsActive(primaryLink.href)
             })}
           />
         </Link>

--- a/src/components/TabLink/TabLink.tsx
+++ b/src/components/TabLink/TabLink.tsx
@@ -15,18 +15,16 @@ const styles: StyleRulesCallback<ClassNames> = (theme: any) => ({
 interface Props {
   to: string;
   title: string;
+  selected?: boolean;
 }
 
 type CombinedProps = Props &  WithStyles<ClassNames>;
 
 class TabLink extends React.Component<CombinedProps> {
 
-  
-
   render() {
     const { classes, title, to } = this.props;
-
-    const pathName = document.location.pathname; 
+    const pathName = document.location.pathname;
 
     return (
         <Link

--- a/src/components/TabLink/TabLink.tsx
+++ b/src/components/TabLink/TabLink.tsx
@@ -1,0 +1,50 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
+
+type ClassNames = 'root' | 'selected';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: any) => ({
+  root: {
+     ...theme.overrides.MuiTab.root,
+  },
+  selected: {}
+});
+
+interface Props {
+  to: string;
+  title: string;
+}
+
+type CombinedProps = Props &  WithStyles<ClassNames>;
+
+class TabLink extends React.Component<CombinedProps> {
+
+  
+
+  render() {
+    const { classes, title, to } = this.props;
+
+    const pathName = document.location.pathname; 
+
+    return (
+        <Link
+          to={to}
+          className={classNames({
+            [classes.root]: true,
+            [classes.selected]: pathName === to
+          })}
+          role="tab"
+          tabIndex={0}
+          aria-selected={pathName === to}
+        >
+          {title}
+        </Link>
+    );
+  }
+}
+
+const styled = withStyles<ClassNames>(styles);
+
+export default styled(TabLink);

--- a/src/components/TabLink/index.ts
+++ b/src/components/TabLink/index.ts
@@ -1,0 +1,2 @@
+import TabLink from './TabLink';
+export default TabLink;

--- a/src/features/Account/AccountLanding.tsx
+++ b/src/features/Account/AccountLanding.tsx
@@ -5,6 +5,7 @@ import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import TabLink from 'src/components/TabLink';
 import Billing from 'src/features/Billing';
 import Users from 'src/features/Users';
 import GlobalSettings from './GlobalSettings';
@@ -47,8 +48,12 @@ class AccountLanding extends React.Component<Props> {
             scrollButtons="on"
           >
             {this.tabs
-              .map(tab => <Tab key={tab.title} label={tab.title} data-qa-tab={tab.title}
-            />)}
+              .map(tab =>
+                <Tab
+                  key={tab.title}
+                  data-qa-tab={tab.title}
+                  component={() => <TabLink to={tab.routeName} title={tab.title} />}
+                />)}
           </Tabs>
         </AppBar>
         <Switch>

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -10,6 +10,7 @@ import setDocs from 'src/components/DocsSidebar/setDocs';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import PromiseLoader, { PromiseLoaderResponse } from 'src/components/PromiseLoader/PromiseLoader';
+import TabLink from 'src/components/TabLink';
 import TagsPanel from 'src/components/TagsPanel';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import { getDomain, getDomainRecords, updateDomain } from 'src/services/domains';
@@ -202,7 +203,11 @@ class DomainDetail extends React.Component<CombinedProps, State> {
           >
             {
               this.tabs.map(tab =>
-                <Tab key={tab.title} label={tab.title} disabled={tab.disabled} />,
+                <Tab
+                  key={tab.title}
+                  disabled={tab.disabled}
+                  component={() => <TabLink to={tab.routeName} title={tab.title} />}
+                />,
               )
             }
           </Tabs>

--- a/src/features/Profile/Profile.tsx
+++ b/src/features/Profile/Profile.tsx
@@ -5,6 +5,7 @@ import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import TabLink from 'src/components/TabLink';
 import APITokens from './APITokens';
 import AuthenticationSettings from './AuthenticationSettings';
 import DisplaySettings from './DisplaySettings';
@@ -57,8 +58,12 @@ class Profile extends React.Component<Props> {
             scrollButtons="on"
           >
             {this.tabs
-              .map(tab => <Tab key={tab.title} label={tab.title} data-qa-tab={tab.title}
-            />)}
+              .map(tab =>
+                <Tab
+                  key={tab.title}
+                  data-qa-tab={tab.title}
+                  component={() => <TabLink to={tab.routeName} title={tab.title} />}
+                />)}
           </Tabs>
         </AppBar>
         <Switch>

--- a/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -18,7 +18,7 @@ interface MenuLink {
 };
 
 const menuLinks: MenuLink[] = [
-  { display: 'My Profile', href: '/profile' },
+  { display: 'My Profile', href: '/profile/display' },
   { display: 'Log Out', href: '/logout' },
 ];
 

--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -11,6 +11,7 @@ import Tabs from 'src/components/core/Tabs';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
+import TabLink from 'src/components/TabLink';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import { getUser, updateUser } from 'src/services/account';
 import { handleUpdate } from 'src/store/profile/profile.actions';
@@ -293,8 +294,12 @@ class UserDetail extends React.Component<CombinedProps> {
             scrollButtons="on"
           >
             {this.tabs
-              .map(tab => <Tab key={tab.title} label={tab.title} data-qa-tab={tab.title}
-            />)}
+              .map(tab =>
+                <Tab
+                  key={tab.title}
+                  data-qa-tab={tab.title}
+                  component={() => <TabLink to={tab.routeName} title={tab.title} />}
+                />)}
           </Tabs>
         </AppBar>
         {createdUsername &&

--- a/src/features/linodes/LinodesDetail/HeaderSections/TabsAndStatusBarPanel.tsx
+++ b/src/features/linodes/LinodesDetail/HeaderSections/TabsAndStatusBarPanel.tsx
@@ -4,6 +4,7 @@ import AppBar from 'src/components/core/AppBar';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
+import TabLink from 'src/components/TabLink';
 import { linodeInTransition } from 'src/features/linodes/transitions';
 import VolumesLanding from 'src/features/Volumes/VolumesLanding';
 import LinodeBackup from '../LinodeBackup';
@@ -20,6 +21,7 @@ type ClassNames = 'root';
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {},
 });
+
 interface Props {
   linodeId: number;
   linodeLabel: string;
@@ -34,7 +36,15 @@ interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const TabsAndStatusBarPanel: React.StatelessComponent<CombinedProps> = (props) => {
-  const { linodeRecentEvent, linodeStatus, url, linodeId, linodeRegion, linodeLabel, linodeConfigs } = props;
+  const {
+    linodeRecentEvent,
+    linodeStatus,
+    url,
+    linodeId,
+    linodeRegion,
+    linodeLabel,
+    linodeConfigs,
+  } = props;
 
   const tabs = [
     /* NB: These must correspond to the routes inside the Switch */
@@ -69,7 +79,13 @@ const TabsAndStatusBarPanel: React.StatelessComponent<CombinedProps> = (props) =
           scrollButtons="on"
         >
           {tabs.map(tab =>
-            <Tab key={tab.title} label={tab.title} data-qa-tab={tab.title} />)}
+            <Tab
+              key={tab.title}
+              label={tab.title}
+              data-qa-tab={tab.title}
+              component={() => <TabLink to={tab.routeName} title={tab.title} />}
+            />
+          )}
         </Tabs>
       </AppBar>
       <Switch>

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -938,15 +938,28 @@ const themeDefaults: ThemeOptions = {
     },
     MuiTab: {
       root: {
-        color: '#C5C6C8',
+        color: 'rgba(0, 0, 0, 0.54)',
         minWidth: 50,
         textTransform: 'inherit',
-        fontFamily: 'LatoWeb',
+        padding: '6px 16px',
+        position: 'relative',
+        overflow: 'hidden',
+        maxWidth: '264',
+        boxSizing: 'border-box',
+        minHeight: 48,
+        flexShrink: 0,
+        display: 'inline-flex',
+        alignItems: 'center',
+        verticalAlign: 'middle',
+        justifyContent: 'center',
+        appearance: 'none',
+        margin: 1,
         [breakpoints.up('md')]: {
           minWidth: 75,
         },
-        '&$selected': {
+        '&$selected, &$selected:hover': {
           fontFamily: 'LatoWebBold',
+          color: primaryColors.headline
         },
         '&:hover': {
           color: primaryColors.main,
@@ -970,6 +983,7 @@ const themeDefaults: ThemeOptions = {
           color: '#32363C',
         },
       },
+      selected: {}
     },
     MuiTable: {
       root: {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -437,6 +437,12 @@ export const dark = createTheme({
           color: '#fff',
         },
       },
+      textColorPrimary: {
+        color: '#fff',
+        '&$selected, &$selected:hover': {
+          color: '#fff',
+        },
+      },
       selected: {}
     },
     MuiTableCell: {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -433,21 +433,11 @@ export const dark = createTheme({
     MuiTab: {
       root: {
         color: '#fff',
-        '&:hover': {
-          color: primaryColors.main,
+        '&$selected, &$selected:hover': {
+          color: '#fff',
         },
       },
-      textColorPrimary: {
-        color: primaryColors.text,
-        '&$selected': {
-          color: primaryColors.text,
-        },
-        '&$disabled': {
-          color: '#666',
-          cursor: 'not-allowed',
-          pointerEvents: 'all !important',
-        },
-      },
+      selected: {}
     },
     MuiTableCell: {
       root: {
@@ -499,11 +489,6 @@ export const dark = createTheme({
         '& a': {
           color: primaryColors.offBlack,
         },
-      },
-    },
-    MuiTableSortLabel: {
-      root: {
-        textDecoration: 'underline',
       },
     },
     MuiTooltip: {


### PR DESCRIPTION
## Ctrl-click enabled navigation patterns

We need to make the navigation more friendly and make use of the <Link /> router component to enable opening links in new window.

## Type of Change
- Non breaking change

## Note to Reviewers

Feature as been added to:
- PrimaryNav
- Tabs: (linode detail, volumes, account, profile)