### PR TITLE
M3-2486 Add: new menulist component to react select

### DIFF
--- a/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
+++ b/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
@@ -129,6 +129,7 @@ class Example extends React.Component<{}, State> {
           placeholder="Choose one fruit"
           onChange={this.handleChangeSingle}
           options={fruit}
+          guidance={'some text'}
         />
         <Select
           label="Always Loading"

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -16,6 +16,7 @@ import {
 Styles added in this file and the below imports will be utilized for the abstraction. */
 import DropdownIndicator from './components/DropdownIndicator';
 import LoadingIndicator from './components/LoadingIndicator';
+import MenuList from './components/MenuList';
 import MultiValueContainer from './components/MultiValueContainer';
 import MultiValueLabel from './components/MultiValueLabel';
 import MultiValueRemove from './components/MultiValueRemove';
@@ -321,6 +322,7 @@ const _components = {
   MultiValueContainer,
   MultiValueLabel,
   MultiValueRemove,
+  MenuList,
   Option,
   DropdownIndicator,
   LoadingIndicator

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -311,7 +311,7 @@ export interface EnhancedSelectProps {
   loadOptions?: (inputValue: string) => Promise<Item | Item[]> | undefined;
   filterOption?: (option: Item, inputValue: string) => boolean | null;
   small?: boolean;
-  guidance?: string;
+  guidance?: string | React.ReactNode;
 }
 
 // Material-UI versions of several React-Select components.

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -311,6 +311,7 @@ export interface EnhancedSelectProps {
   loadOptions?: (inputValue: string) => Promise<Item | Item[]> | undefined;
   filterOption?: (option: Item, inputValue: string) => boolean | null;
   small?: boolean;
+  guidance?: string;
 }
 
 // Material-UI versions of several React-Select components.

--- a/src/components/EnhancedSelect/components/MenuList.tsx
+++ b/src/components/EnhancedSelect/components/MenuList.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { components as reactSelectComponents } from 'react-select';
+import _MenuList, {
+  MenuListComponentProps
+} from 'react-select/lib/components/Menu';
+
+interface Props extends MenuListComponentProps<any> {
+  guidance?: string;
+}
+
+const Menu: React.StatelessComponent<Props> = props => {
+  const { guidance } = props;
+  return (
+    <React.Fragment>
+      <reactSelectComponents.MenuList {...props}>
+        {props.children}
+      </reactSelectComponents.MenuList>
+      {guidance !== undefined && <div>booyah</div>}
+    </React.Fragment>
+  );
+};
+
+export default Menu;

--- a/src/components/EnhancedSelect/components/MenuList.tsx
+++ b/src/components/EnhancedSelect/components/MenuList.tsx
@@ -4,12 +4,10 @@ import _MenuList, {
   MenuListComponentProps
 } from 'react-select/lib/components/Menu';
 
-interface Props extends MenuListComponentProps<any> {
-  guidance?: string;
-}
-
-const Menu: React.StatelessComponent<Props> = props => {
-  const { guidance } = props;
+const Menu: React.StatelessComponent<MenuListComponentProps<any>> = props => {
+  const { guidance } = props.selectProps;
+  console.log(guidance);
+  console.log(props.selectProps);
   return (
     <React.Fragment>
       <reactSelectComponents.MenuList {...props}>

--- a/src/components/EnhancedSelect/components/MenuList.tsx
+++ b/src/components/EnhancedSelect/components/MenuList.tsx
@@ -6,8 +6,7 @@ import _MenuList, {
 
 const Menu: React.StatelessComponent<MenuListComponentProps<any>> = props => {
   const { guidance } = props.selectProps;
-  console.log(guidance);
-  console.log(props.selectProps);
+
   return (
     <React.Fragment>
       <reactSelectComponents.MenuList {...props}>

--- a/src/components/EnhancedSelect/components/MenuList.tsx
+++ b/src/components/EnhancedSelect/components/MenuList.tsx
@@ -1,10 +1,40 @@
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from '@material-ui/core/styles';
+import HelpOutline from '@material-ui/icons/HelpOutline';
 import * as React from 'react';
 import { components as reactSelectComponents } from 'react-select';
 import _MenuList, {
   MenuListComponentProps
 } from 'react-select/lib/components/Menu';
+import Typography from 'src/components/core/Typography';
 
-const Menu: React.StatelessComponent<MenuListComponentProps<any>> = props => {
+type ClassNames = 'guidance' | 'text' | 'helpIcon';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  guidance: {
+    backgroundColor: theme.bg.offWhiteDT,
+    borderTop: `1px solid ${theme.palette.divider}`,
+    padding: theme.spacing.unit * 2
+  },
+  text: {
+    fontSize: '.8rem'
+  },
+  helpIcon: {
+    width: 16,
+    height: 16,
+    position: 'relative',
+    top: 3,
+    marginRight: theme.spacing.unit
+  }
+});
+
+type CombinedProps = MenuListComponentProps<any> & WithStyles<ClassNames>;
+
+const Menu: React.StatelessComponent<CombinedProps> = props => {
+  const { classes } = props;
   const { guidance } = props.selectProps;
 
   return (
@@ -12,9 +42,18 @@ const Menu: React.StatelessComponent<MenuListComponentProps<any>> = props => {
       <reactSelectComponents.MenuList {...props}>
         {props.children}
       </reactSelectComponents.MenuList>
-      {guidance !== undefined && <div>booyah</div>}
+      {guidance !== undefined && (
+        <div className={classes.guidance}>
+          <Typography className={classes.text}>
+            <HelpOutline className={classes.helpIcon} />
+            {guidance}
+          </Typography>
+        </div>
+      )}
     </React.Fragment>
   );
 };
 
-export default Menu;
+const styled = withStyles(styles);
+
+export default styled(Menu);

--- a/src/features/TopMenu/SearchBar/SearchBar.styles.ts
+++ b/src/features/TopMenu/SearchBar/SearchBar.styles.ts
@@ -64,7 +64,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     '& .react-select__menu': {
       marginTop: 12,
       boxShadow: `0 0 5px ${theme.color.boxShadow}`,
-      maxHeight: 325,
+      maxHeight: 350,
       overflowY: 'auto',
       border: 0
     }

--- a/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -124,6 +124,15 @@ class SearchBar extends React.Component<CombinedProps, State> {
     history.push(item.data.path);
   };
 
+  guidanceText = () => {
+    return (
+      <>
+        <b>By field:</b> “tag:my-app” “label:my-linode” &nbsp;&nbsp;
+        <b>With operators</b>: “tag:my-app AND is:domain”
+      </>
+    );
+  };
+
   /* Need to override the default RS filtering; otherwise entities whose label
    * doesn't match the search term will be automatically filtered, meaning that
    * searching by tag won't work. */
@@ -178,6 +187,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
             onMenuOpen={this.onOpen}
             value={false}
             menuIsOpen={menuOpen}
+            guidance={this.guidanceText()}
           />
           <IconButton
             color="inherit"


### PR DESCRIPTION
## Add help text to main search dropdown

We need to let the users know about the new filters available on the search. This PR adds a help bar at the bottom of the search dropdown. Made it avail as an optional `guidance` prop for all react selects that can take a string or function

## Type of Change
- Non breaking change ('update')
