### PR TITLE
M3-2444 Fix: Remove client-side validation for Linode labels

### DIFF
--- a/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
@@ -73,8 +73,11 @@ const connected = connect((state: ApplicationState) => ({
 
 // Regex taken from API documentation.
 const testAPIRequirements = (label: string) => {
-  const linodeLabelRegExp = /^[a-zA-Z]((?!--|__)[a-zA-Z0-9-_])+$/;
-  return linodeLabelRegExp.test(label) && label.length <= 32;
+  // NOTE: This regex is incorrect. We need to replace it with one that is consistent with API requirements.
+  // const linodeLabelRegExp = /^[a-zA-Z]((?!--|__)[a-zA-Z0-9-_])+$/;
+  // return linodeLabelRegExp.test(label) && label.length <= 32;
+
+  return label.length <= 32;
 };
 
 export default withLabelGenerator;

--- a/src/services/linodes/linode.schema.ts
+++ b/src/services/linodes/linode.schema.ts
@@ -49,11 +49,7 @@ export const CreateLinodeSchema = object({
   label: string()
     .nullable(true)
     .min(3, 'Label must contain between 3 and 32 characters.')
-    .max(32, 'Label must contain between 3 and 32 characters.')
-    .matches(
-      /^[a-zA-Z]((?!--|__)[a-zA-Z0-9-_])+$/,
-      'Label can only use alphanumeric characters, dashes, or underscores.'
-    ),
+    .max(32, 'Label must contain between 3 and 32 characters.'),
   tags: array()
     .of(string())
     .notRequired(),
@@ -102,11 +98,7 @@ export const UpdateLinodeSchema = object({
   label: string()
     .nullable(true)
     .min(3, 'Label must contain between 3 and 32 characters.')
-    .max(32, 'Label must contain between 3 and 32 characters.')
-    .matches(
-      /^[a-zA-Z]((?!--|__)[a-zA-Z0-9-_])+$/,
-      'Label can only use alphanumeric characters, dashes, or underscores.'
-    ),
+    .max(32, 'Label must contain between 3 and 32 characters.'),
   tags: array()
     .of(string())
     .notRequired(),


### PR DESCRIPTION
## Description

Remove client-side validation of Linode Labels, as it is inconsistent with actual API requirements.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Test creating Linodes, as well as updating labels on existing Linodes.
