### PR TITLE
M3-OBJ-54: Object Storage link in Primary Nav

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import { getAllVolumes } from 'src/store/volume/volume.requests';
 import composeState from 'src/utilities/composeState';
 import { notifications, theme as themeStorage } from 'src/utilities/storage';
 import WelcomeBanner from 'src/WelcomeBanner';
+import { isObjectStorageEnabled } from './constants';
 import {
   withNodeBalancerActions,
   WithNodeBalancerActions
@@ -67,6 +68,10 @@ const Domains = DefaultLoader({
 
 const Images = DefaultLoader({
   loader: () => import('src/features/Images')
+});
+
+const ObjectStorage = DefaultLoader({
+  loader: () => import('src/features/ObjectStorage')
 });
 
 const Profile = DefaultLoader({
@@ -320,6 +325,12 @@ export class App extends React.Component<CombinedProps, State> {
                             path="/stackscripts"
                             component={StackScripts}
                           />
+                          {isObjectStorageEnabled && (
+                            <Route
+                              path="/object-storage"
+                              component={ObjectStorage}
+                            />
+                          )}
                           <Route path="/account" component={Account} />
                           <Route
                             exact

--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -145,4 +145,36 @@ describe('PrimaryNav', () => {
       expect(findLinkInPrimaryNav('managed')).toHaveLength(1);
     });
   });
+
+  describe('when Object Storage is enabled', () => {
+    it('should have an Object Storage link', () => {
+      const wrapper = shallow(
+        <PrimaryNav
+          classes={mockClasses}
+          closeMenu={jest.fn()}
+          toggleTheme={jest.fn()}
+          isObjectStorageEnabled={true}
+          {...reactRouterProps}
+        />
+      );
+      const findLinkInPrimaryNav = findLinkIn(wrapper);
+      expect(findLinkInPrimaryNav('objectStorage')).toHaveLength(1);
+    });
+  });
+
+  describe('when Object Storage is NOT enabled', () => {
+    it('should NOT have an Object Storage link', () => {
+      const wrapper = shallow(
+        <PrimaryNav
+          classes={mockClasses}
+          closeMenu={jest.fn()}
+          toggleTheme={jest.fn()}
+          isObjectStorageEnabled={false}
+          {...reactRouterProps}
+        />
+      );
+      const findLinkInPrimaryNav = findLinkIn(wrapper);
+      expect(findLinkInPrimaryNav('objectStorage')).toHaveLength(0);
+    });
+  });
 });

--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -145,36 +145,4 @@ describe('PrimaryNav', () => {
       expect(findLinkInPrimaryNav('managed')).toHaveLength(1);
     });
   });
-
-  describe('when Object Storage is enabled', () => {
-    it('should have an Object Storage link', () => {
-      const wrapper = shallow(
-        <PrimaryNav
-          classes={mockClasses}
-          closeMenu={jest.fn()}
-          toggleTheme={jest.fn()}
-          isObjectStorageEnabled={true}
-          {...reactRouterProps}
-        />
-      );
-      const findLinkInPrimaryNav = findLinkIn(wrapper);
-      expect(findLinkInPrimaryNav('objectStorage')).toHaveLength(1);
-    });
-  });
-
-  describe('when Object Storage is NOT enabled', () => {
-    it('should NOT have an Object Storage link', () => {
-      const wrapper = shallow(
-        <PrimaryNav
-          classes={mockClasses}
-          closeMenu={jest.fn()}
-          toggleTheme={jest.fn()}
-          isObjectStorageEnabled={false}
-          {...reactRouterProps}
-        />
-      );
-      const findLinkInPrimaryNav = findLinkIn(wrapper);
-      expect(findLinkInPrimaryNav('objectStorage')).toHaveLength(0);
-    });
-  });
 });

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -16,6 +16,7 @@ import {
   WithTheme
 } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
+import { isObjectStorageEnabled } from 'src/constants';
 import { MapState } from 'src/store/types';
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
 import SpacingToggle from './SpacingToggle';
@@ -301,6 +302,14 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     primaryLinks.push({ display: 'Images', href: '/images', key: 'images' });
     // }
 
+    if (this.props.isObjectStorageEnabled) {
+      primaryLinks.push({
+        display: 'Object Storage',
+        href: '/object-storage',
+        key: 'objectStorage'
+      });
+    }
+
     if (hasAccountAccess) {
       primaryLinks.push({
         display: 'Account',
@@ -511,6 +520,7 @@ interface StateProps {
   hasAccountAccess: boolean;
   isManagedAccount: boolean;
   // isLongviewEnabled: boolean;
+  isObjectStorageEnabled: boolean;
 }
 
 const userHasAccountAccess = (profile: Linode.Profile) => {
@@ -537,15 +547,17 @@ const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
   if (!account || !profile) {
     return {
       hasAccountAccess: false,
-      isManagedAccount: false
+      isManagedAccount: false,
       // isLongviewEnabled: false,
+      isObjectStorageEnabled: false
     };
   }
 
   return {
     hasAccountAccess: userHasAccountAccess(profile),
-    isManagedAccount: accountHasManaged(account)
+    isManagedAccount: accountHasManaged(account),
     // isLongviewEnabled: accountHasLongviewSubscription(account),
+    isObjectStorageEnabled
   };
 };
 

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -302,7 +302,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     primaryLinks.push({ display: 'Images', href: '/images', key: 'images' });
     // }
 
-    if (this.props.isObjectStorageEnabled) {
+    if (isObjectStorageEnabled) {
       primaryLinks.push({
         display: 'Object Storage',
         href: '/object-storage',
@@ -520,7 +520,6 @@ interface StateProps {
   hasAccountAccess: boolean;
   isManagedAccount: boolean;
   // isLongviewEnabled: boolean;
-  isObjectStorageEnabled: boolean;
 }
 
 const userHasAccountAccess = (profile: Linode.Profile) => {
@@ -555,9 +554,8 @@ const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
 
   return {
     hasAccountAccess: userHasAccountAccess(profile),
-    isManagedAccount: accountHasManaged(account),
+    isManagedAccount: accountHasManaged(account)
     // isLongviewEnabled: accountHasLongviewSubscription(account),
-    isObjectStorageEnabled
   };
 };
 

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -546,9 +546,8 @@ const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
   if (!account || !profile) {
     return {
       hasAccountAccess: false,
-      isManagedAccount: false,
+      isManagedAccount: false
       // isLongviewEnabled: false,
-      isObjectStorageEnabled: false
     };
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,7 +35,7 @@ export const ALGOLIA_SEARCH_KEY =
 
 // Features
 export const isObjectStorageEnabled =
-  process.env.REACT_APP_IS_OBJECT_STORAGE_ENABLED || false;
+  !!process.env.REACT_APP_IS_OBJECT_STORAGE_ENABLED || false;
 
 export const DISABLE_EVENT_THROTTLE =
   Boolean(process.env.REACT_APP_DISABLE_EVENT_THROTTLE) || false;

--- a/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface ObjectStorageLanding {}
+
+const ObjectStorage: React.StatelessComponent<ObjectStorageLanding> = () => {
+  return <h1>Object Storage Landing</h1>;
+};
+
+export default ObjectStorage;

--- a/src/features/ObjectStorage/index.tsx
+++ b/src/features/ObjectStorage/index.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import {
+  Route,
+  RouteComponentProps,
+  Switch,
+  withRouter
+} from 'react-router-dom';
+
+import DefaultLoader from 'src/components/DefaultLoader';
+
+const ObjectStorageLanding = DefaultLoader({
+  loader: () => import('./ObjectStorageLanding')
+});
+
+type Props = RouteComponentProps<{}>;
+
+class ObjectStorage extends React.Component<Props> {
+  render() {
+    const {
+      match: { path }
+    } = this.props;
+
+    return (
+      <Switch>
+        <Route component={ObjectStorageLanding} path={path} exact />
+      </Switch>
+    );
+  }
+}
+
+export default withRouter(ObjectStorage);


### PR DESCRIPTION
## Description

Includes link to the Object Storage landing page in the Primary Navbar. 

This is pointed to a feature branch, which I'm planning to complete in three stages:

1) Object Storage link in Navbar (this PR)
2) Bucket listing page
3) GET `buckets` API method 

I'm breaking it up so the PRs aren't huge.

## Note to Reviewers

Make sure the Object Storage link is visible only if `REACT_APP_IS_OBJECT_STORAGE_ENABLED=true` is in your `.env`.
