### PR TITLE
M3-2578 Fix config updating bug

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -603,7 +603,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       return this.setState({
         errors: [
           {
-            reason: 'You must select a valid Disk as your root device.',
+            reason:
+              'You must select a valid Disk or Volume as your root device.',
             field: 'root_device'
           }
         ]

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -41,6 +41,7 @@ import createDevicesFromStrings, {
   DevicesAsStrings
 } from 'src/utilities/createDevicesFromStrings';
 import createStringsFromDevices from 'src/utilities/createStringsFromDevices';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import {
@@ -237,7 +238,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
   renderLoading = () => <CircleProgress />;
 
   renderErrorState = () => (
-    <ErrorState errorText="Unable to loading configurations." />
+    <ErrorState errorText="Unable to load configurations." />
   );
 
   renderForm = (errors?: Linode.ApiFieldError[]) => {
@@ -588,12 +589,32 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       updateLinodeConfig
     } = this.props;
 
+    /**
+     * This is client-side validation to patch an API bug.
+     * Currently, POST requests don't verify that the selected root device
+     * has a valid device attached to it. PUT requests do this, however,
+     * leading to a discrepancy. If root_device is sda and sda is null,
+     * we should head off that error before submitting the request.
+     * @todo remove once the API has fixed this behavior.
+     */
+
+    const isValid = validateConfigData(this.state.fields);
+    if (!isValid) {
+      return this.setState({
+        errors: [
+          {
+            reason: 'You must select a valid Disk as your root device.',
+            field: 'root_device'
+          }
+        ]
+      });
+    }
+
+    const configData = this.convertStateToData(this.state.fields);
+
     /** Editing */
     if (linodeConfigId) {
-      return updateLinodeConfig(
-        linodeConfigId,
-        this.convertStateToData(this.state.fields)
-      )
+      return updateLinodeConfig(linodeConfigId, configData)
         .then(_ => {
           this.props.onClose();
           this.props.onSuccess();
@@ -610,17 +631,16 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     }
 
     /** Creating */
-    return createLinodeConfig(this.convertStateToData(this.state.fields))
-      .then(response => {
+    return createLinodeConfig(configData)
+      .then(_ => {
         this.props.onClose();
         this.props.onSuccess();
       })
       .catch(error =>
         this.setState({
-          errors: pathOr(
-            [{ reason: 'Unable to create config. Please try again.' }],
-            ['response', 'data', 'errors'],
-            error
+          errors: getAPIErrorOrDefault(
+            error,
+            'Unable to create config. Please try again.'
           )
         })
       );
@@ -745,6 +765,17 @@ const isUsingCustomRoot = (value: string) =>
     '/dev/sdg',
     '/dev/sdh'
   ].includes(value) === false;
+
+const validateConfigData = (configData: EditableFields) => {
+  /**
+   * Whatever disk is selected for root_disk can't have a value of null ('none'
+   * in our form state).
+   *
+   */
+  const rootDevice = pathOr('none', [0], configData.root_device.match(/sd./));
+  const selectedDisk = pathOr('none', ['devices', rootDevice], configData);
+  return selectedDisk !== 'none';
+};
 
 const styled = withStyles(styles);
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -196,7 +196,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
           });
       }
       /**
-       * If the linodeConfigId is set, we're editting, so we query to get the config data and
+       * If the linodeConfigId is set, we're editing, so we query to get the config data and
        * fill out the form with the data.
        */
     }

--- a/src/utilities/createDevicesFromStrings/createDevicesFromStrings.test.ts
+++ b/src/utilities/createDevicesFromStrings/createDevicesFromStrings.test.ts
@@ -2,7 +2,7 @@ import createDevicesFromStrings from './createDevicesFromStrings';
 
 describe('LinodeRescue', () => {
   describe('createRescueDevicesPostObject', () => {
-    it('Returns the minumum requirement.', () => {
+    it('Returns the minimum requirement.', () => {
       const result = createDevicesFromStrings({});
       const expected = {
         sda: null,

--- a/src/utilities/createDevicesFromStrings/createDevicesFromStrings.test.ts
+++ b/src/utilities/createDevicesFromStrings/createDevicesFromStrings.test.ts
@@ -54,5 +54,23 @@ describe('LinodeRescue', () => {
 
       expect(result).toEqual(expected);
     });
+
+    it('should return null for a disk that is set to None', () => {
+      const result = createDevicesFromStrings({
+        sda: 'none',
+        sdd: 'disk-456'
+      });
+      const expected = {
+        sda: null,
+        sdb: null,
+        sdc: null,
+        sdd: { disk_id: 456 },
+        sde: null,
+        sdf: null,
+        sdg: null,
+        sdh: null
+      };
+      expect(result).toEqual(expected);
+    });
   });
 });

--- a/src/utilities/createDevicesFromStrings/createDevicesFromStrings.ts
+++ b/src/utilities/createDevicesFromStrings/createDevicesFromStrings.ts
@@ -19,7 +19,7 @@ export interface DevicesAsStrings {
  * The `value` should be formatted as volume-123, disk-123, etc.,
  */
 const createTypeRecord = (value?: string): null | DiskRecord | VolumeRecord => {
-  if (isNil(value)) {
+  if (isNil(value) || value === 'none') {
     return null;
   }
 


### PR DESCRIPTION
## Description

This turned out to be two separate issues.

1. Our createDevicesFromStrings utility was returning "none_id: null" for
the disk ID instead of null as it should have been.
2. There is a small API bug where POST requests for creating a config are not
validated, whereas PUT requests are. This results in a state where it is possible
to create a config that then can't be updated with its initial values.

Fixed #1 by adding a === 'none' check in createDevicesFromStrings, added
temporary client-side validation for #2. (we could also just punt on #2 and let the API handle errors as it wants, since there's nothing we can do about configs created through the API without using Cloud)

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

To test: create a config without selecting anything for the disk chosen as the root_disk. You should receive an error. Changing a previously set disk to "none" when editing the config should work normally.

There's also another open API bug where our requested root_disk isn't being set. Nothing we can do about that for right now so I left it alone.