### PR TITLE
M3-1302 Change: Pre-populate payment amount

### DIFF
--- a/src/containers/account.container.ts
+++ b/src/containers/account.container.ts
@@ -1,0 +1,40 @@
+import { connect, MapDispatchToProps } from 'react-redux';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { ApplicationState } from 'src/store';
+import { requestAccount } from 'src/store/account/account.requests';
+
+export interface AccountProps {
+  account?: Linode.Account;
+  accountLoading: boolean;
+  accountError?: Linode.ApiFieldError[] | Error;
+}
+
+export interface DispatchProps {
+  requestAccount: () => void;
+}
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
+  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
+) => ({
+  requestAccount: () => dispatch(requestAccount())
+});
+
+export default <TInner extends {}, TOutter extends {}>(
+  mapAccountToProps: (
+    ownProps: TOutter,
+    accountLoading: boolean,
+    account?: Linode.Account,
+    accountError?: Linode.ApiFieldError[] | Error
+  ) => TInner
+) =>
+  connect(
+    (state: ApplicationState, ownProps: TOutter) => {
+      const account = state.__resources.account.data;
+      const accountLoading = state.__resources.account.loading;
+      const accountError = state.__resources.account.error;
+
+      return mapAccountToProps(ownProps, accountLoading, account, accountError);
+    },
+    mapDispatchToProps
+  );

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.test.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.test.tsx
@@ -1,4 +1,5 @@
 import {
+  getDefaultPayment,
   isAllowedUSDAmount,
   shouldEnablePaypalButton
 } from './MakeAPaymentPanel';
@@ -24,5 +25,19 @@ describe('Make a Payment Panel', () => {
     expect(shouldEnablePaypalButton(500)).toBeTruthy();
     expect(shouldEnablePaypalButton(15)).toBeTruthy();
     expect(shouldEnablePaypalButton(5)).toBeTruthy();
+  });
+
+  describe('getDefaultPayment helper function', () => {
+    it('should return an empty string if balance is false', () => {
+      expect(getDefaultPayment(false)).toEqual('');
+    });
+
+    it('should return an empty string if the balance is below $5', () => {
+      expect(getDefaultPayment(3.0)).toEqual('');
+    });
+
+    it('should return a formatted string if the balance is above $5', () => {
+      expect(getDefaultPayment(6.1)).toEqual('6.10');
+    });
   });
 });

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -125,7 +125,7 @@ const client = {
 
 const env = process.env.NODE_ENV === 'development' ? 'sandbox' : 'production';
 
-const getDefaultPayment = (balance: number | false): string => {
+export const getDefaultPayment = (balance: number | false): string => {
   if (!balance) {
     return '';
   }

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -1,4 +1,5 @@
 import * as classNames from 'classnames';
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import scriptLoader from 'react-async-script-loader';
 import * as ReactDOM from 'react-dom';
@@ -22,7 +23,9 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
 import TextField from 'src/components/TextField';
-import { withAccount } from 'src/features/Billing/context';
+import AccountContainer, {
+  DispatchProps as AccountDispatchProps
+} from 'src/containers/account.container';
 import {
   executePaypalPayment,
   makePayment,
@@ -97,12 +100,12 @@ interface PaypalScript {
 interface AccountContextProps {
   accountLoading: boolean;
   balance: false | number;
-  request: () => Promise<void>;
   lastFour: string;
 }
 
 type CombinedProps = AccountContextProps &
   PaypalScript &
+  AccountDispatchProps &
   WithStyles<ClassNames>;
 
 type PaypalButton = React.ComponentType<Paypal.PayButtonProps>;
@@ -122,11 +125,19 @@ const client = {
 
 const env = process.env.NODE_ENV === 'development' ? 'sandbox' : 'production';
 
+const getDefaultPayment = (balance: number | false): string => {
+  if (!balance) {
+    return '';
+  }
+  // $5 is the minimum payment amount, so we don't want to set a default if they owe less than that.
+  return balance > 5 ? String(balance.toFixed(2)) : '';
+};
+
 class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
   state: State = {
     type: 'CREDIT_CARD',
     submitting: false,
-    usd: '',
+    usd: getDefaultPayment(this.props.balance),
     cvv: '',
     dialogOpen: false,
     paymentID: '',
@@ -139,7 +150,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
   componentDidUpdate(prevProps: CombinedProps) {
     if (!prevProps.isScriptLoadSucceed && this.props.isScriptLoadSucceed) {
       /*
-       * Becuase the paypal script is now loaded, so now we have access to this React component
+       * Because the paypal script is now loaded, so now we have access to this React component
        * in the window element. This will be used in the render method.
        * See documentation: https://github.com/paypal/paypal-checkout/blob/master/docs/frameworks.md
        */
@@ -148,6 +159,14 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
         ReactDOM
       });
       this.setState({ paypalLoaded: true });
+    }
+
+    if (prevProps.accountLoading && !this.props.accountLoading) {
+      const defaultPayment = getDefaultPayment(this.props.balance);
+      this.setState({
+        usd: defaultPayment,
+        paypalSubmitEnabled: Number(defaultPayment) >= 5
+      });
     }
   }
 
@@ -200,6 +219,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
           submitting: false,
           success: true
         });
+        this.props.requestAccount();
       })
       .catch(errorResponse => {
         this.setState({
@@ -238,7 +258,6 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
       payment_id: paymentID
     })
       .then(() => {
-        this.props.request();
         this.setState({
           isExecutingPaypalPayment: false,
           dialogOpen: false,
@@ -362,7 +381,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
   };
 
   renderForm = () => {
-    const { accountLoading, balance, classes, lastFour } = this.props;
+    const { accountLoading, balance, lastFour, classes } = this.props;
     const { errors, success } = this.state;
 
     const hasErrorFor = getAPIErrorFor(
@@ -542,16 +561,18 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles);
 
-const accountContext = withAccount(context => ({
-  accountLoading: context.loading,
-  balance: context.data && context.data.balance,
-  request: context.request,
-  lastFour: (context.data && context.data.credit_card.last_four) || ''
-}));
+const withAccount = AccountContainer(
+  (ownProps, accountLoading, accountData) => ({
+    ...ownProps,
+    accountLoading,
+    balance: pathOr(false, ['balance'], accountData),
+    lastFour: pathOr(false, ['credit_card', 'last_four'], accountData)
+  })
+);
 
 export default compose<CombinedProps, {}>(
   styled,
-  accountContext,
+  withAccount,
   scriptLoader('https://www.paypalobjects.com/api/checkout.js')
 )(MakeAPaymentPanel);
 


### PR DESCRIPTION
## Description

Pre-populate the payment amount field with the user's current balance if this is a) defined and b) greater than $5 (the minimum for Paypal).

Also removed the AccountContext usage here, since account data is already available in the Redux store, and there were too many /account requests firing here.

Possible issue: I'm using componentDidUpdate to determine whether to set the default value, but it's possible that if something else hits /account while the user is editing the payment amount, it'll get reset to the balance.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

You can use Charles to fudge your balance and/or hard code a value in to the account reducer.

