### PR TITLE
M3-2386 Change: Send GA event upon Display Group Import

### DIFF
--- a/src/features/TagImport/TagImportDrawer.test.tsx
+++ b/src/features/TagImport/TagImportDrawer.test.tsx
@@ -1,9 +1,16 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
 import { domains, linodes } from 'src/__data__/groupImports';
-
-import { getGroupImportList, TagImportDrawer } from './TagImportDrawer';
+import { sendEvent } from 'src/utilities/analytics';
+import {
+  createLabel,
+  getGroupImportList,
+  TagImportDrawer,
+  withUpdates
+} from './TagImportDrawer';
+jest.mock('src/utilities/analytics', () => ({
+  sendEvent: jest.fn()
+}));
 
 const props = {
   actions: {
@@ -20,7 +27,9 @@ const props = {
   classes: { root: '' }
 };
 
-const component = shallow(<TagImportDrawer {...props} />);
+const EnhancedComponent = withUpdates(TagImportDrawer);
+const wrapper = shallow(<EnhancedComponent {...props} />);
+const component = wrapper.dive();
 
 const errors = [
   { reason: 'hello', entityId: 123, entityLabel: 'entity1' },
@@ -55,5 +64,25 @@ describe('TagImportDrawer', () => {
       component.find('[data-qa-cancel]').simulate('click');
       expect(props.actions.close).toHaveBeenCalled();
     });
+  });
+
+  it('should send a GA event on success', () => {
+    wrapper.setProps({ success: true });
+    expect(sendEvent).toHaveBeenCalled();
+  });
+});
+
+describe('GA Label Creator', () => {
+  it('should return the number of Linodes and number of Domains', () => {
+    expect(createLabel(0, 3)).toBe('Linodes: 0; Domains: 3');
+    expect(createLabel(0, 0)).toBe('Linodes: 0; Domains: 0');
+    expect(createLabel(8, 123)).toBe('Linodes: 8; Domains: 123');
+  });
+
+  it('should clamp values if num > 9999', () => {
+    expect(createLabel(1, 10000)).toBe('Linodes: 1; Domains: 9999+');
+    expect(createLabel(99999999, 99999999)).toBe(
+      'Linodes: 9999+; Domains: 9999+'
+    );
   });
 });

--- a/src/features/TagImport/TagImportDrawer.test.tsx
+++ b/src/features/TagImport/TagImportDrawer.test.tsx
@@ -70,6 +70,33 @@ describe('TagImportDrawer', () => {
     wrapper.setProps({ success: true });
     expect(sendEvent).toHaveBeenCalled();
   });
+
+  it('should send a GA event with the number of Linodes and Domains with imported tags', () => {
+    wrapper.setProps({ success: true });
+    expect(sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: 'Linodes: 3; Domains: 2'
+      })
+    );
+  });
+
+  it('should send a GA event with category of "Dashboard"', () => {
+    wrapper.setProps({ success: true });
+    expect(sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'dashboard'
+      })
+    );
+  });
+
+  it('should send a GA event with action of "import display groups"', () => {
+    wrapper.setProps({ success: true });
+    expect(sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'import display groups'
+      })
+    );
+  });
 });
 
 describe('GA Label Creator', () => {


### PR DESCRIPTION
## Description

Sends the following GA event upon successful Display Group Import:

```
sendEvent({
  category: 'dashboard',
  action: 'import display groups',
  label: createLabel(linodes.length, domains.length)
});
```

The function `createLabel` returns a string with this format: `"Linodes: 3; Domains: 0"`.

 Resulting GA dashboard events: 

<img width="740" alt="screen shot 2019-01-31 at 2 47 37 pm" src="https://user-images.githubusercontent.com/16911484/52081632-b4b38080-2568-11e9-8ec5-4146f2205afa.png">


## Type of Change
- Change

## Note to Reviewers

**NOTE: When testing, you may notice the bug fixed here: https://github.com/linode/manager/pull/4461**

### To Test:
1) Have Linodes and Domains with Display Groups without corresponding tags.
2) Make sure you clear the `hasImportedGroups` property from Local Storage.
3) Open the Console
4) From the Dashboard, import groups.
5) **Observe**: if you _don't_ have GA setup to test locally, you'll see a console warning indicating React GA must be initialized. This indicates that we've attempted to send the event. If you _do_ have GA set up to test locally, you'll be able to see this event on your GA dashboard.
