### PR TITLE
CLAPPS: Add defaultImage logic

### DIFF
--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -221,14 +221,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
      */
     const defaultImage = images.length === 1 ? images[0].id : undefined;
 
-    /**
-     * reset the selected Image but only if we're creating a Linode from
-     * a StackScript and not an app
-     */
-    if (this.props.createType !== 'fromApp') {
-      this.setState({ selectedImageID: undefined });
-    }
-
     this.setState({
       selectedStackScriptID: id,
       selectedStackScriptLabel: label,

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -215,6 +215,13 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     defaultData?: any
   ) => {
     /**
+     * If we're switching from one cloud app to another,
+     * usually the only compatible image will be Debian 9. If this
+     * is the case, preselect that value.
+     */
+    const defaultImage = images.length === 1 ? images[0].id : undefined;
+
+    /**
      * reset the selected Image but only if we're creating a Linode from
      * a StackScript and not an app
      */
@@ -230,7 +237,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       availableStackScriptImages: images,
       udfs: defaultData,
       /** reset image because stackscript might not be compatible with selected one */
-      selectedImageID: undefined,
+      selectedImageID: defaultImage,
       errors: undefined
     });
   };


### PR DESCRIPTION
## Description

Set the selected image to Debian 9 when toggling between cloud apps (since this is usually the only option).

This will happen if Debian is, in fact, the only option. Will also run whenever a StackScript (personal or community) only has one compatible option.