### PR TITLE
Configure non-field errors for NodeBalancers

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -697,7 +697,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
           <div className={classes.inner}>
             {globalFormError && (
               <Notice
-                className={'error-for-scroll-0'}
+                className={`error-for-scroll-${configIdx}`}
                 text={globalFormError}
                 error={true}
               />

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -689,10 +689,19 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
       errors
     );
 
+    const globalFormError = hasErrorFor('none');
+
     return (
       <Grid item xs={12}>
         <Paper className={classes.root} data-qa-label-header>
           <div className={classes.inner}>
+            {globalFormError && (
+              <Notice
+                className={'error-for-scroll-0'}
+                text={globalFormError}
+                error={true}
+              />
+            )}
             <Grid
               updateFor={[
                 port,


### PR DESCRIPTION
## Description

Currently we have a bug when there is no field for the error provided we don't display an error and it fails silently. It's a blocker for permissions configuration because it is lower level.

## Type of Change
- Fix error state when there is no error field for NodeBalancers