### PR TITLE
CLAPPS: Adjust default label

### DIFF
--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -307,7 +307,10 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       arg2 = selectedRegion ? selectedRegion.id : '';
     }
 
-    arg3 = this.props.createType;
+    if (this.props.createType === 'fromLinode') {
+      // @todo handle any other custom label cases we'd like to have here
+      arg3 = 'clone';
+    }
 
     return getLabel(arg1, arg2, arg3);
   };

--- a/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
+++ b/src/features/linodes/LinodesCreate/withLabelGenerator.tsx
@@ -88,7 +88,7 @@ export default withLabelGenerator;
 
 // Utilities
 
-// Searches 'existingLabels' and appends a zero-padded incrementer to the original label
+// Searches 'existingLabels' and appends a zero-padded increment-er to the original label
 export const dedupeLabel = (
   label: string,
   existingLabels: string[]


### PR DESCRIPTION
## Description

Chris wasn't thrilled that our default app labels had "fromapp" in them, so I removed this bit of text from the auto-generated labels. The behavior now closely matches what's found in production.
