### PR TITLE
M3-2548 Add: Delete Linode from kebab menu

### DIFF
--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -112,6 +112,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
             e.preventDefault();
             e.stopPropagation();
             toggleConfirmation('delete', linodeId, linodeLabel);
+            closeMenu();
           }
         }
       ];

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -20,7 +20,7 @@ interface Props {
     fn: (id: number) => void
   ) => void;
   toggleConfirmation: (
-    bootOption: Linode.BootAction,
+    bootOption: Linode.KebabAction,
     linodeId: number,
     linodeLabel: string
   ) => void;
@@ -100,6 +100,18 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
             push(`/linodes/${linodeId}/settings`);
             e.preventDefault();
             e.stopPropagation();
+          }
+        },
+        {
+          title: 'Delete',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendEvent({
+              category: 'Linode Action Menu Item',
+              action: 'Delete Linode'
+            });
+            e.preventDefault();
+            e.stopPropagation();
+            toggleConfirmation('delete', linodeId, linodeLabel);
           }
         }
       ];

--- a/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
@@ -7,10 +7,6 @@ import { ListLinodes } from './LinodesLanding';
 
 const RoutedListLinodes = withRouter(ListLinodes);
 
-const actions = {
-  deleteLinode: jest.fn()
-};
-
 describe('ListLinodes', () => {
   const classes = {
     title: '',
@@ -40,7 +36,7 @@ describe('ListLinodes', () => {
             setDocs={setDocs}
             toggleGroupByTag={jest.fn()}
             backupsCTA={false}
-            actions={actions}
+            deleteLinode={jest.fn()}
           />
         </StaticRouter>
       </LinodeThemeWrapper>
@@ -68,7 +64,7 @@ describe('ListLinodes', () => {
             setDocs={setDocs}
             toggleGroupByTag={jest.fn()}
             backupsCTA={false}
-            actions={actions}
+            deleteLinode={jest.fn()}
           />
         </StaticRouter>
       </LinodeThemeWrapper>
@@ -101,7 +97,7 @@ describe('ListLinodes', () => {
             setDocs={setDocs}
             toggleGroupByTag={jest.fn()}
             backupsCTA={false}
-            actions={actions}
+            deleteLinode={jest.fn()}
           />
         </StaticRouter>
       </LinodeThemeWrapper>

--- a/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
@@ -7,6 +7,10 @@ import { ListLinodes } from './LinodesLanding';
 
 const RoutedListLinodes = withRouter(ListLinodes);
 
+const actions = {
+  deleteLinode: jest.fn()
+};
+
 describe('ListLinodes', () => {
   const classes = {
     title: '',
@@ -36,6 +40,7 @@ describe('ListLinodes', () => {
             setDocs={setDocs}
             toggleGroupByTag={jest.fn()}
             backupsCTA={false}
+            actions={actions}
           />
         </StaticRouter>
       </LinodeThemeWrapper>
@@ -63,6 +68,7 @@ describe('ListLinodes', () => {
             setDocs={setDocs}
             toggleGroupByTag={jest.fn()}
             backupsCTA={false}
+            actions={actions}
           />
         </StaticRouter>
       </LinodeThemeWrapper>
@@ -95,6 +101,7 @@ describe('ListLinodes', () => {
             setDocs={setDocs}
             toggleGroupByTag={jest.fn()}
             backupsCTA={false}
+            actions={actions}
           />
         </StaticRouter>
       </LinodeThemeWrapper>

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -192,9 +192,17 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
   deleteLinode = (linodeId: number) => {
     const _deleteLinode = this.props.actions.deleteLinode;
     _deleteLinode(linodeId)
-      .then(_ => this.setState({ confirmationOpen: false })) // @todo do we need to display for this? e.g. this.props.enqueueSnackbar('Linode deleted successfully', { variant: 'info' }))
+      .then(_ =>
+        this.setState({
+          confirmationOpen: false,
+          confirmationLoading: false,
+          confirmationError: undefined
+        })
+      )
+      // @todo do we need to display for this? e.g. ( this.props.enqueueSnackbar('Linode deleted successfully', { variant: 'info' }))
       .catch(err =>
         this.setState({
+          confirmationLoading: false,
           confirmationError: getErrorStringOrDefault(
             err,
             'There was an error deleting your Linode.'
@@ -227,7 +235,6 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
         this.setState({ confirmationOpen: false });
         break;
     }
-    this.setState({ confirmationLoading: false });
   };
 
   dismissCTA = () => {

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -190,7 +190,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
   };
 
   deleteLinode = (linodeId: number) => {
-    const _deleteLinode = this.props.actions.deleteLinode;
+    const _deleteLinode = this.props.deleteLinode;
     _deleteLinode(linodeId)
       .then(_ =>
         this.setState({
@@ -527,17 +527,13 @@ const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
 };
 
 interface DispatchProps {
-  actions: {
-    deleteLinode: (linodeId: number) => Promise<{}>;
-  };
+  deleteLinode: (linodeId: number) => Promise<{}>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
 ) => ({
-  actions: {
-    deleteLinode: (linodeId: number) => dispatch(deleteLinode({ linodeId }))
-  }
+  deleteLinode: (linodeId: number) => dispatch(deleteLinode({ linodeId }))
 });
 
 interface ToggleGroupByTagsProps {

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -5,9 +5,11 @@ import { parse, stringify } from 'qs';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { CSVLink } from 'react-csv';
-import { connect } from 'react-redux';
+import { connect, MapDispatchToProps } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose, withStateHandlers } from 'recompose';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
@@ -30,8 +32,11 @@ import { BackupsCTA } from 'src/features/Backups';
 import LinodeConfigSelectionDrawer, {
   LinodeConfigSelectionDrawerCallback
 } from 'src/features/LinodeConfigSelectionDrawer';
+import { ApplicationState } from 'src/store';
+import { deleteLinode } from 'src/store/linodes/linode.requests';
 import { MapState } from 'src/store/types';
 import { sendEvent } from 'src/utilities/analytics';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import formatDate from 'src/utilities/formatDate';
 import { storage, views } from 'src/utilities/storage';
 import CardView from './CardView';
@@ -53,8 +58,10 @@ interface ConfigDrawerState {
 
 interface State {
   configDrawer: ConfigDrawerState;
-  powerAlertOpen: boolean;
-  bootOption: Linode.BootAction;
+  confirmationOpen: boolean;
+  confirmationError?: string;
+  confirmationLoading: boolean;
+  actionOption: Linode.KebabAction;
   selectedLinodeId: number | null;
   selectedLinodeLabel: string;
   groupByTag: boolean;
@@ -72,6 +79,7 @@ type CombinedProps = WithImagesProps &
   WithWidth &
   ToggleGroupByTagsProps &
   StateProps &
+  DispatchProps &
   RouteProps &
   StyleProps &
   SetDocsProps &
@@ -89,8 +97,10 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
       selected: undefined,
       action: (id: number) => null
     },
-    powerAlertOpen: false,
-    bootOption: null,
+    confirmationOpen: false,
+    confirmationError: undefined,
+    confirmationLoading: false,
+    actionOption: null,
     selectedLinodeId: null,
     selectedLinodeLabel: '',
     groupByTag: false,
@@ -166,31 +176,58 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
   };
 
   toggleDialog = (
-    bootOption: Linode.BootAction,
+    actionOption: Linode.KebabAction,
     selectedLinodeId: number,
     selectedLinodeLabel: string
   ) => {
     this.setState({
-      powerAlertOpen: !this.state.powerAlertOpen,
+      confirmationOpen: !this.state.confirmationOpen,
+      confirmationError: undefined,
       selectedLinodeId,
       selectedLinodeLabel,
-      bootOption
+      actionOption
     });
   };
 
-  rebootOrPowerLinode = () => {
-    const { bootOption, selectedLinodeId, selectedLinodeLabel } = this.state;
-    if (bootOption === 'reboot') {
-      rebootLinode(
-        this.openConfigDrawer,
-        selectedLinodeId!,
-        selectedLinodeLabel,
-        this.props.enqueueSnackbar
+  deleteLinode = (linodeId: number) => {
+    const _deleteLinode = this.props.actions.deleteLinode;
+    _deleteLinode(linodeId)
+      .then(_ => this.setState({ confirmationOpen: false })) // @todo do we need to display for this? e.g. this.props.enqueueSnackbar('Linode deleted successfully', { variant: 'info' }))
+      .catch(err =>
+        this.setState({
+          confirmationError: getErrorStringOrDefault(
+            err,
+            'There was an error deleting your Linode.'
+          )
+        })
       );
-    } else {
-      powerOffLinode(selectedLinodeId!, selectedLinodeLabel);
+  };
+
+  rebootOrPowerLinode = () => {
+    const { actionOption, selectedLinodeId, selectedLinodeLabel } = this.state;
+    this.setState({ confirmationError: undefined, confirmationLoading: true });
+    switch (actionOption) {
+      case 'reboot':
+        rebootLinode(
+          this.openConfigDrawer,
+          selectedLinodeId!,
+          selectedLinodeLabel,
+          this.props.enqueueSnackbar
+        );
+        this.setState({ confirmationOpen: false });
+        break;
+      case 'power_down':
+        powerOffLinode(selectedLinodeId!, selectedLinodeLabel);
+        this.setState({ confirmationOpen: false });
+        break;
+      case 'delete':
+        this.deleteLinode(selectedLinodeId!);
+        break;
+      default:
+        this.setState({ confirmationOpen: false });
+        break;
     }
-    this.setState({ powerAlertOpen: false });
+    this.setState({ confirmationLoading: false });
   };
 
   dismissCTA = () => {
@@ -214,7 +251,12 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
       backupsCTA
     } = this.props;
 
-    const { configDrawer, bootOption, powerAlertOpen } = this.state;
+    const {
+      configDrawer,
+      actionOption,
+      confirmationError,
+      confirmationOpen
+    } = this.state;
 
     const params: Params = parse(this.props.location.search, {
       ignoreQueryPrefix: true
@@ -372,17 +414,18 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
             />
             <ConfirmationDialog
               title={
-                bootOption === 'reboot' ? 'Confirm Reboot' : 'Powering Off'
+                actionOption === 'reboot'
+                  ? 'Confirm Reboot'
+                  : actionOption === 'power_down'
+                  ? 'Powering Off'
+                  : 'Confirm Delete'
               }
               actions={this.renderConfirmationActions}
-              open={powerAlertOpen}
+              open={confirmationOpen}
               onClose={this.closePowerAlert}
+              error={confirmationError}
             >
-              <Typography>
-                {bootOption === 'reboot'
-                  ? 'Are you sure you want to reboot your Linode?'
-                  : 'Are you sure you want to power down your Linode?'}
-              </Typography>
+              <Typography>{getConfirmationMessage(actionOption)}</Typography>
             </ConfirmationDialog>
           </Grid>
         </Grid>
@@ -396,7 +439,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
   }
 
   renderConfirmationActions = () => {
-    const { bootOption } = this.state;
+    const { actionOption, confirmationLoading } = this.state;
     return (
       <ActionsPanel style={{ padding: 0 }}>
         <Button
@@ -410,15 +453,33 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           type="primary"
           onClick={this.rebootOrPowerLinode}
           data-qa-confirm-cancel
+          loading={confirmationLoading}
         >
-          {bootOption === 'reboot' ? 'Reboot' : 'Power Off'}
+          {actionOption === 'reboot'
+            ? 'Reboot'
+            : actionOption === 'power_down'
+            ? 'Power Off'
+            : 'Delete'}
         </Button>
       </ActionsPanel>
     );
   };
 
-  closePowerAlert = () => this.setState({ powerAlertOpen: false });
+  closePowerAlert = () => this.setState({ confirmationOpen: false });
 }
+
+const getConfirmationMessage = (actionOption: Linode.KebabAction) => {
+  switch (actionOption) {
+    case 'reboot':
+      return 'Are you sure you want to reboot your Linode?';
+    case 'power_down':
+      return 'Are you sure you want to power down your Linode?';
+    case 'delete':
+      return 'Are you sure you want to delete your Linode? This will result in permanent data loss.';
+    default:
+      return 'Are you sure?';
+  }
+};
 
 const getUserSelectedDisplay = (
   value?: string
@@ -459,12 +520,29 @@ const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
   };
 };
 
+interface DispatchProps {
+  actions: {
+    deleteLinode: (linodeId: number) => Promise<{}>;
+  };
+}
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
+  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
+) => ({
+  actions: {
+    deleteLinode: (linodeId: number) => dispatch(deleteLinode({ linodeId }))
+  }
+});
+
 interface ToggleGroupByTagsProps {
   groupByTags: boolean;
   toggleGroupByTag: (e: React.ChangeEvent<any>, checked: boolean) => void;
 }
 
-const connected = connect(mapStateToProps);
+const connected = connect(
+  mapStateToProps,
+  mapDispatchToProps
+);
 
 const toggleGroupState = withStateHandlers(
   (ownProps: RouteProps) => {

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -199,7 +199,6 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           confirmationError: undefined
         })
       )
-      // @todo do we need to display for this? e.g. ( this.props.enqueueSnackbar('Linode deleted successfully', { variant: 'info' }))
       .catch(err =>
         this.setState({
           confirmationLoading: false,
@@ -211,7 +210,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
       );
   };
 
-  rebootOrPowerLinode = () => {
+  executeAction = () => {
     const { actionOption, selectedLinodeId, selectedLinodeLabel } = this.state;
     this.setState({ confirmationError: undefined, confirmationLoading: true });
     switch (actionOption) {
@@ -458,7 +457,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
         </Button>
         <Button
           type="primary"
-          onClick={this.rebootOrPowerLinode}
+          onClick={this.executeAction}
           data-qa-confirm-cancel
           loading={confirmationLoading}
         >

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -221,11 +221,11 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           selectedLinodeLabel,
           this.props.enqueueSnackbar
         );
-        this.setState({ confirmationOpen: false });
+        this.setState({ confirmationOpen: false, confirmationLoading: false });
         break;
       case 'power_down':
         powerOffLinode(selectedLinodeId!, selectedLinodeLabel);
-        this.setState({ confirmationOpen: false });
+        this.setState({ confirmationOpen: false, confirmationLoading: false });
         break;
       case 'delete':
         this.deleteLinode(selectedLinodeId!);

--- a/src/types/Linode.ts
+++ b/src/types/Linode.ts
@@ -208,6 +208,8 @@ namespace Linode {
 
   export type BootAction = 'reboot' | 'power_down' | null;
 
+  export type KebabAction = BootAction | 'delete';
+
   interface NetStats {
     in: number[][];
     out: number[][];


### PR DESCRIPTION
## Description

Added Delete option to Linode action menu

## Note to Reviewers
- Renamed some of the existing variables/functions, since the only async actions from the action menu were boot-related and were named accordingly
- There's a separate file with powerActions in it, but I left that alone, since the logic was more specific to booting/rebooting and error handling was different since those are event-based.
- Need feedback on the error/success/loading states
