### PR TITLE
change: Add last auth IP address and last auth time to trusted devices table

### DIFF
--- a/src/features/Profile/AuthenticationSettings/TrustedDevices.tsx
+++ b/src/features/Profile/AuthenticationSettings/TrustedDevices.tsx
@@ -80,6 +80,8 @@ class TrustedDevices extends React.PureComponent<CombinedProps, {}> {
               <TableHead>
                 <TableRow>
                   <TableCell>Device</TableCell>
+                  <TableCell>Last IP</TableCell>
+                  <TableCell>Last Used</TableCell>
                   <TableCell>Expires</TableCell>
                   <TableCell />
                 </TableRow>

--- a/src/features/Profile/AuthenticationSettings/TrustedDevicesTable.tsx
+++ b/src/features/Profile/AuthenticationSettings/TrustedDevicesTable.tsx
@@ -36,7 +36,7 @@ class TrustedDevicesTable extends React.PureComponent<CombinedProps, {}> {
   render() {
     const { loading, error, data } = this.props;
     if (loading) {
-      return <TableRowLoading colSpan={4} />;
+      return <TableRowLoading colSpan={6} />;
     }
 
     if (error) {
@@ -49,7 +49,7 @@ class TrustedDevicesTable extends React.PureComponent<CombinedProps, {}> {
     }
 
     if (!data || data.length === 0) {
-      return <TableRowEmpty colSpan={4} />;
+      return <TableRowEmpty colSpan={6} />;
     }
 
     return (
@@ -59,6 +59,15 @@ class TrustedDevicesTable extends React.PureComponent<CombinedProps, {}> {
             <TableRow key={eachDevice.id}>
               <TableCell parentColumn="Device">
                 {eachDevice.user_agent}
+              </TableCell>
+              <TableCell parentColumn="Last IP">
+                {eachDevice.last_remote_addr}
+              </TableCell>
+              <TableCell parentColumn="Last Used">
+                <DateTimeDisplay
+                  value={eachDevice.last_authenticated}
+                  humanizeCutoff="month"
+                />
               </TableCell>
               <TableCell parentColumn="Expires">
                 <DateTimeDisplay


### PR DESCRIPTION
## Description
Currently, the Trusted Devices table does not display the last IP a device was used from or last time the device was used. The API already includes these fields, so adding them will give users better insight into activity on their user account.

Looks like this:
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/1588395/53817899-eb4c3480-3f34-11e9-91c5-f2a96917560a.png">

## Type of Change
- Non breaking change

## Note to Reviewers
This is my first PR against manager, so if this is totally wrong just let me know. Tested it in Firefox on OS X with various window widths and it looked about as expected.
