### PR TITLE
POC for error mapping function

### DIFF
--- a/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -21,7 +21,7 @@ import { getNodeBalancers } from 'src/services/nodebalancers';
 import { createSupportTicket, uploadAttachment } from 'src/services/support';
 import { getVolumes } from 'src/services/volumes';
 import composeState from 'src/utilities/composeState';
-import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+import { getErrorMap } from 'src/utilities/errorUtils';
 import { getVersionString } from 'src/utilities/getVersionString';
 import AttachFileForm, { FileAttachment } from '../AttachFileForm';
 import { AttachmentError } from '../SupportTicketDetail/SupportTicketDetail';
@@ -425,17 +425,14 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
     const requirementsMet =
       ticket.description.length > 0 && ticket.summary.length > 0;
 
-    const hasErrorFor = getAPIErrorFor(
-      {
-        summary: 'Summary',
-        description: 'Description'
-      },
+    const hasErrorFor = getErrorMap(
+      ['summary', 'description', 'input'],
       errors
     );
-    const summaryError = hasErrorFor('summary');
-    const descriptionError = hasErrorFor('description');
-    const generalError = hasErrorFor('none');
-    const inputError = hasErrorFor('input');
+    const summaryError = hasErrorFor.summary;
+    const descriptionError = hasErrorFor.description;
+    const generalError = hasErrorFor.none;
+    const inputError = hasErrorFor.input;
 
     const hasNoEntitiesMessage = this.getHasNoEntitiesMessage();
 

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -19,3 +19,50 @@ export const getErrorStringOrDefault = (
 ): string => {
   return pathOr<string>(defaultError, [0, 'reason'], errors);
 };
+
+/**
+ * Returns a mapping of error fields to responses. Intended for mapping
+ * API errors to input fields or other field-specific displays.
+ *
+ * Any errors which do not have a field, or do not match any specified field,
+ * will be assigned to the 'none' key. If there are multiple errors in this category,
+ * only one will be included in the map. This is not ideal, but the point of this
+ * function is to make sure that if a request returns an error, some usable feedback
+ * will be available to the user.
+ *
+ * @example getErrorMap(['label','password'], errors)
+ *
+ * {
+ *    'label': 'This label is too long.',
+ *    'password': 'Must contain special characters.',
+ *    'none': 'You forgot to check for region errors.'
+ * }
+ *
+ *
+ * @param fields optional list of fields to include in the response object
+ * @param errors an API error response
+ */
+export const getErrorMap = (
+  fields: string[] = [],
+  errors?: Linode.ApiFieldError[]
+): Record<string, string | undefined> => {
+  if (!errors) {
+    return {};
+  }
+  return errors.reduce(
+    (accum, thisError) => {
+      if (thisError.field && fields.includes(thisError.field)) {
+        return {
+          ...accum,
+          [thisError.field]: thisError.reason
+        };
+      } else {
+        return {
+          ...accum,
+          none: thisError.reason
+        };
+      }
+    },
+    { none: undefined }
+  );
+};


### PR DESCRIPTION
## Description

POC for mapping errors to input fields. Currently we use getApiErrorFor, which ignores errors with fields that you don't explicitly tell it to check for. This may have been what happened with the Support drawer feedback email we received a few days ago.

This way, any sort of error will always register somewhere. Not thrilled with the approach, feedback welcome.

## To Test

Use mockAPIError from services/support.ts to create a bunch of fake errors.