### PR TITLE
M3-2511 Fix: Linodes with no type data cause error state

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
@@ -56,7 +56,7 @@ const MutationNotification: React.StatelessComponent<CombinedProps> = props => {
 
   /** Mutate */
   if (!linodeTypeData) {
-    throw Error(`Unable to locate type information.`);
+    return null;
   }
 
   const successorId = linodeTypeData.successor;


### PR DESCRIPTION
## Description

Previously, `MutationNotifications` threw an error if there was no type data, ~crashing the application~ causing an error state.

Now, it simply returns `null` if there is no type data. 

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers
See ticket for testing instructions.

