### PR TITLE
M3-2377 Upgrade and Fix PayPal

### DIFF
--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -124,14 +124,16 @@ const client = {
     'AWdnFJ_Yx5X9uqKZQdbdkLfCnEJwtauQJ2tyesKf3S0IxSrkRLmB2ZN2ACSwy37gxY_AZoTagHWlZCOA'
 };
 
+const paypalSrcQueryParams = `&disable-funding=card,credit&currency=USD&commit=false`;
+
 const paypalScriptSrc = (isProduction: boolean) => {
   return isProduction
     ? `https://www.paypal.com/sdk/js?client-id=${
         client.production
-      }&disable-funding=card,credit&currency=USD&intent=authorize`
+      }${paypalSrcQueryParams}`
     : `https://www.paypal.com/sdk/js?client-id=${
         client.sandbox
-      }&disable-funding=card,credit&currency=USD&intent=authorize`;
+      }${paypalSrcQueryParams}`;
 };
 
 const env = process.env.NODE_ENV === 'development' ? 'sandbox' : 'production';
@@ -306,8 +308,11 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
    * See documentation:
    * https://github.com/paypal/paypal-checkout-components/blob/master/docs/implement-checkout.md
    */
-  onApprove = (data: Paypal.AuthData) => {
+  onApprove = (data: Paypal.AuthData, actions: any) => {
     const { usd } = this.state;
+
+    console.log(data);
+    console.log(actions);
 
     this.setState({
       dialogOpen: true,

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -150,7 +150,7 @@ const client = {
 
 const paypalSrcQueryParams = `&disable-funding=card,credit&currency=USD&commit=false&intent=capture`;
 
-const paypalScriptSrc = (isProduction: boolean) => {
+const paypalScriptSrc = () => {
   return isProduction
     ? `https://www.paypal.com/sdk/js?client-id=${
         client.production
@@ -433,11 +433,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <ExpansionPanel
-          defaultExpanded
-          heading="Make a Payment"
-          actions={this.renderActions}
-        >
+        <ExpansionPanel heading="Make a Payment" actions={this.renderActions}>
           <Grid container>
             {/* Payment */}
             <Grid item xs={12}>
@@ -584,7 +580,7 @@ const withAccount = AccountContainer(
 export default compose<CombinedProps, {}>(
   styled,
   withAccount,
-  scriptLoader(paypalScriptSrc(isProduction))
+  scriptLoader(paypalScriptSrc())
 )(MakeAPaymentPanel);
 
 export const isAllowedUSDAmount = (usd: number) => {

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -360,7 +360,8 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
    */
   onCancel = () => {
     this.setState({
-      successMessage: 'Payment Cancelled'
+      successMessage: 'Payment Cancelled',
+      dialogOpen: false
     });
   };
 

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -285,7 +285,9 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
         this.setState({
           isExecutingPaypalPayment: false,
           dialogOpen: false,
-          successMessage: `Payment for ${this.state.usd} successfully submitted`
+          successMessage: `Payment for $${
+            this.state.usd
+          } successfully submitted`
         });
       })
       .catch(errorResponse => {
@@ -310,7 +312,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
    * See documentation:
    * https://github.com/paypal/paypal-checkout-components/blob/master/docs/implement-checkout.md
    */
-  onApprove = (data: Paypal.AuthData, actions: any) => {
+  onApprove = (data: Paypal.AuthData) => {
     this.setState({
       payerID: data.payerID
     });
@@ -545,7 +547,7 @@ const withAccount = AccountContainer(
 export default compose<CombinedProps, {}>(
   styled,
   withAccount,
-  scriptLoader(paypalScriptSrc(true || process.env.NODE_ENV === 'production'))
+  scriptLoader(paypalScriptSrc(false || process.env.NODE_ENV === 'production'))
 )(MakeAPaymentPanel);
 
 export const isAllowedUSDAmount = (usd: number) => {

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -42,6 +42,7 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
 import TextField from 'src/components/TextField';
+import { isProduction } from 'src/constants';
 import AccountContainer, {
   DispatchProps as AccountDispatchProps
 } from 'src/containers/account.container';
@@ -583,7 +584,7 @@ const withAccount = AccountContainer(
 export default compose<CombinedProps, {}>(
   styled,
   withAccount,
-  scriptLoader(paypalScriptSrc(false || process.env.NODE_ENV === 'production'))
+  scriptLoader(paypalScriptSrc(isProduction))
 )(MakeAPaymentPanel);
 
 export const isAllowedUSDAmount = (usd: number) => {

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/PaymentBits/CreditCardDialog.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/PaymentBits/CreditCardDialog.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react';
 import { compose } from 'recompose';
 
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+
 interface Actions {
   executePayment: () => void;
   cancel: () => void;
+  isMakingPayment: boolean;
 }
 
 interface Props extends Actions {
@@ -14,7 +20,38 @@ interface Props extends Actions {
 type CombinedProps = Props;
 
 const CreditCardDialog: React.SFC<CombinedProps> = props => {
-  return <div>hello world</div>;
+  const { cancel, open, usd, ...actionsProps } = props;
+
+  return (
+    <ConfirmationDialog
+      open={open}
+      title="Confirm Payment"
+      onClose={cancel}
+      actions={<DialogActions {...actionsProps} cancel={cancel} />}
+    >
+      <Typography>{`Confirm payment of $${usd} USD to Linode LLC?`}</Typography>
+    </ConfirmationDialog>
+  );
 };
 
 export default compose<CombinedProps, Props>(React.memo)(CreditCardDialog);
+
+class DialogActions extends React.PureComponent<Actions> {
+  render() {
+    return (
+      <ActionsPanel>
+        <Button type="cancel" onClick={this.props.cancel} data-qa-cancel>
+          Cancel
+        </Button>
+        <Button
+          type="secondary"
+          loading={this.props.isMakingPayment}
+          onClick={this.props.executePayment}
+          data-qa-submit
+        >
+          Confirm Payment
+        </Button>
+      </ActionsPanel>
+    );
+  }
+}

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/PaymentBits/CreditCardDialog.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/PaymentBits/CreditCardDialog.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+
+interface Actions {
+  executePayment: () => void;
+  cancel: () => void;
+}
+
+interface Props extends Actions {
+  open: boolean;
+  usd: string;
+}
+
+type CombinedProps = Props;
+
+const CreditCardDialog: React.SFC<CombinedProps> = props => {
+  return <div>hello world</div>;
+};
+
+export default compose<CombinedProps, Props>(React.memo)(CreditCardDialog);

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/PaymentBits/PaypalDialog.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/PaymentBits/PaypalDialog.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+import DialogActions, {
+  Props as ActionsProps
+} from './PaypalDialogActionButtons';
+
+interface Props extends ActionsProps {
+  open: boolean;
+  usd: string;
+}
+
+type CombinedProps = Props;
+
+interface Content {
+  title: string;
+  message?: string;
+  error?: string;
+}
+
+const PaypalDialog: React.SFC<CombinedProps> = props => {
+  const {
+    open,
+    closeDialog,
+    usd,
+    ...rest // ...rest being the other unused ActionsProps
+  } = props;
+
+  const renderActions = () => (
+    <DialogActions closeDialog={closeDialog} {...rest} />
+  );
+
+  const handleCloseDialog = () => closeDialog(false);
+
+  const dialogContent: Content = props.isStagingPaypalPayment
+    ? {
+        title: 'Preparing Payment'
+      }
+    : props.paypalPaymentFailed
+    ? {
+        title: 'Payment failed',
+        error: 'Could not complete PayPal payment'
+      }
+    : {
+        title: 'Confirm Payment',
+        message: `Confirm PayPal payment for $${usd} USD to Linode LLC?`
+      };
+
+  return (
+    <ConfirmationDialog
+      open={open}
+      error={dialogContent.error}
+      title={dialogContent.title}
+      onClose={handleCloseDialog}
+      actions={renderActions()}
+    >
+      <Typography>{dialogContent.message || ''}</Typography>
+    </ConfirmationDialog>
+  );
+};
+
+export default compose<CombinedProps, Props>(React.memo)(PaypalDialog);

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/PaymentBits/PaypalDialogActionButtons.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/PaymentBits/PaypalDialogActionButtons.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+
+export interface Props {
+  isStagingPaypalPayment: boolean;
+  paypalPaymentFailed: boolean;
+  isExecutingPayment: boolean;
+  initExecutePayment: () => void;
+  closeDialog: (wasCancelled: boolean) => void;
+}
+
+type CombinedProps = Props;
+
+const PaypalDialogActionButtons: React.SFC<CombinedProps> = props => {
+  const {
+    isStagingPaypalPayment,
+    paypalPaymentFailed,
+    isExecutingPayment,
+    initExecutePayment,
+    closeDialog
+  } = props;
+
+  /** intentionally displays "payment cancelled" message to the user */
+  const handleCancelPayment = () => closeDialog(true);
+
+  const handleCloseDialog = () => closeDialog(false);
+
+  if (isStagingPaypalPayment) {
+    return (
+      <ActionsPanel>
+        <Button loading={true}>Preparing Payment</Button>
+      </ActionsPanel>
+    );
+  } else if (paypalPaymentFailed) {
+    return (
+      <ActionsPanel>
+        <Button onClick={handleCloseDialog}>Got it</Button>
+      </ActionsPanel>
+    );
+  } else {
+    return (
+      <ActionsPanel>
+        <Button type="cancel" onClick={handleCancelPayment} data-qa-cancel>
+          Cancel
+        </Button>
+        <Button
+          type="secondary"
+          loading={isExecutingPayment}
+          onClick={initExecutePayment}
+          data-qa-submit
+        >
+          Confirm Payment
+        </Button>
+      </ActionsPanel>
+    );
+  }
+};
+
+export default compose<CombinedProps, Props>(React.memo)(
+  PaypalDialogActionButtons
+);

--- a/src/services/account/payments.ts
+++ b/src/services/account/payments.ts
@@ -33,10 +33,6 @@ interface SaveCreditCardData {
   expiry_month: number;
 }
 
-interface PaymentID {
-  payment_id: string;
-}
-
 /**
  * getPayments
  *
@@ -71,6 +67,11 @@ export const makePayment = (data: { usd: string; cvv?: string }) =>
     setData(data, PaymentSchema)
   ).then(response => response.data);
 
+interface StagePaypalData {
+  checkout_token: string;
+  payment_id: string;
+}
+
 /**
  * stagePaypalPayment
  *
@@ -85,7 +86,7 @@ export const makePayment = (data: { usd: string; cvv?: string }) =>
  *
  */
 export const stagePaypalPayment = (data: Paypal) =>
-  Request<PaymentID>(
+  Request<StagePaypalData>(
     setURL(`${API_ROOT}/account/payments/paypal`),
     setMethod('POST'),
     setData(data, StagePaypalPaymentSchema)

--- a/src/types/Paypal.ts
+++ b/src/types/Paypal.ts
@@ -24,8 +24,8 @@ namespace Paypal {
     onApprove: (data: AuthData, actions?: any) => void;
     onCancel: () => void;
     onClick?: () => void;
-    // createOrder: (data?: any, actions?: any) => Promise<any>;
-    // commit?: boolean;
+    /** callback function that NEEDS to return the order id */
+    createOrder: () => Promise<string | void>;
     style?: any;
   }
 }

--- a/src/types/Paypal.ts
+++ b/src/types/Paypal.ts
@@ -21,11 +21,11 @@ namespace Paypal {
   export interface PayButtonProps {
     env: Env;
     client: Client;
-    onAuthorize: (data: AuthData) => void;
+    onApprove: (data: AuthData) => void;
     onCancel: () => void;
     onClick?: () => void;
-    payment: (data?: any, actions?: any) => Promise<any>;
-    commit?: boolean;
+    // createOrder: (data?: any, actions?: any) => Promise<any>;
+    // commit?: boolean;
     style?: any;
   }
 }

--- a/src/types/Paypal.ts
+++ b/src/types/Paypal.ts
@@ -21,7 +21,7 @@ namespace Paypal {
   export interface PayButtonProps {
     env: Env;
     client: Client;
-    onApprove: (data: AuthData) => void;
+    onApprove: (data: AuthData, actions?: any) => void;
     onCancel: () => void;
     onClick?: () => void;
     // createOrder: (data?: any, actions?: any) => Promise<any>;


### PR DESCRIPTION
## Description

Upgrade to new PayPal SDK and change logic to match new documentation.

Also abstract out the new credit card dialog

## Type of Change
- Non breaking change ('update', 'change')

### Notes

It's important to note these docs:

https://developer.paypal.com/docs/checkout/reference/server-integration/set-up-transaction/#on-the-server

Contrary to the old version of the JS SDK, the `createOrder` callback expects a promise that returns a `order_id`. In the past, this callback was named `payment` and expected a promise that returned a `payment_id`. This was changed for God knows why and now it needs to be changed. All other logic remained mostly the same.

So here's how it works

1. User types in their payment and clicks the paypal button
2. At this point, the APIv4 request should fire (`v4/account/paypal`) - this endpoint now returns a `checkout_token` which is another name for `order_id`. This `order_id` MUST be returned in the `createOrder` callback
3. Then the user does whatever he needs to do on Paypal and a callback function called `onAuthorize` fires
4. Once the window closes, a `payer_id` is returned from Paypal.
5. Back on Cloud, the user confirms they want to make a  payment
6. Call to `v4/account/paypal/execute` fires and the payment goes through