### PR TITLE
M3-2319 Update: Summary Panels in Sidebar

### DIFF
--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -391,12 +391,9 @@ class Select extends React.PureComponent<CombinedProps, {}> {
         isMulti={isMulti}
         isDisabled={disabled}
         classes={classes}
-        className={classNames(
-          {
-            [classes.root]: true
-          },
-          className
-        )}
+        className={classNames(className, {
+          [classes.root]: true
+        })}
         classNamePrefix="react-select"
         styles={styleOverrides}
         textFieldProps={{

--- a/src/components/TagsPanel/TagsPanel.tsx
+++ b/src/components/TagsPanel/TagsPanel.tsx
@@ -37,8 +37,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     flexWrap: 'wrap'
   },
   tag: {
-    position: 'relative',
-    top: theme.spacing.unit,
+    marginTop: theme.spacing.unit / 2,
     marginRight: theme.spacing.unit,
     [theme.breakpoints.down('xs')]: {
       marginRight: 16
@@ -46,13 +45,13 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   addButtonWrapper: {
     width: '100%',
-    marginTop: theme.spacing.unit,
-    marginBottom: theme.spacing.unit
+    marginTop: 15,
+    marginBottom: 17
   },
   addButton: {
     padding: 0,
     position: 'relative',
-    top: theme.spacing.unit / 2,
+    top: 2,
     '& svg': {
       marginRight: theme.spacing.unit
     },
@@ -65,12 +64,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   selectTag: {
     marginTop: theme.spacing.unit,
-    // height: '48px',
     width: '100%',
     position: 'relative',
     zIndex: 3,
     animation: 'fadeIn .3s ease-in-out forwards',
-    border: '1px solid #ccc',
+    maxWidth: 275,
     '& > div > div': {
       marginTop: 0
     },
@@ -80,10 +78,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       flexWrap: 'wrap-reverse'
     },
     '& .input': {
-      minHeight: 'auto',
-      border: 0,
-      backgroundColor: 'transparent',
-      boxShadow: 'none',
       '& p': {
         fontSize: '.9rem',
         color: theme.color.grey1,
@@ -110,7 +104,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       backgroundColor: 'transparent'
     },
     '& .react-select__value-container': {
-      maxWidth: 415,
       padding: '6px'
     }
   }
@@ -335,6 +328,7 @@ class TagsPanel extends React.Component<CombinedProps, State> {
             autoFocus
             className={classes.selectTag}
             blurInputOnSelect={false}
+            menuIsOpen={true}
           />
         ) : (
           <div className={classes.addButtonWrapper}>

--- a/src/components/TagsPanel/TagsPanel.tsx
+++ b/src/components/TagsPanel/TagsPanel.tsx
@@ -3,18 +3,24 @@ import { InjectedNotistackProps, withSnackbar } from 'notistack';
 import { clone, pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
-import IconButton from 'src/components/core/IconButton';
+import Button from 'src/components/core/Button';
 import {
   StyleRulesCallback,
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import Tooltip from 'src/components/core/Tooltip';
+import Typography from 'src/components/core/Typography';
 import Select from 'src/components/EnhancedSelect/Select';
 import { getTags } from 'src/services/tags';
 import TagsPanelItem from './TagsPanelItem';
 
-type ClassNames = 'root' | 'tag' | 'addButton' | 'selectTag';
+type ClassNames =
+  | 'root'
+  | 'tag'
+  | 'addButtonWrapper'
+  | 'addButton'
+  | 'tagsPanelItemWrapper'
+  | 'selectTag';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   '@keyframes fadeIn': {
@@ -38,18 +44,36 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       marginRight: 16
     }
   },
+  addButtonWrapper: {
+    width: '100%',
+    marginTop: theme.spacing.unit,
+    marginBottom: theme.spacing.unit
+  },
   addButton: {
-    marginTop: theme.spacing.unit / 2,
+    padding: 0,
     position: 'relative',
-    top: 6
+    top: theme.spacing.unit / 2,
+    '& svg': {
+      marginRight: theme.spacing.unit
+    },
+    '&:hover p': {
+      color: theme.palette.primary.main
+    }
+  },
+  tagsPanelItemWrapper: {
+    marginBottom: theme.spacing.unit * 2
   },
   selectTag: {
-    marginTop: theme.spacing.unit / 2,
-    height: '48px',
-    width: 'auto',
+    marginTop: theme.spacing.unit,
+    // height: '48px',
+    width: '100%',
     position: 'relative',
     zIndex: 3,
     animation: 'fadeIn .3s ease-in-out forwards',
+    border: '1px solid #ccc',
+    '& > div > div': {
+      marginTop: 0
+    },
     '& .error-for-scroll > div': {
       width: 'auto',
       flexDirection: 'row',
@@ -86,7 +110,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       backgroundColor: 'transparent'
     },
     '& .react-select__value-container': {
-      width: 160
+      maxWidth: 415,
+      padding: '6px'
     }
   }
 });
@@ -277,24 +302,26 @@ class TagsPanel extends React.Component<CombinedProps, State> {
 
     return (
       <div className={classes.root}>
-        {tags.map(eachTag => {
-          return (
-            <TagsPanelItem
-              key={eachTag}
-              label={eachTag}
-              tagLabel={eachTag}
-              onDelete={this.handleDeleteTag}
-              className={classes.tag}
-              loading={listDeletingTags.some(inProgressTag => {
-                /*
-                 * The tag is getting deleted if it appears in the state
-                 * which holds the list of tags queued for deletion
-                 */
-                return eachTag === inProgressTag;
-              })}
-            />
-          );
-        })}
+        <div className={classes.tagsPanelItemWrapper}>
+          {tags.map(eachTag => {
+            return (
+              <TagsPanelItem
+                key={eachTag}
+                label={eachTag}
+                tagLabel={eachTag}
+                onDelete={this.handleDeleteTag}
+                className={classes.tag}
+                loading={listDeletingTags.some(inProgressTag => {
+                  /*
+                   * The tag is getting deleted if it appears in the state
+                   * which holds the list of tags queued for deletion
+                   */
+                  return eachTag === inProgressTag;
+                })}
+              />
+            );
+          })}
+        </div>
         {isCreatingTag ? (
           <Select
             onChange={this.handleCreateTag}
@@ -310,14 +337,16 @@ class TagsPanel extends React.Component<CombinedProps, State> {
             blurInputOnSelect={false}
           />
         ) : (
-          <Tooltip title="Add New Tag" placement="right">
-            <IconButton
+          <div className={classes.addButtonWrapper}>
+            <Button
               onClick={this.toggleTagInput}
               className={classes.addButton}
+              type="primary"
             >
               <AddCircle data-qa-add-tag />
-            </IconButton>
-          </Tooltip>
+              <Typography>Add New Tag</Typography>
+            </Button>
+          </div>
         )}
       </div>
     );

--- a/src/containers/SummaryPanels.styles.ts
+++ b/src/containers/SummaryPanels.styles.ts
@@ -39,7 +39,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
         right: 0
       }
     }
-  }
+  },
+  main: {},
+  sidebar: {},
+  domainSidebar: {},
+  titleWrapper: {}
 });
 
 export default withStyles(styles);

--- a/src/containers/SummaryPanels.styles.ts
+++ b/src/containers/SummaryPanels.styles.ts
@@ -31,12 +31,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     ...theme.typography.body1,
     '& .dif': {
       position: 'relative',
-      paddingRight: 35,
       width: 'auto',
       '& .chip': {
         position: 'absolute',
         top: '-4px',
-        right: 0
+        right: -10
       }
     }
   },

--- a/src/containers/SummaryPanels.styles.ts
+++ b/src/containers/SummaryPanels.styles.ts
@@ -27,8 +27,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     marginBottom: theme.spacing.unit * 3
   },
   section: {
-    display: 'flex',
-    alignItems: 'center',
     marginBottom: theme.spacing.unit,
     ...theme.typography.body1,
     '& .dif': {

--- a/src/containers/SummaryPanels.styles.ts
+++ b/src/containers/SummaryPanels.styles.ts
@@ -11,7 +11,8 @@ export type StyleProps = WithStyles<ClassNames>;
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
     [theme.breakpoints.up('md')]: {
-      paddingLeft: theme.spacing.unit
+      paddingLeft: theme.spacing.unit,
+      paddingTop: theme.spacing.unit
     },
     [theme.breakpoints.up('lg')]: {
       padding: theme.spacing.unit,

--- a/src/containers/SummaryPanels.styles.ts
+++ b/src/containers/SummaryPanels.styles.ts
@@ -1,0 +1,46 @@
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+
+type ClassNames = 'root' | 'title' | 'summarySection' | 'section';
+
+export type StyleProps = WithStyles<ClassNames>;
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: theme.spacing.unit
+    },
+    [theme.breakpoints.up('lg')]: {
+      padding: theme.spacing.unit,
+      paddingRight: 0
+    }
+  },
+  title: {
+    marginBottom: theme.spacing.unit * 2
+  },
+  summarySection: {
+    padding: theme.spacing.unit * 2,
+    marginBottom: theme.spacing.unit * 3
+  },
+  section: {
+    display: 'flex',
+    alignItems: 'center',
+    marginBottom: theme.spacing.unit,
+    ...theme.typography.body1,
+    '& .dif': {
+      position: 'relative',
+      paddingRight: 35,
+      width: 'auto',
+      '& .chip': {
+        position: 'absolute',
+        top: '-4px',
+        right: 0
+      }
+    }
+  }
+});
+
+export default withStyles(styles);

--- a/src/features/Billing/BillingDetail.test.tsx
+++ b/src/features/Billing/BillingDetail.test.tsx
@@ -10,7 +10,9 @@ describe('Account Landing', () => {
     <BillingDetail
       classes={{
         root: '',
-        heading: ''
+        heading: '',
+        main: '',
+        sidebar: ''
       }}
       setDocs={jest.fn()}
       clearDocs={jest.fn()}

--- a/src/features/Billing/BillingDetail.test.tsx
+++ b/src/features/Billing/BillingDetail.test.tsx
@@ -33,8 +33,6 @@ describe('Account Landing', () => {
   });
 
   it('should render Summary Panel', () => {
-    expect(
-      component.find('WithStyles(WithConfigs(SummaryPanel))')
-    ).toHaveLength(1);
+    expect(component.find('[data-qa-summary-panel]')).toHaveLength(1);
   });
 });

--- a/src/features/Billing/BillingDetail.tsx
+++ b/src/features/Billing/BillingDetail.tsx
@@ -36,7 +36,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     }
   },
   heading: {
-    marginTop: theme.spacing.unit * 4,
+    marginTop: theme.spacing.unit,
     marginBottom: theme.spacing.unit * 2
   }
 });

--- a/src/features/Billing/BillingDetail.tsx
+++ b/src/features/Billing/BillingDetail.tsx
@@ -125,7 +125,7 @@ export class BillingDetail extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <DocumentTitleSegment segment={`Account & Billing`} />
         <AccountProvider value={this.state.account}>
-          <Typography role="header" variant="h1" className={classes.heading}>
+          <Typography role="header" variant="h2" className={classes.heading}>
             Billing
           </Typography>
           <Grid container>

--- a/src/features/Billing/BillingDetail.tsx
+++ b/src/features/Billing/BillingDetail.tsx
@@ -8,6 +8,7 @@ import {
 import Typography from 'src/components/core/Typography';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Grid from 'src/components/Grid';
 import { AccountsAndPasswords, BillingAndPayments } from 'src/documentation';
 import { Requestable } from 'src/requestableContext';
 import { getAccountInfo } from 'src/services/account';
@@ -20,10 +21,20 @@ import UpdateContactInformationPanel from './BillingPanels/UpdateContactInformat
 import UpdateCreditCardPanel from './BillingPanels/UpdateCreditCardPanel';
 import { AccountProvider } from './context';
 
-type ClassNames = 'root' | 'heading';
+type ClassNames = 'root' | 'main' | 'sidebar' | 'heading';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
+  main: {
+    [theme.breakpoints.up('md')]: {
+      order: 1
+    }
+  },
+  sidebar: {
+    [theme.breakpoints.up('md')]: {
+      order: 2
+    }
+  },
   heading: {
     marginTop: theme.spacing.unit * 4,
     marginBottom: theme.spacing.unit * 2
@@ -117,13 +128,18 @@ export class BillingDetail extends React.Component<CombinedProps, State> {
           <Typography role="header" variant="h1" className={classes.heading}>
             Billing
           </Typography>
-          <SummaryPanel />
-
-          <UpdateContactInformationPanel />
-          <UpdateCreditCardPanel />
-          <MakeAPaymentPanel />
-          <RecentInvoicesPanel />
-          <RecentPaymentsPanel />
+          <Grid container>
+            <Grid item xs={12} md={3} className={classes.sidebar}>
+              <SummaryPanel />
+            </Grid>
+            <Grid item xs={12} md={9} className={classes.main}>
+              <UpdateContactInformationPanel />
+              <UpdateCreditCardPanel />
+              <MakeAPaymentPanel />
+              <RecentInvoicesPanel />
+              <RecentPaymentsPanel />
+            </Grid>
+          </Grid>
         </AccountProvider>
       </React.Fragment>
     );

--- a/src/features/Billing/BillingDetail.tsx
+++ b/src/features/Billing/BillingDetail.tsx
@@ -130,7 +130,7 @@ export class BillingDetail extends React.Component<CombinedProps, State> {
           </Typography>
           <Grid container>
             <Grid item xs={12} md={3} className={classes.sidebar}>
-              <SummaryPanel />
+              <SummaryPanel data-qa-summary-panel />
             </Grid>
             <Grid item xs={12} md={9} className={classes.main}>
               <UpdateContactInformationPanel />

--- a/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.test.tsx
+++ b/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.test.tsx
@@ -60,16 +60,6 @@ describe('SummaryPanel', () => {
     />
   );
 
-  it('should first render a headline of "Summary"', () => {
-    expect(
-      componentExpiredCC
-        .find('WithStyles(Typography)[variant="h2"]')
-        .first()
-        .children()
-        .text()
-    ).toBe('Summary');
-  });
-
   it('should render "Expired" text next to the CC expiration if has an old date', () => {
     expect(
       componentExpiredCC.find('span').filterWhere(n => {

--- a/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.test.tsx
+++ b/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.test.tsx
@@ -21,7 +21,16 @@ describe('SummaryPanel', () => {
     balance: 0
   };
 
-  const mockClasses = { root: '', expired: '', item: '', address2: '' };
+  const mockClasses = {
+    root: '',
+    title: '',
+    summarySection: '',
+    section: '',
+    expired: '',
+    balance: '',
+    positive: '',
+    negative: ''
+  };
 
   const componentExpiredCC = shallow(
     <SummaryPanel
@@ -32,6 +41,8 @@ describe('SummaryPanel', () => {
         ...account,
         credit_card: { ...account.credit_card, expiry: '02/2012' }
       }}
+      accountLoading={false}
+      balance={0}
     />
   );
 
@@ -44,6 +55,8 @@ describe('SummaryPanel', () => {
         ...account,
         credit_card: { ...account.credit_card, expiry: '02/2020' }
       }}
+      accountLoading={false}
+      balance={0}
     />
   );
 

--- a/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
+++ b/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
@@ -17,6 +17,10 @@ import { withAccount } from '../../context';
 type ClassNames = 'expired' | 'balance' | 'positive' | 'negative';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  title: {},
+  summarySection: {},
+  section: {},
   expired: {
     color: theme.color.red
   },
@@ -96,8 +100,6 @@ export class SummaryPanel extends React.Component<CombinedProps, {}> {
         ? `$${Math.abs(balance).toFixed(2)}`
         : '';
 
-    console.log(balance);
-
     return (
       <React.Fragment>
         <Paper className={classes.summarySection}>
@@ -125,7 +127,6 @@ export class SummaryPanel extends React.Component<CombinedProps, {}> {
               <div>{`${city} ${city && state && ', '} ${state} ${zip}`}</div>
             </div>
           </div>
-
           <div className={classes.section} data-qa-contact-email>
             <strong>Email:&nbsp;</strong>
             {email}
@@ -154,7 +155,6 @@ export class SummaryPanel extends React.Component<CombinedProps, {}> {
               {balance < 0 && ` (credit)`}
             </Typography>
           </div>
-
           <div className={classes.section} data-qa-contact-cc>
             <strong>Credit Card: </strong>
             {last_four ? `xxxx-xxxx-xxxx-${last_four}` : 'None'}

--- a/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
+++ b/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
@@ -21,6 +21,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   title: {},
   summarySection: {},
   section: {},
+  main: {},
+  sidebar: {},
+  domainSidebar: {},
+  titleWrapper: {},
   expired: {
     color: theme.color.red
   },

--- a/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
+++ b/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import { compose } from 'ramda';
 import * as React from 'react';
 import CircleProgress from 'src/components/CircleProgress';
@@ -9,26 +10,24 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import ErrorState from 'src/components/ErrorState';
-import Grid from 'src/components/Grid';
+import styled, { StyleProps } from 'src/containers/SummaryPanels.styles';
 import isCreditCardExpired from 'src/utilities/isCreditCardExpired';
 import { withAccount } from '../../context';
 
-type ClassNames = 'root' | 'expired' | 'item' | 'address2';
+type ClassNames = 'expired' | 'balance' | 'positive' | 'negative';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {
-    padding: theme.spacing.unit * 2
-  },
   expired: {
     color: theme.color.red
   },
-  item: {
-    marginBottom: theme.spacing.unit,
-    ...theme.typography.body1
+  balance: {
+    display: 'flex'
   },
-  address2: {
-    marginTop: -15,
-    paddingLeft: theme.spacing.unit * 7.5
+  positive: {
+    color: theme.color.green
+  },
+  negative: {
+    color: theme.color.red
   }
 });
 
@@ -37,35 +36,26 @@ interface AccountContextProps {
   errors?: Linode.ApiFieldError[];
   lastUpdated: number;
   data?: Linode.Account;
+  accountLoading: boolean;
+  balance: false | number;
 }
 
-type CombinedProps = AccountContextProps & WithStyles<ClassNames>;
+type CombinedProps = AccountContextProps & StyleProps & WithStyles<ClassNames>;
 
 export class SummaryPanel extends React.Component<CombinedProps, {}> {
   render() {
-    const { classes, data, loading, errors, lastUpdated } = this.props;
+    const { data, loading, errors, lastUpdated } = this.props;
 
     return (
-      <Paper className={classes.root} data-qa-contact-summary>
-        <Grid container>
-          <Grid item xs={12}>
-            <Typography role="header" variant="h2">
-              Summary
-            </Typography>
-          </Grid>
-          <Grid item xs={12}>
-            <Grid container>
-              {loading && lastUpdated === 0
-                ? this.loading()
-                : errors
-                ? this.error()
-                : data
-                ? this.info()
-                : null}
-            </Grid>
-          </Grid>
-        </Grid>
-      </Paper>
+      <div>
+        {loading && lastUpdated === 0
+          ? this.loading()
+          : errors
+          ? this.error()
+          : data
+          ? this.info()
+          : null}
+      </div>
     );
   }
 
@@ -96,86 +86,98 @@ export class SummaryPanel extends React.Component<CombinedProps, {}> {
         state,
         zip
       },
+      balance,
+      accountLoading,
       classes
     } = this.props;
 
+    const balanceDisplay =
+      !accountLoading && balance !== false
+        ? `$${Math.abs(balance).toFixed(2)}`
+        : '';
+
+    console.log(balance);
+
     return (
       <React.Fragment>
-        <Grid item md={7}>
-          <Grid container>
-            <Grid item xs={12}>
-              <Typography role="header" variant="h3">
-                Contact Information
-              </Typography>
-            </Grid>
-            <Grid item sm={6}>
-              <div className={classes.item} data-qa-company>
-                <strong>Company Name: </strong>
-                {company ? company : 'None'}
-              </div>
-              <div className={classes.item} data-qa-contact-name>
-                <strong>Name: </strong>
-                {!(first_name || last_name) && 'None'}
-                {`${first_name} ${last_name}`}
-              </div>
-              <div className={classes.item} data-qa-contact-address>
-                <strong>Address: </strong>
-                <div className={classes.address2}>
-                  {!(address_1 || address_2 || city || state || zip) && 'None'}
-                  <span>{address_1}</span>
-                  <div>{address_2}</div>
-                  <div>{`${city} ${city &&
-                    state &&
-                    ', '} ${state} ${zip}`}</div>
-                </div>
-              </div>
-            </Grid>
-            <Grid item sm={6}>
-              <div className={classes.item} data-qa-contact-email>
-                <strong>Email: </strong>
-                {email}
-              </div>
-              <div className={classes.item} data-qa-contact-phone>
-                <strong>Phone Number: </strong>
-                {phone ? phone : 'None'}
-              </div>
-            </Grid>
-          </Grid>
-        </Grid>
+        <Paper className={classes.summarySection}>
+          <Typography role="header" variant="h3" className={classes.title}>
+            Contact Information
+          </Typography>
 
-        <Grid item md={5}>
-          <Grid item xs={12}>
-            <Grid container>
-              <Grid item xs={12}>
-                <Typography role="header" variant="h3">
-                  Billing Information
-                </Typography>
-              </Grid>
-              <Grid item xs={12}>
-                <div className={classes.item} data-qa-contact-cc>
-                  <strong>Credit Card: </strong>
-                  {last_four ? `xxxx-xxxx-xxxx-${last_four}` : 'None'}
-                </div>
-                <div className={classes.item} data-qa-contact-cc-exp-date>
-                  <strong>Expiration Date: </strong>
-                  {expiry ? `${expiry} ` : 'None'}
-                  {expiry && isCreditCardExpired(expiry) && (
-                    <span className={classes.expired}>Expired</span>
-                  )}
-                </div>
-              </Grid>
-            </Grid>
-          </Grid>
-        </Grid>
+          <div className={classes.section} data-qa-company>
+            <strong>Company Name:&nbsp;</strong>
+            {company ? company : 'None'}
+          </div>
+          <div className={classes.section} data-qa-contact-name>
+            <strong>Name:&nbsp;</strong>
+            {!(first_name || last_name) && 'None'}
+            {`${first_name} ${last_name}`}
+          </div>
+          <div className={classes.section} data-qa-contact-address>
+            <div>
+              <strong>Address:&nbsp;</strong>
+            </div>
+            <div>
+              {!(address_1 || address_2 || city || state || zip) && 'None'}
+              <span>{address_1}</span>
+              <div>{address_2}</div>
+              <div>{`${city} ${city && state && ', '} ${state} ${zip}`}</div>
+            </div>
+          </div>
+
+          <div className={classes.section} data-qa-contact-email>
+            <strong>Email:&nbsp;</strong>
+            {email}
+          </div>
+          <div className={classes.section} data-qa-contact-phone>
+            <strong>Phone Number:&nbsp;</strong>
+            {phone ? phone : 'None'}
+          </div>
+        </Paper>
+
+        <Paper className={classes.summarySection}>
+          <Typography role="header" variant="h3" className={classes.title}>
+            Billing Information
+          </Typography>
+
+          <div className={`${classes.section} ${classes.balance}`}>
+            <strong>Balance:&nbsp;</strong>
+            <Typography
+              component={'span'}
+              className={classNames({
+                [classes.negative]: balance > 0,
+                [classes.positive]: balance <= 0
+              })}
+            >
+              {balanceDisplay}
+              {balance < 0 && ` (credit)`}
+            </Typography>
+          </div>
+
+          <div className={classes.section} data-qa-contact-cc>
+            <strong>Credit Card: </strong>
+            {last_four ? `xxxx-xxxx-xxxx-${last_four}` : 'None'}
+          </div>
+          <div className={classes.section} data-qa-contact-cc-exp-date>
+            <strong>Expiration Date: </strong>
+            {expiry ? `${expiry} ` : 'None'}
+            {expiry && isCreditCardExpired(expiry) && (
+              <span className={classes.expired}>Expired</span>
+            )}
+          </div>
+        </Paper>
       </React.Fragment>
     );
   };
 }
 
-const styled = withStyles(styles);
+const localStyles = withStyles(styles);
 
 const accountContext = withAccount(
   ({ data, errors, loading, lastUpdated }) => ({
+    accountLoading: loading,
+    balance: data && data.balance,
     errors,
     lastUpdated,
     loading,
@@ -185,6 +187,7 @@ const accountContext = withAccount(
 
 const enhanced = compose(
   styled,
+  localStyles,
   accountContext
 );
 

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-router-dom';
 import Breadcrumb from 'src/components/Breadcrumb';
 import AppBar from 'src/components/core/AppBar';
+import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
   withStyles,
@@ -16,6 +17,7 @@ import {
 } from 'src/components/core/styles';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
+import Typography from 'src/components/core/Typography';
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
@@ -24,6 +26,7 @@ import PromiseLoader, {
 } from 'src/components/PromiseLoader/PromiseLoader';
 import TabLink from 'src/components/TabLink';
 import TagsPanel from 'src/components/TagsPanel';
+import styled, { StyleProps } from 'src/containers/SummaryPanels.styles';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import { getDomain, getDomainRecords } from 'src/services/domains';
 import {
@@ -46,27 +49,35 @@ interface PreloadedProps {
   records: PromiseLoaderResponse<Linode.DomainRecord>;
 }
 
-type ClassNames = 'root' | 'titleWrapper' | 'backButton';
+type ClassNames = 'main' | 'sidebar' | 'domainSidebar' | 'titleWrapper';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {},
+  main: {
+    [theme.breakpoints.up('md')]: {
+      order: 1
+    }
+  },
+  sidebar: {
+    [theme.breakpoints.up('md')]: {
+      order: 2
+    }
+  },
+  domainSidebar: {
+    [theme.breakpoints.up('md')]: {
+      marginTop: theme.spacing.unit * 4
+    }
+  },
   titleWrapper: {
     display: 'flex',
     alignItems: 'center',
     wordBreak: 'break-all'
-  },
-  backButton: {
-    margin: '2px 0 0 -16px',
-    '& svg': {
-      width: 34,
-      height: 34
-    }
   }
 });
 
 type CombinedProps = DomainActionsProps &
   RouteProps &
   PreloadedProps &
+  StyleProps &
   WithStyles<ClassNames>;
 
 const preloaded = PromiseLoader<CombinedProps>({
@@ -186,13 +197,36 @@ class DomainDetail extends React.Component<CombinedProps, State> {
 
   renderDomainRecords = () => {
     const { domain, records } = this.state;
+    const { classes } = this.props;
     return (
-      <DomainRecords
-        domain={domain}
-        domainRecords={records}
-        updateRecords={this.updateRecords}
-        updateDomain={this.updateDomain}
-      />
+      <Grid container>
+        <Grid
+          item
+          xs={12}
+          md={3}
+          className={`${classes.sidebar} ${classes.domainSidebar}`}
+        >
+          <Paper className={classes.summarySection}>
+            <Typography
+              role="header"
+              variant="h3"
+              className={classes.title}
+              data-qa-title
+            >
+              Tags
+            </Typography>
+            <TagsPanel tags={domain.tags} updateTags={this.handleUpdateTags} />
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md={9} className={classes.main}>
+          <DomainRecords
+            domain={domain}
+            domainRecords={records}
+            updateRecords={this.updateRecords}
+            updateDomain={this.updateDomain}
+          />
+        </Grid>
+      </Grid>
     );
   };
 
@@ -237,7 +271,6 @@ class DomainDetail extends React.Component<CombinedProps, State> {
           </Grid>
         </Grid>
         <AppBar position="static" color="default">
-          <TagsPanel tags={domain.tags} updateTags={this.handleUpdateTags} />
           <Tabs
             value={this.tabs.findIndex(tab => matches(tab.routeName))}
             onChange={this.handleTabChange}
@@ -281,7 +314,7 @@ class DomainDetail extends React.Component<CombinedProps, State> {
   }
 }
 
-const styled = withStyles(styles);
+const localStyles = withStyles(styles);
 const reloaded = reloadableWithRouter<PreloadedProps, { domainId?: number }>(
   (routePropsOld, routePropsNew) => {
     return (
@@ -291,9 +324,10 @@ const reloaded = reloadableWithRouter<PreloadedProps, { domainId?: number }>(
   }
 );
 
-export default compose<any, any, any, any, any, any>(
+export default compose<any, any, any, any, any, any, any>(
   setDocs(DomainDetail.docs),
   reloaded,
+  localStyles,
   styled,
   preloaded,
   withDomainActions

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -24,7 +24,6 @@ import Grid from 'src/components/Grid';
 import PromiseLoader, {
   PromiseLoaderResponse
 } from 'src/components/PromiseLoader/PromiseLoader';
-import TabLink from 'src/components/TabLink';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import {
   getNodeBalancer,
@@ -290,9 +289,6 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
                   key={tab.title}
                   label={tab.title}
                   data-qa-tab={tab.title}
-                  component={() => (
-                    <TabLink to={tab.routeName} title={tab.title} />
-                  )}
                 />
               ))}
             </Tabs>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -25,7 +25,6 @@ import PromiseLoader, {
   PromiseLoaderResponse
 } from 'src/components/PromiseLoader/PromiseLoader';
 import TabLink from 'src/components/TabLink';
-import TagsPanel from 'src/components/TagsPanel';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import {
   getNodeBalancer,
@@ -277,10 +276,6 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
               />
             </Grid>
           </Grid>
-          <TagsPanel
-            tags={nodeBalancer.tags || []}
-            updateTags={this.updateTags}
-          />
           <AppBar position="static" color="default">
             <Tabs
               value={this.tabs.findIndex(tab => any(matches)(tab.routeNames))}

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -24,6 +24,7 @@ import Grid from 'src/components/Grid';
 import PromiseLoader, {
   PromiseLoaderResponse
 } from 'src/components/PromiseLoader/PromiseLoader';
+import TabLink from 'src/components/TabLink';
 import TagsPanel from 'src/components/TagsPanel';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import {
@@ -294,6 +295,9 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
                   key={tab.title}
                   label={tab.title}
                   data-qa-tab={tab.title}
+                  component={() => (
+                    <TabLink to={tab.routeName} title={tab.title} />
+                  )}
                 />
               ))}
             </Tabs>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -36,6 +36,7 @@ import {
 } from 'src/store/nodeBalancer/nodeBalancer.containers';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { NodeBalancerProvider } from './context';
 import NodeBalancerConfigurations from './NodeBalancerConfigurations';
 import NodeBalancerSettings from './NodeBalancerSettings';
 import NodeBalancerSummary from './NodeBalancerSummary';
@@ -253,90 +254,100 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
         ? this.state.labelInput
         : nodeBalancer.label;
 
+    const p = {
+      updateTags: this.updateTags
+    };
+
     return (
-      <React.Fragment>
-        <Grid container justify="space-between">
-          <Grid item className={classes.titleWrapper}>
-            <Breadcrumb
-              linkTo="/nodebalancers"
-              linkText="NodeBalancers"
-              labelTitle={nodeBalancerLabel}
-              labelOptions={{ linkTo: this.getLabelLink() }}
-              onEditHandlers={{
-                onEdit: this.updateLabel,
-                onCancel: this.cancelUpdate,
-                errorText: apiErrorText
-              }}
-            />
+      <NodeBalancerProvider value={p}>
+        <React.Fragment>
+          <Grid container justify="space-between">
+            <Grid item className={classes.titleWrapper}>
+              <Breadcrumb
+                linkTo="/nodebalancers"
+                linkText="NodeBalancers"
+                labelTitle={nodeBalancerLabel}
+                labelOptions={{ linkTo: this.getLabelLink() }}
+                onEditHandlers={{
+                  onEdit: this.updateLabel,
+                  onCancel: this.cancelUpdate,
+                  errorText: apiErrorText
+                }}
+              />
+            </Grid>
           </Grid>
-        </Grid>
-        <TagsPanel
-          tags={nodeBalancer.tags || []}
-          updateTags={this.updateTags}
-        />
-        <AppBar position="static" color="default">
-          <Tabs
-            value={this.tabs.findIndex(tab => any(matches)(tab.routeNames))}
-            onChange={this.handleTabChange}
-            indicatorColor="primary"
-            textColor="primary"
-            variant="scrollable"
-            scrollButtons="on"
-          >
-            {this.tabs.map(tab => (
-              <Tab key={tab.title} label={tab.title} data-qa-tab={tab.title} />
-            ))}
-          </Tabs>
-        </AppBar>
-        <Switch>
-          <Route
-            exact
-            path={`${path}/summary`}
-            render={() => (
-              <NodeBalancerSummary
-                nodeBalancer={nodeBalancer}
-                errorResponses={pathOr(
-                  undefined,
-                  ['location', 'state', 'errors'],
-                  this.props
-                )}
-              />
-            )}
+          <TagsPanel
+            tags={nodeBalancer.tags || []}
+            updateTags={this.updateTags}
           />
-          <Route
-            exact
-            path={`${path}/settings`}
-            render={() => (
-              <NodeBalancerSettings
-                nodeBalancerId={nodeBalancer.id}
-                nodeBalancerLabel={nodeBalancer.label}
-                nodeBalancerClientConnThrottle={
-                  nodeBalancer.client_conn_throttle
-                }
-              />
-            )}
-          />
-          <Route
-            exact
-            path={`${path}/configurations`}
-            render={() => (
-              <NodeBalancerConfigurations
-                nodeBalancerLabel={nodeBalancer.label}
-              />
-            )}
-          />
-          <Route
-            path={`${path}/configurations/:configId`}
-            render={() => (
-              <NodeBalancerConfigurations
-                nodeBalancerLabel={nodeBalancer.label}
-              />
-            )}
-          />
-          {/* 404 */}
-          <Redirect to={`${url}/summary`} />
-        </Switch>
-      </React.Fragment>
+          <AppBar position="static" color="default">
+            <Tabs
+              value={this.tabs.findIndex(tab => any(matches)(tab.routeNames))}
+              onChange={this.handleTabChange}
+              indicatorColor="primary"
+              textColor="primary"
+              variant="scrollable"
+              scrollButtons="on"
+            >
+              {this.tabs.map(tab => (
+                <Tab
+                  key={tab.title}
+                  label={tab.title}
+                  data-qa-tab={tab.title}
+                />
+              ))}
+            </Tabs>
+          </AppBar>
+          <Switch>
+            <Route
+              exact
+              path={`${path}/summary`}
+              render={() => (
+                <NodeBalancerSummary
+                  nodeBalancer={nodeBalancer}
+                  errorResponses={pathOr(
+                    undefined,
+                    ['location', 'state', 'errors'],
+                    this.props
+                  )}
+                />
+              )}
+            />
+            <Route
+              exact
+              path={`${path}/settings`}
+              render={() => (
+                <NodeBalancerSettings
+                  nodeBalancerId={nodeBalancer.id}
+                  nodeBalancerLabel={nodeBalancer.label}
+                  nodeBalancerClientConnThrottle={
+                    nodeBalancer.client_conn_throttle
+                  }
+                />
+              )}
+            />
+            <Route
+              exact
+              path={`${path}/configurations`}
+              render={() => (
+                <NodeBalancerConfigurations
+                  nodeBalancerLabel={nodeBalancer.label}
+                />
+              )}
+            />
+            <Route
+              path={`${path}/configurations/:configId`}
+              render={() => (
+                <NodeBalancerConfigurations
+                  nodeBalancerLabel={nodeBalancer.label}
+                />
+              )}
+            />
+            {/* 404 */}
+            <Redirect to={`${url}/summary`} />
+          </Switch>
+        </React.Fragment>
+      </NodeBalancerProvider>
     );
   }
 }

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
@@ -5,16 +5,27 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Grid from 'src/components/Grid';
 import NodeBalancerCreationErrors, {
   ConfigOrNodeErrorResponse
 } from './NodeBalancerCreationErrors';
 import SummaryPanel from './SummaryPanel';
 import TablesPanel from './TablesPanel';
 
-type ClassNames = 'root';
+type ClassNames = 'root' | 'main' | 'sidebar';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {}
+  root: {},
+  main: {
+    [theme.breakpoints.up('md')]: {
+      order: 1
+    }
+  },
+  sidebar: {
+    [theme.breakpoints.up('md')]: {
+      order: 2
+    }
+  }
 });
 
 interface Props {
@@ -25,13 +36,19 @@ interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const NodeBalancerSummary: React.StatelessComponent<CombinedProps> = props => {
-  const { nodeBalancer, errorResponses } = props;
+  const { nodeBalancer, errorResponses, classes } = props;
   return (
     <React.Fragment>
       <DocumentTitleSegment segment={`${nodeBalancer.label} - Summary`} />
       <NodeBalancerCreationErrors errors={errorResponses} />
-      <SummaryPanel nodeBalancer={nodeBalancer} />
-      <TablesPanel nodeBalancer={nodeBalancer} />
+      <Grid container>
+        <Grid item xs={12} md={3} className={classes.sidebar}>
+          <SummaryPanel nodeBalancer={nodeBalancer} />
+        </Grid>
+        <Grid item xs={12} md={9} className={classes.main}>
+          <TablesPanel nodeBalancer={nodeBalancer} />
+        </Grid>
+      </Grid>
     </React.Fragment>
   );
 };

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -14,9 +14,18 @@ import { formatRegion } from 'src/utilities';
 import { convertMegabytesTo } from 'src/utilities/convertMegabytesTo';
 import { NodeBalancerConsumer } from '../context';
 
-type ClassNames = 'IPgrouping' | 'nodeTransfer';
+type ClassNames =
+  | 'NBsummarySection'
+  | 'IPgrouping'
+  | 'nodeTransfer'
+  | 'hostName';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
+  NBsummarySection: {
+    [theme.breakpoints.up('md')]: {
+      marginTop: theme.spacing.unit * 6
+    }
+  },
   IPgrouping: {
     margin: '-2px 0 0 2px',
     display: 'flex',
@@ -24,6 +33,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   nodeTransfer: {
     marginTop: 12
+  },
+  hostName: {
+    wordBreak: 'break-word'
   }
 });
 
@@ -41,7 +53,11 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = props => {
       {({ updateTags }) => {
         return (
           <div className={classes.root}>
-            <Paper className={classes.summarySection}>
+            <Paper
+              className={`${classes.summarySection} ${
+                classes.NBsummarySection
+              }`}
+            >
               <Typography
                 role="header"
                 variant="h3"
@@ -70,7 +86,11 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = props => {
                 </Typography>
               </div>
               <div className={classes.section}>
-                <Typography variant="body1" data-qa-hostname>
+                <Typography
+                  variant="body1"
+                  className={classes.hostName}
+                  data-qa-hostname
+                >
                   <strong>Host Name: </strong>
                   {nodeBalancer.hostname}
                 </Typography>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
@@ -6,38 +7,18 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid';
+import styled, { StyleProps } from 'src/containers/SummaryPanels.styles';
 import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
 import { formatRegion } from 'src/utilities';
 import { convertMegabytesTo } from 'src/utilities/convertMegabytesTo';
 
-type ClassNames =
-  | 'root'
-  | 'title'
-  | 'IPWrapper'
-  | 'IPgrouping'
-  | 'marginTop'
-  | 'nodeTransfer';
+type ClassNames = 'IPgrouping' | 'nodeTransfer';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {
-    padding: theme.spacing.unit * 2,
-    marginTop: theme.spacing.unit * 2
-  },
-  title: {
-    marginBottom: theme.spacing.unit * 2
-  },
-  IPWrapper: {
-    display: 'flex',
-    alignItems: 'flex-start'
-  },
   IPgrouping: {
     margin: '-2px 0 0 2px',
     display: 'flex',
     flexDirection: 'column'
-  },
-  marginTop: {
-    marginTop: theme.spacing.unit * 2
   },
   nodeTransfer: {
     marginTop: 12
@@ -48,75 +29,79 @@ interface Props {
   nodeBalancer: Linode.ExtendedNodeBalancer;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props & StyleProps & WithStyles<ClassNames>;
 
 const SummaryPanel: React.StatelessComponent<CombinedProps> = props => {
   const { nodeBalancer, classes } = props;
   return (
-    <Paper className={classes.root}>
-      <Grid container>
-        <Grid item xs={12}>
-          <Typography
-            role="header"
-            variant="h1"
-            className={classes.title}
-            data-qa-title
-          >
-            Summary
-          </Typography>
-        </Grid>
-        <Grid item xs={12} sm={6}>
-          <div className={classes.IPWrapper}>
-            <Typography variant="body1">
-              <strong>IP:</strong>
-            </Typography>
-            <div className={classes.IPgrouping} data-qa-ip>
-              <IPAddress ips={[nodeBalancer.ipv4]} copyRight showMore />
-              {nodeBalancer.ipv6 && (
-                <IPAddress ips={[nodeBalancer.ipv6]} copyRight />
-              )}
-            </div>
-          </div>
-          <Typography
-            variant="body1"
-            data-qa-ports
-            className={classes.marginTop}
-          >
+    <div className={classes.root}>
+      <Paper className={classes.summarySection}>
+        <Typography
+          role="header"
+          variant="h3"
+          className={classes.title}
+          data-qa-title
+        >
+          NodeBalancer Details
+        </Typography>
+        <div className={classes.section}>
+          <Typography variant="body1" data-qa-ports>
             <strong>Ports: </strong> {nodeBalancer.ports.length === 0 && 'None'}
             {nodeBalancer.ports.join(', ')}
           </Typography>
-          <Grid container className={classes.nodeTransfer}>
-            <Grid item xs={12} sm={6}>
-              <Typography variant="body1" data-qa-node-status>
-                <strong>Node Status:</strong>{' '}
-                {`${nodeBalancer.up} up, ${nodeBalancer.down} down`}
-              </Typography>
-            </Grid>
-            <Grid item xs={12} sm={6}>
-              <Typography variant="body1" data-qa-transferred>
-                <strong>Transferred:</strong>{' '}
-                {convertMegabytesTo(nodeBalancer.transfer.total)}
-              </Typography>
-            </Grid>
-          </Grid>
-        </Grid>
-        <Grid item xs={12} sm={6}>
-          <Typography variant="body1" data-qa-hostname>
-            <strong>Host Name:</strong> {nodeBalancer.hostname}
+        </div>
+        <div className={classes.section}>
+          <Typography variant="body1" data-qa-node-status>
+            <strong>Node Status:</strong>{' '}
+            {`${nodeBalancer.up} up, ${nodeBalancer.down} down`}
           </Typography>
-          <Typography
-            variant="body1"
-            data-qa-region
-            className={classes.marginTop}
-          >
+        </div>
+        <div className={classes.section}>
+          <Typography variant="body1" data-qa-transferred>
+            <strong>Transferred:</strong>{' '}
+            {convertMegabytesTo(nodeBalancer.transfer.total)}
+          </Typography>
+        </div>
+        <div className={classes.section}>
+          <Typography variant="body1" data-qa-hostname>
+            <strong>Host Name:</strong>
+            {nodeBalancer.hostname}
+          </Typography>
+        </div>
+        <div className={classes.section}>
+          <Typography variant="body1" data-qa-region>
             <strong>Region:</strong> {formatRegion(nodeBalancer.region)}
           </Typography>
-        </Grid>
-      </Grid>
-    </Paper>
+        </div>
+      </Paper>
+
+      <Paper className={classes.summarySection}>
+        <Typography
+          role="header"
+          variant="h3"
+          className={classes.title}
+          data-qa-title
+        >
+          IP Addresses
+        </Typography>
+        <div className={`${classes.section}`}>
+          <div className={classes.IPgrouping} data-qa-ip>
+            <IPAddress ips={[nodeBalancer.ipv4]} copyRight showMore />
+            {nodeBalancer.ipv6 && (
+              <IPAddress ips={[nodeBalancer.ipv6]} copyRight />
+            )}
+          </div>
+        </div>
+      </Paper>
+    </div>
   );
 };
 
-const styled = withStyles(styles);
+const localStyles = withStyles(styles);
 
-export default styled(SummaryPanel);
+const enhanced = compose<CombinedProps, Props>(
+  styled,
+  localStyles
+);
+
+export default enhanced(SummaryPanel);

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -7,10 +7,12 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import TagsPanel from 'src/components/TagsPanel';
 import styled, { StyleProps } from 'src/containers/SummaryPanels.styles';
 import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
 import { formatRegion } from 'src/utilities';
 import { convertMegabytesTo } from 'src/utilities/convertMegabytesTo';
+import { NodeBalancerConsumer } from '../context';
 
 type ClassNames = 'IPgrouping' | 'nodeTransfer';
 
@@ -33,67 +35,76 @@ type CombinedProps = Props & StyleProps & WithStyles<ClassNames>;
 
 const SummaryPanel: React.StatelessComponent<CombinedProps> = props => {
   const { nodeBalancer, classes } = props;
-  return (
-    <div className={classes.root}>
-      <Paper className={classes.summarySection}>
-        <Typography
-          role="header"
-          variant="h3"
-          className={classes.title}
-          data-qa-title
-        >
-          NodeBalancer Details
-        </Typography>
-        <div className={classes.section}>
-          <Typography variant="body1" data-qa-ports>
-            <strong>Ports: </strong> {nodeBalancer.ports.length === 0 && 'None'}
-            {nodeBalancer.ports.join(', ')}
-          </Typography>
-        </div>
-        <div className={classes.section}>
-          <Typography variant="body1" data-qa-node-status>
-            <strong>Node Status:</strong>{' '}
-            {`${nodeBalancer.up} up, ${nodeBalancer.down} down`}
-          </Typography>
-        </div>
-        <div className={classes.section}>
-          <Typography variant="body1" data-qa-transferred>
-            <strong>Transferred:</strong>{' '}
-            {convertMegabytesTo(nodeBalancer.transfer.total)}
-          </Typography>
-        </div>
-        <div className={classes.section}>
-          <Typography variant="body1" data-qa-hostname>
-            <strong>Host Name:</strong>
-            {nodeBalancer.hostname}
-          </Typography>
-        </div>
-        <div className={classes.section}>
-          <Typography variant="body1" data-qa-region>
-            <strong>Region:</strong> {formatRegion(nodeBalancer.region)}
-          </Typography>
-        </div>
-      </Paper>
 
-      <Paper className={classes.summarySection}>
-        <Typography
-          role="header"
-          variant="h3"
-          className={classes.title}
-          data-qa-title
-        >
-          IP Addresses
-        </Typography>
-        <div className={`${classes.section}`}>
-          <div className={classes.IPgrouping} data-qa-ip>
-            <IPAddress ips={[nodeBalancer.ipv4]} copyRight showMore />
-            {nodeBalancer.ipv6 && (
-              <IPAddress ips={[nodeBalancer.ipv6]} copyRight />
-            )}
+  return (
+    <NodeBalancerConsumer>
+      {({ updateTags }) => {
+        return (
+          <div className={classes.root}>
+            <Paper className={classes.summarySection}>
+              <Typography
+                role="header"
+                variant="h3"
+                className={classes.title}
+                data-qa-title
+              >
+                NodeBalancer Details
+              </Typography>
+              <TagsPanel tags={nodeBalancer.tags} updateTags={updateTags} />
+              <div className={classes.section}>
+                <Typography variant="body1" data-qa-ports>
+                  <strong>Ports: </strong>{' '}
+                  {nodeBalancer.ports.length === 0 && 'None'}
+                  {nodeBalancer.ports.join(', ')}
+                </Typography>
+              </div>
+              <div className={classes.section}>
+                <Typography variant="body1" data-qa-node-status>
+                  <strong>Node Status:</strong>{' '}
+                  {`${nodeBalancer.up} up, ${nodeBalancer.down} down`}
+                </Typography>
+              </div>
+              <div className={classes.section}>
+                <Typography variant="body1" data-qa-transferred>
+                  <strong>Transferred:</strong>{' '}
+                  {convertMegabytesTo(nodeBalancer.transfer.total)}
+                </Typography>
+              </div>
+              <div className={classes.section}>
+                <Typography variant="body1" data-qa-hostname>
+                  <strong>Host Name:</strong>
+                  {nodeBalancer.hostname}
+                </Typography>
+              </div>
+              <div className={classes.section}>
+                <Typography variant="body1" data-qa-region>
+                  <strong>Region:</strong> {formatRegion(nodeBalancer.region)}
+                </Typography>
+              </div>
+            </Paper>
+
+            <Paper className={classes.summarySection}>
+              <Typography
+                role="header"
+                variant="h3"
+                className={classes.title}
+                data-qa-title
+              >
+                IP Addresses
+              </Typography>
+              <div className={`${classes.section}`}>
+                <div className={classes.IPgrouping} data-qa-ip>
+                  <IPAddress ips={[nodeBalancer.ipv4]} copyRight showMore />
+                  {nodeBalancer.ipv6 && (
+                    <IPAddress ips={[nodeBalancer.ipv6]} copyRight />
+                  )}
+                </div>
+              </div>
+            </Paper>
           </div>
-        </div>
-      </Paper>
-    </div>
+        );
+      }}
+    </NodeBalancerConsumer>
   );
 };
 

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -52,26 +52,26 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = props => {
               </Typography>
               <div className={classes.section}>
                 <Typography variant="body1" data-qa-ports>
-                  <strong>Ports: </strong>{' '}
+                  <strong>Ports: </strong>
                   {nodeBalancer.ports.length === 0 && 'None'}
                   {nodeBalancer.ports.join(', ')}
                 </Typography>
               </div>
               <div className={classes.section}>
                 <Typography variant="body1" data-qa-node-status>
-                  <strong>Node Status:</strong>{' '}
+                  <strong>Node Status: </strong>
                   {`${nodeBalancer.up} up, ${nodeBalancer.down} down`}
                 </Typography>
               </div>
               <div className={classes.section}>
                 <Typography variant="body1" data-qa-transferred>
-                  <strong>Transferred:</strong>{' '}
+                  <strong>Transferred: </strong>
                   {convertMegabytesTo(nodeBalancer.transfer.total)}
                 </Typography>
               </div>
               <div className={classes.section}>
                 <Typography variant="body1" data-qa-hostname>
-                  <strong>Host Name:</strong>
+                  <strong>Host Name: </strong>
                   {nodeBalancer.hostname}
                 </Typography>
               </div>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -21,6 +21,10 @@ type ClassNames =
   | 'hostName';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  title: {},
+  summarySection: {},
+  section: {},
   NBsummarySection: {
     [theme.breakpoints.up('md')]: {
       marginTop: theme.spacing.unit * 6

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -50,7 +50,6 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = props => {
               >
                 NodeBalancer Details
               </Typography>
-              <TagsPanel tags={nodeBalancer.tags} updateTags={updateTags} />
               <div className={classes.section}>
                 <Typography variant="body1" data-qa-ports>
                   <strong>Ports: </strong>{' '}
@@ -100,6 +99,18 @@ const SummaryPanel: React.StatelessComponent<CombinedProps> = props => {
                   )}
                 </div>
               </div>
+            </Paper>
+
+            <Paper className={classes.summarySection}>
+              <Typography
+                role="header"
+                variant="h3"
+                className={classes.title}
+                data-qa-title
+              >
+                Tags
+              </Typography>
+              <TagsPanel tags={nodeBalancer.tags} updateTags={updateTags} />
             </Paper>
           </div>
         );

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -23,7 +23,6 @@ type ClassNames =
   | 'chart'
   | 'leftLegend'
   | 'bottomLegend'
-  | 'graphTitle'
   | 'graphControls'
   | 'blue'
   | 'green'
@@ -76,10 +75,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
           marginBottom: theme.spacing.unit * 2
         }
       }
-    },
-    graphTitle: {
-      marginRight: theme.spacing.unit * 2,
-      marginTop: theme.spacing.unit * 2
     },
     graphControls: {
       margin: `${theme.spacing.unit * 2}px 0`,
@@ -348,11 +343,7 @@ class TablesPanel extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <React.Fragment>
           <div className={classes.graphControls}>
-            <Typography
-              role="header"
-              variant="h2"
-              className={classes.graphTitle}
-            >
+            <Typography role="header" variant="h2">
               Graphs
             </Typography>
           </div>

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -77,9 +77,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
       }
     },
     graphControls: {
-      margin: `${theme.spacing.unit * 2}px 0`,
       display: 'flex',
-      alignItems: 'center'
+      alignItems: 'center',
+      [theme.breakpoints.up('md')]: {
+        margin: `${theme.spacing.unit * 2}px 0`
+      }
     },
     blue: {
       '&:before': {

--- a/src/features/NodeBalancers/NodeBalancerDetail/context.ts
+++ b/src/features/NodeBalancers/NodeBalancerDetail/context.ts
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+const { Provider, Consumer } = React.createContext<any>(null);
+
+export const NodeBalancerProvider = Provider;
+export const NodeBalancerConsumer = Consumer;

--- a/src/features/Users/UsersLanding.tsx
+++ b/src/features/Users/UsersLanding.tsx
@@ -235,12 +235,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Users" />
-        <Grid
-          container
-          justify="space-between"
-          alignItems="flex-end"
-          style={{ marginTop: 8 }}
-        >
+        <Grid container justify="space-between" alignItems="flex-end">
           <Grid item>
             <Typography
               role="header"

--- a/src/features/Users/UsersLanding.tsx
+++ b/src/features/Users/UsersLanding.tsx
@@ -239,7 +239,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
           <Grid item>
             <Typography
               role="header"
-              variant="h1"
+              variant="h2"
               data-qa-title
               className={classes.title}
             >

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -14,6 +14,7 @@ describe('LinodeSummary', () => {
       classes={{
         main: '',
         sidebar: '',
+        headerWrapper: '',
         chart: '',
         leftLegend: '',
         bottomLegend: '',

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -12,6 +12,8 @@ describe('LinodeSummary', () => {
       linodeData={linodes[0]}
       volumesData={[]}
       classes={{
+        main: '',
+        sidebar: '',
         chart: '',
         leftLegend: '',
         bottomLegend: '',

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -657,12 +657,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
         <Grid container>
           <Grid item xs={12} md={3} className={classes.sidebar}>
-            <SummaryPanel
-              linode={linode}
-              volumes={volumes}
-              typesLongLabel={longLabel}
-              linodeImageId={linode.image}
-            />
+            <SummaryPanel volumes={volumes} typesLongLabel={longLabel} />
           </Grid>
           <Grid item xs={12} md={9} className={classes.main}>
             <div className={classes.graphControls}>

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -40,6 +40,7 @@ setUpCharts();
 type ClassNames =
   | 'main'
   | 'sidebar'
+  | 'headerWrapper'
   | 'chart'
   | 'leftLegend'
   | 'bottomLegend'
@@ -58,6 +59,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
       [theme.breakpoints.up('md')]: {
         order: 2
       }
+    },
+    headerWrapper: {
+      marginTop: theme.spacing.unit,
+      marginBottom: theme.spacing.unit * 2
     },
     chart: {
       position: 'relative',
@@ -97,8 +102,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
       marginRight: theme.spacing.unit * 2
     },
     graphControls: {
-      marginTop: theme.spacing.unit / 2,
-      marginBottom: theme.spacing.unit * 2 + theme.spacing.unit / 2,
       display: 'flex',
       alignItems: 'center'
     },
@@ -658,30 +661,48 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
         <Grid container>
           <Grid item xs={12} md={3} className={classes.sidebar}>
-            <SummaryPanel volumes={volumes} typesLongLabel={longLabel} />
+            <SummaryPanel volumes={volumes} />
           </Grid>
           <Grid item xs={12} md={9} className={classes.main}>
-            <div className={classes.graphControls}>
-              <Typography
-                role="header"
-                variant="h2"
-                className={classes.graphTitle}
-              >
-                Graphs
-              </Typography>
-              <FormControl style={{ marginTop: 0 }}>
-                <InputLabel htmlFor="chartRange" disableAnimation hidden>
-                  Select Time Range
-                </InputLabel>
-                <Select
-                  value={rangeSelection}
-                  onChange={this.handleChartRangeChange}
-                  inputProps={{ name: 'chartRange', id: 'chartRange' }}
+            <Grid
+              container
+              justify="space-between"
+              alignItems="center"
+              className={classes.headerWrapper}
+            >
+              <Grid item>
+                <Typography
+                  role="header"
+                  variant="h2"
+                  className={classes.graphTitle}
                 >
-                  {this.rangeSelectOptions}
-                </Select>
-              </FormControl>
-            </div>
+                  {longLabel}
+                </Typography>
+              </Grid>
+              <Grid item className="py0">
+                <div className={classes.graphControls}>
+                  <Typography
+                    role="header"
+                    variant="h3"
+                    className={classes.graphTitle}
+                  >
+                    Graphs
+                  </Typography>
+                  <FormControl style={{ marginTop: 0 }}>
+                    <InputLabel htmlFor="chartRange" disableAnimation hidden>
+                      Select Time Range
+                    </InputLabel>
+                    <Select
+                      value={rangeSelection}
+                      onChange={this.handleChartRangeChange}
+                      inputProps={{ name: 'chartRange', id: 'chartRange' }}
+                    >
+                      {this.rangeSelectOptions}
+                    </Select>
+                  </FormControl>
+                </div>
+              </Grid>
+            </Grid>
 
             <StatsPanel
               title="CPU Usage"

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -38,6 +38,8 @@ import TotalTraffic, { TotalTrafficProps } from './TotalTraffic';
 setUpCharts();
 
 type ClassNames =
+  | 'main'
+  | 'sidebar'
   | 'chart'
   | 'leftLegend'
   | 'bottomLegend'
@@ -47,15 +49,25 @@ type ClassNames =
 
 const styles: StyleRulesCallback<ClassNames> = theme => {
   return {
+    main: {
+      [theme.breakpoints.up('md')]: {
+        order: 1
+      }
+    },
+    sidebar: {
+      [theme.breakpoints.up('md')]: {
+        order: 2
+      }
+    },
     chart: {
       position: 'relative',
       width: 'calc(100vw - 80px)',
       paddingLeft: theme.spacing.unit * 4,
       [theme.breakpoints.up('md')]: {
-        width: 'calc(100vw - 310px)'
+        width: 'calc(80vw - 310px)'
       },
       [theme.breakpoints.up('xl')]: {
-        width: 'calc(100vw - 370px)'
+        width: 'calc(80vw - 370px)'
       }
     },
     leftLegend: {
@@ -642,60 +654,64 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment={`${linode.label} - Summary`} />
-        <SummaryPanel
-          linode={linode}
-          volumes={volumes}
-          typesLongLabel={longLabel}
-          linodeImageId={linode.image}
-        />
 
-        <React.Fragment>
-          <div className={classes.graphControls}>
-            <Typography
-              role="header"
-              variant="h2"
-              className={classes.graphTitle}
-            >
-              Graphs
-            </Typography>
-            <FormControl style={{ marginTop: 0 }}>
-              <InputLabel htmlFor="chartRange" disableAnimation hidden>
-                Select Time Range
-              </InputLabel>
-              <Select
-                value={rangeSelection}
-                onChange={this.handleChartRangeChange}
-                inputProps={{ name: 'chartRange', id: 'chartRange' }}
+        <Grid container>
+          <Grid item xs={12} md={3} className={classes.sidebar}>
+            <SummaryPanel
+              linode={linode}
+              volumes={volumes}
+              typesLongLabel={longLabel}
+              linodeImageId={linode.image}
+            />
+          </Grid>
+          <Grid item xs={12} md={9} className={classes.main}>
+            <div className={classes.graphControls}>
+              <Typography
+                role="header"
+                variant="h2"
+                className={classes.graphTitle}
               >
-                {this.rangeSelectOptions}
-              </Select>
-            </FormControl>
-          </div>
+                Graphs
+              </Typography>
+              <FormControl style={{ marginTop: 0 }}>
+                <InputLabel htmlFor="chartRange" disableAnimation hidden>
+                  Select Time Range
+                </InputLabel>
+                <Select
+                  value={rangeSelection}
+                  onChange={this.handleChartRangeChange}
+                  inputProps={{ name: 'chartRange', id: 'chartRange' }}
+                >
+                  {this.rangeSelectOptions}
+                </Select>
+              </FormControl>
+            </div>
 
-          <StatsPanel
-            title="CPU Usage"
-            renderBody={this.renderCPUChart}
-            {...chartProps}
-          />
+            <StatsPanel
+              title="CPU Usage"
+              renderBody={this.renderCPUChart}
+              {...chartProps}
+            />
 
-          <StatsPanel
-            title="IPv4 Traffic"
-            renderBody={this.renderIPv4TrafficChart}
-            {...chartProps}
-          />
+            <StatsPanel
+              title="IPv4 Traffic"
+              renderBody={this.renderIPv4TrafficChart}
+              {...chartProps}
+            />
 
-          <StatsPanel
-            title="IPv6 Traffic"
-            renderBody={this.renderIPv6TrafficChart}
-            {...chartProps}
-          />
+            <StatsPanel
+              title="IPv6 Traffic"
+              renderBody={this.renderIPv6TrafficChart}
+              {...chartProps}
+            />
 
-          <StatsPanel
-            title="Disk IO"
-            renderBody={this.renderDiskIOChart}
-            {...chartProps}
-          />
-        </React.Fragment>
+            <StatsPanel
+              title="Disk IO"
+              renderBody={this.renderDiskIOChart}
+              {...chartProps}
+            />
+          </Grid>
+        </Grid>
       </React.Fragment>
     );
   }

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -97,7 +97,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
       marginRight: theme.spacing.unit * 2
     },
     graphControls: {
-      margin: `${theme.spacing.unit * 2}px 0`,
+      marginTop: theme.spacing.unit / 2,
+      marginBottom: theme.spacing.unit * 2 + theme.spacing.unit / 2,
       display: 'flex',
       alignItems: 'center'
     },

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -29,7 +29,6 @@ type ClassNames =
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
-    marginTop: theme.spacing.unit,
     [theme.breakpoints.up('md')]: {
       paddingLeft: theme.spacing.unit
     },

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -8,7 +8,6 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid';
 import withImage from 'src/containers/withImage.container';
 import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
 import { formatRegion } from 'src/utilities';
@@ -16,6 +15,7 @@ import { formatRegion } from 'src/utilities';
 type ClassNames =
   | 'root'
   | 'title'
+  | 'summarySection'
   | 'section'
   | 'region'
   | 'volumeLink'
@@ -23,12 +23,21 @@ type ClassNames =
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
-    padding: theme.spacing.unit * 2,
-    paddingBottom: 12,
-    marginTop: theme.spacing.unit * 2
+    marginTop: theme.spacing.unit,
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: theme.spacing.unit
+    },
+    [theme.breakpoints.up('lg')]: {
+      padding: theme.spacing.unit,
+      paddingRight: 0
+    }
   },
   title: {
     marginBottom: theme.spacing.unit * 2
+  },
+  summarySection: {
+    padding: theme.spacing.unit * 2,
+    marginBottom: theme.spacing.unit * 3
   },
   section: {
     display: 'flex',
@@ -98,59 +107,51 @@ class SummaryPanel extends React.Component<CombinedProps> {
     const { classes, linode, volumes, typesLongLabel } = this.props;
 
     return (
-      <Paper className={classes.root}>
-        <Grid container>
-          <Grid item xs={12}>
-            <Typography
-              role="header"
-              variant="h2"
-              className={classes.title}
-              data-qa-title
+      <div className={classes.root}>
+        <Paper className={classes.summarySection}>
+          <Typography
+            role="header"
+            variant="h3"
+            className={classes.title}
+            data-qa-title
+          >
+            Linode Details
+          </Typography>
+          <div className={classes.section}>{this.renderImage()}</div>
+          <div className={classes.section}>{<span>{typesLongLabel}</span>}</div>
+          <div className={classes.section} data-qa-volumes={volumes.length}>
+            Volumes:&#160;
+            <Link
+              className={classes.volumeLink}
+              to={`/linodes/${linode.id}/volumes`}
             >
-              Summary
-            </Typography>
-          </Grid>
-          <Grid item xs={12} sm={6} lg={4}>
-            <div className={classes.section}>{this.renderImage()}</div>
+              {volumes.length}
+            </Link>
+          </div>
+          <div className={`${classes.section}`}>
+            {formatRegion(linode.region)}
+          </div>
+        </Paper>
+
+        <Paper className={classes.summarySection}>
+          <Typography
+            role="header"
+            variant="h3"
+            className={classes.title}
+            data-qa-title
+          >
+            IP Addresses
+          </Typography>
+          <div className={classes.section}>
+            <IPAddress ips={linode.ipv4} copyRight showMore />
+          </div>
+          {linode.ipv6 && (
             <div className={classes.section}>
-              {<span>{typesLongLabel}</span>}
+              <IPAddress ips={[linode.ipv6]} copyRight showMore />
             </div>
-          </Grid>
-          <Grid item xs={12} sm={6} lg={4}>
-            <div className={classes.section}>
-              <IPAddress ips={linode.ipv4} copyRight showMore />
-            </div>
-            {linode.ipv6 && (
-              <div className={classes.section}>
-                <IPAddress ips={[linode.ipv6]} copyRight showMore />
-              </div>
-            )}
-          </Grid>
-          <Grid item xs={12} sm={6} lg={4} className={classes.region}>
-            <Grid container>
-              <Grid item xs={12} sm={6} lg={12} className={classes.regionInner}>
-                <div className={`${classes.section}`}>
-                  {formatRegion(linode.region)}
-                </div>
-              </Grid>
-              <Grid item xs={12} sm={6} lg={12} className={classes.regionInner}>
-                <div
-                  className={classes.section}
-                  data-qa-volumes={volumes.length}
-                >
-                  Volumes:&#160;
-                  <Link
-                    className={classes.volumeLink}
-                    to={`/linodes/${linode.id}/volumes`}
-                  >
-                    {volumes.length}
-                  </Link>
-                </div>
-              </Grid>
-            </Grid>
-          </Grid>
-        </Grid>
-      </Paper>
+          )}
+        </Paper>
+      </div>
     );
   }
 }

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -22,6 +22,10 @@ import { withLinode } from '../context';
 type ClassNames = 'region' | 'volumeLink' | 'regionInner';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  title: {},
+  summarySection: {},
+  section: {},
   region: {
     [theme.breakpoints.between('sm', 'md')]: {
       flexBasis: '100%',

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -144,7 +144,6 @@ class SummaryPanel extends React.Component<CombinedProps> {
           >
             Linode Details
           </Typography>
-          <TagsPanel tags={linodeTags} updateTags={this.updateTags} />
           <div className={classes.section}>{this.renderImage()}</div>
           <div className={classes.section}>{<span>{typesLongLabel}</span>}</div>
           <div className={classes.section} data-qa-volumes={volumes.length}>
@@ -178,6 +177,17 @@ class SummaryPanel extends React.Component<CombinedProps> {
               <IPAddress ips={[linodeIpv6]} copyRight showMore />
             </div>
           )}
+        </Paper>
+        <Paper className={classes.summarySection}>
+          <Typography
+            role="header"
+            variant="h3"
+            className={classes.title}
+            data-qa-title
+          >
+            Tags
+          </Typography>
+          <TagsPanel tags={linodeTags} updateTags={this.updateTags} />
         </Paper>
       </div>
     );

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import TagsPanel from 'src/components/TagsPanel';
+import styled, { StyleProps } from 'src/containers/SummaryPanels.styles';
 import withImage from 'src/containers/withImage.container';
 import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
 import {
@@ -18,48 +19,9 @@ import {
 import { formatRegion } from 'src/utilities';
 import { withLinode } from '../context';
 
-type ClassNames =
-  | 'root'
-  | 'title'
-  | 'summarySection'
-  | 'section'
-  | 'region'
-  | 'volumeLink'
-  | 'regionInner';
+type ClassNames = 'region' | 'volumeLink' | 'regionInner';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {
-    [theme.breakpoints.up('md')]: {
-      paddingLeft: theme.spacing.unit
-    },
-    [theme.breakpoints.up('lg')]: {
-      padding: theme.spacing.unit,
-      paddingRight: 0
-    }
-  },
-  title: {
-    marginBottom: theme.spacing.unit * 2
-  },
-  summarySection: {
-    padding: theme.spacing.unit * 2,
-    marginBottom: theme.spacing.unit * 3
-  },
-  section: {
-    display: 'flex',
-    alignItems: 'center',
-    marginBottom: theme.spacing.unit,
-    ...theme.typography.body1,
-    '& .dif': {
-      position: 'relative',
-      paddingRight: 35,
-      width: 'auto',
-      '& .chip': {
-        position: 'absolute',
-        top: '-4px',
-        right: 0
-      }
-    }
-  },
   region: {
     [theme.breakpoints.between('sm', 'md')]: {
       flexBasis: '100%',
@@ -98,6 +60,7 @@ type CombinedProps = Props &
   LinodeContextProps &
   LinodeActionsProps &
   WithImage &
+  StyleProps &
   WithStyles<ClassNames>;
 
 class SummaryPanel extends React.Component<CombinedProps> {
@@ -193,7 +156,7 @@ class SummaryPanel extends React.Component<CombinedProps> {
   }
 }
 
-const styled = withStyles(styles);
+const localStyles = withStyles(styles);
 
 interface WithImage {
   image?: Linode.Image;
@@ -221,6 +184,7 @@ const linodeContext = withLinode(context => ({
 
 const enhanced = compose<CombinedProps, Props>(
   styled,
+  localStyles,
   linodeContext,
   withLinodeActions,
   withImage<LinodeContextProps & WithImage, LinodeContextProps>(

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -53,7 +53,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 interface Props {
   volumes: Linode.Volume[];
-  typesLongLabel: string;
 }
 
 type CombinedProps = Props &
@@ -87,7 +86,6 @@ class SummaryPanel extends React.Component<CombinedProps> {
     const {
       classes,
       volumes,
-      typesLongLabel,
       linodeTags,
       linodeId,
       linodeRegion,
@@ -107,7 +105,6 @@ class SummaryPanel extends React.Component<CombinedProps> {
             Linode Details
           </Typography>
           <div className={classes.section}>{this.renderImage()}</div>
-          <div className={classes.section}>{<span>{typesLongLabel}</span>}</div>
           <div className={classes.section} data-qa-volumes={volumes.length}>
             Volumes:&#160;
             <Link

--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader.tsx
@@ -6,7 +6,6 @@ import { compose } from 'recompose';
 import 'rxjs/add/observable/timer';
 import 'rxjs/add/operator/debounce';
 import 'rxjs/add/operator/filter';
-import TagsPanel from 'src/components/TagsPanel';
 import { lishLaunch } from 'src/features/Lish';
 import { scheduleOrQueueMigration } from 'src/services/linodes';
 import {
@@ -118,7 +117,6 @@ class LinodesDetailHeader extends React.Component<CombinedProps, State> {
       notifications,
       url,
       openConfigDrawer,
-      linodeTags,
       linodeId,
       linodeLabel,
       linodeRegion,
@@ -152,7 +150,6 @@ class LinodesDetailHeader extends React.Component<CombinedProps, State> {
             onEdit: this.editLabel
           }}
         />
-        <TagsPanel tags={linodeTags} updateTags={this.handleUpdateTags} />
         <TabsAndStatusBarPanel
           url={url}
           history={this.props.history}

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -35,6 +35,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   root: {
     marginBottom: theme.spacing.unit / 2,
     width: '100%',
+    maxWidth: '100%',
     '&:last-child': {
       marginBottom: 0
     },
@@ -46,7 +47,8 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   row: {
     display: 'flex',
-    alignItems: 'flex-start'
+    alignItems: 'flex-start',
+    width: '100%'
   },
   left: {
     marginLeft: theme.spacing.unit
@@ -63,8 +65,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   ip: {
     color: theme.palette.text.primary,
-    fontSize: '.9rem',
-    wordBreak: 'break-all'
+    fontSize: '.9rem'
   },
   ipLink: {
     color: theme.palette.primary.main,
@@ -122,9 +123,8 @@ export class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
       <div className={`${classes.ipLink}`} data-qa-copy-ip>
         <CopyTooltip
           text={ip}
-          className={`${classes.icon} ${showCopyOnHover ? classes.hide : ''} ${
-            copyRight ? classes.right : classes.left
-          }`}
+          className={`${classes.icon} ${showCopyOnHover ? classes.hide : ''}
+            ${copyRight ? classes.right : classes.left} copy`}
         />
       </div>
     );
@@ -134,7 +134,7 @@ export class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     const { classes } = this.props;
     return (
       <div key={key} className={classes.row}>
-        <div className={`${classes.ip} ${'ip'}`} data-qa-ip-main>
+        <div className={`${classes.ip} ${'ip xScroll'}`} data-qa-ip-main>
           {ip}
         </div>
         {copyRight && this.renderCopyIcon(ip)}

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -46,7 +46,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   row: {
     display: 'flex',
-    alignItems: 'center'
+    alignItems: 'flex-start'
   },
   left: {
     marginLeft: theme.spacing.unit
@@ -63,7 +63,8 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   ip: {
     color: theme.palette.text.primary,
-    fontSize: '.9rem'
+    fontSize: '.9rem',
+    wordBreak: 'break-all'
   },
   ipLink: {
     color: theme.palette.primary.main,

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,6 @@
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: inherit;
 }
 
@@ -13,7 +15,7 @@ body {
   height: 100%;
   margin: 0;
   padding: 0;
-  font-family: "LatoWeb", sans-serif;
+  font-family: 'LatoWeb', sans-serif;
 }
 
 @media screen and (min-width: 960px) {
@@ -25,8 +27,10 @@ body {
 }
 
 @media print {
-  /** Setting margins */       
-  @page { margin: 1cm }
+  /** Setting margins */
+  @page {
+    margin: 1cm;
+  }
 
   body {
     font-size: 13pt !important;
@@ -36,8 +40,8 @@ body {
   }
 
   #root {
-    width: 100%; 
-    margin: 0; 
+    width: 100%;
+    margin: 0;
     float: none;
   }
 
@@ -45,8 +49,12 @@ body {
     font-size: 24pt;
     color: #000 !important;
   }
-  
-  h2, h3, h4, h5, h6 {
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     font-size: 14pt;
     margin-top: 25px;
     color: #000 !important;
@@ -84,7 +92,7 @@ body {
     color: #000 !important;
     background-color: #fff !important;
   }
-  
+
   td > span:last-child {
     text-align: left;
     word-break: normal;
@@ -104,15 +112,35 @@ body {
   display: inline-flex;
 }
 
+.xScroll {
+  overflow-x: auto;
+  padding-bottom: 12px;
+  margin-bottom: -12px;
+}
+.xScroll::-webkit-scrollbar {
+  -webkit-appearance: none;
+}
+.xScroll::-webkit-scrollbar:horizontal {
+  height: 6px;
+}
+.xScroll::-webkit-scrollbar-thumb {
+  border-radius: 8px;
+  background-color: #ccc;
+}
+.xScroll::-webkit-scrollbar-track {
+  background-color: #fff;
+  border-radius: 8px;
+}
+
 a {
   text-decoration: none;
-  color: #3683DC;
+  color: #3683dc;
   cursor: pointer;
 }
 
 strong,
 bold {
-  font-family: "LatoWebBold";
+  font-family: 'LatoWebBold';
 }
 
 .visually-hidden {
@@ -149,27 +177,27 @@ a.blue {
 }
 
 a.blue:visited {
-  color: #3683DC;
+  color: #3683dc;
 }
 
 a.blue:hover {
-  color: #4D99F1;
+  color: #4d99f1;
 }
 
 a.blue:active {
-  color: #2466B3;
+  color: #2466b3;
 }
 
 a.black {
-  color: #32363C;
+  color: #32363c;
 }
 
 a.black:visited {
-  color: #32363C;
+  color: #32363c;
 }
 
 a.black:not(.nu):hover {
-  color: #32363C;
+  color: #32363c;
   text-decoration: underline;
 }
 
@@ -206,7 +234,7 @@ a.black:not(.nu):active {
 @media (min-width: 1280px) {
   .mlMain {
     max-width: 78.8%;
-    flex-basis: 78.8%
+    flex-basis: 78.8%;
   }
   .mlSidebar {
     max-width: 21.2%;
@@ -242,8 +270,8 @@ a.black:not(.nu):active {
 }
 
 button::-moz-focus-inner {
-    padding: 0;
-    border: 0;
+  padding: 0;
+  border: 0;
 }
 
 @keyframes fadeIn {
@@ -256,7 +284,7 @@ button::-moz-focus-inner {
 }
 
 .fade-in-table {
-  animation: fadeIn .3s ease-in-out;
+  animation: fadeIn 0.3s ease-in-out;
 }
 
 .no-transition *,

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1002,11 +1002,11 @@ const themeDefaults: ThemeOptions = {
         }
       },
       labelContainer: {
-        paddingLeft: 9,
-        paddingRight: 9,
+        paddingLeft: 0,
+        paddingRight: 0,
         [breakpoints.up('md')]: {
-          paddingLeft: 18,
-          paddingRight: 18
+          paddingLeft: 0,
+          paddingRight: 0
         }
       },
       textColorPrimary: {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -432,10 +432,11 @@ const themeDefaults: ThemeOptions = {
         [breakpoints.down('xs')]: {
           marginLeft: 8,
           marginRight: -8,
+          marginTop: -6,
           color: 'white !important',
           '& svg': {
-            width: 22,
-            height: 22,
+            width: 20,
+            height: 20,
             borderRadius: '50%',
             backgroundColor: primaryColors.main
           }


### PR DESCRIPTION
## Summary Sidebar

This PR implements a new UI pattern in which we feature the summary panel in a new sidebar. It was a major rework in order to move the TagsPanel in there as well. 

This pattern is implemented for the following entities:
- linodes
- nodebalancers
- domains
- account

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

linodes/[id]/summary
/nodebalancers/[id]/summary
domains/[id]/records
/account/billing