### PR TITLE
StackScripts e2e test maintenance

### DIFF
--- a/e2e/pageobjects/linode-detail/linode-detail-settings.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-settings.page.js
@@ -1,7 +1,7 @@
 const { constants } = require('../../constants');
 const {
     generatePassword,
-    getDistrobutionLabel,
+    getDistributionLabel
  } = require('../../utils/common')
 
 import Page from '../page';
@@ -82,7 +82,7 @@ class Settings extends Page {
         imageSelect.waitForVisible(constants.wait.normal);
         this.diskLabelInput.setValue(diskLabel);
         imageSelect.click();
-        const displayImage = getDistrobutionLabel([imageId])[0];
+        const displayImage = getDistributionLabel([imageId])[0];
         imageSelect.setValue(displayImage);
         const imageSelection = `[data-qa-option="linode/${imageId}"]`;
         $(imageSelection).waitForVisible(constants.wait.normal);

--- a/e2e/pageobjects/list-stackscripts.page.js
+++ b/e2e/pageobjects/list-stackscripts.page.js
@@ -26,7 +26,7 @@ class ListStackScripts extends Page {
     get stackScriptRows() { return $$('[data-qa-table-row]'); }
     get stackScriptTitle() { return $('[data-qa-stackscript-title]'); }
     get stackScriptDeploys() { return $('[data-qa-stackscript-deploys]'); }
-    get stackScriptCompatibleDistrobutions() { return $('[data-qa-stackscript-images]'); }
+    get stackScriptCompatibleDistributions() { return $('[data-qa-stackscript-images]'); }
     get stackScriptActionMenu() { return $('[data-qa-action-menu]'); }
     get stackScriptActionMenuLink() { return $('[data-qa-action-menu-link]'); }
     get stackScriptRevision() { return $('[data-qa-stackscript-revision]'); }

--- a/e2e/pageobjects/stackscripts/stackscript-detail.page.js
+++ b/e2e/pageobjects/stackscripts/stackscript-detail.page.js
@@ -42,8 +42,8 @@ class StackScriptDetail extends Page {
         return $(`${selector}="${stackScriptAuthor}"]`);
     }
 
-    getStackScriptCompatibleDisrobutions(){
-        this.compatibleDistrobutions.waitForVisible(constants.wait.normal);
+    getStackScriptCompatibleDistributions(){
+        this.compatibleDistributions.waitForVisible(constants.wait.normal);
         const distroListText = this.compatibleDistributions.getText();
         const cleanText = distroListText.replace('Compatible with: ','');
         return cleanText.split(',').map(distro=> distro.trim());

--- a/e2e/specs/stackscripts/stackscript-detail.spec.js
+++ b/e2e/specs/stackscripts/stackscript-detail.spec.js
@@ -1,7 +1,7 @@
 const { constants } = require('../../constants');
 import {
     apiDeleteMyStackScripts,
-    getDistrobutionLabel,
+    getDistributionLabel,
     timestamp,
     switchTab,
 } from '../../utils/common';
@@ -21,25 +21,25 @@ describe('StackScript - detail page and drawer suite', () => {
       }, constants.wait.normal);
       const titleAndAuthor = $$(`${ListStackScripts.stackScriptTitle.selector} h3`)[0].getText();
       const deploys = $$(ListStackScripts.stackScriptDeploys.selector)[0].getText();
-      const compatibleDisrobutions = $$(ListStackScripts.stackScriptCompatibleDistrobutions.selector)[0].$$('div').map(distro => distro.getText());
+      const compatibleDistributions = $$(ListStackScripts.stackScriptCompatibleDistributions.selector)[0].$$('div').map(distro => distro.getText());
       const getTitleAndAuthor = titleAndAuthor.split('/');
       const stackScriptDetails = {
           title: getTitleAndAuthor[1].trim(),
           author: getTitleAndAuthor[0].trim(),
           deploys: deploys,
-          distrobutions: compatibleDisrobutions
+          distributions: compatibleDistributions
       }
       return stackScriptDetails;
   }
 
-  const verifyStackScriptDetailPageOrDrawer = (title,author,deployments,disrobutions,description,code) => {
+  const verifyStackScriptDetailPageOrDrawer = (title,author,deployments,distributions,description,code) => {
       expect(StackScriptDetail.stackScriptTitle(title).isVisible()).toBe(true);
       expect(StackScriptDetail.stackScriptAuthor(author).isVisible()).toBe(true);
       expect(StackScriptDetail.stackScriptDeployments.getText()).toContain(deployments);
-      const selectedDistrobutionLabels = getDistrobutionLabel(disrobutions);
-      const displayedDistrobutionLabels = StackScriptDetail.getStackScriptCompatibleDisrobutions();
-      selectedDistrobutionLabels.forEach((distro) => {
-          expect(displayedDistrobutionLabels.includes(distro)).toBe(true);
+      const selectedDistributionLabels = getDistributionLabel(distributions);
+      const displayedDistributionsLabels = StackScriptDetail.getStackScriptCompatibleDistributions();
+      selectedDistributionLabels.forEach((distro) => {
+          expect(displayedDistributionsLabels.includes(distro)).toBe(true);
       });
       if(description){
           expect(StackScriptDetail.stackScriptDescription.getText()).toContain(description);
@@ -72,7 +72,7 @@ describe('StackScript - detail page and drawer suite', () => {
       });
 
       it('Verify StackScript details correspond to the row clicked', () => {
-          verifyStackScriptDetailPageOrDrawer(selectedStackScript.title,selectedStackScript.author,selectedStackScript.deploys,selectedStackScript.distrobutions);
+          verifyStackScriptDetailPageOrDrawer(selectedStackScript.title,selectedStackScript.author,selectedStackScript.deploys,selectedStackScript.distributions);
       });
 
       it('Breadcrumb link navigates back to StackScript landing', () => {
@@ -160,7 +160,7 @@ describe('StackScript - detail page and drawer suite', () => {
       });
 
       it('Verify StackScript drawer details correspond to the row clicked', () => {
-          verifyStackScriptDetailPageOrDrawer(selectedStackScript.title,selectedStackScript.author,selectedStackScript.deploys,selectedStackScript.distrobutions);
+          verifyStackScriptDetailPageOrDrawer(selectedStackScript.title,selectedStackScript.author,selectedStackScript.deploys,selectedStackScript.distributions);
           expect(StackScriptDetail.drawerTitle.getText()).toEqual(`${selectedStackScript.author} / ${selectedStackScript.title}`);
           StackScriptDetail.drawerClose.click();
           ConfigureLinode.drawerBase.waitForVisible(constants.wait.normal, true);

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -232,14 +232,14 @@ export const switchTab = () => {
     browser.switchTab(newTab);
 }
 
-export const getDistrobutionLabel = (distrobutionTags) => {
+export const getDistributionLabel = (distributionTags) => {
     const token = readToken(browser.options.testUser);
-    let distrobutionLabel = [];
-    distrobutionTags.forEach((distro) => {
+    let distributionLabel = [];
+    distributionTags.forEach((distro) => {
         const distroDetails = browser.getLinodeImage(token,distro.trim());
-        distrobutionLabel.push(distroDetails.label);
+        distributionLabel.push(distroDetails.label);
     });
-    return distrobutionLabel;
+    return distributionLabel;
 }
 
 export const getLocalStorageValue = (key) => {


### PR DESCRIPTION
## Description

Fix StackScripts e2e tests that were failing due to spelling errors.

## Note to Reviewers

To test, run: `yarn e2e --file e2e/specs/stackscripts/stackscript-detail.spec.js`.