### PR TITLE
M3-2436 Change: Order support tickets by date created

### DIFF
--- a/src/features/Support/SupportTickets/ticketUtils.ts
+++ b/src/features/Support/SupportTickets/ticketUtils.ts
@@ -39,7 +39,7 @@ export const getTicketsPage = (
   ticketStatus: 'open' | 'closed' | 'all'
 ) => {
   const status = getStatusFilter(ticketStatus);
-  const ordering = { '+order_by': 'updated', '+order': 'desc' };
+  const ordering = { '+order_by': 'opened', '+order': 'desc' };
   const filter = { ...status, ...ordering, ...filters };
   return getTickets(params, filter).then(response => response.data);
 };


### PR DESCRIPTION
## Description

Use `order_by: opened` instead of `order_by: updated` for the X-filter when requesting pages of support tickets..

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Can't be tested until API bug ticket is merged, currently the API is not honoring this sorting request.