### PR TITLE
M3-OBJ Update Object Storage CTA

### DIFF
--- a/src/features/ObjectStorage/ClusterSelect.tsx
+++ b/src/features/ObjectStorage/ClusterSelect.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import FormControl from 'src/components/core/FormControl';
-import InputLabel from 'src/components/core/InputLabel';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import clustersContainer, {
   StateProps
@@ -31,22 +29,18 @@ export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
     : undefined;
 
   return (
-    <FormControl fullWidth>
-      <InputLabel htmlFor="cluster" disableAnimation shrink={true}>
-        Cluster
-      </InputLabel>
-      <Select
-        data-qa-select-cluster
-        name="cluster"
-        options={options}
-        placeholder="All Clusters"
-        onChange={(item: Item<string>) => onChange(item.value)}
-        onBlur={onBlur}
-        isSearchable={false}
-        isClearable={false}
-        errorText={errorText}
-      />
-    </FormControl>
+    <Select
+      data-qa-select-cluster
+      name="cluster"
+      label="Cluster"
+      options={options}
+      placeholder="All Clusters"
+      onChange={(item: Item<string>) => onChange(item.value)}
+      onBlur={onBlur}
+      isSearchable={false}
+      isClearable={false}
+      errorText={errorText}
+    />
   );
 };
 

--- a/src/features/ObjectStorage/ObjectStorageLanding.test.tsx
+++ b/src/features/ObjectStorage/ObjectStorageLanding.test.tsx
@@ -1,8 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { buckets } from 'src/__data__/buckets';
-// @todo: remove router import when bucket creation is supported
-import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { ObjectStorageLanding } from './ObjectStorageLanding';
 
 describe('ObjectStorageLanding', () => {
@@ -11,8 +9,8 @@ describe('ObjectStorageLanding', () => {
       classes={{ root: '', title: '', titleWrapper: '' }}
       bucketsData={buckets}
       bucketsLoading={false}
-      // @todo: remove router props when bucket creation is supported
-      {...reactRouterProps}
+      openBucketDrawer={jest.fn()}
+      closeBucketDrawer={jest.fn()}
     />
   );
 

--- a/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-// @todo: remove router imports when bucket creation is supported
-import { RouterProps, withRouter } from 'react-router';
 import { compose } from 'recompose';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
 import AddNewLink from 'src/components/AddNewLink';
@@ -34,22 +32,16 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   }
 });
 
-// @todo: remove RouterProps when bucket creation is supported
-type CombinedProps = StateProps &
-  DispatchProps &
-  RouterProps &
-  WithStyles<ClassNames>;
+type CombinedProps = StateProps & DispatchProps & WithStyles<ClassNames>;
 
 export const ObjectStorageLanding: React.StatelessComponent<
   CombinedProps
 > = props => {
-  // @todo: remove router.history prop when bucket creation is supported
   const {
     classes,
     bucketsData,
     bucketsLoading,
     bucketsError,
-    history,
     openBucketDrawer
   } = props;
 
@@ -62,14 +54,7 @@ export const ObjectStorageLanding: React.StatelessComponent<
   }
 
   if (bucketsData.length === 0) {
-    // Our call-to-action should be "Create a Bucket". Since that feature
-    // doesn't exist yet, the call-to-action is temporarily a link to API Tokens.
-    return (
-      <RenderEmpty
-        onClick={() => history.push(`/profile/tokens`)}
-        data-qa-empty-state
-      />
-    );
+    return <RenderEmpty onClick={openBucketDrawer} data-qa-empty-state />;
   }
 
   return (
@@ -131,17 +116,15 @@ const RenderEmpty: React.StatelessComponent<{
 }> = props => {
   return (
     <React.Fragment>
-      <DocumentTitleSegment segment="Domains" />
+      <DocumentTitleSegment segment="Buckets" />
       <Placeholder
         title="Add a Bucket"
-        // NOTE: This copy is only temporary, until bucket creation exists.
-        // It will never be customer facing.
-        copy="Bucket Creation coming soon! For now, create buckets by generating an Object Storage key pair, and use with an S3-compatible client."
+        copy="Click below to add a Bucket and start using Object Storage today."
         // @todo: replace with bucket icon
         icon={VolumeIcon}
         buttonProps={{
           onClick: props.onClick,
-          children: 'Go to API Tokens'
+          children: 'Add a Bucket'
         }}
       />
     </React.Fragment>
@@ -151,8 +134,6 @@ const RenderEmpty: React.StatelessComponent<{
 const styled = withStyles(styles);
 
 const enhanced = compose<CombinedProps, {}>(
-  // @todo: remove withRouter HOC once bucket creation is support
-  withRouter,
   styled,
   bucketContainer,
   bucketDrawerContainer


### PR DESCRIPTION
## Description

Now that it's possible to create buckets, I changed the CTA behavior from "Go to API Tokens" to "Add a Bucket".

Also includes tiny adjustment to ClusterSelect.

## Note to Reviewers

To test, either

a) Use a test account with no buckets. 
b) Use Charles to edit the response of `/object-storage/buckets`
c) Change line 56 of ObjectStorageLanding.tsx to `if (true) {`

... and go to the Object Storage landing page.