### PR TITLE
M3-2297 fix: aria label on VolumeTableWrapper

### DIFF
--- a/src/features/Volumes/VolumeTableWrapper.tsx
+++ b/src/features/Volumes/VolumeTableWrapper.tsx
@@ -31,7 +31,7 @@ const DomainsTableWrapper: React.StatelessComponent<CombinedProps> = (props) => 
     <Paper className={classes.paperWrapper}>
       <Grid container className="my0">
         <Grid item xs={12} className="py0">
-          <Table arial-label="List of Linodes">
+          <Table aria-label="List of Volumes">
             <SortableVolumesTableHeader
               order={order}
               orderBy={orderBy}


### PR DESCRIPTION
## Description

Was incorrectly labeled as "List of Linodes" instead of "List of Volumes".

## Type of Change
- Bug fix ('fix', 'repair', 'bug')