### PR TITLE
[Cloud Apps] Remove Tab Handling from SelectStackScriptPanel

### DIFF
--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -30,7 +30,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   }
 });
 
-type onClickFn = (e: React.MouseEvent<HTMLElement>) => void;
+type onClickFn = (e: React.ChangeEvent<HTMLTableRowElement>) => void;
 
 interface Props {
   rowLink?: string | onClickFn;
@@ -45,7 +45,10 @@ type CombinedProps = Props &
   WithStyles<ClassNames>;
 
 class TableRow extends React.Component<CombinedProps> {
-  rowClick = (e: any, target: string | onClickFn) => {
+  rowClick = (
+    e: React.ChangeEvent<HTMLTableRowElement>,
+    target: string | onClickFn
+  ) => {
     const body = document.body as any;
     // Inherit the ROW click unless the element is a <button> or an <a> or is contained within them
     const isButton =
@@ -90,7 +93,7 @@ class TableRow extends React.Component<CombinedProps> {
 
     return (
       <_TableRow
-        onClick={e => rowLink && this.rowClick(e, rowLink)}
+        onClick={(e: any) => rowLink && this.rowClick(e, rowLink)}
         hover={rowLink !== undefined}
         role={role}
         className={classNames(className, {

--- a/src/features/Domains/DomainTableRow.tsx
+++ b/src/features/Domains/DomainTableRow.tsx
@@ -58,7 +58,9 @@ interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const handleRowClick = (
-  e: React.MouseEvent<any, MouseEvent>,
+  e:
+    | React.ChangeEvent<HTMLTableRowElement>
+    | React.MouseEvent<HTMLAnchorElement, MouseEvent>,
   props: CombinedProps
 ) => {
   const { domain, id, type, onEdit } = props;

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -149,15 +149,6 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
     this.mounted = false;
   }
 
-  handleTabChange = () => {
-    /*
-     * if we're coming from a query string, the stackscript will be preselected
-     * however, we don't want the user to have their stackscript still preselected
-     * when they change StackScript tabs
-     */
-    this.props.resetSelectedStackScript();
-  };
-
   resetStackScript = () => {
     this.setState({ stackScript: undefined, stackScriptLoading: false });
   };
@@ -196,7 +187,6 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
                   label={stackScript.label}
                   stackScriptUsername={stackScript.username}
                   disabledCheckedSelect
-                  onSelect={() => {}}
                   description={truncateText(stackScript.description, 100)}
                   images={stripImageName(stackScript.images)}
                   deploymentsActive={stackScript.deployments_active}

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
@@ -23,7 +23,7 @@ export interface Props {
   deploymentsActive: number;
   updated: string;
   disabledCheckedSelect?: boolean;
-  onSelect: (e: any | React.ChangeEvent<HTMLElement>, value: boolean) => void;
+  onSelect?: (e: React.ChangeEvent<HTMLElement>, value: boolean) => void;
   checked?: boolean;
   stackScriptID: number;
   stackScriptUsername: string;
@@ -97,7 +97,7 @@ export class StackScriptSelectionRow extends React.Component<
       <React.Fragment>
         <TableRow
           data-qa-table-row={label}
-          rowLink={() => onSelect({}, !checked)}
+          rowLink={onSelect ? e => onSelect(e, !checked) : undefined}
         >
           <TableCell>
             <Radio

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -344,7 +344,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       /* a backup selection is also required */
       this.setState(
         {
-          errors: [{ field: 'backup_id', reason: 'You must select a Backup' }]
+          errors: [{ field: 'backup_id', reason: 'You must select a Backup.' }]
         },
         () => {
           scrollErrorIntoView();
@@ -358,7 +358,21 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
         () => ({
           errors: [
             {
-              reason: 'You must select a StackScript to create from',
+              reason: 'You must select a StackScript.',
+              field: 'stackscript_id'
+            }
+          ]
+        }),
+        () => scrollErrorIntoView()
+      );
+    }
+
+    if (type === 'createFromApp' && !this.state.selectedStackScriptID) {
+      return this.setState(
+        () => ({
+          errors: [
+            {
+              reason: 'You must select a One-Click App.',
               field: 'stackscript_id'
             }
           ]

--- a/src/features/linodes/LinodesCreate/SelectAppPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectAppPanel.tsx
@@ -77,15 +77,8 @@ const SelectAppPanel: React.SFC<CombinedProps> = props => {
     return null;
   }
 
-  /** hacky and bad */
-  const interceptedError = error ? 'You must select an App to create from' : '';
-
   return (
-    <Panel
-      className={classes.panel}
-      error={interceptedError}
-      title="Select App"
-    >
+    <Panel className={classes.panel} error={error} title="Select App">
       <Grid className={classes.flatImagePanelSelections} container>
         {appInstances.map(eachApp => (
           <SelectionCardWrapper

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -131,7 +131,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps> {
       tags
     } = this.props;
 
-    handleSubmitForm('createFromStackScript', {
+    handleSubmitForm('createFromApp', {
       region: selectedRegionID,
       type: selectedTypeID,
       stackscript_id: selectedStackScriptID,

--- a/src/features/linodes/LinodesCreate/types.ts
+++ b/src/features/linodes/LinodesCreate/types.ts
@@ -83,7 +83,12 @@ export interface ReduxStateProps {
 }
 
 export type HandleSubmit = (
-  type: 'create' | 'clone' | 'createFromStackScript' | 'createFromBackup',
+  type:
+    | 'create'
+    | 'clone'
+    | 'createFromStackScript'
+    | 'createFromBackup'
+    | 'createFromApp',
   payload: CreateLinodeRequest,
   linodeID?: number
 ) => void;


### PR DESCRIPTION
## Description

Remove any stray logic we had from `SelectStackScriptPanel` that was doing tab handling, since this panel is now tab-less

## Type of Change
- Non breaking change ('update', 'change')

### Note to Reviewers

Also fixed some typings