### PR TITLE
Apps UI Edits

### DIFF
--- a/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/src/components/CheckoutBar/CheckoutBar.tsx
@@ -1,6 +1,5 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
-import { StickyProps } from 'react-sticky';
 import Button from 'src/components/Button';
 import {
   StyleRulesCallback,
@@ -67,13 +66,12 @@ interface Props {
   onDeploy: () => void;
   heading: string;
   calculatedPrice?: number;
-  isSticky?: boolean;
   disabled?: boolean;
   isMakingRequest?: boolean;
   displaySections?: { title: string; details?: string | number }[];
 }
 
-type CombinedProps = Props & StickyProps & WithStyles<ClassNames>;
+type CombinedProps = Props & WithStyles<ClassNames>;
 
 class CheckoutBar extends React.Component<CombinedProps> {
   static defaultProps: Partial<Props> = {
@@ -82,13 +80,6 @@ class CheckoutBar extends React.Component<CombinedProps> {
 
   render() {
     const {
-      /**
-       * Note:
-       * This 'style' prop is what gives us the "sticky" styles. Other special
-       * props are available, see https://github.com/captivationsoftware/react-sticky
-       */
-      style,
-      isSticky,
       classes,
       onDeploy,
       heading,
@@ -98,16 +89,8 @@ class CheckoutBar extends React.Component<CombinedProps> {
       isMakingRequest
     } = this.props;
 
-    let finalStyle;
-    if (isSticky) {
-      finalStyle = {
-        ...style,
-        paddingTop: 24
-      };
-    }
-
     return (
-      <div className={classes.root} style={finalStyle}>
+      <div className={classes.root}>
         <Typography
           role="header"
           variant="h2"

--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -299,7 +299,7 @@ export class LinodeCreate extends React.PureComponent<
 
     return (
       <React.Fragment>
-        <Grid item className={`mlMain`}>
+        <Grid item className={`mlMain py0`}>
           <AppBar position="static" color="default">
             <Tabs
               value={selectedTab}

--- a/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreate.tsx
@@ -196,18 +196,7 @@ export class LinodeCreate extends React.PureComponent<
           updatePassword,
           ...rest
         } = this.props;
-        return (
-          <FromBackupsContent
-            notice={{
-              level: 'warning',
-              text: `This newly created Linode will be created with
-                      the same password and SSH Keys (if any) as the original Linode.
-                      Also note that this Linode will need to be manually booted after it finishes
-                      provisioning.`
-            }}
-            {...rest}
-          />
-        );
+        return <FromBackupsContent {...rest} />;
       }
     },
     {
@@ -230,16 +219,7 @@ export class LinodeCreate extends React.PureComponent<
           regionsError,
           ...rest
         } = this.props;
-        return (
-          <FromLinodeContent
-            notice={{
-              level: 'warning',
-              text: `This newly created Linode will be created with
-                      the same password and SSH Keys (if any) as the original Linode.`
-            }}
-            {...rest}
-          />
-        );
+        return <FromLinodeContent {...rest} />;
       }
     },
     {

--- a/src/features/linodes/LinodesCreate/CALinodeCreateSubTabs.tsx
+++ b/src/features/linodes/LinodesCreate/CALinodeCreateSubTabs.tsx
@@ -22,9 +22,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     backgroundColor: theme.color.white
   },
   inner: {
-    padding: theme.spacing.unit * 2,
+    padding: `${theme.spacing.unit * 2}px ${theme.spacing.unit * 2}px 0 ${theme
+      .spacing.unit * 2}px`,
     [theme.breakpoints.up('sm')]: {
-      padding: theme.spacing.unit * 3
+      padding: `${theme.spacing.unit * 3}px ${theme.spacing.unit *
+        3}px 0 ${theme.spacing.unit * 3}px`
     }
   }
 });
@@ -109,7 +111,7 @@ class CALinodeCreateSubTabs extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <Grid item className="mlMain">
+        <Grid item className="mlMain py0">
           <Paper className={`${classes.root}`}>
             <div className={`${classes.inner}`}>
               <Typography role="header" variant="h2">

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -409,7 +409,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     return (
       <StickyContainer>
         <DocumentTitleSegment segment="Create a Linode" />
-        <Grid container>
+        <Grid container spacing={0}>
           <Grid item xs={12}>
             <Typography role="header" variant="h1" data-qa-create-linode-header>
               Create New Linode

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -33,6 +33,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   }
 });
 
+interface Notice {
+  text: string;
+  level: 'warning' | 'error'; // most likely only going to need these two
+}
+
 interface Props {
   linodes: ExtendedLinode[];
   selectedLinodeID?: number;
@@ -40,6 +45,7 @@ interface Props {
   error?: string;
   header?: string;
   disabled?: boolean;
+  notice?: Notice;
 }
 
 type StyledProps = Props & WithStyles<ClassNames>;
@@ -64,11 +70,18 @@ class SelectLinodePanel extends React.Component<CombinedProps> {
   }
 
   render() {
-    const { error, classes, linodes, header } = this.props;
+    const { error, classes, linodes, header, notice, disabled } = this.props;
 
     return (
       <Paper className={`${classes.root}`} data-qa-select-linode-panel>
         <div className={classes.inner}>
+          {notice && !disabled && (
+            <Notice
+              text={notice.text}
+              error={notice.level === 'error'}
+              warning={notice.level === 'warning'}
+            />
+          )}
           {error && <Notice text={error} error />}
           <Typography role="header" variant="h2" data-qa-select-linode-header>
             {!!header ? header : 'Select Linode'}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -40,7 +40,7 @@ type ClassNames = 'sidebar' | 'emptyImagePanel' | 'emptyImagePanelText';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   sidebar: {
     [theme.breakpoints.up('lg')]: {
-      marginTop: -130
+      marginTop: '-130px !important'
     }
   },
   emptyImagePanel: {
@@ -194,7 +194,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps> {
 
     return (
       <React.Fragment>
-        <Grid item className={`mlMain`}>
+        <Grid item className={`mlMain py0`}>
           <CreateLinodeDisabled isDisabled={userCannotCreateLinode} />
           {generalError && <Notice text={generalError} error={true} />}
           <SelectAppPanel

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -16,7 +16,6 @@ import {
 import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
 import Grid from 'src/components/Grid';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
-import Notice from 'src/components/Notice';
 import Placeholder from 'src/components/Placeholder';
 import { getLinodeBackups } from 'src/services/linodes';
 import {
@@ -50,7 +49,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 });
 
 interface Props {
-  notice?: Notice;
   linodesData: Linode.Linode[];
   selectedBackupFromQuery?: number;
   selectedLinodeFromQuery?: number;
@@ -74,11 +72,6 @@ type CombinedProps = Props &
   WithAll &
   WithDisplayData &
   WithStyles<ClassNames>;
-
-interface Notice {
-  text: string;
-  level: 'warning' | 'error'; // most likely only going to need these two
-}
 
 const errorResources = {
   type: 'A plan selection',

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -203,7 +203,6 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
       accountBackupsEnabled,
       classes,
       errors,
-      notice,
       privateIPEnabled,
       selectedBackupID,
       selectedDiskSize,
@@ -226,7 +225,6 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
       updateLabel
     } = this.props;
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
-    const generalError = hasErrorFor('none');
 
     const imageInfo = selectedBackupInfo;
 
@@ -248,14 +246,6 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
           ) : (
             <React.Fragment>
               <CreateLinodeDisabled isDisabled={disabled} />
-              {notice && !disabled && (
-                <Notice
-                  text={notice.text}
-                  error={notice.level === 'error'}
-                  warning={notice.level === 'warning'}
-                />
-              )}
-              {generalError && <Notice text={generalError} error={true} />}
               <SelectLinodePanel
                 error={hasErrorFor('linode_id')}
                 linodes={ramdaCompose(
@@ -267,6 +257,13 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                 handleSelection={updateLinodeID}
                 updateFor={[selectedLinodeID, errors]}
                 disabled={disabled}
+                notice={{
+                  level: 'warning',
+                  text: `This newly created Linode will be created with
+                          the same password and SSH Keys (if any) as the original Linode.
+                          Also note that this Linode will need to be manually booted after it finishes
+                          provisioning.`
+                }}
               />
               <SelectBackupPanel
                 error={hasErrorFor('backup_id')}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -7,6 +7,7 @@ import { compose } from 'recompose';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import CheckoutBar from 'src/components/CheckoutBar';
 import CircleProgress from 'src/components/CircleProgress';
+import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
   withStyles,
@@ -40,17 +41,10 @@ type ClassNames = 'root' | 'main' | 'sidebar';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
-  main: {
-    '&.mlMain': {
-      [theme.breakpoints.up('lg')]: {
-        order: 3
-      }
-    }
-  },
+  main: {},
   sidebar: {
     [theme.breakpoints.up('lg')]: {
-      marginTop: -130,
-      order: 2
+      marginTop: '-130px !important'
     }
   }
 });
@@ -232,17 +226,21 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <Grid item className={`${classes.main} mlMain`}>
+        <Grid item className={`${classes.main} mlMain py0`}>
           {this.state.isGettingBackups ? (
-            <CircleProgress noTopMargin />
+            <Paper>
+              <CircleProgress noTopMargin />
+            </Paper>
           ) : !this.userHasBackups() ? (
-            <Placeholder
-              icon={VolumeIcon}
-              copy="You either do not have backups enabled for any Linode
+            <Paper>
+              <Placeholder
+                icon={VolumeIcon}
+                copy="You either do not have backups enabled for any Linode
                 or your Linodes have not been backed up. Please visit the 'Backups'
                 panel in the Linode Settings view"
-              title="Create from Backup"
-            />
+                title="Create from Backup"
+              />
+            </Paper>
           ) : (
             <React.Fragment>
               <CreateLinodeDisabled isDisabled={disabled} />

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -25,14 +25,19 @@ import { renderBackupsDisplaySection } from './utils';
 
 import { BaseFormStateAndHandlers, WithAll, WithDisplayData } from '../types';
 
-type ClassNames = 'root' | 'main' | 'sidebar';
+type ClassNames = 'root' | 'main' | 'sidebarPrivate' | 'sidebarPublic';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   main: {},
-  sidebar: {
+  sidebarPrivate: {
     [theme.breakpoints.up('lg')]: {
-      marginTop: -130
+      marginTop: '-130px !important'
+    }
+  },
+  sidebarPublic: {
+    [theme.breakpoints.up('lg')]: {
+      marginTop: '0 !important'
     }
   }
 });
@@ -115,7 +120,7 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
 
     if (variant === 'private' && privateImages.length === 0) {
       return (
-        <Grid item className={`${classes.main} mlMain`}>
+        <Grid item className={`${classes.main} mlMain py0`}>
           <Paper>
             <Placeholder
               title="My Images"
@@ -134,7 +139,7 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
 
     return (
       <React.Fragment>
-        <Grid item className={`${classes.main} mlMain`}>
+        <Grid item className={`${classes.main} mlMain py0`}>
           {notice && (
             <Notice
               text={notice.text}
@@ -226,7 +231,15 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
             disabled={userCannotCreateLinode}
           />
         </Grid>
-        <Grid item className={`${classes.sidebar} mlSidebar`}>
+        <Grid
+          item
+          className={
+            'mlSidebar ' +
+            (variant === 'private'
+              ? classes.sidebarPrivate
+              : classes.sidebarPublic)
+          }
+        >
           <Sticky topOffset={-24} disableCompensation>
             {(props: StickyProps) => {
               const displaySections = [];

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -5,6 +5,7 @@ import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
 import AccessPanel from 'src/components/AccessPanel';
 import CheckoutBar from 'src/components/CheckoutBar';
+import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
   withStyles,
@@ -115,16 +116,18 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
     if (variant === 'private' && privateImages.length === 0) {
       return (
         <Grid item className={`${classes.main} mlMain`}>
-          <Placeholder
-            title="My Images"
-            copy={
-              <span>
-                You don't have any private Images. Visit the{' '}
-                <Link to="/images">Images section</Link> to create an Image from
-                one of your Linode's disks.
-              </span>
-            }
-          />
+          <Paper>
+            <Placeholder
+              title="My Images"
+              copy={
+                <span>
+                  You don't have any private Images. Visit the{' '}
+                  <Link to="/images">Images section</Link> to create an Image
+                  from one of your Linode's disks.
+                </span>
+              }
+            />
+          </Paper>
         </Grid>
       );
     }

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -99,7 +99,6 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
 
   render() {
     const {
-      notice,
       classes,
       errors,
       accountBackupsEnabled,
@@ -121,7 +120,6 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
     } = this.props;
 
     const hasErrorFor = getAPIErrorsFor(errorResources, errors);
-    const generalError = hasErrorFor('none');
 
     const hasBackups = backupsEnabled || accountBackupsEnabled;
 
@@ -140,14 +138,6 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
           <React.Fragment>
             <Grid item className={`${classes.main} mlMain`}>
               <CreateLinodeDisabled isDisabled={userCannotCreateLinode} />
-              {notice && !userCannotCreateLinode && (
-                <Notice
-                  text={notice.text}
-                  error={notice.level === 'error'}
-                  warning={notice.level === 'warning'}
-                />
-              )}
-              {generalError && <Notice text={generalError} error={true} />}
               <SelectLinodePanel
                 error={hasErrorFor('linode_id')}
                 linodes={extendLinodes(linodes, images, types)}
@@ -156,6 +146,11 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
                 handleSelection={this.handleSelectLinode}
                 updateFor={[selectedLinodeID, errors]}
                 disabled={userCannotCreateLinode}
+                notice={{
+                  level: 'warning',
+                  text: `This newly created Linode will be created with
+                          the same password and SSH Keys (if any) as the original Linode.`
+                }}
               />
               <SelectRegionPanel
                 error={hasErrorFor('region')}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -4,6 +4,7 @@ import { Sticky, StickyProps } from 'react-sticky';
 import { compose } from 'recompose';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import CheckoutBar from 'src/components/CheckoutBar';
+import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
   withStyles,
@@ -34,17 +35,10 @@ type ClassNames = 'root' | 'main' | 'sidebar';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
-  main: {
-    '&.mlMain': {
-      [theme.breakpoints.up('lg')]: {
-        order: 3
-      }
-    }
-  },
+  main: {},
   sidebar: {
     [theme.breakpoints.up('lg')]: {
-      marginTop: -130,
-      order: 2
+      marginTop: '-130px !important'
     }
   }
 });
@@ -126,17 +120,19 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
     return (
       <React.Fragment>
         {linodes && linodes.length === 0 ? (
-          <Grid item className={`${classes.main}`}>
-            <Placeholder
-              icon={VolumeIcon}
-              copy="You do not have any existing Linodes to clone from.
-                  Please first create a Linode from either an Image or StackScript."
-              title="Clone from Existing Linode"
-            />
+          <Grid item className={`${classes.main} py0`}>
+            <Paper>
+              <Placeholder
+                icon={VolumeIcon}
+                copy="You do not have any existing Linodes to clone from.
+                    Please first create a Linode from either an Image or StackScript."
+                title="Clone from Existing Linode"
+              />
+            </Paper>
           </Grid>
         ) : (
           <React.Fragment>
-            <Grid item className={`${classes.main} mlMain`}>
+            <Grid item className={`${classes.main} mlMain py0`}>
               <CreateLinodeDisabled isDisabled={userCannotCreateLinode} />
               <SelectLinodePanel
                 error={hasErrorFor('linode_id')}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -13,7 +13,6 @@ import {
 import CreateLinodeDisabled from 'src/components/CreateLinodeDisabled';
 import Grid from 'src/components/Grid';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
-import Notice from 'src/components/Notice';
 import Placeholder from 'src/components/Placeholder';
 import SelectRegionPanel from 'src/components/SelectRegionPanel';
 
@@ -43,15 +42,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   }
 });
 
-interface Notice {
-  text: string;
-  level: 'warning' | 'error'; // most likely only going to need these two
-}
-
-interface Props {
-  notice?: Notice;
-}
-
 const errorResources = {
   type: 'A plan selection',
   region: 'A region selection',
@@ -59,8 +49,7 @@ const errorResources = {
   root_pass: 'A root password'
 };
 
-type CombinedProps = Props &
-  WithStyles<ClassNames> &
+type CombinedProps = WithStyles<ClassNames> &
   WithDisplayData &
   CloneFormStateHandlers &
   WithLinodesImagesTypesAndRegions;
@@ -241,6 +230,6 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, Props & CloneFormStateHandlers>(styled);
+const enhanced = compose<CombinedProps, CloneFormStateHandlers>(styled);
 
 export default enhanced(FromLinodeContent);

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -41,17 +41,10 @@ type ClassNames =
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
-  main: {
-    '&.mlMain': {
-      [theme.breakpoints.up('lg')]: {
-        order: 3
-      }
-    }
-  },
+  main: {},
   sidebar: {
     [theme.breakpoints.up('lg')]: {
-      marginTop: -130,
-      order: 2
+      marginTop: '-130px !important'
     }
   },
   emptyImagePanel: {
@@ -219,7 +212,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
 
     return (
       <React.Fragment>
-        <Grid item className={`${classes.main} mlMain`}>
+        <Grid item className={`${classes.main} mlMain py0`}>
           <CreateLinodeDisabled isDisabled={disabled} />
           {!disabled && notice && (
             <Notice

--- a/src/index.css
+++ b/src/index.css
@@ -242,6 +242,9 @@ a.black:not(.nu):active {
     flex-basis: 78.8%;
   }
   .mlSidebar {
+    position: sticky;
+    top: 0;
+    align-self: flex-start;
     max-width: 21.2%;
     max-width: 21.2%;
     padding-left: 16px !important;

--- a/src/index.css
+++ b/src/index.css
@@ -247,7 +247,7 @@ a.black:not(.nu):active {
     align-self: flex-start;
     max-width: 21.2%;
     max-width: 21.2%;
-    padding-left: 16px !important;
+    padding: 8px 24px !important;
     margin-top: 0 !important;
   }
 }


### PR DESCRIPTION
## Description

UI edits for Apps work: 
• Notices are now part of Backups and Linodes, as well as adding Paper to a few of the different 'states' of the components (loading, null imagery, etc.) 
• Grid alignment updates
• Making checkout bar use css sticky instead of external library. 

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

This work is most noticeable under the 'My Images' tab, but 'Distributions' tab and 'Create NodeBalancer' flow should be reviewed as well since I impacted CheckoutBar. 

Also, if there are other places where Paper component should be added/ notice messaging needs to be moved, please call it out and I will address either here or in a separate issue. 