### PR TITLE
M3-OBJ-54 GET buckets API method/actions/reducer/container

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -40,7 +40,8 @@ it('renders without crashing', () => {
               requestSettings: jest.fn(),
               requestTypes: jest.fn(),
               requestRegions: jest.fn(),
-              requestVolumes: jest.fn()
+              requestVolumes: jest.fn(),
+              requestBuckets: jest.fn()
             }}
             documentation={[]}
             toggleTheme={jest.fn()}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -204,22 +204,26 @@ export class App extends React.Component<CombinedProps, State> {
       nodeBalancerActions: { getAllNodeBalancersWithConfigs }
     } = this.props;
 
+    const dataFetchingPromises: Promise<any>[] = [
+      actions.requestProfile(),
+      actions.requestDomains(),
+      actions.requestImages(),
+      actions.requestLinodes(),
+      actions.requestNotifications(),
+      actions.requestSettings(),
+      actions.requestTypes(),
+      actions.requestRegions(),
+      actions.requestVolumes(),
+      getAllNodeBalancersWithConfigs()
+    ];
+
+    // Make this request only if the feature is enabled.
+    if (isObjectStorageEnabled) {
+      dataFetchingPromises.push(actions.requestBuckets());
+    }
+
     try {
-      await Promise.all([
-        actions.requestProfile(),
-        actions.requestDomains(),
-        actions.requestImages(),
-        actions.requestLinodes(),
-        actions.requestNotifications(),
-        actions.requestSettings(),
-        actions.requestTypes(),
-        actions.requestRegions(),
-        actions.requestVolumes(),
-        actions.requestBuckets(),
-        getAllNodeBalancersWithConfigs()
-      ] as any);
-      // The type definition for Promise.all includes up to 10 promises, so I
-      // added "as any" to keep it from complaining.
+      await Promise.all(dataFetchingPromises);
     } catch (error) {
       /** We choose to do nothing, relying on the Redux error state. */
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import TopMenu from 'src/features/TopMenu';
 import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
 import { ApplicationState } from 'src/store';
 import { requestAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
+import { getAllBuckets } from 'src/store/bucket/bucket.requests';
 import { requestDomains } from 'src/store/domains/domains.actions';
 import { requestImages } from 'src/store/image/image.requests';
 import { requestLinodes } from 'src/store/linodes/linodes.actions';
@@ -214,8 +215,11 @@ export class App extends React.Component<CombinedProps, State> {
         actions.requestTypes(),
         actions.requestRegions(),
         actions.requestVolumes(),
+        actions.requestBuckets(),
         getAllNodeBalancersWithConfigs()
-      ]);
+      ] as any);
+      // The type definition for Promise.all includes up to 10 promises, so I
+      // added "as any" to keep it from complaining.
     } catch (error) {
       /** We choose to do nothing, relying on the Redux error state. */
     }
@@ -398,6 +402,7 @@ interface DispatchProps {
     requestTypes: () => Promise<Linode.LinodeType[]>;
     requestRegions: () => Promise<Linode.Region[]>;
     requestVolumes: () => Promise<Linode.Volume[]>;
+    requestBuckets: () => Promise<Linode.Bucket[]>;
   };
 }
 
@@ -414,7 +419,8 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
       requestSettings: () => dispatch(requestAccountSettings()),
       requestTypes: () => dispatch(requestTypes()),
       requestRegions: () => dispatch(requestRegions()),
-      requestVolumes: () => dispatch(getAllVolumes())
+      requestVolumes: () => dispatch(getAllVolumes()),
+      requestBuckets: () => dispatch(getAllBuckets())
     }
   };
 };

--- a/src/containers/bucket.container.ts
+++ b/src/containers/bucket.container.ts
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+import { ApplicationState } from 'src/store';
+
+export interface Props {
+  bucketsData: Linode.Bucket[];
+  bucketsLoading: boolean;
+  bucketsError?: Error;
+}
+
+export default connect((state: ApplicationState) => {
+  return {
+    bucketsData: state.__resources.buckets.data,
+    bucketsLoading: state.__resources.buckets.loading,
+    bucketsError: state.__resources.buckets.error
+  };
+});

--- a/src/features/ObjectStorage/BucketTableRow.tsx
+++ b/src/features/ObjectStorage/BucketTableRow.tsx
@@ -29,9 +29,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   hostname: { paddingTop: theme.spacing.unit }
 });
 
-interface BucketRowProps extends Linode.Bucket {}
+// BucketTableRow has the same props as Linode.Bucket.
+// Aliased for convention's sake.
+type BucketTableRowProps = Linode.Bucket;
 
-type CombinedProps = BucketRowProps & WithStyles<ClassNames>;
+type CombinedProps = BucketTableRowProps & WithStyles<ClassNames>;
 
 export const BucketTableRow: React.StatelessComponent<
   CombinedProps

--- a/src/features/ObjectStorage/ListBuckets.tsx
+++ b/src/features/ObjectStorage/ListBuckets.tsx
@@ -13,7 +13,6 @@ import Table from 'src/components/Table';
 import TableRow from 'src/components/TableRow';
 import TableSortCell from 'src/components/TableSortCell';
 import BucketTableRow from './BucketTableRow';
-``;
 
 type ClassNames = 'root' | 'label';
 

--- a/src/features/ObjectStorage/ObjectStorageLanding.test.tsx
+++ b/src/features/ObjectStorage/ObjectStorageLanding.test.tsx
@@ -4,7 +4,11 @@ import { ObjectStorageLanding } from './ObjectStorageLanding';
 
 describe('ObjectStorageLanding', () => {
   const wrapper = shallow(
-    <ObjectStorageLanding classes={{ root: '', title: '', titleWrapper: '' }} />
+    <ObjectStorageLanding
+      classes={{ root: '', title: '', titleWrapper: '' }}
+      bucketsData={[]}
+      bucketsLoading={false}
+    />
   );
 
   it('renders without crashing', () => {

--- a/src/features/ObjectStorage/ObjectStorageLanding.test.tsx
+++ b/src/features/ObjectStorage/ObjectStorageLanding.test.tsx
@@ -1,13 +1,18 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { buckets } from 'src/__data__/buckets';
+// @todo: remove router import when bucket creation is supported
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { ObjectStorageLanding } from './ObjectStorageLanding';
 
 describe('ObjectStorageLanding', () => {
   const wrapper = shallow(
     <ObjectStorageLanding
       classes={{ root: '', title: '', titleWrapper: '' }}
-      bucketsData={[]}
+      bucketsData={buckets}
       bucketsLoading={false}
+      // @todo: remove router props when bucket creation is supported
+      {...reactRouterProps}
     />
   );
 
@@ -26,5 +31,23 @@ describe('ObjectStorageLanding', () => {
 
   it('renders an "OrderBy" component, ordered by label', () => {
     expect(wrapper.find('OrderBy').prop('orderBy')).toBe('label');
+  });
+
+  it('renders a loading state when the data is loading', () => {
+    wrapper.setProps({ bucketsLoading: true });
+    expect(wrapper.find('[data-qa-loading-state]')).toHaveLength(1);
+  });
+
+  it('renders an empty state when there is no data', () => {
+    wrapper.setProps({ bucketsData: [], bucketsLoading: false });
+    expect(wrapper.find('[data-qa-empty-state]')).toHaveLength(1);
+  });
+
+  it('renders an error state when there is an error', () => {
+    wrapper.setProps({
+      bucketsError: [{ reason: 'An error occurred.' }],
+      bucketsLoading: false
+    });
+    expect(wrapper.find('[data-qa-error-state]')).toHaveLength(1);
   });
 });

--- a/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import { buckets } from 'src/__data__/buckets';
 import {
   StyleRulesCallback,
   WithStyles,
@@ -10,6 +9,9 @@ import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
+import bucketContainer, {
+  Props as BucketContainerProps
+} from 'src/containers/bucket.container';
 import ListBuckets from './ListBuckets';
 
 type ClassNames = 'root' | 'titleWrapper' | 'title';
@@ -24,12 +26,12 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   }
 });
 
-type CombinedProps = WithStyles<ClassNames>;
+type CombinedProps = BucketContainerProps & WithStyles<ClassNames>;
 
 export const ObjectStorageLanding: React.StatelessComponent<
   CombinedProps
 > = props => {
-  const { classes } = props;
+  const { classes, bucketsData } = props;
 
   return (
     <React.Fragment>
@@ -53,7 +55,7 @@ export const ObjectStorageLanding: React.StatelessComponent<
       </Grid>
       <Grid item xs={12}>
         {/* @todo: source buckets from Redux (via API) */}
-        <OrderBy data={buckets} order={'asc'} orderBy={'label'}>
+        <OrderBy data={bucketsData} order={'asc'} orderBy={'label'}>
           {({ data: orderedData, handleOrderChange, order, orderBy }) => {
             const listBucketsProps = {
               orderBy,
@@ -71,6 +73,9 @@ export const ObjectStorageLanding: React.StatelessComponent<
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, {}>(styled);
+const enhanced = compose<CombinedProps, {}>(
+  styled,
+  bucketContainer
+);
 
 export default enhanced(ObjectStorageLanding);

--- a/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -1,5 +1,9 @@
 import * as React from 'react';
+// @todo: remove router imports when bucket creation is supported
+import { RouterProps, withRouter } from 'react-router';
 import { compose } from 'recompose';
+import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
+import CircleProgress from 'src/components/CircleProgress';
 import {
   StyleRulesCallback,
   WithStyles,
@@ -7,8 +11,10 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
+import Placeholder from 'src/components/Placeholder';
 import bucketContainer, {
   Props as BucketContainerProps
 } from 'src/containers/bucket.container';
@@ -26,12 +32,35 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   }
 });
 
-type CombinedProps = BucketContainerProps & WithStyles<ClassNames>;
+// @todo: remove RouterProps when bucket creation is supported
+type CombinedProps = BucketContainerProps &
+  RouterProps &
+  WithStyles<ClassNames>;
 
 export const ObjectStorageLanding: React.StatelessComponent<
   CombinedProps
 > = props => {
-  const { classes, bucketsData } = props;
+  // @todo: remove router.history prop when bucket creation is supported
+  const { classes, bucketsData, bucketsLoading, bucketsError, history } = props;
+
+  if (bucketsLoading) {
+    return <RenderLoading data-qa-loading-state />;
+  }
+
+  if (bucketsError) {
+    return <RenderError data-qa-error-state />;
+  }
+
+  if (bucketsData.length === 0) {
+    // Our call-to-action should be "Create a Bucket". Since that feature
+    // doesn't exist yet, the call-to-action is temporarily a link to API Tokens.
+    return (
+      <RenderEmpty
+        onClick={() => history.push(`/profile/tokens`)}
+        data-qa-empty-state
+      />
+    );
+  }
 
   return (
     <React.Fragment>
@@ -54,7 +83,6 @@ export const ObjectStorageLanding: React.StatelessComponent<
         </Grid>
       </Grid>
       <Grid item xs={12}>
-        {/* @todo: source buckets from Redux (via API) */}
         <OrderBy data={bucketsData} order={'asc'} orderBy={'label'}>
           {({ data: orderedData, handleOrderChange, order, orderBy }) => {
             const listBucketsProps = {
@@ -71,9 +99,43 @@ export const ObjectStorageLanding: React.StatelessComponent<
   );
 };
 
+const RenderLoading: React.StatelessComponent<{}> = () => {
+  return <CircleProgress />;
+};
+
+const RenderError: React.StatelessComponent<{}> = () => {
+  return (
+    <ErrorState errorText="There was an error retrieving your buckets. Please reload and try again." />
+  );
+};
+
+const RenderEmpty: React.StatelessComponent<{
+  onClick: () => void;
+}> = props => {
+  return (
+    <React.Fragment>
+      <DocumentTitleSegment segment="Domains" />
+      <Placeholder
+        title="Add a Bucket"
+        // NOTE: This copy is only temporary, until bucket creation exists.
+        // It will never be customer facing.
+        copy="Bucket Creation coming soon! For now, create buckets by generating an Object Storage key pair, and use with an S3-compatible client."
+        // @todo: replace with bucket icon
+        icon={VolumeIcon}
+        buttonProps={{
+          onClick: props.onClick,
+          children: 'Go to API Tokens'
+        }}
+      />
+    </React.Fragment>
+  );
+};
+
 const styled = withStyles(styles);
 
 const enhanced = compose<CombinedProps, {}>(
+  // @todo: remove withRouter HOC once bucket creation is support
+  withRouter,
   styled,
   bucketContainer
 );

--- a/src/services/objectStorage/buckets.ts
+++ b/src/services/objectStorage/buckets.ts
@@ -1,0 +1,17 @@
+import { API_ROOT } from 'src/constants';
+import Request, { setMethod, setParams, setURL, setXFilter } from '../index';
+
+type Page<T> = Linode.ResourcePage<T>;
+
+/**
+ * getBuckets
+ *
+ * Gets a list of a user's Object Storage Buckets
+ */
+export const getBuckets = (params?: any, filters?: any) =>
+  Request<Page<Linode.Bucket>>(
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filters),
+    setURL(`${API_ROOT}beta/object-storage/buckets`)
+  ).then(response => response.data);

--- a/src/store/bucket/bucket.actions.ts
+++ b/src/store/bucket/bucket.actions.ts
@@ -1,0 +1,9 @@
+import { actionCreatorFactory } from 'typescript-fsa';
+
+export const actionCreator = actionCreatorFactory('@@manager/buckets');
+
+export const getAllBucketsActions = actionCreator.async<
+  {},
+  Linode.Bucket[],
+  Linode.ApiFieldError[]
+>('get-all');

--- a/src/store/bucket/bucket.reducer.ts
+++ b/src/store/bucket/bucket.reducer.ts
@@ -1,0 +1,55 @@
+import { Reducer } from 'redux';
+import { RequestableData } from 'src/store/types';
+import { isType } from 'typescript-fsa';
+import { onError, onStart } from '../store.helpers';
+import { getAllBucketsActions } from './bucket.actions';
+
+/**
+ * State
+ */
+
+// We are unable to use the "EntityState" pattern we've adopted, since IDs
+// do not exist on buckets.
+export type State = RequestableData<Linode.Bucket[]>;
+
+export const defaultState: State = {
+  data: [],
+  loading: true,
+  lastUpdated: 0,
+  error: undefined
+};
+
+/**
+ * Reducer
+ */
+const reducer: Reducer<State> = (state = defaultState, action) => {
+  /*
+   * Get All Buckets
+   **/
+
+  // START
+  if (isType(action, getAllBucketsActions.started)) {
+    return onStart(state);
+  }
+
+  // DONE
+  if (isType(action, getAllBucketsActions.done)) {
+    const { result } = action.payload;
+    return {
+      ...state,
+      data: result,
+      lastUpdated: Date.now(),
+      loading: false
+    };
+  }
+
+  // FAILED
+  if (isType(action, getAllBucketsActions.failed)) {
+    const { error } = action.payload;
+    return onError(error, state);
+  }
+
+  return state;
+};
+
+export default reducer;

--- a/src/store/bucket/bucket.reducer.ts
+++ b/src/store/bucket/bucket.reducer.ts
@@ -1,7 +1,7 @@
 import { Reducer } from 'redux';
 import { RequestableData } from 'src/store/types';
 import { isType } from 'typescript-fsa';
-import { onError, onStart } from '../store.helpers';
+import { onStart } from '../store.helpers';
 import { getAllBucketsActions } from './bucket.actions';
 
 /**
@@ -46,7 +46,11 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   // FAILED
   if (isType(action, getAllBucketsActions.failed)) {
     const { error } = action.payload;
-    return onError(error, state);
+    return {
+      ...state,
+      loading: false,
+      error
+    };
   }
 
   return state;

--- a/src/store/bucket/bucket.requests.ts
+++ b/src/store/bucket/bucket.requests.ts
@@ -1,0 +1,16 @@
+import { getBuckets as _getBuckets } from 'src/services/objectStorage/buckets';
+import { getAll } from 'src/utilities/getAll';
+import { createRequestThunk } from '../store.helpers';
+import { getAllBucketsActions } from './bucket.actions';
+
+/*
+ * Get All Buckets
+ */
+const _getAll = getAll<Linode.Bucket>(_getBuckets);
+
+const getAllBucketsRequest = () => _getAll().then(({ data }) => data);
+
+export const getAllBuckets = createRequestThunk(
+  getAllBucketsActions,
+  getAllBucketsRequest
+);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -70,6 +70,10 @@ import regions, {
   defaultState as defaultRegionsState,
   State as RegionsState
 } from 'src/store/regions/regions.reducer';
+import buckets, {
+  defaultState as defaultBucketsState,
+  State as BucketsState
+} from 'src/store/bucket/bucket.reducer';
 import stackScriptDrawer, {
   defaultState as stackScriptDrawerDefaultState,
   State as StackScriptDrawerState
@@ -118,7 +122,8 @@ const __resourcesDefaultState = {
   profile: defaultProfileState,
   regions: defaultRegionsState,
   types: defaultTypesState,
-  volumes: defaultVolumesState
+  volumes: defaultVolumesState,
+  buckets: defaultBucketsState
 };
 
 export interface ResourcesState {
@@ -136,6 +141,7 @@ export interface ResourcesState {
   regions: RegionsState;
   types: TypesState;
   volumes: VolumesState;
+  buckets: BucketsState;
 }
 
 export interface ApplicationState {
@@ -179,7 +185,8 @@ const __resources = combineReducers({
   profile,
   regions,
   types,
-  volumes
+  volumes,
+  buckets
 });
 
 const reducers = combineReducers<ApplicationState>({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -16,6 +16,10 @@ import backups, {
   defaultState as backupsDefaultState,
   State as BackupDrawerState
 } from 'src/store/backupDrawer';
+import buckets, {
+  defaultState as defaultBucketsState,
+  State as BucketsState
+} from 'src/store/bucket/bucket.reducer';
 import documentation, {
   defaultState as documentationDefaultState,
   State as DocumentationState
@@ -70,10 +74,6 @@ import regions, {
   defaultState as defaultRegionsState,
   State as RegionsState
 } from 'src/store/regions/regions.reducer';
-import buckets, {
-  defaultState as defaultBucketsState,
-  State as BucketsState
-} from 'src/store/bucket/bucket.reducer';
 import stackScriptDrawer, {
   defaultState as stackScriptDrawerDefaultState,
   State as StackScriptDrawerState


### PR DESCRIPTION
## Description

This PR adds the GET `/buckets` API method and related actions, reducer, and container. ObjectStorageLanding is now using the bucket container, which means the data is real.

**This is the 3rd and final PR for this feature branch.**

To merge first: 

~1) https://github.com/linode/manager/pull/4660~ **DONE**
~2) https://github.com/linode/manager/pull/4665~ **DONE**

**TO DO:** 

- [x] Loading/Empty/Error states for bucket listing.

## Note to Reviewers

You'll need actual buckets (or you could mock them). DM me for details, or use test account 6.

- On ObjectStorageLanding, test Loading, Error, and Empty states.
- Test that the `/buckets` request is being made _only_ if you have the feature flag enabled in `.env`.

Note that the CTA (link to Profile > API Tokens) is only temporary, until creating buckets is supported. This is well documented in the code.