### PR TITLE
M3-2449 Change: Remove Tokyo 1

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,7 +68,7 @@ export const dcDisplayNames = {
   'us-southeast-1a': 'Atlanta, GA',
   'eu-central-1a': 'Frankfurt, DE',
   'eu-west-1a': 'London, UK',
-  'ap-northeast-1a': 'Tokyo, JP',
+  'ap-northeast-1a': 'Tokyo, JP', // @todo should we remove this and change the display name of Tokyo 2 to Tokyo?
   'ap-northeast-1b': 'Tokyo 2, JP',
   'us-central': 'Dallas, TX',
   'us-west': 'Fremont, CA',

--- a/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -795,7 +795,9 @@ const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
 const connected = connect(mapStateToProps);
 
 const withRegions = regionsContainer(({ data, loading, error }) => ({
-  regionsData: data.map(r => ({ ...r, display: dcDisplayNames[r.id] })),
+  regionsData: data
+    .filter(region => region.id !== 'ap-northeast-1a') // Don't show Tokyo1 as an option
+    .map(r => ({ ...r, display: dcDisplayNames[r.id] })),
   regionsLoading: loading,
   regionsError: error
 }));

--- a/src/features/linodes/LinodesCreate/LinodesCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodesCreate.tsx
@@ -506,7 +506,9 @@ interface WithRegions {
 }
 
 const withRegions = regionsContainer(({ data, loading, error }) => ({
-  regionsData: data.map(r => ({ ...r, display: dcDisplayNames[r.id] })),
+  regionsData: data
+    .filter(region => region.id !== 'ap-northeast-1a')
+    .map(r => ({ ...r, display: dcDisplayNames[r.id] })),
   regionsLoading: loading,
   regionsError: error
 }));

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -107,7 +107,7 @@ interface Notice {
 
 const errorResources = {
   type: 'A plan selection',
-  region: 'A region selection',
+  region: 'region',
   label: 'A label',
   root_pass: 'A root password',
   tags: 'Tags for this Linode'

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -95,7 +95,7 @@ export type TypeInfo =
 
 const errorResources = {
   type: 'A plan selection',
-  region: 'A region selection',
+  region: 'region',
   label: 'A label',
   root_pass: 'A root password',
   image: 'Image',

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -91,7 +91,7 @@ interface Props {
 
 const errorResources = {
   type: 'A plan selection',
-  region: 'A region selection',
+  region: 'region',
   label: 'A label',
   root_pass: 'A root password'
 };

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -121,7 +121,7 @@ interface State {
 
 const errorResources = {
   type: 'A plan selection',
-  region: 'A region selection',
+  region: 'region',
   label: 'A label',
   root_pass: 'A root password',
   image: 'image',


### PR DESCRIPTION
## Description

Prevent Tokyo 1 from being shown as an option when selecting a region for Linodes and NodeBalancers (it is already excluded from block storage selections).

Opted to do this on an individual component level, since some users still have Linodes in this region. We could *probably* just filter it out in Redux without affecting these users, but this way is safest. Eventually the API will no longer return this region at all, at which point the display name value etc. can be removed.

Also includes a fix for regions error messaging when creating a Linode (currently fix is already on a feature branch, but this fix should go out as soon as possible).

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
- Non breaking change ('update', 'change')

