### PR TITLE
NB region cell alignment

### DIFF
--- a/src/features/NodeBalancers/NodeBalancersLanding/SortableTableHead.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/SortableTableHead.tsx
@@ -14,7 +14,8 @@ type ClassNames =
   | 'ports'
   | 'tagGroup'
   | 'title'
-  | 'transferred';
+  | 'transferred'
+  | 'region';
 
 const styles: StyleRulesCallback<ClassNames> = (theme) => ({
   ip: {
@@ -25,6 +26,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme) => ({
     width: '15%',
     minWidth: 150,
     paddingLeft: 65
+  },
+  region: {
+    width: '15%',
+    minWidth: 150,
   },
   nodeStatus: {
     width: '10%',
@@ -71,7 +76,7 @@ const SortableTableHead: React.StatelessComponent<CombinedProps> = (props) => {
         <TableCell className={classes.ports}>Ports</TableCell>
         <TableCell className={classes.ip} noWrap>IP Addresses</TableCell>
         <TableSortCell
-          className={classes.nameCell}
+          className={classes.region}
           active={isActive('region')}
           label="region"
           direction={order}


### PR DESCRIPTION
## Description

Fixes a visual regression where the NodeBalancer region cell wasn't lining up. The region cell had the same className as `nameCell`, which we added left padding to.

<img width="390" alt="screen shot 2019-01-24 at 2 29 49 pm" src="https://user-images.githubusercontent.com/16911484/51703685-fe3e2180-1fe4-11e9-9bf5-1b1a3733c5d0.png">

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

