### PR TITLE
M3-1100 Only force grid view at XS breakpoint

### DIFF
--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -312,7 +312,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                   Linodes
                 </Typography>
               </Grid>
-              <Hidden smDown>
+              <Hidden xsDown>
                 <FormControlLabel
                   className={classes.tagGroup}
                   control={
@@ -500,9 +500,9 @@ const getDisplayType = (
   userSelect?: 'grid' | 'list'
 ) => {
   /**
-   * We force the use of grid view at sm and xs viewports.
+   * We force the use of grid view at xs viewports.
    */
-  if (['sm', 'xs'].includes(width)) {
+  if (['xs'].includes(width)) {
     return 'grid';
   }
 


### PR DESCRIPTION
## Description

Grid view was being forced on linodes landing for both xs and sm breakpoints, it is now set to be xs only. 

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

To test, emulate an ipad experience vs an iphone and see that you can change your view experience for ipad as you would on larger breakpoints.
