### PR TITLE
M3-2441 Fix: Tag error display

### DIFF
--- a/src/components/TagsInput/TagsInput.tsx
+++ b/src/components/TagsInput/TagsInput.tsx
@@ -60,7 +60,7 @@ class TagsInput extends React.Component<Props, State> {
         });
         this.setState({ accountTags });
       })
-      .catch(errors => {
+      .catch(_ => {
         const defaultError = [
           { reason: 'There was an error retrieving your tags.' }
         ];

--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -28,7 +28,7 @@ import {
   DomainActionsProps,
   withDomainActions
 } from 'src/store/domains/domains.container';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { getAPIErrorOrDefault, getTagErrors } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
@@ -126,6 +126,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
 
     const generalError = errorFor('none');
     const masterIPsError = errorFor('master_ips');
+    const tagError = path<string | undefined>([0], getTagErrors(errors));
 
     return (
       <Drawer title="Add a new Domain" open={open} onClose={this.closeDrawer}>
@@ -207,7 +208,11 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
             />
           </React.Fragment>
         )}
-        <TagsInput value={tags} onChange={this.updateTags} />
+        <TagsInput
+          value={tags}
+          onChange={this.updateTags}
+          tagError={tagError}
+        />
         <ActionsPanel>
           {!submitting ? (
             <Button type="primary" onClick={this.submit} data-qa-submit>

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -6,6 +6,7 @@ import {
   Lens,
   lensPath,
   over,
+  path as ramdaPath,
   pathOr,
   set,
   view
@@ -40,6 +41,7 @@ import {
   withNodeBalancerActions,
   WithNodeBalancerActions
 } from 'src/store/nodeBalancer/nodeBalancer.containers';
+import { getTagErrors } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import NodeBalancerConfigPanel from './NodeBalancerConfigPanel';
@@ -89,7 +91,8 @@ interface State {
 const errorResources = {
   label: 'label',
   region: 'region',
-  address: 'address'
+  address: 'address',
+  tags: 'tags'
 };
 
 class NodeBalancerCreate extends React.Component<CombinedProps, State> {
@@ -445,6 +448,10 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     const { classes, regionsData } = this.props;
     const { nodeBalancerFields, linodesWithPrivateIPs } = this.state;
     const hasErrorFor = getAPIErrorFor(errorResources, this.state.errors);
+    const tagError = ramdaPath<string | undefined>(
+      [0],
+      getTagErrors(this.state.errors)
+    );
     const generalError = hasErrorFor('none');
 
     if (this.props.regionsLoading) {
@@ -486,7 +493,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
                     }))
                   : [],
                 onChange: this.tagsChange,
-                tagError: hasErrorFor('tag')
+                tagError
               }}
             />
             <SelectRegionPanel

--- a/src/features/Volumes/VolumeDrawer/utils.ts
+++ b/src/features/Volumes/VolumeDrawer/utils.ts
@@ -1,4 +1,5 @@
 import { isEmpty, isNil, path } from 'ramda';
+import { tagRegEx } from 'src/utilities/errorUtils';
 
 export const isNilOrEmpty = (v: any) => isNil(v) || isEmpty(v);
 
@@ -17,7 +18,12 @@ export const handleFieldErrors = (callback: Function, response: any) => {
 
   const mappedFieldErrors = fieldErrors.reduce(
     (result, { field, reason }) =>
-      field ? { ...result, [field]: reason } : result,
+      field
+        ? // Tags have a field of 'tags[0]', so need to handle them separately:
+          tagRegEx.test(field)
+          ? { ...result, tags: reason }
+          : { ...result, [field]: reason }
+        : result,
     {}
   );
 

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -1,6 +1,6 @@
 import * as Promise from 'bluebird';
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { compose as ramdaCompose, pathOr } from 'ramda';
+import { compose as ramdaCompose, path, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
@@ -24,6 +24,7 @@ import {
   withLinodeActions
 } from 'src/store/linodes/linode.containers';
 import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
+import { getAPIErrorOrDefault, getTagErrors } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import getLinodeInfo from 'src/utilities/getLinodeInfo';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
@@ -275,8 +276,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
         }
 
         this.setState(() => ({
-          errors:
-            error.response && error.response.data && error.response.data.errors
+          errors: getAPIErrorOrDefault(error)
         }));
       })
       .finally(() => {
@@ -373,6 +373,9 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     } = this.props;
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
+    // getTagErrors returns a string[]; for now, just use the first one
+    // since tagError is expecting string | undefined.
+    const tagError = path<string | undefined>([0], getTagErrors(errors));
 
     const imageInfo = selectedBackupInfo;
 
@@ -449,7 +452,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                 tagsInputProps={{
                   value: tags,
                   onChange: this.handleChangeTags,
-                  tagError: hasErrorFor('tag')
+                  tagError
                 }}
                 updateFor={[tags, label, errors]}
               />

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -1,5 +1,5 @@
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { find, pathOr } from 'ramda';
+import { find, path, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
@@ -26,6 +26,7 @@ import {
   withLinodeActions
 } from 'src/store/linodes/linode.containers';
 import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
+import { getAPIErrorOrDefault, getTagErrors } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
@@ -236,10 +237,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
         this.setState(
           () => ({
-            errors:
-              error.response &&
-              error.response.data &&
-              error.response.data.errors
+            errors: getAPIErrorOrDefault(error)
           }),
           () => {
             scrollErrorIntoView();
@@ -299,6 +297,9 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
+    // getTagErrors returns a string[]; for now, just use the first one
+    // since tagError is expecting string | undefined.
+    const tagError = path<string | undefined>([0], getTagErrors(errors));
 
     const imageInfo = this.getImageInfo(
       this.props.images.find(image => image.id === selectedImageID)
@@ -356,7 +357,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
             tagsInputProps={{
               value: tags,
               onChange: this.handleChangeTags,
-              tagError: hasErrorFor('tag')
+              tagError
             }}
             updateFor={[tags, label, errors]}
           />

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -1,5 +1,5 @@
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { pathOr } from 'ramda';
+import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Sticky, StickyProps } from 'react-sticky';
@@ -23,6 +23,7 @@ import { resetEventsPolling } from 'src/events';
 import { cloneLinode } from 'src/services/linodes';
 import { upsertLinode } from 'src/store/linodes/linodes.actions';
 import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
+import { getAPIErrorOrDefault, getTagErrors } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
@@ -188,10 +189,7 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
 
         this.setState(
           () => ({
-            errors:
-              error.response &&
-              error.response.data &&
-              error.response.data.errors
+            errors: getAPIErrorOrDefault(error)
           }),
           () => {
             scrollErrorIntoView();
@@ -254,6 +252,9 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
+    // getTagErrors returns a string[]; for now, just use the first one
+    // since tagError is expecting string | undefined.
+    const tagError = path<string | undefined>([0], getTagErrors(errors));
 
     const regionInfo = getRegionInfo(selectedRegionID);
 
@@ -319,7 +320,7 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
                 tagsInputProps={{
                   value: tags,
                   onChange: this.handleChangeTags,
-                  tagError: hasErrorFor('tag')
+                  tagError
                 }}
                 updateFor={[tags, label, errors]}
               />

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -1,5 +1,5 @@
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { path, pathOr } from 'ramda';
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Sticky, StickyProps } from 'react-sticky';
@@ -23,7 +23,7 @@ import { resetEventsPolling } from 'src/events';
 import { cloneLinode } from 'src/services/linodes';
 import { upsertLinode } from 'src/store/linodes/linodes.actions';
 import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
-import { getAPIErrorOrDefault, getTagErrors } from 'src/utilities/errorUtils';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
@@ -251,9 +251,6 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
-    // getTagErrors returns a string[]; for now, just use the first one
-    // since tagError is expecting string | undefined.
-    const tagError = path<string | undefined>([0], getTagErrors(errors));
 
     const regionInfo = getRegionInfo(selectedRegionID);
 

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -1,5 +1,5 @@
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { assocPath, pathOr } from 'ramda';
+import { assocPath, path, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
@@ -32,6 +32,7 @@ import {
   withLinodeActions
 } from 'src/store/linodes/linode.containers';
 import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
+import { getAPIErrorOrDefault, getTagErrors } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
@@ -322,22 +323,14 @@ export class FromStackScriptContent extends React.Component<
         if (!this.mounted) {
           return;
         }
-
-        if (
-          error.response &&
-          error.response.data &&
-          error.response.data.errors
-        ) {
-          const listOfErrors = error.response.data.errors;
-          this.setState(
-            () => ({
-              errors: listOfErrors
-            }),
-            () => {
-              scrollErrorIntoView();
-            }
-          );
-        }
+        this.setState(
+          () => ({
+            errors: getAPIErrorOrDefault(error)
+          }),
+          () => {
+            scrollErrorIntoView();
+          }
+        );
       })
       .finally(() => {
         if (!this.mounted) {
@@ -410,6 +403,9 @@ export class FromStackScriptContent extends React.Component<
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
+    // getTagErrors returns a string[]; for now, just use the first one
+    // since tagError is expecting string | undefined.
+    const tagError = path<string | undefined>([0], getTagErrors(errors));
 
     const hasBackups = Boolean(backups || accountBackups);
 
@@ -524,7 +520,7 @@ export class FromStackScriptContent extends React.Component<
             tagsInputProps={{
               value: tags,
               onChange: this.handleChangeTags,
-              tagError: hasErrorFor('tag')
+              tagError
             }}
             updateFor={[tags, label, errors]}
           />

--- a/src/utilities/errorUtils.test.ts
+++ b/src/utilities/errorUtils.test.ts
@@ -1,0 +1,72 @@
+import {
+  getAPIErrorOrDefault,
+  getErrorStringOrDefault,
+  getTagErrors
+} from './errorUtils';
+
+const error = [{ field: 'a field', reason: 'a reason' }];
+
+const multiError = [
+  { field: 'field 1', reason: 'reason 1' },
+  { field: 'field 2', reason: 'reason 2' }
+];
+
+describe('Error handling utilities', () => {
+  describe('getAPIErrorOrDefault', () => {
+    it('if no error is passed in, it should return a default API error using the provided string', () => {
+      expect(getAPIErrorOrDefault([], 'Default error')).toEqual([
+        { reason: 'Default error' }
+      ]);
+    });
+
+    it('should provide a default error if no error string is provided', () => {
+      expect(getAPIErrorOrDefault([])).toEqual([
+        { reason: 'An unexpected error occurred.' }
+      ]);
+    });
+
+    it('should use the optional 3rd param as a field name for the default error (if provided)', () => {
+      expect(getAPIErrorOrDefault([], 'Label error', 'label')).toEqual([
+        { field: 'label', reason: 'Label error' }
+      ]);
+    });
+  });
+
+  describe('getErrorStringOrDefault', () => {
+    it('should return the reason for the first error in the APIError array', () => {
+      expect(getErrorStringOrDefault(error)).toMatch('a reason');
+      expect(getErrorStringOrDefault(multiError)).toMatch('reason 1');
+    });
+
+    it('should return the given default string if the error object is empty', () => {
+      expect(getErrorStringOrDefault([], 'A horrible error occurred.')).toMatch(
+        'A horrible error occurred.'
+      );
+    });
+
+    it('should return its own default as a final fallback', () => {
+      expect(getErrorStringOrDefault([])).toMatch(
+        'An unexpected error occurred.'
+      );
+    });
+  });
+
+  describe('getTagErrors', () => {
+    it('should return an empty array if there are no errors', () => {
+      expect(getTagErrors()).toEqual([]);
+    });
+
+    it('should return an empty array if there are no tag errors', () => {
+      expect(getTagErrors(multiError)).toEqual([]);
+    });
+
+    it('should return an array of strings, one string for each tag error', () => {
+      const tagErrors = [
+        ...multiError,
+        { field: 'tags[0]', reason: 'error1' },
+        { field: 'tags[1]', reason: 'error2' }
+      ];
+      expect(getTagErrors(tagErrors)).toEqual(['error1', 'error2']);
+    });
+  });
+});

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -20,7 +20,7 @@ export const getErrorStringOrDefault = (
   return pathOr<string>(defaultError, [0, 'reason'], errors);
 };
 
-const tagRegEx = new RegExp(/tags/);
+export const tagRegEx = new RegExp(/tags/);
 
 export const getTagErrors = (errors?: Linode.ApiFieldError[]): string[] => {
   if (!errors) {

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -19,3 +19,14 @@ export const getErrorStringOrDefault = (
 ): string => {
   return pathOr<string>(defaultError, [0, 'reason'], errors);
 };
+
+const tagRegEx = new RegExp(/tags/);
+
+export const getTagErrors = (errors?: Linode.ApiFieldError[]): string[] => {
+  if (!errors) {
+    return [];
+  }
+  return errors
+    .filter(error => Boolean(error.field) && tagRegEx.test(error.field!))
+    .map(error => error.reason);
+};

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -28,5 +28,9 @@ export const getTagErrors = (errors?: Linode.ApiFieldError[]): string[] => {
   }
   return errors
     .filter(error => Boolean(error.field) && tagRegEx.test(error.field!))
-    .map(error => error.reason);
+    .map(error => adjustTagErrorText(error.reason));
 };
+
+// @todo remove after hotfix
+const adjustTagErrorText = (error: string) =>
+  error.replace('3 and 50', '4 and 50');


### PR DESCRIPTION
## Description

Adds an errorUtil `getTagErrors` that handles the special case of tag errors having a field `tag[0]` or `tag[1]`. For now, only displaying a single error string: since tagError is expecting a string, I'm trying to keep the footprint of this fix small.

This will need to be tested in each of the separate creation flows, also please make sure existing error handling is not affected.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
