### PR TITLE
M3-2520 Improve placement of entity icons on mobile tables

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -74,7 +74,7 @@ interface Props {
   isResponsive?: boolean; // back-door for tables that don't need to be responsive
   spacingTop?: 0 | 8 | 16 | 24;
   spacingBottom?: 0 | 8 | 16 | 24;
-  removeLabelonMobile?: boolean; //only for table instances where we want to hide the cell label for small screens
+  removeLabelonMobile?: boolean; // only for table instances where we want to hide the cell label for small screens
 }
 
 type CombinedProps = Props & TableProps & WithStyles<ClassNames>;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -7,7 +7,7 @@ import {
 } from 'src/components/core/styles';
 import Table, { TableProps } from 'src/components/core/Table';
 
-type ClassNames = 'root' | 'border' | 'responsive';
+type ClassNames = 'root' | 'border' | 'responsive' | 'noMobileLabel';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
@@ -48,6 +48,18 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       }
     }
   },
+  noMobileLabel: {
+    [theme.breakpoints.down('sm')]: {
+      '& tbody > tr > td:first-child': {
+        '& > span:first-child': {
+          display: 'none'
+        }
+      },
+      '& .data': {
+        marginLeft: 0
+      }
+    }
+  },
   border: {
     border: `1px solid ${theme.palette.divider}`,
     borderBottom: 0
@@ -62,6 +74,7 @@ interface Props {
   isResponsive?: boolean; // back-door for tables that don't need to be responsive
   spacingTop?: 0 | 8 | 16 | 24;
   spacingBottom?: 0 | 8 | 16 | 24;
+  removeLabelonMobile?: boolean; //only for table instances where we want to hide the cell label for small screens
 }
 
 type CombinedProps = Props & TableProps & WithStyles<ClassNames>;
@@ -77,6 +90,7 @@ class WrappedTable extends React.Component<CombinedProps> {
       noOverflow,
       spacingTop,
       spacingBottom,
+      removeLabelonMobile,
       ...rest
     } = this.props;
 
@@ -87,7 +101,8 @@ class WrappedTable extends React.Component<CombinedProps> {
           {
             [classes.root]: !noOverflow,
             [classes.responsive]: !(isResponsive === false), // must be explicity set to false
-            [classes.border]: border
+            [classes.border]: border,
+            [classes.noMobileLabel]: removeLabelonMobile
           },
           className
         )}

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -80,7 +80,9 @@ class WrappedTableCell extends React.Component<CombinedProps> {
             <Hidden mdUp>
               <span>{parentColumn}</span>
             </Hidden>
-            <span className={classes.data}>{this.props.children}</span>
+            <span className={`${classes.data} data`}>
+              {this.props.children}
+            </span>
           </React.Fragment>
         ) : (
           this.props.children

--- a/src/features/Domains/ListDomains.tsx
+++ b/src/features/Domains/ListDomains.tsx
@@ -50,7 +50,7 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
       }) => (
         <React.Fragment>
           <Paper>
-            <Table aria-label="List of your Domains">
+            <Table removeLabelonMobile aria-label="List of your Domains">
               <TableHead>
                 <TableRow>
                   <TableSortCell

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersTableWrapper.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersTableWrapper.tsx
@@ -30,7 +30,7 @@ const NodeBalancersTableWrapper: React.StatelessComponent<
     <Paper className={classes.paperWrapper}>
       <Grid container className="my0">
         <Grid item xs={12} className="py0">
-          <Table aria-label="List of NodeBalancers">
+          <Table removeLabelonMobile aria-label="List of NodeBalancers">
             <SortableTableHead
               order={order}
               orderBy={orderBy}

--- a/src/features/Volumes/ListVolumes.tsx
+++ b/src/features/Volumes/ListVolumes.tsx
@@ -54,6 +54,7 @@ const ListVolumes: React.StatelessComponent<CombinedProps> = props => {
         <React.Fragment>
           <Paper>
             <Table
+              removeLabelonMobile
               aria-label="List of your Volumes"
               className={
                 renderProps.isVolumesLanding


### PR DESCRIPTION
## Description

Adding a prop, `removeLabelonMobile` to `Table` that will hide the cell label for smaller screensizes. 

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

This should only affect mobile tables with an entity icon, so Volumes, NodeBalancers, and Domains.
