### PR TITLE
M3 Fix clapps advanced option bug

### DIFF
--- a/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
+++ b/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
@@ -56,15 +56,9 @@ class ShowMoreExpansion extends React.Component<CombinedProps, State> {
 
   handleNameClick = () => {
     this.setState({
-      open: !this.props.defaultExpanded
+      open: !this.state.open
     });
   };
-
-  componentDidUpdate(prevProps: Props, prevState: State) {
-    if (prevState.open !== this.props.defaultExpanded) {
-      this.setState({ open: this.props.defaultExpanded });
-    }
-  }
 
   render() {
     const { name, classes, children } = this.props;

--- a/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
+++ b/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
@@ -60,6 +60,15 @@ class ShowMoreExpansion extends React.Component<CombinedProps, State> {
     });
   };
 
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (
+      prevState.open !== this.props.defaultExpanded &&
+      prevProps.defaultExpanded !== this.props.defaultExpanded
+    ) {
+      this.setState({ open: this.props.defaultExpanded });
+    }
+  }
+
   render() {
     const { name, classes, children } = this.props;
     const { open } = this.state;


### PR DESCRIPTION
Standard cDU malfunction, expansion panels for advanced options UDFs were closing if typed in. Added an extra check that seems to fix it.