### PR TITLE
M3-2543 Linode Detail Vertical alignment of top items

### DIFF
--- a/src/components/EditableText/EditableText.tsx
+++ b/src/components/EditableText/EditableText.tsx
@@ -47,7 +47,8 @@ const styles: StyleRulesCallback = theme => ({
     border: '1px solid transparent',
     transition: theme.transitions.create(['opacity']),
     wordBreak: 'break-all',
-    textDecoration: 'inherit'
+    textDecoration: 'inherit',
+    lineHeight: 1
   },
   container: {
     display: 'flex',
@@ -55,8 +56,7 @@ const styles: StyleRulesCallback = theme => ({
     alignItems: 'center',
     maxHeight: 48,
     position: 'relative',
-    top: -1,
-    left: -2
+    transform: 'translate(-2px, -0.5px)'
   },
   initial: {
     border: '1px solid transparent',

--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -30,7 +30,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     alignItems: 'center'
   },
   controls: {
-    marginTop: theme.spacing.unit / 2,
+    marginTop: 9 - theme.spacing.unit / 2, // 4
     [theme.breakpoints.down('sm')]: {
       margin: 0,
       display: 'flex',
@@ -38,8 +38,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     }
   },
   launchButton: {
-    position: 'relative',
-    top: 1,
     lineHeight: 1,
     '&:hover': {
       backgroundColor: 'transparent',
@@ -56,7 +54,7 @@ type CombinedProps = LinodeDetailContext &
   EditableLabelProps &
   WithStyles<ClassNames>;
 
-const Thingy: React.StatelessComponent<CombinedProps> = props => {
+const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
   const {
     classes,
     linode,
@@ -156,13 +154,13 @@ const Thingy: React.StatelessComponent<CombinedProps> = props => {
 const styled = withStyles(styles);
 
 const enhanced = compose<CombinedProps, {}>(
-  styled,
   withConfigDrawerState,
   withEditableLabelState,
   withLinodeDetailContext(({ linode, updateLinode }) => ({
     linode,
     updateLinode
-  }))
+  })),
+  styled
 );
 
-export default enhanced(Thingy);
+export default enhanced(LinodeControls);


### PR DESCRIPTION
## Linode Detail Vertical alignment of top items

Aligning things properly.

![image (1)](https://user-images.githubusercontent.com/205353/54384558-e0974b00-466a-11e9-9a52-7252243f0078.png)


## Type of Change
- Bug fix ('fix', 'repair', 'bug')

To test on chrome and FF both regular and compact modes