### PR TITLE
M3-2523 Fix extra scrollbar on tables on Firefox Compact Mode)

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -12,6 +12,7 @@ type ClassNames = 'root' | 'border' | 'responsive';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
     overflowX: 'auto',
+    overflowY: 'hidden',
     '& tbody': {
       transition: [theme.transitions.create('opacity')]
     },


### PR DESCRIPTION
## Fix extra scrollbar on tables on Firefox

Some tables (ex: linodes landing) were inheriting a scroll bar with compact mode (FF only). Apparently FF needs an explicit overflow-y declaration id overflow-x is setup to avoid this issue.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
