### PR TITLE
M3-2291 fix: add missing typography to nodeBalancers landing page labels

### DIFF
--- a/src/features/NodeBalancers/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding.tsx
@@ -358,7 +358,7 @@ export class NodeBalancersLanding extends React.Component<CombinedProps, State> 
                   <NodeBalancer className={classes.icon}/>
                 </Grid>
                 <Grid item>
-                  {nodeBalancer.label}
+                  <Typography variant="h3">{nodeBalancer.label}</Typography>
                   <div className={classes.tagWrapper}>
                     <Tags tags={nodeBalancer.tags} />
                   </div>


### PR DESCRIPTION
## Add missing typography to nodeBalancers landing page labels

Please start the pull request title with the jira ticket corresponding to the work if applicable. Please include a short summary of the feature added, the change, or issue fixed.

## Type of Change
- Bug fix 