### PR TITLE
M3-2389 Change: Limit SearchBar results to 20

### DIFF
--- a/src/features/TopMenu/SearchBar/SearchBar.test.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.test.tsx
@@ -1,0 +1,88 @@
+import { createFinalOptions } from './SearchBar';
+
+const createMockItems = (numberOfItemsToCreate: number) => {
+  const mockItems = [];
+  for (let i = 0; i < numberOfItemsToCreate; i++) {
+    mockItems.push({ value: `test-value-${i}`, label: `test-label-${i}` });
+  }
+  return mockItems;
+};
+
+describe('createFinalOptions', () => {
+  it('returns an empty array when there are no results', () => {
+    expect(createFinalOptions([])).toEqual([]);
+  });
+
+  it('inserts a default option at the beginning if there is 1 or more result', () => {
+    let mockItems = createMockItems(1);
+    expect(createFinalOptions(mockItems, '')[0].value).toBe('redirect');
+
+    mockItems = createMockItems(100);
+    expect(createFinalOptions(mockItems, '')[0].value).toBe('redirect');
+  });
+
+  it('should include a default option with a message based on searchText', () => {
+    const mockItems = createMockItems(3);
+    expect(createFinalOptions(mockItems, 'my-search')[0].label).toBe(
+      'View search results page for "my-search"'
+    );
+    expect(createFinalOptions(mockItems, '')[0].label).toBe(
+      'View search results page for ""'
+    );
+    expect(createFinalOptions(mockItems, '  ')[0].label).toBe(
+      'View search results page for "  "'
+    );
+  });
+
+  it('appends a default option at the end only if there are more than 20 results', () => {
+    let mockItems = createMockItems(20);
+    let finalOptions = createFinalOptions(mockItems, '');
+    let lastOption = finalOptions[finalOptions.length - 1];
+    expect(lastOption.value).not.toBe('redirect');
+
+    mockItems = createMockItems(21);
+    finalOptions = createFinalOptions(mockItems, '');
+    lastOption = finalOptions[finalOptions.length - 1];
+    expect(lastOption.value).toBe('redirect');
+    const secondToLastOption = finalOptions[finalOptions.length - 2];
+    expect(secondToLastOption.value).toBe('test-value-19');
+
+    mockItems = createMockItems(40);
+    finalOptions = createFinalOptions(mockItems, '');
+    lastOption = finalOptions[finalOptions.length - 1];
+    expect(lastOption.value).toBe('redirect');
+  });
+
+  it('should include results length and searchText in the final default message', () => {
+    let mockItems = createMockItems(22);
+    let finalOptions = createFinalOptions(mockItems, 'my-search');
+    let lastOption = finalOptions[finalOptions.length - 1];
+    expect(lastOption.label).toBe('View all 22 results for "my-search"');
+
+    mockItems = createMockItems(50);
+    finalOptions = createFinalOptions(mockItems, ' ');
+    lastOption = finalOptions[finalOptions.length - 1];
+    expect(lastOption.label).toBe('View all 50 results for " "');
+  });
+
+  it('includes a maximum of 20 results (plus the default options)', () => {
+    let mockItems = createMockItems(25);
+    let finalOptions = createFinalOptions(mockItems, '');
+    // Length should be 22 (20 results + 2 default options)
+    expect(finalOptions.length).toBe(22);
+
+    mockItems = createMockItems(100);
+    finalOptions = createFinalOptions(mockItems, '');
+    // Length should be 22 (20 results + 2 default options)
+    expect(finalOptions.length).toBe(22);
+
+    mockItems = createMockItems(15);
+    finalOptions = createFinalOptions(mockItems, '');
+    // Length should be 16 (15 results + 1 default option)
+    expect(finalOptions.length).toBe(16);
+  });
+
+  it('returns an empty array if input is bad', () => {
+    expect(createFinalOptions(undefined!, '')).toEqual([]);
+  });
+});

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -1,6 +1,6 @@
 import Close from '@material-ui/icons/Close';
 import Search from '@material-ui/icons/Search';
-import { compose } from 'ramda';
+import { compose, take } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -134,18 +134,9 @@ class SearchBar extends React.Component<CombinedProps, State> {
   render() {
     const { classes, combinedResults, entitiesLoading } = this.props;
     const { searchActive, searchText, menuOpen } = this.state;
-    const defaultOption = {
-      label: `View search results page for "${searchText}"`,
-      value: 'redirect',
-      data: {
-        searchText
-      }
-    };
 
-    const finalOptions =
-      !combinedResults || combinedResults.length === 0
-        ? []
-        : [defaultOption, ...combinedResults];
+    const finalOptions = createFinalOptions(combinedResults, searchText);
+
     return (
       <React.Fragment>
         <IconButton
@@ -226,3 +217,36 @@ export default compose(
   })),
   withStoreSearch()
 )(SearchBar) as React.ComponentType<{}>;
+
+export const createFinalOptions = (
+  results: Item[],
+  searchText: string = ''
+) => {
+  if (!results || results.length === 0) {
+    return [];
+  }
+
+  const defaultOption = {
+    value: 'redirect',
+    data: {
+      searchText
+    }
+  };
+
+  const firstOption = {
+    ...defaultOption,
+    label: `View search results page for "${searchText}"`
+  };
+
+  const lastOption = {
+    ...defaultOption,
+    label: `View all ${results.length} results for "${searchText}"`
+  };
+
+  if (results.length <= 20) {
+    return [firstOption, ...results];
+  }
+
+  const first20Results = take(20, results);
+  return [firstOption, ...first20Results, lastOption];
+};

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -222,30 +222,32 @@ export const createFinalOptions = (
   results: Item[],
   searchText: string = ''
 ) => {
+  // NO RESULTS:
   if (!results || results.length === 0) {
     return [];
   }
 
-  const defaultOption = {
+  const firstOption = {
     value: 'redirect',
     data: {
       searchText
-    }
-  };
-
-  const firstOption = {
-    ...defaultOption,
+    },
     label: `View search results page for "${searchText}"`
   };
 
-  const lastOption = {
-    ...defaultOption,
-    label: `View all ${results.length} results for "${searchText}"`
-  };
-
+  // LESS THAN 20 RESULTS:
   if (results.length <= 20) {
     return [firstOption, ...results];
   }
+
+  // MORE THAN 20 RESULTS:
+  const lastOption = {
+    value: 'redirect',
+    data: {
+      searchText
+    },
+    label: `View all ${results.length} results for "${searchText}"`
+  };
 
   const first20Results = take(20, results);
   return [firstOption, ...first20Results, lastOption];


### PR DESCRIPTION
## Description

Limit search results in the SearchBar dropdown to **20.** This is for performance and accessibility. See ticket for more details.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
Use an account with many entities. Try generic queries like `is:linode` that yield many results.