### PR TITLE
M3-2570 Fix: Only disable Linode Boot if there are no configs

### DIFF
--- a/src/components/ActionMenu/ActionMenu.test.tsx
+++ b/src/components/ActionMenu/ActionMenu.test.tsx
@@ -8,7 +8,8 @@ const classes = {
   button: '',
   hidden: '',
   item: '',
-  root: ''
+  root: '',
+  menu: ''
 };
 
 describe('ActionMenu', () => {

--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -13,10 +13,17 @@ export interface Action {
   title: string;
   disabled?: boolean;
   tooltip?: string;
+  isLoading?: boolean;
   onClick: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
-type CSSClasses = 'root' | 'item' | 'button' | 'actionSingleLink' | 'hidden';
+type CSSClasses =
+  | 'root'
+  | 'item'
+  | 'button'
+  | 'actionSingleLink'
+  | 'hidden'
+  | 'menu';
 
 const styles: StyleRulesCallback<CSSClasses> = theme => ({
   root: {
@@ -60,6 +67,9 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   hidden: {
     height: 0,
     padding: 0
+  },
+  menu: {
+    maxWidth: theme.spacing.unit * 25
   }
 });
 
@@ -130,6 +140,7 @@ export class ActionMenu extends React.Component<CombinedProps, State> {
         </IconButton>
         <Menu
           id="action-menu"
+          className={classes.menu}
           anchorEl={anchorEl}
           getContentAnchorEl={undefined}
           anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
@@ -146,6 +157,7 @@ export class ActionMenu extends React.Component<CombinedProps, State> {
               data-qa-action-menu-item={a.title}
               disabled={a.disabled}
               tooltip={a.tooltip}
+              isLoading={a.isLoading}
             >
               {a.title}
             </MenuItem>

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -1,5 +1,6 @@
 import HelpOutline from '@material-ui/icons/HelpOutline';
 import * as React from 'react';
+import CircularProgress from 'src/components/core/CircularProgress';
 import IconButton from 'src/components/core/IconButton';
 import MenuItem, { MenuItemProps } from 'src/components/core/MenuItem';
 import {
@@ -14,11 +15,13 @@ type CSSClasses =
   | 'labelWrapper'
   | 'label'
   | 'helpButton'
-  | 'helpIcon';
+  | 'helpIcon'
+  | 'circleProgress';
 
 interface Props {
   tooltip?: string;
   className?: string;
+  isLoading?: boolean;
 }
 
 const styles: StyleRulesCallback<CSSClasses> = theme => ({
@@ -68,26 +71,33 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   helpIcon: {
     width: 20,
     height: 20
+  },
+  circleProgress: {
+    padding: theme.spacing.unit
   }
 });
 
 const handleClick = (e: any) => {
   e.stopPropagation();
 };
-
 type CombinedProps = MenuItemProps & Props & WithStyles<CSSClasses>;
 
 const WrapperMenuItem: React.StatelessComponent<CombinedProps> = props => {
-  const { tooltip, classes, className, ...rest } = props;
+  const { tooltip, classes, className, isLoading, ...rest } = props;
+
+  const shouldWrapLabel = isLoading || tooltip;
 
   return (
     <MenuItem
       {...rest}
       className={`${classes.root} ${className} ${tooltip && 'hasTooltip'}`}
     >
-      <span className={tooltip && classes.labelWrapper}>
-        <span className={tooltip && classes.label}>{props.children}</span>
-        {tooltip && (
+      <span className={shouldWrapLabel && classes.labelWrapper}>
+        <span className={shouldWrapLabel && classes.label}>
+          {props.children}
+        </span>
+        {isLoading && <CircularProgress size={20} />}
+        {tooltip && !isLoading && (
           <IconButton
             className={classes.helpButton}
             onClick={handleClick}

--- a/src/components/MenuItem/MenuItem.tsx
+++ b/src/components/MenuItem/MenuItem.tsx
@@ -62,6 +62,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   helpButton: {
     width: 28,
     height: 28,
+    padding: 0,
     color: theme.palette.primary.main,
     pointerEvents: 'initial',
     '&:hover, &:focus': {
@@ -73,7 +74,10 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     height: 20
   },
   circleProgress: {
-    padding: theme.spacing.unit
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    margin: '0 auto'
   }
 });
 
@@ -92,11 +96,13 @@ const WrapperMenuItem: React.StatelessComponent<CombinedProps> = props => {
       {...rest}
       className={`${classes.root} ${className} ${tooltip && 'hasTooltip'}`}
     >
+      {isLoading && (
+        <CircularProgress size={20} className={classes.circleProgress} />
+      )}
       <span className={shouldWrapLabel && classes.labelWrapper}>
         <span className={shouldWrapLabel && classes.label}>
           {props.children}
         </span>
-        {isLoading && <CircularProgress size={20} />}
         {tooltip && !isLoading && (
           <IconButton
             className={classes.helpButton}

--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.test.tsx
@@ -22,7 +22,7 @@ describe('Linode Power Control Dialogs', () => {
       label="Test Linode"
       status="running"
       openConfigDrawer={jest.fn()}
-      noImage={false}
+      noConfigs={false}
     />
   );
 

--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -114,7 +114,7 @@ interface Props {
   id: number;
   label: string;
   status: Linode.LinodeStatus;
-  noImage: boolean;
+  noConfigs: boolean;
   recentEvent?: Linode.Event;
   openConfigDrawer: (
     config: Linode.Config[],
@@ -178,7 +178,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { status, classes, recentEvent, noImage } = this.props;
+    const { status, classes, recentEvent, noConfigs } = this.props;
     const {
       menu: { anchorEl },
       bootOption,
@@ -286,10 +286,10 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
               onClick={this.powerOn}
               className={classes.menuItem}
               data-qa-set-power="powerOn"
-              disabled={noImage}
+              disabled={noConfigs}
               tooltip={
-                noImage
-                  ? 'An image needs to be added before powering on a Linode'
+                noConfigs
+                  ? 'A config needs to be added before powering on a Linode'
                   : undefined
               }
             >

--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -89,7 +89,7 @@ const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
       .catch(err => {
         const errors: Linode.ApiFieldError[] = getAPIErrorOrDefault(
           err,
-          'An error occured while updating label',
+          'An error occurred while updating label',
           'label'
         );
         const errorStrings: string[] = errors.map(e => e.reason);
@@ -135,7 +135,7 @@ const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
           recentEvent={linode.recentEvent}
           id={linode.id}
           label={linode.label}
-          noImage={!linode.image}
+          noConfigs={linode._configs.length === 0}
           openConfigDrawer={openConfigDrawer}
         />
       </Grid>
@@ -159,7 +159,8 @@ const enhanced = compose<CombinedProps, {}>(
   withEditableLabelState,
   withLinodeDetailContext(({ linode, updateLinode }) => ({
     linode,
-    updateLinode
+    updateLinode,
+    configs: linode._configs
   })),
   styled
 );


### PR DESCRIPTION
## Description

Previously, we disabled a Linode’s "Power On" option if the API response for the Linode didn’t include an image. **Instead we should be checking to see if the Linode has configs.**

This was easy on LinodeDetails, since the configs are already attached to the Linode’s context. 

Not so much on LinodesLanding, because we haven’t requested the configs yet. I opted to send the request for a specific Linode’s configs when the kebab menu for that specific Linode is clicked. This means there is a brief “loading” state on the “Power On” menu item in the ActionMenu.

**TO DO:**
- [x] Clean up styles

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

To test, either:

a) Create a Linode in Classic Manager and deploy an image to it.
b) Create a LInode in Cloud Manager from a backup

Then, in Cloud Manager, try to boot the Linode from LinodesLanding (kebab menu) and Linodes Detail (PowerControls).