### PR TITLE
M3-2408 Add: count to dashboard entities

### DIFF
--- a/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
+++ b/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
@@ -11,6 +11,7 @@ import {
 import Typography from 'src/components/core/Typography';
 import { parseString } from 'xml2js';
 import DashboardCard from '../DashboardCard';
+import ViewAllLink from '../ViewAllLink';
 
 const parseXMLStringPromise = (str: string) =>
   new Promise((resolve, reject) =>
@@ -121,14 +122,12 @@ export class BlogDashboardCard extends React.Component<CombinedProps, State> {
   };
 
   renderAction = () => (
-    <a
-      href="https://blog.linode.com/"
-      className="blue"
-      target="_blank"
+    <ViewAllLink
+      text="Read More"
+      link={'https://blog.linode.com/'}
       data-qa-read-more
-    >
-      Read More
-    </a>
+      external
+    />
   );
 }
 

--- a/src/features/Dashboard/DashboardCard.tsx
+++ b/src/features/Dashboard/DashboardCard.tsx
@@ -17,7 +17,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   headerAction: {
     position: 'relative',
-    top: theme.spacing.unit / 2
+    top: theme.spacing.unit - 3,
+    left: -theme.spacing.unit * 2,
+    marginLeft: theme.spacing.unit / 2
   }
 });
 
@@ -40,7 +42,7 @@ const DashboardCard: React.StatelessComponent<CombinedProps> = props => {
       data-qa-card={title}
     >
       <Grid item xs={12} className={!title || !headerAction ? 'p0' : ''}>
-        <Grid container justify="space-between" alignItems="flex-start">
+        <Grid container alignItems="flex-start">
           {title && (
             <Grid item className={'py0'}>
               <Typography variant="h2">{title}</Typography>

--- a/src/features/Dashboard/DashboardCard.tsx
+++ b/src/features/Dashboard/DashboardCard.tsx
@@ -17,7 +17,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   headerAction: {
     position: 'relative',
-    top: theme.spacing.unit - 3,
+    top: theme.spacing.unit - 2,
     left: -theme.spacing.unit * 2,
     marginLeft: theme.spacing.unit / 2
   }

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -85,7 +85,11 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
 
   renderAction = () =>
     this.props.domainCount > 5 ? (
-      <ViewAllLink link={'/domains'} count={this.props.domainCount} />
+      <ViewAllLink
+        text="View All"
+        link={'/domains'}
+        count={this.props.domainCount}
+      />
     ) : null;
 
   renderContent = () => {

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -24,6 +24,7 @@ import {
   isInProgressEvent
 } from 'src/store/events/event.helpers';
 import DashboardCard from '../DashboardCard';
+import ViewAllLink from '../ViewAllLink';
 
 type ClassNames =
   | 'root'
@@ -83,8 +84,8 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
   }
 
   renderAction = () =>
-    this.props.domains.length > 5 ? (
-      <Link to={'/domains'}>View All</Link>
+    this.props.domainCount > 5 ? (
+      <ViewAllLink link={'/domains'} count={this.props.domainCount} />
     ) : null;
 
   renderContent = () => {
@@ -150,6 +151,7 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
 const styled = withStyles(styles);
 interface WithUpdatingDomainsProps {
   domains: Linode.Domain[];
+  domainCount: number;
   loading: boolean;
   error?: Linode.ApiFieldError[];
 }
@@ -162,6 +164,7 @@ const withUpdatingDomains = connect((state: ApplicationState, ownProps: {}) => {
       sortBy(prop('domain'))
     )(state.__resources.domains.entities),
     loading: state.__resources.domains.loading,
+    domainCount: state.__resources.domains.entities.length,
     error: state.__resources.domains.error
   };
 });

--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -31,7 +31,9 @@ type ClassNames =
   | 'labelCol'
   | 'moreCol'
   | 'actionsCol'
-  | 'wrapHeader';
+  | 'wrapHeader'
+  | 'count'
+  | 'countNumber';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
@@ -52,6 +54,12 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   wrapHeader: {
     whiteSpace: 'nowrap'
+  },
+  count: {
+    marginRight: theme.spacing.unit / 2
+  },
+  countNumber: {
+    fontFamily: 'LatoWebBold'
   }
 });
 
@@ -82,8 +90,18 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
     );
   }
 
-  renderAction = () =>
-    this.props.linodeCount > 5 ? <Link to={'/linodes'}>View All</Link> : null;
+  renderAction = () => {
+    const { classes } = this.props;
+    return this.props.linodeCount > 5 ? (
+      <>
+        <span className={classes.count}>
+          (<span className={classes.countNumber}>{this.props.linodeCount}</span>
+          )
+        </span>
+        <Link to={'/linodes'}>View All</Link>
+      </>
+    ) : null;
+  };
 
   renderContent = () => {
     const { loading, linodes, error } = this.props;

--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -84,7 +84,11 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
 
   renderAction = () => {
     return this.props.linodeCount > 5 ? (
-      <ViewAllLink link={'/linodes'} count={this.props.linodeCount} />
+      <ViewAllLink
+        text="View All"
+        link={'/linodes'}
+        count={this.props.linodeCount}
+      />
     ) : null;
   };
 

--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -1,7 +1,6 @@
 import { compose, prop, sortBy, take } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
 import {
@@ -24,6 +23,7 @@ import {
   isInProgressEvent
 } from 'src/store/events/event.helpers';
 import DashboardCard from '../DashboardCard';
+import ViewAllLink from '../ViewAllLink';
 
 type ClassNames =
   | 'root'
@@ -31,9 +31,7 @@ type ClassNames =
   | 'labelCol'
   | 'moreCol'
   | 'actionsCol'
-  | 'wrapHeader'
-  | 'count'
-  | 'countNumber';
+  | 'wrapHeader';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
@@ -54,12 +52,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   wrapHeader: {
     whiteSpace: 'nowrap'
-  },
-  count: {
-    marginRight: theme.spacing.unit / 2
-  },
-  countNumber: {
-    fontFamily: 'LatoWebBold'
   }
 });
 
@@ -91,15 +83,8 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
   }
 
   renderAction = () => {
-    const { classes } = this.props;
     return this.props.linodeCount > 5 ? (
-      <>
-        <span className={classes.count}>
-          (<span className={classes.countNumber}>{this.props.linodeCount}</span>
-          )
-        </span>
-        <Link to={'/linodes'}>View All</Link>
-      </>
+      <ViewAllLink link={'/linodes'} count={this.props.linodeCount} />
     ) : null;
   };
 

--- a/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -23,6 +23,7 @@ import { events$ } from 'src/events';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
 import { getNodeBalancers } from 'src/services/nodebalancers';
 import DashboardCard from '../DashboardCard';
+import ViewAllLink from '../ViewAllLink';
 
 type ClassNames =
   | 'root'
@@ -153,7 +154,11 @@ class NodeBalancersDashboardCard extends React.Component<CombinedProps, State> {
 
   renderAction = () =>
     this.state.results && this.state.results > 5 ? (
-      <Link to={'/nodebalancers'}>View All</Link>
+      <ViewAllLink
+        text="View All"
+        link={'/nodebalancers'}
+        count={this.state.results}
+      />
     ) : null;
 
   renderContent = () => {

--- a/src/features/Dashboard/ViewAllLink.tsx
+++ b/src/features/Dashboard/ViewAllLink.tsx
@@ -10,8 +10,10 @@ import {
 type ClassNames = 'link' | 'noCount' | 'count' | 'countNumber';
 
 interface Props {
-  count?: number;
+  text: string;
   link: string;
+  count?: number;
+  external?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -34,7 +36,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 });
 
 const ViewAllLink: React.StatelessComponent<CombinedProps> = props => {
-  const { classes, count, link } = props;
+  const { classes, count, text, link, external } = props;
   return (
     <>
       {count && (
@@ -42,15 +44,28 @@ const ViewAllLink: React.StatelessComponent<CombinedProps> = props => {
           (<span className={classes.countNumber}>{count}</span>)
         </span>
       )}
-      <Link
-        to={link}
-        className={classNames({
-          [classes.link]: true,
-          [classes.noCount]: !count
-        })}
-      >
-        View All
-      </Link>
+      {!external ? (
+        <Link
+          to={link}
+          className={classNames({
+            [classes.link]: true,
+            [classes.noCount]: !count
+          })}
+        >
+          {text}
+        </Link>
+      ) : (
+        <a
+          href={link}
+          className={classNames({
+            [classes.link]: true,
+            [classes.noCount]: !count
+          })}
+          target="_blank"
+        >
+          {text}
+        </a>
+      )}
     </>
   );
 };

--- a/src/features/Dashboard/ViewAllLink.tsx
+++ b/src/features/Dashboard/ViewAllLink.tsx
@@ -1,0 +1,60 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+
+type ClassNames = 'link' | 'noCount' | 'count' | 'countNumber';
+
+interface Props {
+  count?: number;
+  link: string;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  link: {
+    '&:hover': {
+      textDecoration: 'underline'
+    }
+  },
+  noCount: {
+    marginLeft: theme.spacing.unit
+  },
+  count: {
+    marginRight: theme.spacing.unit / 2
+  },
+  countNumber: {
+    fontFamily: 'LatoWebBold'
+  }
+});
+
+const ViewAllLink: React.StatelessComponent<CombinedProps> = props => {
+  const { classes, count, link } = props;
+  return (
+    <>
+      {count && (
+        <span className={classes.count}>
+          (<span className={classes.countNumber}>{count}</span>)
+        </span>
+      )}
+      <Link
+        to={link}
+        className={classNames({
+          [classes.link]: true,
+          [classes.noCount]: !count
+        })}
+      >
+        View All
+      </Link>
+    </>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(ViewAllLink);

--- a/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
@@ -1,6 +1,5 @@
 import { compose, take } from 'ramda';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { Subscription } from 'rxjs/Subscription';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import Hidden from 'src/components/core/Hidden';
@@ -23,6 +22,7 @@ import { events$ } from 'src/events';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
 import { getVolumes } from 'src/services/volumes';
 import DashboardCard from '../DashboardCard';
+import ViewAllLink from '../ViewAllLink';
 
 type ClassNames =
   | 'root'
@@ -154,7 +154,11 @@ class VolumesDashboardCard extends React.Component<CombinedProps, State> {
 
   renderAction = () =>
     this.state.results && this.state.results > 5 ? (
-      <Link to={'/volumes'}>View All</Link>
+      <ViewAllLink
+        text="View All"
+        link={'/volumes'}
+        count={this.state.results}
+      />
     ) : null;
 
   renderContent = () => {


### PR DESCRIPTION
## Add count to dashboard entities

Add count to dashboard entities if > 5 along with the view more link (re-styles as we needed to make it more visible by appending it next to the card title

## Type of Change
- Non breaking change ('update', 'change')
