### PR TITLE
Reset creation state on tab change

### DIFF
--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -57,6 +57,7 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
     event: React.ChangeEvent<HTMLDivElement>,
     value: number
   ) => {
+    this.props.resetCreationState();
     this.props.history.push({
       search: `?type=${event.target.textContent}`
     });
@@ -89,7 +90,13 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
     {
       title: 'One-Click',
       render: () => {
-        return <SubTabs history={this.props.history} type="oneClick" />;
+        return (
+          <SubTabs
+            history={this.props.history}
+            reset={this.props.resetCreationState}
+            type="oneClick"
+          />
+        );
       }
     },
     {
@@ -97,6 +104,7 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
       render: () => {
         return (
           <SubTabs
+            reset={this.props.resetCreationState}
             history={this.props.history}
             type="myImages"
             tabs={this.myImagesTabs()}

--- a/src/features/linodes/LinodesCreate/CALinodeCreateSubTabs.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreateSubTabs.tsx
@@ -12,6 +12,7 @@ export interface Tab {
 
 interface Props {
   history: any;
+  reset: () => void;
   tabs?: Tab[];
   type: 'oneClick' | 'myImages';
 }
@@ -67,6 +68,8 @@ class CALinodeCreateSubTabs extends React.PureComponent<CombinedProps, State> {
     event: React.ChangeEvent<HTMLDivElement>,
     value: number
   ) => {
+    /** Reset the top-level creation flow state */
+    this.props.reset();
     /** get the query params as an object, excluding the "?" */
     const queryParams = parse(location.search.replace('?', ''));
 

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -74,14 +74,28 @@ type CombinedProps = InjectedNotistackProps &
   DispatchProps &
   RouteComponentProps<{}>;
 
+const defaultState: State = {
+  privateIPEnabled: false,
+  backupsEnabled: false,
+  label: '',
+  password: '',
+  selectedImageID: 'linode/debian9',
+  selectedDiskSize: undefined,
+  selectedLinodeID: undefined,
+  selectedStackScriptID: undefined,
+  selectedRegionID: undefined,
+  selectedTypeID: undefined,
+  tags: [],
+  formIsSubmitting: false
+};
+
 class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
-  state: State = {
-    privateIPEnabled: false,
-    backupsEnabled: false,
-    label: '',
-    password: '',
-    selectedImageID: 'linode/debian9',
-    formIsSubmitting: false
+  state: State = defaultState;
+
+  clearCreationState = () => {
+    this.setState({
+      ...defaultState
+    });
   };
 
   setImageID = (id: string) => {
@@ -355,6 +369,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
               formIsSubmitting={this.state.formIsSubmitting}
               history={this.props.history}
               handleSubmitForm={this.submitForm}
+              resetCreationState={this.clearCreationState}
             />
           </Grid>
         </Grid>

--- a/src/features/linodes/LinodesCreate/types.ts
+++ b/src/features/linodes/LinodesCreate/types.ts
@@ -87,6 +87,7 @@ export interface BaseFormStateAndHandlers {
   togglePrivateIPEnabled: () => void;
   tags?: Tag[];
   updateTags: (tags: Tag[]) => void;
+  resetCreationState: () => void;
 }
 
 /**


### PR DESCRIPTION
## Description

Since Linode create state is now shared across creation flows, reset the state on each tab and subtab change.
