### PR TITLE
Fix: Events Middleware with Creating w/ No Image

### DIFF
--- a/src/store/linodes/linodes.events.ts
+++ b/src/store/linodes/linodes.events.ts
@@ -141,12 +141,6 @@ const handleLinodeCreation = (
   id: number,
   state: ApplicationState
 ) => {
-  const found = state.__resources.linodes.results.find(i => i === id);
-
-  if (found) {
-    return;
-  }
-
   switch (status) {
     case 'failed':
     case 'finished':


### PR DESCRIPTION
## Description

Fixes an issue where if the user created a Linode with no image, the events middleware wouldn't do anything, so you would end up looking at the Linode Landing with an indefinitely loading Linode.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

### Note to Reviewers

Please create a bunch of Linodes, some with images and some without to test