### PR TITLE
M3-2332 Change: Clicking a tag prepends "tag:" to the query

### DIFF
--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -118,7 +118,7 @@ class Tag extends React.Component<CombinedProps, {}> {
       this.props.closeMenu();
     }
     const { history, label } = this.props;
-    history.push(`/search/?query=${label}`);
+    history.push(`/search/?query=tag:${label}`);
   };
 
   render() {


### PR DESCRIPTION
## Description

Clicking a tag takes you to the Search Landing page, with a query of the tag name.

This PR prepends `tag:` to the query, so that only entities with a match on _tag_ will be displayed.

## Type of Change
- Non breaking change ('update', 'change')

## To Test:
Click on any tag. You should be taken to the Search Results Landing page, and you should see the text: `Search Results for "tag:[TAG NAME]"`.