### PR TITLE
M3-2494 Smaller Entity Icons on Comp Mode

### DIFF
--- a/src/components/EntityIcon/EntityIcon.tsx
+++ b/src/components/EntityIcon/EntityIcon.tsx
@@ -5,6 +5,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import { spacing as themeSpacingStorage } from 'src/utilities/storage';
 
 import DomainIcon from 'src/assets/icons/entityIcons/domain.svg';
 import LinodeIcon from 'src/assets/icons/entityIcons/linode.svg';
@@ -84,7 +85,11 @@ const EntityIcon: React.StatelessComponent<CombinedProps> = props => {
     stopAnimation
   } = props;
 
-  const iconSize = size ? size : 40;
+  const iconSize = size
+    ? size
+    : themeSpacingStorage.get() === 'compact'
+    ? 34
+    : 40;
   const iconMap = {
     linode: LinodeIcon,
     nodebalancer: NodeBalancerIcon,

--- a/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -2,7 +2,6 @@ import { compose, take } from 'ramda';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Subscription } from 'rxjs/Subscription';
-import NodeBalancerIcon from 'src/assets/addnewmenu/nodebalancer.svg';
 import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
 import {
@@ -14,6 +13,7 @@ import Table from 'src/components/core/Table';
 import TableBody from 'src/components/core/TableBody';
 import TableCell from 'src/components/core/TableCell';
 import Typography from 'src/components/core/Typography';
+import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
@@ -197,7 +197,7 @@ class NodeBalancersDashboardCard extends React.Component<CombinedProps, State> {
           <Link to={`/nodebalancers/${id}`} className={'black nu block'}>
             <Grid container wrap="nowrap" alignItems="center">
               <Grid item className="py0">
-                <NodeBalancerIcon className={classes.icon} />
+                <EntityIcon variant="nodebalancer" />
               </Grid>
               <Grid item className={classes.labelGridWrapper}>
                 <Typography

--- a/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
@@ -1,7 +1,6 @@
 import { compose, take } from 'ramda';
 import * as React from 'react';
 import { Subscription } from 'rxjs/Subscription';
-import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
 import {
@@ -13,6 +12,7 @@ import Table from 'src/components/core/Table';
 import TableBody from 'src/components/core/TableBody';
 import TableCell from 'src/components/core/TableCell';
 import Typography from 'src/components/core/Typography';
+import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
@@ -196,7 +196,7 @@ class VolumesDashboardCard extends React.Component<CombinedProps, State> {
         <TableCell className={classes.labelCol}>
           <Grid container wrap="nowrap" alignItems="center">
             <Grid item className="py0">
-              <VolumeIcon className={classes.icon} />
+              <EntityIcon variant="volume" />
             </Grid>
             <Grid item className={classes.labelGridWrapper}>
               <Typography

--- a/src/features/Domains/DomainTableRow.tsx
+++ b/src/features/Domains/DomainTableRow.tsx
@@ -14,7 +14,12 @@ import TableRow from 'src/components/TableRow';
 import Tags from 'src/components/Tags';
 import ActionMenu from './DomainActionMenu';
 
-type ClassNames = 'domain' | 'labelStatusWrapper' | 'tagWrapper' | 'domainRow';
+type ClassNames =
+  | 'domain'
+  | 'labelStatusWrapper'
+  | 'tagWrapper'
+  | 'domainRow'
+  | 'domainCellContainer';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   domain: {
@@ -22,6 +27,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   domainRow: {
     backgroundColor: theme.bg.white
+  },
+  domainCellContainer: {
+    padding: `${theme.spacing.unit}px !important`
   },
   labelStatusWrapper: {
     display: 'flex',
@@ -69,7 +77,7 @@ const DomainTableRow: React.StatelessComponent<CombinedProps> = props => {
                 loading={status === 'edit_mode'}
               />
             </Grid>
-            <Grid item>
+            <Grid item className={classes.domainCellContainer}>
               <div className={classes.labelStatusWrapper}>
                 <Typography role="header" variant="h3" data-qa-label>
                   {domain}

--- a/src/features/Domains/ListDomains.tsx
+++ b/src/features/Domains/ListDomains.tsx
@@ -20,7 +20,7 @@ type ClassNames = 'root' | 'label';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   label: {
-    paddingLeft: 65
+    paddingLeft: theme.spacing.unit * 2 + 49
   }
 });
 

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import NodeBalancer from 'src/assets/addnewmenu/nodebalancer.svg';
 import {
   StyleRulesCallback,
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
@@ -84,7 +84,7 @@ const NodeBalancersLandingTableRows: React.StatelessComponent<
               <Link to={`/nodebalancers/${nodeBalancer.id}`}>
                 <Grid container wrap="nowrap" alignItems="center">
                   <Grid item className="py0">
-                    <NodeBalancer className={classes.icon} />
+                    <EntityIcon variant="nodebalancer" marginTop={1} />
                   </Grid>
                   <Grid item>
                     <Typography variant="h3">{nodeBalancer.label}</Typography>

--- a/src/features/NodeBalancers/NodeBalancersLanding/SortableTableHead.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/SortableTableHead.tsx
@@ -14,7 +14,7 @@ type ClassNames =
   | 'ip'
   | 'nameCell'
   | 'nodeStatus'
-  | 'nodeStatus'
+  | 'tags'
   | 'ports'
   | 'tagGroup'
   | 'title'
@@ -29,11 +29,16 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   nameCell: {
     width: '15%',
     minWidth: 150,
-    paddingLeft: 65
+    paddingLeft: theme.spacing.unit * 2 + 49
   },
   region: {
     width: '15%',
     minWidth: 150
+  },
+  tags: {
+    width: '10%',
+    minWidth: 100,
+    textAlign: 'center'
   },
   nodeStatus: {
     width: '10%',
@@ -75,7 +80,7 @@ const SortableTableHead: React.StatelessComponent<CombinedProps> = props => {
         >
           Name
         </TableSortCell>
-        <TableCell className={classes.nodeStatus} noWrap>
+        <TableCell className={classes.tags} noWrap>
           Tags
         </TableCell>
         <TableCell className={classes.nodeStatus} noWrap>

--- a/src/features/Volumes/SortableVolumesTableHeader.tsx
+++ b/src/features/Volumes/SortableVolumesTableHeader.tsx
@@ -52,7 +52,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   labelCol: {
     width: '20%',
     minWidth: 150,
-    paddingLeft: 65
+    paddingLeft: theme.spacing.unit * 2 + 49
   },
   attachmentCol: {
     width: '15%',

--- a/src/features/Volumes/VolumeTableRow.tsx
+++ b/src/features/Volumes/VolumeTableRow.tsx
@@ -1,7 +1,6 @@
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import VolumesIcon from 'src/assets/addnewmenu/volume.svg';
 import {
   StyleRulesCallback,
   withStyles,
@@ -9,6 +8,7 @@ import {
 } from 'src/components/core/styles';
 import TableRow from 'src/components/core/TableRow';
 import Typography from 'src/components/core/Typography';
+import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
 import TableCell from 'src/components/TableCell';
@@ -20,7 +20,6 @@ type ClassNames =
   | 'root'
   | 'title'
   | 'labelCol'
-  | 'icon'
   | 'labelStatusWrapper'
   | 'attachmentCol'
   | 'sizeCol'
@@ -54,18 +53,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     width: '25%',
     minWidth: 150,
     paddingLeft: 65
-  },
-  icon: {
-    position: 'relative',
-    top: 3,
-    width: 40,
-    height: 40,
-    '& .circle': {
-      fill: theme.bg.offWhiteDT
-    },
-    '& .outerCircle': {
-      stroke: theme.bg.main
-    }
   },
   labelStatusWrapper: {
     display: 'flex',
@@ -156,7 +143,7 @@ const VolumeTableRow: React.StatelessComponent<CombinedProps> = props => {
       <TableCell data-qa-volume-cell-label={label}>
         <Grid container wrap="nowrap" alignItems="center">
           <Grid item className="py0">
-            <VolumesIcon className={classes.icon} />
+            <EntityIcon variant="volume" marginTop={1} />
           </Grid>
           <Grid item>
             <div className={classes.labelStatusWrapper}>
@@ -181,7 +168,7 @@ const VolumeTableRow: React.StatelessComponent<CombinedProps> = props => {
       <TableCell parentColumn="Label" data-qa-volume-cell-label={volume.label}>
         <Grid container wrap="nowrap" alignItems="center">
           <Grid item className="py0">
-            <VolumesIcon className={classes.icon} />
+            <EntityIcon variant="volume" marginTop={1} />
           </Grid>
           <Grid item>
             <div className={classes.labelStatusWrapper}>

--- a/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -38,7 +38,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     height: 'auto',
     '& td': {
       // This is maintaining the spacing between groups because of how tables handle margin/padding. Adjust with care!
-      padding: '20px 0 10px',
+      padding: `${theme.spacing.unit * 2 + 4}px 0 ${theme.spacing.unit + 2}px`,
       borderBottom: 'none'
     }
   },

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -73,8 +73,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     alignItems: 'center'
   },
   labelGridWrapper: {
-    paddingLeft: `${theme.spacing.unit / 2}px !important`,
-    paddingRight: `${theme.spacing.unit / 2}px !important`
+    padding: `${theme.spacing.unit}px ${theme.spacing.unit / 2}px !important`
   },
   wrapHeader: {
     wordBreak: 'break-all'
@@ -186,11 +185,11 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
 const styled = withStyles(styles);
 const enhanced = compose<CombinedProps, Props>(
   withDisplayType,
-  styled,
   withImages((ownProps, imagesData, imagesLoading) => ({
     ...ownProps,
     imagesData: imagesData.filter(i => i.is_public === true)
-  }))
+  })),
+  styled
 );
 
 export default enhanced(LinodeRowHeadCell);

--- a/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -15,7 +15,7 @@ type ClassNames = 'root' | 'label' | 'tagHeader';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   label: {
-    paddingLeft: 65
+    paddingLeft: theme.spacing.unit * 4 + 33
   },
   tagHeader: {
     textAlign: 'center'

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -498,9 +498,6 @@ export const dark = () =>
           }
         },
         hover: {
-          '& > td:first-child': {
-            paddingLeft: 13
-          },
           '& a': {
             color: primaryColors.main
           }


### PR DESCRIPTION
## Smaller Icons on Comp Mode

 This PR improves the layout of tables rows for Comp Mode:
- smaller entity icons
- better alignment of sortable headers
- better cell spacing

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

This PR will affect landing page table rows/cells on compact mode.
