### PR TITLE
Fix "Remove Linode" Test

### DIFF
--- a/e2e/pageobjects/linode-detail/linode-detail-settings.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-settings.page.js
@@ -118,8 +118,9 @@ class Settings extends Page {
     }
 
     remove() {
-        const linodeLabel = browser.getText('[data-qa-label]');
-        const confirmTitle = 'Confirm Deletion';
+        /** linode label sourced from the editable text H1 in the header */
+        const linodeLabel = browser.getText('[data-qa-editable-text]');
+        const confirmTitle = `Confirm Deletion of ${linodeLabel}`;
         const confirmContent = 'Deleting a Linode will result in permanent data loss. Are you sure?';
         this.delete.click();
         this.deleteDialogTitle.waitForText();


### PR DESCRIPTION
## Description

Fix remove Linode test because the confirmation modal now contains the Linode label

### To Test

`yarn && yarn start`
`yarn selenium`
`yarn e2e --spec=e2e/specs/linodes/detail/smoke-settings.spec.js --browser=headlessChrome`