### PR TITLE
M3-2468 Add: Theme Spacing/Compact mode Switcher

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -44,6 +44,7 @@ it('renders without crashing', () => {
             }}
             documentation={[]}
             toggleTheme={jest.fn()}
+            toggleSpacing={jest.fn()}
           />
         </StaticRouter>
       </Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,10 +126,10 @@ const styles: StyleRulesCallback = theme => ({
   content: {
     flex: 1,
     [theme.breakpoints.up('md')]: {
-      marginLeft: 215
+      marginLeft: theme.spacing.unit * 17 + 79 // 215
     },
     [theme.breakpoints.up('xl')]: {
-      marginLeft: 275
+      marginLeft: theme.spacing.unit * 22 + 99 // 275
     }
   },
   wrapper: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,6 +159,7 @@ const styles: StyleRulesCallback = theme => ({
 
 interface Props {
   toggleTheme: () => void;
+  toggleSpacing: () => void;
   location: RouteProps['location'];
 }
 
@@ -269,7 +270,13 @@ export class App extends React.Component<CombinedProps, State> {
 
   render() {
     const { menuOpen, hasError } = this.state;
-    const { classes, toggleTheme, profileLoading, profileError } = this.props;
+    const {
+      classes,
+      toggleSpacing,
+      toggleTheme,
+      profileLoading,
+      profileError
+    } = this.props;
 
     if (profileError || hasError) {
       return <TheApplicationIsOnFire />;
@@ -290,6 +297,7 @@ export class App extends React.Component<CombinedProps, State> {
                   open={menuOpen}
                   closeMenu={this.closeMenu}
                   toggleTheme={toggleTheme}
+                  toggleSpacing={toggleSpacing}
                 />
                 <main className={classes.content}>
                   <TopMenu openSideMenu={this.openMenu} />

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react';
 import { MuiThemeProvider } from 'src/components/core/styles';
 import { dark, light } from 'src/themes';
-import { theme as themeStorage } from 'src/utilities/storage';
+import {
+  Spacing,
+  spacing as spacingStorage,
+  theme as themeStorage
+} from 'src/utilities/storage';
 
 interface State {
   themeChoice: 'light' | 'dark';
+  spacing: Spacing;
 }
-type RenderChildren = (toggle: () => void) => React.ReactNode;
+type RenderChildren = (
+  toggle: () => void,
+  spacing: () => void
+) => React.ReactNode;
 interface Props {
   children: RenderChildren | React.ReactNode;
 }
@@ -15,7 +23,8 @@ const themes = { light, dark };
 
 class LinodeThemeWrapper extends React.Component<Props, State> {
   state: State = {
-    themeChoice: 'light'
+    themeChoice: 'light',
+    spacing: 'normal'
   };
 
   componentDidUpdate() {
@@ -25,11 +34,13 @@ class LinodeThemeWrapper extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    if (themeStorage.get() === 'dark') {
-      return this.setState({ themeChoice: 'dark' });
-    }
+    const themeSetting = themeStorage.get();
+    const spacingSetting = spacingStorage.get();
 
-    return this.setState({ themeChoice: 'light' });
+    return this.setState({
+      themeChoice: themeSetting,
+      spacing: spacingSetting
+    });
   }
 
   toggleTheme = () => {
@@ -43,14 +54,31 @@ class LinodeThemeWrapper extends React.Component<Props, State> {
     }
   };
 
+  toggleSpacing = () => {
+    console.log('toggling');
+    const { spacing } = this.state;
+    if (spacing === 'compact') {
+      this.setState({ spacing: 'normal' });
+      spacingStorage.set('normal');
+    } else {
+      this.setState({ spacing: 'compact' });
+      spacingStorage.set('compact');
+    }
+  };
+
   render() {
     const { children } = this.props;
-    const { themeChoice } = this.state;
-    const theme = themes[themeChoice];
+    const { themeChoice, spacing } = this.state;
+    const theme = {
+      ...themes[themeChoice],
+      spacing: { unit: spacing === 'compact' ? 4 : 8 }
+    };
 
     return (
       <MuiThemeProvider theme={theme}>
-        {isRenderChildren(children) ? children(this.toggleTheme) : children}
+        {isRenderChildren(children)
+          ? children(this.toggleTheme, this.toggleSpacing)
+          : children}
       </MuiThemeProvider>
     );
   }

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -55,27 +55,23 @@ class LinodeThemeWrapper extends React.Component<Props, State> {
   };
 
   toggleSpacing = () => {
-    console.log('toggling');
     const { spacing } = this.state;
     if (spacing === 'compact') {
-      this.setState({ spacing: 'normal' });
       spacingStorage.set('normal');
+      this.setState({ spacing: 'normal' });
     } else {
-      this.setState({ spacing: 'compact' });
       spacingStorage.set('compact');
+      this.setState({ spacing: 'compact' });
     }
   };
 
   render() {
     const { children } = this.props;
-    const { themeChoice, spacing } = this.state;
-    const theme = {
-      ...themes[themeChoice],
-      spacing: { unit: spacing === 'compact' ? 4 : 8 }
-    };
+    const { themeChoice } = this.state;
+    const theme = themes[themeChoice];
 
     return (
-      <MuiThemeProvider theme={theme}>
+      <MuiThemeProvider theme={theme()}>
         {isRenderChildren(children)
           ? children(this.toggleTheme, this.toggleSpacing)
           : children}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -67,8 +67,8 @@ const styles: StyleRulesCallback = theme => ({
       right: 0,
       bottom: 0,
       margin: '0 auto',
-      width: 22,
-      height: 22,
+      width: theme.spacing.unit + 14,
+      height: theme.spacing.unit + 14,
       animation: 'rotate 2s linear infinite'
     }
   },

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -79,7 +79,7 @@ const DDrawer: React.StatelessComponent<CombinedProps> = props => {
         justify="space-between"
         alignItems="center"
         className={classes.drawerHeader}
-        updateFor={[title]}
+        updateFor={[title, classes]}
       >
         <Grid item>
           <Typography role="header" variant="h2" data-qa-drawer-title>

--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -24,6 +24,7 @@ const mockClasses = {
   sublinkActive: '',
   sublinkPanel: '',
   settings: '',
+  settingsBackdrop: '',
   activeSettings: '',
   menu: '',
   paper: ''

--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -17,11 +17,16 @@ const mockClasses = {
   listItem: '',
   listItemAccount: '',
   logoItem: '',
+  logoItemCompact: '',
   menuGrid: '',
   spacer: '',
   sublink: '',
   sublinkActive: '',
-  sublinkPanel: ''
+  sublinkPanel: '',
+  settings: '',
+  activeSettings: '',
+  menu: '',
+  paper: ''
 };
 
 describe('PrimaryNav', () => {
@@ -33,6 +38,7 @@ describe('PrimaryNav', () => {
       wrapper = shallow(
         <PrimaryNav
           classes={mockClasses}
+          theme={{ spacing: [] }}
           closeMenu={jest.fn()}
           toggleTheme={jest.fn()}
           hasAccountAccess={false}
@@ -97,6 +103,7 @@ describe('PrimaryNav', () => {
       wrapper = shallow(
         <PrimaryNav
           classes={mockClasses}
+          theme={{ spacing: [] }}
           closeMenu={jest.fn()}
           toggleTheme={jest.fn()}
           hasAccountAccess={true}
@@ -121,6 +128,7 @@ describe('PrimaryNav', () => {
       wrapper = shallow(
         <PrimaryNav
           classes={mockClasses}
+          theme={{ spacing: [] }}
           closeMenu={jest.fn()}
           toggleTheme={jest.fn()}
           hasAccountAccess={false}

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -159,7 +159,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     backgroundColor: 'rgba(0, 0, 0, 0.12)'
   },
   settings: {
-    padding: '16px 40px 34px 24px',
+    padding: '16px 40px 24px 24px',
     alignItems: 'center',
     marginTop: 'auto',
     justifyContent: 'center',

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -164,7 +164,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     backgroundColor: 'rgba(0, 0, 0, 0.12)'
   },
   settings: {
-    padding: '16px 40px 24px 24px',
+    padding: '24px 0',
     alignItems: 'center',
     marginTop: 'auto',
     justifyContent: 'center',
@@ -184,7 +184,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     padding: 8,
     position: 'absolute',
     backgroundColor: theme.bg.navy,
-    left: '18px !important',
     border: '1px solid #999',
     outline: 0
   }
@@ -491,8 +490,8 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
               onClose={this.handleClose}
               getContentAnchorEl={undefined}
               PaperProps={{ square: true, className: classes.paper }}
-              anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
-              transformOrigin={{ vertical: 'bottom', horizontal: -16 }}
+              anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+              transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
               className={classes.menu}
             >
               <ThemeToggle toggleTheme={toggleTheme} />

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -7,7 +7,6 @@ import Logo from 'src/assets/logo/logo-text.svg';
 import Divider from 'src/components/core/Divider';
 import Hidden from 'src/components/core/Hidden';
 import IconButton from 'src/components/core/IconButton';
-import ListItem from 'src/components/core/ListItem';
 import ListItemText from 'src/components/core/ListItemText';
 import Menu from 'src/components/core/Menu';
 import {

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -13,7 +13,8 @@ import Menu from 'src/components/core/Menu';
 import {
   StyleRulesCallback,
   withStyles,
-  WithStyles
+  WithStyles,
+  WithTheme
 } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import { MapState } from 'src/store/types';
@@ -31,6 +32,7 @@ type ClassNames =
   | 'menuGrid'
   | 'fadeContainer'
   | 'logoItem'
+  | 'logoItemCompact'
   | 'listItem'
   | 'collapsible'
   | 'linkItem'
@@ -73,14 +75,17 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       .spacing.unit +
       theme.spacing.unit / 2}px`
   },
+  logoItemCompact: {
+    padding: `${theme.spacing.unit + 2}px 0 ${theme.spacing.unit}px`
+  },
   listItem: {
     borderLeft: '6px solid transparent',
     transition: theme.transitions.create([
       'background-color',
       'border-left-color'
     ]),
-    padding: `${theme.spacing.unit + 2}px ${theme.spacing.unit * 4 -
-      2}px ${theme.spacing.unit + 2}px ${theme.spacing.unit * 3}px`,
+    padding: `${theme.spacing.unit / 2 + 6}px ${theme.spacing.unit * 4 -
+      2}px ${theme.spacing.unit / 2 + 6}px ${theme.spacing.unit * 3}px`,
     '&:hover': {
       backgroundColor: 'rgba(0, 0, 0, 0.1)',
       '& $linkItem': {
@@ -198,7 +203,7 @@ interface State {
   anchorEl?: HTMLElement;
 }
 
-type CombinedProps = Props & StateProps;
+type CombinedProps = Props & StateProps & WithTheme;
 
 export class PrimaryNav extends React.Component<CombinedProps, State> {
   state: State = {
@@ -377,8 +382,9 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { classes, toggleSpacing, toggleTheme } = this.props;
+    const { classes, toggleSpacing, toggleTheme, theme } = this.props;
     const { expandedMenus, anchorEl } = this.state;
+    const { spacing: spacingUnit } = theme;
 
     return (
       <React.Fragment>
@@ -394,11 +400,19 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
           role="menu"
         >
           <Grid item>
-            <div className={classes.logoItem}>
-              <Link to={`/dashboard`}>
-                <Logo width={115} height={43} />
-              </Link>
-            </div>
+            {spacingUnit.unit === 8 ? (
+              <div className={classes.logoItem}>
+                <Link to={`/dashboard`}>
+                  <Logo width={115} height={43} />
+                </Link>
+              </div>
+            ) : (
+              <div className={classes.logoItemCompact}>
+                <Link to={`/dashboard`}>
+                  <Logo width={100} height={37} />
+                </Link>
+              </div>
+            )}
           </Grid>
           <div
             className={classNames({
@@ -535,4 +549,6 @@ const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
 
 const connected = connect(mapStateToProps);
 
-export default withStyles(styles)(withRouter(connected(PrimaryNav)));
+export default withStyles(styles, { withTheme: true })(
+  withRouter(connected(PrimaryNav))
+);

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -1,3 +1,4 @@
+import Settings from '@material-ui/icons/Settings';
 import * as classNames from 'classnames';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -5,8 +6,10 @@ import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import Logo from 'src/assets/logo/logo-text.svg';
 import Divider from 'src/components/core/Divider';
 import Hidden from 'src/components/core/Hidden';
+import IconButton from 'src/components/core/IconButton';
 import ListItem from 'src/components/core/ListItem';
 import ListItemText from 'src/components/core/ListItemText';
+import Menu from 'src/components/core/Menu';
 import {
   StyleRulesCallback,
   withStyles,
@@ -39,7 +42,11 @@ type ClassNames =
   | 'sublinkPanel'
   | 'spacer'
   | 'listItemAccount'
-  | 'divider';
+  | 'divider'
+  | 'menu'
+  | 'paper'
+  | 'settings'
+  | 'activeSettings';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   menuGrid: {
@@ -150,6 +157,31 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   divider: {
     backgroundColor: 'rgba(0, 0, 0, 0.12)'
+  },
+  settings: {
+    padding: '16px 40px 34px 24px',
+    alignItems: 'center',
+    marginTop: 'auto',
+    justifyContent: 'center',
+    display: 'flex',
+    color: '#e7e7e7',
+    transition: theme.transitions.create('color'),
+    '&:hover': {
+      color: theme.color.green
+    }
+  },
+  activeSettings: {
+    color: theme.color.green
+  },
+  menu: {},
+  paper: {
+    maxWidth: 350,
+    padding: 8,
+    position: 'absolute',
+    backgroundColor: theme.bg.navy,
+    left: '18px !important',
+    border: '1px solid #999',
+    outline: 0
   }
 });
 
@@ -163,6 +195,7 @@ interface State {
   drawerOpen: boolean;
   expandedMenus: Record<string, boolean>;
   primaryLinks: PrimaryLink[];
+  anchorEl?: HTMLElement;
 }
 
 type CombinedProps = Props & StateProps;
@@ -174,7 +207,8 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
       account: false,
       support: false
     },
-    primaryLinks: []
+    primaryLinks: [],
+    anchorEl: undefined
   };
 
   mounted: boolean = false;
@@ -305,6 +339,14 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     this.navigate('/logout');
   };
 
+  handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  handleClose = () => {
+    this.setState({ anchorEl: undefined });
+  };
+
   renderPrimaryLink = (primaryLink: PrimaryLink, isLast: boolean) => {
     const { classes } = this.props;
 
@@ -336,7 +378,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
 
   render() {
     const { classes, toggleSpacing, toggleTheme } = this.props;
-    const { expandedMenus } = this.state;
+    const { expandedMenus, anchorEl } = this.state;
 
     return (
       <React.Fragment>
@@ -419,8 +461,29 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
               </ListItem>
             </Hidden>
             <div className={classes.spacer} />
-            <ThemeToggle toggleTheme={toggleTheme} />
-            <SpacingToggle toggleSpacing={toggleSpacing} />
+            <IconButton
+              onClick={this.handleClick}
+              className={classNames({
+                [classes.settings]: true,
+                [classes.activeSettings]: anchorEl
+              })}
+            >
+              <Settings />
+            </IconButton>
+            <Menu
+              id="settings-menu"
+              anchorEl={anchorEl}
+              open={Boolean(anchorEl)}
+              onClose={this.handleClose}
+              getContentAnchorEl={undefined}
+              PaperProps={{ square: true, className: classes.paper }}
+              anchorOrigin={{ vertical: 'top', horizontal: 'left' }}
+              transformOrigin={{ vertical: 'bottom', horizontal: -16 }}
+              className={classes.menu}
+            >
+              <ThemeToggle toggleTheme={toggleTheme} />
+              <SpacingToggle toggleSpacing={toggleSpacing} />
+            </Menu>
           </div>
         </Grid>
       </React.Fragment>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -15,6 +15,7 @@ import {
 import Grid from 'src/components/Grid';
 import { MapState } from 'src/store/types';
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
+import SpacingToggle from './SpacingToggle';
 import ThemeToggle from './ThemeToggle';
 
 interface PrimaryLink {
@@ -419,12 +420,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
             </Hidden>
             <div className={classes.spacer} />
             <ThemeToggle toggleTheme={toggleTheme} />
-            <a
-              style={{ margin: 20, textAlign: 'center' }}
-              onClick={toggleSpacing}
-            >
-              Toggle spacing
-            </a>
+            <SpacingToggle toggleSpacing={toggleSpacing} />
           </div>
         </Grid>
       </React.Fragment>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -445,6 +445,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
                 className={classNames({
                   [classes.listItem]: true,
                   [classes.active]:
+                    expandedMenus.support ||
                     this.linkIsActive('/profile/display') === true
                 })}
               >

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -155,6 +155,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 interface Props extends WithStyles<ClassNames>, RouteComponentProps<{}> {
   closeMenu: () => void;
   toggleTheme: () => void;
+  toggleSpacing: () => void;
 }
 
 interface State {
@@ -333,7 +334,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { classes, toggleTheme } = this.props;
+    const { classes, toggleSpacing, toggleTheme } = this.props;
     const { expandedMenus } = this.state;
 
     return (
@@ -418,6 +419,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
             </Hidden>
             <div className={classes.spacer} />
             <ThemeToggle toggleTheme={toggleTheme} />
+            <button onClick={toggleSpacing} />
           </div>
         </Grid>
       </React.Fragment>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -436,53 +436,44 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
 
             <Hidden mdUp>
               <Divider className={classes.divider} />
-              <ListItem
-                button
-                component="li"
-                focusRipple={true}
-                onClick={this.goToProfile}
+              <Link
+                role="menuitem"
+                to="/profile/display"
+                href="javascript:void(0)"
+                onClick={this.props.closeMenu}
+                data-qa-nav-item="/profile/display"
                 className={classNames({
                   [classes.listItem]: true,
-                  [classes.collapsible]: true,
                   [classes.active]:
                     this.linkIsActive('/profile/display') === true
                 })}
               >
                 <ListItemText
+                  primary="My Profile"
                   disableTypography={true}
                   className={classNames({
-                    [classes.linkItem]: true,
-                    [classes.activeLink]:
-                      expandedMenus.support ||
-                      this.linkIsActive('/profile/display') === true
+                    [classes.linkItem]: true
                   })}
-                >
-                  My Profile
-                </ListItemText>
-              </ListItem>
-              <ListItem
-                button
-                component="li"
-                focusRipple={true}
-                onClick={this.logOut}
+                />
+              </Link>
+              <Link
+                role="menuitem"
+                to="/logout"
+                href="javascript:void(0)"
+                onClick={this.props.closeMenu}
+                data-qa-nav-item="/logout"
                 className={classNames({
-                  [classes.listItem]: true,
-                  [classes.collapsible]: true,
-                  [classes.active]: this.linkIsActive('/logout') === true
+                  [classes.listItem]: true
                 })}
               >
                 <ListItemText
+                  primary="Log Out"
                   disableTypography={true}
                   className={classNames({
-                    [classes.linkItem]: true,
-                    [classes.activeLink]:
-                      expandedMenus.support ||
-                      this.linkIsActive('/logout') === true
+                    [classes.linkItem]: true
                   })}
-                >
-                  Log Out
-                </ListItemText>
-              </ListItem>
+                />
+              </Link>
             </Hidden>
             <div className={classes.spacer} />
             <IconButton

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -419,7 +419,12 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
             </Hidden>
             <div className={classes.spacer} />
             <ThemeToggle toggleTheme={toggleTheme} />
-            <button onClick={toggleSpacing} />
+            <a
+              style={{ margin: 20, textAlign: 'center' }}
+              onClick={toggleSpacing}
+            >
+              Toggle spacing
+            </a>
           </div>
         </Grid>
       </React.Fragment>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -48,7 +48,8 @@ type ClassNames =
   | 'menu'
   | 'paper'
   | 'settings'
-  | 'activeSettings';
+  | 'activeSettings'
+  | 'settingsBackdrop';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   menuGrid: {
@@ -164,19 +165,26 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     backgroundColor: 'rgba(0, 0, 0, 0.12)'
   },
   settings: {
-    padding: '24px 0',
+    width: 30,
+    margin: '24px auto 16px',
     alignItems: 'center',
     marginTop: 'auto',
     justifyContent: 'center',
     display: 'flex',
     color: '#e7e7e7',
-    transition: theme.transitions.create('color'),
+    transition: theme.transitions.create(['color']),
+    '& svg': {
+      transition: theme.transitions.create(['transform'])
+    },
     '&:hover': {
       color: theme.color.green
     }
   },
   activeSettings: {
-    color: theme.color.green
+    color: theme.color.green,
+    '& svg': {
+      transform: 'rotate(90deg)'
+    }
   },
   menu: {},
   paper: {
@@ -186,6 +194,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     backgroundColor: theme.bg.navy,
     border: '1px solid #999',
     outline: 0
+  },
+  settingsBackdrop: {
+    backgroundColor: 'rgba(0,0,0,.3)'
   }
 });
 
@@ -493,6 +504,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
               anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
               transformOrigin={{ vertical: 'bottom', horizontal: 'center' }}
               className={classes.menu}
+              BackdropProps={{ className: classes.settingsBackdrop }}
             >
               <ThemeToggle toggleTheme={toggleTheme} />
               <SpacingToggle toggleSpacing={toggleSpacing} />

--- a/src/components/PrimaryNav/SpacingToggle.tsx
+++ b/src/components/PrimaryNav/SpacingToggle.tsx
@@ -1,0 +1,86 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles,
+  WithTheme
+} from 'src/components/core/styles';
+import Toggle from 'src/components/Toggle';
+
+type ClassNames = 'switchWrapper' | 'switchText' | 'toggle';
+
+export const styles: StyleRulesCallback<ClassNames> = theme => ({
+  switchText: {
+    color: '#777',
+    fontSize: '.8rem',
+    transition: theme.transitions.create(['color']),
+    '&.active': {
+      transition: theme.transitions.create(['color']),
+      color: '#C9CACB'
+    }
+  },
+  switchWrapper: {
+    padding: '16px 40px 0 34px',
+    alignItems: 'center',
+    marginTop: 'auto',
+    width: 'calc(100% - 20px)',
+    justifyContent: 'center',
+    display: 'flex'
+  },
+  toggle: {
+    '& > span:last-child': {
+      backgroundColor: '#f4f4f4 !important',
+      opacity: `0.38 !important`
+    },
+    '&.darkTheme .square': {
+      fill: '#444 !important'
+    }
+  }
+});
+
+interface Props {
+  toggleSpacing: () => void;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames> & WithTheme;
+
+export const SpacingToggle: React.StatelessComponent<CombinedProps> = props => {
+  const { classes, toggleSpacing, theme } = props;
+  const { spacing: spacingUnit } = theme;
+
+  return (
+    <div className={classes.switchWrapper}>
+      <span
+        className={classNames({
+          [classes.switchText]: true,
+          active: spacingUnit.unit === 8
+        })}
+      >
+        Normal
+      </span>
+      <Toggle
+        onChange={toggleSpacing}
+        checked={spacingUnit.unit !== 8}
+        className={classNames({
+          [classes.toggle]: true,
+          [spacingUnit.unit]: true
+        })}
+        aria-label="Switch Spacing"
+      />
+      <span
+        className={classNames({
+          [classes.switchText]: true,
+          active: spacingUnit.unit === 4
+        })}
+        style={{ marginLeft: 4 }}
+      >
+        Compact
+      </span>
+    </div>
+  );
+};
+
+const styled = withStyles(styles, { withTheme: true });
+
+export default styled(SpacingToggle);

--- a/src/components/PrimaryNav/SpacingToggle.tsx
+++ b/src/components/PrimaryNav/SpacingToggle.tsx
@@ -21,10 +21,8 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
     }
   },
   switchWrapper: {
-    padding: '16px 40px 0 34px',
     alignItems: 'center',
     marginTop: 'auto',
-    width: 'calc(100% - 20px)',
     justifyContent: 'center',
     display: 'flex'
   },
@@ -33,7 +31,7 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
       backgroundColor: '#f4f4f4 !important',
       opacity: `0.38 !important`
     },
-    '&.darkTheme .square': {
+    '&.dt .square': {
       fill: '#444 !important'
     }
   }
@@ -64,7 +62,7 @@ export const SpacingToggle: React.StatelessComponent<CombinedProps> = props => {
         checked={spacingUnit.unit !== 8}
         className={classNames({
           [classes.toggle]: true,
-          [spacingUnit.unit]: true
+          dt: spacingUnit.unit === 4
         })}
         aria-label="Switch Spacing"
       />

--- a/src/components/PrimaryNav/ThemeToggle.test.tsx
+++ b/src/components/PrimaryNav/ThemeToggle.test.tsx
@@ -15,7 +15,7 @@ describe('ThemeToggle', () => {
       <ThemeToggle
         toggleTheme={jest.fn()}
         classes={mockClasses}
-        theme={light}
+        theme={light()}
       />
     );
   });

--- a/src/components/PrimaryNav/ThemeToggle.tsx
+++ b/src/components/PrimaryNav/ThemeToggle.tsx
@@ -21,12 +21,11 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
     }
   },
   switchWrapper: {
-    padding: '16px 40px 0 34px',
     alignItems: 'center',
     marginTop: 'auto',
-    width: 'calc(100% - 20px)',
     justifyContent: 'center',
-    display: 'flex'
+    display: 'flex',
+    marginLeft: -10
   },
   toggle: {
     '& > span:last-child': {

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -13,12 +13,12 @@ type ClassNames = 'menuPaper' | 'menuDocked';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   menuPaper: {
     height: '100%',
-    width: 215,
+    width: theme.spacing.unit * 17 + 79, // 215
     backgroundColor: theme.bg.navy,
     left: 'inherit',
     boxShadow: 'none',
     [theme.breakpoints.up('xl')]: {
-      width: 275
+      width: theme.spacing.unit * 22 + 99 // 275
     }
   },
   menuDocked: {

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -30,13 +30,14 @@ interface Props {
   open: boolean;
   closeMenu: () => void;
   toggleTheme: () => void;
+  toggleSpacing: () => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 class SideMenu extends React.Component<CombinedProps> {
   render() {
-    const { classes, open, closeMenu, toggleTheme } = this.props;
+    const { classes, open, closeMenu, toggleSpacing, toggleTheme } = this.props;
 
     return (
       <React.Fragment>
@@ -50,7 +51,11 @@ class SideMenu extends React.Component<CombinedProps> {
               keepMounted: true // Better open performance on mobile.
             }}
           >
-            <PrimaryNav closeMenu={closeMenu} toggleTheme={toggleTheme} />
+            <PrimaryNav
+              closeMenu={closeMenu}
+              toggleTheme={toggleTheme}
+              toggleSpacing={toggleSpacing}
+            />
           </Drawer>
         </Hidden>
         <Hidden smDown implementation="css">
@@ -62,7 +67,11 @@ class SideMenu extends React.Component<CombinedProps> {
               docked: classes.menuDocked
             }}
           >
-            <PrimaryNav closeMenu={closeMenu} toggleTheme={toggleTheme} />
+            <PrimaryNav
+              closeMenu={closeMenu}
+              toggleTheme={toggleTheme}
+              toggleSpacing={toggleSpacing}
+            />
           </Drawer>
         </Hidden>
       </React.Fragment>

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -79,6 +79,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
       nextProps.type !== this.props.type ||
       nextProps.disabled !== this.props.disabled ||
       nextProps.helperText !== this.props.helperText ||
+      nextProps.classes !== this.props.classes ||
       Boolean(
         this.props.select && nextProps.children !== this.props.children
       ) ||

--- a/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -155,7 +155,11 @@ class UpdateContactInformationPanel extends React.Component<
           </Grid>
         )}
 
-        <Grid item xs={12} updateFor={[fields.company, hasErrorFor('company')]}>
+        <Grid
+          item
+          xs={12}
+          updateFor={[fields.company, hasErrorFor('company'), classes]}
+        >
           <Grid container>
             <Grid item xs={12} sm={6}>
               <TextField
@@ -173,7 +177,7 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.email, hasErrorFor('email')]}
+          updateFor={[fields.email, hasErrorFor('email'), classes]}
         >
           <TextField
             label="Email"
@@ -189,7 +193,7 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.phone, hasErrorFor('phone')]}
+          updateFor={[fields.phone, hasErrorFor('phone'), classes]}
         >
           <TextField
             label="Phone Number"
@@ -205,7 +209,7 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.first_name, hasErrorFor('first_name')]}
+          updateFor={[fields.first_name, hasErrorFor('first_name'), classes]}
         >
           <TextField
             label="First Name"
@@ -220,7 +224,7 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.last_name, hasErrorFor('last_name')]}
+          updateFor={[fields.last_name, hasErrorFor('last_name'), classes]}
         >
           <TextField
             label="Last Name"
@@ -235,7 +239,7 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.address_1, hasErrorFor('address_1')]}
+          updateFor={[fields.address_1, hasErrorFor('address_1'), classes]}
         >
           <TextField
             label="Address"
@@ -250,7 +254,7 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.address_2, hasErrorFor('address2')]}
+          updateFor={[fields.address_2, hasErrorFor('address2'), classes]}
         >
           <TextField
             label="Address 2"
@@ -265,7 +269,7 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.city, hasErrorFor('city')]}
+          updateFor={[fields.city, hasErrorFor('city'), classes]}
         >
           <TextField
             label="City"
@@ -284,7 +288,8 @@ class UpdateContactInformationPanel extends React.Component<
             fields.state,
             fields.zip,
             hasErrorFor('state'),
-            hasErrorFor('zip')
+            hasErrorFor('zip'),
+            classes
           ]}
         >
           <Grid container className={classes.stateZip}>
@@ -313,7 +318,7 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.country, hasErrorFor('country')]}
+          updateFor={[fields.country, hasErrorFor('country'), classes]}
         >
           <TextField
             label="Country"
@@ -331,7 +336,7 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.tax_id, hasErrorFor('tax_id')]}
+          updateFor={[fields.tax_id, hasErrorFor('tax_id'), classes]}
         >
           <TextField
             label="Tax ID"

--- a/src/features/Dashboard/Dashboard.test.tsx
+++ b/src/features/Dashboard/Dashboard.test.tsx
@@ -14,7 +14,7 @@ const props = {
   backupError: undefined,
   entitiesWithGroupsToImport: { linodes: [], domains: [] },
   classes: { root: '' },
-  theme: light
+  theme: light()
 };
 
 const component = shallow(<Dashboard {...props} />);

--- a/src/features/Dashboard/DashboardCard.tsx
+++ b/src/features/Dashboard/DashboardCard.tsx
@@ -17,8 +17,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   headerAction: {
     position: 'relative',
-    top: theme.spacing.unit - 2,
-    left: -theme.spacing.unit * 2,
+    top: 6,
+    left: -16,
     marginLeft: theme.spacing.unit / 2
   }
 });
@@ -41,7 +41,7 @@ const DashboardCard: React.StatelessComponent<CombinedProps> = props => {
       })}
       data-qa-card={title}
     >
-      <Grid item xs={12} className={!title || !headerAction ? 'p0' : ''}>
+      <Grid item xs={12}>
         <Grid container alignItems="flex-start">
           {title && (
             <Grid item className={'py0'}>

--- a/src/features/Dashboard/DashboardCard.tsx
+++ b/src/features/Dashboard/DashboardCard.tsx
@@ -41,22 +41,24 @@ const DashboardCard: React.StatelessComponent<CombinedProps> = props => {
       })}
       data-qa-card={title}
     >
-      <Grid item xs={12}>
-        <Grid container alignItems="flex-start">
-          {title && (
-            <Grid item className={'py0'}>
-              <Typography variant="h2">{title}</Typography>
-            </Grid>
-          )}
-          {headerAction && (
-            <Grid item className={'py0'}>
-              <Typography variant="body1" className={classes.headerAction}>
-                {headerAction()}
-              </Typography>
-            </Grid>
-          )}
+      {(title || headerAction) && (
+        <Grid item xs={12}>
+          <Grid container alignItems="flex-start">
+            {title && (
+              <Grid item className={'py0'}>
+                <Typography variant="h2">{title}</Typography>
+              </Grid>
+            )}
+            {headerAction && (
+              <Grid item className={'py0'}>
+                <Typography variant="body1" className={classes.headerAction}>
+                  {headerAction()}
+                </Typography>
+              </Grid>
+            )}
+          </Grid>
         </Grid>
-      </Grid>
+      )}
       <Grid item xs={12}>
         {props.children}
       </Grid>

--- a/src/features/Dashboard/GroupImportCard/GroupImportCard.tsx
+++ b/src/features/Dashboard/GroupImportCard/GroupImportCard.tsx
@@ -14,15 +14,11 @@ import {
 import Typography from 'src/components/core/Typography';
 import DashboardCard from '../DashboardCard';
 
-type ClassNames = 'root' | 'header' | 'section' | 'title' | 'button' | 'icon';
+type ClassNames = 'root' | 'section' | 'title' | 'button' | 'icon';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
     width: '100%'
-  },
-  header: {
-    textAlign: 'center',
-    fontSize: 18
   },
   section: {
     padding: theme.spacing.unit * 3,
@@ -34,19 +30,18 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
     display: 'flex',
     flexFlow: 'row nowrap',
     alignItems: 'center',
-    justifyContent: 'center',
-    padding: `${theme.spacing.unit}px !important`,
+    padding: `${theme.spacing.unit}px ${theme.spacing.unit * 3}px !important`,
     [theme.breakpoints.down('md')]: {
       justifyContent: 'space-between',
       alignItems: 'flex-start'
     }
   },
   button: {
-    marginTop: '18px'
+    marginTop: theme.spacing.unit * 3
   },
   icon: {
     position: 'absolute',
-    top: 10,
+    top: theme.spacing.unit,
     right: 0,
     cursor: 'pointer',
     border: 'none',
@@ -94,12 +89,7 @@ export const GroupImportCard: React.StatelessComponent<
           [classes.title]: true
         })}
       >
-        <Typography
-          className={classes.header}
-          variant="h1"
-          component="h3"
-          data-qa-group-cta-header
-        >
+        <Typography variant="h2" data-qa-group-cta-header>
           Import Display Groups as Tags
         </Typography>
         <div>
@@ -138,14 +128,14 @@ GroupImportCard.displayName = 'ImportGroupsCard';
 const styled = withStyles(styles);
 
 const enhanced = compose<CombinedProps, Props>(
-  styled,
   withStateHandlers(
     { hidden: false },
     {
       hide: () => () => ({ hidden: true })
     }
   ),
-  onlyUpdateForKeys(['hidden', 'theme'])
+  onlyUpdateForKeys(['hidden', 'theme']),
+  styled
 )(GroupImportCard);
 
 export default enhanced;

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -32,6 +32,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     padding: theme.spacing.unit * 3
   },
   card: {
+    marginTop: 8,
     [theme.breakpoints.down('sm')]: {
       marginTop: 0
     }

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -32,7 +32,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     padding: `${theme.spacing.unit * 4}px ${theme.spacing.unit * 3}px`
   },
   card: {
-    marginTop: 8,
+    marginTop: 24,
     [theme.breakpoints.down('sm')]: {
       marginTop: 0
     }

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -29,7 +29,7 @@ type ClassNames =
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
     marginTop: 0,
-    padding: theme.spacing.unit * 3
+    padding: `${theme.spacing.unit * 4}px ${theme.spacing.unit * 3}px`
   },
   card: {
     marginTop: 8,

--- a/src/features/Footer/Footer.tsx
+++ b/src/features/Footer/Footer.tsx
@@ -15,10 +15,10 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     backgroundColor: theme.bg.main,
     margin: 0,
     [theme.breakpoints.up('md')]: {
-      paddingLeft: 215
+      paddingLeft: theme.spacing.unit * 17 + 79 // 215
     },
     [theme.breakpoints.up('xl')]: {
-      paddingLeft: 275
+      paddingLeft: theme.spacing.unit * 22 + 99 // 275
     }
   },
   version: {

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -281,7 +281,8 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       changeDisk,
       changeLinode,
       changeLabel,
-      changeDescription
+      changeDescription,
+      classes
     } = this.props;
     const { disks, linodes, notice } = this.state;
     const { errors } = this.state;
@@ -320,7 +321,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
             selectedLinode={selectedLinode || 'none'}
             linodeError={linodeError}
             handleChange={changeLinode}
-            updateFor={[linodes, selectedLinode, linodeError]}
+            updateFor={[linodes, selectedLinode, linodeError, classes]}
           />
         )}
 
@@ -330,7 +331,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
             disks={disks}
             diskError={diskError}
             handleChange={changeDisk}
-            updateFor={[disks, selectedDisk, diskError]}
+            updateFor={[disks, selectedDisk, diskError, classes]}
             disabled={mode === modes.IMAGIZING}
             data-qa-disk-select
           />
@@ -360,7 +361,10 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
           </React.Fragment>
         )}
 
-        <ActionsPanel style={{ marginTop: 16 }} updateFor={[requirementsMet]}>
+        <ActionsPanel
+          style={{ marginTop: 16 }}
+          updateFor={[requirementsMet, classes]}
+        >
           <Button
             onClick={this.onSubmit}
             disabled={requirementsMet}

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -288,7 +288,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
           container
           justify="space-between"
           alignItems="flex-end"
-          updateFor={[]}
+          updateFor={[classes]}
           style={{ paddingBottom: 0 }}
         >
           <Grid item>
@@ -353,7 +353,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
                             onDeploy={this.deployNewLinode}
                             onEdit={this.openForEdit}
                             onDelete={this.openRemoveDialog}
-                            updateFor={[image]}
+                            updateFor={[image, classes]}
                           />
                         ))}
                       </TableBody>

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -50,7 +50,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     paddingLeft: theme.spacing.unit * 2,
     marginLeft: -theme.spacing.unit,
     [theme.breakpoints.down('md')]: {
-      marginLeft: -32,
       marginTop: -theme.spacing.unit
     },
     [theme.breakpoints.down('xs')]: {

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -45,6 +45,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     marginBottom: theme.spacing.unit
   },
   backendIPAction: {
+    display: 'flex',
+    alignItems: 'flex-end',
     paddingLeft: theme.spacing.unit * 2,
     marginLeft: -theme.spacing.unit,
     [theme.breakpoints.down('md')]: {

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -378,7 +378,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
       healthCheckTimeout,
       healthCheckType,
       protocol,
-      disabled
+      disabled,
+      classes
     } = this.props;
 
     const hasErrorFor = getAPIErrorFor(
@@ -397,7 +398,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
       <Grid item xs={12} md={4} xl={2}>
         <Grid container>
           <Grid
-            updateFor={[]} // never update after initial render
+            updateFor={[classes]} // never update after initial render
             item
             xs={12}
           >
@@ -410,7 +411,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
               protocol,
               healthCheckType,
               hasErrorFor('check'),
-              configIdx
+              configIdx,
+              classes
             ]}
             item
             xs={12}
@@ -451,7 +453,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 updateFor={[
                   healthCheckInterval,
                   hasErrorFor('check_interval'),
-                  configIdx
+                  configIdx,
+                  classes
                 ]}
                 item
                 xs={12}
@@ -477,7 +480,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 updateFor={[
                   healthCheckTimeout,
                   hasErrorFor('check_timeout'),
-                  configIdx
+                  configIdx,
+                  classes
                 ]}
                 item
                 xs={12}
@@ -503,7 +507,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 updateFor={[
                   healthCheckAttempts,
                   hasErrorFor('check_attempts'),
-                  configIdx
+                  configIdx,
+                  classes
                 ]}
                 item
                 xs={12}
@@ -529,7 +534,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                     checkPath,
                     healthCheckType,
                     hasErrorFor('check_path'),
-                    configIdx
+                    configIdx,
+                    classes
                   ]}
                   item
                   xs={12}
@@ -552,7 +558,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                     checkBody,
                     healthCheckType,
                     hasErrorFor('check_body'),
-                    configIdx
+                    configIdx,
+                    classes
                   ]}
                   item
                   xs={12}
@@ -581,7 +588,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
 
     return (
       <Grid item xs={12} md={6}>
-        <Grid updateFor={[checkPassive]} container>
+        <Grid updateFor={[checkPassive, classes]} container>
           <Grid item xs={12}>
             <Typography
               role="header"
@@ -668,7 +675,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 hasErrorFor('ssl_key'),
                 configIdx,
                 sslCertificate,
-                privateKey
+                privateKey,
+                classes
               ]}
               container
             >
@@ -728,7 +736,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                       hasErrorFor('ssl_cert'),
                       privateKey,
                       hasErrorFor('ssl_key'),
-                      configIdx
+                      configIdx,
+                      classes
                     ]}
                     container
                   >
@@ -825,9 +834,9 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
               </Grid>
             </Grid>
 
-            <Grid updateFor={[nodes, errors, nodeMessage]} container>
+            <Grid updateFor={[nodes, errors, nodeMessage, classes]} container>
               <Grid item xs={12}>
-                <Grid updateFor={[nodeMessage]} item xs={12}>
+                <Grid updateFor={[nodeMessage, classes]} item xs={12}>
                   {nodeMessage && <Notice text={nodeMessage} success />}
                 </Grid>
                 <Typography
@@ -864,7 +873,13 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                       return (
                         <React.Fragment key={`nb-node-${idx}`}>
                           <Grid
-                            updateFor={[nodes.length, node, errors, configIdx]}
+                            updateFor={[
+                              nodes.length,
+                              node,
+                              errors,
+                              configIdx,
+                              classes
+                            ]}
                             item
                             data-qa-node
                             xs={12}
@@ -931,7 +946,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                 nodes.length,
                                 node,
                                 errors,
-                                configIdx
+                                configIdx,
+                                classes
                               ]}
                               container
                               data-qa-node
@@ -1120,7 +1136,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   <Grid
                     item
                     xs={12}
-                    updateFor={[]}
+                    updateFor={[classes]}
                     // is the Save/Delete ActionsPanel showing?
                     style={
                       forEdit || configIdx !== 0
@@ -1141,17 +1157,17 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
 
             {(forEdit || configIdx !== 0) && (
               <React.Fragment>
-                <Grid updateFor={[]} item xs={12}>
+                <Grid updateFor={[classes]} item xs={12}>
                   <Divider className={classes.divider} />
                 </Grid>
                 <Grid
-                  updateFor={[submitting]}
+                  updateFor={[submitting, classes]}
                   container
                   justify="space-between"
                   alignItems="center"
                 >
-                  <Grid item style={{ marginTop: 16 }} className="py0">
-                    <ActionsPanel style={{ padding: 0 }}>
+                  <Grid item>
+                    <ActionsPanel>
                       {forEdit && (
                         <Button
                           type="primary"

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -1002,7 +1002,8 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
           configSubmitting[idx],
           configErrors[idx],
           panelMessages[idx],
-          panelNodeMessages[idx]
+          panelNodeMessages[idx],
+          classes
         ]}
         defaultExpanded={isNewConfig || isExpanded}
         success={panelMessages[idx]}

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -26,7 +26,9 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 type ClassNames = 'root' | 'title' | 'inner' | 'expPanelButton';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {},
+  root: {
+    padding: theme.spacing.unit * 3
+  },
   title: {
     marginTop: theme.spacing.unit,
     marginBottom: theme.spacing.unit * 2
@@ -139,7 +141,7 @@ class NodeBalancerSettings extends React.Component<CombinedProps, State> {
         <Typography role="header" variant="h1" className={classes.title}>
           Settings
         </Typography>
-        <Paper style={{ padding: 24 }}>
+        <Paper className={classes.root}>
           <Grid item xs={12}>
             {generalError && <Notice error text={generalError} />}
             {success && <Notice success text={success} />}

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/SummaryPanel.tsx
@@ -32,7 +32,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   titleWrapper: {},
   NBsummarySection: {
     [theme.breakpoints.up('md')]: {
-      marginTop: theme.spacing.unit * 6
+      marginTop: theme.spacing.unit * 3 + 24
     }
   },
   IPgrouping: {

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
@@ -145,7 +145,7 @@ export class EnableTwoFactorForm extends React.Component<CombinedProps, State> {
           <QRCodeForm
             secret={secret}
             secretLink={secretLink}
-            updateFor={[secret, secretLink]}
+            updateFor={[secret, secretLink, classes]}
           />
         )}
         <Divider className={classes.divider} />
@@ -157,7 +157,7 @@ export class EnableTwoFactorForm extends React.Component<CombinedProps, State> {
           handleChange={this.handleTokenInputChange}
           onCancel={this.onCancel}
           onSubmit={this.onSubmit}
-          updateFor={[token, tokenError, submitting]}
+          updateFor={[token, tokenError, submitting, classes]}
         />
       </React.Fragment>
     );

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
@@ -16,16 +16,17 @@ declare module 'qrcode.react' {
   }
 }
 
-type ClassNames = 'root' | 'instructions' | 'qrcode';
+type ClassNames = 'root' | 'instructions' | 'qrcodeContainer';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   instructions: {
     marginTop: theme.spacing.unit * 2
   },
-  qrcode: {
+  qrcodeContainer: {
     margin: `${theme.spacing.unit * 2}px 0`,
-    border: `5px solid #fff`
+    border: `5px solid #fff`,
+    display: 'inline-block'
   }
 });
 
@@ -48,13 +49,15 @@ const QRCodeForm: React.StatelessComponent<CombinedProps> = props => {
       >
         Scan this QR code to add your Linode account to your TFA app:
       </Typography>
-      <QRCode
-        size={200}
-        level="H" // QR code error checking level ("High"); gives a higher resolution code
-        value={secretLink}
-        className={classes.qrcode}
-        data-qa-qr-code
-      />
+      <div className={classes.qrcodeContainer}>
+        <QRCode
+          size={200}
+          level="H" // QR code error checking level ("High"); gives a higher resolution code
+          value={secretLink}
+          data-qa-qr-code
+          className="qrCode"
+        />
+      </div>
       <Typography
         role="header"
         variant="h3"

--- a/src/features/StackScripts/Partials/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/Partials/StackScriptTableHead.tsx
@@ -41,8 +41,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   tableHead: {
     position: 'sticky',
-    top: 72,
-    backgroundColor: theme.bg.offWhite,
+    top: theme.spacing.unit * 9,
+    backgroundColor: 'rgba(0, 0, 0, 0.15)',
     paddingTop: 0,
     paddingBottom: 0,
     height: 48,

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -173,7 +173,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
                   deploymentsActive={stackScript.deployments_active}
                   updated={formatDate(stackScript.updated, false)}
                   checked={selectedId === stackScript.id}
-                  updateFor={[selectedId === stackScript.id]}
+                  updateFor={[selectedId === stackScript.id, classes]}
                   stackScriptID={stackScript.id}
                 />
               </tbody>

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptsSection.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptsSection.tsx
@@ -51,7 +51,7 @@ const SelectStackScriptsSection: React.StatelessComponent<
       updated={formatDate(s.updated, false)}
       onSelect={() => onSelect(s)}
       checked={selectedId === s.id}
-      updateFor={[selectedId === s.id]}
+      updateFor={[selectedId === s.id, classes]}
       stackScriptID={s.id}
       disabled={disabled}
     />

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -55,7 +55,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           field={field}
           udf_data={props.udf_data}
           updateFormState={handleChange}
-          updateFor={[props.udf_data[field.name]]}
+          updateFor={[props.udf_data[field.name], classes]}
           isOptional={isOptional}
         />
       );
@@ -66,7 +66,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           field={field}
           updateFormState={handleChange}
           udf_data={props.udf_data}
-          updateFor={[props.udf_data[field.name]]}
+          updateFor={[props.udf_data[field.name], classes]}
           isOptional={isOptional}
           key={field.name}
         />
@@ -80,7 +80,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           isPassword={true}
           field={field}
           udf_data={props.udf_data}
-          updateFor={[props.udf_data[field.name]]}
+          updateFor={[props.udf_data[field.name], classes]}
           isOptional={isOptional}
           placeholder={field.example}
         />
@@ -92,7 +92,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
         updateFormState={handleChange}
         field={field}
         udf_data={props.udf_data}
-        updateFor={[props.udf_data[field.name]]}
+        updateFor={[props.udf_data[field.name], classes]}
         isOptional={isOptional}
         placeholder={field.example}
       />

--- a/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -118,7 +118,7 @@ export class SupportTicketsLanding extends React.Component<
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Support Tickets" />
-        <Grid container justify="space-between" updateFor={[]}>
+        <Grid container justify="space-between" updateFor={[classes]}>
           <Grid item className={classes.titleWrapper}>
             <Breadcrumb
               linkTo="/support"

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -50,7 +50,7 @@ const styles: StyleRulesCallback = theme => ({
     minHeight: 40,
     paddingRight: `calc(${theme.spacing.unit * 3}px + 24px)`,
     [theme.breakpoints.down('sm')]: {
-      padding: '6px 11px 7px 14px'
+      padding: '6px 11px 7px 11px'
     }
   },
   caret: {

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -50,7 +50,7 @@ const styles: StyleRulesCallback = theme => ({
     minHeight: 40,
     paddingRight: `calc(${theme.spacing.unit * 3}px + 24px)`,
     [theme.breakpoints.down('sm')]: {
-      padding: '6px 11px 7px 11px'
+      padding: '6px 34px 7px 11px'
     }
   },
   caret: {

--- a/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -70,9 +70,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   caption: {
     marginTop: -8,
-    paddingLeft: 39,
+    paddingLeft: theme.spacing.unit * 2 + 23, // 39,
     [theme.breakpoints.up('md')]: {
-      paddingLeft: 55
+      paddingLeft: theme.spacing.unit * 4 + 23 // 55
     }
   }
 });

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -423,7 +423,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                 )(linodesWithBackups!)}
                 selectedLinodeID={selectedLinodeID}
                 handleSelection={this.handleSelectLinode}
-                updateFor={[selectedLinodeID, errors]}
+                updateFor={[selectedLinodeID, errors, classes]}
                 disabled={disabled}
               />
               <SelectBackupPanel
@@ -437,7 +437,12 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                 selectedBackupID={selectedBackupID}
                 handleChangeBackup={this.handleSelectBackupID}
                 handleChangeBackupInfo={this.handleSelectBackupInfo}
-                updateFor={[selectedLinodeID, selectedBackupID, errors]}
+                updateFor={[
+                  selectedLinodeID,
+                  selectedBackupID,
+                  errors,
+                  classes
+                ]}
               />
               <SelectPlanPanel
                 error={hasErrorFor('type')}
@@ -445,7 +450,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                 onSelect={this.handleSelectPlan}
                 selectedID={selectedTypeID}
                 selectedDiskSize={selectedDiskSize}
-                updateFor={[selectedTypeID, selectedDiskSize, errors]}
+                updateFor={[selectedTypeID, selectedDiskSize, errors, classes]}
                 disabled={disabled}
               />
               <LabelAndTagsPanel
@@ -462,7 +467,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                   tagError: hasErrorFor('tags'),
                   disabled
                 }}
-                updateFor={[tags, label, errors]}
+                updateFor={[tags, label, errors, classes]}
               />
               <AddonsPanel
                 backups={backups}
@@ -471,7 +476,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                 changePrivateIP={this.handleTogglePrivateIP}
                 backupsMonthly={getBackupsMonthlyPrice(selectedTypeID)}
                 privateIP={privateIP}
-                updateFor={[privateIP, backups, selectedTypeID]}
+                updateFor={[privateIP, backups, selectedTypeID, classes]}
                 disabled={disabled}
               />
             </React.Fragment>

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -330,7 +330,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
             images={images}
             handleSelection={this.handleSelectImage}
             selectedImageID={selectedImageID}
-            updateFor={[selectedImageID, errors]}
+            updateFor={[selectedImageID, errors, classes]}
             initTab={initTab}
             error={hasErrorFor('image')}
             disabled={disabled}
@@ -341,7 +341,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
             handleSelection={this.handleSelectRegion}
             selectedID={selectedRegionID}
             copy="Determine the best location for your Linode."
-            updateFor={[selectedRegionID, errors]}
+            updateFor={[selectedRegionID, errors, classes]}
             disabled={disabled}
           />
           <SelectPlanPanel
@@ -349,7 +349,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
             types={types}
             onSelect={this.handleSelectPlan}
             selectedID={selectedTypeID}
-            updateFor={[selectedTypeID, errors]}
+            updateFor={[selectedTypeID, errors, classes]}
             disabled={disabled}
           />
           <LabelAndTagsPanel
@@ -366,7 +366,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
               tagError: hasErrorFor('tags'),
               disabled
             }}
-            updateFor={[tags, label, errors]}
+            updateFor={[tags, label, errors, classes]}
           />
           <AccessPanel
             /* disable the password field if we haven't selected an image */
@@ -378,7 +378,13 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
             error={hasErrorFor('root_pass')}
             password={password}
             handleChange={this.handleTypePassword}
-            updateFor={[password, errors, userSSHKeys, selectedImageID]}
+            updateFor={[
+              password,
+              errors,
+              userSSHKeys,
+              selectedImageID,
+              classes
+            ]}
             users={userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []}
           />
           <AddonsPanel
@@ -388,7 +394,7 @@ export class FromImageContent extends React.Component<CombinedProps, State> {
             privateIP={privateIP}
             changeBackups={this.handleToggleBackups}
             changePrivateIP={this.handleTogglePrivateIP}
-            updateFor={[privateIP, backups, selectedTypeID]}
+            updateFor={[privateIP, backups, selectedTypeID, classes]}
             disabled={disabled}
           />
         </Grid>

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -294,7 +294,7 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
                 selectedLinodeID={selectedLinodeID}
                 header={'Select Linode to Clone From'}
                 handleSelection={this.handleSelectLinode}
-                updateFor={[selectedLinodeID, errors]}
+                updateFor={[selectedLinodeID, errors, classes]}
                 disabled={disabled}
               />
               <SelectRegionPanel
@@ -303,7 +303,7 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
                 handleSelection={this.handleSelectRegion}
                 selectedID={selectedRegionID}
                 copy="Determine the best location for your Linode."
-                updateFor={[selectedRegionID, errors]}
+                updateFor={[selectedRegionID, errors, classes]}
                 disabled={disabled}
               />
               <SelectPlanPanel
@@ -312,7 +312,7 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
                 onSelect={this.handleSelectPlan}
                 selectedID={selectedTypeID}
                 selectedDiskSize={selectedDiskSize}
-                updateFor={[selectedDiskSize, selectedTypeID, errors]}
+                updateFor={[selectedDiskSize, selectedTypeID, errors, classes]}
                 disabled={disabled}
               />
               <LabelAndTagsPanel
@@ -323,7 +323,7 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
                   errorText: hasErrorFor('label'),
                   disabled
                 }}
-                updateFor={[label, errors]}
+                updateFor={[label, errors, classes]}
               />
               <AddonsPanel
                 backups={backups}
@@ -332,7 +332,7 @@ export class FromLinodeContent extends React.Component<CombinedProps, State> {
                 privateIP={privateIP}
                 changeBackups={this.handleToggleBackups}
                 changePrivateIP={this.handleTogglePrivateIP}
-                updateFor={[privateIP, backups, selectedTypeID]}
+                updateFor={[privateIP, backups, selectedTypeID, classes]}
                 disabled={disabled}
               />
             </Grid>

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -454,7 +454,7 @@ export class FromStackScriptContent extends React.Component<
             error={hasErrorFor('stackscript_id')}
             selectedId={selectedStackScriptID}
             selectedUsername={selectedStackScriptUsername}
-            updateFor={[selectedStackScriptID, errors]}
+            updateFor={[selectedStackScriptID, errors, classes]}
             onSelect={this.handleSelectStackScript}
             publicImages={this.filterPublicImages(images) || []}
             resetSelectedStackScript={this.resetStackScriptSelection}
@@ -467,7 +467,7 @@ export class FromStackScriptContent extends React.Component<
               selectedUsername={selectedStackScriptUsername}
               handleChange={this.handleChangeUDF}
               userDefinedFields={userDefinedFields}
-              updateFor={[userDefinedFields, udf_data, errors]}
+              updateFor={[userDefinedFields, udf_data, errors, classes]}
               udf_data={udf_data}
             />
           )}
@@ -475,7 +475,7 @@ export class FromStackScriptContent extends React.Component<
             <SelectImagePanel
               images={compatibleImages}
               handleSelection={this.handleSelectImage}
-              updateFor={[selectedImageID, compatibleImages, errors]}
+              updateFor={[selectedImageID, compatibleImages, errors, classes]}
               selectedImageID={selectedImageID}
               error={hasErrorFor('image')}
               hideMyImages={true}
@@ -503,7 +503,7 @@ export class FromStackScriptContent extends React.Component<
             regions={regions}
             handleSelection={this.handleSelectRegion}
             selectedID={selectedRegionID}
-            updateFor={[selectedRegionID, errors]}
+            updateFor={[selectedRegionID, errors, classes]}
             copy="Determine the best location for your Linode."
             disabled={disabled}
           />
@@ -511,7 +511,7 @@ export class FromStackScriptContent extends React.Component<
             error={hasErrorFor('type')}
             types={types}
             onSelect={this.handleSelectPlan}
-            updateFor={[selectedTypeID, errors]}
+            updateFor={[selectedTypeID, errors, classes]}
             selectedID={selectedTypeID}
             disabled={disabled}
           />
@@ -529,7 +529,7 @@ export class FromStackScriptContent extends React.Component<
               tagError: hasErrorFor('tags'),
               disabled
             }}
-            updateFor={[tags, label, errors]}
+            updateFor={[tags, label, errors, classes]}
           />
           <AccessPanel
             /* disable the password field if we haven't selected an image */
@@ -539,7 +539,13 @@ export class FromStackScriptContent extends React.Component<
               }
             }
             error={hasErrorFor('root_pass')}
-            updateFor={[password, errors, userSSHKeys, selectedImageID]}
+            updateFor={[
+              password,
+              errors,
+              userSSHKeys,
+              selectedImageID,
+              classes
+            ]}
             password={password}
             handleChange={this.handleTypePassword}
             users={userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []}
@@ -551,7 +557,7 @@ export class FromStackScriptContent extends React.Component<
             privateIP={privateIP}
             changeBackups={this.handleToggleBackups}
             changePrivateIP={this.handleTogglePrivateIP}
-            updateFor={[privateIP, backups, selectedTypeID]}
+            updateFor={[privateIP, backups, selectedTypeID, classes]}
             disabled={disabled}
           />
         </Grid>

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -543,7 +543,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
             linodeSharedIPs={sharedIPs}
             linodeRegion={linodeRegion}
             refreshIPs={this.refreshIPs}
-            updateFor={[publicIPs, sharedIPs, linodeID, linodeRegion]}
+            updateFor={[publicIPs, sharedIPs, linodeID, linodeRegion, classes]}
           />
         </Grid>
       </Grid>

--- a/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
@@ -40,7 +40,7 @@ interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
-  const { devices, onChange, getSelected, slots, rescue } = props;
+  const { devices, onChange, getSelected, slots, rescue, classes } = props;
 
   const counter = defaultTo(0, props.counter);
 
@@ -48,7 +48,11 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
     <React.Fragment>
       {slots.map((slot, idx) => {
         return counter < idx ? null : (
-          <FormControl updateFor={[getSelected(slot)]} key={slot} fullWidth>
+          <FormControl
+            updateFor={[getSelected(slot), classes]}
+            key={slot}
+            fullWidth
+          >
             <InputLabel
               htmlFor={`rescueDevice_${slot}`}
               disableAnimation

--- a/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { compose } from 'recompose';
 import Divider from 'src/components/core/Divider';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import InputAdornment from 'src/components/core/InputAdornment';
@@ -137,4 +138,7 @@ class AlertSection extends React.Component<CombinedProps> {
 
 const styled = withStyles(styles);
 
-export default styled(RenderGuard<CombinedProps>(AlertSection));
+export default compose<CombinedProps, any>(
+  RenderGuard,
+  styled
+)(AlertSection);

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -287,7 +287,13 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
           item
           xs={12}
           className={classes.section}
-          updateFor={[errorFor('label'), errorFor('comments'), label, comments]}
+          updateFor={[
+            errorFor('label'),
+            errorFor('comments'),
+            label,
+            comments,
+            classes
+          ]}
         >
           <Typography role="header" variant="h3">
             Label and Comments
@@ -314,7 +320,12 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
 
         <Divider className={classes.divider} />
 
-        <Grid item xs={12} className={classes.section} updateFor={[virt_mode]}>
+        <Grid
+          item
+          xs={12}
+          className={classes.section}
+          updateFor={[virt_mode, classes]}
+        >
           <Typography role="header" variant="h3">
             Virtual Machine
           </Typography>
@@ -353,7 +364,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             errorFor('kernel'),
             run_level,
             memory_limit,
-            errorFor('memory_limit')
+            errorFor('memory_limit'),
+            classes
           ]}
         >
           <Typography role="header" variant="h3">
@@ -384,7 +396,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
           )}
 
           <FormControl
-            updateFor={[run_level]}
+            updateFor={[run_level, classes]}
             fullWidth
             component={'fieldset' as 'div'}
           >
@@ -492,7 +504,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               helpers.updatedb_disabled,
               helpers.modules_dep,
               helpers.devtmpfs_automount,
-              helpers.network
+              helpers.network,
+              classes
             ]}
             fullWidth
             component={'fieldset' as 'div'}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -270,6 +270,7 @@ class LinodeSettingsAlertsPanel extends React.Component<CombinedProps, State> {
   };
 
   public render() {
+    const { classes } = this.props;
     const alertSections: Section[] = this.renderAlertSections();
     const hasErrorFor = getAPIErrorFor({}, this.state.errors);
     const generalError = hasErrorFor('none');
@@ -283,7 +284,7 @@ class LinodeSettingsAlertsPanel extends React.Component<CombinedProps, State> {
         {generalError && <Notice error>{generalError}</Notice>}
         {alertSections.map((p, idx) => (
           <AlertSection
-            updateFor={[p.state, p.value, this.state.errors]}
+            updateFor={[p.state, p.value, this.state.errors, classes]}
             key={idx}
             {...p}
           />

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -55,7 +55,9 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   right: {
     marginLeft: theme.spacing.unit,
-    display: 'flex'
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
   },
   icon: {
     '& svg': {

--- a/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
@@ -37,7 +37,7 @@ describe('LinodeRow', () => {
   const mockProps: CombinedProps = {
     classes: mockClasses,
     toggleConfirmation: jest.fn(),
-    theme: light,
+    theme: light(),
     recentEvent: undefined,
     openConfigDrawer: jest.fn(),
     mutationAvailable: false,

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
@@ -20,7 +20,7 @@ describe('LinodeRow', () => {
   const mockProps: CombinedProps = {
     classes: mockClasses,
     toggleConfirmation: jest.fn(),
-    theme: light,
+    theme: light(),
     recentEvent: undefined,
     openConfigDrawer: jest.fn(),
     mutationAvailable: false,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -83,7 +83,7 @@ const renderLish = () => (
 
 const renderApp = (props: RouteProps) => (
   <LinodeThemeWrapper>
-    {toggle => (
+    {(toggle, spacing) => (
       <SnackBar
         anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         maxSnack={3}
@@ -91,7 +91,11 @@ const renderApp = (props: RouteProps) => (
         data-qa-toast
         hideIconVariant={true}
       >
-        <App toggleTheme={toggle} location={props.location} />
+        <App
+          toggleTheme={toggle}
+          toggleSpacing={spacing}
+          location={props.location}
+        />
       </SnackBar>
     )}
   </LinodeThemeWrapper>

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -3,7 +3,7 @@ import createBreakpoints from 'src/components/core/styles/createBreakpoints';
 import createMuiTheme, {
   ThemeOptions
 } from 'src/components/core/styles/createMuiTheme';
-import { spacing as spacingStorage, theme } from 'src/utilities/storage';
+import { spacing as spacingStorage } from 'src/utilities/storage';
 
 /**
  * Augmenting Palette and Palette Options

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1011,6 +1011,7 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
           justifyContent: 'center',
           appearance: 'none',
           margin: 1,
+          lineHeight: 1.3,
           [breakpoints.up('md')]: {
             minWidth: 75
           },

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -479,8 +479,8 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
       MuiDialogActions: {
         root: {
           margin: 0,
-          padding: `0 ${spacingUnit * 3}px, ${spacingUnit *
-            3}px, ${spacingUnit * 3}px`,
+          padding: `0 ${spacingUnit * 3}px ${spacingUnit * 3}px ${spacingUnit *
+            3}px`,
           justifyContent: 'flex-start',
           '& .actionPanel': {
             padding: 0

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -3,7 +3,7 @@ import createBreakpoints from 'src/components/core/styles/createBreakpoints';
 import createMuiTheme, {
   ThemeOptions
 } from 'src/components/core/styles/createMuiTheme';
-import { spacing as spacingStorage } from 'src/utilities/storage';
+import { spacing as spacingStorage, theme } from 'src/utilities/storage';
 
 /**
  * Augmenting Palette and Palette Options
@@ -609,7 +609,7 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
       },
       MuiFormControlLabel: {
         root: {
-          marginLeft: -11
+          marginLeft: -(spacingUnit + 3)
         }
       },
       MuiFormLabel: {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -3,6 +3,7 @@ import createBreakpoints from 'src/components/core/styles/createBreakpoints';
 import createMuiTheme, {
   ThemeOptions
 } from 'src/components/core/styles/createMuiTheme';
+import { spacing as spacingStorage } from 'src/utilities/storage';
 
 /**
  * Augmenting Palette and Palette Options
@@ -61,7 +62,16 @@ declare module '@material-ui/core/styles/createMuiTheme' {
 }
 
 const breakpoints = createBreakpoints({});
-const spacingUnit = 8;
+const sp = spacingStorage.get();
+const GetSpacingUnit = () => {
+  switch (sp) {
+    case 'compact':
+      return 4;
+    default:
+      return 8;
+  }
+};
+const spacingUnit = GetSpacingUnit();
 
 const primaryColors = {
   main: '#3683dc',

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -61,17 +61,13 @@ declare module '@material-ui/core/styles/createMuiTheme' {
   }
 }
 
+type ThemeDefaults = (options: ThemeArguments) => ThemeOptions;
+
+interface ThemeArguments {
+  spacing: 'compact' | 'normal';
+}
+
 const breakpoints = createBreakpoints({});
-const sp = spacingStorage.get();
-const GetSpacingUnit = () => {
-  switch (sp) {
-    case 'compact':
-      return 4;
-    default:
-      return 8;
-  }
-};
-const spacingUnit = GetSpacingUnit();
 
 const primaryColors = {
   main: '#3683dc',
@@ -101,1078 +97,1090 @@ const iconCircleAnimation = {
   }
 };
 
-const themeDefaults: ThemeOptions = {
-  breakpoints,
-  shadows: [
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none',
-    'none'
-  ],
-  spacing: {
-    unit: spacingUnit
-  },
-  '@keyframes rotate': {
-    from: {
-      transform: 'rotate(0deg)'
+const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
+  const spacingUnit = options.spacing === 'compact' ? 4 : 8;
+
+  return {
+    breakpoints,
+    shadows: [
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none',
+      'none'
+    ],
+    spacing: {
+      unit: spacingUnit
     },
-    to: {
-      transform: 'rotate(360deg)'
-    }
-  },
-  '@keyframes dash': {
-    to: {
-      'stroke-dashoffset': 0
-    }
-  },
-  bg: {
-    main: '#f4f4f4',
-    offWhite: '#fbfbfb',
-    offWhiteDT: '#fbfbfb', // better handing for dark theme
-    navy: '#32363c',
-    lightBlue: '#d7e3ef',
-    white: '#fff',
-    pureWhite: '#fff',
-    tableHeader: '#fbfbfb'
-  },
-  color: {
-    headline: primaryColors.headline,
-    red: '#ca0813',
-    green: '#00b159',
-    yellow: '#fecf2f',
-    border1: '#abadaf',
-    border2: '#c5c6c8',
-    border3: '#eee',
-    borderPagination: '#ccc',
-    grey1: '#abadaf',
-    grey2: '#e7e7e7',
-    grey3: '#ccc',
-    white: '#fff',
-    black: '#222',
-    offBlack: primaryColors.offBlack,
-    boxShadow: '#ddd',
-    focusBorder: '#999',
-    absWhite: '#fff',
-    blueDTwhite: '#3683dc',
-    selectDropDowns: primaryColors.main,
-    borderRow: 'white',
-    tableHeaderText: 'rgba(0, 0, 0, 0.54)',
-    toggleActive: '#606469',
-    diskSpaceBorder: '#f4f4f4',
-    drawerBackdrop: 'rgba(255, 255, 255, 0.5)',
-    label: '#555',
-    disabledText: '#c9cacb'
-  },
-  animateCircleIcon: {
-    ...iconCircleAnimation
-  },
-  notificationList: {
-    padding: '16px 32px 16px 23px',
-    borderBottom: '1px solid #fbfbfb',
-    transition: 'background-color 225ms ease-in-out',
-    '&:hover': {
-      backgroundColor: '#f4f4f4'
-    }
-  },
-  palette: {
-    divider: primaryColors.divider,
-    primary: primaryColors,
-    text: {
-      primary: primaryColors.text
-    },
-    status: {
-      success: '#d7e3ef',
-      successDark: '#3682dd',
-      warning: '#fdf4da',
-      warningDark: '#ffd002',
-      error: '#f8dedf',
-      errorDark: '#cd2227'
-    }
-  },
-  typography: {
-    useNextVariants: true,
-    fontFamily: '"LatoWeb", sans-serif',
-    fontSize: 16,
-    h1: {
-      color: primaryColors.headline,
-      fontSize: '1.25rem',
-      lineHeight: '1.75rem',
-      fontFamily: 'LatoWebBold',
-      [breakpoints.up('lg')]: {
-        fontSize: '1.5rem',
-        lineHeight: '1.875rem'
-      }
-    },
-    h2: {
-      color: primaryColors.headline,
-      fontSize: '1.125rem',
-      fontFamily: 'LatoWebBold',
-      lineHeight: '1.5rem'
-    },
-    h3: {
-      color: primaryColors.headline,
-      fontSize: '1rem',
-      fontFamily: 'LatoWebBold',
-      lineHeight: '1rem'
-    },
-    body1: {
-      fontSize: '0.875rem',
-      lineHeight: '1rem'
-    },
-    body2: {
-      fontSize: '0.875rem',
-      lineHeight: '1rem'
-    },
-    caption: {
-      fontSize: '0.625rem',
-      lineHeight: '0.625rem',
-      color: primaryColors.text
-    },
-    h4: {
-      fontSize: '2.188rem',
-      lineHeight: '2.188rem',
-      color: primaryColors.text,
-      [breakpoints.up('lg')]: {
-        fontSize: '2.5rem',
-        lineHeight: '2.5rem'
-      }
-    }
-  },
-  overrides: {
-    MuiAppBar: {
-      colorDefault: {
-        backgroundColor: 'inherit'
-      }
-    },
-    MuiBackdrop: {
-      root: {
-        backgroundColor: 'rgba(255, 255, 255, 0.8)'
-      }
-    },
-    MuiButton: {
-      label: {
-        position: 'relative'
+    '@keyframes rotate': {
+      from: {
+        transform: 'rotate(0deg)'
       },
-      root: {
-        textTransform: 'inherit',
-        borderRadius: 0,
-        fontSize: '1rem',
-        lineHeight: 1,
-        fontFamily: 'LatoWebBold',
-        color: primaryColors.main,
-        padding: `${spacingUnit * 2}px ${spacingUnit * 3 +
-          spacingUnit / 2}px ${spacingUnit * 2}px`,
-        maxHeight: 48,
-        '&:hover': {
-          backgroundColor: '#fff'
-        },
-        '&:focus': {
-          backgroundColor: 'transparent'
-        },
-        '&[aria-expanded="true"]': {
-          backgroundColor: primaryColors.dark
-        },
-        '&$disabled': {
-          color: '#bbb'
-        },
-        '&.loading': {
-          color: primaryColors.text
-        }
-      },
+      to: {
+        transform: 'rotate(360deg)'
+      }
+    },
+    '@keyframes dash': {
+      to: {
+        'stroke-dashoffset': 0
+      }
+    },
+    bg: {
+      main: '#f4f4f4',
+      offWhite: '#fbfbfb',
+      offWhiteDT: '#fbfbfb', // better handing for dark theme
+      navy: '#32363c',
+      lightBlue: '#d7e3ef',
+      white: '#fff',
+      pureWhite: '#fff',
+      tableHeader: '#fbfbfb'
+    },
+    color: {
+      headline: primaryColors.headline,
+      red: '#ca0813',
+      green: '#00b159',
+      yellow: '#fecf2f',
+      border1: '#abadaf',
+      border2: '#c5c6c8',
+      border3: '#eee',
+      borderPagination: '#ccc',
+      grey1: '#abadaf',
+      grey2: '#e7e7e7',
+      grey3: '#ccc',
+      white: '#fff',
+      black: '#222',
+      offBlack: primaryColors.offBlack,
+      boxShadow: '#ddd',
+      focusBorder: '#999',
+      absWhite: '#fff',
+      blueDTwhite: '#3683dc',
+      selectDropDowns: primaryColors.main,
+      borderRow: 'white',
+      tableHeaderText: 'rgba(0, 0, 0, 0.54)',
+      toggleActive: '#606469',
+      diskSpaceBorder: '#f4f4f4',
+      drawerBackdrop: 'rgba(255, 255, 255, 0.5)',
+      label: '#555',
+      disabledText: '#c9cacb'
+    },
+    animateCircleIcon: {
+      ...iconCircleAnimation
+    },
+    notificationList: {
+      padding: '16px 32px 16px 23px',
+      borderBottom: '1px solid #fbfbfb',
+      transition: 'background-color 225ms ease-in-out',
+      '&:hover': {
+        backgroundColor: '#f4f4f4'
+      }
+    },
+    palette: {
+      divider: primaryColors.divider,
+      primary: primaryColors,
       text: {
-        padding: `${spacingUnit * 2}px ${spacingUnit * 3 +
-          spacingUnit / 2}px ${spacingUnit * 2}px`,
-        '&:hover': {
-          color: primaryColors.light
+        primary: primaryColors.text
+      },
+      status: {
+        success: '#d7e3ef',
+        successDark: '#3682dd',
+        warning: '#fdf4da',
+        warningDark: '#ffd002',
+        error: '#f8dedf',
+        errorDark: '#cd2227'
+      }
+    },
+    typography: {
+      useNextVariants: true,
+      fontFamily: '"LatoWeb", sans-serif',
+      fontSize: 16,
+      h1: {
+        color: primaryColors.headline,
+        fontSize: '1.25rem',
+        lineHeight: '1.75rem',
+        fontFamily: 'LatoWebBold',
+        [breakpoints.up('lg')]: {
+          fontSize: '1.5rem',
+          lineHeight: '1.875rem'
         }
       },
-      flat: {
-        '&.cancel:hover': {
-          backgroundColor: 'transparent'
+      h2: {
+        color: primaryColors.headline,
+        fontSize: '1.125rem',
+        fontFamily: 'LatoWebBold',
+        lineHeight: '1.5rem'
+      },
+      h3: {
+        color: primaryColors.headline,
+        fontSize: '1rem',
+        fontFamily: 'LatoWebBold',
+        lineHeight: '1rem'
+      },
+      body1: {
+        fontSize: '0.875rem',
+        lineHeight: '1rem'
+      },
+      body2: {
+        fontSize: '0.875rem',
+        lineHeight: '1rem'
+      },
+      caption: {
+        fontSize: '0.625rem',
+        lineHeight: '0.625rem',
+        color: primaryColors.text
+      },
+      h4: {
+        fontSize: '2.188rem',
+        lineHeight: '2.188rem',
+        color: primaryColors.text,
+        [breakpoints.up('lg')]: {
+          fontSize: '2.5rem',
+          lineHeight: '2.5rem'
+        }
+      }
+    },
+    overrides: {
+      MuiAppBar: {
+        colorDefault: {
+          backgroundColor: 'inherit'
         }
       },
-      containedPrimary: {
-        '&:hover, &:focus': {
-          backgroundColor: primaryColors.light
+      MuiBackdrop: {
+        root: {
+          backgroundColor: 'rgba(255, 255, 255, 0.8)'
+        }
+      },
+      MuiButton: {
+        label: {
+          position: 'relative'
         },
-        '&:active': {
-          backgroundColor: primaryColors.dark
-        },
-        '&$disabled': {
-          color: 'white'
-        },
-        '&.loading': {
-          backgroundColor: primaryColors.text
-        },
-        '&.cancel': {
-          '&:hover, &:focus': {
-            borderColor: '#222'
+        root: {
+          textTransform: 'inherit',
+          borderRadius: 0,
+          fontSize: '1rem',
+          lineHeight: 1,
+          fontFamily: 'LatoWebBold',
+          color: primaryColors.main,
+          padding: `${spacingUnit * 2}px ${spacingUnit * 3 +
+            spacingUnit / 2}px ${spacingUnit * 2}px`,
+          maxHeight: 48,
+          '&:hover': {
+            backgroundColor: '#fff'
+          },
+          '&:focus': {
+            backgroundColor: 'transparent'
+          },
+          '&[aria-expanded="true"]': {
+            backgroundColor: primaryColors.dark
+          },
+          '&$disabled': {
+            color: '#bbb'
+          },
+          '&.loading': {
+            color: primaryColors.text
           }
-        }
-      },
-      containedSecondary: {
-        backgroundColor: 'transparent',
-        color: primaryColors.main,
-        border: `1px solid ${primaryColors.main}`,
-        padding: `${spacingUnit * 2 - 1}px ${spacingUnit * 3 +
-          spacingUnit / 2}px ${spacingUnit * 2 - 1}px`,
-        transition: 'border 225ms ease-in-out, color 225ms ease-in-out',
-        '&:hover, &:focus': {
-          backgroundColor: 'transparent !important',
-          color: primaryColors.light,
-          borderColor: primaryColors.light
         },
-        '&:active': {
-          backgroundColor: 'transparent',
-          color: primaryColors.dark,
-          borderColor: primaryColors.dark
+        text: {
+          padding: `${spacingUnit * 2}px ${spacingUnit * 3 +
+            spacingUnit / 2}px ${spacingUnit * 2}px`,
+          '&:hover': {
+            color: primaryColors.light
+          }
         },
-        '&$disabled': {
-          borderColor: '#c9cacb',
-          backgroundColor: 'transparent',
-          color: '#c9cacb'
-        },
-        '&.cancel': {
-          borderColor: 'transparent',
-          '&:hover, &:focus': {
-            borderColor: primaryColors.light,
+        flat: {
+          '&.cancel:hover': {
             backgroundColor: 'transparent'
           }
         },
-        '&.destructive': {
-          borderColor: '#c44742',
-          color: '#c44742',
+        containedPrimary: {
           '&:hover, &:focus': {
-            color: '#df6560',
-            borderColor: '#df6560',
-            backgroundColor: 'transparent'
+            backgroundColor: primaryColors.light
           },
           '&:active': {
-            color: '#963530',
-            borderColor: '#963530'
-          }
-        },
-        '&.loading': {
-          borderColor: primaryColors.text,
-          color: primaryColors.text,
-          minWidth: 100,
-          '& svg': {
-            width: 22,
-            height: 22,
-            animation: 'rotate 2s linear infinite'
-          }
-        }
-      }
-    },
-    MuiButtonBase: {
-      root: {
-        fontSize: '1rem'
-      }
-    },
-    MuiCardHeader: {
-      root: {
-        backgroundColor: '#fbfbfb'
-      },
-      content: {
-        // This is necessary for text to ellipsis responsively without the need for a hard set width value that won't play well with flexbox.
-        minWidth: 0
-      }
-    },
-    MuiChip: {
-      root: {
-        backgroundColor: '#f4f4f4',
-        height: 20,
-        display: 'inline-flex',
-        alignItems: 'center',
-        borderRadius: 4,
-        marginTop: 2,
-        marginBottom: 2,
-        marginRight: 4,
-        paddingLeft: 2,
-        paddingRight: 2,
-        color: primaryColors.text,
-        fontSize: '.8rem',
-        '&:last-child': {
-          marginRight: 0
-        },
-        '&:hover': {
-          '& $deleteIcon': {
-            color: primaryColors.white,
-            '&:hover': {
-              color: primaryColors.main,
-              backgroundColor: primaryColors.white
+            backgroundColor: primaryColors.dark
+          },
+          '&$disabled': {
+            color: 'white'
+          },
+          '&.loading': {
+            backgroundColor: primaryColors.text
+          },
+          '&.cancel': {
+            '&:hover, &:focus': {
+              borderColor: '#222'
             }
           }
         },
-        '&:focus': {
-          outline: '1px dotted #999'
-        }
-      },
-      label: {
-        paddingLeft: 4,
-        paddingRight: 4,
-        position: 'relative',
-        top: -1
-      },
-      deleteIcon: {
-        padding: 2,
-        marginLeft: 4,
-        marginRight: 2,
-        color: primaryColors.text,
-        borderRadius: '50%',
-        width: 18,
-        height: 18,
-        '& svg': {
-          width: 12,
-          height: 12,
-          borderRadius: '50%'
-        },
-        [breakpoints.down('xs')]: {
-          marginLeft: 8,
-          marginRight: -8,
-          marginTop: -6,
-          color: 'white !important',
-          '& svg': {
-            width: 20,
-            height: 20,
-            borderRadius: '50%',
-            backgroundColor: primaryColors.main
+        containedSecondary: {
+          backgroundColor: 'transparent',
+          color: primaryColors.main,
+          border: `1px solid ${primaryColors.main}`,
+          padding: `${spacingUnit * 2 - 1}px ${spacingUnit * 3 +
+            spacingUnit / 2}px ${spacingUnit * 2 - 1}px`,
+          transition: 'border 225ms ease-in-out, color 225ms ease-in-out',
+          '&:hover, &:focus': {
+            backgroundColor: 'transparent !important',
+            color: primaryColors.light,
+            borderColor: primaryColors.light
+          },
+          '&:active': {
+            backgroundColor: 'transparent',
+            color: primaryColors.dark,
+            borderColor: primaryColors.dark
+          },
+          '&$disabled': {
+            borderColor: '#c9cacb',
+            backgroundColor: 'transparent',
+            color: '#c9cacb'
+          },
+          '&.cancel': {
+            borderColor: 'transparent',
+            '&:hover, &:focus': {
+              borderColor: primaryColors.light,
+              backgroundColor: 'transparent'
+            }
+          },
+          '&.destructive': {
+            borderColor: '#c44742',
+            color: '#c44742',
+            '&:hover, &:focus': {
+              color: '#df6560',
+              borderColor: '#df6560',
+              backgroundColor: 'transparent'
+            },
+            '&:active': {
+              color: '#963530',
+              borderColor: '#963530'
+            }
+          },
+          '&.loading': {
+            borderColor: primaryColors.text,
+            color: primaryColors.text,
+            minWidth: 100,
+            '& svg': {
+              width: 22,
+              height: 22,
+              animation: 'rotate 2s linear infinite'
+            }
           }
         }
-      }
-    },
-    MuiCircularProgress: {
-      circle: {
-        strokeLinecap: 'inherit'
-      }
-    },
-    MuiCollapse: {
-      container: {
-        width: '100%'
-      }
-    },
-    MuiDialog: {
-      paper: {
-        boxShadow: '0 0 5px #bbb'
-      }
-    },
-    MuiDialogActions: {
-      root: {
-        margin: 0,
-        padding: `0 ${spacingUnit * 3}px, ${spacingUnit * 3}px, ${spacingUnit *
-          3}px`,
-        justifyContent: 'flex-start',
-        '& .actionPanel': {
-          padding: 0
+      },
+      MuiButtonBase: {
+        root: {
+          fontSize: '1rem'
         }
       },
-      action: {
-        margin: 0
-      }
-    },
-    MuiDialogTitle: {
-      root: {
-        borderBottom: '1px solid #eee',
-        marginBottom: spacingUnit * 2 + spacingUnit / 2,
-        '& h2': {
-          color: primaryColors.headline
-        }
-      }
-    },
-    MuiDrawer: {
-      paper: {
-        boxShadow: '0 0 5px #bbb',
-        /** @todo This is breaking typing. */
-        // overflowY: 'overlay',
-        display: 'block',
-        fallbacks: {
-          overflowY: 'auto'
-        }
-      }
-    },
-    MuiExpansionPanel: {
-      root: {
-        '& .actionPanel': {
-          paddingLeft: spacingUnit * 2,
-          paddingRight: spacingUnit * 2
-        },
-        '& table': {
-          border: `1px solid ${primaryColors.divider}`,
-          borderBottom: 0
-        }
-      }
-    },
-    MuiExpansionPanelDetails: {
-      root: {
-        padding: spacingUnit * 2,
-        backgroundColor: 'white'
-      }
-    },
-    MuiExpansionPanelSummary: {
-      root: {
-        '&$focused': {
+      MuiCardHeader: {
+        root: {
           backgroundColor: '#fbfbfb'
         },
-        padding: `0 ${spacingUnit * 2 + 2}px`,
-        backgroundColor: '#fbfbfb',
-        justifyContent: 'flex-start',
-        minHeight: spacingUnit * 6,
-        '& h3': {
-          transition: 'color 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'
-        },
-        '&:hover': {
-          '& h3': {
-            color: primaryColors.light
-          },
-          '& $expandIcon': {
-            '& svg': {
-              fill: primaryColors.light,
-              stroke: 'white'
-            }
-          }
-        },
-        '&:focus': {
-          outline: '1px dotted #999',
-          zIndex: 2
-        },
-        '&$expanded': {
-          minHeight: spacingUnit * 6
+        content: {
+          // This is necessary for text to ellipsis responsively without the need for a hard set width value that won't play well with flexbox.
+          minWidth: 0
         }
       },
-      content: {
-        flexGrow: 0,
-        order: 2,
-        margin: `${spacingUnit + spacingUnit / 2}px 0`,
-        '&$expanded': {
+      MuiChip: {
+        root: {
+          backgroundColor: '#f4f4f4',
+          height: 20,
+          display: 'inline-flex',
+          alignItems: 'center',
+          borderRadius: 4,
+          marginTop: 2,
+          marginBottom: 2,
+          marginRight: 4,
+          paddingLeft: 2,
+          paddingRight: 2,
+          color: primaryColors.text,
+          fontSize: '.8rem',
+          '&:last-child': {
+            marginRight: 0
+          },
+          '&:hover': {
+            '& $deleteIcon': {
+              color: primaryColors.white,
+              '&:hover': {
+                color: primaryColors.main,
+                backgroundColor: primaryColors.white
+              }
+            }
+          },
+          '&:focus': {
+            outline: '1px dotted #999'
+          }
+        },
+        label: {
+          paddingLeft: 4,
+          paddingRight: 4,
+          position: 'relative',
+          top: -1
+        },
+        deleteIcon: {
+          padding: 2,
+          marginLeft: 4,
+          marginRight: 2,
+          color: primaryColors.text,
+          borderRadius: '50%',
+          width: 18,
+          height: 18,
+          '& svg': {
+            width: 12,
+            height: 12,
+            borderRadius: '50%'
+          },
+          [breakpoints.down('xs')]: {
+            marginLeft: 8,
+            marginRight: -8,
+            marginTop: -6,
+            color: 'white !important',
+            '& svg': {
+              width: 20,
+              height: 20,
+              borderRadius: '50%',
+              backgroundColor: primaryColors.main
+            }
+          }
+        }
+      },
+      MuiCircularProgress: {
+        circle: {
+          strokeLinecap: 'inherit'
+        }
+      },
+      MuiCollapse: {
+        container: {
+          width: '100%'
+        }
+      },
+      MuiDialog: {
+        paper: {
+          boxShadow: '0 0 5px #bbb'
+        }
+      },
+      MuiDialogActions: {
+        root: {
+          margin: 0,
+          padding: `0 ${spacingUnit * 3}px, ${spacingUnit *
+            3}px, ${spacingUnit * 3}px`,
+          justifyContent: 'flex-start',
+          '& .actionPanel': {
+            padding: 0
+          }
+        },
+        action: {
           margin: 0
         }
       },
-      expanded: {
-        margin: 0
+      MuiDialogTitle: {
+        root: {
+          borderBottom: '1px solid #eee',
+          marginBottom: spacingUnit * 2 + spacingUnit / 2,
+          '& h2': {
+            color: primaryColors.headline
+          }
+        }
       },
-      expandIcon: {
-        display: 'flex',
-        order: 1,
-        top: 0,
-        right: 0,
-        transform: 'none',
-        color: primaryColors.main,
-        position: 'relative',
-        marginLeft: -spacingUnit * 2,
-        '& svg': {
-          fill: '#fff',
-          transition: `${'stroke 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, '}
+      MuiDrawer: {
+        paper: {
+          boxShadow: '0 0 5px #bbb',
+          /** @todo This is breaking typing. */
+          // overflowY: 'overlay',
+          display: 'block',
+          fallbacks: {
+            overflowY: 'auto'
+          }
+        }
+      },
+      MuiExpansionPanel: {
+        root: {
+          '& .actionPanel': {
+            paddingLeft: spacingUnit * 2,
+            paddingRight: spacingUnit * 2
+          },
+          '& table': {
+            border: `1px solid ${primaryColors.divider}`,
+            borderBottom: 0
+          }
+        }
+      },
+      MuiExpansionPanelDetails: {
+        root: {
+          padding: spacingUnit * 2,
+          backgroundColor: 'white'
+        }
+      },
+      MuiExpansionPanelSummary: {
+        root: {
+          '&$focused': {
+            backgroundColor: '#fbfbfb'
+          },
+          padding: `0 ${spacingUnit * 2 + 2}px`,
+          backgroundColor: '#fbfbfb',
+          justifyContent: 'flex-start',
+          minHeight: spacingUnit * 6,
+          '& h3': {
+            transition: 'color 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'
+          },
+          '&:hover': {
+            '& h3': {
+              color: primaryColors.light
+            },
+            '& $expandIcon': {
+              '& svg': {
+                fill: primaryColors.light,
+                stroke: 'white'
+              }
+            }
+          },
+          '&:focus': {
+            outline: '1px dotted #999',
+            zIndex: 2
+          },
+          '&$expanded': {
+            minHeight: spacingUnit * 6
+          }
+        },
+        content: {
+          flexGrow: 0,
+          order: 2,
+          margin: `${spacingUnit + spacingUnit / 2}px 0`,
+          '&$expanded': {
+            margin: 0
+          }
+        },
+        expanded: {
+          margin: 0
+        },
+        expandIcon: {
+          display: 'flex',
+          order: 1,
+          top: 0,
+          right: 0,
+          transform: 'none',
+          color: primaryColors.main,
+          position: 'relative',
+          marginLeft: -spacingUnit * 2,
+          '& svg': {
+            fill: '#fff',
+            transition: `${'stroke 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms, '}
             ${'fill 400ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'}`,
-          width: 22,
-          height: 22
+            width: 22,
+            height: 22
+          },
+          '& .border': {
+            stroke: `${primaryColors.light} !important`
+          },
+          '&$expanded': {
+            transform: 'none'
+          }
         },
-        '& .border': {
-          stroke: `${primaryColors.light} !important`
+        focused: {}
+      },
+      MuiFormControl: {
+        root: {
+          marginTop: spacingUnit * 2,
+          minWidth: 120,
+          '&.copy > div': {
+            backgroundColor: '#f4f4f4'
+          },
+          [breakpoints.down('xs')]: {
+            width: '100%'
+          }
+        }
+      },
+      MuiFormControlLabel: {
+        root: {
+          marginLeft: -11
+        }
+      },
+      MuiFormLabel: {
+        root: {
+          color: '#555',
+          fontFamily: 'LatoWebBold',
+          fontSize: '.9rem',
+          marginBottom: 2,
+          '&$focused': {
+            color: '#555'
+          },
+          '&$error': {
+            color: '#555'
+          },
+          '&$disabled': {
+            color: '#555',
+            opacity: 0.5
+          }
+        }
+      },
+      MuiFormHelperText: {
+        root: {
+          '&$error': {
+            color: '#ca0813'
+          }
+        }
+      },
+      MuiIconButton: {
+        root: {
+          padding: spacingUnit + spacingUnit / 2,
+          color: primaryColors.main,
+          '&:hover': {
+            color: primaryColors.light,
+            backgroundColor: 'transparent'
+          }
+        }
+      },
+      MuiRadio: {
+        root: {
+          '& $checked': {
+            color: primaryColors.main
+          },
+          color: primaryColors.main
         },
-        '&$expanded': {
+        checked: {},
+        colorSecondary: {
+          color: primaryColors.main,
+          '&$checked': {
+            color: primaryColors.main
+          }
+        }
+      },
+      MuiInput: {
+        root: {
+          '&$disabled': {
+            borderColor: '#ccc',
+            color: '#ccc',
+            opacity: 0.5
+          },
+          '&$focused': {
+            borderColor: primaryColors.main,
+            boxShadow: '0 0 2px 1px #e1edfa'
+          },
+          maxWidth: 415,
+          border: '1px solid #ccc',
+          alignItems: 'center',
+          transition: 'border-color 225ms ease-in-out',
+          lineHeight: 1,
+          minHeight: spacingUnit * 6,
+          color: primaryColors.text,
+          boxSizing: 'border-box',
+          backgroundColor: '#fff',
+          [breakpoints.down('xs')]: {
+            maxWidth: '100%',
+            width: '100%'
+          },
+          '& svg': {
+            fontSize: 18,
+            color: primaryColors.main,
+            '&:hover': {
+              color: '#5e9aea'
+            }
+          },
+          '&.affirmative': {
+            borderColor: '#00b159'
+          }
+        },
+        inputMultiline: {
+          minHeight: 125,
+          padding: `${spacingUnit + 1}px ${spacingUnit * 2 -
+            spacingUnit / 2}px`,
+          lineHeight: 1.4
+        },
+        focused: {},
+        error: {
+          borderColor: '#ca0813'
+        },
+        disabled: {},
+        input: {
+          padding: `${spacingUnit * 2 - spacingUnit / 2}px ${spacingUnit * 2 -
+            spacingUnit / 2}px ${spacingUnit * 2 - spacingUnit / 2 + 1}px`,
+          fontSize: '.9rem',
+          boxSizing: 'border-box'
+        },
+        inputType: {
+          height: 'auto'
+        },
+        formControl: {
+          'label + &': {
+            marginTop: 0
+          }
+        }
+      },
+      MuiInputAdornment: {
+        root: {
+          fontSize: '.9rem',
+          color: '#606469',
+          whiteSpace: 'nowrap',
+          '& p': {
+            fontSize: '.9rem',
+            color: '#606469'
+          }
+        },
+        positionEnd: {
+          marginRight: spacingUnit + 2
+        }
+      },
+      MuiInputLabel: {
+        formControl: {
+          position: 'relative'
+        },
+        shrink: {
           transform: 'none'
         }
       },
-      focused: {}
-    },
-    MuiFormControl: {
-      root: {
-        marginTop: spacingUnit * 2,
-        minWidth: 120,
-        '&.copy > div': {
-          backgroundColor: '#f4f4f4'
+      MuiList: {
+        padding: {
+          paddingTop: 0,
+          paddingBottom: 0
         },
-        [breakpoints.down('xs')]: {
-          width: '100%'
-        }
-      }
-    },
-    MuiFormControlLabel: {
-      root: {
-        marginLeft: -11
-      }
-    },
-    MuiFormLabel: {
-      root: {
-        color: '#555',
-        fontFamily: 'LatoWebBold',
-        fontSize: '.9rem',
-        marginBottom: 2,
-        '&$focused': {
-          color: '#555'
-        },
-        '&$error': {
-          color: '#555'
-        },
-        '&$disabled': {
-          color: '#555',
-          opacity: 0.5
-        }
-      }
-    },
-    MuiFormHelperText: {
-      root: {
-        '&$error': {
-          color: '#ca0813'
-        }
-      }
-    },
-    MuiIconButton: {
-      root: {
-        padding: spacingUnit + spacingUnit / 2,
-        color: primaryColors.main,
-        '&:hover': {
-          color: primaryColors.light,
-          backgroundColor: 'transparent'
-        }
-      }
-    },
-    MuiRadio: {
-      root: {
-        '& $checked': {
-          color: primaryColors.main
-        },
-        color: primaryColors.main
-      },
-      checked: {},
-      colorSecondary: {
-        color: primaryColors.main,
-        '&$checked': {
-          color: primaryColors.main
-        }
-      }
-    },
-    MuiInput: {
-      root: {
-        '&$disabled': {
-          borderColor: '#ccc',
-          color: '#ccc',
-          opacity: 0.5
-        },
-        '&$focused': {
-          borderColor: primaryColors.main,
-          boxShadow: '0 0 2px 1px #e1edfa'
-        },
-        maxWidth: 415,
-        border: '1px solid #ccc',
-        alignItems: 'center',
-        transition: 'border-color 225ms ease-in-out',
-        lineHeight: 1,
-        minHeight: spacingUnit * 6,
-        color: primaryColors.text,
-        boxSizing: 'border-box',
-        backgroundColor: '#fff',
-        [breakpoints.down('xs')]: {
-          maxWidth: '100%',
-          width: '100%'
-        },
-        '& svg': {
-          fontSize: 18,
-          color: primaryColors.main,
-          '&:hover': {
-            color: '#5e9aea'
-          }
-        },
-        '&.affirmative': {
-          borderColor: '#00b159'
-        }
-      },
-      inputMultiline: {
-        minHeight: 125,
-        padding: `${spacingUnit + 1}px ${spacingUnit * 2 - spacingUnit / 2}px`,
-        lineHeight: 1.4
-      },
-      focused: {},
-      error: {
-        borderColor: '#ca0813'
-      },
-      disabled: {},
-      input: {
-        padding: `${spacingUnit * 2 - spacingUnit / 2}px ${spacingUnit * 2 -
-          spacingUnit / 2}px ${spacingUnit * 2 - spacingUnit / 2 + 1}px`,
-        fontSize: '.9rem',
-        boxSizing: 'border-box'
-      },
-      inputType: {
-        height: 'auto'
-      },
-      formControl: {
-        'label + &': {
-          marginTop: 0
-        }
-      }
-    },
-    MuiInputAdornment: {
-      root: {
-        fontSize: '.9rem',
-        color: '#606469',
-        whiteSpace: 'nowrap',
-        '& p': {
-          fontSize: '.9rem',
-          color: '#606469'
-        }
-      },
-      positionEnd: {
-        marginRight: spacingUnit + 2
-      }
-    },
-    MuiInputLabel: {
-      formControl: {
-        position: 'relative'
-      },
-      shrink: {
-        transform: 'none'
-      }
-    },
-    MuiList: {
-      padding: {
-        paddingTop: 0,
-        paddingBottom: 0
-      },
-      root: {
-        '&.reset': {
-          padding: 'inherit',
-          margin: 'inherit',
-          listStyle: 'initial',
-          '& li': {
-            display: 'list-item',
-            padding: 0,
-            listStyleType: 'initial'
+        root: {
+          '&.reset': {
+            padding: 'inherit',
+            margin: 'inherit',
+            listStyle: 'initial',
+            '& li': {
+              display: 'list-item',
+              padding: 0,
+              listStyleType: 'initial'
+            }
           }
         }
-      }
-    },
-    MuiListItem: {
-      root: {
-        color: primaryColors.text,
-        '&$disabled': {
-          opacity: 0.5
-        },
-        '&$selected, &$selected:hover': {
-          backgroundColor: 'transparent',
-          color: primaryColors.main
-        },
+      },
+      MuiListItem: {
+        root: {
+          color: primaryColors.text,
+          '&$disabled': {
+            opacity: 0.5
+          },
+          '&$selected, &$selected:hover': {
+            backgroundColor: 'transparent',
+            color: primaryColors.main
+          },
 
-        '&.selectHeader': {
-          opacity: 1,
-          fontFamily: 'LatoWebBold',
-          fontSize: '1rem',
-          color: primaryColors.text
-        }
-      },
-      disabled: {},
-      selected: {}
-    },
-    MuiListItemText: {
-      secondary: {
-        marginTop: spacingUnit / 2,
-        lineHeight: '1.2em'
-      }
-    },
-    MuiMenu: {
-      paper: {
-        maxWidth: 350,
-        '&.selectMenuDropdown': {
-          boxShadow: 'none',
-          position: 'absolute',
-          boxSizing: 'content-box',
-          border: `1px solid ${primaryColors.main}`,
-          margin: '0 0 0 -1px',
-          outline: 0,
-          borderRadius: 0
-        },
-        '& .selectMenuList': {
-          maxHeight: 250,
-          overflowY: 'auto',
-          overflowX: 'hidden',
-          boxSizing: 'content-box',
-          padding: spacingUnit / 2,
-          '& li': {
-            paddingLeft: spacingUnit + 2,
-            paddingRight: spacingUnit + 2
-          },
-          [breakpoints.down('xs')]: {
-            minWidth: 200
-          }
-        }
-      }
-    },
-    MuiMenuItem: {
-      root: {
-        height: 'auto',
-        fontFamily: 'LatoWeb',
-        fontSize: '.9rem',
-        whiteSpace: 'initial',
-        textOverflow: 'initial',
-        color: primaryColors.text,
-        transition: `${'background-color 150ms cubic-bezier(0.4, 0, 0.2, 1), '}
-        ${'color .2s cubic-bezier(0.4, 0, 0.2, 1)'}`,
-        '&$selected, &$selected:hover': {
-          backgroundColor: 'transparent',
-          color: primaryColors.main,
-          opacity: 1
-        },
-        '&:hover': {
-          backgroundColor: primaryColors.main,
-          color: 'white'
-        },
-        '& em': {
-          fontStyle: 'normal !important'
-        }
-      },
-      selected: {}
-    },
-    MuiPaper: {
-      rounded: {
-        borderRadius: 0
-      }
-    },
-    MuiPopover: {
-      paper: {
-        boxShadow: '0 0 5px #ddd',
-        borderRadius: 0,
-        minWidth: 200,
-        [breakpoints.up('lg')]: {
-          minWidth: 250
-        }
-      }
-    },
-    MuiSelect: {
-      selectMenu: {
-        '&$disabled': {
-          '&+ input + $icon': {
-            opacity: '.5'
-          }
-        },
-        padding: `${spacingUnit * 2}px ${spacingUnit * 4}px ${spacingUnit *
-          2}px ${spacingUnit + 4}px`,
-        color: primaryColors.text,
-        backgroundColor: '#fff',
-        lineHeight: 1,
-        minHeight: spacingUnit * 6 - 2,
-        minWidth: 150,
-        '&:focus': {
-          backgroundColor: '#fff'
-        },
-        '& em': {
-          fontStyle: 'normal'
-        }
-      },
-      select: {
-        '&[aria-pressed="true"]': {
-          '&+ input + $icon': {
-            opacity: 1
-          }
-        }
-      },
-      icon: {
-        marginTop: -2,
-        marginRight: 4,
-        width: 28,
-        height: 28,
-        transition: 'color 225ms ease-in-out',
-        color: '#aaa !important',
-        opacity: 0.5
-      },
-      disabled: {}
-    },
-    MuiSnackbar: {
-      root: {}
-    },
-    MuiSnackbarContent: {
-      root: {
-        boxShadow: '0 0 5px #ddd',
-        color: '#606469',
-        backgroundColor: 'white',
-        borderLeft: `6px solid transparent`,
-        borderRadius: 0,
-        [breakpoints.up('md')]: {
-          borderRadius: 0
-        }
-      }
-    },
-    MuiSwitch: {
-      root: {
-        '& $checked': {
-          transform: 'translateX(20px)',
-          color: `${primaryColors.main} !important`,
-          '& input': {
-            left: -20
-          },
-          '& .square': {
-            fill: 'white'
-          },
-          '& + $bar': {
+          '&.selectHeader': {
             opacity: 1,
-            backgroundColor: '#f4f4f4'
+            fontFamily: 'LatoWebBold',
+            fontSize: '1rem',
+            color: primaryColors.text
           }
         },
-        '& $disabled': {
-          '&$switchBase': {
-            opacity: 0.5,
-            '& + $bar': {
-              backgroundColor: '#ddd',
-              borderColor: '#ccc'
+        disabled: {},
+        selected: {}
+      },
+      MuiListItemText: {
+        secondary: {
+          marginTop: spacingUnit / 2,
+          lineHeight: '1.2em'
+        }
+      },
+      MuiMenu: {
+        paper: {
+          maxWidth: 350,
+          '&.selectMenuDropdown': {
+            boxShadow: 'none',
+            position: 'absolute',
+            boxSizing: 'content-box',
+            border: `1px solid ${primaryColors.main}`,
+            margin: '0 0 0 -1px',
+            outline: 0,
+            borderRadius: 0
+          },
+          '& .selectMenuList': {
+            maxHeight: 250,
+            overflowY: 'auto',
+            overflowX: 'hidden',
+            boxSizing: 'content-box',
+            padding: spacingUnit / 2,
+            '& li': {
+              paddingLeft: spacingUnit + 2,
+              paddingRight: spacingUnit + 2
             },
-            '& .square': {
-              fill: 'white'
+            [breakpoints.down('xs')]: {
+              minWidth: 200
+            }
+          }
+        }
+      },
+      MuiMenuItem: {
+        root: {
+          height: 'auto',
+          fontFamily: 'LatoWeb',
+          fontSize: '.9rem',
+          whiteSpace: 'initial',
+          textOverflow: 'initial',
+          color: primaryColors.text,
+          transition: `${'background-color 150ms cubic-bezier(0.4, 0, 0.2, 1), '}
+        ${'color .2s cubic-bezier(0.4, 0, 0.2, 1)'}`,
+          '&$selected, &$selected:hover': {
+            backgroundColor: 'transparent',
+            color: primaryColors.main,
+            opacity: 1
+          },
+          '&:hover': {
+            backgroundColor: primaryColors.main,
+            color: 'white'
+          },
+          '& em': {
+            fontStyle: 'normal !important'
+          }
+        },
+        selected: {}
+      },
+      MuiPaper: {
+        rounded: {
+          borderRadius: 0
+        }
+      },
+      MuiPopover: {
+        paper: {
+          boxShadow: '0 0 5px #ddd',
+          borderRadius: 0,
+          minWidth: 200,
+          [breakpoints.up('lg')]: {
+            minWidth: 250
+          }
+        }
+      },
+      MuiSelect: {
+        selectMenu: {
+          '&$disabled': {
+            '&+ input + $icon': {
+              opacity: '.5'
+            }
+          },
+          padding: `${spacingUnit * 2}px ${spacingUnit * 4}px ${spacingUnit *
+            2}px ${spacingUnit + 4}px`,
+          color: primaryColors.text,
+          backgroundColor: '#fff',
+          lineHeight: 1,
+          minHeight: spacingUnit * 6 - 2,
+          minWidth: 150,
+          '&:focus': {
+            backgroundColor: '#fff'
+          },
+          '& em': {
+            fontStyle: 'normal'
+          }
+        },
+        select: {
+          '&[aria-pressed="true"]': {
+            '&+ input + $icon': {
+              opacity: 1
             }
           }
         },
-        '& .icon': {
-          transition: 'transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-          position: 'relative',
-          left: 0,
-          width: 16,
-          height: 16,
-          borderRadius: 0
+        icon: {
+          marginTop: -2,
+          marginRight: 4,
+          width: 28,
+          height: 28,
+          transition: 'color 225ms ease-in-out',
+          color: '#aaa !important',
+          opacity: 0.5
         },
-        '& .square': {
-          transition: 'fill 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'
-        },
-        '&:hover, &:focus': {
+        disabled: {}
+      },
+      MuiSnackbar: {
+        root: {}
+      },
+      MuiSnackbarContent: {
+        root: {
+          boxShadow: '0 0 5px #ddd',
+          color: '#606469',
+          backgroundColor: 'white',
+          borderLeft: `6px solid transparent`,
+          borderRadius: 0,
+          [breakpoints.up('md')]: {
+            borderRadius: 0
+          }
+        }
+      },
+      MuiSwitch: {
+        root: {
+          '& $checked': {
+            transform: 'translateX(20px)',
+            color: `${primaryColors.main} !important`,
+            '& input': {
+              left: -20
+            },
+            '& .square': {
+              fill: 'white'
+            },
+            '& + $bar': {
+              opacity: 1,
+              backgroundColor: '#f4f4f4'
+            }
+          },
           '& $disabled': {
             '&$switchBase': {
               opacity: 0.5,
               '& + $bar': {
                 backgroundColor: '#ddd',
                 borderColor: '#ccc'
+              },
+              '& .square': {
+                fill: 'white'
               }
             }
           },
-          '& $bar, & + $bar': {
-            borderColor: '#606469'
+          '& .icon': {
+            transition: 'transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
+            position: 'relative',
+            left: 0,
+            width: 16,
+            height: 16,
+            borderRadius: 0
           },
           '& .square': {
-            fill: '#aaa'
+            transition: 'fill 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'
           },
-          '& $checked': {
+          '&:hover, &:focus': {
+            '& $disabled': {
+              '&$switchBase': {
+                opacity: 0.5,
+                '& + $bar': {
+                  backgroundColor: '#ddd',
+                  borderColor: '#ccc'
+                }
+              }
+            },
+            '& $bar, & + $bar': {
+              borderColor: '#606469'
+            },
             '& .square': {
-              fill: '#eee'
+              fill: '#aaa'
+            },
+            '& $checked': {
+              '& .square': {
+                fill: '#eee'
+              }
             }
           }
-        }
-      },
-      disabled: {},
-      checked: {},
-      bar: {
-        top: 12,
-        left: 12,
-        marginLeft: 0,
-        marginTop: 0,
-        width: 42,
-        height: 22,
-        borderRadius: 0,
-        backgroundColor: '#f4f4f4',
-        border: '1px solid #999',
-        boxSizing: 'content-box',
-        transition: 'border 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'
-      },
-      switchBase: {
-        color: primaryColors.main
-      }
-    },
-    MuiTab: {
-      root: {
-        color: 'rgba(0, 0, 0, 0.54)',
-        minWidth: 50,
-        textTransform: 'inherit',
-        padding: '6px 16px',
-        position: 'relative',
-        overflow: 'hidden',
-        maxWidth: '264',
-        boxSizing: 'border-box',
-        minHeight: spacingUnit * 6,
-        flexShrink: 0,
-        display: 'inline-flex',
-        alignItems: 'center',
-        verticalAlign: 'middle',
-        justifyContent: 'center',
-        appearance: 'none',
-        margin: 1,
-        [breakpoints.up('md')]: {
-          minWidth: 75
         },
-        '&$selected, &$selected:hover': {
-          fontFamily: 'LatoWebBold',
-          color: primaryColors.headline
+        disabled: {},
+        checked: {},
+        bar: {
+          top: 12,
+          left: 12,
+          marginLeft: 0,
+          marginTop: 0,
+          width: 42,
+          height: 22,
+          borderRadius: 0,
+          backgroundColor: '#f4f4f4',
+          border: '1px solid #999',
+          boxSizing: 'content-box',
+          transition: 'border 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms'
         },
-        '&:hover': {
+        switchBase: {
           color: primaryColors.main
         }
       },
-      label: {
-        [breakpoints.up('md')]: {
-          fontSize: '1rem'
+      MuiTab: {
+        root: {
+          color: 'rgba(0, 0, 0, 0.54)',
+          minWidth: 50,
+          textTransform: 'inherit',
+          padding: '6px 16px',
+          position: 'relative',
+          overflow: 'hidden',
+          maxWidth: '264',
+          boxSizing: 'border-box',
+          minHeight: spacingUnit * 6,
+          flexShrink: 0,
+          display: 'inline-flex',
+          alignItems: 'center',
+          verticalAlign: 'middle',
+          justifyContent: 'center',
+          appearance: 'none',
+          margin: 1,
+          [breakpoints.up('md')]: {
+            minWidth: 75
+          },
+          '&$selected, &$selected:hover': {
+            fontFamily: 'LatoWebBold',
+            color: primaryColors.headline
+          },
+          '&:hover': {
+            color: primaryColors.main
+          }
+        },
+        label: {
+          [breakpoints.up('md')]: {
+            fontSize: '1rem'
+          }
+        },
+        labelContainer: {
+          padding: `${spacingUnit - 2}px 0`,
+          [breakpoints.up('md')]: {
+            padding: `${spacingUnit - 2}px 0`
+          }
+        },
+        textColorPrimary: {
+          '&$selected': {
+            color: '#32363c'
+          }
+        },
+        selected: {}
+      },
+      MuiTable: {
+        root: {
+          borderCollapse: 'initial'
         }
       },
-      labelContainer: {
-        padding: `${spacingUnit - 2}px 0`,
-        [breakpoints.up('md')]: {
-          padding: `${spacingUnit - 2}px 0`
+      MuiTableCell: {
+        root: {
+          padding: spacingUnit + 2,
+          borderBottom: `2px solid ${primaryColors.divider}`,
+          '&:last-child': {
+            paddingRight: spacingUnit + 2
+          }
+        },
+        head: {
+          fontSize: '.9rem'
+        },
+        body: {
+          fontSize: '.9rem'
         }
       },
-      textColorPrimary: {
-        '&$selected': {
-          color: '#32363c'
-        }
-      },
-      selected: {}
-    },
-    MuiTable: {
-      root: {
-        borderCollapse: 'initial'
-      }
-    },
-    MuiTableCell: {
-      root: {
-        padding: spacingUnit + 2,
-        borderBottom: `2px solid ${primaryColors.divider}`,
-        '&:last-child': {
-          paddingRight: spacingUnit + 2
-        }
-      },
-      head: {
-        fontSize: '.9rem'
-      },
-      body: {
-        fontSize: '.9rem'
-      }
-    },
-    MuiTabs: {
-      root: {
-        margin: `${spacingUnit * 2}px 0`,
-        boxShadow: 'inset 0 -1px 0 #c5c6c8',
-        minHeight: spacingUnit * 6
-      },
-      fixed: {
-        overflowX: 'auto'
-      },
-      flexContainer: {
-        position: 'relative',
-        '& $scrollButtons:first-child': {
-          position: 'absolute',
-          bottom: 6,
-          zIndex: 2,
-          '& svg': {
-            backgroundColor: 'rgba(232, 232, 232, .9)',
-            height: 39,
-            width: 38,
-            padding: '7px 4px',
-            borderRadius: '50%'
+      MuiTabs: {
+        root: {
+          margin: `${spacingUnit * 2}px 0`,
+          boxShadow: 'inset 0 -1px 0 #c5c6c8',
+          minHeight: spacingUnit * 6
+        },
+        fixed: {
+          overflowX: 'auto'
+        },
+        flexContainer: {
+          position: 'relative',
+          '& $scrollButtons:first-child': {
+            position: 'absolute',
+            bottom: 6,
+            zIndex: 2,
+            '& svg': {
+              backgroundColor: 'rgba(232, 232, 232, .9)',
+              height: 39,
+              width: 38,
+              padding: '7px 4px',
+              borderRadius: '50%'
+            }
+          }
+        },
+        scrollButtons: {
+          flex: '0 0 40px'
+        },
+        indicator: {
+          primary: {
+            backgroundColor: primaryColors.main
+          },
+          secondary: {
+            backgroundColor: primaryColors.main
           }
         }
       },
-      scrollButtons: {
-        flex: '0 0 40px'
-      },
-      indicator: {
-        primary: {
-          backgroundColor: primaryColors.main
+      MuiTableRow: {
+        root: {
+          backgroundColor: primaryColors.white,
+          backfaceVisibility: 'hidden',
+          position: 'relative',
+          zIndex: 1,
+          height: spacingUnit * 6,
+          '&:before': {
+            borderLeftColor: 'white'
+          },
+          '&:hover': {
+            '&$hover': {
+              backgroundColor: '#fbfbfb',
+              '&:before': {
+                backgroundColor: primaryColors.main
+              }
+            }
+          }
         },
-        secondary: {
-          backgroundColor: primaryColors.main
-        }
-      }
-    },
-    MuiTableRow: {
-      root: {
-        backgroundColor: primaryColors.white,
-        backfaceVisibility: 'hidden',
-        position: 'relative',
-        zIndex: 1,
-        height: spacingUnit * 6,
-        '&:before': {
-          borderLeftColor: 'white'
+        head: {
+          height: 'auto',
+          backgroundColor: '#fbfbfb',
+          '&:before': {
+            borderLeftColor: '#fbfbfb'
+          }
         },
-        '&:hover': {
-          '&$hover': {
-            backgroundColor: '#fbfbfb',
-            '&:before': {
-              backgroundColor: primaryColors.main
+        hover: {
+          cursor: 'pointer',
+          '& a.secondaryLink': {
+            color: primaryColors.main,
+            '&:hover': {
+              textDecoration: 'underline'
             }
           }
         }
       },
-      head: {
-        height: 'auto',
-        backgroundColor: '#fbfbfb',
-        '&:before': {
-          borderLeftColor: '#fbfbfb'
-        }
-      },
-      hover: {
-        cursor: 'pointer',
-        '& a.secondaryLink': {
+      MuiTableSortLabel: {
+        root: {
+          fontSize: '.9rem',
+          transition: 'color 225ms ease-in-out',
+          '&:hover': {
+            color: primaryColors.main
+          },
+          '&:focus': {
+            outline: '1px dotted #999'
+          }
+        },
+        active: {
           color: primaryColors.main,
           '&:hover': {
-            textDecoration: 'underline'
+            color: primaryColors.main
           }
-        }
-      }
-    },
-    MuiTableSortLabel: {
-      root: {
-        fontSize: '.9rem',
-        transition: 'color 225ms ease-in-out',
-        '&:hover': {
-          color: primaryColors.main
         },
-        '&:focus': {
-          outline: '1px dotted #999'
+        icon: {
+          opacity: 1,
+          marginTop: 2
         }
       },
-      active: {
-        color: primaryColors.main,
-        '&:hover': {
-          color: primaryColors.main
-        }
-      },
-      icon: {
-        opacity: 1,
-        marginTop: 2
-      }
-    },
-    MuiTooltip: {
-      popper: {
-        opacity: 1
-      },
-      tooltip: {
-        borderRadius: 0,
-        maxWidth: 200,
-        backgroundColor: 'white',
-        boxShadow: '0 0 5px #bbb',
-        color: '#606469',
-        textAlign: 'left',
-        [breakpoints.up('sm')]: {
-          padding: '8px 10px',
-          fontSize: '.9rem'
+      MuiTooltip: {
+        popper: {
+          opacity: 1
+        },
+        tooltip: {
+          borderRadius: 0,
+          maxWidth: 200,
+          backgroundColor: 'white',
+          boxShadow: '0 0 5px #bbb',
+          color: '#606469',
+          textAlign: 'left',
+          [breakpoints.up('sm')]: {
+            padding: '8px 10px',
+            fontSize: '.9rem'
+          }
         }
       }
     }
-  }
+  };
 };
 
 export default (options: ThemeOptions) =>
-  createMuiTheme(mergeDeepRight(themeDefaults, options));
+  createMuiTheme(
+    mergeDeepRight(
+      themeDefaults({
+        spacing: spacingStorage.get()
+      }),
+      options
+    )
+  );

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -564,7 +564,7 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
           order: 2,
           margin: `${spacingUnit + spacingUnit / 2}px 0`,
           '&$expanded': {
-            margin: 0
+            margin: `${spacingUnit + spacingUnit / 2}px 0`
           }
         },
         expanded: {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -3,9 +3,10 @@ import createTheme from './themeFactory';
 
 const breakpoints = createBreakpoints({});
 
-export const light = createTheme({
-  name: 'lightTheme'
-});
+export const light = () =>
+  createTheme({
+    name: 'lightTheme'
+  });
 
 const primaryColors = {
   main: '#3683dc',
@@ -35,494 +36,495 @@ const iconCircleAnimation = {
   }
 };
 
-export const dark = createTheme({
-  name: 'darkTheme',
-  breakpoints,
-  '@keyframes rotate': {
-    from: {
-      transform: 'rotate(0deg)'
-    },
-    to: {
-      transform: 'rotate(360deg)'
-    }
-  },
-  '@keyframes dash': {
-    to: {
-      'stroke-dashoffset': 0
-    }
-  },
-  bg: {
-    main: '#2f3236',
-    offWhite: '#111111',
-    offWhiteDT: '#444', // better handing for dark theme
-    navy: '#32363c',
-    lightBlue: '#222',
-    white: '#32363c',
-    pureWhite: '#000',
-    tableHeader: 'rgba(0, 0, 0, 0.15)'
-  },
-  color: {
-    headline: primaryColors.headline,
-    red: '#ca0813',
-    green: '#00b159',
-    yellow: '#fecf2f',
-    border1: '#000',
-    border2: '#111',
-    border3: '#222',
-    borderPagination: '#222222',
-    grey1: '#abadaf',
-    grey2: 'rgba(0, 0, 0, 0.2)',
-    grey3: '#999',
-    white: '#32363c',
-    black: '#fff',
-    offBlack: primaryColors.offBlack,
-    boxShadow: '#222',
-    focusBorder: '#999',
-    absWhite: '#000',
-    blueDTwhite: '#fff',
-    selectDropDowns: primaryColors.main,
-    borderRow: 'rgba(0, 0, 0, 0.15)',
-    tableHeaderText: '#fff',
-    toggleActive: '#444',
-    diskSpaceBorder: '#222222',
-    drawerBackdrop: 'rgba(0, 0, 0, 0.5)',
-    label: '#c9cacb',
-    disabledText: '#c9cacb'
-  },
-  animateCircleIcon: {
-    ...iconCircleAnimation
-  },
-  notificationList: {
-    borderBottom: '1px solid #f4f4f4',
-    '&:hover': {
-      backgroundColor: '#111111'
-    }
-  },
-  palette: {
-    divider: primaryColors.divider,
-    primary: primaryColors,
-    text: {
-      primary: primaryColors.text
-    }
-  },
-  typography: {
-    h1: {
-      color: primaryColors.headline
-    },
-    h2: {
-      color: primaryColors.headline
-    },
-    h3: {
-      color: primaryColors.headline
-    },
-    caption: {
-      color: primaryColors.text
-    },
-    h4: {
-      color: primaryColors.text
-    }
-  },
-  overrides: {
-    MuiAppBar: {
-      colorDefault: {
-        backgroundColor: 'transparent'
+export const dark = () =>
+  createTheme({
+    name: 'darkTheme',
+    breakpoints,
+    '@keyframes rotate': {
+      from: {
+        transform: 'rotate(0deg)'
+      },
+      to: {
+        transform: 'rotate(360deg)'
       }
     },
-    MuiBackdrop: {
-      root: {
-        backgroundColor: 'rgba(0, 0, 0, 0.5)'
+    '@keyframes dash': {
+      to: {
+        'stroke-dashoffset': 0
       }
     },
-    MuiButton: {
-      label: {
-        position: 'relative'
-      },
-      root: {
-        color: primaryColors.main,
-        '&:hover': {
-          backgroundColor: '#000'
-        },
-        '&[aria-expanded="true"]': {
-          backgroundColor: primaryColors.dark
-        },
-        '&$disabled': {
-          color: '#888'
-        },
-        '&.loading': {
-          color: primaryColors.text
-        }
-      },
+    bg: {
+      main: '#2f3236',
+      offWhite: '#111111',
+      offWhiteDT: '#444', // better handing for dark theme
+      navy: '#32363c',
+      lightBlue: '#222',
+      white: '#32363c',
+      pureWhite: '#000',
+      tableHeader: 'rgba(0, 0, 0, 0.15)'
+    },
+    color: {
+      headline: primaryColors.headline,
+      red: '#ca0813',
+      green: '#00b159',
+      yellow: '#fecf2f',
+      border1: '#000',
+      border2: '#111',
+      border3: '#222',
+      borderPagination: '#222222',
+      grey1: '#abadaf',
+      grey2: 'rgba(0, 0, 0, 0.2)',
+      grey3: '#999',
+      white: '#32363c',
+      black: '#fff',
+      offBlack: primaryColors.offBlack,
+      boxShadow: '#222',
+      focusBorder: '#999',
+      absWhite: '#000',
+      blueDTwhite: '#fff',
+      selectDropDowns: primaryColors.main,
+      borderRow: 'rgba(0, 0, 0, 0.15)',
+      tableHeaderText: '#fff',
+      toggleActive: '#444',
+      diskSpaceBorder: '#222222',
+      drawerBackdrop: 'rgba(0, 0, 0, 0.5)',
+      label: '#c9cacb',
+      disabledText: '#c9cacb'
+    },
+    animateCircleIcon: {
+      ...iconCircleAnimation
+    },
+    notificationList: {
+      borderBottom: '1px solid #f4f4f4',
+      '&:hover': {
+        backgroundColor: '#111111'
+      }
+    },
+    palette: {
+      divider: primaryColors.divider,
+      primary: primaryColors,
       text: {
-        '&:hover': {
+        primary: primaryColors.text
+      }
+    },
+    typography: {
+      h1: {
+        color: primaryColors.headline
+      },
+      h2: {
+        color: primaryColors.headline
+      },
+      h3: {
+        color: primaryColors.headline
+      },
+      caption: {
+        color: primaryColors.text
+      },
+      h4: {
+        color: primaryColors.text
+      }
+    },
+    overrides: {
+      MuiAppBar: {
+        colorDefault: {
           backgroundColor: 'transparent'
         }
       },
-      containedPrimary: {
-        '&:hover, &:focus': {
-          backgroundColor: primaryColors.light
-        },
-        '&:active': {
-          backgroundColor: primaryColors.dark
-        },
-        '&$disabled': {
-          color: '#888'
-        },
-        '&.loading': {
-          backgroundColor: primaryColors.text
-        },
-        '&.cancel': {
-          '&:hover, &:focus': {
-            borderColor: '#fff'
-          }
+      MuiBackdrop: {
+        root: {
+          backgroundColor: 'rgba(0, 0, 0, 0.5)'
         }
       },
-      containedSecondary: {
-        color: primaryColors.main,
-        border: `1px solid ${primaryColors.main}`,
-        '&:hover, &:focus': {
-          color: primaryColors.light,
-          borderColor: primaryColors.light
+      MuiButton: {
+        label: {
+          position: 'relative'
         },
-        '&:active': {
-          color: primaryColors.dark,
-          borderColor: primaryColors.dark
-        },
-        '&$disabled': {
-          borderColor: '#c9cacb',
-          color: '#c9cacb'
-        },
-        '&.cancel': {
-          borderColor: 'transparent',
-          '&:hover, &:focus': {
-            borderColor: primaryColors.light
+        root: {
+          color: primaryColors.main,
+          '&:hover': {
+            backgroundColor: '#000'
+          },
+          '&[aria-expanded="true"]': {
+            backgroundColor: primaryColors.dark
+          },
+          '&$disabled': {
+            color: '#888'
+          },
+          '&.loading': {
+            color: primaryColors.text
           }
         },
-        '&.destructive': {
-          borderColor: '#c44742',
-          color: '#c44742',
-          '&:hover, &:focus': {
-            color: '#df6560',
-            borderColor: '#df6560',
+        text: {
+          '&:hover': {
             backgroundColor: 'transparent'
+          }
+        },
+        containedPrimary: {
+          '&:hover, &:focus': {
+            backgroundColor: primaryColors.light
           },
           '&:active': {
-            color: '#963530',
-            borderColor: '#963530'
-          }
-        },
-        '&.loading': {
-          borderColor: primaryColors.text,
-          color: primaryColors.text,
-          minWidth: 100,
-          '& svg': {
-            width: 22,
-            height: 22,
-            animation: 'rotate 2s linear infinite'
-          }
-        }
-      }
-    },
-    MuiButtonBase: {
-      root: {
-        fontSize: '1rem'
-      }
-    },
-    MuiCardHeader: {
-      root: {
-        backgroundColor: 'rgba(0, 0, 0, 0.2)'
-      }
-    },
-    MuiChip: {
-      root: {
-        color: primaryColors.text,
-        backgroundColor: primaryColors.main
-      }
-    },
-    MuiCardActions: {
-      root: {
-        backgroundColor: 'rgba(0, 0, 0, 0.2) !important'
-      }
-    },
-    MuiDialog: {
-      paper: {
-        boxShadow: '0 0 5px #222',
-        background: '#000'
-      }
-    },
-    MuiDialogTitle: {
-      root: {
-        borderBottom: '1px solid #222',
-        '& h2': {
-          color: primaryColors.headline
-        }
-      }
-    },
-    MuiDrawer: {
-      paper: {
-        boxShadow: '0 0 5px #222'
-      }
-    },
-    MuiExpansionPanel: {
-      root: {
-        '& table': {
-          border: `1px solid ${primaryColors.divider}`
-        }
-      }
-    },
-    MuiExpansionPanelDetails: {
-      root: {
-        backgroundColor: '#32363c'
-      }
-    },
-    MuiExpansionPanelSummary: {
-      root: {
-        '& $focused': {
-          backgroundColor: '#111111'
-        },
-        backgroundColor: '#32363c',
-        '&:hover': {
-          '& h3': {
-            color: primaryColors.light
+            backgroundColor: primaryColors.dark
           },
-          '& $expandIcon': {
-            '& svg': {
-              fill: primaryColors.light
+          '&$disabled': {
+            color: '#888'
+          },
+          '&.loading': {
+            backgroundColor: primaryColors.text
+          },
+          '&.cancel': {
+            '&:hover, &:focus': {
+              borderColor: '#fff'
             }
           }
-        }
-      },
-      expandIcon: {
-        color: primaryColors.main,
-        '& svg': {
-          fill: 'transparent'
         },
-        '& .border': {
-          stroke: `${primaryColors.light} !important`
-        }
-      },
-      focused: {}
-    },
-    MuiFormControl: {
-      root: {
-        '&.copy > div': {
-          backgroundColor: '#2f3236'
-        }
-      }
-    },
-    MuiFormControlLabel: {
-      root: {
-        '& $disabled': {
-          color: '#aaa !important'
-        }
-      },
-      disabled: {}
-    },
-    MuiFormLabel: {
-      root: {
-        color: '#c9cacb',
-        '&$focused': {
-          color: '#c9cacb'
-        },
-        '&$error': {
-          color: '#c9cacb'
-        },
-        '&$disabled': {
-          color: '#c9cacb'
-        }
-      }
-    },
-    MuiFormHelperText: {
-      root: {
-        color: '#c9cacb',
-        '&$error': {
-          color: '#ca0813'
-        }
-      }
-    },
-    MuiIconButton: {
-      root: {
-        color: primaryColors.main,
-        '&:hover': {
-          color: primaryColors.light
-        }
-      }
-    },
-    MuiInput: {
-      root: {
-        '&$disabled': {
-          borderColor: '#606469',
-          color: '#ccc !important'
-        },
-        '&$focused': {
-          borderColor: primaryColors.main,
-          boxShadow: '0 0 2px 1px #222'
-        },
-        border: '1px solid #222',
-        color: primaryColors.text,
-        backgroundColor: '#444',
-        '& svg': {
-          color: primaryColors.main
-        }
-      },
-      focused: {},
-      disabled: {}
-    },
-    MuiInputAdornment: {
-      root: {
-        color: '#eee',
-        '& p': {
-          color: '#eee'
-        }
-      }
-    },
-    MuiListItem: {
-      root: {
-        color: primaryColors.text,
-        '&.selectHeader': {
-          color: primaryColors.text
-        }
-      }
-    },
-    MuiMenuItem: {
-      root: {
-        color: primaryColors.text,
-        '&$selected, &$selected:hover': {
-          backgroundColor: 'transparent',
+        containedSecondary: {
           color: primaryColors.main,
-          opacity: 1
-        }
-      },
-      selected: {}
-    },
-    MuiPaper: {
-      root: {
-        backgroundColor: '#32363c'
-      }
-    },
-    MuiPopover: {
-      paper: {
-        boxShadow: '0 0 5px #222'
-      }
-    },
-    MuiSelect: {
-      selectMenu: {
-        color: primaryColors.text,
-        backgroundColor: '#444',
-        '&:focus': {
-          backgroundColor: '#444'
-        }
-      }
-    },
-    MuiSnackbarContent: {
-      root: {
-        backgroundColor: '#32363c',
-        color: primaryColors.text,
-        boxShadow: '0 0 5px #222'
-      }
-    },
-    MuiSwitch: {
-      root: {
-        '& $checked': {
-          color: `#abadaf !important`,
-          '& .square': {
-            fill: 'white !important'
-          }
-        }
-      },
-      checked: {},
-      switchBase: {
-        color: '#abadaf !important'
-      },
-      bar: {
-        border: '1px solid #222'
-      }
-    },
-    MuiTab: {
-      root: {
-        color: '#fff',
-        '&$selected, &$selected:hover': {
-          color: '#fff'
-        }
-      },
-      textColorPrimary: {
-        color: '#fff',
-        '&$selected, &$selected:hover': {
-          color: '#fff'
-        }
-      },
-      selected: {}
-    },
-    MuiTableCell: {
-      root: {
-        borderBottom: `2px solid ${primaryColors.divider}`
-      },
-      head: {
-        color: primaryColors.text,
-        backgroundColor: 'rgba(0, 0, 0, 0.15)'
-      }
-    },
-    MuiTabs: {
-      root: {
-        boxShadow: 'inset 0 -1px 0 #222'
-      },
-      flexContainer: {
-        '& $scrollButtons:first-child': {
-          color: '#222'
-        }
-      },
-      scrollButtons: {
-        color: '#fff'
-      }
-    },
-    MuiTableRow: {
-      root: {
-        backgroundColor: '#32363c',
-        '&:before': {
-          borderLeftColor: '#32363c'
-        },
-        '&:hover': {
-          '&$hover': {
-            backgroundColor: 'rgba(0, 0, 0, 0.1)',
-            '&:before': {
-              borderLeftColor: primaryColors.main
+          border: `1px solid ${primaryColors.main}`,
+          '&:hover, &:focus': {
+            color: primaryColors.light,
+            borderColor: primaryColors.light
+          },
+          '&:active': {
+            color: primaryColors.dark,
+            borderColor: primaryColors.dark
+          },
+          '&$disabled': {
+            borderColor: '#c9cacb',
+            color: '#c9cacb'
+          },
+          '&.cancel': {
+            borderColor: 'transparent',
+            '&:hover, &:focus': {
+              borderColor: primaryColors.light
+            }
+          },
+          '&.destructive': {
+            borderColor: '#c44742',
+            color: '#c44742',
+            '&:hover, &:focus': {
+              color: '#df6560',
+              borderColor: '#df6560',
+              backgroundColor: 'transparent'
+            },
+            '&:active': {
+              color: '#963530',
+              borderColor: '#963530'
+            }
+          },
+          '&.loading': {
+            borderColor: primaryColors.text,
+            color: primaryColors.text,
+            minWidth: 100,
+            '& svg': {
+              width: 22,
+              height: 22,
+              animation: 'rotate 2s linear infinite'
             }
           }
         }
       },
-      head: {
-        backgroundColor: '#32363c',
-        '&:before': {
-          backgroundColor: 'rgba(0, 0, 0, 0.15) !important'
+      MuiButtonBase: {
+        root: {
+          fontSize: '1rem'
         }
       },
-      hover: {
-        '& > td:first-child': {
-          paddingLeft: 13
-        },
-        '& a': {
-          color: primaryColors.main
+      MuiCardHeader: {
+        root: {
+          backgroundColor: 'rgba(0, 0, 0, 0.2)'
         }
-      }
-    },
-    MuiTooltip: {
-      tooltip: {
-        backgroundColor: '#444',
-        boxShadow: '0 0 5px #222',
-        color: '#fff'
-      }
-    },
-    MuiTypography: {
-      root: {
-        '& a.black': {
-          color: primaryColors.text
+      },
+      MuiChip: {
+        root: {
+          color: primaryColors.text,
+          backgroundColor: primaryColors.main
+        }
+      },
+      MuiCardActions: {
+        root: {
+          backgroundColor: 'rgba(0, 0, 0, 0.2) !important'
+        }
+      },
+      MuiDialog: {
+        paper: {
+          boxShadow: '0 0 5px #222',
+          background: '#000'
+        }
+      },
+      MuiDialogTitle: {
+        root: {
+          borderBottom: '1px solid #222',
+          '& h2': {
+            color: primaryColors.headline
+          }
+        }
+      },
+      MuiDrawer: {
+        paper: {
+          boxShadow: '0 0 5px #222'
+        }
+      },
+      MuiExpansionPanel: {
+        root: {
+          '& table': {
+            border: `1px solid ${primaryColors.divider}`
+          }
+        }
+      },
+      MuiExpansionPanelDetails: {
+        root: {
+          backgroundColor: '#32363c'
+        }
+      },
+      MuiExpansionPanelSummary: {
+        root: {
+          '& $focused': {
+            backgroundColor: '#111111'
+          },
+          backgroundColor: '#32363c',
+          '&:hover': {
+            '& h3': {
+              color: primaryColors.light
+            },
+            '& $expandIcon': {
+              '& svg': {
+                fill: primaryColors.light
+              }
+            }
+          }
         },
-        '& a.black:visited': {
-          color: primaryColors.text
+        expandIcon: {
+          color: primaryColors.main,
+          '& svg': {
+            fill: 'transparent'
+          },
+          '& .border': {
+            stroke: `${primaryColors.light} !important`
+          }
         },
-        '& a.black:hover': {
-          color: primaryColors.text
+        focused: {}
+      },
+      MuiFormControl: {
+        root: {
+          '&.copy > div': {
+            backgroundColor: '#2f3236'
+          }
+        }
+      },
+      MuiFormControlLabel: {
+        root: {
+          '& $disabled': {
+            color: '#aaa !important'
+          }
+        },
+        disabled: {}
+      },
+      MuiFormLabel: {
+        root: {
+          color: '#c9cacb',
+          '&$focused': {
+            color: '#c9cacb'
+          },
+          '&$error': {
+            color: '#c9cacb'
+          },
+          '&$disabled': {
+            color: '#c9cacb'
+          }
+        }
+      },
+      MuiFormHelperText: {
+        root: {
+          color: '#c9cacb',
+          '&$error': {
+            color: '#ca0813'
+          }
+        }
+      },
+      MuiIconButton: {
+        root: {
+          color: primaryColors.main,
+          '&:hover': {
+            color: primaryColors.light
+          }
+        }
+      },
+      MuiInput: {
+        root: {
+          '&$disabled': {
+            borderColor: '#606469',
+            color: '#ccc !important'
+          },
+          '&$focused': {
+            borderColor: primaryColors.main,
+            boxShadow: '0 0 2px 1px #222'
+          },
+          border: '1px solid #222',
+          color: primaryColors.text,
+          backgroundColor: '#444',
+          '& svg': {
+            color: primaryColors.main
+          }
+        },
+        focused: {},
+        disabled: {}
+      },
+      MuiInputAdornment: {
+        root: {
+          color: '#eee',
+          '& p': {
+            color: '#eee'
+          }
+        }
+      },
+      MuiListItem: {
+        root: {
+          color: primaryColors.text,
+          '&.selectHeader': {
+            color: primaryColors.text
+          }
+        }
+      },
+      MuiMenuItem: {
+        root: {
+          color: primaryColors.text,
+          '&$selected, &$selected:hover': {
+            backgroundColor: 'transparent',
+            color: primaryColors.main,
+            opacity: 1
+          }
+        },
+        selected: {}
+      },
+      MuiPaper: {
+        root: {
+          backgroundColor: '#32363c'
+        }
+      },
+      MuiPopover: {
+        paper: {
+          boxShadow: '0 0 5px #222'
+        }
+      },
+      MuiSelect: {
+        selectMenu: {
+          color: primaryColors.text,
+          backgroundColor: '#444',
+          '&:focus': {
+            backgroundColor: '#444'
+          }
+        }
+      },
+      MuiSnackbarContent: {
+        root: {
+          backgroundColor: '#32363c',
+          color: primaryColors.text,
+          boxShadow: '0 0 5px #222'
+        }
+      },
+      MuiSwitch: {
+        root: {
+          '& $checked': {
+            color: `#abadaf !important`,
+            '& .square': {
+              fill: 'white !important'
+            }
+          }
+        },
+        checked: {},
+        switchBase: {
+          color: '#abadaf !important'
+        },
+        bar: {
+          border: '1px solid #222'
+        }
+      },
+      MuiTab: {
+        root: {
+          color: '#fff',
+          '&$selected, &$selected:hover': {
+            color: '#fff'
+          }
+        },
+        textColorPrimary: {
+          color: '#fff',
+          '&$selected, &$selected:hover': {
+            color: '#fff'
+          }
+        },
+        selected: {}
+      },
+      MuiTableCell: {
+        root: {
+          borderBottom: `2px solid ${primaryColors.divider}`
+        },
+        head: {
+          color: primaryColors.text,
+          backgroundColor: 'rgba(0, 0, 0, 0.15)'
+        }
+      },
+      MuiTabs: {
+        root: {
+          boxShadow: 'inset 0 -1px 0 #222'
+        },
+        flexContainer: {
+          '& $scrollButtons:first-child': {
+            color: '#222'
+          }
+        },
+        scrollButtons: {
+          color: '#fff'
+        }
+      },
+      MuiTableRow: {
+        root: {
+          backgroundColor: '#32363c',
+          '&:before': {
+            borderLeftColor: '#32363c'
+          },
+          '&:hover': {
+            '&$hover': {
+              backgroundColor: 'rgba(0, 0, 0, 0.1)',
+              '&:before': {
+                borderLeftColor: primaryColors.main
+              }
+            }
+          }
+        },
+        head: {
+          backgroundColor: '#32363c',
+          '&:before': {
+            backgroundColor: 'rgba(0, 0, 0, 0.15) !important'
+          }
+        },
+        hover: {
+          '& > td:first-child': {
+            paddingLeft: 13
+          },
+          '& a': {
+            color: primaryColors.main
+          }
+        }
+      },
+      MuiTooltip: {
+        tooltip: {
+          backgroundColor: '#444',
+          boxShadow: '0 0 5px #222',
+          color: '#fff'
+        }
+      },
+      MuiTypography: {
+        root: {
+          '& a.black': {
+            color: primaryColors.text
+          },
+          '& a.black:visited': {
+            color: primaryColors.text
+          },
+          '& a.black:hover': {
+            color: primaryColors.text
+          }
         }
       }
     }
-  }
-});
+  });

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -34,7 +34,7 @@ const GROUP_VOLUMES = `GROUP_VOLUMES`;
 const BACKUPSCTA_DISMISSED = 'BackupsCtaDismissed';
 
 type Theme = 'dark' | 'light';
-type Spacing = 'compact' | 'normal';
+export type Spacing = 'compact' | 'normal';
 type Beta = 'open' | 'closed';
 type LinodeView = 'grid' | 'list';
 

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -22,6 +22,7 @@ export const setStorage = (key: string, value: string) => {
 };
 
 const THEME = 'themeChoice';
+const SPACING = 'spacingChoice';
 const BETA_NOTIFICATION = 'BetaNotification';
 const LINODE_VIEW = 'linodesViewStyle';
 const GROUP_LINODES = 'GROUP_LINODES';
@@ -33,6 +34,7 @@ const GROUP_VOLUMES = `GROUP_VOLUMES`;
 const BACKUPSCTA_DISMISSED = 'BackupsCtaDismissed';
 
 type Theme = 'dark' | 'light';
+type Spacing = 'compact' | 'normal';
 type Beta = 'open' | 'closed';
 type LinodeView = 'grid' | 'list';
 
@@ -40,6 +42,10 @@ export interface Storage {
   theme: {
     get: () => Theme;
     set: (theme: Theme) => void;
+  };
+  spacing: {
+    get: () => Spacing;
+    set: (spacing: Spacing) => void;
   };
   notifications: {
     welcome: {
@@ -91,6 +97,10 @@ export const storage: Storage = {
   theme: {
     get: () => getStorage(THEME, 'light'),
     set: v => setStorage(THEME, v)
+  },
+  spacing: {
+    get: () => getStorage(SPACING, 'normal'),
+    set: v => setStorage(SPACING, v)
   },
   notifications: {
     welcome: {
@@ -145,4 +155,4 @@ export const storage: Storage = {
   }
 };
 
-export const { theme, notifications, views } = storage;
+export const { theme, spacing, notifications, views } = storage;


### PR DESCRIPTION
## Theme Spacing/Compact mode Switcher

This PR is a big theme rework to allow more user preference values and customization. Along with the light/dark theme, we feature now a switch to select a compact/normal mode.

There was quite a bit of refactoring happen due to renderGuard and exports, and there was a lof of styles that for fixed. This work also will pave the way for any other customization we'd like to implement in the future.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

The compact theme should be tested everywhere to check for consistency. I also recommend switching back and forth through the testing to check for performance hits (lots of re-rendering can happen). I have not noticed anything wrong, and users won't toggle like crazy, but something to keep in mind.
