### PR TITLE
M3-2173 Change: Remove "Reboot" option unless Linode is running

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { LinodePowerButton } from './LinodePowerControl';
 
 describe('Linode Power Control Dialogs', () => {
-  const component =
+  const component = (
     <LinodePowerButton
       classes={{
         root: '',
@@ -16,34 +16,40 @@ describe('Linode Power Control Dialogs', () => {
         powerOff: '',
         rotate: '',
         fadeIn: '',
-        hidden: '',
+        hidden: ''
       }}
       id={1}
       label="Test Linode"
       status="running"
       openConfigDrawer={jest.fn()}
-    />;
+    />
+  );
 
   it('powerAlertOpen state should be true if reboot menu item is clicked', () => {
     const renderedComponent = shallow(component);
-    const button = renderedComponent
-      .find('WithStyles(WrapperMenuItem)[data-qa-set-power="reboot"]');
+    const button = renderedComponent.find(
+      'WithStyles(WrapperMenuItem)[data-qa-set-power="reboot"]'
+    );
     button.simulate('click');
     expect(renderedComponent.state('powerAlertOpen')).toBeTruthy();
   });
 
   it('powerAlertOpen state should be true if power off menu item is clicked', () => {
     const renderedComponent = shallow(component);
-    const button = renderedComponent
-      .find('WithStyles(WrapperMenuItem)[data-qa-set-power="powerOff"]');
+    const button = renderedComponent.find(
+      'WithStyles(WrapperMenuItem)[data-qa-set-power="powerOff"]'
+    );
     button.simulate('click');
     expect(renderedComponent.state('powerAlertOpen')).toBeTruthy();
   });
 
   it('Confirmation Dialog cancel button should set powerAlertOpen state is false', () => {
     const renderedComponent = shallow(component);
-    const cancelButton = renderedComponent.find('WithStyles(ConfirmationDialog)')
-      .dive().dive().find('[data-qa-confirm-cancel]');
+    const cancelButton = renderedComponent
+      .find('WithStyles(ConfirmationDialog)')
+      .dive()
+      .dive()
+      .find('[data-qa-confirm-cancel]');
     cancelButton.simulate('click');
     expect(renderedComponent.state('powerAlertOpen')).toBeFalsy();
   });

--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.test.tsx
@@ -53,4 +53,20 @@ describe('Linode Power Control Dialogs', () => {
     cancelButton.simulate('click');
     expect(renderedComponent.state('powerAlertOpen')).toBeFalsy();
   });
+
+  it('should only have the option to reboot if the status is "running"', () => {
+    const renderedComponent = shallow(component);
+
+    // "Running"
+    renderedComponent.setProps({ status: 'running' });
+    expect(
+      renderedComponent.find('[data-qa-set-power="reboot"]').exists()
+    ).toBeTruthy();
+
+    // "Offline"
+    renderedComponent.setProps({ status: 'offline' });
+    expect(
+      renderedComponent.find('[data-qa-set-power="reboot"]').exists()
+    ).toBeFalsy();
+  });
 });

--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -241,14 +241,16 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
           transformOrigin={{ vertical: -10, horizontal: 'right' }}
         >
           <MenuItem key="placeholder" aria-hidden className={classes.hidden} />
-          <MenuItem
-            onClick={this.toggleRebootDialog}
-            className={classes.menuItem}
-            data-qa-set-power="reboot"
-          >
-            <Reload className={`${classes.icon}`} />
-            Reboot
-          </MenuItem>
+          {isRunning && (
+            <MenuItem
+              onClick={this.toggleRebootDialog}
+              className={classes.menuItem}
+              data-qa-set-power="reboot"
+            >
+              <Reload className={`${classes.icon}`} />
+              Reboot
+            </MenuItem>
+          )}
           {isRunning && (
             <MenuItem
               onClick={this.togglePowerDownDialog}


### PR DESCRIPTION
## Description

The PR removes the option to Reboot a Linode unless the Linode currently has a status of `running`.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

### To Test:
1. Go to the Details page of a Linode that is _powered off._
2. Click the Power Controls button in the top-right corner.
3. **Observe:** The only option displayed is "Power On". 

<img width="334" alt="screen shot 2019-01-29 at 10 24 27 am" src="https://user-images.githubusercontent.com/16911484/51918876-5479de80-23b0-11e9-8dee-34f26e960da5.png">


1. Go to the Details page of a Linode that is _powered on._
2. Click the Power Controls button in the top-right corner.
3. **Observe:** Two options are present: "Reboot" and "Power Off"

<img width="342" alt="screen shot 2019-01-29 at 10 26 32 am" src="https://user-images.githubusercontent.com/16911484/51918897-5e9bdd00-23b0-11e9-8578-b0ddf1d246d7.png">
