### PR TITLE
M3-2202 Imagize Disk Busy Status

### DIFF
--- a/src/features/linodes/transitions.ts
+++ b/src/features/linodes/transitions.ts
@@ -17,7 +17,8 @@ export const transitionStatus = [
 export const transitionAction = [
   'linode_snapshot',
   'disk_resize',
-  'backups_restore'
+  'backups_restore',
+  'disk_imagize'
 ];
 
 export const linodeInTransition = (

--- a/src/store/linodes/linodes.events.ts
+++ b/src/store/linodes/linodes.events.ts
@@ -23,6 +23,7 @@ const linodeEventsHandler: EventHandler = (event, dispatch, getState) => {
     case 'linode_resize':
     case 'backups_enable':
     case 'backups_cancel':
+    case 'disk_imagize':
       return handleLinodeUpdate(dispatch, status, id);
 
     /** Remove Linode */


### PR DESCRIPTION
## Description

Adds progress for Linodes that have one of their disks being imagized

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

API does not return a `busy` status for Linodes that have disks being imagized, so we really can't do anything about the status icon 🤷‍♀️ 