### PR TITLE
Events Polling Updates

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -32,9 +32,9 @@ export const INTERVAL: number = 1000;
 
 let inProgress = false;
 
-export const resetEventsPolling = () => {
-  eventRequestDeadline = Date.now() + INTERVAL;
-  pollIteration = 1;
+export const resetEventsPolling = (newPollIteration = 1) => {
+  eventRequestDeadline = Date.now() + INTERVAL * newPollIteration;
+  pollIteration = newPollIteration;
 };
 
 export const requestEvents = () => {
@@ -62,7 +62,8 @@ setInterval(
        * overlapping requests.
        */
       if (inProgress) {
-        pollIteration = 1;
+        /** leaving this commented out for now because I'm not sure if it'll break anything */
+        // pollIteration = 1;
         return;
       }
 

--- a/src/store/linodes/linodes.events.ts
+++ b/src/store/linodes/linodes.events.ts
@@ -76,10 +76,10 @@ const handleLinodeUpdate = (
     case 'failed':
     case 'finished':
     case 'notification':
+    case 'scheduled':
       return dispatch(requestLinodeForStore(id));
 
     /** no point in re-requesting the linode for in-progress events  */
-    case 'scheduled':
     case 'started':
     default:
       return;

--- a/src/store/linodes/linodes.events.ts
+++ b/src/store/linodes/linodes.events.ts
@@ -76,10 +76,11 @@ const handleLinodeUpdate = (
     case 'failed':
     case 'finished':
     case 'notification':
-    case 'scheduled':
-    case 'started':
       return dispatch(requestLinodeForStore(id));
 
+    /** no point in re-requesting the linode for in-progress events  */
+    case 'scheduled':
+    case 'started':
     default:
       return;
   }

--- a/src/store/middleware/combineEventsMiddleware.ts
+++ b/src/store/middleware/combineEventsMiddleware.ts
@@ -50,7 +50,12 @@ const eventsMiddlewareFactory = (
        * interval to keep things moving quickly.
        */
       if (isInProgressEvent(event)) {
-        resetEventsPolling();
+        /**
+         * purely experimental - no real reason for the number 4
+         * the main point here is we don't want to poll the events endpoint
+         * excessively
+         */
+        resetEventsPolling(4);
       }
     }
   }


### PR DESCRIPTION
## Description

Decrease the amount of times we're polling `/events` when we have in-progress events happening.

### To Test

1. Trigger an action (such as Linode Resize)
2. Check the Network tab3
3. Every request to `/events` should happen after 4 seconds

If no action is running, the polling should work as normal (with intervals of 1, 2, 4, 8, 16 seconds)

Pls run a lot of different events and try your hardest to break something