### PR TITLE
Manually update volume status on volume_create notification event

### DIFF
--- a/src/store/volume/volume.events.ts
+++ b/src/store/volume/volume.events.ts
@@ -36,11 +36,11 @@ const handleVolumeCreate = (dispatch: Dispatch<any>, status: Linode.EventStatus,
     case 'notification':
       updateVolumeStatus(dispatch, volumeId, 'active');
 
-      case 'failed':
-      case 'finished':
-      case 'scheduled':
-      case 'started':
-        dispatch(getOneVolume({ volumeId }));
+    case 'failed':
+    case 'finished':
+    case 'scheduled':
+    case 'started':
+      dispatch(getOneVolume({ volumeId }));
 
     default:
       return;

--- a/src/store/volume/volume.events.ts
+++ b/src/store/volume/volume.events.ts
@@ -9,9 +9,11 @@ const volumeEventsHandler: EventHandler = (event, dispatch) => {
 
   switch (action) {
     case 'volume_create':
+      return handleVolumeCreate(dispatch, status, id);
+
     case 'volume_attach':
     case 'volume_detach':
-    return handleVolumeUpdate(dispatch, status, id);
+      return handleVolumeUpdate(dispatch, status, id);
 
     case 'volume_resize':
       return handleVolumeResize(dispatch, status, id);
@@ -21,6 +23,24 @@ const volumeEventsHandler: EventHandler = (event, dispatch) => {
 
     case 'volume_delete':
       return handleVolumeDelete(dispatch, status, id);
+
+    default:
+      return;
+  }
+}
+
+// Manually set the status of this volume to "active", instead of dispatching "getOneVolume", because
+// when we get this volume back from the API, it may still be "creating"
+const handleVolumeCreate = (dispatch: Dispatch<any>, status: Linode.EventStatus, volumeId: number) => {
+  switch (status) {
+    case 'notification':
+      updateVolumeStatus(dispatch, volumeId, 'active');
+
+      case 'failed':
+      case 'finished':
+      case 'scheduled':
+      case 'started':
+        dispatch(getOneVolume({ volumeId }));
 
     default:
       return;


### PR DESCRIPTION
## Description

Previously, any time a `volume_create` event came through, we were re-requesting that volume to make sure it most up-to-date. But, if we get the event back when the volume is still has a status of "creating", the volume will be displayed with a spinner until the user refreshes the page.

This PR makes is such that we manually set the status to `active` when getting a `volume_create` notification event from the API.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
