### PR TITLE
use loading and error states from store instead of hardcoded values

### DIFF
--- a/src/containers/domains.container.ts
+++ b/src/containers/domains.container.ts
@@ -10,7 +10,7 @@ export interface Props {
 export default connect((state: ApplicationState) => {
   return {
     domainsData: state.__resources.domains.entities,
-    domainsLoading: false,
-    domainsError: undefined,
-  }
+    domainsLoading: state.__resources.domains.loading,
+    domainsError: state.__resources.domains.error
+  };
 });


### PR DESCRIPTION
## Description

Previously, in `domains.container.ts`, values for `domainsLoading` and `domainsError` were hard-coded. This PR fixes that so they are sourced from the store.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
