### PR TITLE
Fix: Error scroll in RebuildFromStackScripts

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -127,6 +127,7 @@ export const RebuildFromStackScript: React.StatelessComponent<
       setErrors([
         { field: 'stackscript_id', reason: 'You must select a StackScript' }
       ]);
+      setIsDialogOpen(false);
       return;
     }
 

--- a/src/hooks/useErrors.ts
+++ b/src/hooks/useErrors.ts
@@ -13,7 +13,7 @@ export const useErrors = (): [
     if (errors) {
       scrollErrorIntoView();
     }
-  });
+  }, [errors]);
 
   const resetErrors = () => setErrors([]);
 


### PR DESCRIPTION
## Description

Fixes a bug in RebuildFromStackScript where "scroll to error" was happening on each re-render if there were errors. This was noticeable if the StackScript had many UDFs. `useEffect()` inside "useErrors" hook needed a second argument to fire only when `errors` changed.

**To test:** 

1) Go to Linode Detail > Rebuild > From StackScript
2) Click on a StackScript with many UDFs.
3) Click "Rebuild".
4) Observe: errors appear
5) Scroll up/down to a UDF
6) Type something in a UDF field.
7) Observe: no scrolling happens.

Also, fixed a bug where the confirmation modal wasn't being dismissed if there was an ImageID error.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')