### PR TITLE
M3-2372 Fix: clear ImageDrawer error on submit

### DIFF
--- a/src/components/TagsInput/TagsInput.test.tsx
+++ b/src/components/TagsInput/TagsInput.test.tsx
@@ -34,7 +34,7 @@ describe('TagsInput', () => {
     expect(component.state('accountTags')).toHaveLength(mockTags.length);
   });
 
-  it('calls onChange hanlder when the value is updated', () => {
+  it('calls onChange handler when the value is updated', () => {
     const newValue = ['someTag', 'anotherTag', 'onMoreTag'].map(tag => ({
       value: tag,
       label: tag

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -161,7 +161,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       selectedLinode
     } = this.props;
 
-    this.setState({ errors: undefined });
+    this.setState({ errors: undefined, notice: undefined });
     const safeDescription = description ? description : ' ';
 
     switch (mode) {

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -160,6 +160,8 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       selectedDisk,
       selectedLinode
     } = this.props;
+
+    this.setState({ errors: undefined });
     const safeDescription = description ? description : ' ';
 
     switch (mode) {


### PR DESCRIPTION
## Description

Clear error and success state when submitting ImageDrawer form. Currently these are only cleared when closing the drawer.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

