### PR TITLE
M3-2235 fix: Typo in "Manual Snapshot" copy

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -527,7 +527,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
           </Typography>
           <Typography variant="body1" data-qa-manual-desc>
             You can make a manual backup of your Linode by taking a snapshot.
-            Creating the manual snapshot can take serval minutes, depending on
+            Creating the manual snapshot can take several minutes, depending on
             the size of your Linode and the amount of data you have stored on
             it.
           </Typography>


### PR DESCRIPTION
## Description

One-word typo fix.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

99% of the diff is Prettier formatting changes. The real change occurs on (old) line 458:

![screen shot 2019-01-28 at 2 01 40 pm](https://user-images.githubusercontent.com/16911484/51859541-5aff4c00-2305-11e9-8d65-eae46ced844a.png)

