### PR TITLE
M3-2271 Update: re-style help landing page

### DIFF
--- a/src/components/EnhancedSelect/EnhancedSelect.tsx
+++ b/src/components/EnhancedSelect/EnhancedSelect.tsx
@@ -28,7 +28,7 @@ const styles: StyleRulesCallback = (theme) => ({
     top: '100%',
     padding: 0,
     borderRadius: 0,
-    border: '1px solid #999',
+    border: `1px solid ${theme.palette.primary.main}`,
     overflowY: 'auto',
     maxWidth: '100%',
     zIndex: 2,

--- a/src/features/Help/HelpLanding.tsx
+++ b/src/features/Help/HelpLanding.tsx
@@ -8,7 +8,10 @@ import SearchPanel from './Panels/SearchPanel';
 type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
-  root: {},
+  root: {
+    maxWidth: 960,
+    margin: '0 auto'
+  },
 });
 
 type CombinedProps = WithStyles<ClassNames>;

--- a/src/features/Help/HelpLanding.tsx
+++ b/src/features/Help/HelpLanding.tsx
@@ -8,11 +8,7 @@ import SearchPanel from './Panels/SearchPanel';
 type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
-  root: {
-    [theme.breakpoints.up('lg')]: {
-      padding: `${theme.spacing.unit * 2}px ${theme.spacing.unit * 14}px`,
-    },
-  },
+  root: {},
 });
 
 type CombinedProps = WithStyles<ClassNames>;

--- a/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -23,7 +23,7 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     }
   },
   searchItemHighlighted: {
-    backgroundColor: theme.color.grey2,
+    backgroundColor: theme.palette.divider,
     cursor: 'pointer',
   },
   textfield: {

--- a/src/features/Help/Panels/SearchPanel.tsx
+++ b/src/features/Help/Panels/SearchPanel.tsx
@@ -1,46 +1,26 @@
 import * as React from 'react';
-import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import Paper from 'src/components/core/Paper';
 import { StyleRulesCallback, withStyles, WithStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import AlgoliaSearchBar from './AlgoliaSearchBar';
 
 type ClassNames = 'root'
-  | 'bgIcon'
   | 'searchHeading';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   root: {
-    padding: theme.spacing.unit * 4,
-    backgroundColor: theme.color.green,
+    backgroundColor: 'transparent',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
     position: 'relative',
     [theme.breakpoints.up('md')]: {
-      padding: theme.spacing.unit * 8,
+      padding: theme.spacing.unit * 2,
     }
-  },
-  bgIcon: {
-    color: '#04994D',
-    position: 'absolute',
-    left: 0,
-    width: 250,
-    height: 250,
-    '& .circle': {
-      fill: 'transparent',
-    },
-    '& .outerCircle': {
-      stroke: 'transparent',
-    },
-    '& .insidePath path': {
-      stroke: '#04994D',
-    },
   },
   searchHeading: {
     textAlign: 'center',
-    color: theme.color.white,
     position: 'relative',
     zIndex: 2,
   },
@@ -56,7 +36,6 @@ class SearchPanel extends React.Component<CombinedProps, {}> {
         <Paper
           className={classes.root}
         >
-          <LinodeIcon className={classes.bgIcon} />
           <Typography
             variant="h1"
             className={classes.searchHeading}

--- a/src/features/Users/UsersLanding.tsx
+++ b/src/features/Users/UsersLanding.tsx
@@ -53,9 +53,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     '&:hover': {
       color: theme.palette.primary.main,
     },
-    [theme.breakpoints.up('md')]: {
-      padding: 8,
-    },
   },
   avatar: {
     borderRadius: '50%',


### PR DESCRIPTION
## re-style help landing page

Help landing's design needed an update as the layout/colors were differing too much from the rest of the app. Removed the green bg color and extra padding. also adjusted the Algolia drop down styles to match the rest of the selects

## Type of Change
- Non breaking change