### PR TITLE
Update volume landing

### DIFF
--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -357,8 +357,13 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     history.push(`/linodes/${linodeId}/settings`);
   };
 
+  goToSupportTicket = () => {
+    const { history } = this.props;
+    history.push(`/support/tickets`);
+  };
+
   renderEmpty = () => {
-    const { linodeConfigs } = this.props;
+    const { linodeConfigs, linodeRegion } = this.props;
 
     if (linodeConfigs && linodeConfigs.length === 0) {
       return (
@@ -371,6 +376,23 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
             buttonProps={{
               onClick: this.gotToSettings,
               children: 'View Linode Configurations'
+            }}
+          />
+        </React.Fragment>
+      );
+    }
+
+    if (linodeRegion === 'us-southeast') {
+      return (
+        <React.Fragment>
+          <DocumentTitleSegment segment="Volumes" />
+          <Placeholder
+            title="Volumes are not available in this data center"
+            copy="You can request a migration to a data center with Block Storage by opening a support ticket"
+            icon={VolumesIcon}
+            buttonProps={{
+              onClick: this.goToSupportTicket,
+              children: 'Open Support Ticket'
             }}
           />
         </React.Fragment>

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -388,7 +388,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           <DocumentTitleSegment segment="Volumes" />
           <Placeholder
             title="Volumes are not available in this data center"
-            copy="You can request a migration to a data center with Block Storage by opening a support ticket"
+            copy="You can request a migration to a data center with Block Storage by opening a support ticket."
             icon={VolumesIcon}
             buttonProps={{
               onClick: this.goToSupportTicket,

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -22,6 +22,7 @@ import { PaginationProps } from 'src/components/Pagey';
 import Placeholder from 'src/components/Placeholder';
 import TableRowError from 'src/components/TableRowError';
 import Toggle from 'src/components/Toggle';
+import { regionsWithoutBlockStorage } from 'src/constants';
 import _withEvents, { EventsProps } from 'src/containers/events.container';
 import localStorageContainer from 'src/containers/localStorage.container';
 import withVolumes, {
@@ -365,6 +366,23 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   renderEmpty = () => {
     const { linodeConfigs, linodeRegion } = this.props;
 
+    if (regionsWithoutBlockStorage.some(region => region === linodeRegion)) {
+      return (
+        <React.Fragment>
+          <DocumentTitleSegment segment="Volumes" />
+          <Placeholder
+            title="Volumes are not available in this data center"
+            copy="You can request a migration to a data center with Block Storage by opening a support ticket."
+            icon={VolumesIcon}
+            buttonProps={{
+              onClick: this.goToSupportTicket,
+              children: 'Open Support Ticket'
+            }}
+          />
+        </React.Fragment>
+      );
+    }
+
     if (linodeConfigs && linodeConfigs.length === 0) {
       return (
         <React.Fragment>
@@ -376,23 +394,6 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
             buttonProps={{
               onClick: this.gotToSettings,
               children: 'View Linode Configurations'
-            }}
-          />
-        </React.Fragment>
-      );
-    }
-
-    if (linodeRegion === 'us-southeast') {
-      return (
-        <React.Fragment>
-          <DocumentTitleSegment segment="Volumes" />
-          <Placeholder
-            title="Volumes are not available in this data center"
-            copy="You can request a migration to a data center with Block Storage by opening a support ticket."
-            icon={VolumesIcon}
-            buttonProps={{
-              onClick: this.goToSupportTicket,
-              children: 'Open Support Ticket'
             }}
           />
         </React.Fragment>

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -371,8 +371,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
         <React.Fragment>
           <DocumentTitleSegment segment="Volumes" />
           <Placeholder
-            title="Volumes are not available in this data center"
-            copy="You can request a migration to a data center with Block Storage by opening a support ticket."
+            title="Volumes are not available in this region"
+            copy="You can request a migration to a region with Block Storage by opening a support ticket."
             icon={VolumesIcon}
             buttonProps={{
               onClick: this.goToSupportTicket,

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -358,11 +358,6 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     history.push(`/linodes/${linodeId}/settings`);
   };
 
-  goToSupportTicket = () => {
-    const { history } = this.props;
-    history.push(`/support/tickets`);
-  };
-
   renderEmpty = () => {
     const { linodeConfigs, linodeRegion } = this.props;
 
@@ -372,12 +367,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           <DocumentTitleSegment segment="Volumes" />
           <Placeholder
             title="Volumes are not available in this region"
-            copy="You can request a migration to a region with Block Storage by opening a support ticket."
+            copy=""
             icon={VolumesIcon}
-            buttonProps={{
-              onClick: this.goToSupportTicket,
-              children: 'Open Support Ticket'
-            }}
           />
         </React.Fragment>
       );


### PR DESCRIPTION
## Description

Regina had a call with a customer that was trying to create a Volume in ATL. This option is filtered out when creating a Volume through `/volumes` but it is still available from `/linodes/$linodeID/volumes`. When clicked nothing happens, no error or success message is shown. Console shows:
`POST https://cloud.linode.com/api/v4/volumes 400 (BAD REQUEST)`

This would present them with an option to open a support ticket to migrate to a data center that has block storage available, but it could easily be changed to just show an error message. I thought about filtering out the Volumes tab entirely when the Linode is in us-southeast but I think it's better that people know the reason it is not an option and it then gives them a next step which is to migrate in order to use block storage.


## Type of Change
- Non breaking change ('change')

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
