### PR TITLE
PreCommit Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "mock": "./scripts/mb.js",
     "test": "node scripts/test.js --env=jsdom",
     "test:debug": "node --inspect-brk scripts/test.js --runInBand --env=jsdom",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook -p 6006 --ci",
     "storybook-static": "build-storybook -c .storybook -o .out",
     "storybook:e2e": "./node_modules/.bin/wdio ./e2e/config/wdio.storybook.conf.js",
     "storyshots": "docker-compose -f storyshots.yml up --build --exit-code-from manager-storyshots && docker-compose -f storyshots.yml down -v",

--- a/src/components/EnhancedSelect/components/Guidance.tsx
+++ b/src/components/EnhancedSelect/components/Guidance.tsx
@@ -27,6 +27,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   }
 });
 
+/** arbitrary comment lolololol */
+
 interface GuidanceProps {
   text: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11995,18 +11995,17 @@ react-color@^2.14.1:
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
 
+react-csv@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-csv/-/react-csv-1.1.1.tgz#718dadd2607a1795bfc8dbd32ca282a043739634"
+  integrity sha512-eQSrkEfzPN+1IeXT58kJaDNmpFr3RhdjfE09jTrw+jdTEp0g0Ig9NOI+TpvMBbCukE1HQhOf4dyrLDRFKgZzbA==
+
 react-currency-formatter@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-currency-formatter/-/react-currency-formatter-1.1.0.tgz#69296c82efd6ef7a9e74bcae52414a5e23bcdba2"
   integrity sha512-5AIHYk8WKKKfXfxQW7i7V3DTQkDNqRcqAWyTy3KTs89qooOTj1o5VWkPOLjIxKOSGir6nUt8Aw8WXxAGn5nY6w==
   dependencies:
     prop-types "^15.6.0"
-
-react-csv@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/react-csv/-/react-csv-1.1.1.tgz#718dadd2607a1795bfc8dbd32ca282a043739634"
-  integrity sha512-eQSrkEfzPN+1IeXT58kJaDNmpFr3RhdjfE09jTrw+jdTEp0g0Ig9NOI+TpvMBbCukE1HQhOf4dyrLDRFKgZzbA==
-
 
 react-dev-utils@^6.1.0:
   version "6.1.1"


### PR DESCRIPTION
## Description

Prevent storybook from auto-opening a browser when `yarn storybook` is run

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Also tried to fix the following issue but I was not willing to spend an entire day upgrading our testing libs

```
DEPRECATION: Setting stopOnSpecFailure directly is deprecated, please use the failFast option in `configure`
```