### PR TITLE
M3-1545 Change: Only display regions with block storage in Volumes Drawer

### DIFF
--- a/src/components/EnhancedSelect/EnhancedSelect.tsx
+++ b/src/components/EnhancedSelect/EnhancedSelect.tsx
@@ -41,7 +41,7 @@ const styles: StyleRulesCallback = theme => ({
   }
 });
 
-interface Props {
+export interface Props {
   options: Item[];
   value: string;
   handleSelect: (selected: Item) => void;

--- a/src/components/EnhancedSelect/EnhancedSelect.tsx
+++ b/src/components/EnhancedSelect/EnhancedSelect.tsx
@@ -41,7 +41,7 @@ const styles: StyleRulesCallback = theme => ({
   }
 });
 
-export interface Props {
+interface Props {
   options: Item[];
   value: string;
   handleSelect: (selected: Item) => void;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -98,3 +98,5 @@ export const dcDisplayCountry = {
   'eu-central': 'DE',
   'ap-northeast': 'JP'
 };
+
+export const regionsWithoutBlockStorage = ['us-southeast', 'ap-northeast-1a'];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -99,4 +99,5 @@ export const dcDisplayCountry = {
   'ap-northeast': 'JP'
 };
 
+// At this time, the following regions do not support block storage.
 export const regionsWithoutBlockStorage = ['us-southeast', 'ap-northeast-1a'];

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
@@ -167,7 +167,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               onBlur={handleBlur}
               onChange={handleChange}
               value={values.region}
-              shouldOnlyIncludeRegionsWithBlockStorage={true}
+              shouldOnlyDisplayRegionsWithBlockStorage={true}
             />
 
             <LinodeSelect
@@ -176,7 +176,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               onBlur={handleBlur}
               onChange={(id: number) => setFieldValue('linodeId', id)}
               region={values.region}
-              shouldOnlyIncludeRegionsWithBlockStorage={true}
+              shouldOnlyDisplayRegionsWithBlockStorage={true}
             />
 
             <TagsInput

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
@@ -167,6 +167,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               onBlur={handleBlur}
               onChange={handleChange}
               value={values.region}
+              shouldOnlyIncludeRegionsWithBlockStorage={true}
             />
 
             <LinodeSelect
@@ -175,6 +176,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               onBlur={handleBlur}
               onChange={(id: number) => setFieldValue('linodeId', id)}
               region={values.region}
+              shouldOnlyIncludeRegionsWithBlockStorage={true}
             />
 
             <TagsInput

--- a/src/features/Volumes/VolumeDrawer/LinodeSelect.test.tsx
+++ b/src/features/Volumes/VolumeDrawer/LinodeSelect.test.tsx
@@ -1,0 +1,64 @@
+import { shallow } from 'enzyme';
+import { pathOr } from 'ramda';
+import * as React from 'react';
+import { Item } from 'src/components/EnhancedSelect/Select';
+import { doesRegionSupportBlockStorage } from 'src/utilities/doesRegionSupportBlockStorage';
+import { LinodeSelect } from './LinodeSelect';
+
+const linodes: Item[] = [
+  {
+    label: 'test-linode-001',
+    value: 1,
+    data: {
+      region: 'us-central'
+    }
+  },
+  {
+    label: 'test-linode-002',
+    value: 2,
+    data: {
+      region: 'us-southeast'
+    }
+  },
+  {
+    label: 'test-linode-003',
+    value: 3,
+    data: {
+      region: 'ap-northeast-1a'
+    }
+  }
+];
+
+describe('Linode Select', () => {
+  const wrapper = shallow(
+    <LinodeSelect
+      classes={{ root: '', disabledTooltip: '' }}
+      onChange={jest.fn()}
+      name=""
+      onBlur={jest.fn()}
+      region=""
+    />
+  );
+  it('renders', () => {
+    expect(wrapper).toHaveLength(1);
+  });
+  it('renders all linodes by default', () => {
+    wrapper.setState({ linodes });
+    const { options } = wrapper.find('WithStyles(Select)').props() as any;
+    const regions = options
+      .filter((option: Item) => option.data)
+      .map((option: Item) => option.data.region);
+    linodes.forEach(linode => {
+      expect(regions.includes(linode.data.region)).toBe(true);
+    });
+  });
+  it('disables Linodes in regions that support block storage when prop specified', () => {
+    wrapper.setState({ linodes });
+    wrapper.setProps({ shouldOnlyIncludeRegionsWithBlockStorage: true });
+    const { options } = wrapper.find('WithStyles(Select)').props() as any;
+    options.forEach((option: any) => {
+      const region = pathOr('', ['data', 'region'], option);
+      expect(doesRegionSupportBlockStorage(region)).toBe(true);
+    });
+  });
+});

--- a/src/features/Volumes/VolumeDrawer/LinodeSelect.test.tsx
+++ b/src/features/Volumes/VolumeDrawer/LinodeSelect.test.tsx
@@ -54,7 +54,7 @@ describe('Linode Select', () => {
   });
   it('disables Linodes in regions that support block storage when prop specified', () => {
     wrapper.setState({ linodes });
-    wrapper.setProps({ shouldOnlyIncludeRegionsWithBlockStorage: true });
+    wrapper.setProps({ shouldOnlyDisplayRegionsWithBlockStorage: true });
     const { options } = wrapper.find('WithStyles(Select)').props() as any;
     options.forEach((option: any) => {
       const region = pathOr('', ['data', 'region'], option);

--- a/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
@@ -29,7 +29,7 @@ interface Props {
   name: string;
   onBlur: (e: any) => void;
   region: string;
-  shouldOnlyIncludeRegionsWithBlockStorage?: boolean;
+  shouldOnlyDisplayRegionsWithBlockStorage?: boolean;
 }
 
 interface State {
@@ -167,11 +167,11 @@ export class LinodeSelect extends React.Component<CombinedProps, State> {
       error,
       name,
       onBlur,
-      shouldOnlyIncludeRegionsWithBlockStorage
+      shouldOnlyDisplayRegionsWithBlockStorage
     } = this.props;
     const { loading, linodes, selectedLinodeId } = this.state;
 
-    const options = shouldOnlyIncludeRegionsWithBlockStorage
+    const options = shouldOnlyDisplayRegionsWithBlockStorage
       ? linodes.filter(linode => {
           const region = pathOr('', ['data', 'region'], linode);
           return doesRegionSupportBlockStorage(region);

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.test.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.test.tsx
@@ -33,7 +33,7 @@ describe('Region Select', () => {
     });
   });
   it('disables regions without block storage if prop specified', () => {
-    wrapper.setProps({ shouldOnlyIncludeRegionsWithBlockStorage: true });
+    wrapper.setProps({ shouldOnlyDisplayRegionsWithBlockStorage: true });
     regionsWithoutBlockStorage.forEach(region => {
       expect(
         wrapper.find(`[data-qa-attach-to-region="${region}"]`)

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.test.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.test.tsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { regionsWithoutBlockStorage } from 'src/constants';
-import { RegionSelect, regionSupportMessage } from './RegionSelect';
+import { RegionSelect } from './RegionSelect';
 
 const regionsData: Linode.Region[] = [
   { id: 'us-southeast', country: 'US' },
@@ -34,38 +34,10 @@ describe('Region Select', () => {
   });
   it('disables regions without block storage if prop specified', () => {
     wrapper.setProps({ shouldOnlyIncludeRegionsWithBlockStorage: true });
-    regionsData.forEach(region => {
-      if (regionsWithoutBlockStorage.includes(region.id)) {
-        expect(
-          wrapper
-            .find(`[data-qa-attach-to-region="${region.id}"]`)
-            .prop('disabled')
-        ).toBe(true);
-      } else {
-        expect(
-          wrapper
-            .find(`[data-qa-attach-to-region="${region.id}"]`)
-            .prop('disabled')
-        ).toBe(false);
-      }
-    });
-  });
-  it('displays tooltip for regions without block storage if prop specified', () => {
-    wrapper.setProps({ shouldOnlyIncludeRegionsWithBlockStorage: true });
-    regionsData.forEach(region => {
-      if (regionsWithoutBlockStorage.includes(region.id)) {
-        expect(
-          wrapper
-            .find(`[data-qa-attach-to-region="${region.id}"]`)
-            .prop('tooltip')
-        ).toBe(regionSupportMessage);
-      } else {
-        expect(
-          wrapper
-            .find(`[data-qa-attach-to-region="${region.id}"]`)
-            .prop('tooltip')
-        ).toBe('');
-      }
+    regionsWithoutBlockStorage.forEach(region => {
+      expect(
+        wrapper.find(`[data-qa-attach-to-region="${region}"]`)
+      ).toHaveLength(0);
     });
   });
 });

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.test.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.test.tsx
@@ -1,0 +1,71 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { regionsWithoutBlockStorage } from 'src/constants';
+import { RegionSelect, regionSupportMessage } from './RegionSelect';
+
+const regionsData: Linode.Region[] = [
+  { id: 'us-southeast', country: 'US' },
+  { id: 'us-west', country: 'US' },
+  { id: 'ap-northeast-1a', country: 'JP' }
+];
+
+describe('Region Select', () => {
+  const wrapper = shallow(
+    <RegionSelect
+      classes={{ root: '' }}
+      name=""
+      onChange={jest.fn()}
+      onBlur={jest.fn()}
+      value=""
+      regionsData={regionsData}
+      regionsLoading={false}
+    />
+  );
+
+  it('renders', () => {
+    expect(wrapper).toHaveLength(1);
+  });
+  it('includes all regions by default.', () => {
+    regionsData.forEach(region => {
+      expect(
+        wrapper.find(`[data-qa-attach-to-region="${region.id}"]`)
+      ).toHaveLength(1);
+    });
+  });
+  it('disables regions without block storage if prop specified', () => {
+    wrapper.setProps({ shouldOnlyIncludeRegionsWithBlockStorage: true });
+    regionsData.forEach(region => {
+      if (regionsWithoutBlockStorage.includes(region.id)) {
+        expect(
+          wrapper
+            .find(`[data-qa-attach-to-region="${region.id}"]`)
+            .prop('disabled')
+        ).toBe(true);
+      } else {
+        expect(
+          wrapper
+            .find(`[data-qa-attach-to-region="${region.id}"]`)
+            .prop('disabled')
+        ).toBe(false);
+      }
+    });
+  });
+  it('displays tooltip for regions without block storage if prop specified', () => {
+    wrapper.setProps({ shouldOnlyIncludeRegionsWithBlockStorage: true });
+    regionsData.forEach(region => {
+      if (regionsWithoutBlockStorage.includes(region.id)) {
+        expect(
+          wrapper
+            .find(`[data-qa-attach-to-region="${region.id}"]`)
+            .prop('tooltip')
+        ).toBe(regionSupportMessage);
+      } else {
+        expect(
+          wrapper
+            .find(`[data-qa-attach-to-region="${region.id}"]`)
+            .prop('tooltip')
+        ).toBe('');
+      }
+    });
+  });
+});

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
@@ -14,25 +14,36 @@ import regionsContainer, {
   DefaultProps as WithRegions
 } from 'src/containers/regions.container';
 import { formatRegion } from 'src/utilities';
+import { doesRegionSupportBlockStorage } from 'src/utilities/doesRegionSupportBlockStorage';
+export const regionSupportMessage =
+  'This region does not currently support Block Storage.';
 
 type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {}
 });
-
 interface Props {
   error?: string;
   name: string;
   onChange: (e: React.ChangeEvent<any>) => void;
   onBlur: (e: any) => void;
   value: any;
+  shouldOnlyIncludeRegionsWithBlockStorage?: boolean;
 }
 
 type CombinedProps = Props & WithRegions & WithStyles<ClassNames>;
 
-const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
-  const { error, onChange, onBlur, regionsData, value, name } = props;
+export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
+  const {
+    error,
+    onChange,
+    onBlur,
+    regionsData,
+    value,
+    name,
+    shouldOnlyIncludeRegionsWithBlockStorage
+  } = props;
 
   return (
     <FormControl fullWidth>
@@ -51,15 +62,22 @@ const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
         <MenuItem key="none" value="none">
           All Regions
         </MenuItem>
-        {regionsData.map(eachRegion => (
-          <MenuItem
-            key={eachRegion.id}
-            value={eachRegion.id}
-            data-qa-attach-to-region={eachRegion.id}
-          >
-            {formatRegion('' + eachRegion.id)}
-          </MenuItem>
-        ))}
+        {regionsData.map(eachRegion => {
+          const shouldDisableRegion =
+            shouldOnlyIncludeRegionsWithBlockStorage &&
+            !doesRegionSupportBlockStorage(eachRegion.id);
+          return (
+            <MenuItem
+              data-qa-attach-to-region={eachRegion.id}
+              key={eachRegion.id}
+              value={eachRegion.id}
+              disabled={shouldDisableRegion}
+              tooltip={shouldDisableRegion ? regionSupportMessage : ''}
+            >
+              {formatRegion('' + eachRegion.id)}
+            </MenuItem>
+          );
+        })}
       </Select>
       {error && <FormHelperText error>{error}</FormHelperText>}
     </FormControl>

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
@@ -45,6 +45,10 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
     shouldOnlyIncludeRegionsWithBlockStorage
   } = props;
 
+  const regions = shouldOnlyIncludeRegionsWithBlockStorage
+    ? regionsData.filter(region => doesRegionSupportBlockStorage(region.id))
+    : regionsData;
+
   return (
     <FormControl fullWidth>
       <InputLabel htmlFor="region" disableAnimation shrink={true}>
@@ -62,17 +66,12 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
         <MenuItem key="none" value="none">
           All Regions
         </MenuItem>
-        {regionsData.map(eachRegion => {
-          const shouldDisableRegion =
-            shouldOnlyIncludeRegionsWithBlockStorage &&
-            !doesRegionSupportBlockStorage(eachRegion.id);
+        {regions.map(eachRegion => {
           return (
             <MenuItem
               data-qa-attach-to-region={eachRegion.id}
               key={eachRegion.id}
               value={eachRegion.id}
-              disabled={shouldDisableRegion}
-              tooltip={shouldDisableRegion ? regionSupportMessage : ''}
             >
               {formatRegion('' + eachRegion.id)}
             </MenuItem>
@@ -80,6 +79,11 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
         })}
       </Select>
       {error && <FormHelperText error>{error}</FormHelperText>}
+      {!error && shouldOnlyIncludeRegionsWithBlockStorage && (
+        <FormHelperText data-qa-volume-region>
+          Only regions supporting block storage are displayed.
+        </FormHelperText>
+      )}
     </FormControl>
   );
 };

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
@@ -29,7 +29,7 @@ interface Props {
   onChange: (e: React.ChangeEvent<any>) => void;
   onBlur: (e: any) => void;
   value: any;
-  shouldOnlyIncludeRegionsWithBlockStorage?: boolean;
+  shouldOnlyDisplayRegionsWithBlockStorage?: boolean;
 }
 
 type CombinedProps = Props & WithRegions & WithStyles<ClassNames>;
@@ -42,10 +42,10 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
     regionsData,
     value,
     name,
-    shouldOnlyIncludeRegionsWithBlockStorage
+    shouldOnlyDisplayRegionsWithBlockStorage: shouldOnlyDisplayRegionsWithBlockStorage
   } = props;
 
-  const regions = shouldOnlyIncludeRegionsWithBlockStorage
+  const regions = shouldOnlyDisplayRegionsWithBlockStorage
     ? regionsData.filter(region => doesRegionSupportBlockStorage(region.id))
     : regionsData;
 
@@ -79,7 +79,7 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
         })}
       </Select>
       {error && <FormHelperText error>{error}</FormHelperText>}
-      {!error && shouldOnlyIncludeRegionsWithBlockStorage && (
+      {!error && shouldOnlyDisplayRegionsWithBlockStorage && (
         <FormHelperText data-qa-volume-region>
           Only regions supporting block storage are displayed.
         </FormHelperText>

--- a/src/utilities/doesRegionSupportBlockStorage.test.ts
+++ b/src/utilities/doesRegionSupportBlockStorage.test.ts
@@ -1,0 +1,14 @@
+import { doesRegionSupportBlockStorage } from './doesRegionSupportBlockStorage';
+
+describe('does region support block storage', () => {
+  it('returns true if the region supports block storage', () => {
+    expect(doesRegionSupportBlockStorage('us-central')).toBe(true);
+    expect(doesRegionSupportBlockStorage('us-east')).toBe(true);
+    expect(doesRegionSupportBlockStorage('us-central')).toBe(true);
+  });
+
+  it('returns false if the region does not support block storage', () => {
+    expect(doesRegionSupportBlockStorage('ap-northeast-1a')).toBe(false);
+    expect(doesRegionSupportBlockStorage('us-southeast')).toBe(false);
+  });
+});

--- a/src/utilities/doesRegionSupportBlockStorage.ts
+++ b/src/utilities/doesRegionSupportBlockStorage.ts
@@ -1,0 +1,5 @@
+import { regionsWithoutBlockStorage } from 'src/constants';
+
+export const doesRegionSupportBlockStorage = (region: string) => {
+  return !regionsWithoutBlockStorage.includes(region);
+};


### PR DESCRIPTION
## Description

In the Volume Creation Drawer, only display regions that support block storage. Similarly, only display Linodes in regions that support block storage.

Helper text has been added explaining why not all regions are displayed. 

<img width="479" alt="screen shot 2019-02-05 at 4 55 46 pm" src="https://user-images.githubusercontent.com/16911484/52306821-f710ff00-2966-11e9-872d-5689f1c6959f.png">


## Type of Change
- Non breaking change ('update', 'change')