### PR TITLE
M3-2455 Humanize Suspended Linode Error

### DIFF
--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -122,7 +122,7 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
         <React.Fragment>
           One or more of your Linodes is suspended. Please{' '}
           <Link to="/support/tickets">open a support ticket </Link>
-          if you have questions
+          if you have questions.
         </React.Fragment>
       );
     }

--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -1,6 +1,7 @@
-import { compose, prop, sortBy, take } from 'ramda';
+import { compose, pathOr, prop, sortBy, take } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
 import {
@@ -113,9 +114,21 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
     return <TableRowLoading colSpan={3} />;
   };
 
-  renderErrors = (errors: Linode.ApiFieldError[]) => (
-    <TableRowError colSpan={3} message={`Unable to load Linodes.`} />
-  );
+  renderErrors = (errors: Linode.ApiFieldError[]) => {
+    let errorText = pathOr('Unable to load Linodes.', [0, 'reason'], errors);
+
+    if (errorText.toLowerCase() === 'this linode has been suspended') {
+      errorText = (
+        <React.Fragment>
+          One or more of your Linodes is suspended. Please{' '}
+          <Link to="/support/tickets">open a support ticket </Link>
+          if you have questions
+        </React.Fragment>
+      );
+    }
+
+    return <TableRowError colSpan={3} message={errorText} />;
+  };
 
   renderEmpty = () => <TableRowEmptyState colSpan={3} />;
 

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
@@ -59,7 +59,6 @@ type CombinedProps = Props &
 
 const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
   const { onClose, onSuccess, classes, createVolume, disabled } = props;
-  console.log('disabled', disabled);
   return (
     <Formik
       initialValues={initialValues}

--- a/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.container.tsx
@@ -1,5 +1,5 @@
 import { compose } from 'recompose';
-import initLinode from './initLinode';
+// import initLinode from './initLinode';
 import initLinodeConfigs from './initLinodeConfigs';
 import initLinodeDisks from './initLinodeDisks';
 import maybeRenderError from './maybeRenderError';
@@ -16,7 +16,7 @@ export interface InnerProps {
 }
 
 export default compose<InnerProps, OutterProps>(
-  initLinode,
+  // initLinode,
   initLinodeConfigs,
   initLinodeDisks,
   maybeRenderError,

--- a/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -1,6 +1,7 @@
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { branch, compose, renderComponent } from 'recompose';
 import ErrorState from 'src/components/ErrorState';
 import { MapState } from 'src/store/types';
@@ -50,11 +51,22 @@ export default compose(
   branch(
     ({ error }) => Boolean(error),
     renderComponent((props: any) => {
-      const errorText = pathOr(
+      let errorText = pathOr(
         'Unable to load Linode',
         ['error', 'response', 'error', 0, 'reason'],
         props
       );
+
+      if (errorText.toLowerCase() === 'this linode has been suspended') {
+        errorText = (
+          <React.Fragment>
+            One or more of your Linodes is suspended. Please{' '}
+            <Link to="/support/tickets">open a support ticket </Link>
+            if you have questions.
+          </React.Fragment>
+        );
+      }
+
       return <ErrorState errorText={errorText} />;
     })
   )

--- a/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -53,7 +53,7 @@ export default compose(
     renderComponent((props: any) => {
       let errorText = pathOr(
         'Unable to load Linode',
-        ['error', 'response', 'error', 0, 'reason'],
+        ['error', 0, 'reason'],
         props
       );
 

--- a/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -1,3 +1,4 @@
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { branch, compose, renderComponent } from 'recompose';
@@ -48,6 +49,13 @@ export default compose(
   connect(collectErrors),
   branch(
     ({ error }) => Boolean(error),
-    renderComponent(() => <ErrorState errorText="Unable to load Linode" />)
+    renderComponent((props: any) => {
+      const errorText = pathOr(
+        'Unable to load Linode',
+        ['error', 'response', 'error', 0, 'reason'],
+        props
+      );
+      return <ErrorState errorText={errorText} />;
+    })
   )
 );

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -250,7 +250,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           <React.Fragment>
             One or more of your Linodes is suspended. Please{' '}
             <Link to="/support/tickets">open a support ticket </Link>
-            if you have questions
+            if you have questions.
           </React.Fragment>
         );
       }

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -6,7 +6,7 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { CSVLink } from 'react-csv';
 import { connect } from 'react-redux';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose, withStateHandlers } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -239,10 +239,26 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
     };
 
     if (imagesError || linodesRequestError) {
+      let errorText = pathOr(
+        'Error loading linodes',
+        [0, 'reason'],
+        linodesRequestError
+      );
+
+      if (errorText.toLowerCase() === 'this linode has been suspended') {
+        errorText = (
+          <React.Fragment>
+            One or more of your Linodes is suspended. Please{' '}
+            <Link to="/support/tickets">open a support ticket </Link>
+            if you have questions
+          </React.Fragment>
+        );
+      }
+
       return (
         <React.Fragment>
           <DocumentTitleSegment segment="Linodes" />
-          <ErrorState errorText="Error loading data" />
+          <ErrorState errorText={errorText} />
         </React.Fragment>
       );
     }


### PR DESCRIPTION
## Description

API Team requested we display a human-readable error to the user if one of their Linodes has been suspended. So if we get that error, we need to display an error along with a link to the support page.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

This error will not get returned from `v4/linodes/instances` but instead will be returned from `v4/linodes/instances/:id` or `v4/linodes/instances/:id/whatever`