### PR TITLE
Volume events/actions adjustments

### DIFF
--- a/src/store/volume/volume.actions.ts
+++ b/src/store/volume/volume.actions.ts
@@ -23,10 +23,10 @@ export const detachVolumeActions = actionCreator.async<VolumeId, {}, Linode.ApiF
 export const cloneVolumeActions = actionCreator.async<CloneVolumeParams, Linode.Volume, Linode.ApiFieldError[]>(`clone`);
 export const resizeVolumeActions = actionCreator.async<ResizeVolumeParams, Linode.Volume, Linode.ApiFieldError[]>(`resize`);
 
-export const getAllVolumesActions = actionCreator.async<void, Linode.Volume[], Linode.ApiFieldError[]>('get-all');
-
-export interface UpdateVolumeInStore {
-  volumeId: number;
-  update: (volume: Linode.Volume) => Linode.Volume;
+// We want to provide the option NOT to set { loading: true } when requesting all Volumes.
+// Specifically, after cloning, we need to "getAllVolumes", but we want to do this "in the background",
+// so that the loading spinner doesn't take over the page.
+export interface GetAllVolumesOptions {
+  setLoading?: boolean;
 }
-export const updateVolumeInStore = actionCreator<UpdateVolumeInStore>('update-volume-in-store');
+export const getAllVolumesActions = actionCreator.async<GetAllVolumesOptions, Linode.Volume[], Linode.ApiFieldError[]>('get-all');


### PR DESCRIPTION
## Description

Previously we were updating the store upon `200 Success` for all volume actions. This is because we could not accurately rely on events to indicate status of Volumes. Since we're removing Status Indicators for volumes, this is not necessary anymore, and we can update Volumes with `notification` events.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

The store is updated upon API `200 Success` for the following actions:

- Volume Create
- Volume Update
- Volume Delete

The store is updated upon receiving an event for the following actions:

- Volume Create
- Volume Delete
- Volume Resize
- Volume Clone
- Volume Attach
- Volume Detach

### To Test:
Open two side-by-side tabs and try performing all Volume actions. They should both be in sync (except Volume Update, which doesn't have Events).