### PR TITLE
One-click app feedback

### DIFF
--- a/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -100,7 +100,7 @@ export class LinodeCreate extends React.PureComponent<
       title: 'Distributions',
       type: 'fromImage',
       render: () => {
-        /** ...rest being all the formstate props and display data */
+        /** ...rest being all the form state props and display data */
         const {
           history,
           handleSelectUDFs,

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -147,7 +147,11 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
         // Each of these will be undefined if not included in the URL, so this will behave correctly:
         selectedStackScriptID: Number(params.stackScriptID),
         selectedStackScriptLabel: params.stackScriptLabel,
-        selectedStackScriptUsername: params.stackScriptUserName
+        selectedStackScriptUsername: params.stackScriptUserName,
+
+        // This set is for creating from a Backup
+        selectedBackupID: params.backupID,
+        selectedLinodeID: params.linodeID
       });
     }
     this.setState({ appInstancesLoading: true });

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -161,7 +161,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       .catch(e => {
         this.setState({
           appInstancesLoading: false,
-          appInstancesError: 'There was an error loading Cloud Apps.'
+          appInstancesError: 'There was an error loading One-Click Apps.'
         });
       });
   }

--- a/src/features/linodes/LinodesCreate/PublicImages.tsx
+++ b/src/features/linodes/LinodesCreate/PublicImages.tsx
@@ -29,6 +29,7 @@ interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const distroIcons = {
+  Alpine: 'alpine',
   Arch: 'archlinux',
   CentOS: 'centos',
   CoreOS: 'coreos',
@@ -49,9 +50,9 @@ const PublicImages: React.StatelessComponent<CombinedProps> = props => {
     oldImages,
     selectedImageID
   } = props;
-  const renderImages = (images: Linode.Image[]) =>
-    images.length &&
-    images.map((image: Linode.Image, idx: number) => (
+  const renderImages = (imageList: Linode.Image[]) =>
+    imageList.length &&
+    imageList.map((image: Linode.Image, idx: number) => (
       <SelectionCard
         key={idx}
         checked={image.id === String(selectedImageID)}

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -419,7 +419,9 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
     const { history, linodeID } = this.props;
     history.push(
       '/linodes/create' +
-        `?type=fromBackup&backupID=${backup.id}&linodeID=${linodeID}`
+        `?type=My%20Images&subtype=Backups&backupID=${
+          backup.id
+        }&linodeID=${linodeID}`
     );
   };
 


### PR DESCRIPTION

Review feedback part 1
- Fixed shadowed variable name images in PublicImages.tsx
- Re-added Alpine to PublicImages.tsx
- Update error message to use new One-Click Apps branding
- Fix routing when deploying from a backup
