### PR TITLE
M3-2495 Change: Add Confirmation Dialog before rebuilding Linode

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildDialog.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildDialog.tsx
@@ -40,7 +40,8 @@ export const RebuildDialog: React.StatelessComponent<
       actions={actions}
     >
       <Typography>
-        <b>Delete all existing data</b> on this Linode and redeploy?
+        Are you sure you want to rebuild your Linode? This will result in
+        permanent data loss.
       </Typography>
     </ConfirmationDialog>
   );

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildDialog.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildDialog.tsx
@@ -40,7 +40,7 @@ export const RebuildDialog: React.StatelessComponent<
       actions={actions}
     >
       <Typography>
-        Are you sure you want to rebuild your Linode? This will result in
+        Are you sure you want to rebuild this Linode? This will result in
         permanent data loss.
       </Typography>
     </ConfirmationDialog>

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildDialog.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildDialog.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+
+interface RebuildDialogProps {
+  isOpen: boolean;
+  isLoading: boolean;
+  handleClose: () => void;
+  handleSubmit: () => void;
+}
+
+export const RebuildDialog: React.StatelessComponent<
+  RebuildDialogProps
+> = props => {
+  const { isOpen, isLoading, handleClose, handleSubmit } = props;
+
+  const actions = () => (
+    <ActionsPanel>
+      <Button type="cancel" onClick={handleClose} data-qa-cancel>
+        Cancel
+      </Button>
+      <Button
+        type="secondary"
+        destructive
+        onClick={handleSubmit}
+        loading={isLoading}
+      >
+        Rebuild
+      </Button>
+    </ActionsPanel>
+  );
+
+  return (
+    <ConfirmationDialog
+      open={isOpen}
+      onClose={handleClose}
+      title="Confirm Linode Rebuild"
+      actions={actions}
+    >
+      <Typography>
+        <b>Delete all existing data</b> on this Linode and redeploy?
+      </Typography>
+    </ConfirmationDialog>
+  );
+};


### PR DESCRIPTION
## Description

Added a ConfirmationDialog after a user presses the “Rebuild ” button, since this is a destructive action.

NOTE: Ideally we’d do form validation before opening the confirmation dialog, but this will require larger changes and consideration. I thought this solution would be fine in the short-term.

## Type of Change
- Non breaking change ('update', 'change')
