### PR TITLE
M3-2216 Change: Friendly error message when graph data is unavailable

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.test.tsx
@@ -15,6 +15,7 @@ const component = shallow(
       'root':'',
       'spinner':'',
       'title':'',
+      'graphsUnavailable': ''
     }}
     title={title}
     height={300}
@@ -39,5 +40,9 @@ describe("StatsPanel component", () => {
   it("should call its renderContent function if neither error or loading", () => {
     component.setProps({ error: undefined });
     expect(renderMain).toHaveBeenCalled();
+  });
+  it("should render a friendly message if graph data is not yet available", () => {
+    component.setProps({ isTooEarlyForGraphData: true });
+    expect(component.find('[data-qa-graphs-unavailable]').children().text()).toBe('Graphs for this Linode are not yet available – check back later');
   });
 });

--- a/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
@@ -23,7 +23,8 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
     width: '100%',
-    paddingBottom: '32px'
+    padding: theme.spacing.unit * 2,
+    paddingTop: 0
   },
   title: {
     padding: theme.spacing.unit * 2

--- a/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/StatsPanel.tsx
@@ -5,7 +5,7 @@ import { StyleRulesCallback, Theme, withStyles, WithStyles } from 'src/component
 import Typography from 'src/components/core/Typography';
 import ErrorState from 'src/components/ErrorState';
 
-type ClassNames = 'root' | 'spinner' | 'title';
+type ClassNames = 'root' | 'spinner' | 'title' | 'graphsUnavailable';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
@@ -18,6 +18,13 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     justifyContent: 'center',
     width: '100%',
   },
+  graphsUnavailable: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    paddingBottom: '32px'
+  },
   title: {
     padding: theme.spacing.unit * 2
   }
@@ -29,12 +36,14 @@ interface Props {
   error?: string;
   title: string;
   height: number;
+  isTooEarlyForGraphData?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const StatsPanel: React.StatelessComponent<CombinedProps> = (props) => {
-  const { classes, error, height, loading, renderBody, title } = props;
+  const { classes, error, height, loading, renderBody, title, isTooEarlyForGraphData } = props;
+
   return (
     <Paper className={classes.root} >
       <Typography
@@ -44,11 +53,15 @@ export const StatsPanel: React.StatelessComponent<CombinedProps> = (props) => {
       >
         {title}
       </Typography>
-      {loading
-        ? <div className={classes.spinner} style={{minHeight: height}}><CircleProgress mini /></div>
-        : error
-          ? <ErrorState errorText={error} />
-          : renderBody()
+      {isTooEarlyForGraphData
+        ? <Typography data-qa-graphs-unavailable className={classes.graphsUnavailable}>
+            Graphs for this Linode are not yet available – check back later
+          </Typography>
+        : loading
+          ? <div className={classes.spinner} style={{minHeight: height}}><CircleProgress mini /></div>
+          : error
+            ? <ErrorState errorText={error} />
+            : renderBody()
       }
     </Paper>
   );

--- a/src/utilities/isRecent.test.ts
+++ b/src/utilities/isRecent.test.ts
@@ -1,0 +1,28 @@
+import * as moment from 'moment';
+import { isRecent } from './isRecent';
+
+describe('isRecent', () => {
+
+  const m = moment.utc(['2019', '00', '01']).format();
+
+  it('should return false if time is in the future', () => {
+    const t = moment(m).add(1, 'minute').format();
+    expect(isRecent(t, m)).toBe(false);
+  });
+
+  it('should return true if time within 24 hours in the past', () => {
+    const t1 = moment(m).subtract(1, 'minute').format();
+    expect(isRecent(t1, m)).toBe(true);
+
+    const t2 = moment(m).subtract(23, 'hours').subtract(59, 'minutes').subtract(59, 'seconds').format()
+    expect(isRecent(t2, m)).toBe(true);
+  });
+
+  it('should return false if time is more than 24 hours ago', () => {
+    const t1 = moment(m).subtract(1, 'day').format();
+    expect(isRecent(t1, m)).toBe(false);
+
+    const t2 = moment(m).subtract(23, 'hours').subtract(59, 'minutes').subtract(60, 'seconds').format()
+    expect(isRecent(t2, m)).toBe(false);
+  });
+});

--- a/src/utilities/isRecent.ts
+++ b/src/utilities/isRecent.ts
@@ -1,0 +1,9 @@
+import * as moment from 'moment';
+
+// Returns true if "a" is within the previous 24 hours of "b"
+export const isRecent = (a: string, b: string) => {
+  const timeToCompare = moment.utc(a);
+  const twentyFourHoursBeforeB = moment.utc(b).subtract(24, 'hours');
+
+  return timeToCompare.isBefore(moment.utc(b)) && timeToCompare.isAfter(twentyFourHoursBeforeB);
+}


### PR DESCRIPTION
## Description

If no graph data is available for a Linode, we get an error from the API. This is guaranteed to happen when a user first creates a Linode, since there _isn't_ any graph data yet. But currently, we show the graphs in an error state, which is extremely jarring. 

This PR checks the `linodeCreated` prop first. If we receive an error, and it hasn't been 24 hours since the Linode was created, we show a friendlier message (same one from Classic Manager): "Graphs for this Linode are not yet available – check back later"

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

- New utility with tests: `isRecent`
- StatsPanel component now takes a boolean prop, `isTooEarlyForGraphData`

Please verify with long running Linodes, new Linodes, Linodes without images, etc.