### PR TITLE
OCA-608 Setup GA to track usage

### DIFF
--- a/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -130,7 +130,6 @@ class FromAppsContent extends React.PureComponent<CombinedProps> {
       privateIPEnabled,
       tags
     } = this.props;
-
     handleSubmitForm('createFromApp', {
       region: selectedRegionID,
       type: selectedTypeID,

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -14,7 +14,6 @@ import Grid from 'src/components/Grid';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
 import Placeholder from 'src/components/Placeholder';
 import SelectRegionPanel from 'src/components/SelectRegionPanel';
-
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import AddonsPanel from '../AddonsPanel';
 import SelectLinodePanel from '../SelectLinodePanel';


### PR DESCRIPTION
## Description

Adding GA events to Create button. Generally, you should see the following pattern:
{
category: "Create Linode",
action: "one-click" | "image" | "stackscript" | "backup" | "clone";
label: `one-click-app-name` |  `image-name` | `stackscript-name` | `backup-name` | `clone-name`; 
}

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please test a variety of creation types: distribution, one-click, stackscript, image, backup, and clone.
