### PR TITLE
Add event types and account events messages

### DIFF
--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -12,6 +12,12 @@ interface CreatorsForStatus {
 
 /** @see https://leo.stcloudstate.edu/grammar/tenses.html */
 export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
+  account_update: {
+    notification: e => `Your account settings have been updated.`
+  },
+  account_settings_update: {
+    notification: e => `Your account settings have been updated.`
+  },
   backups_cancel: {
     notification: e => `Backups have been cancelled for ${e.entity!.label}.`
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,9 +77,14 @@ namespace Linode {
   }
 
   export type EventAction =
+    | 'account_update'
+    | 'account_settings_update'
     | 'backups_cancel'
     | 'backups_enable'
     | 'backups_restore'
+    | 'community_like'
+    | 'community_question_reply'
+    | 'credit_card_updated'
     | 'disk_create'
     | 'disk_update'
     | 'disk_delete'
@@ -100,6 +105,7 @@ namespace Linode {
     | 'linode_create'
     | 'linode_update'
     | 'linode_delete'
+    | 'linode_deleteip'
     | 'linode_migrate'
     | 'linode_reboot'
     | 'linode_resize'
@@ -121,6 +127,9 @@ namespace Linode {
     | 'stackscript_delete'
     | 'stackscript_publicize'
     | 'stackscript_revise'
+    | 'tfa_enabled'
+    | 'tfa_disabled'
+    | 'ticket_attachment_upload'
     | 'user_ssh_key_add'
     | 'user_ssh_key_update'
     | 'user_ssh_key_delete'


### PR DESCRIPTION
## Description

Add some event types and messages for missing new events. 



## Note to Reviewers

To test, change some account settings and check your console afterwards. Shouldn't see any "Unknown API Event Received" warnings logged there.