### PR TITLE
M3-2211 Change: Graph Display Options ("Last 30 Days")

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -1,0 +1,33 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { linodes } from 'src/__data__/linodes';
+
+import { LinodeSummary } from './LinodeSummary';
+
+describe('LinodeSummary', () => {
+  const wrapper = shallow(
+    <LinodeSummary
+      linodeCreated="2018-11-01T00:00:00"
+      linodeId={1234}
+      linodeData={linodes[0]}
+      volumesData={[]}
+      classes={{ chart: '', leftLegend: '', bottomLegend: '', graphControls: '', graphTitle: '', totalTraffic: ''}}
+      typesData={[]}
+    />
+  );
+
+  it('should include "Last 24 Hours" as the first option', () => {
+    expect(wrapper.find('WithStyles(MenuItem)').at(0).children().text()).toBe('Last 24 Hours');
+    expect(wrapper.find('WithStyles(MenuItem)').at(0).props().value).toBe('24');
+  });
+
+  it('should include "Last 30 Days" as the second option', () => {
+    const currentMonth = new Date().getMonth() + 1;
+    const currentYear = new Date().getFullYear();
+
+    const paddedCurrentMonth = currentMonth.toString().padStart(2, '0')
+
+    expect(wrapper.find('WithStyles(MenuItem)').at(1).children().text()).toBe('Last 30 Days');
+    expect(wrapper.find('WithStyles(MenuItem)').at(1).props().value).toBe(`${currentYear} ${paddedCurrentMonth}`);
+  });
+});

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -130,16 +130,25 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         : moment.utc(linodeCreated).month() + 1,
       moment.utc(linodeCreated).year(),
     ];
+
+    const currentMonth = moment.utc().month() + 1; // Add 1 here because JS months are 0-indexed
+    const currentYear = moment.utc().year();
+
     const creationFirstOfMonth = moment(`${createYear}-${createMonth}-01`);
-    let [testMonth, testYear] = [
-      moment.utc().month() + 1,
-      moment.utc().year()
-    ];
+    let [testMonth, testYear] = [currentMonth, currentYear];
     let formattedTestDate;
     do {
+      // When we request Linode stats for the CURRENT month/year, the data we get back is
+      // from the last 30 days. We want the options to reflect this.
+      //
+      // Example: If it's Jan. 15, the options would be "Last 24 Hours", "Last 30 Days", "Dec 2018" ... etc.
+      const optionDisplay = (testYear === currentYear && testMonth === currentMonth)
+        ? 'Last 30 Days'
+        :  `${moment().month(testMonth - 1).format('MMM')} ${testYear}`;
+
       options.push([
         `${testYear} ${testMonth.toString().padStart(2, '0')}`,
-        `${moment().month(testMonth - 1).format('MMM')} ${testYear}`,
+        optionDisplay
       ]);
 
       if (testMonth === 1) {


### PR DESCRIPTION
## Description

Currently, graph display options are as follows: 

1) Last 24 Hours
2) {CURRENT MONTH}
3) {CURRENT MONTH - 1}
..etc

However, when we request graph data for the CURRENT month, what we're actually getting from the API is the last 30 days of data. Therefore, the second option above is mislabeled. This PR fixes that, and correctly labels it as "Last 30 Days".

<img width="255" alt="screen shot 2019-01-23 at 2 05 39 pm" src="https://user-images.githubusercontent.com/16911484/51630373-fc5a5c80-1f17-11e9-9262-2fbef5ba2434.png">

## Type of Change
- Non breaking change ('update', 'change')



## Note to Reviewers

Please check behavior on newly created Linodes, as well as longer-running Linodes.