### PR TITLE
M3-2359 Add max height to React Select with scroll overflow

### DIFF
--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -90,7 +90,20 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     },
     '& .react-select__menu-list': {
       padding: theme.spacing.unit / 2,
-      backgroundColor: theme.bg.white
+      backgroundColor: theme.bg.white,
+      height: '101%',
+      overflow: 'auto',
+      maxHeight: 285,
+      '&::-webkit-scrollbar': {
+        appearance: 'none'
+      },
+      '&::-webkit-scrollbar:vertical': {
+        width: 8
+      },
+      '&::-webkit-scrollbar-thumb': {
+        borderRadius: 8,
+        backgroundColor: '#ccc'
+      }
     },
     '& .react-select__option': {
       transition: theme.transitions.create(['background-color', 'color']),


### PR DESCRIPTION
## Add max height to React Select with scroll overflow

Right now the react selects can get too high (ex: too many tags) so we need a max height and scroll capabilities

## Type of Change
- Non breaking change ('update')
