### PR TITLE
Apps UDF Improvements

### DIFF
--- a/src/components/AccessPanel/AccessPanel.tsx
+++ b/src/components/AccessPanel/AccessPanel.tsx
@@ -71,6 +71,7 @@ interface Props {
   users?: UserSSHKeyObject[];
   disabled?: boolean;
   disabledReason?: string;
+  hideStrengthLabel?: boolean;
 }
 
 export interface UserSSHKeyObject {
@@ -97,7 +98,8 @@ class AccessPanel extends React.Component<CombinedProps> {
       placeholder,
       users,
       disabled,
-      disabledReason
+      disabledReason,
+      hideStrengthLabel
     } = this.props;
 
     return (
@@ -113,6 +115,7 @@ class AccessPanel extends React.Component<CombinedProps> {
             label={label || 'Root Password'}
             placeholder={placeholder || 'Enter a password.'}
             onChange={this.handleChange}
+            hideStrengthLabel={hideStrengthLabel}
           />
           {users && users.length > 0 && this.renderUserSSHKeyTable(users)}
         </div>

--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -15,6 +15,7 @@ type Props = TextFieldProps & {
   value?: string;
   required?: boolean;
   disabledReason?: string;
+  hideStrengthLabel?: boolean;
 };
 
 interface State {
@@ -62,7 +63,14 @@ class PasswordInput extends React.Component<CombinedProps, State> {
 
   render() {
     const { strength } = this.state;
-    const { classes, value, required, disabledReason, ...rest } = this.props;
+    const {
+      classes,
+      value,
+      required,
+      disabledReason,
+      hideStrengthLabel,
+      ...rest
+    } = this.props;
 
     return (
       <Grid container className={classes.container}>
@@ -78,7 +86,10 @@ class PasswordInput extends React.Component<CombinedProps, State> {
         </Grid>
         {
           <Grid item xs={12} className={`${classes.strengthIndicator} py0`}>
-            <StrengthIndicator strength={strength} />
+            <StrengthIndicator
+              strength={strength}
+              hideStrengthLabel={hideStrengthLabel}
+            />
           </Grid>
         }
       </Grid>

--- a/src/components/PasswordInput/StrengthIndicator.tsx
+++ b/src/components/PasswordInput/StrengthIndicator.tsx
@@ -11,6 +11,7 @@ import Grid from 'src/components/Grid';
 
 interface Props {
   strength: null | 0 | 1 | 2 | 3;
+  hideStrengthLabel?: boolean;
 }
 type ClassNames = 'root' | 'block' | 'strengthText' | 'strengthLabel';
 
@@ -49,7 +50,7 @@ const styled = withStyles<ClassNames>(styles);
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const StrengthIndicator: React.StatelessComponent<CombinedProps> = props => {
-  const { classes, strength } = props;
+  const { classes, strength, hideStrengthLabel } = props;
 
   return (
     <Grid
@@ -75,7 +76,9 @@ const StrengthIndicator: React.StatelessComponent<CombinedProps> = props => {
           className={classes.strengthText}
           data-qa-password-strength
         >
-          <span className={classes.strengthLabel}>Strength:</span>
+          {!hideStrengthLabel && (
+            <span className={classes.strengthLabel}>Strength:</span>
+          )}
           {strength
             ? (strength === 1 && ' Weak') ||
               (strength === 2 && ' Fair') ||

--- a/src/components/ShowMoreExpansion/ShowMoreExpansion.stories.tsx
+++ b/src/components/ShowMoreExpansion/ShowMoreExpansion.stories.tsx
@@ -4,7 +4,7 @@ import Typography from 'src/components/core/Typography';
 import ShowMoreExpansion from './ShowMoreExpansion';
 
 storiesOf('ShowMoreExpansion', module).add('default', () => (
-  <ShowMoreExpansion name="Show Older Images">
+  <ShowMoreExpansion name="Show Older Images" defaultExpanded={false}>
     <Typography>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
       tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim

--- a/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
+++ b/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
@@ -52,7 +52,7 @@ interface State {
 type CombinedProps = Props & WithStyles<CSSClasses>;
 
 class ShowMoreExpansion extends React.Component<CombinedProps, State> {
-  state = { open: this.props.defaultExpanded };
+  state = { open: this.props.defaultExpanded || false };
 
   handleNameClick = () => {
     this.setState({

--- a/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
+++ b/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
@@ -42,6 +42,7 @@ const styles: StyleRulesCallback = theme => ({
 
 interface Props {
   name: string;
+  defaultExpanded: boolean;
 }
 
 interface State {
@@ -51,15 +52,19 @@ interface State {
 type CombinedProps = Props & WithStyles<CSSClasses>;
 
 class ShowMoreExpansion extends React.Component<CombinedProps, State> {
-  state = {
-    open: false
-  };
+  state = { open: this.props.defaultExpanded };
 
   handleNameClick = () => {
     this.setState({
-      open: !this.state.open
+      open: !this.props.defaultExpanded
     });
   };
+
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (prevState.open !== this.props.defaultExpanded) {
+      this.setState({ open: this.props.defaultExpanded });
+    }
+  }
 
   render() {
     const { name, classes, children } = this.props;

--- a/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
+++ b/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
@@ -42,11 +42,11 @@ const styles: StyleRulesCallback = theme => ({
 
 interface Props {
   name: string;
-  defaultExpanded: boolean;
+  defaultExpanded?: boolean;
 }
 
 interface State {
-  open: boolean;
+  open: boolean | undefined;
 }
 
 type CombinedProps = Props & WithStyles<CSSClasses>;

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedMultiSelect.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedMultiSelect.tsx
@@ -15,9 +15,7 @@ type ClassNames = 'root' | 'toggle';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
-    margin: `${theme.spacing.unit * 3}px 0`,
-    paddingBottom: theme.spacing.unit * 3,
-    borderBottom: `1px solid ${theme.palette.divider}`
+    margin: `${theme.spacing.unit * 3}px 0 0`
   },
   toggle: {}
 });

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.tsx
@@ -14,9 +14,7 @@ type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
-    margin: `${theme.spacing.unit * 3}px 0`,
-    paddingBottom: theme.spacing.unit * 3,
-    borderBottom: `1px solid ${theme.palette.divider}`
+    margin: `${theme.spacing.unit * 3}px 0 0`
   }
 });
 

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
@@ -54,6 +54,7 @@ class UserDefinedText extends React.Component<CombinedProps, {}> {
         noPadding
         placeholder={placeholder}
         error={error}
+        hideStrengthLabel
       />
     );
   };

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
@@ -12,9 +12,11 @@ type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
-    margin: `${theme.spacing.unit * 3}px 0`,
-    paddingBottom: theme.spacing.unit * 3,
-    borderBottom: `1px solid ${theme.palette.divider}`
+    '.optionalFieldWrapper &': {
+      [theme.breakpoints.up('lg')]: {
+        maxWidth: '70%'
+      }
+    }
   }
 });
 

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
@@ -11,13 +11,7 @@ import TextField from 'src/components/TextField';
 type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {
-    '.optionalFieldWrapper &': {
-      [theme.breakpoints.up('lg')]: {
-        maxWidth: '70%'
-      }
-    }
-  }
+  root: {}
 });
 
 interface Props {

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -55,7 +55,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
     const isOptional = field.hasOwnProperty('default');
     if (isMultiSelect(field)) {
       return (
-        <Grid item xs={12}>
+        <Grid item xs={12} key={field.name}>
           <UserDefinedMultiSelect
             key={field.name}
             field={field}
@@ -70,7 +70,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
     }
     if (isOneSelect(field)) {
       return (
-        <Grid item xs={12}>
+        <Grid item xs={12} key={field.name}>
           <UserDefinedSelect
             field={field}
             updateFormState={handleChange}
@@ -85,7 +85,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
     }
     if (isPasswordField(field.name)) {
       return (
-        <Grid item xs={12} sm={6} md={4}>
+        <Grid item xs={12} sm={6} md={4} key={field.name}>
           <UserDefinedText
             key={field.name}
             updateFormState={handleChange}
@@ -101,7 +101,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
       );
     }
     return (
-      <Grid item xs={12} sm={6} md={4}>
+      <Grid item xs={12} sm={6} md={4} key={field.name}>
         <UserDefinedText
           key={field.name}
           updateFormState={handleChange}

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -49,15 +49,12 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const UserDefinedFieldsPanel: React.StatelessComponent<
-  CombinedProps
-> = props => {
-  const { userDefinedFields, classes, handleChange } = props;
-
-  const renderField = (
+class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
+  renderField = (
     field: Linode.StackScript.UserDefinedField,
     error?: string
   ) => {
+    const { udf_data, handleChange } = this.props;
     // if the 'default' key is returned from the API, the field is optional
     const isOptional = field.hasOwnProperty('default');
     if (isMultiSelect(field)) {
@@ -66,9 +63,9 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           <UserDefinedMultiSelect
             key={field.name}
             field={field}
-            udf_data={props.udf_data}
+            udf_data={udf_data}
             updateFormState={handleChange}
-            updateFor={[props.udf_data[field.name], error]}
+            updateFor={[udf_data[field.name], error]}
             isOptional={isOptional}
             error={error}
           />
@@ -81,8 +78,8 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           <UserDefinedSelect
             field={field}
             updateFormState={handleChange}
-            udf_data={props.udf_data}
-            updateFor={[props.udf_data[field.name], error]}
+            udf_data={udf_data}
+            updateFor={[udf_data[field.name], error]}
             isOptional={isOptional}
             key={field.name}
             error={error}
@@ -97,8 +94,8 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
             updateFormState={handleChange}
             isPassword={true}
             field={field}
-            udf_data={props.udf_data}
-            updateFor={[props.udf_data[field.name], error]}
+            udf_data={udf_data}
+            updateFor={[udf_data[field.name], error]}
             isOptional={isOptional}
             placeholder={field.example}
             error={error}
@@ -111,8 +108,8 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
         <UserDefinedText
           updateFormState={handleChange}
           field={field}
-          udf_data={props.udf_data}
-          updateFor={[props.udf_data[field.name], error]}
+          udf_data={udf_data}
+          updateFor={[udf_data[field.name], error]}
           isOptional={isOptional}
           placeholder={field.example}
           error={error}
@@ -121,46 +118,66 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
     );
   };
 
-  return (
-    <Paper className={classes.root}>
-      <Typography role="header" variant="h2" data-qa-user-defined-field-header>
-        <span>{`${props.selectedLabel} Options`}</span>
-      </Typography>
+  render() {
+    const { userDefinedFields, classes } = this.props;
 
-      {/* Required Fields */}
-      {userDefinedFields!
-        .filter(
-          (field: Linode.StackScript.UserDefinedField) =>
-            field.hasOwnProperty('default') !== true
-        )
-        .map((field: Linode.StackScript.UserDefinedField) => {
-          const error = getError(field, props.errors);
-          return renderField(field, error);
-        })}
+    /** [true, false, true, false] */
+    const hasOnlyOptionalFields = userDefinedFields!
+      .map(eachUDF => {
+        return Object.keys(eachUDF).some(eachKey => eachKey === 'default');
+      })
+      .every(eachValue => eachValue === true);
 
-      {/* Optional Fields */}
-      <ShowMoreExpansion name="Show Advanced Options">
-        <Typography variant="body1" className={classes.advDescription}>
-          These fields are additional configuration options and are not required
-          for creation.
+    return (
+      <Paper className={classes.root}>
+        <Typography
+          role="header"
+          variant="h2"
+          data-qa-user-defined-field-header
+        >
+          <span>{`${this.props.selectedLabel} Options`}</span>
         </Typography>
-        <div className={`${classes.optionalFieldWrapper} optionalFieldWrapper`}>
-          <Grid container alignItems="center">
-            {userDefinedFields!
-              .filter(
-                (field: Linode.StackScript.UserDefinedField) =>
-                  field.hasOwnProperty('default') === true
-              )
-              .map((field: Linode.StackScript.UserDefinedField) => {
-                const error = getError(field, props.errors);
-                return renderField(field, error);
-              })}
-          </Grid>
-        </div>
-      </ShowMoreExpansion>
-    </Paper>
-  );
-};
+
+        {/* Required Fields */}
+        {userDefinedFields!
+          .filter(
+            (field: Linode.StackScript.UserDefinedField) =>
+              field.hasOwnProperty('default') !== true
+          )
+          .map((field: Linode.StackScript.UserDefinedField) => {
+            const error = getError(field, this.props.errors);
+            return this.renderField(field, error);
+          })}
+
+        {/* Optional Fields */}
+        <ShowMoreExpansion
+          name="Show Advanced Options"
+          defaultExpanded={hasOnlyOptionalFields}
+        >
+          <Typography variant="body1" className={classes.advDescription}>
+            These fields are additional configuration options and are not
+            required for creation.
+          </Typography>
+          <div
+            className={`${classes.optionalFieldWrapper} optionalFieldWrapper`}
+          >
+            <Grid container alignItems="center">
+              {userDefinedFields!
+                .filter(
+                  (field: Linode.StackScript.UserDefinedField) =>
+                    field.hasOwnProperty('default') === true
+                )
+                .map((field: Linode.StackScript.UserDefinedField) => {
+                  const error = getError(field, this.props.errors);
+                  return this.renderField(field, error);
+                })}
+            </Grid>
+          </div>
+        </ShowMoreExpansion>
+      </Paper>
+    );
+  }
+}
 
 const getError = (
   field: Linode.StackScript.UserDefinedField,

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -7,6 +7,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import RenderGuard from 'src/components/RenderGuard';
+import ShowMoreExpansion from 'src/components/ShowMoreExpansion';
 import UserDefinedMultiSelect from './FieldTypes/UserDefinedMultiSelect';
 import UserDefinedSelect from './FieldTypes/UserDefinedSelect';
 import UserDefinedText from './FieldTypes/UserDefinedText';
@@ -113,10 +114,31 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
         } / `}</span>
         <span>{`${props.selectedLabel} Options`}</span>
       </Typography>
-      {userDefinedFields!.map((field: Linode.StackScript.UserDefinedField) => {
+
+      {userDefinedFields!
+        .filter(field => field.hasOwnProperty('default') !== true)
+        .map((field: Linode.StackScript.UserDefinedField) => {
+          const error = getError(field, props.errors);
+          <React.Fragment>{renderField(field, error)}</React.Fragment>;
+        })}
+
+      <ShowMoreExpansion name="Show Advanced Options">
+        <Typography variant="body1">
+          These fields are additional configuration options and are not required
+          for creation.
+        </Typography>
+        {userDefinedFields!
+          .filter(field => field.hasOwnProperty('default') === true)
+          .map((field: Linode.StackScript.UserDefinedField) => {
+            const error = getError(field, props.errors);
+            <React.Fragment>{renderField(field, error)}</React.Fragment>;
+          })}
+      </ShowMoreExpansion>
+
+      {/* {userDefinedFields!.map((field: Linode.StackScript.UserDefinedField) => {
         const error = getError(field, props.errors);
         return renderField(field, error);
-      })}
+      })} */}
     </Paper>
   );
 };

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -57,56 +57,36 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
     const isOptional = field.hasOwnProperty('default');
     if (isMultiSelect(field)) {
       return (
-        <Grid item xs={12}>
-          <UserDefinedMultiSelect
-            key={field.name}
-            field={field}
-            udf_data={props.udf_data}
-            updateFormState={handleChange}
-            updateFor={[props.udf_data[field.name], error]}
-            isOptional={isOptional}
-            error={error}
-          />
-        </Grid>
+        <UserDefinedMultiSelect
+          key={field.name}
+          field={field}
+          udf_data={props.udf_data}
+          updateFormState={handleChange}
+          updateFor={[props.udf_data[field.name], error]}
+          isOptional={isOptional}
+          error={error}
+        />
       );
     }
     if (isOneSelect(field)) {
       return (
-        <Grid item xs={12}>
-          <UserDefinedSelect
-            field={field}
-            updateFormState={handleChange}
-            udf_data={props.udf_data}
-            updateFor={[props.udf_data[field.name], error]}
-            isOptional={isOptional}
-            key={field.name}
-            error={error}
-          />
-        </Grid>
+        <UserDefinedSelect
+          field={field}
+          updateFormState={handleChange}
+          udf_data={props.udf_data}
+          updateFor={[props.udf_data[field.name], error]}
+          isOptional={isOptional}
+          key={field.name}
+          error={error}
+        />
       );
     }
     if (isPasswordField(field.name)) {
       return (
-        <Grid item xs={12}>
-          <UserDefinedText
-            key={field.name}
-            updateFormState={handleChange}
-            isPassword={true}
-            field={field}
-            udf_data={props.udf_data}
-            updateFor={[props.udf_data[field.name], error]}
-            isOptional={isOptional}
-            placeholder={field.example}
-            error={error}
-          />
-        </Grid>
-      );
-    }
-    return (
-      <Grid item xs={12}>
         <UserDefinedText
           key={field.name}
           updateFormState={handleChange}
+          isPassword={true}
           field={field}
           udf_data={props.udf_data}
           updateFor={[props.udf_data[field.name], error]}
@@ -114,7 +94,19 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           placeholder={field.example}
           error={error}
         />
-      </Grid>
+      );
+    }
+    return (
+      <UserDefinedText
+        key={field.name}
+        updateFormState={handleChange}
+        field={field}
+        udf_data={props.udf_data}
+        updateFor={[props.udf_data[field.name], error]}
+        isOptional={isOptional}
+        placeholder={field.example}
+        error={error}
+      />
     );
   };
 

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -28,9 +28,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   username: {
     color: theme.color.grey1
   },
-  optionalFieldWrapper: {
-    maxWidth: 860
-  }
+  optionalFieldWrapper: {}
 });
 
 interface Props {
@@ -57,36 +55,56 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
     const isOptional = field.hasOwnProperty('default');
     if (isMultiSelect(field)) {
       return (
-        <UserDefinedMultiSelect
-          key={field.name}
-          field={field}
-          udf_data={props.udf_data}
-          updateFormState={handleChange}
-          updateFor={[props.udf_data[field.name], error]}
-          isOptional={isOptional}
-          error={error}
-        />
+        <Grid item xs={12}>
+          <UserDefinedMultiSelect
+            key={field.name}
+            field={field}
+            udf_data={props.udf_data}
+            updateFormState={handleChange}
+            updateFor={[props.udf_data[field.name], error]}
+            isOptional={isOptional}
+            error={error}
+          />
+        </Grid>
       );
     }
     if (isOneSelect(field)) {
       return (
-        <UserDefinedSelect
-          field={field}
-          updateFormState={handleChange}
-          udf_data={props.udf_data}
-          updateFor={[props.udf_data[field.name], error]}
-          isOptional={isOptional}
-          key={field.name}
-          error={error}
-        />
+        <Grid item xs={12}>
+          <UserDefinedSelect
+            field={field}
+            updateFormState={handleChange}
+            udf_data={props.udf_data}
+            updateFor={[props.udf_data[field.name], error]}
+            isOptional={isOptional}
+            key={field.name}
+            error={error}
+          />{' '}
+        </Grid>
       );
     }
     if (isPasswordField(field.name)) {
       return (
+        <Grid item xs={12} sm={6} md={4}>
+          <UserDefinedText
+            key={field.name}
+            updateFormState={handleChange}
+            isPassword={true}
+            field={field}
+            udf_data={props.udf_data}
+            updateFor={[props.udf_data[field.name], error]}
+            isOptional={isOptional}
+            placeholder={field.example}
+            error={error}
+          />
+        </Grid>
+      );
+    }
+    return (
+      <Grid item xs={12} sm={6} md={4}>
         <UserDefinedText
           key={field.name}
           updateFormState={handleChange}
-          isPassword={true}
           field={field}
           udf_data={props.udf_data}
           updateFor={[props.udf_data[field.name], error]}
@@ -94,19 +112,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           placeholder={field.example}
           error={error}
         />
-      );
-    }
-    return (
-      <UserDefinedText
-        key={field.name}
-        updateFormState={handleChange}
-        field={field}
-        udf_data={props.udf_data}
-        updateFor={[props.udf_data[field.name], error]}
-        isOptional={isOptional}
-        placeholder={field.example}
-        error={error}
-      />
+      </Grid>
     );
   };
 
@@ -134,7 +140,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           for creation.
         </Typography>
         <div className={`${classes.optionalFieldWrapper} optionalFieldWrapper`}>
-          <Grid container>
+          <Grid container alignItems="center">
             {userDefinedFields!
               .filter(
                 (field: Linode.StackScript.UserDefinedField) =>
@@ -142,11 +148,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
               )
               .map((field: Linode.StackScript.UserDefinedField) => {
                 const error = getError(field, props.errors);
-                return (
-                  <Grid item xs={12} sm={6} md={4}>
-                    {renderField(field, error)}
-                  </Grid>
-                );
+                return renderField(field, error);
               })}
           </Grid>
         </div>

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -116,10 +116,13 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
       </Typography>
 
       {userDefinedFields!
-        .filter(field => field.hasOwnProperty('default') !== true)
+        .filter(
+          (field: Linode.StackScript.UserDefinedField) =>
+            field.hasOwnProperty('default') !== true
+        )
         .map((field: Linode.StackScript.UserDefinedField) => {
           const error = getError(field, props.errors);
-          <React.Fragment>{renderField(field, error)}</React.Fragment>;
+          return renderField(field, error);
         })}
 
       <ShowMoreExpansion name="Show Advanced Options">
@@ -128,17 +131,15 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           for creation.
         </Typography>
         {userDefinedFields!
-          .filter(field => field.hasOwnProperty('default') === true)
+          .filter(
+            (field: Linode.StackScript.UserDefinedField) =>
+              field.hasOwnProperty('default') === true
+          )
           .map((field: Linode.StackScript.UserDefinedField) => {
             const error = getError(field, props.errors);
-            <React.Fragment>{renderField(field, error)}</React.Fragment>;
+            return renderField(field, error);
           })}
       </ShowMoreExpansion>
-
-      {/* {userDefinedFields!.map((field: Linode.StackScript.UserDefinedField) => {
-        const error = getError(field, props.errors);
-        return renderField(field, error);
-      })} */}
     </Paper>
   );
 };

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -28,7 +28,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   username: {
     color: theme.color.grey1
   },
-  optionalFieldWrapper: {}
+  optionalFieldWrapper: {
+    maxWidth: 860
+  }
 });
 
 interface Props {
@@ -55,7 +57,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
     const isOptional = field.hasOwnProperty('default');
     if (isMultiSelect(field)) {
       return (
-        <Grid item xs={12} md={8}>
+        <Grid item xs={12}>
           <UserDefinedMultiSelect
             key={field.name}
             field={field}
@@ -70,7 +72,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
     }
     if (isOneSelect(field)) {
       return (
-        <Grid item xs={12} md={8}>
+        <Grid item xs={12}>
           <UserDefinedSelect
             field={field}
             updateFormState={handleChange}
@@ -85,7 +87,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
     }
     if (isPasswordField(field.name)) {
       return (
-        <Grid item xs={12} md={8}>
+        <Grid item xs={12}>
           <UserDefinedText
             key={field.name}
             updateFormState={handleChange}
@@ -101,7 +103,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
       );
     }
     return (
-      <Grid item xs={12} md={8}>
+      <Grid item xs={12}>
         <UserDefinedText
           key={field.name}
           updateFormState={handleChange}

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -6,6 +6,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
 import RenderGuard from 'src/components/RenderGuard';
 import ShowMoreExpansion from 'src/components/ShowMoreExpansion';
 import UserDefinedMultiSelect from './FieldTypes/UserDefinedMultiSelect';
@@ -27,11 +28,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   username: {
     color: theme.color.grey1
   },
-  optionalFieldWrapper: {
-    [theme.breakpoints.up('lg')]: {
-      columnCount: 3
-    }
-  }
+  optionalFieldWrapper: {}
 });
 
 interface Props {
@@ -58,36 +55,56 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
     const isOptional = field.hasOwnProperty('default');
     if (isMultiSelect(field)) {
       return (
-        <UserDefinedMultiSelect
-          key={field.name}
-          field={field}
-          udf_data={props.udf_data}
-          updateFormState={handleChange}
-          updateFor={[props.udf_data[field.name], error]}
-          isOptional={isOptional}
-          error={error}
-        />
+        <Grid item xs={12} md={8}>
+          <UserDefinedMultiSelect
+            key={field.name}
+            field={field}
+            udf_data={props.udf_data}
+            updateFormState={handleChange}
+            updateFor={[props.udf_data[field.name], error]}
+            isOptional={isOptional}
+            error={error}
+          />
+        </Grid>
       );
     }
     if (isOneSelect(field)) {
       return (
-        <UserDefinedSelect
-          field={field}
-          updateFormState={handleChange}
-          udf_data={props.udf_data}
-          updateFor={[props.udf_data[field.name], error]}
-          isOptional={isOptional}
-          key={field.name}
-          error={error}
-        />
+        <Grid item xs={12} md={8}>
+          <UserDefinedSelect
+            field={field}
+            updateFormState={handleChange}
+            udf_data={props.udf_data}
+            updateFor={[props.udf_data[field.name], error]}
+            isOptional={isOptional}
+            key={field.name}
+            error={error}
+          />
+        </Grid>
       );
     }
     if (isPasswordField(field.name)) {
       return (
+        <Grid item xs={12} md={8}>
+          <UserDefinedText
+            key={field.name}
+            updateFormState={handleChange}
+            isPassword={true}
+            field={field}
+            udf_data={props.udf_data}
+            updateFor={[props.udf_data[field.name], error]}
+            isOptional={isOptional}
+            placeholder={field.example}
+            error={error}
+          />
+        </Grid>
+      );
+    }
+    return (
+      <Grid item xs={12} md={8}>
         <UserDefinedText
           key={field.name}
           updateFormState={handleChange}
-          isPassword={true}
           field={field}
           udf_data={props.udf_data}
           updateFor={[props.udf_data[field.name], error]}
@@ -95,28 +112,13 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           placeholder={field.example}
           error={error}
         />
-      );
-    }
-    return (
-      <UserDefinedText
-        key={field.name}
-        updateFormState={handleChange}
-        field={field}
-        udf_data={props.udf_data}
-        updateFor={[props.udf_data[field.name], error]}
-        isOptional={isOptional}
-        placeholder={field.example}
-        error={error}
-      />
+      </Grid>
     );
   };
 
   return (
     <Paper className={classes.root}>
       <Typography role="header" variant="h2" data-qa-user-defined-field-header>
-        <span className={classes.username}>{`${
-          props.selectedUsername
-        } / `}</span>
         <span>{`${props.selectedLabel} Options`}</span>
       </Typography>
 
@@ -138,15 +140,21 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           for creation.
         </Typography>
         <div className={`${classes.optionalFieldWrapper} optionalFieldWrapper`}>
-          {userDefinedFields!
-            .filter(
-              (field: Linode.StackScript.UserDefinedField) =>
-                field.hasOwnProperty('default') === true
-            )
-            .map((field: Linode.StackScript.UserDefinedField) => {
-              const error = getError(field, props.errors);
-              return renderField(field, error);
-            })}
+          <Grid container>
+            {userDefinedFields!
+              .filter(
+                (field: Linode.StackScript.UserDefinedField) =>
+                  field.hasOwnProperty('default') === true
+              )
+              .map((field: Linode.StackScript.UserDefinedField) => {
+                const error = getError(field, props.errors);
+                return (
+                  <Grid item xs={12} sm={6} md={4}>
+                    {renderField(field, error)}
+                  </Grid>
+                );
+              })}
+          </Grid>
         </div>
       </ShowMoreExpansion>
     </Paper>

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -12,7 +12,7 @@ import UserDefinedMultiSelect from './FieldTypes/UserDefinedMultiSelect';
 import UserDefinedSelect from './FieldTypes/UserDefinedSelect';
 import UserDefinedText from './FieldTypes/UserDefinedText';
 
-type ClassNames = 'root' | 'username';
+type ClassNames = 'root' | 'username' | 'optionalFieldWrapper';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
@@ -26,6 +26,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   username: {
     color: theme.color.grey1
+  },
+  optionalFieldWrapper: {
+    [theme.breakpoints.up('lg')]: {
+      columnCount: 3
+    }
   }
 });
 
@@ -115,6 +120,7 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
         <span>{`${props.selectedLabel} Options`}</span>
       </Typography>
 
+      {/* Required Fields */}
       {userDefinedFields!
         .filter(
           (field: Linode.StackScript.UserDefinedField) =>
@@ -125,20 +131,23 @@ const UserDefinedFieldsPanel: React.StatelessComponent<
           return renderField(field, error);
         })}
 
+      {/* Optional Fields */}
       <ShowMoreExpansion name="Show Advanced Options">
         <Typography variant="body1">
           These fields are additional configuration options and are not required
           for creation.
         </Typography>
-        {userDefinedFields!
-          .filter(
-            (field: Linode.StackScript.UserDefinedField) =>
-              field.hasOwnProperty('default') === true
-          )
-          .map((field: Linode.StackScript.UserDefinedField) => {
-            const error = getError(field, props.errors);
-            return renderField(field, error);
-          })}
+        <div className={`${classes.optionalFieldWrapper} optionalFieldWrapper`}>
+          {userDefinedFields!
+            .filter(
+              (field: Linode.StackScript.UserDefinedField) =>
+                field.hasOwnProperty('default') === true
+            )
+            .map((field: Linode.StackScript.UserDefinedField) => {
+              const error = getError(field, props.errors);
+              return renderField(field, error);
+            })}
+        </div>
       </ShowMoreExpansion>
     </Paper>
   );

--- a/src/features/Support/TicketAttachmentList.tsx
+++ b/src/features/Support/TicketAttachmentList.tsx
@@ -84,6 +84,7 @@ export const TicketAttachmentList: React.StatelessComponent<
               name={
                 !showMoreAttachments ? 'Show More Files' : 'Show Less Files'
               }
+              defaultExpanded={false}
             >
               <TicketAttachmentRow
                 attachments={slice(5, Infinity, attachments)}

--- a/src/features/linodes/LinodesCreate/PublicImages.tsx
+++ b/src/features/linodes/LinodesCreate/PublicImages.tsx
@@ -74,7 +74,7 @@ const PublicImages: React.StatelessComponent<CombinedProps> = props => {
         {renderImages(images)}
       </Grid>
       {oldImages.length > 0 && (
-        <ShowMoreExpansion name="Show Older Images">
+        <ShowMoreExpansion name="Show Older Images" defaultExpanded={false}>
           <Grid container spacing={16} style={{ marginTop: 16 }}>
             {renderImages(oldImages)}
           </Grid>


### PR DESCRIPTION
## Description

-Splitting out required fields from optional so we can put the latter in a collapsible container. 
-Some associated styling as well. 
-Also added a new prop to the password component, hideStrengthLabel determines if the `Strength:` span will display or not (default is it is displayed).

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

To test: Under one-click, select an app with alot of UDFs, note that the optional fields now live under an 'advanced options' container. 
