### PR TITLE
M3-2354 Resolve circular dependancies

### DIFF
--- a/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
@@ -10,6 +10,12 @@ import Typography from 'src/components/core/Typography';
 import RenderGuard from 'src/components/RenderGuard';
 import CopyableTextField from 'src/features/Volumes/CopyableTextField';
 
+declare module 'qrcode.react' {
+  export interface QRCodeProps {
+    className: any;
+  }
+}
+
 type ClassNames = 'root' | 'instructions' | 'qrcode';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/qrcode.react.d.ts
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/qrcode.react.d.ts
@@ -1,7 +1,0 @@
-import * as qrcode from 'qrcode.react';
-
-declare module 'qrcode.react' {
-  export interface QRCodeProps {
-    className: any;
-  }
-}

--- a/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -9,7 +9,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import eventMessageGenerator from 'src/eventMessageGenerator';
-import { ExtendedEvent } from 'src/store/events/event.reducer';
+import { ExtendedEvent } from 'src/store/events/event.helpers';
 import UserEventsListItem, {
   Props as UserEventsListItemProps
 } from './UserEventsListItem';

--- a/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
@@ -15,10 +15,10 @@ import { attachVolume } from 'src/services/volumes';
 import { openForCreating } from 'src/store/volumeDrawer';
 import { number, object } from 'yup';
 import ConfigSelect from './ConfigSelect';
+import { modes } from './modes';
 import ModeSelection from './ModeSelection';
 import NoticePanel from './NoticePanel';
 import { handleFieldErrors, handleGeneralErrors } from './utils';
-import { modes } from './VolumeDrawer';
 import VolumesActionsPanel from './VolumesActionsPanel';
 import VolumeSelect from './VolumeSelect';
 

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -21,6 +21,7 @@ import { CreateVolumeSchema } from 'src/services/volumes/volumes.schema.ts';
 import { openForAttaching } from 'src/store/volumeDrawer';
 import ConfigSelect from './ConfigSelect';
 import LabelField from './LabelField';
+import { modes } from './modes';
 import ModeSelection from './ModeSelection';
 import NoticePanel from './NoticePanel';
 import PricePanel from './PricePanel';
@@ -30,7 +31,6 @@ import {
   handleGeneralErrors,
   maybeCastToNumber
 } from './utils';
-import { modes } from './VolumeDrawer';
 import VolumesActionsPanel from './VolumesActionsPanel';
 
 type ClassNames = 'root' | 'textWrapper';

--- a/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
+++ b/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
@@ -13,21 +13,10 @@ import CloneVolumeForm from './CloneVolumeForm';
 import CreateVolumeForLinodeForm from './CreateVolumeForLinodeForm';
 import CreateVolumeForm from './CreateVolumeForm';
 import EditVolumeForm from './EditVolumeForm';
+import { modes } from './modes';
 import ResizeVolumeForm from './ResizeVolumeForm';
 import ResizeVolumesInstruction from './ResizeVolumesInstruction';
 import VolumeConfigForm from './VolumeConfigForm';
-
-export const modes = {
-  ATTACHING: 'attaching',
-  CLONING: 'cloning',
-  CLOSED: 'closed',
-  CREATING_FOR_LINODE: 'creating_for_linode',
-  CREATING: 'creating',
-  EDITING: 'editing',
-  RESIZING: 'resizing',
-  VIEW_RESIZE_INSTRUCTIONS: 'viewing_resize_instructions',
-  VIEWING_CONFIG: 'viewing_config'
-};
 
 type CombinedProps = StateProps & DispatchProps;
 

--- a/src/features/Volumes/VolumeDrawer/index.ts
+++ b/src/features/Volumes/VolumeDrawer/index.ts
@@ -1,3 +1,4 @@
-import VolumeDrawer, { modes as _modes } from './VolumeDrawer';
+import { modes as _modes } from './modes';
+import VolumeDrawer from './VolumeDrawer';
 export const modes = _modes;
 export default VolumeDrawer;

--- a/src/features/Volumes/VolumeDrawer/modes.ts
+++ b/src/features/Volumes/VolumeDrawer/modes.ts
@@ -1,0 +1,11 @@
+export const modes = {
+  ATTACHING: 'attaching',
+  CLONING: 'cloning',
+  CLOSED: 'closed',
+  CREATING_FOR_LINODE: 'creating_for_linode',
+  CREATING: 'creating',
+  EDITING: 'editing',
+  RESIZING: 'resizing',
+  VIEW_RESIZE_INSTRUCTIONS: 'viewing_resize_instructions',
+  VIEWING_CONFIG: 'viewing_config'
+};

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -44,8 +44,7 @@ import FromBackupsContent from './TabbedContent/FromBackupsContent';
 import FromImageContent from './TabbedContent/FromImageContent';
 import FromLinodeContent from './TabbedContent/FromLinodeContent';
 import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
-
-export type Info = { title: string; details?: string } | undefined;
+import { Info } from './util';
 
 export type TypeInfo =
   | {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -18,7 +18,6 @@ import Notice from 'src/components/Notice';
 import Placeholder from 'src/components/Placeholder';
 import { Tag } from 'src/components/TagsInput';
 import { resetEventsPolling } from 'src/events';
-import { Info } from 'src/features/linodes/LinodesCreate/LinodesCreate';
 import { getLinodeBackups } from 'src/services/linodes';
 import {
   LinodeActionsProps,
@@ -33,6 +32,7 @@ import AddonsPanel from '../AddonsPanel';
 import SelectBackupPanel from '../SelectBackupPanel';
 import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
+import { Info } from '../util';
 import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
 import { renderBackupsDisplaySection } from './utils';
 

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -18,7 +18,6 @@ import SelectRegionPanel, {
 } from 'src/components/SelectRegionPanel';
 import { Tag } from 'src/components/TagsInput';
 import { resetEventsPolling } from 'src/events';
-import { Info } from 'src/features/linodes/LinodesCreate/LinodesCreate';
 import userSSHKeyHoc, {
   State as UserSSHKeyProps
 } from 'src/features/linodes/userSSHKeyHoc';
@@ -32,6 +31,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
 import SelectImagePanel from '../SelectImagePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
+import { Info } from '../util';
 import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
 import { renderBackupsDisplaySection } from './utils';
 const DEFAULT_IMAGE = 'linode/debian9';

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -20,7 +20,6 @@ import SelectRegionPanel, {
 } from 'src/components/SelectRegionPanel';
 import { Tag } from 'src/components/TagsInput';
 import { resetEventsPolling } from 'src/events';
-import { Info } from 'src/features/linodes/LinodesCreate/LinodesCreate';
 import { cloneLinode } from 'src/services/linodes';
 import { upsertLinode } from 'src/store/linodes/linodes.actions';
 import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
@@ -29,6 +28,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
 import SelectLinodePanel, { ExtendedLinode } from '../SelectLinodePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
+import { Info } from '../util';
 import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
 import { renderBackupsDisplaySection } from './utils';
 

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -23,7 +23,6 @@ import SelectRegionPanel, {
 } from 'src/components/SelectRegionPanel';
 import { Tag } from 'src/components/TagsInput';
 import { resetEventsPolling } from 'src/events';
-import { Info } from 'src/features/linodes/LinodesCreate/LinodesCreate';
 import userSSHKeyHoc from 'src/features/linodes/userSSHKeyHoc';
 import SelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel';
 import StackScriptDrawer from 'src/features/StackScripts/StackScriptDrawer';
@@ -38,6 +37,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
 import SelectImagePanel from '../SelectImagePanel';
 import SelectPlanPanel, { ExtendedType } from '../SelectPlanPanel';
+import { Info } from '../util';
 import withLabelGenerator, { LabelProps } from '../withLabelGenerator';
 import { renderBackupsDisplaySection } from './utils';
 

--- a/src/features/linodes/LinodesCreate/util.ts
+++ b/src/features/linodes/LinodesCreate/util.ts
@@ -1,0 +1,1 @@
+export type Info = { title: string; details?: string } | undefined;

--- a/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
@@ -1,12 +1,9 @@
 import * as moment from 'moment-timezone';
 import * as React from 'react';
-
 import TableRow from 'src/components/core/TableRow';
-
 import TableCell from 'src/components/TableCell';
-
-import { formatBackupDate } from './LinodeBackup';
 import LinodeBackupActionMenu from './LinodeBackupActionMenu';
+import { formatBackupDate } from './util';
 
 interface Props {
   backup: Linode.LinodeBackup;

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -55,6 +55,7 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { withLinode } from '../context';
 import BackupTableRow from './BackupTableRow';
 import RestoreToLinodeDrawer from './RestoreToLinodeDrawer';
+import { formatBackupDate } from './util';
 
 type ClassNames =
   | 'paper'
@@ -162,13 +163,6 @@ export const aggregateBackups = (
   return (
     backups && [...backups.automatic!, manualSnapshot!].filter(b => Boolean(b))
   );
-};
-
-export const formatBackupDate = (backupDate: string) => {
-  return moment
-    .utc(backupDate)
-    .local()
-    .fromNow();
 };
 
 class LinodeBackup extends React.Component<CombinedProps, State> {

--- a/src/features/linodes/LinodesDetail/LinodeBackup/index.ts
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/index.ts
@@ -1,3 +1,4 @@
 import LinodeBackup from './LinodeBackup';
-export { aggregateBackups, formatBackupDate } from './LinodeBackup';
+export { aggregateBackups } from './LinodeBackup';
+export { formatBackupDate } from './util';
 export default LinodeBackup;

--- a/src/features/linodes/LinodesDetail/LinodeBackup/util.ts
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/util.ts
@@ -1,0 +1,8 @@
+import * as moment from 'moment';
+
+export const formatBackupDate = (backupDate: string) => {
+  return moment
+    .utc(backupDate)
+    .local()
+    .fromNow();
+};

--- a/src/services/nodebalancers/configs.ts
+++ b/src/services/nodebalancers/configs.ts
@@ -8,28 +8,6 @@ import { combineConfigNodeAddressAndPort } from './utils';
 
 type Page<T> = Linode.ResourcePage<T>;
 
-/** DEPRECATED!!!! */
-/** DEPRECATED!!!! */
-/** DEPRECATED!!!! */
-export interface NodeBalancerConfigFields {
-  id?: number;
-  algorithm?: 'roundrobin' | 'leastconn' | 'source';
-  check_attempts?: number /** 1..30 */;
-  check_body?: string;
-  check_interval?: number;
-  check_passive?: boolean;
-  check_path?: string;
-  check_timeout?: number /** 1..30 */;
-  check?: 'none' | 'connection' | 'http' | 'http_body';
-  cipher_suite?: 'recommended' | 'legacy';
-  port?: number /** 1..65535 */;
-  protocol?: 'http' | 'https' | 'tcp';
-  ssl_cert?: string;
-  ssl_key?: string;
-  stickiness?: 'none' | 'table' | 'http_cookie';
-  nodes: Linode.NodeBalancerConfigNodeFields[];
-}
-
 export interface CreateNodeBalancerConfig {
   port?: number;
   protocol?: 'http' | 'https' | 'tcp';

--- a/src/services/nodebalancers/index.ts
+++ b/src/services/nodebalancers/index.ts
@@ -3,3 +3,5 @@ export * from './nodebalancers';
 export * from './configs';
 
 export * from './configNodes';
+
+export * from './interfaces';

--- a/src/services/nodebalancers/interfaces.ts
+++ b/src/services/nodebalancers/interfaces.ts
@@ -1,0 +1,25 @@
+// NodeBalancerConfigFields is defined in this file to solve
+// a circular dependency issue. @todo: we should be consistent
+// about where we define these types.
+
+/** DEPRECATED!!!! */
+/** DEPRECATED!!!! */
+/** DEPRECATED!!!! */
+export interface NodeBalancerConfigFields {
+  id?: number;
+  algorithm?: 'roundrobin' | 'leastconn' | 'source';
+  check_attempts?: number /** 1..30 */;
+  check_body?: string;
+  check_interval?: number;
+  check_passive?: boolean;
+  check_path?: string;
+  check_timeout?: number /** 1..30 */;
+  check?: 'none' | 'connection' | 'http' | 'http_body';
+  cipher_suite?: 'recommended' | 'legacy';
+  port?: number /** 1..65535 */;
+  protocol?: 'http' | 'https' | 'tcp';
+  ssl_cert?: string;
+  ssl_key?: string;
+  stickiness?: 'none' | 'table' | 'http_cookie';
+  nodes: Linode.NodeBalancerConfigNodeFields[];
+}

--- a/src/services/nodebalancers/nodebalancers.schema.ts
+++ b/src/services/nodebalancers/nodebalancers.schema.ts
@@ -1,6 +1,6 @@
 import { array, boolean, mixed, number, object, string } from 'yup';
 
-import { NodeBalancerConfigFields } from './configs';
+import { NodeBalancerConfigFields } from './interfaces';
 
 export const nodeBalancerConfigNodeSchema = object({
   label: string()

--- a/src/store/domains/domains.events.ts
+++ b/src/store/domains/domains.events.ts
@@ -1,6 +1,6 @@
 import { getDomain } from 'src/services/domains';
 import { deleteDomain, upsertDomain } from 'src/store/domains/domains.actions';
-import { EventHandler } from 'src/store/middleware/combineEventsMiddleware';
+import { EventHandler } from 'src/store/types';
 
 const handler: EventHandler = (event, dispatch) => {
   const { action } = event;

--- a/src/store/events/event.actions.ts
+++ b/src/store/events/event.actions.ts
@@ -1,5 +1,5 @@
 import actionCreatorFactory from 'typescript-fsa';
-import { ExtendedEvent } from './event.reducer';
+import { ExtendedEvent } from './event.helpers';
 
 type Event = ExtendedEvent;
 

--- a/src/store/events/event.helpers.test.ts
+++ b/src/store/events/event.helpers.test.ts
@@ -9,7 +9,7 @@ import {
   setDeletedEvents,
   updateInProgressEvents
 } from './event.helpers';
-import { ExtendedEvent } from './event.reducer';
+import { ExtendedEvent } from './event.helpers';
 
 describe('event.helpers', () => {
   describe('findInEvents', () => {

--- a/src/store/events/event.helpers.ts
+++ b/src/store/events/event.helpers.ts
@@ -1,7 +1,11 @@
 import * as moment from 'moment';
 import { compose, equals, findIndex, omit, take, update } from 'ramda';
 import updateRight from 'src/utilities/updateRight';
-import { ExtendedEvent } from './event.reducer';
+
+export interface ExtendedEvent extends Linode.Event {
+  _deleted?: string;
+  _initial?: boolean;
+}
 
 type Event = ExtendedEvent;
 

--- a/src/store/events/event.reducer.ts
+++ b/src/store/events/event.reducer.ts
@@ -3,16 +3,12 @@ import { isType } from 'typescript-fsa';
 import { addEvents, updateEventsAsSeen } from './event.actions';
 import {
   epoch,
+  ExtendedEvent,
   getNumUnseenEvents,
   mostRecentCreated,
   updateEvents,
   updateInProgressEvents
 } from './event.helpers';
-
-export interface ExtendedEvent extends Linode.Event {
-  _deleted?: string;
-  _initial?: boolean;
-}
 
 export interface State {
   events: ExtendedEvent[];

--- a/src/store/linodes/linodes.events.ts
+++ b/src/store/linodes/linodes.events.ts
@@ -1,6 +1,6 @@
 import { Dispatch } from 'redux';
 import { ApplicationState } from 'src/store';
-import { EventHandler } from 'src/store/middleware/combineEventsMiddleware';
+import { EventHandler } from 'src/store/types';
 import {
   deleteLinode,
   requestLinodeForStore,

--- a/src/store/middleware/combineEventsMiddleware.ts
+++ b/src/store/middleware/combineEventsMiddleware.ts
@@ -1,20 +1,14 @@
 import { compose, equals, uniqWith } from 'ramda';
-import { Dispatch, Middleware } from 'redux';
+import { Middleware } from 'redux';
 import { resetEventsPolling } from 'src/events';
 import {
   isEntityEvent,
   isInProgressEvent
 } from 'src/store/events/event.helpers';
+import { EventHandler } from 'src/store/types';
 import { isType } from 'typescript-fsa';
 import { addEvents } from '../events/event.actions';
 import { ExtendedEvent } from '../events/event.helpers';
-import { ApplicationState } from '../index';
-
-export type EventHandler = (
-  event: Linode.EntityEvent,
-  dispatch: Dispatch<any>,
-  getState: () => ApplicationState
-) => void;
 
 const eventsMiddlewareFactory = (
   ...eventHandlers: EventHandler[]

--- a/src/store/middleware/combineEventsMiddleware.ts
+++ b/src/store/middleware/combineEventsMiddleware.ts
@@ -7,7 +7,7 @@ import {
 } from 'src/store/events/event.helpers';
 import { isType } from 'typescript-fsa';
 import { addEvents } from '../events/event.actions';
-import { ExtendedEvent } from '../events/event.reducer';
+import { ExtendedEvent } from '../events/event.helpers';
 import { ApplicationState } from '../index';
 
 export type EventHandler = (

--- a/src/store/middleware/imageEvents.ts
+++ b/src/store/middleware/imageEvents.ts
@@ -1,6 +1,6 @@
 import { removeImage } from 'src/store/image/image.actions';
 import { requestImages } from 'src/store/image/image.requests';
-import { EventHandler } from './combineEventsMiddleware';
+import { EventHandler } from 'src/store/types';
 
 const imageEventsHandler: EventHandler = (event, dispatch) => {
   const { action } = event;

--- a/src/store/nodeBalancer/nodeBalancer.events.ts
+++ b/src/store/nodeBalancer/nodeBalancer.events.ts
@@ -1,4 +1,4 @@
-import { EventHandler } from 'src/store/middleware/combineEventsMiddleware';
+import { EventHandler } from 'src/store/types';
 import { ApplicationState } from '..';
 import { removeNodeBalancerConfigs } from '../nodeBalancerConfig/nodeBalancerConfig.actions';
 import { ThunkDispatch } from '../types';

--- a/src/store/nodeBalancerConfig/nodeBalancerConfig.events.ts
+++ b/src/store/nodeBalancerConfig/nodeBalancerConfig.events.ts
@@ -1,4 +1,4 @@
-import { EventHandler } from 'src/store/middleware/combineEventsMiddleware';
+import { EventHandler } from 'src/store/types';
 import { updateNodeBalancerConfigs } from './nodeBalancerConfig.requests';
 
 /**

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -2,7 +2,7 @@ import {
   ActionCreator,
   MapStateToProps as _MapStateToProps
 } from 'react-redux';
-import { Action } from 'redux';
+import { Action, Dispatch } from 'redux';
 import { ThunkAction, ThunkDispatch as _ThunkDispatch } from 'redux-thunk';
 import { ApplicationState } from 'src/store';
 
@@ -55,3 +55,9 @@ export interface RequestableData<D> {
   data?: D;
   error?: Error | Linode.ApiFieldError[];
 }
+
+export type EventHandler = (
+  event: Linode.EntityEvent,
+  dispatch: Dispatch<any>,
+  getState: () => ApplicationState
+) => void;

--- a/src/store/volume/volume.events.ts
+++ b/src/store/volume/volume.events.ts
@@ -1,5 +1,5 @@
 import { Dispatch } from 'redux';
-import { EventHandler } from '../middleware/combineEventsMiddleware';
+import { EventHandler } from 'src/store/types';
 import { deleteVolumeActions } from './volume.actions';
 import { getAllVolumes, getOneVolume } from './volume.requests';
 


### PR DESCRIPTION
## Description

Upon adding Madge as a pre-commit hook, 18 circular dependencies were discovered. This PR addresses them.

```bash
1) store/events/event.actions.ts > store/events/event.reducer.ts
2) store/events/event.reducer.ts > store/events/event.helpers.ts
3) features/Profile/AuthenticationSettings/TwoFactor/qrcode.react.d.ts
4) features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx > features/Volumes/VolumeDrawer/VolumeDrawer.tsx
5) features/Volumes/VolumeDrawer/VolumeDrawer.tsx > features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
6) features/linodes/LinodesCreate/LinodesCreate.tsx > features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
7) features/linodes/LinodesCreate/LinodesCreate.tsx > features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
8) features/linodes/LinodesCreate/LinodesCreate.tsx > features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
9) features/linodes/LinodesCreate/LinodesCreate.tsx > features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
10) features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx > features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
11) services/nodebalancers/nodebalancers.schema.ts > services/nodebalancers/configs.ts
12) store/domains/domains.events.ts > store/middleware/combineEventsMiddleware.ts > store/index.ts
13) store/middleware/combineEventsMiddleware.ts > store/index.ts > store/linodes/linodes.events.ts
14) store/middleware/combineEventsMiddleware.ts > store/index.ts
15) store/middleware/combineEventsMiddleware.ts > store/index.ts > store/middleware/imageEvents.ts
16) store/middleware/combineEventsMiddleware.ts > store/index.ts > store/nodeBalancer/nodeBalancer.events.ts
17) store/middleware/combineEventsMiddleware.ts > store/index.ts > store/nodeBalancerConfig/nodeBalancerConfig.events.ts
18) store/middleware/combineEventsMiddleware.ts > store/index.ts > store/volume/volume.events.ts
```

## Note to reviewers
The above issues were resolved by individual commits, which are numbered.

Run `npx madge --circular --extensions ts src/` to verify no circular dependancies are present.

![screen shot 2019-02-05 at 12 27 40 pm](https://user-images.githubusercontent.com/16911484/52291894-71c72380-2941-11e9-8bc3-a187ed7539c1.png)
