### PR TITLE
Fix: M3-2377 Paypal Payments Non-Functional

### DIFF
--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -1,8 +1,8 @@
 import * as classNames from 'classnames';
-import { compose } from 'ramda';
 import * as React from 'react';
 import scriptLoader from 'react-async-script-loader';
 import * as ReactDOM from 'react-dom';
+import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
@@ -549,14 +549,11 @@ const accountContext = withAccount(context => ({
   lastFour: (context.data && context.data.credit_card.last_four) || ''
 }));
 
-const enhanced = compose(
+export default compose<CombinedProps, {}>(
   styled,
-  accountContext
-);
-
-export default scriptLoader('https://www.paypalobjects.com/api/checkout.v4.js')(
-  enhanced(MakeAPaymentPanel)
-);
+  accountContext,
+  scriptLoader('https://www.paypalobjects.com/api/checkout.js')
+)(MakeAPaymentPanel);
 
 export const isAllowedUSDAmount = (usd: number) => {
   return !!(usd >= 5 && usd <= 500);


### PR DESCRIPTION
## Description

Use different paypal src to not hardcode version number

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

This fixes an issue with v4.0.240 of Paypal that was causing 302 responses for a subset of users. Please see https://github.com/paypal/paypal-checkout-components/issues/1031

This PR fixes the issue, but we ideally want to be in a place where we can merge #4509 but is currently being blocked by ARB-1098

### To Test

Point your .env at dev services

Try to make a paypal payment. Find dummy credentials in 1password or hit me up for them if you can't find them

Proof that production payments work:

![screen shot 2019-02-19 at 8 55 23 am](https://user-images.githubusercontent.com/7387001/53020064-2c682300-3424-11e9-9e58-d099dee46e72.png)
