### PR TITLE
M3-2471 Tech Fix: React-select isClearable logic

### DIFF
--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -395,7 +395,8 @@ class Select extends React.PureComponent<CombinedProps, {}> {
     return (
       <BaseSelect
         {...restOfProps}
-        isClearable={isClearable || true}
+        // If isClearable hasn't been supplied, default to true
+        isClearable={isClearable === undefined ? true : isClearable}
         isSearchable
         blurInputOnSelect={blurInputOnSelect}
         isLoading={isLoading}


### PR DESCRIPTION
## Description

Previously the `isClearable` logic in our React-Select abstraction was: 

```jsx
<Select 
  isClearable={isClearable || true}
  // ...
</Select>
```

This means it was impossible to set `isClearable: false`.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')