### PR TITLE
M3-2464 Fix: NB ssl error handling

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -664,6 +664,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 hasErrorFor('algorithm'),
                 sessionStickiness,
                 hasErrorFor('stickiness'),
+                hasErrorFor('ssl_cert'),
+                hasErrorFor('ssl_key'),
                 configIdx,
                 sslCertificate,
                 privateKey
@@ -738,7 +740,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                         value={sslCertificate || ''}
                         onChange={this.onSslCertificateChange}
                         required={protocol === 'https'}
-                        errorText={hasErrorFor('ssl_cert') || hasErrorFor('configs')}
+                        errorText={hasErrorFor('ssl_cert')}
                         errorGroup={forEdit ? `${configIdx}` : undefined}
                         data-qa-cert-field
                         small

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -738,7 +738,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                         value={sslCertificate || ''}
                         onChange={this.onSslCertificateChange}
                         required={protocol === 'https'}
-                        errorText={hasErrorFor('ssl_cert')}
+                        errorText={hasErrorFor('ssl_cert') || hasErrorFor('configs')}
                         errorGroup={forEdit ? `${configIdx}` : undefined}
                         data-qa-cert-field
                         small

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -433,6 +433,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     </ActionsPanel>
   );
 
+  // @todo get linodes data from store
   componentDidMount() {
     getLinodes()
       .then(result => {


### PR DESCRIPTION
## Description

updateFor logic didn't include ssl cert or key errors, so those errors were not being displayed to the user (unless they interacted with the fields)

## Type of Change
- Bug fix ('fix', 'repair', 'bug')


## Note to Reviewers

- Two users complained about this happening with their certs, but I'm not able to reproduce errors with correct certs (self-signed cert & key).
- You can test this fix by using `1` in both the cert and key input boxes.
