### PR TITLE
Change: M3-2084 Expire Token on Logout

### DIFF
--- a/src/layouts/Logout.test.tsx
+++ b/src/layouts/Logout.test.tsx
@@ -10,7 +10,9 @@ import { Logout } from './Logout';
 window.location.assign = jest.fn();
 
 describe('layouts/Logout', () => {
-  const component = shallow<Logout>(<Logout dispatchLogout={jest.fn()} />);
+  const component = shallow<Logout>(
+    <Logout token="" dispatchLogout={jest.fn()} />
+  );
 
   it('dispatches logout action on componentDidMount', () => {
     const instance = component.instance();

--- a/src/layouts/Logout.tsx
+++ b/src/layouts/Logout.tsx
@@ -1,14 +1,15 @@
+import { pathOr } from 'ramda';
 import { Component } from 'react';
-import { connect, MapDispatchToProps } from 'react-redux';
-import { LOGIN_ROOT } from 'src/constants';
-import { handleLogout } from 'src/store/authentication/authentication.actions';
+import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { CLIENT_ID } from 'src/constants';
+import { ApplicationState } from 'src/store';
+import { handleLogout } from 'src/store/authentication/authentication.requests';
 
-export class Logout extends Component<DispatchProps> {
+export class Logout extends Component<DispatchProps & StateProps> {
   componentDidMount() {
-    this.props.dispatchLogout();
-
-    /** send the user back to login */
-    window.location.assign(`${LOGIN_ROOT}/logout`);
+    this.props.dispatchLogout(CLIENT_ID || '', this.props.token);
   }
 
   render() {
@@ -16,18 +17,32 @@ export class Logout extends Component<DispatchProps> {
   }
 }
 
-interface DispatchProps {
-  dispatchLogout: () => void;
+interface StateProps {
+  token: string;
 }
 
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => {
+const mapStateToProps: MapStateToProps<StateProps, {}, ApplicationState> = (
+  state,
+  ownProps
+) => ({
+  token: pathOr('', ['authentication', 'token'], state)
+});
+
+interface DispatchProps {
+  dispatchLogout: (client_id: string, token: string) => void;
+}
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
+  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
+) => {
   return {
-    dispatchLogout: () => dispatch(handleLogout())
+    dispatchLogout: (client_id: string, token: string) =>
+      dispatch(handleLogout(client_id, token))
   };
 };
 
 const connected = connect(
-  undefined,
+  mapStateToProps,
   mapDispatchToProps
 );
 

--- a/src/services/authentication/index.ts
+++ b/src/services/authentication/index.ts
@@ -1,3 +1,4 @@
+import { stringify } from 'querystring';
 import { LOGIN_ROOT } from 'src/constants';
 import Request, { setData, setHeaders, setMethod, setURL } from '../index';
 
@@ -16,11 +17,13 @@ export const revokeToken = (client_id: string, token: string) =>
   Request<Success>(
     setURL(`${LOGIN_ROOT}/oauth/revoke`),
     setMethod('POST'),
-    setData({
-      client_id,
-      token
-    }),
+    setData(
+      stringify({
+        client_id,
+        token
+      })
+    ),
     setHeaders({
-      'Content-Type': 'application/x-www-form-urlencoded'
+      'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8'
     })
   ).then(response => response.data);

--- a/src/services/authentication/index.ts
+++ b/src/services/authentication/index.ts
@@ -1,0 +1,26 @@
+import { LOGIN_ROOT } from 'src/constants';
+import Request, { setData, setHeaders, setMethod, setURL } from '../index';
+
+export interface Success {
+  success: true;
+}
+
+/**
+ * Revokes auth token used to make HTTP requests
+ *
+ * @param { string } client_id - the ID of the client app
+ * @param { string } token - the auth token used to make HTTP requests
+ *
+ */
+export const revokeToken = (client_id: string, token: string) =>
+  Request<Success>(
+    setURL(`${LOGIN_ROOT}/oauth/revoke`),
+    setMethod('POST'),
+    setData({
+      client_id,
+      token
+    }),
+    setHeaders({
+      'Content-Type': 'application/x-www-form-urlencoded'
+    })
+  ).then(response => response.data);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -8,7 +8,8 @@ const L = {
   params: lensPath(['params']),
   data: lensPath(['data']),
   xFilter: lensPath(['headers', 'X-Filter']),
-  validationErrors: lensPath(['validationErrors'])
+  validationErrors: lensPath(['validationErrors']),
+  headers: lensPath(['headers'])
 };
 
 const isNotEmpty = compose(
@@ -26,6 +27,9 @@ export const setMethod = (method: 'GET' | 'POST' | 'PUT' | 'DELETE') =>
 /** Param */
 export const setParams = (params: any = {}) =>
   when(() => isNotEmpty(params), set(L.params, params));
+
+export const setHeaders = (headers: any = {}) =>
+  when(() => isNotEmpty(headers), set(L.headers, headers));
 
 /**
  * Validate and set data in the request configuration object.

--- a/src/store/authentication/authentication.requests.ts
+++ b/src/store/authentication/authentication.requests.ts
@@ -1,0 +1,30 @@
+import { LOGIN_ROOT } from 'src/constants';
+import { revokeToken, Success } from 'src/services/authentication';
+import { ThunkActionCreator } from 'src/store/types';
+import { handleLogout as _handleLogout } from './authentication.actions';
+
+/**
+ * Revokes auth token used to make HTTP requests
+ *
+ * @param { string } client_id - the ID of the client app
+ * @param { string } token - the auth token used to make HTTP requests
+ *
+ */
+export const handleLogout: ThunkActionCreator<Promise<Success>> = (
+  client_id: string,
+  token: string
+) => dispatch => {
+  return revokeToken(client_id, token)
+    .then(response => {
+      dispatch(_handleLogout());
+      /** send the user back to login */
+      window.location.assign(`${LOGIN_ROOT}/logout`);
+      return response;
+    })
+    .catch(err => {
+      dispatch(_handleLogout());
+      /** send the user back to login */
+      window.location.assign(`${LOGIN_ROOT}/logout`);
+      return err;
+    });
+};


### PR DESCRIPTION
## Description

Expire token on logout

1. User clicks logout
2. We hit an endpoint to expire the token
3. Then redirect the user to login

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Use development api services

Your OAuth App must be public. In other words, the _Public_ checkbox must be clicked.

![Screen Shot 2019-04-22 at 12 29 51 PM](https://user-images.githubusercontent.com/7387001/56511345-5a3c1780-64fa-11e9-9367-4584b52f0d6b.png)
