### PR TITLE
M3-2441 update tag errors

### DIFF
--- a/src/components/TagsInput/TagsInput.spec.js
+++ b/src/components/TagsInput/TagsInput.spec.js
@@ -15,7 +15,7 @@ describe('Tags Input Suite', () => {
       $$(tagOptions)[0].click();
       try {
         inputError.waitForVisible(constants.wait.normal);
-        expect(inputError.getText()).toContain('Length must be 3-25 characters');
+        expect(inputError.getText()).toContain('Length must be 3-50 characters');
       } catch (e) {
 
       }
@@ -71,10 +71,10 @@ describe('Tags Input Suite', () => {
         $('svg[height="20"]').click();
     });
 
-    it('a tag must be between 3-25 characters', () => {
+    it('a tag must be between 3-50 characters', () => {
         inputValidation('aa');
         navigateToStory(component, childStories[0]);
-        inputValidation('aaaaaaaaaaaaaaaaaaaaaaaaaa');
+        inputValidation('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
     });
 
     describe('Tags Input with api error', () => {

--- a/src/components/TagsInput/TagsInput.tsx
+++ b/src/components/TagsInput/TagsInput.tsx
@@ -36,9 +36,9 @@ class TagsInput extends React.Component<Props, State> {
     const newTag = { value: inputValue, label: inputValue };
     const updatedSelectedTags = concat(value, [newTag]);
 
-    if (inputValue.length < 3 || inputValue.length > 25) {
+    if (inputValue.length < 3 || inputValue.length > 50) {
       this.setState({
-        errors: [{ field: 'label', reason: 'Length must be 3-25 characters' }]
+        errors: [{ field: 'label', reason: 'Length must be 3-50 characters' }]
       });
     } else {
       this.setState({

--- a/src/features/Domains/DomainCreateDrawer.tsx
+++ b/src/features/Domains/DomainCreateDrawer.tsx
@@ -32,7 +32,7 @@ import {
   DomainActionsProps,
   withDomainActions
 } from 'src/store/domains/domains.container';
-import { getAPIErrorOrDefault, getTagErrors } from 'src/utilities/errorUtils';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
@@ -130,7 +130,6 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
 
     const generalError = errorFor('none');
     const masterIPsError = errorFor('master_ips');
-    const tagError = path<string | undefined>([0], getTagErrors(errors));
 
     return (
       <Drawer title="Add a new Domain" open={open} onClose={this.closeDrawer}>
@@ -229,7 +228,7 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
         <TagsInput
           value={tags}
           onChange={this.updateTags}
-          tagError={tagError}
+          tagError={errorFor('tags')}
           disabled={disabled}
         />
         <ActionsPanel>
@@ -258,7 +257,8 @@ class DomainCreateDrawer extends React.Component<CombinedProps, State> {
   errorResources = {
     domain: 'Domain',
     type: 'Type',
-    soa_email: 'SOA Email'
+    soa_email: 'SOA Email',
+    tags: 'Tags'
   };
 
   resetInternalState = () => {

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -6,8 +6,6 @@ import {
   Lens,
   lensPath,
   over,
-  path as ramdaPath,
-  pathOr,
   set,
   view
 } from 'ramda';
@@ -47,7 +45,7 @@ import {
   WithNodeBalancerActions
 } from 'src/store/nodeBalancer/nodeBalancer.containers';
 import { MapState } from 'src/store/types';
-import { getTagErrors } from 'src/utilities/errorUtils';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import NodeBalancerConfigPanel from './NodeBalancerConfigPanel';
@@ -310,12 +308,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
         this.props.history.push(`/nodebalancers/${nodeBalancer.id}/summary`)
       )
       .catch(errorResponse => {
-        const defaultError = [{ reason: `An unexpected error has occured.` }];
-        const errors = pathOr(
-          defaultError,
-          ['response', 'data', 'errors'],
-          errorResponse
-        );
+        const errors = getAPIErrorOrDefault(errorResponse);
         this.setNodeErrors(
           errors.map((e: Linode.ApiFieldError) => ({
             ...e,
@@ -459,10 +452,6 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     const { classes, regionsData, disabled } = this.props;
     const { nodeBalancerFields, linodesWithPrivateIPs } = this.state;
     const hasErrorFor = getAPIErrorFor(errorResources, this.state.errors);
-    const tagError = ramdaPath<string | undefined>(
-      [0],
-      getTagErrors(this.state.errors)
-    );
     const generalError = hasErrorFor('none');
 
     if (this.props.regionsLoading) {
@@ -513,7 +502,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
                     }))
                   : [],
                 onChange: this.tagsChange,
-                tagError,
+                tagError: hasErrorFor('tags'),
                 disabled
               }}
             />

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -24,6 +24,7 @@ import {
 import { CreateVolumeSchema } from 'src/services/volumes/volumes.schema.ts';
 import { MapState } from 'src/store/types';
 import { openForAttaching } from 'src/store/volumeDrawer';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import ConfigSelect from './ConfigSelect';
 import LabelField from './LabelField';
 import { modes } from './modes';
@@ -204,7 +205,10 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               tagError={
                 touched.tags
                   ? errors.tags
-                    ? 'Unable to tag volume.'
+                    ? getErrorStringOrDefault(
+                        errors.tags,
+                        'Unable to tag volume.'
+                      )
                     : undefined
                   : undefined
               }

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
@@ -20,6 +20,7 @@ import {
 } from 'src/features/Profile/permissionsHelpers';
 import { CreateVolumeSchema } from 'src/services/volumes/volumes.schema.ts';
 import { MapState } from 'src/store/types';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import ConfigSelect from './ConfigSelect';
 import LabelField from './LabelField';
 import LinodeSelect from './LinodeSelect';
@@ -59,7 +60,6 @@ type CombinedProps = Props &
 
 const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
   const { onClose, onSuccess, classes, createVolume, disabled } = props;
-  console.log('disabled', disabled);
   return (
     <Formik
       initialValues={initialValues}
@@ -205,7 +205,10 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               tagError={
                 touched.tags
                   ? errors.tags
-                    ? 'Unable to tag volume.'
+                    ? getErrorStringOrDefault(
+                        errors.tags,
+                        'Unable to tag Volume.'
+                      )
                     : undefined
                   : undefined
               }

--- a/src/features/Volumes/VolumeDrawer/utils.ts
+++ b/src/features/Volumes/VolumeDrawer/utils.ts
@@ -1,5 +1,4 @@
 import { isEmpty, isNil, path } from 'ramda';
-import { tagRegEx } from 'src/utilities/errorUtils';
 
 export const isNilOrEmpty = (v: any) => isNil(v) || isEmpty(v);
 
@@ -18,12 +17,7 @@ export const handleFieldErrors = (callback: Function, response: any) => {
 
   const mappedFieldErrors = fieldErrors.reduce(
     (result, { field, reason }) =>
-      field
-        ? // Tags have a field of 'tags[0]', so need to handle them separately:
-          tagRegEx.test(field)
-          ? { ...result, tags: reason }
-          : { ...result, [field]: reason }
-        : result,
+      field ? { ...result, [field]: reason } : result,
     {}
   );
 

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -1,6 +1,6 @@
 import * as Promise from 'bluebird';
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { compose as ramdaCompose, path, pathOr } from 'ramda';
+import { compose as ramdaCompose, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
@@ -25,7 +25,7 @@ import {
   withLinodeActions
 } from 'src/store/linodes/linode.containers';
 import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
-import { getAPIErrorOrDefault, getTagErrors } from 'src/utilities/errorUtils';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import getLinodeInfo from 'src/utilities/getLinodeInfo';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
@@ -109,7 +109,8 @@ const errorResources = {
   type: 'A plan selection',
   region: 'A region selection',
   label: 'A label',
-  root_pass: 'A root password'
+  root_pass: 'A root password',
+  tags: 'Tags for this Linode'
 };
 
 const filterLinodesWithBackups = (linodes: Linode.LinodeWithBackups[]) => {
@@ -376,9 +377,6 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     } = this.props;
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
-    // getTagErrors returns a string[]; for now, just use the first one
-    // since tagError is expecting string | undefined.
-    const tagError = path<string | undefined>([0], getTagErrors(errors));
 
     const imageInfo = selectedBackupInfo;
 
@@ -459,7 +457,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                 tagsInputProps={{
                   value: tags,
                   onChange: this.handleChangeTags,
-                  tagError,
+                  tagError: hasErrorFor('tags'),
                   disabled
                 }}
                 updateFor={[tags, label, errors]}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -1,5 +1,5 @@
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { find, path, pathOr } from 'ramda';
+import { find, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
@@ -27,7 +27,7 @@ import {
   withLinodeActions
 } from 'src/store/linodes/linode.containers';
 import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
-import { getAPIErrorOrDefault, getTagErrors } from 'src/utilities/errorUtils';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
@@ -98,7 +98,8 @@ const errorResources = {
   region: 'A region selection',
   label: 'A label',
   root_pass: 'A root password',
-  image: 'Image'
+  image: 'Image',
+  tags: 'Tags'
 };
 
 type CombinedProps = Props &
@@ -300,9 +301,6 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
-    // getTagErrors returns a string[]; for now, just use the first one
-    // since tagError is expecting string | undefined.
-    const tagError = path<string | undefined>([0], getTagErrors(errors));
 
     const imageInfo = this.getImageInfo(
       this.props.images.find(image => image.id === selectedImageID)
@@ -365,7 +363,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
             tagsInputProps={{
               value: tags,
               onChange: this.handleChangeTags,
-              tagError,
+              tagError: hasErrorFor('tags'),
               disabled
             }}
             updateFor={[tags, label, errors]}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -1,5 +1,5 @@
 import { InjectedNotistackProps, withSnackbar } from 'notistack';
-import { assocPath, path, pathOr } from 'ramda';
+import { assocPath, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
@@ -33,7 +33,7 @@ import {
   withLinodeActions
 } from 'src/store/linodes/linode.containers';
 import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
-import { getAPIErrorOrDefault, getTagErrors } from 'src/utilities/errorUtils';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AddonsPanel from '../AddonsPanel';
@@ -124,7 +124,8 @@ const errorResources = {
   region: 'A region selection',
   label: 'A label',
   root_pass: 'A root password',
-  image: 'image'
+  image: 'image',
+  tags: 'Tags'
 };
 
 type CombinedProps = Props &
@@ -406,9 +407,6 @@ export class FromStackScriptContent extends React.Component<
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
     const generalError = hasErrorFor('none');
-    // getTagErrors returns a string[]; for now, just use the first one
-    // since tagError is expecting string | undefined.
-    const tagError = path<string | undefined>([0], getTagErrors(errors));
 
     const hasBackups = Boolean(backups || accountBackups);
 
@@ -528,7 +526,7 @@ export class FromStackScriptContent extends React.Component<
             tagsInputProps={{
               value: tags,
               onChange: this.handleChangeTags,
-              tagError,
+              tagError: hasErrorFor('tags'),
               disabled
             }}
             updateFor={[tags, label, errors]}

--- a/src/services/volumes/volumes.schema.ts
+++ b/src/services/volumes/volumes.schema.ts
@@ -12,6 +12,11 @@ const createSizeValidation = (minSize: number = 10) =>
     )
     .required(`A size is required.`);
 
+// @todo this should be used in CreateVolumeForm and CreateVolumeFromLinodeForm
+// export const tag = string()
+//   .min(3, "Tags must be between 3 and 50 characters.")
+//   .max(50, "Tags must be between 3 and 50 characters.")
+
 export const CreateVolumeSchema = object({
   region: string().when('linode_id', {
     is: id => id === undefined || id === '',

--- a/src/utilities/errorUtils.test.ts
+++ b/src/utilities/errorUtils.test.ts
@@ -1,8 +1,4 @@
-import {
-  getAPIErrorOrDefault,
-  getErrorStringOrDefault,
-  getTagErrors
-} from './errorUtils';
+import { getAPIErrorOrDefault, getErrorStringOrDefault } from './errorUtils';
 
 const error = [{ field: 'a field', reason: 'a reason' }];
 
@@ -48,25 +44,6 @@ describe('Error handling utilities', () => {
       expect(getErrorStringOrDefault([])).toMatch(
         'An unexpected error occurred.'
       );
-    });
-  });
-
-  describe('getTagErrors', () => {
-    it('should return an empty array if there are no errors', () => {
-      expect(getTagErrors()).toEqual([]);
-    });
-
-    it('should return an empty array if there are no tag errors', () => {
-      expect(getTagErrors(multiError)).toEqual([]);
-    });
-
-    it('should return an array of strings, one string for each tag error', () => {
-      const tagErrors = [
-        ...multiError,
-        { field: 'tags[0]', reason: 'error1' },
-        { field: 'tags[1]', reason: 'error2' }
-      ];
-      expect(getTagErrors(tagErrors)).toEqual(['error1', 'error2']);
     });
   });
 });

--- a/src/utilities/errorUtils.test.ts
+++ b/src/utilities/errorUtils.test.ts
@@ -45,5 +45,9 @@ describe('Error handling utilities', () => {
         'An unexpected error occurred.'
       );
     });
+
+    it('should just return the string if you pass it a string', () => {
+      expect(getErrorStringOrDefault('a', 'b')).toBe('a');
+    });
   });
 });

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -14,8 +14,11 @@ export const getAPIErrorOrDefault = (
 };
 
 export const getErrorStringOrDefault = (
-  errors: Linode.ApiFieldError[],
+  errors: Linode.ApiFieldError[] | string,
   defaultError: string = 'An unexpected error occurred.'
 ): string => {
+  if (typeof errors === 'string') {
+    return errors;
+  }
   return pathOr<string>(defaultError, [0, 'reason'], errors);
 };

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -19,18 +19,3 @@ export const getErrorStringOrDefault = (
 ): string => {
   return pathOr<string>(defaultError, [0, 'reason'], errors);
 };
-
-export const tagRegEx = new RegExp(/tags/);
-
-export const getTagErrors = (errors?: Linode.ApiFieldError[]): string[] => {
-  if (!errors) {
-    return [];
-  }
-  return errors
-    .filter(error => Boolean(error.field) && tagRegEx.test(error.field!))
-    .map(error => adjustTagErrorText(error.reason));
-};
-
-// @todo remove after hotfix
-const adjustTagErrorText = (error: string) =>
-  error.replace('3 and 50', '4 and 50');


### PR DESCRIPTION
## Description

Adjusts tag error handling (introduced in 0.48.1) for the new API release. Tag errors will have the field 'tags' rather than 'tags[0]', so our special logic for this is no longer necessary.

## Note to Reviewers

To test:

- change the conditional in line 39 of TagsInput to `false` (turn off client-side tag checking)
- Submit a short tag (< 3 chars)
- Use dev services