### PR TITLE
M3-2410 Change handling of Linode Resize

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -1,10 +1,9 @@
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
-
-import { types } from 'src/__data__/types';
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
-
+import { types } from 'src/__data__/types';
 import { LinodeResize } from './LinodeResize';
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
 
 describe('LinodeResize', () => {
   const mockTypes = types.map(LinodeResize.extendType);
@@ -13,6 +12,8 @@ describe('LinodeResize', () => {
     <LinodeResize
       onPresentSnackbar={jest.fn()}
       enqueueSnackbar={jest.fn()}
+      requestNotifications={jest.fn()}
+      {...reactRouterProps}
       classes={{
         root: '',
         title: '',
@@ -33,6 +34,8 @@ describe('LinodeResize', () => {
         <LinodeResize
           onPresentSnackbar={jest.fn()}
           enqueueSnackbar={jest.fn()}
+          requestNotifications={jest.fn()}
+          {...reactRouterProps}
           classes={{
             root: '',
             title: '',
@@ -64,6 +67,8 @@ describe('LinodeResize', () => {
             <LinodeResize
               onPresentSnackbar={jest.fn()}
               enqueueSnackbar={jest.fn()}
+              requestNotifications={jest.fn()}
+              {...reactRouterProps}
               classes={{
                 root: '',
                 title: '',
@@ -97,6 +102,8 @@ describe('LinodeResize', () => {
             <LinodeResize
               onPresentSnackbar={jest.fn()}
               enqueueSnackbar={jest.fn()}
+              requestNotifications={jest.fn()}
+              {...reactRouterProps}
               classes={{
                 root: '',
                 title: '',

--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -1,9 +1,9 @@
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
-import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
-import { types } from 'src/__data__/types';
-import { LinodeResize } from './LinodeResize';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import { types } from 'src/__data__/types';
+import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
+import { LinodeResize } from './LinodeResize';
 
 describe('LinodeResize', () => {
   const mockTypes = types.map(LinodeResize.extendType);

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -2,6 +2,7 @@ import { InjectedNotistackProps, withSnackbar } from 'notistack';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -24,7 +25,6 @@ import { linodeInTransition } from 'src/features/linodes/transitions';
 import { resizeLinode } from 'src/services/linodes';
 import { ApplicationState } from 'src/store';
 import { withNotifications } from 'src/store/notification/notification.containers';
-import { RouteComponentProps, withRouter } from 'react-router';
 
 type ClassNames = 'root' | 'title' | 'subTitle' | 'currentPlanContainer';
 

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -61,6 +61,7 @@ interface LinodeContextProps {
 
 interface State {
   selectedId: string;
+  isLoading: boolean;
   errors?: Linode.ApiFieldError[];
 }
 
@@ -77,7 +78,8 @@ type CombinedProps = WithTypesProps &
 
 export class LinodeResize extends React.Component<CombinedProps, State> {
   state: State = {
-    selectedId: ''
+    selectedId: '',
+    isLoading: false
   };
 
   static extendType = (type: Linode.LinodeType): ExtendedType => {
@@ -112,9 +114,11 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
       return;
     }
 
+    this.setState({ isLoading: true });
+
     resizeLinode(linodeId, selectedId)
       .then(_ => {
-        this.setState({ selectedId: '' });
+        this.setState({ selectedId: '', isLoading: false });
         resetEventsPolling();
         enqueueSnackbar('Linode queued for resize.', {
           variant: 'info'
@@ -132,7 +136,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
             variant: 'error'
           })
         );
-        this.setState({ selectedId: '' });
+        this.setState({ selectedId: '', isLoading: false });
       });
   };
 
@@ -218,6 +222,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
               !this.state.selectedId ||
               linodeInTransition(this.props.linodeStatus || '')
             }
+            loading={this.state.isLoading}
             type="primary"
             onClick={this.onSubmit}
             data-qa-submit


### PR DESCRIPTION
## Description

_Must be using dev services to test._

The API behavior of Linode Resize is changing. Instead of the FE immediately receiving a `scheduled` event, the resize will be queued. The resize will begin shortly after, and we'll start receiving `linode_resize` events as before.

In this queued state, we'll receive a pending migration notification for the Linode in question, which is why I've dispatched a `requestNotifications` action after submitting the resize request.

## Type of Change
- Non breaking change ('update', 'change')