### PR TITLE
M3-2448 Hotfix: Deactivate tag input on FromLinodeContent

### DIFF
--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -231,7 +231,6 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
       backups,
       privateIP,
       selectedLinodeID,
-      tags,
       selectedRegionID,
       selectedTypeID,
       selectedDiskSize,
@@ -316,12 +315,7 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
                   onChange: updateCustomLabel,
                   errorText: hasErrorFor('label')
                 }}
-                tagsInputProps={{
-                  value: tags,
-                  onChange: this.handleChangeTags,
-                  tagError: hasErrorFor('tag')
-                }}
-                updateFor={[tags, label, errors]}
+                updateFor={[label, errors]}
               />
               <AddonsPanel
                 backups={backups}


### PR DESCRIPTION
## Description

We display a tags input field when creating a Linode from an existing Linode (cloning), but the cloning endpoint is ignoring the tags that we send with the POST request.

If the API changes its behavior, we can include the tags input; until then, we should remove it.

## Note to Reviewers

I left in the tag handling code, just removed sending it to LabelAndTagsPanel. If this change is permanent, we can remove that logic as well.