### PR TITLE
Add test:debug script

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "prepush": "./scripts/pre-push.sh",
     "mock": "./scripts/mb.js",
     "test": "node scripts/test.js --env=jsdom",
+    "test:debug": "node --inspect-brk scripts/test.js --runInBand --env=jsdom",
     "storybook": "start-storybook -p 6006",
     "storybook-static": "build-storybook -c .storybook -o .out",
     "storybook:e2e": "./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js",


### PR DESCRIPTION
## Description

Playing with Node/Chrome/Jest debugging integration

## Note to Reviewers

To test: 

1. Add a `debugger` statement to any Jest test
2. Run `yarn test:debug`
3. In chrome, visit chrome://inspect
4. Click on the Node icon
5. et voila, step through with the debugger as you would normally.