### PR TITLE
M3-1724 toronto region in linodes

### DIFF
--- a/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -1,3 +1,4 @@
+import CA from 'flag-icon-css/flags/4x3/ca.svg';
 import DE from 'flag-icon-css/flags/4x3/de.svg';
 import UK from 'flag-icon-css/flags/4x3/gb.svg';
 import JP from 'flag-icon-css/flags/4x3/jp.svg';
@@ -28,7 +29,8 @@ const flags = {
     />
   ),
   uk: () => <UK width="32" height="24" viewBox="0 0 640 480" />,
-  de: () => <DE width="32" height="24" viewBox="0 0 720 480" />
+  de: () => <DE width="32" height="24" viewBox="0 0 720 480" />,
+  ca: () => <CA width="32" height="24" viewBox="0 0 640 480" />
 };
 
 export interface ExtendedRegion extends Linode.Region {
@@ -53,7 +55,7 @@ interface Props {
 }
 
 const getNARegions = (regions: ExtendedRegion[]) =>
-  regions.filter(r => /us/.test(r.country));
+  regions.filter(r => /(us|ca)/.test(r.country));
 
 const getEURegions = (regions: ExtendedRegion[]) =>
   regions.filter(r => /(de|uk)/.test(r.country));

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,7 +58,8 @@ export const ZONES = {
   'ap-northeast-1a': 'tokyo',
   'ap-northeast-1b': 'shinagawa1',
   'ap-south': 'singapore',
-  'ap-south-1a': 'singapore'
+  'ap-south-1a': 'singapore',
+  'ca-east': 'toronto' // @todo check this after approval
 };
 
 export const dcDisplayNames = {
@@ -77,7 +78,8 @@ export const dcDisplayNames = {
   'eu-west': 'London, UK',
   'ap-south': 'Singapore, SG',
   'eu-central': 'Frankfurt, DE',
-  'ap-northeast': 'Tokyo 2, JP'
+  'ap-northeast': 'Tokyo 2, JP',
+  'ca-east': 'Toronto, CA'
 };
 
 export const dcDisplayCountry = {
@@ -96,7 +98,8 @@ export const dcDisplayCountry = {
   'eu-west': 'UK',
   'ap-south': 'SG',
   'eu-central': 'DE',
-  'ap-northeast': 'JP'
+  'ap-northeast': 'JP',
+  'ca-east': 'CA'
 };
 
 // At this time, the following regions do not support block storage.

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -368,7 +368,6 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
   };
 
   getRegionInfo = (selectedRegionID?: string | null): Info => {
-    console.log(this.props.regionsData)
     const selectedRegion = this.props.regionsData.find(
       region => region.id === selectedRegionID
     );

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -368,6 +368,7 @@ export class LinodeCreate extends React.Component<CombinedProps, State> {
   };
 
   getRegionInfo = (selectedRegionID?: string | null): Info => {
+    console.log(this.props.regionsData)
     const selectedRegion = this.props.regionsData.find(
       region => region.id === selectedRegionID
     );

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -95,7 +95,7 @@ export type TypeInfo =
 
 const errorResources = {
   type: 'A plan selection',
-  region: 'Region',
+  region: 'region',
   label: 'A label',
   root_pass: 'A root password',
   image: 'Image',

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -95,7 +95,7 @@ export type TypeInfo =
 
 const errorResources = {
   type: 'A plan selection',
-  region: 'A region selection',
+  region: 'Region',
   label: 'A label',
   root_pass: 'A root password',
   image: 'Image',

--- a/src/store/regions/regions.actions.ts
+++ b/src/store/regions/regions.actions.ts
@@ -17,7 +17,12 @@ export const requestRegions: ThunkActionCreator<
 
   return getRegions()
     .then(({ data }) => {
-      dispatch(regionsRequestActions.done({ result: data }));
+      // Mock in the Toronto region for testing
+      dispatch(
+        regionsRequestActions.done({
+          result: [...data, { country: 'ca', id: 'ca-east' }]
+        })
+      );
       return data;
     })
     .catch(error => {

--- a/src/utilities/doesRegionSupportBlockStorage.test.ts
+++ b/src/utilities/doesRegionSupportBlockStorage.test.ts
@@ -5,6 +5,7 @@ describe('does region support block storage', () => {
     expect(doesRegionSupportBlockStorage('us-central')).toBe(true);
     expect(doesRegionSupportBlockStorage('us-east')).toBe(true);
     expect(doesRegionSupportBlockStorage('us-central')).toBe(true);
+    expect(doesRegionSupportBlockStorage('ca-east')).toBe(true);
   });
 
   it('returns false if the region does not support block storage', () => {


### PR DESCRIPTION
--- Sorry guys, had to re-create this one

## Description

Add the Toronto region to the region select when creating a new Linode.


## Note to Reviewers

- The display name is provisional, pending management approval.
- Instead of Charles, I'm manually appending the new DC when dispatching `getRegions.done`.
- This is going to live in the feature branch until the DC is available, est. March 18.
