### PR TITLE
CA: Move SSH HOC to container

### DIFF
--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -13,6 +13,7 @@ import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
 
 import {
   AllFormStateAndHandlers,
+  WithAll,
   WithDisplayData,
   WithLinodesImagesTypesAndRegions
 } from './types';
@@ -24,6 +25,7 @@ interface Props {
 type CombinedProps = Props &
   WithLinodesImagesTypesAndRegions &
   WithDisplayData &
+  WithAll &
   AllFormStateAndHandlers;
 
 interface State {

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -21,6 +21,9 @@ import { Tag } from 'src/components/TagsInput';
 
 import { dcDisplayNames } from 'src/constants';
 import { typeLabelDetails } from 'src/features/linodes/presentation';
+import userSSHKeyHoc, {
+  State as userSSHKeyProps
+} from 'src/features/linodes/userSSHKeyHoc';
 import {
   hasGrant,
   isRestrictedUser
@@ -71,6 +74,7 @@ interface State {
 type CombinedProps = InjectedNotistackProps &
   LinodeActionsProps &
   WithLinodesImagesTypesAndRegions &
+  userSSHKeyProps &
   DispatchProps &
   RouteComponentProps<{}>;
 
@@ -370,6 +374,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
               history={this.props.history}
               handleSubmitForm={this.submitForm}
               resetCreationState={this.clearCreationState}
+              userSSHKeys={this.props.userSSHKeys}
             />
           </Grid>
         </Grid>
@@ -454,5 +459,6 @@ export default recompose<CombinedProps, {}>(
   withLinodeActions,
   connected,
   withRouter,
-  withSnackbar
+  withSnackbar,
+  userSSHKeyHoc
 )(LinodeCreateContainer);

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -97,9 +97,8 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   state: State = defaultState;
 
   clearCreationState = () => {
-    this.setState({
-      ...defaultState
-    });
+    this.props.resetSSHKeys();
+    this.setState(defaultState);
   };
 
   setImageID = (id: string) => {
@@ -375,6 +374,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
               handleSubmitForm={this.submitForm}
               resetCreationState={this.clearCreationState}
               userSSHKeys={this.props.userSSHKeys}
+              resetSSHKeys={this.props.resetSSHKeys}
             />
           </Grid>
         </Grid>

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -14,20 +14,13 @@ import Grid from 'src/components/Grid';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
 import Notice from 'src/components/Notice';
 import SelectRegionPanel from 'src/components/SelectRegionPanel';
-import userSSHKeyHoc, {
-  State as UserSSHKeyProps
-} from 'src/features/linodes/userSSHKeyHoc';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import AddonsPanel from '../AddonsPanel';
 import SelectImagePanel from '../SelectImagePanel';
 import SelectPlanPanel from '../SelectPlanPanel';
 import { renderBackupsDisplaySection } from './utils';
 
-import {
-  BaseFormStateAndHandlers,
-  WithDisplayData,
-  WithImagesRegionsTypesAndAccountState
-} from '../types';
+import { BaseFormStateAndHandlers, WithAll, WithDisplayData } from '../types';
 
 type ClassNames = 'root' | 'main' | 'sidebar';
 
@@ -66,11 +59,10 @@ const errorResources = {
 };
 
 type CombinedProps = Props &
-  UserSSHKeyProps &
   WithStyles<ClassNames> &
   WithDisplayData &
   BaseFormStateAndHandlers &
-  WithImagesRegionsTypesAndAccountState;
+  WithAll;
 
 export class FromImageContent extends React.PureComponent<CombinedProps> {
   /** create the Linode */
@@ -275,12 +267,8 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
 
 const styled = withStyles(styles);
 
-const enhanced = compose<
-  CombinedProps,
-  Props & WithDisplayData & WithImagesRegionsTypesAndAccountState
->(
-  styled,
-  userSSHKeyHoc
+const enhanced = compose<CombinedProps, Props & WithDisplayData & WithAll>(
+  styled
 );
 
 export default enhanced(FromImageContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -17,9 +17,6 @@ import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
 import Notice from 'src/components/Notice';
 import SelectRegionPanel from 'src/components/SelectRegionPanel';
 import { Tag } from 'src/components/TagsInput';
-import userSSHKeyHoc, {
-  State as SSHKeys
-} from 'src/features/linodes/userSSHKeyHoc';
 import CASelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel/CASelectStackScriptPanel';
 import StackScriptDrawer from 'src/features/StackScripts/StackScriptDrawer';
 import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
@@ -31,8 +28,8 @@ import { renderBackupsDisplaySection } from './utils';
 
 import {
   StackScriptFormStateHandlers,
-  WithDisplayData,
-  WithLinodesImagesTypesAndRegions
+  WithAll,
+  WithDisplayData
 } from '../types';
 
 type ClassNames =
@@ -83,12 +80,11 @@ const errorResources = {
   tags: 'Tags'
 };
 
-type InnerProps = Props & WithLinodesImagesTypesAndRegions;
+type InnerProps = Props & WithAll;
 
 type CombinedProps = InnerProps &
   StackScriptFormStateHandlers &
   WithDisplayData &
-  SSHKeys &
   WithStyles<ClassNames>;
 
 export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
@@ -426,9 +422,6 @@ export const filterUDFErrors = (errors?: Linode.ApiFieldError[]) => {
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, InnerProps>(
-  styled,
-  userSSHKeyHoc
-);
+const enhanced = compose<CombinedProps, InnerProps>(styled);
 
 export default enhanced(FromStackScriptContent);

--- a/src/features/linodes/LinodesCreate/types.ts
+++ b/src/features/linodes/LinodesCreate/types.ts
@@ -1,5 +1,6 @@
 import { ExtendedRegion } from 'src/components/SelectRegionPanel';
 import { Tag } from 'src/components/TagsInput';
+import { State as userSSHKeysProps } from 'src/features/linodes/userSSHKeyHoc';
 import { CreateLinodeRequest } from 'src/services/linodes';
 import { ExtendedType } from './SelectPlanPanel';
 
@@ -136,3 +137,5 @@ export type WithImagesRegionsTypesAndAccountState = WithImagesProps &
   WithRegions &
   WithTypesProps &
   ReduxStateProps;
+
+export type WithAll = WithImagesRegionsTypesAndAccountState & userSSHKeysProps;

--- a/src/features/linodes/userSSHKeyHoc.ts
+++ b/src/features/linodes/userSSHKeyHoc.ts
@@ -9,12 +9,18 @@ import { getEmailHash } from 'src/utilities/gravatar';
 
 export interface State {
   userSSHKeys: UserSSHKeyObject[];
+  resetSSHKeys?: () => void;
 }
 
 export default (Component: React.ComponentType<any>) => {
   class WrappedComponent extends React.PureComponent<StateProps, State> {
+    resetSSHKeys = () => {
+      this.setState({ userSSHKeys: [] });
+    };
+
     state = {
-      userSSHKeys: []
+      userSSHKeys: [],
+      resetSSHKeys: this.resetSSHKeys
     };
 
     mounted: boolean = false;

--- a/src/features/linodes/userSSHKeyHoc.ts
+++ b/src/features/linodes/userSSHKeyHoc.ts
@@ -1,4 +1,4 @@
-import { path } from 'ramda';
+import { assoc, map, path } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { UserSSHKeyObject } from 'src/components/AccessPanel';
@@ -9,13 +9,19 @@ import { getEmailHash } from 'src/utilities/gravatar';
 
 export interface State {
   userSSHKeys: UserSSHKeyObject[];
-  resetSSHKeys?: () => void;
+  resetSSHKeys: () => void;
 }
+
+const resetKeys = (key: UserSSHKeyObject) => {
+  return assoc('selected', false, key);
+};
 
 export default (Component: React.ComponentType<any>) => {
   class WrappedComponent extends React.PureComponent<StateProps, State> {
     resetSSHKeys = () => {
-      this.setState({ userSSHKeys: [] });
+      const { userSSHKeys } = this.state;
+      const newKeys = map(resetKeys, userSSHKeys);
+      this.setState({ userSSHKeys: newKeys });
     };
 
     state = {


### PR DESCRIPTION
## Description

- Rather than wrap each individual FromLinodeContent etc. with the SSHKey HOC, wrap the container and use state from there.
- Also added a function to reset all SSHKeys to `selected:false` which wasn't needed before (I don't think) since the individual components would re-render whenever tabbing back to them.