### PR TITLE
M3-2365 Change "G" to "GB" in plan details

### DIFF
--- a/src/features/linodes/presentation.test.tsx
+++ b/src/features/linodes/presentation.test.tsx
@@ -1,0 +1,28 @@
+import { typeLabelDetails } from './presentation';
+
+describe('type label details', () => {
+  it('should return a string with memory, disk, and cpu details', () => {
+    const typedLabel = typeLabelDetails(2048, 2048, 1);
+    expect(typedLabel).toBe('1 CPU, 2GB Storage, 2GB RAM');
+  });
+
+  it('should return storage in GB', () => {
+    const typedLabel = typeLabelDetails(1024, 2048, 1);
+    expect(typedLabel.includes('2GB Storage'));
+  });
+
+  it('should return memory in GB', () => {
+    const typedLabel = typeLabelDetails(1024, 2048, 1);
+    expect(typedLabel.includes('1GB Ram'));
+  });
+
+  it('should return number of CPUs', () => {
+    const typedLabel = typeLabelDetails(1024, 2048, 4);
+    expect(typedLabel.includes('4CPU'));
+  });
+
+  it('should return number of CPUs', () => {
+    const typedLabel = typeLabelDetails(1024, 2048, 4);
+    expect(typedLabel.includes('4CPU'));
+  });
+});

--- a/src/features/linodes/presentation.ts
+++ b/src/features/linodes/presentation.ts
@@ -26,7 +26,7 @@ export const typeLabelDetails = (
 ) => {
   const memG = memory / 1024;
   const diskG = disk / 1024;
-  return `${cpus} CPU, ${diskG}G Storage, ${memG}G RAM`;
+  return `${cpus} CPU, ${diskG}GB Storage, ${memG}GB RAM`;
 };
 
 export const displayType = (


### PR DESCRIPTION
## Description

For Linode plan details, display "GB" instead of "G" for storage and memory.

## Type of Change
- Non breaking change ('update', 'change')


### Old:
<img width="365" alt="screen shot 2019-0
2-08 at 3 19 11 pm" src="https://user-images.githubusercontent.com/16911484/52503972-0c7b6880-2bb5-11e9-9c58-0f31e1120712.png">

### New:
<img width="383" alt="screen shot 2019-02-08 at 3 18 53 pm" src="https://user-images.githubusercontent.com/16911484/52503969-09807800-2bb5-11e9-9fef-a5b0b70b77c0.png">
