### PR TITLE
[SPR-141] update NB nodes to support backup mode

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -1095,6 +1095,12 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                     >
                                       Reject
                                     </MenuItem>
+                                    <MenuItem
+                                      value="backup"
+                                      data-node-idx={idx}
+                                    >
+                                      Backup
+                                    </MenuItem>
                                     <MenuItem value="drain" data-node-idx={idx}>
                                       Drain
                                     </MenuItem>

--- a/src/services/nodebalancers/configNodes.ts
+++ b/src/services/nodebalancers/configNodes.ts
@@ -5,7 +5,11 @@ import { mergeAddressAndPort } from './utils';
 
 type Page<T> = Linode.ResourcePage<T>;
 
-export type NodeBalancerConfigNodeMode = 'accept' | 'reject' | 'drain';
+export type NodeBalancerConfigNodeMode =
+  | 'accept'
+  | 'reject'
+  | 'backup'
+  | 'drain';
 
 export interface CreateNodeBalancerConfigNode {
   address: string;

--- a/src/services/nodebalancers/nodebalancers.schema.ts
+++ b/src/services/nodebalancers/nodebalancers.schema.ts
@@ -13,7 +13,10 @@ export const nodeBalancerConfigNodeSchema = object({
     .required('Label is required.'),
 
   address: string()
-    .matches(/^192\.168\.\d{1,3}\.\d{1,3}$/, 'Must be a valid private IPv4 address.')
+    .matches(
+      /^192\.168\.\d{1,3}\.\d{1,3}$/,
+      'Must be a valid private IPv4 address.'
+    )
     .required('IP address is required.'),
 
   port: number()
@@ -27,7 +30,7 @@ export const nodeBalancerConfigNodeSchema = object({
     .min(1, `Weight must be between 1 and 255.`)
     .max(255, `Weight must be between 1 and 255.`),
 
-  mode: mixed().oneOf(['accept', 'reject', 'drain'])
+  mode: mixed().oneOf(['accept', 'reject', 'backup', 'drain'])
 });
 
 export const createNodeBalancerConfigSchema = object({

--- a/src/types/NodeBalancer.ts
+++ b/src/types/NodeBalancer.ts
@@ -32,7 +32,11 @@ namespace Linode {
     total: number;
   }
 
-  export type NodeBalancerConfigNodeMode = 'accept' | 'reject' | 'drain';
+  export type NodeBalancerConfigNodeMode =
+    | 'accept'
+    | 'reject'
+    | 'backup'
+    | 'drain';
 
   export interface NodeBalancerConfigNode {
     id: number;


### PR DESCRIPTION
## Description

Adds `backup` mode to NodeBalancers, where nodes set to `backup` only receive traffic if all non-backup nodes are down.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

- Requires corresponding API changes.
- If a node is set to `backup` the current Manager displays a blank entry in the drop-down, and the mode can still be updated to existing values.