### PR TITLE
M3-2336 update underline links instances

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -13,6 +13,7 @@ describe('Breadcrumb component', () => {
         root: '',
         backButton: 'backButton',
         linkText: '',
+        linkTextWrapper: '',
         labelText: '',
         subtitleLinkText: '',
         prefixComponentWrapper: ''

--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -16,6 +16,7 @@ type ClassNames =
   | 'root'
   | 'backButton'
   | 'linkText'
+  | 'linkTextWrapper'
   | 'labelText'
   | 'subtitleLinkText'
   | 'prefixComponentWrapper';
@@ -38,32 +39,39 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     display: 'flex',
     alignItems: 'center',
     color: '#3683DC',
-    textDecoration: 'underline',
     borderColor: theme.color.grey,
     whiteSpace: 'nowrap',
     '&:after': {
       content: "''",
       display: 'inline-block',
       padding: '0 8px 0 6px',
-      height: '38px',
+      height: '39px',
       borderRight: `1px solid ${theme.color.grey1}`
     },
     [theme.breakpoints.down('sm')]: {
       display: 'none'
     }
   },
+  linkTextWrapper: {
+    position: 'relative',
+    top: 2
+  },
   subtitleLinkText: {
     display: 'flex',
     alignItems: 'flex-start',
     color: '#3683DC',
-    textDecoration: 'underline',
     borderColor: theme.color.grey,
     whiteSpace: 'nowrap',
     '&:after': {
-      content: "'|'",
+      content: "''",
       display: 'inline-block',
       padding: '0 0 0 8px',
-      color: theme.color.grey1
+      color: theme.color.grey1,
+      borderRight: `1px solid ${theme.color.grey1}`,
+      height: 24,
+      marginTop: -7,
+      position: 'relative',
+      top: 4
     },
     [theme.breakpoints.down('sm')]: {
       display: 'none'
@@ -129,7 +137,7 @@ export const Breadcrumb: React.StatelessComponent<CombinedProps> = props => {
               }
               data-qa-link-text
             >
-              {linkText}
+              <span className={classes.linkTextWrapper}>{linkText}</span>
             </Typography>
           )}
         </IconButton>

--- a/src/features/Help/Panels/PopularPosts.tsx
+++ b/src/features/Help/Panels/PopularPosts.tsx
@@ -46,7 +46,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     fontSize: '1rem',
     fontFamily: 'LatoWebBold',
     lineHeight: '1.2em',
-    textDecoration: 'underline'
+    '&:hover': {
+      textDecoration: 'underline'
+    }
   },
   withSeparator: {
     borderRight: `1px solid ${theme.palette.divider}`

--- a/src/features/Support/SupportTickets/TicketList.tsx
+++ b/src/features/Support/SupportTickets/TicketList.tsx
@@ -9,6 +9,7 @@ import {
 } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
+import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import Pagey, { PaginationProps } from 'src/components/Pagey';
 import PaginationFooter from 'src/components/PaginationFooter';
@@ -114,7 +115,9 @@ class TicketList extends React.Component<CombinedProps, {}> {
         rowLink={`/support/tickets/${ticket.id}`}
       >
         <TableCell parentColumn="Subject" data-qa-support-subject>
-          <Link to={`/support/tickets/${ticket.id}`}>{ticket.summary}</Link>
+          <Link to={`/support/tickets/${ticket.id}`}>
+            <Typography variant="h3">{ticket.summary}</Typography>
+          </Link>
         </TableCell>
         <TableCell parentColumn="Ticket ID" data-qa-support-id>
           {ticket.id}

--- a/src/features/TopMenu/UserEventsMenu/UserEventsListItem.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsListItem.tsx
@@ -25,7 +25,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
       transition: theme.transitions.create(['border-color', 'opacity']),
       outline: 0,
       '&:hover, &:focus': {
-        backgroundColor: theme.bg.main
+        backgroundColor: theme.palette.primary.main,
+        '& $title, & $content': {
+          color: 'white'
+        }
       }
     },
     title: {
@@ -46,8 +49,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
     },
     pointer: {
       '& > h3': {
-        lineHeight: '1.2',
-        textDecoration: 'underline'
+        lineHeight: '1.2'
       }
     }
   };


### PR DESCRIPTION
## Update underline links instances in breadcrumb and event menu 

For some reason this commit was empty on https://github.com/linode/manager/pull/4474 - reapplying here

## Type of Change
- Non breaking change ('update')
