### PR TITLE
M3-2326 Fix: Kernel Select

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -361,6 +361,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
           className={classes.section}
           updateFor={[
             kernel,
+            kernels,
             errorFor('kernel'),
             run_level,
             memory_limit,


### PR DESCRIPTION
## Description

The "Select a Kernel" component in `Linode > Settings > Advanced Configurations > Edit` was not being populated at times.

To fix this, I added `kernels` to RenderGuard's `updateFor`. 

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

#### To test: 

1) Log out of Cloud Manager. 
2) Log in to Cloud Manager. 
3) From the Dashboard, click on a Linode that has at least one configuration. 
4) From Linode Details, go to the "Settings" tab. 
5) Expand the "Advanced Configurations" accordion. 
6) On a config, click the kabob menu, then click "Edit".
7) **Observe:** the "Kernel" input component should be fully populated.
