### PR TITLE
M3-2498 Fix: Keyboard scrolling on on custom MenuList component

### DIFF
--- a/src/components/EnhancedSelect/components/Guidance.tsx
+++ b/src/components/EnhancedSelect/components/Guidance.tsx
@@ -1,0 +1,49 @@
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from '@material-ui/core/styles';
+import HelpOutline from '@material-ui/icons/HelpOutline';
+import * as React from 'react';
+import Typography from 'src/components/core/Typography';
+
+type ClassNames = 'guidance' | 'text' | 'helpIcon';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  guidance: {
+    backgroundColor: theme.bg.offWhiteDT,
+    borderTop: `1px solid ${theme.palette.divider}`,
+    padding: theme.spacing.unit * 2
+  },
+  text: {
+    fontSize: '.8rem'
+  },
+  helpIcon: {
+    width: 16,
+    height: 16,
+    position: 'relative',
+    top: 3,
+    marginRight: theme.spacing.unit
+  }
+});
+
+interface GuidanceProps {
+  text: string;
+}
+type CombinedProps = GuidanceProps & WithStyles<ClassNames>;
+
+const Guidance: React.StatelessComponent<CombinedProps> = props => {
+  const { classes, text } = props;
+  return (
+    <div className={classes.guidance}>
+      <Typography className={classes.text}>
+        <HelpOutline className={classes.helpIcon} />
+        {text}
+      </Typography>
+    </div>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(Guidance);

--- a/src/components/EnhancedSelect/components/MenuList.tsx
+++ b/src/components/EnhancedSelect/components/MenuList.tsx
@@ -1,40 +1,11 @@
-import {
-  StyleRulesCallback,
-  withStyles,
-  WithStyles
-} from '@material-ui/core/styles';
-import HelpOutline from '@material-ui/icons/HelpOutline';
 import * as React from 'react';
 import { components as reactSelectComponents } from 'react-select';
-import _MenuList, {
-  MenuListComponentProps
-} from 'react-select/lib/components/Menu';
-import Typography from 'src/components/core/Typography';
+import { MenuListComponentProps } from 'react-select/lib/components/Menu';
+import Guidance from './Guidance';
 
-type ClassNames = 'guidance' | 'text' | 'helpIcon';
-
-const styles: StyleRulesCallback<ClassNames> = theme => ({
-  guidance: {
-    backgroundColor: theme.bg.offWhiteDT,
-    borderTop: `1px solid ${theme.palette.divider}`,
-    padding: theme.spacing.unit * 2
-  },
-  text: {
-    fontSize: '.8rem'
-  },
-  helpIcon: {
-    width: 16,
-    height: 16,
-    position: 'relative',
-    top: 3,
-    marginRight: theme.spacing.unit
-  }
-});
-
-type CombinedProps = MenuListComponentProps<any> & WithStyles<ClassNames>;
+type CombinedProps = MenuListComponentProps<any>;
 
 const Menu: React.StatelessComponent<CombinedProps> = props => {
-  const { classes } = props;
   const { guidance } = props.selectProps;
 
   return (
@@ -42,18 +13,9 @@ const Menu: React.StatelessComponent<CombinedProps> = props => {
       <reactSelectComponents.MenuList {...props}>
         {props.children}
       </reactSelectComponents.MenuList>
-      {guidance !== undefined && (
-        <div className={classes.guidance}>
-          <Typography className={classes.text}>
-            <HelpOutline className={classes.helpIcon} />
-            {guidance}
-          </Typography>
-        </div>
-      )}
+      {guidance !== undefined && <Guidance text={guidance} />}
     </React.Fragment>
   );
 };
 
-const styled = withStyles(styles);
-
-export default styled(Menu);
+export default Menu;


### PR DESCRIPTION
## Description

Using `withStyles` was replacing `innerRef` on the new custom MenuList component, which was breaking keyboard scrolling navigation. I extracted the "Guidance" part of the component out, so styles could still be applied. There's probably a better solution, though. 

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Test that the main SearchBar works and that you can scroll with keyboard up/down if there are many entities.
