### PR TITLE
Fix: Default lastFour to empty string instead of false

### DIFF
--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -566,7 +566,7 @@ const withAccount = AccountContainer(
     ...ownProps,
     accountLoading,
     balance: pathOr(false, ['balance'], accountData),
-    lastFour: pathOr(false, ['credit_card', 'last_four'], accountData)
+    lastFour: pathOr('', ['credit_card', 'last_four'], accountData)
   })
 );
 


### PR DESCRIPTION
## Description

If you didn't have a credit card on file, the string 'false' would be displayed. Use a blank string instead to fix this.