### PR TITLE
CLAPPS - Tab State in Redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "typeface-lato": "^0.0.54",
     "typeface-ubuntu-mono": "^0.0.54",
     "typescript-fsa": "^3.0.0-beta-2",
+    "typescript-fsa-reducers": "^1.2.0",
     "xml2js": "^0.4.19",
     "xterm": "^3.3.0",
     "yup": "^0.26.3",

--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -1,11 +1,16 @@
 import { parse } from 'querystring';
 import * as React from 'react';
+import { connect, MapDispatchToProps } from 'react-redux';
 import CircleProgress from 'src/components/CircleProgress';
 import AppBar from 'src/components/core/AppBar';
 import MUITab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import Grid from 'src/components/Grid';
 import { getStackScriptsByUser } from 'src/features/StackScripts/stackScriptUtils';
+import {
+  CreateTypes,
+  handleChangeCreateType
+} from 'src/store/linodeCreate/linodeCreate.actions';
 import SubTabs, { Tab } from './CALinodeCreateSubTabs';
 import FromImageContent from './TabbedContent/FromImageContent';
 import FromLinodeContent from './TabbedContent/FromLinodeContent';
@@ -24,6 +29,7 @@ interface Props {
 type CombinedProps = Props &
   WithLinodesImagesTypesAndRegions &
   WithDisplayData &
+  DispatchProps &
   AllFormStateAndHandlers;
 
 interface State {
@@ -59,17 +65,18 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
   ) => {
     this.props.resetCreationState();
 
-    this.setState({
-      selectedTab: value
-    });
+    this.props.setTab(event.target.textContent as CreateTypes);
     this.props.history.push({
       search: `?type=${event.target.textContent}`
+    });
+    this.setState({
+      selectedTab: value
     });
   };
 
   tabs: Tab[] = [
     {
-      title: 'Distros',
+      title: 'Distrubutions',
       render: () => {
         /** ...rest being all the formstate props and display data */
         const {
@@ -96,6 +103,7 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
             history={this.props.history}
             reset={this.props.resetCreationState}
             type="oneClick"
+            onClick={this.props.setTab}
           />
         );
       }
@@ -109,6 +117,7 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
             history={this.props.history}
             type="myImages"
             tabs={this.myImagesTabs()}
+            onClick={this.props.setTab}
           />
         );
       }
@@ -123,7 +132,7 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
       }
     },
     {
-      title: 'Clone From Existing Linode',
+      title: 'Clone from Existing Linode',
       render: () => {
         /**
          * rest being just the props that FromLinodeContent needs
@@ -227,4 +236,20 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
   }
 }
 
-export default LinodeCreate;
+interface DispatchProps {
+  setTab: (newType: CreateTypes) => void;
+}
+
+const mapDispatchToProps: MapDispatchToProps<
+  DispatchProps,
+  Props
+> = dispatch => ({
+  setTab: newType => dispatch(handleChangeCreateType(newType))
+});
+
+const connected = connect(
+  undefined,
+  mapDispatchToProps
+);
+
+export default connected(LinodeCreate);

--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -7,14 +7,15 @@ import MUITab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import Grid from 'src/components/Grid';
 import { getStackScriptsByUser } from 'src/features/StackScripts/stackScriptUtils';
-import {
-  CreateTypes,
-  handleChangeCreateType
-} from 'src/store/linodeCreate/linodeCreate.actions';
 import SubTabs, { Tab } from './CALinodeCreateSubTabs';
 import FromImageContent from './TabbedContent/FromImageContent';
 import FromLinodeContent from './TabbedContent/FromLinodeContent';
 import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
+
+import {
+  CreateTypes,
+  handleChangeCreateType
+} from 'src/store/linodeCreate/linodeCreate.actions';
 
 import {
   AllFormStateAndHandlers,
@@ -29,15 +30,17 @@ interface Props {
 type CombinedProps = Props &
   WithLinodesImagesTypesAndRegions &
   WithDisplayData &
-  DispatchProps &
   AllFormStateAndHandlers;
 
 interface State {
   selectedTab: number;
 }
 
-export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
-  constructor(props: CombinedProps) {
+export class LinodeCreate extends React.PureComponent<
+  CombinedProps & DispatchProps,
+  State
+> {
+  constructor(props: CombinedProps & DispatchProps) {
     super(props);
 
     /** get the query params as an object, excluding the "?" */
@@ -65,7 +68,9 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
   ) => {
     this.props.resetCreationState();
 
-    this.props.setTab(event.target.textContent as CreateTypes);
+    /** set the tab in redux state */
+    this.props.setTab(this.tabs[value].type);
+
     this.props.history.push({
       search: `?type=${event.target.textContent}`
     });
@@ -77,6 +82,7 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
   tabs: Tab[] = [
     {
       title: 'Distrubutions',
+      type: 'fromImage',
       render: () => {
         /** ...rest being all the formstate props and display data */
         const {
@@ -97,27 +103,28 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
     },
     {
       title: 'One-Click',
+      type: 'fromApp',
       render: () => {
         return (
           <SubTabs
             history={this.props.history}
             reset={this.props.resetCreationState}
-            type="oneClick"
-            onClick={this.props.setTab}
+            tabs={this.oneClickTabs()}
+            handleClick={this.props.setTab}
           />
         );
       }
     },
     {
       title: 'My Images',
+      type: 'fromImage',
       render: () => {
         return (
           <SubTabs
             reset={this.props.resetCreationState}
             history={this.props.history}
-            type="myImages"
             tabs={this.myImagesTabs()}
-            onClick={this.props.setTab}
+            handleClick={this.props.setTab}
           />
         );
       }
@@ -127,12 +134,14 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
   myImagesTabs = (): Tab[] => [
     {
       title: 'Backups and My Images',
+      type: 'fromBackup',
       render: () => {
         return <React.Fragment />;
       }
     },
     {
       title: 'Clone from Existing Linode',
+      type: 'fromLinode',
       render: () => {
         /**
          * rest being just the props that FromLinodeContent needs
@@ -164,6 +173,7 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
     },
     {
       title: 'My StackScripts',
+      type: 'fromStackScript',
       render: () => {
         const {
           accountBackupsEnabled,
@@ -179,6 +189,23 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
             {...rest}
           />
         );
+      }
+    }
+  ];
+
+  oneClickTabs = (): Tab[] => [
+    {
+      title: 'One-Click Apps',
+      type: 'fromApp',
+      render: () => {
+        return <React.Fragment />;
+      }
+    },
+    {
+      title: 'Community StackScripts',
+      type: 'fromStackScript',
+      render: () => {
+        return <div>community stackscripts</div>;
       }
     }
   ];
@@ -237,14 +264,14 @@ export class LinodeCreate extends React.PureComponent<CombinedProps, State> {
 }
 
 interface DispatchProps {
-  setTab: (newType: CreateTypes) => void;
+  setTab: (value: CreateTypes) => void;
 }
 
 const mapDispatchToProps: MapDispatchToProps<
   DispatchProps,
-  Props
+  CombinedProps
 > = dispatch => ({
-  setTab: newType => dispatch(handleChangeCreateType(newType))
+  setTab: value => dispatch(handleChangeCreateType(value))
 });
 
 const connected = connect(

--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -81,7 +81,7 @@ export class LinodeCreate extends React.PureComponent<
 
   tabs: Tab[] = [
     {
-      title: 'Distrubutions',
+      title: 'Distributions',
       type: 'fromImage',
       render: () => {
         /** ...rest being all the formstate props and display data */

--- a/src/features/linodes/LinodesCreate/CALinodeCreateSubTabs.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreateSubTabs.tsx
@@ -8,16 +8,16 @@ import Grid from 'src/components/Grid';
 import { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
 
 export interface Tab {
-  title: CreateTypes;
+  title: string;
   render: () => JSX.Element;
+  type: CreateTypes;
 }
 
 interface Props {
   history: any;
   reset: () => void;
-  tabs?: Tab[];
-  type: 'oneClick' | 'myImages';
-  onClick: (newType: CreateTypes) => void;
+  tabs: Tab[];
+  handleClick: (value: CreateTypes) => void;
 }
 
 interface State {
@@ -42,34 +42,10 @@ class CALinodeCreateSubTabs extends React.Component<CombinedProps, State> {
   constructor(props: CombinedProps) {
     super(props);
 
-    const tabsToRender = this.getTabsToRender(props.type, props.tabs);
-
     this.state = {
-      selectedTab: determinePreselectedTab(tabsToRender)
+      selectedTab: determinePreselectedTab(props.tabs)
     };
   }
-
-  oneClickTabs: Tab[] = [
-    {
-      title: 'One-Click Apps',
-      render: () => {
-        return <React.Fragment />;
-      }
-    },
-    {
-      title: 'Community StackScripts',
-      render: () => {
-        return <div>community stackscripts</div>;
-      }
-    }
-  ];
-
-  getTabsToRender = (type: string, tabs?: Tab[]) => {
-    if (tabs) {
-      return tabs;
-    }
-    return type === 'oneClick' ? this.oneClickTabs : [];
-  };
 
   handleTabChange = (
     event: React.ChangeEvent<HTMLDivElement>,
@@ -80,8 +56,8 @@ class CALinodeCreateSubTabs extends React.Component<CombinedProps, State> {
     /** get the query params as an object, excluding the "?" */
     const queryParams = parse(location.search.replace('?', ''));
 
-    /** set the tab in redux state */
-    this.props.onClick(event.target.textContent as CreateTypes);
+    /** set the type in redux state */
+    this.props.handleClick(this.props.tabs[value].type);
 
     this.props.history.push({
       search: `?type=${queryParams.type}&subtype=${event.target.textContent}`
@@ -92,10 +68,9 @@ class CALinodeCreateSubTabs extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { type, tabs } = this.props;
+    const { tabs } = this.props;
     const { selectedTab: selectedTabFromState } = this.state;
 
-    const tabsToRender = this.getTabsToRender(type, tabs);
     const queryParams = parse(location.search.replace('?', ''));
 
     /**
@@ -108,7 +83,7 @@ class CALinodeCreateSubTabs extends React.Component<CombinedProps, State> {
      */
     const selectedTab = !queryParams.subtype ? 0 : selectedTabFromState;
 
-    const selectedTabContentRender = tabsToRender[selectedTab].render;
+    const selectedTabContentRender = tabs[selectedTab].render;
 
     return (
       <Grid container>
@@ -122,7 +97,7 @@ class CALinodeCreateSubTabs extends React.Component<CombinedProps, State> {
               variant="scrollable"
               scrollButtons="on"
             >
-              {tabsToRender.map((tab, idx) => (
+              {tabs.map((tab, idx) => (
                 <MUITab
                   key={idx}
                   label={tab.title}

--- a/src/features/linodes/LinodesCreate/CALinodeCreateSubTabs.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreateSubTabs.tsx
@@ -5,8 +5,10 @@ import MUITab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import Grid from 'src/components/Grid';
 
+import { CreateTypes } from 'src/store/linodeCreate/linodeCreate.actions';
+
 export interface Tab {
-  title: string;
+  title: CreateTypes;
   render: () => JSX.Element;
 }
 
@@ -15,6 +17,7 @@ interface Props {
   reset: () => void;
   tabs?: Tab[];
   type: 'oneClick' | 'myImages';
+  onClick: (newType: CreateTypes) => void;
 }
 
 interface State {
@@ -76,6 +79,9 @@ class CALinodeCreateSubTabs extends React.Component<CombinedProps, State> {
     this.props.reset();
     /** get the query params as an object, excluding the "?" */
     const queryParams = parse(location.search.replace('?', ''));
+
+    /** set the tab in redux state */
+    this.props.onClick(event.target.textContent as CreateTypes);
 
     this.props.history.push({
       search: `?type=${queryParams.type}&subtype=${event.target.textContent}`

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -40,6 +40,7 @@ import { resetEventsPolling } from 'src/events';
 import { cloneLinode } from 'src/services/linodes';
 
 import { ApplicationState } from 'src/store';
+import { CreateFlows } from 'src/store/linodeCreate/linodeCreate.reducer';
 import { upsertLinode } from 'src/store/linodes/linodes.actions';
 import { MapState } from 'src/store/types';
 
@@ -69,6 +70,8 @@ interface State {
 }
 
 type CombinedProps = InjectedNotistackProps &
+  ReduxStateProps &
+  TabName &
   LinodeActionsProps &
   WithLinodesImagesTypesAndRegions &
   DispatchProps &
@@ -378,7 +381,14 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   }
 }
 
-const mapStateToProps: MapState<ReduxStateProps, CombinedProps> = state => ({
+interface TabName {
+  createType: CreateFlows;
+}
+
+const mapStateToProps: MapState<
+  ReduxStateProps & TabName,
+  CombinedProps
+> = state => ({
   accountBackupsEnabled: pathOr(
     false,
     ['__resources', 'accountSettings', 'data', 'backups_enabled'],
@@ -389,7 +399,8 @@ const mapStateToProps: MapState<ReduxStateProps, CombinedProps> = state => ({
    * and do not have the "add_linodes" grant
    */
   userCannotCreateLinode:
-    isRestrictedUser(state) && !hasGrant(state, 'add_linodes')
+    isRestrictedUser(state) && !hasGrant(state, 'add_linodes'),
+  createType: state.createLinode.type
 });
 
 interface DispatchProps {

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -40,7 +40,6 @@ import { resetEventsPolling } from 'src/events';
 import { cloneLinode } from 'src/services/linodes';
 
 import { ApplicationState } from 'src/store';
-import { CreateFlows } from 'src/store/linodeCreate/linodeCreate.reducer';
 import { upsertLinode } from 'src/store/linodes/linodes.actions';
 import { MapState } from 'src/store/types';
 
@@ -71,7 +70,6 @@ interface State {
 
 type CombinedProps = InjectedNotistackProps &
   ReduxStateProps &
-  TabName &
   LinodeActionsProps &
   WithLinodesImagesTypesAndRegions &
   DispatchProps &
@@ -381,14 +379,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   }
 }
 
-interface TabName {
-  createType: CreateFlows;
-}
-
-const mapStateToProps: MapState<
-  ReduxStateProps & TabName,
-  CombinedProps
-> = state => ({
+const mapStateToProps: MapState<ReduxStateProps, CombinedProps> = state => ({
   accountBackupsEnabled: pathOr(
     false,
     ['__resources', 'accountSettings', 'data', 'backups_enabled'],
@@ -399,8 +390,7 @@ const mapStateToProps: MapState<
    * and do not have the "add_linodes" grant
    */
   userCannotCreateLinode:
-    isRestrictedUser(state) && !hasGrant(state, 'add_linodes'),
-  createType: state.createLinode.type
+    isRestrictedUser(state) && !hasGrant(state, 'add_linodes')
 });
 
 interface DispatchProps {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -37,6 +37,10 @@ import images, {
   defaultState as defaultImagesState,
   State as ImagesStata
 } from 'src/store/image/image.reducer';
+import linodeCreateReducer, {
+  defaultState as linodeCreateDefaultState,
+  State as LinodeCreateState
+} from 'src/store/linodeCreate/linodeCreate.reducer';
 import linodeConfigs, {
   defaultState as defaultLinodeConfigsState,
   State as LinodeConfigsState
@@ -148,6 +152,7 @@ export interface ApplicationState {
   stackScriptDrawer: StackScriptDrawerState;
   tagImportDrawer: TagImportDrawerState;
   volumeDrawer: VolumeDrawerState;
+  createLinode: LinodeCreateState;
 }
 
 const defaultState: ApplicationState = {
@@ -159,7 +164,8 @@ const defaultState: ApplicationState = {
   events: eventsDefaultState,
   stackScriptDrawer: stackScriptDrawerDefaultState,
   tagImportDrawer: tagDrawerDefaultState,
-  volumeDrawer: volumeDrawerDefaultState
+  volumeDrawer: volumeDrawerDefaultState,
+  createLinode: linodeCreateDefaultState
 };
 
 /**
@@ -191,7 +197,8 @@ const reducers = combineReducers<ApplicationState>({
   stackScriptDrawer,
   tagImportDrawer,
   volumeDrawer,
-  events
+  events,
+  createLinode: linodeCreateReducer
 });
 
 const enhancers = compose(

--- a/src/store/linodeCreate/linodeCreate.actions.ts
+++ b/src/store/linodeCreate/linodeCreate.actions.ts
@@ -1,0 +1,15 @@
+import actionCreatorFactory from 'typescript-fsa';
+
+const actionBase = actionCreatorFactory('@@manager/create-linode');
+
+export type CreateTypes =
+  | 'One-Click Apps'
+  | 'Community StackScripts'
+  | 'Distrubutions'
+  | 'Backups and My Images'
+  | 'Clone from Existing Linode'
+  | 'My StackScripts'
+  | 'One-Click'
+  | 'My Images';
+
+export const handleChangeCreateType = actionBase<CreateTypes>('change-type');

--- a/src/store/linodeCreate/linodeCreate.actions.ts
+++ b/src/store/linodeCreate/linodeCreate.actions.ts
@@ -3,13 +3,10 @@ import actionCreatorFactory from 'typescript-fsa';
 const actionBase = actionCreatorFactory('@@manager/create-linode');
 
 export type CreateTypes =
-  | 'One-Click Apps'
-  | 'Community StackScripts'
-  | 'Distrubutions'
-  | 'Backups and My Images'
-  | 'Clone from Existing Linode'
-  | 'My StackScripts'
-  | 'One-Click'
-  | 'My Images';
+  | 'fromApp'
+  | 'fromStackScript'
+  | 'fromImage'
+  | 'fromBackup'
+  | 'fromLinode';
 
 export const handleChangeCreateType = actionBase<CreateTypes>('change-type');

--- a/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -1,0 +1,83 @@
+import { parse } from 'querystring';
+import { Reducer } from 'redux';
+import { reducerWithInitialState } from 'typescript-fsa-reducers';
+import { handleChangeCreateType } from './linodeCreate.actions';
+
+export interface State {
+  type: CreateFlows;
+}
+
+export type CreateFlows =
+  | 'fromStackScript'
+  | 'fromImage'
+  | 'fromBackup'
+  | 'fromLinode'
+  | 'fromApp';
+
+const getInitialType = (): CreateFlows => {
+  const queryParams = parse(location.search.replace('?', '').toLowerCase());
+
+  if (queryParams.type) {
+    if (queryParams.subtype) {
+      /**
+       * we have a subtype in the query string so now we need to deduce what
+       * endpoint we should be POSTing to based on what is in the query params
+       */
+      if (queryParams.subtype.includes('stackscript')) {
+        return 'fromStackScript';
+      } else if (queryParams.subtype.includes('clone')) {
+        return 'fromLinode';
+      } else if (queryParams.subtype.includes('backup')) {
+        return 'fromBackup';
+      } else {
+        return 'fromApp';
+      }
+    } else {
+      /**
+       * here we know we don't have a subtype in the query string
+       * but we do have a type (AKA a parent tab is selected). In this case,
+       * we can assume the first child tab is selected within the parent tabs
+       */
+      if (queryParams.type.includes('one-click')) {
+        return 'fromApp';
+      } else if (queryParams.type.includes('images')) {
+        return 'fromImage';
+      } else {
+        return 'fromImage';
+      }
+    }
+  }
+
+  /** always backup to 'fromImage' */
+  return 'fromImage';
+};
+
+export const defaultState: State = {
+  type: getInitialType()
+};
+
+const reducer: Reducer<State> = reducerWithInitialState(
+  defaultState
+).caseWithAction(handleChangeCreateType, (state, action) => {
+  const { payload } = action;
+  const tabTitle = payload.toLowerCase();
+
+  /** default to fromImage */
+  let type: CreateFlows = 'fromImage';
+
+  if (tabTitle.includes('stackscript')) {
+    type = 'fromStackScript';
+  } else if (tabTitle.includes('backup')) {
+    type = 'fromBackup';
+  } else if (tabTitle.includes('clone')) {
+    type = 'fromLinode';
+  } else if (tabTitle.includes('one-click')) {
+    type = 'fromApp';
+  }
+  return {
+    ...state,
+    type
+  };
+});
+
+export default reducer;

--- a/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -1,20 +1,13 @@
 import { parse } from 'querystring';
 import { Reducer } from 'redux';
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
-import { handleChangeCreateType } from './linodeCreate.actions';
+import { CreateTypes, handleChangeCreateType } from './linodeCreate.actions';
 
 export interface State {
-  type: CreateFlows;
+  type: CreateTypes;
 }
 
-export type CreateFlows =
-  | 'fromStackScript'
-  | 'fromImage'
-  | 'fromBackup'
-  | 'fromLinode'
-  | 'fromApp';
-
-const getInitialType = (): CreateFlows => {
+const getInitialType = (): CreateTypes => {
   const queryParams = parse(location.search.replace('?', '').toLowerCase());
 
   if (queryParams.type) {
@@ -60,23 +53,12 @@ const reducer: Reducer<State> = reducerWithInitialState(
   defaultState
 ).caseWithAction(handleChangeCreateType, (state, action) => {
   const { payload } = action;
-  const tabTitle = payload.toLowerCase();
 
-  /** default to fromImage */
-  let type: CreateFlows = 'fromImage';
+  console.log(payload);
 
-  if (tabTitle.includes('stackscript')) {
-    type = 'fromStackScript';
-  } else if (tabTitle.includes('backup')) {
-    type = 'fromBackup';
-  } else if (tabTitle.includes('clone')) {
-    type = 'fromLinode';
-  } else if (tabTitle.includes('one-click')) {
-    type = 'fromApp';
-  }
   return {
     ...state,
-    type
+    type: payload
   };
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14151,6 +14151,11 @@ typescript-estree@^18.1.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+typescript-fsa-reducers@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/typescript-fsa-reducers/-/typescript-fsa-reducers-1.2.0.tgz#015043b22440ce517e696f24564f7233b6a5a67b"
+  integrity sha512-JGIqBDf4SV+pE8CDenTqtr13cts7kwS3/YbYhLoKZZMZWSIhwn+xwwbrg/oEfvftLykyE9PXrySy6A62m6gEaw==
+
 typescript-fsa@^3.0.0-beta-2:
   version "3.0.0-beta-2"
   resolved "https://registry.yarnpkg.com/typescript-fsa/-/typescript-fsa-3.0.0-beta-2.tgz#1cc1d0c014c025fd51cba097776033ac4b6b753c"


### PR DESCRIPTION
## Description

Move over all the tab state into Redux, for the purposes of the container component knowing which endpoint to POST to and what payload to send

## Type of Change
- Non breaking change ('update', 'change')

### Notes
* Initial redux state is determined by the query params in the URL
* Every action takes a `type` param which will set state based on the tab title.