### PR TITLE
M3-2533 Personal Access Token always line wraps 

### DIFF
--- a/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/src/features/Profile/APITokens/APITokenTable.tsx
@@ -571,6 +571,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
           actions={this.renderPersonalAccessTokenDisplayActions}
           open={Boolean(this.state.token && this.state.token.open)}
           onClose={this.closeTokenDialog}
+          maxWidth="md"
         >
           <Typography variant="body1">
             {`Your personal access token has been created.


### PR DESCRIPTION
## Description

Changed dialog size to `md` to accommodate for api token width. Please note this will only resolve for larger screens.

## Type of Change
- Non breaking change ('update', 'change')