### PR TITLE
[OCA] Add Analytics to Creation Flow

### DIFF
--- a/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -131,7 +131,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps> {
       tags
     } = this.props;
 
-    handleSubmitForm('createFromApp', {
+    handleSubmitForm({
       region: selectedRegionID,
       type: selectedTypeID,
       stackscript_id: selectedStackScriptID,

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -146,7 +146,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
 
     const tagsToAdd = tags ? tags.map(item => item.value) : undefined;
 
-    this.props.handleSubmitForm('createFromBackup', {
+    this.props.handleSubmitForm({
       region: selectedRegionID,
       type: selectedTypeID,
       private_ip: privateIPEnabled,

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -76,7 +76,7 @@ export type CombinedProps = Props &
 export class FromImageContent extends React.PureComponent<CombinedProps> {
   /** create the Linode */
   createLinode = () => {
-    this.props.handleSubmitForm('create', {
+    this.props.handleSubmitForm({
       type: this.props.selectedTypeID,
       region: this.props.selectedRegionID,
       image: this.props.selectedImageID,

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -68,7 +68,6 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
 
   cloneLinode = () => {
     return this.props.handleSubmitForm(
-      'clone',
       {
         region: this.props.selectedRegionID,
         type: this.props.selectedTypeID,

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -146,7 +146,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
       tags
     } = this.props;
 
-    handleSubmitForm('createFromStackScript', {
+    handleSubmitForm({
       region: selectedRegionID,
       type: selectedTypeID,
       stackscript_id: selectedStackScriptID,

--- a/src/features/linodes/LinodesCreate/types.ts
+++ b/src/features/linodes/LinodesCreate/types.ts
@@ -83,12 +83,6 @@ export interface ReduxStateProps {
 }
 
 export type HandleSubmit = (
-  type:
-    | 'create'
-    | 'clone'
-    | 'createFromStackScript'
-    | 'createFromBackup'
-    | 'createFromApp',
   payload: CreateLinodeRequest,
   linodeID?: number
 ) => void;


### PR DESCRIPTION
## Description

Adds Google Analytic Events to the _Linode Create_ flow.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Here's what the output looks like on analytics.google.com:

![Screen Shot 2019-03-28 at 12 11 08 PM](https://user-images.githubusercontent.com/7387001/55174914-b22e6b00-5154-11e9-8f14-d092db0a8caf.png)

## To Test

Add the manager.dev GA ID to your `.env` file. Please reach out if you don't already have that variable

example:

```
REACT_APP_GA_ID=xxxxxxx
```