### PR TITLE
M3-2311 fix regression with nodeBalancers header spacing

### DIFF
--- a/src/components/IconTextLink/IconTextLink.tsx
+++ b/src/components/IconTextLink/IconTextLink.tsx
@@ -18,7 +18,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     padding: 12,
     color: theme.palette.primary.main,
     transition: theme.transitions.create(['color']),
-    margin: '0 -12px 2px 0',
+    margin: '0 -12px 4px 0',
     minHeight: 'auto',
     '&:hover': {
       color: theme.palette.primary.light,

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -217,12 +217,7 @@ export class NodeBalancersLanding extends React.Component<
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="NodeBalancers" />
-        <Grid
-          container
-          justify="space-between"
-          alignItems="flex-end"
-          style={{ marginTop: 8 }}
-        >
+        <Grid container justify="space-between" alignItems="flex-end">
           <Grid item className={classes.titleWrapper}>
             <Typography
               role="header"
@@ -248,7 +243,7 @@ export class NodeBalancersLanding extends React.Component<
           </Grid>
           <Grid item>
             <Grid container alignItems="flex-end" style={{ width: 'auto' }}>
-              <Grid item>
+              <Grid item className="pt0">
                 <AddNewLink
                   onClick={() => history.push('/nodebalancers/create')}
                   label="Add a NodeBalancer"


### PR DESCRIPTION
## fix regression with nodeBalancers header spacing

The nodeBalancers landing page had a regression when the last feature was merged and the header spacing differed from the other landing pages

## Type of Change
- Bug fix