### PR TITLE
Fix: M3-2525 Allow W6 Backups Timeslot

### DIFF
--- a/src/services/linodes/linode.schema.ts
+++ b/src/services/linodes/linode.schema.ts
@@ -84,7 +84,21 @@ const schedule = object({
     'Invalid day value.'
   ),
   window: mixed().oneOf(
-    ['W0', 'W2', 'W4', 'W8', 'W10', 'W12', 'W14', 'W16', 'W18', 'W20', 'W22'],
+    [
+      'W0',
+      'W2',
+      'W4',
+      'W6',
+      'W8',
+      'W10',
+      'W12',
+      'W14',
+      'W16',
+      'W18',
+      'W20',
+      'W22',
+      'W24'
+    ],
     'Invalid schedule value.'
   )
 });


### PR DESCRIPTION
## Description

Fix incorrect client-side validation that didn't allow for `W6` as a backups timeslot option

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
