### PR TITLE
M3-2461 Graphs need better breakpoints

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -303,7 +303,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         </div>
         <div className={classes.bottomLegend}>
           <Grid container>
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} lg={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -393,7 +393,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         </div>
         <div className={classes.bottomLegend}>
           <Grid container>
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} lg={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -411,7 +411,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 ]}
               />
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} lg={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -502,7 +502,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         </div>
         <div className={classes.bottomLegend}>
           <Grid container>
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} lg={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -520,7 +520,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 ]}
               />
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} lg={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -541,7 +541,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           </Grid>
         </div>
         {rangeSelection === '24' && (
-          <Grid item xs={12} sm={6} className={classes.totalTraffic}>
+          <Grid item xs={12} lg={6} className={classes.totalTraffic}>
             <TotalTraffic
               inTraffic={totalTraffic.inTraffic}
               outTraffic={totalTraffic.outTraffic}
@@ -589,7 +589,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         </div>
         <div className={classes.bottomLegend}>
           <Grid container>
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} lg={6}>
               <MetricsDisplay
                 rows={[
                   {
@@ -601,7 +601,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 ]}
               />
             </Grid>
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} lg={6}>
               <MetricsDisplay
                 rows={[
                   {

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -432,7 +432,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           </Grid>
         </div>
         {rangeSelection === '24' && (
-          <Grid item xs={12} sm={6} className={classes.totalTraffic}>
+          <Grid item xs={12} lg={6} className={classes.totalTraffic}>
             <TotalTraffic
               inTraffic={totalTraffic.inTraffic}
               outTraffic={totalTraffic.outTraffic}


### PR DESCRIPTION
## Description

Adjusting breakpoint for when graph info should stack (now set for large so users never get scrolling).

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

• Go to a linode detail with graphs
• Shrink screen to 1015px
• Note that graph info no longer scrolls, but stacks as it should for smaller breakpoints as well. 
