### PR TITLE
M3-2538: do not show Hively icons from 'Linode' user

### DIFF
--- a/src/features/Support/ExpandableTicketPanel.test.tsx
+++ b/src/features/Support/ExpandableTicketPanel.test.tsx
@@ -1,32 +1,6 @@
 import * as moment from 'moment';
 
-import { ExpandableTicketPanel } from './ExpandableTicketPanel';
-
-const classes = {
-  root: '',
-  userWrapper: '',
-  leftIcon: '',
-  userName: '',
-  paper: '',
-  paperOpen: '',
-  avatarCol: '',
-  userCol: '',
-  descCol: '',
-  expCol: '',
-  expButton: '',
-  toggle: '',
-  isCurrentUser: '',
-  formattedText: '',
-  hivelyLink: '',
-  hivelyImage: '',
-  hivelyContainer: '',
-  hivelyLinkIcon: ''
-};
-
-const component = new ExpandableTicketPanel({
-  isCurrentUser: false,
-  classes
-});
+import { shouldRenderHively } from './ExpandableTicketPanel';
 
 const recent = moment()
   .subtract(6, 'days')
@@ -38,21 +12,21 @@ const user = 'Linode'
 
 describe('shouldRenderHively function', () => {
   it('should return true if an improperly formatted date is passed', () => {
-    expect(component.shouldRenderHively(true, 'blah')).toBeTruthy();
+    expect(shouldRenderHively(true, 'blah')).toBeTruthy();
   });
   it('should return true if the date is now', () => {
-    expect(component.shouldRenderHively(true, moment().format())).toBeTruthy();
+    expect(shouldRenderHively(true, moment().format())).toBeTruthy();
   });
   it('should return true if the date is within the past 7 days', () => {
-    expect(component.shouldRenderHively(true, recent)).toBeTruthy();
+    expect(shouldRenderHively(true, recent)).toBeTruthy();
   });
   it('should return false for dates older than 7 days', () => {
-    expect(component.shouldRenderHively(true, old)).toBeFalsy();
+    expect(shouldRenderHively(true, old)).toBeFalsy();
   });
   it('should return false if the fromLinode parameter is false', () => {
-    expect(component.shouldRenderHively(false, recent)).toBeFalsy();
+    expect(shouldRenderHively(false, recent)).toBeFalsy();
   });
   it('should return false if the user is Linode', () => {
-    expect(component.shouldRenderHively(false, recent, user)).toBeFalsy();
+    expect(shouldRenderHively(false, recent, user)).toBeFalsy();
   });
 });

--- a/src/features/Support/ExpandableTicketPanel.test.tsx
+++ b/src/features/Support/ExpandableTicketPanel.test.tsx
@@ -34,6 +34,7 @@ const recent = moment()
 const old = moment()
   .subtract(3, 'months')
   .format();
+const user = 'Linode'
 
 describe('shouldRenderHively function', () => {
   it('should return true if an improperly formatted date is passed', () => {
@@ -50,5 +51,8 @@ describe('shouldRenderHively function', () => {
   });
   it('should return false if the fromLinode parameter is false', () => {
     expect(component.shouldRenderHively(false, recent)).toBeFalsy();
+  });
+  it('should return false if the user is Linode', () => {
+    expect(component.shouldRenderHively(false, recent, user)).toBeFalsy();
   });
 });

--- a/src/features/Support/ExpandableTicketPanel.tsx
+++ b/src/features/Support/ExpandableTicketPanel.tsx
@@ -226,13 +226,15 @@ export class ExpandableTicketPanel extends React.Component<
     return data!;
   };
 
-  shouldRenderHively = (fromLinode: boolean, updated: string) => {
+  shouldRenderHively = (fromLinode: boolean, updated: string, username?: string) => {
     /* Render Hively only for replies marked as from_linode,
-     * and are on tickets less than 7 days old.
+     * and are on tickets less than 7 days old,
+     * and when the user is not "Linode"
      * Defaults to showing Hively if there are any errors parsing dates
      * or the date is invalid.
      */
     try {
+      if (username === 'Linode') return false;
       const lastUpdated = moment(updated);
       if (!lastUpdated.isValid()) {
         return true;
@@ -388,7 +390,7 @@ export class ExpandableTicketPanel extends React.Component<
               </Grid>
             )}
           </Grid>
-          {this.shouldRenderHively(data.from_linode, data.updated) &&
+          {this.shouldRenderHively(data.from_linode, data.updated, data.username) &&
             this.renderHively(data.username, data.ticket_id, data.reply_id)}
         </Paper>
       </Grid>

--- a/src/features/Support/ExpandableTicketPanel.tsx
+++ b/src/features/Support/ExpandableTicketPanel.tsx
@@ -166,6 +166,29 @@ interface Data {
   updated: string;
 }
 
+export const shouldRenderHively = (fromLinode: boolean, updated: string, username?: string) => {
+  /* Render Hively only for replies marked as from_linode,
+   * and are on tickets less than 7 days old,
+   * and when the user is not "Linode"
+   * Defaults to showing Hively if there are any errors parsing dates
+   * or the date is invalid.
+   */
+  try {
+    if (username === 'Linode') {
+      return false;
+    }
+    const lastUpdated = moment(updated);
+    if (!lastUpdated.isValid()) {
+      return true;
+    }
+    const diff = moment.duration(moment().diff(lastUpdated));
+    return fromLinode && diff <= moment.duration(7, 'days');
+  } catch {
+    return true;
+  }
+};
+
+
 export class ExpandableTicketPanel extends React.Component<
   CombinedProps,
   State
@@ -224,26 +247,6 @@ export class ExpandableTicketPanel extends React.Component<
     }
 
     return data!;
-  };
-
-  shouldRenderHively = (fromLinode: boolean, updated: string, username?: string) => {
-    /* Render Hively only for replies marked as from_linode,
-     * and are on tickets less than 7 days old,
-     * and when the user is not "Linode"
-     * Defaults to showing Hively if there are any errors parsing dates
-     * or the date is invalid.
-     */
-    try {
-      if (username === 'Linode') return false;
-      const lastUpdated = moment(updated);
-      if (!lastUpdated.isValid()) {
-        return true;
-      }
-      const diff = moment.duration(moment().diff(lastUpdated));
-      return fromLinode && diff <= moment.duration(7, 'days');
-    } catch {
-      return true;
-    }
   };
 
   renderHively = (
@@ -390,7 +393,7 @@ export class ExpandableTicketPanel extends React.Component<
               </Grid>
             )}
           </Grid>
-          {this.shouldRenderHively(data.from_linode, data.updated, data.username) &&
+          {shouldRenderHively(data.from_linode, data.updated, data.username) &&
             this.renderHively(data.username, data.ticket_id, data.reply_id)}
         </Paper>
       </Grid>


### PR DESCRIPTION
## Description

https://jira.linode.com/browse/M3-2538

This change updates the `shouldRenderHively` function so it returns false if the user is "Linode".

As it is when these icons are clicked it leads to an error. 

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
