### PR TITLE
M3-XXXX Change: Object Storage credentials creation

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,12 @@
 const PRODUCTION = 'production';
+const DEVELOPMENT = 'development';
 
 export const GA_ID = process.env.REACT_APP_GA_ID;
 
 export const GTM_ID = process.env.REACT_APP_GTM_ID;
 
 export const isProduction = process.env.NODE_ENV === PRODUCTION;
+export const isDevelopment = process.env.NODE_ENV === DEVELOPMENT;
 export const isTest = process.env.REACT_APP_TEST_ENVIRONMENT === 'true';
 
 export const APP_ROOT =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,12 +1,10 @@
 const PRODUCTION = 'production';
-const DEVELOPMENT = 'development';
 
 export const GA_ID = process.env.REACT_APP_GA_ID;
 
 export const GTM_ID = process.env.REACT_APP_GTM_ID;
 
 export const isProduction = process.env.NODE_ENV === PRODUCTION;
-export const isDevelopment = process.env.NODE_ENV === DEVELOPMENT;
 export const isTest = process.env.REACT_APP_TEST_ENVIRONMENT === 'true';
 
 export const APP_ROOT =
@@ -34,6 +32,10 @@ export const ALGOLIA_APPLICATION_ID =
   process.env.REACT_APP_ALGOLIA_APPLICATION_ID || '';
 export const ALGOLIA_SEARCH_KEY =
   process.env.REACT_APP_ALGOLIA_SEARCH_KEY || '';
+
+// Features
+export const isObjectStorageEnabled =
+  process.env.REACT_APP_IS_OBJECT_STORAGE_ENABLED || false;
 
 export const DISABLE_EVENT_THROTTLE =
   Boolean(process.env.REACT_APP_DISABLE_EVENT_THROTTLE) || false;

--- a/src/features/Profile/APITokens/APITokens.tsx
+++ b/src/features/Profile/APITokens/APITokens.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import { isDevelopment } from 'src/constants';
+import { isObjectStorageEnabled } from 'src/constants';
 import APITokenTable from './APITokenTable';
 import ObjectStorageKeys from './ObjectStorageKeys';
 
@@ -18,7 +18,7 @@ export const APITokens: React.StatelessComponent = () => {
         type="OAuth Client Token"
       />
 
-      {isDevelopment && <ObjectStorageKeys />}
+      {isObjectStorageEnabled && <ObjectStorageKeys />}
     </React.Fragment>
   );
 };

--- a/src/features/Profile/APITokens/APITokens.tsx
+++ b/src/features/Profile/APITokens/APITokens.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-
+import { isDevelopment } from 'src/constants';
 import APITokenTable from './APITokenTable';
+import ObjectStorageKeys from './ObjectStorageKeys';
 
 export const APITokens: React.StatelessComponent = () => {
   return (
@@ -17,6 +17,8 @@ export const APITokens: React.StatelessComponent = () => {
         title="Third Party Access Tokens"
         type="OAuth Client Token"
       />
+
+      {isDevelopment && <ObjectStorageKeys />}
     </React.Fragment>
   );
 };

--- a/src/features/Profile/APITokens/ObjectStorageDrawer.test.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageDrawer.test.tsx
@@ -35,4 +35,25 @@ describe('ObjectStorageDrawer', () => {
       'An error occurred.'
     );
   });
+  it('can display multiple errors', () => {
+    wrapper.setProps({
+      errors: [
+        { field: 'none', reason: 'An error occurred.' },
+        { field: 'label', reason: 'Another error occurred.' }
+      ]
+    });
+    expect(wrapper.find('[data-qa-error]')).toHaveLength(2);
+    expect(
+      wrapper
+        .find('[data-qa-error]')
+        .at(0)
+        .prop('text')
+    ).toBe('An error occurred.');
+    expect(
+      wrapper
+        .find('[data-qa-error]')
+        .at(1)
+        .prop('text')
+    ).toBe('Another error occurred.');
+  });
 });

--- a/src/features/Profile/APITokens/ObjectStorageDrawer.test.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageDrawer.test.tsx
@@ -1,0 +1,38 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { ObjectStorageDrawer, Props } from './ObjectStorageDrawer';
+
+describe('ObjectStorageDrawer', () => {
+  const props = {
+    classes: { root: '' },
+    open: true,
+    onSubmit: jest.fn(),
+    onClose: jest.fn()
+  };
+  const wrapper = shallow<Props>(<ObjectStorageDrawer {...props} />);
+  it('renders without crashing', () => {
+    expect(wrapper).toHaveLength(1);
+  });
+  it('calls onSubmit when the submit button is clicked', () => {
+    const submitButton = wrapper.find('[data-qa-submit]');
+    submitButton.simulate('click');
+    expect(props.onSubmit).toHaveBeenCalled();
+  });
+  it('calls onClose when the cancel button is clicked', () => {
+    const submitButton = wrapper.find('[data-qa-cancel]');
+    submitButton.simulate('click');
+    expect(props.onClose).toHaveBeenCalled();
+  });
+  it('does not display errors if none are supplied', () => {
+    expect(wrapper.find('[data-qa-error]')).toHaveLength(0);
+  });
+  it('displays errors if they are supplied', () => {
+    wrapper.setProps({
+      errors: [{ field: 'none', reason: 'An error occurred.' }]
+    });
+    expect(wrapper.find('[data-qa-error]')).toHaveLength(1);
+    expect(wrapper.find('[data-qa-error]').prop('text')).toBe(
+      'An error occurred.'
+    );
+  });
+});

--- a/src/features/Profile/APITokens/ObjectStorageDrawer.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageDrawer.tsx
@@ -30,10 +30,12 @@ export const ObjectStorageDrawer: React.StatelessComponent<
   CombinedProps
 > = props => {
   const { open, onClose, onSubmit, errors } = props;
-
   return (
     <Drawer title="Create an Object Storage Key" open={open} onClose={onClose}>
-      {errors && <Notice text={errors[0].reason} error data-qa-error />}
+      {errors &&
+        errors.map(error => (
+          <Notice key={error.reason} text={error.reason} error data-qa-error />
+        ))}
       <Typography>
         Generate an Object Storage key pair for use with an S3-compatible
         client.

--- a/src/features/Profile/APITokens/ObjectStorageDrawer.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageDrawer.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Drawer from 'src/components/Drawer';
+import Notice from 'src/components/Notice';
+import TextField from 'src/components/TextField';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {}
+});
+
+export interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+  errors?: Linode.ApiFieldError[];
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export const ObjectStorageDrawer: React.StatelessComponent<
+  CombinedProps
+> = props => {
+  const { open, onClose, onSubmit, errors } = props;
+
+  return (
+    <Drawer title="Create an Object Storage Key" open={open} onClose={onClose}>
+      {errors && <Notice text={errors[0].reason} error data-qa-error />}
+      <Typography>
+        Generate an Object Storage key pair for use with an S3-compatible
+        client.
+      </Typography>
+
+      {/* @todo: This label field doesn't actually do anything yet */}
+      <TextField label="Label" data-qa-add-label />
+
+      <ActionsPanel>
+        <Button type="primary" onClick={onSubmit} data-qa-submit>
+          Submit
+        </Button>
+        <Button
+          onClick={onClose}
+          data-qa-cancel
+          type="secondary"
+          className="cancel"
+        >
+          Cancel
+        </Button>
+      </ActionsPanel>
+    </Drawer>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(ObjectStorageDrawer);

--- a/src/features/Profile/APITokens/ObjectStorageKeys.test.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageKeys.test.tsx
@@ -1,0 +1,22 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { ObjectStorageKeys } from './ObjectStorageKeys';
+
+describe('ObjectStorageKeys', () => {
+  const props = {
+    classes: {
+      headline: '',
+      paper: '',
+      helperText: '',
+      labelCell: '',
+      createdCell: '',
+      confirmationDialog: ''
+    }
+  };
+  const wrapper = shallow(<ObjectStorageKeys {...props} />);
+  it('renders without crashing', () => {
+    expect(wrapper).toHaveLength(1);
+  });
+
+  // @todo: Add more tests. (Enzyme hooks support? React-test-renderer? React-testing-library?)
+});

--- a/src/features/Profile/APITokens/ObjectStorageKeys.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageKeys.tsx
@@ -1,0 +1,201 @@
+import { pathOr } from 'ramda';
+import * as React from 'react';
+import { compose } from 'recompose';
+import AddNewLink from 'src/components/AddNewLink';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Button from 'src/components/core/Button';
+import Paper from 'src/components/core/Paper';
+import {
+  StyleRulesCallback,
+  WithStyles,
+  withStyles
+} from 'src/components/core/styles';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
+import Table from 'src/components/Table';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
+import { createObjectStorageKeys } from 'src/services/profile/objectStorageKeys';
+import ObjectStorageDrawer from './ObjectStorageDrawer';
+
+type ClassNames =
+  | 'headline'
+  | 'paper'
+  | 'helperText'
+  | 'labelCell'
+  | 'createdCell'
+  | 'confirmationDialog';
+
+const styles: StyleRulesCallback<ClassNames> = theme => {
+  return {
+    headline: {
+      marginTop: theme.spacing.unit * 2,
+      marginBottom: theme.spacing.unit * 2
+    },
+    paper: {
+      marginBottom: theme.spacing.unit * 2
+    },
+    labelCell: {
+      width: '40%'
+    },
+    createdCell: {
+      width: '30%'
+    },
+    helperText: {
+      marginBottom: theme.spacing.unit * 3
+    },
+    confirmationDialog: {
+      paddingBottom: 0,
+      marginBottom: 0
+    }
+  };
+};
+
+interface KeysState {
+  dialogOpen: boolean;
+  accessKey?: string;
+  secretKey?: string;
+}
+
+interface DrawerState {
+  open: boolean;
+  errors?: Linode.ApiFieldError[];
+}
+
+type Props = WithStyles<ClassNames>;
+
+export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
+  const { classes } = props;
+
+  const [keys, setKeys] = React.useState<KeysState>({ dialogOpen: false });
+  const [drawer, setDrawer] = React.useState<DrawerState>({ open: false });
+
+  const handleSubmit = () => {
+    createObjectStorageKeys()
+      .then(data => {
+        // Keys are returned from the API in an array – for now, just use the first pair.
+        if (data.keys && data.keys.length > 1) {
+          const accessKey = data.keys[0].access_key;
+          const secretKey = data.keys[0].secret_key;
+
+          setKeys({ accessKey, secretKey, dialogOpen: true });
+          setDrawer({ open: false });
+        }
+      })
+      .catch(err => {
+        const defaultError: Linode.ApiFieldError[] = [
+          {
+            field: 'none',
+            reason: 'Could not generate Object Storage Keys at this time.'
+          }
+        ];
+        const errors: Linode.ApiFieldError[] = pathOr(
+          defaultError,
+          ['response', 'data', 'errors'],
+          err
+        );
+        setDrawer({ ...drawer, errors });
+      });
+  };
+
+  const confirmationDialogActions = (
+    <Button
+      type="secondary"
+      onClick={() => setKeys({ ...keys, dialogOpen: false })}
+      data-qa-close-dialog
+    >
+      OK
+    </Button>
+  );
+
+  return (
+    <React.Fragment>
+      <Grid container justify="space-between" alignItems="flex-end">
+        <Grid item>
+          <Typography
+            role="header"
+            variant="h2"
+            className={classes.headline}
+            data-qa-table="Object Storage Keys"
+          >
+            Object Storage Keys
+          </Typography>
+        </Grid>
+        <Grid item>
+          <AddNewLink
+            onClick={() => setDrawer({ open: true })}
+            label="Create an Object Storage Key"
+          />
+        </Grid>
+      </Grid>
+      <Paper className={classes.paper}>
+        <Table aria-label="List of Object Storage Keys">
+          <TableHead>
+            <TableRow data-qa-table-head>
+              <TableCell className={classes.labelCell}>Label</TableCell>
+              <TableCell className={classes.labelCell}>Access Key</TableCell>
+              <TableCell className={classes.createdCell}>Created</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {/* @todo: List Object Storage Access Keys when returned by API */}
+            <TableRowEmptyState colSpan={6} />
+          </TableBody>
+        </Table>
+      </Paper>
+
+      <ObjectStorageDrawer
+        open={drawer.open}
+        onClose={() => setDrawer({ open: false })}
+        onSubmit={handleSubmit}
+        errors={drawer.errors}
+      />
+
+      <ConfirmationDialog
+        title="Object Storage Keys"
+        actions={confirmationDialogActions}
+        open={keys.dialogOpen}
+        onClose={() => setKeys({ ...keys, dialogOpen: false })}
+        className={classes.confirmationDialog}
+      >
+        <Typography variant="body1" className={classes.helperText}>
+          Your Object Storage keys have been created. Store these credentials.
+          They won't be shown again.
+        </Typography>
+
+        <Typography>
+          <b>Access Key:</b>
+        </Typography>
+        <Notice
+          spacingTop={16}
+          typeProps={{ variant: 'body1' }}
+          warning
+          text={keys.accessKey}
+          breakWords
+        />
+
+        <Typography>
+          <b>Secret Key:</b>
+        </Typography>
+        <Notice
+          spacingTop={16}
+          typeProps={{ variant: 'body1' }}
+          warning
+          text={keys.secretKey}
+          breakWords
+        />
+      </ConfirmationDialog>
+    </React.Fragment>
+  );
+};
+
+const styled = withStyles(styles);
+
+const enhanced = compose(styled);
+
+export default enhanced(ObjectStorageKeys);

--- a/src/features/Profile/APITokens/ObjectStorageKeys.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageKeys.tsx
@@ -78,7 +78,7 @@ export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
     createObjectStorageKeys()
       .then(data => {
         // Keys are returned from the API in an array – for now, just use the first pair.
-        if (data.keys && data.keys.length > 1) {
+        if (data.keys && data.keys.length > 0) {
           const accessKey = data.keys[0].access_key;
           const secretKey = data.keys[0].secret_key;
 

--- a/src/services/profile/objectStorageKeys.ts
+++ b/src/services/profile/objectStorageKeys.ts
@@ -1,0 +1,14 @@
+import { API_ROOT } from 'src/constants';
+import Request, { setMethod, setURL } from '../index';
+
+/**
+ * createObjectStorageKeys
+ *
+ * Creates an Object Storage User and returns the Access Key and Secret Key
+ */
+export const createObjectStorageKeys = () =>
+  Request<{ id: number; keys: Linode.ObjectStorageKeyPair[] }>(
+    setMethod('POST'),
+    // Yes, this endpoint is v4beta/object-storage
+    setURL(`${API_ROOT}beta/object-storage`)
+  ).then(response => response.data);

--- a/src/types/Profile.ts
+++ b/src/types/Profile.ts
@@ -41,6 +41,11 @@ namespace Linode {
     created: string;
   }
 
+  export interface ObjectStorageKeyPair {
+    access_key: string;
+    secret_key: string;
+  }
+
   export interface OAuthClient {
     id: string;
     label: string;


### PR DESCRIPTION
## Description

_Must be using development services._

This PR adds a new section in Profile > API Tokens, called “Object Storage Keys”. Clicking “Create an Object Storage Key” will allow you to create Object Storage credentials. 

This new section should only be rendered when `REACT_APP_IS_OBJECT_STORAGE_ENABLED=true`. 

**You'll need to add this to your `.env` file.**

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

- Nothing should actually be populating the Object Storage Keys table. Once existing key labels are returned from the API, that’s where they’ll go.
- The “Label” text field doesn’t do anything yet.