### PR TITLE
Fix: M3-1181 Clear Backups Selection Only Upon New Linode Selection

### DIFF
--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -179,13 +179,15 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
   };
 
   handleSelectLinode = (linode: Linode.Linode) => {
-    this.setState({
-      selectedLinodeID: linode.id,
-      selectedTypeID: null,
-      selectedRegionID: linode.region,
-      selectedDiskSize: linode.specs.disk,
-      selectedBackupID: undefined
-    });
+    if (linode.id !== this.state.selectedLinodeID) {
+      this.setState({
+        selectedLinodeID: linode.id,
+        selectedTypeID: null,
+        selectedRegionID: linode.region,
+        selectedDiskSize: linode.specs.disk,
+        selectedBackupID: undefined
+      });
+    }
   };
 
   handleSelectBackupID = (id: number) => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -118,11 +118,13 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
   mounted: boolean = false;
 
   handleSelectLinode = (linode: Linode.Linode) => {
-    this.setState({
-      selectedLinodeID: linode.id,
-      selectedTypeID: null,
-      selectedDiskSize: linode.specs.disk
-    });
+    if (linode.id !== this.state.selectedLinodeID) {
+      this.setState({
+        selectedLinodeID: linode.id,
+        selectedTypeID: null,
+        selectedDiskSize: linode.specs.disk
+      });
+    }
   };
 
   handleSelectRegion = (id: string) => {


### PR DESCRIPTION
## Description

Previously, if user visited the _create from backup_ flow and selected a Linode and a backup, clicking on the same Linode would clear the backups selection.

Now, the backups selection will only clear if a new Linode is selected

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Also applied the same logic to _clone from existing_ flow