### PR TITLE
M3-2458 Download PDF link color inconsistency in dark theme

### DIFF
--- a/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
+++ b/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
@@ -19,6 +19,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   emptyState: {
     textAlign: 'center',
     padding: '5em 2em',
+    color: theme.palette.text.primary,
     [theme.breakpoints.up('sm')]: {
       padding: '10em'
     }

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -500,7 +500,7 @@ export const dark = createTheme({
           paddingLeft: 13
         },
         '& a': {
-          color: primaryColors.offBlack
+          color: primaryColors.main
         }
       }
     },


### PR DESCRIPTION
## Description

Made download link blue instead of white for DT. Also fixed the stackscript panel's empty state text color for DT as well. 

## Type of Change
- Non breaking change ('update', 'change')

## To test

1) Switch to dark theme. 
2) Navigate to account page. 
3) Expand recent invoices and recent payments panels.
