### PR TITLE
M3-2335 Update treatment for lengthy domain records

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -30,7 +30,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       '& tbody > tr': {
         marginBottom: 0,
         '& > td:first-child': {
-          backgroundColor: theme.bg.offWhite,
+          backgroundColor: theme.bg.tableHeader,
           fontFamily: 'LatoWebBold'
         }
       },

--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -40,13 +40,19 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import ActionMenu from './DomainRecordActionMenu';
 import Drawer from './DomainRecordDrawer';
 
-type ClassNames = 'root' | 'titles' | 'linkContainer';
+type ClassNames = 'root' | 'cells' | 'titles' | 'linkContainer';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
     [theme.breakpoints.down('xs')]: {
       flexDirection: 'column',
       alignItems: 'flex-start'
+    }
+  },
+  cells: {
+    [theme.breakpoints.up('md')]: {
+      maxWidth: 300,
+      wordBreak: 'break-all'
     }
   },
   titles: {
@@ -739,6 +745,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                                                     parentColumn={title}
                                                     key={columnIndex}
                                                     data-qa-column={title}
+                                                    className={classes.cells}
                                                   >
                                                     {render(data)}
                                                   </TableCell>


### PR DESCRIPTION
## Update treatment for lengthy domain records

On the domain records page, long domain names (at certain breakpoints) would require the user to scroll the table right to access (or even know) there is an action button. This PR wraps the text so that it does not happen anymore. It is not the most elegant solution to wrap strings like this but this is the best option that we have unless we start using the mobile view (stacked cells) at a higher breakpoint for this table (which is a pretty big design change i'd rather not introduce).

## Type of Change
- Non breaking change ('update', 'change')
