### PR TITLE
M3-2510 Render Guard Spacing Check

### DIFF
--- a/src/components/RenderGuard.tsx
+++ b/src/components/RenderGuard.tsx
@@ -21,7 +21,8 @@ const renderGuard = <P extends {}>(
         // this is a deep comparison
         return (
           !equals(this.props.updateFor, nextProps.updateFor) ||
-          this.props.theme.name !== nextProps.theme.name
+          this.props.theme.name !== nextProps.theme.name ||
+          this.props.theme.spacing.unit !== nextProps.theme.spacing.unit
         );
       }
       // if updateFor isn't provided, always update (this is React's default behavior)

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -239,7 +239,7 @@ export const RebuildFromStackScript: React.StatelessComponent<
       <AccessPanel
         password={form.password}
         handleChange={value => setField('password', value)}
-        updateFor={[classes, form.password, errors, userSSHKeys, ss.id]}
+        updateFor={[form.password, errors, userSSHKeys, ss.id]}
         error={hasErrorFor.root_pass}
         users={userSSHKeys}
         data-qa-access-panel


### PR DESCRIPTION
## Description

Re-Render Renderguard if the `theme.spacing.unit` has changed

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

So we don't have to constantly be passing `props.classes` to a RenderGuarded component