### PR TITLE
M3-OBJ-126 Rename Object Storage Keys

### DIFF
--- a/src/features/Profile/APITokens/ObjectStorageDrawer.test.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageDrawer.test.tsx
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { ObjectStorageDrawer, Props } from './ObjectStorageDrawer';
+import { MODES } from './ObjectStorageKeys';
 
 describe('ObjectStorageDrawer', () => {
   const props = {
@@ -10,7 +11,8 @@ describe('ObjectStorageDrawer', () => {
     onClose: jest.fn(),
     label: 'test-label',
     updateLabel: jest.fn(),
-    isLoading: false
+    isLoading: false,
+    mode: 'creating' as MODES
   };
   const wrapper = shallow<Props>(<ObjectStorageDrawer {...props} />);
   it('renders without crashing', () => {

--- a/src/features/Profile/APITokens/ObjectStorageDrawer.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageDrawer.tsx
@@ -61,8 +61,7 @@ export const ObjectStorageDrawer: React.StatelessComponent<
           handleChange,
           handleBlur,
           handleSubmit,
-          isSubmitting,
-          resetForm
+          isSubmitting
         }) => (
           <>
             {status && (
@@ -98,10 +97,7 @@ export const ObjectStorageDrawer: React.StatelessComponent<
                   Submit
                 </Button>
                 <Button
-                  onClick={() => {
-                    resetForm();
-                    onClose();
-                  }}
+                  onClick={onClose}
                   data-qa-cancel
                   type="secondary"
                   className="cancel"

--- a/src/features/Profile/APITokens/ObjectStorageDrawer.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageDrawer.tsx
@@ -11,8 +11,9 @@ import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import { CreateObjectStorageKeyRequest } from 'src/services/profile/objectStorageKeys';
+import { ObjectStorageKeyRequest } from 'src/services/profile/objectStorageKeys';
 import { createObjectStorageKeysSchema } from 'src/services/profile/objectStorageKeys.schema';
+import { MODES } from './ObjectStorageKeys';
 
 type ClassNames = 'root';
 
@@ -23,7 +24,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 export interface Props {
   open: boolean;
   onClose: () => void;
-  onSubmit: (values: CreateObjectStorageKeyRequest, formikProps: any) => void;
+  onSubmit: (values: ObjectStorageKeyRequest, formikProps: any) => void;
+  mode: MODES;
+  // If the mode is 'editing', we should have an ObjectStorageKey to edit
+  objectStorageKey?: Linode.ObjectStorageKey;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -31,12 +35,20 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export const ObjectStorageDrawer: React.StatelessComponent<
   CombinedProps
 > = props => {
-  const { open, onClose, onSubmit } = props;
+  const { open, onClose, onSubmit, mode, objectStorageKey } = props;
+
+  const title =
+    mode === 'creating'
+      ? 'Create an Object Storage Key'
+      : 'Edit Object Storage Key';
+
+  const initialLabelValue =
+    mode === 'editing' && objectStorageKey ? objectStorageKey.label : '';
 
   return (
-    <Drawer title="Create an Object Storage Key" open={open} onClose={onClose}>
+    <Drawer title={title} open={open} onClose={onClose}>
       <Formik
-        initialValues={{ label: '' }}
+        initialValues={{ label: initialLabelValue }}
         validationSchema={createObjectStorageKeysSchema}
         validateOnChange={false}
         validateOnBlur={true}
@@ -57,10 +69,13 @@ export const ObjectStorageDrawer: React.StatelessComponent<
               <Notice key={status} text={status} error data-qa-error />
             )}
 
-            <Typography>
-              Generate an Object Storage key pair for use with an S3-compatible
-              client.
-            </Typography>
+            {/* Explainer copy if we're in 'creating' mode */}
+            {mode === 'creating' && (
+              <Typography>
+                Generate an Object Storage key pair for use with an
+                S3-compatible client.
+              </Typography>
+            )}
 
             <form onSubmit={handleSubmit}>
               <TextField

--- a/src/features/Profile/APITokens/ObjectStorageKeyMenu.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageKeyMenu.tsx
@@ -9,20 +9,27 @@ interface Props {
   // prop-drilled from grandparent:
   // ObjectStorageKeys --> ObjectStorageKeyTable --> HERE
   openRevokeDialog: (key: Linode.ObjectStorageKey) => void;
+  openDrawerForEditing: (key: Linode.ObjectStorageKey) => void;
 }
 
 type CombinedProps = Props;
 
 const ObjectStorageKeyMenu: React.StatelessComponent<CombinedProps> = props => {
   const createActions = () => {
-    const { openRevokeDialog, objectStorageKey } = props;
+    const { openRevokeDialog, objectStorageKey, openDrawerForEditing } = props;
 
     return (closeMenu: Function): Action[] => {
       return [
-        // @todo: "Rename" action will go here
+        {
+          title: 'Rename',
+          onClick: () => {
+            openDrawerForEditing(objectStorageKey);
+            closeMenu();
+          }
+        },
         {
           title: 'Revoke',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
+          onClick: () => {
             openRevokeDialog(objectStorageKey);
             closeMenu();
           }

--- a/src/features/Profile/APITokens/ObjectStorageKeyMenu.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageKeyMenu.tsx
@@ -21,7 +21,7 @@ const ObjectStorageKeyMenu: React.StatelessComponent<CombinedProps> = props => {
     return (closeMenu: Function): Action[] => {
       return [
         {
-          title: 'Rename',
+          title: 'Rename Key',
           onClick: () => {
             openDrawerForEditing(objectStorageKey);
             closeMenu();

--- a/src/features/Profile/APITokens/ObjectStorageKeyTable.test.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageKeyTable.test.tsx
@@ -17,6 +17,7 @@ describe('ObjectStorageKeyTable', () => {
           labelCell: '',
           copyIcon: ''
         }}
+        openDrawerForEditing={jest.fn()}
         openRevokeDialog={jest.fn()}
         {...pageyProps}
       />

--- a/src/features/Profile/APITokens/ObjectStorageKeyTable.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageKeyTable.tsx
@@ -47,6 +47,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
 
 interface Props {
   openRevokeDialog: (objectStorageKey: Linode.ObjectStorageKey) => void;
+  openDrawerForEditing: (objectStorageKey: Linode.ObjectStorageKey) => void;
 }
 
 export type CombinedProps = Props &
@@ -56,7 +57,14 @@ export type CombinedProps = Props &
 export const ObjectStorageKeyTable: React.StatelessComponent<
   CombinedProps
 > = props => {
-  const { classes, data, loading, error, openRevokeDialog } = props;
+  const {
+    classes,
+    data,
+    loading,
+    error,
+    openRevokeDialog,
+    openDrawerForEditing
+  } = props;
 
   const renderContent = () => {
     if (loading) {
@@ -100,6 +108,7 @@ export const ObjectStorageKeyTable: React.StatelessComponent<
           <ObjectStorageKeyMenu
             objectStorageKey={eachKey}
             openRevokeDialog={openRevokeDialog}
+            openDrawerForEditing={openDrawerForEditing}
           />
         </TableCell>
       </TableRow>

--- a/src/features/Profile/APITokens/ObjectStorageKeys.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageKeys.tsx
@@ -14,10 +14,11 @@ import PaginationFooter from 'src/components/PaginationFooter';
 import { useErrors } from 'src/hooks/useErrors';
 import { useOpenClose } from 'src/hooks/useOpenClose';
 import {
-  CreateObjectStorageKeyRequest,
   createObjectStorageKeys,
   getObjectStorageKeys,
-  revokeObjectStorageKey
+  ObjectStorageKeyRequest,
+  revokeObjectStorageKey,
+  updateObjectStorageKey
 } from 'src/services/profile/objectStorageKeys';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 import ObjectStorageKeyDisplayDialog from './ObjectStorageDisplayDialog';
@@ -38,15 +39,25 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
 
 type Props = PaginationProps<Linode.ObjectStorageKey> & WithStyles<ClassNames>;
 
-export type FormikProps = FormikBag<Props, CreateObjectStorageKeyRequest>;
+export type FormikProps = FormikBag<Props, ObjectStorageKeyRequest>;
+
+export type MODES = 'creating' | 'editing';
 
 export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
   const { classes, ...paginationProps } = props;
+
+  const [mode, setMode] = React.useState<MODES>('creating');
 
   // Key to display in Confirmation Modal upon creation
   const [
     keyToDisplay,
     setKeyToDisplay
+  ] = React.useState<Linode.ObjectStorageKey | null>(null);
+
+  // Key to rename (by clicking on a key's kebab menu )
+  const [
+    keyToEdit,
+    setKeyToEdit
   ] = React.useState<Linode.ObjectStorageKey | null>(null);
 
   // Key to revoke (by clicking on a key's kebab menu )
@@ -59,17 +70,19 @@ export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
 
   const displayKeysDialog = useOpenClose();
   const revokeKeysDialog = useOpenClose();
-  const createDrawer = useOpenClose();
+  const createOrEditDrawer = useOpenClose();
 
   // Request object storage key when component is first rendered
   React.useEffect(() => {
     paginationProps.request();
   }, []);
 
-  const handleSubmit = (
-    values: CreateObjectStorageKeyRequest,
+  const handleCreateKey = (
+    values: ObjectStorageKeyRequest,
     { setSubmitting, setErrors, setStatus }: FormikProps
   ) => {
+    // Clear out status (used for general errors)
+    setStatus(null);
     setSubmitting(true);
 
     createObjectStorageKeys(values)
@@ -81,7 +94,7 @@ export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
         // "Refresh" keys to include the newly created key
         paginationProps.request();
 
-        createDrawer.close();
+        createOrEditDrawer.close();
         displayKeysDialog.open();
       })
       .catch(errorResponse => {
@@ -90,6 +103,46 @@ export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
         const errors = getAPIErrorOrDefault(
           errorResponse,
           'There was an issue creating Object Storage Keys.'
+        );
+        const mappedErrors = getErrorMap(['label'], errors);
+
+        // `status` holds general errors
+        if (mappedErrors.none) {
+          setStatus(mappedErrors.none);
+        }
+
+        setErrors(mappedErrors);
+      });
+  };
+
+  const handleEditKey = (
+    values: ObjectStorageKeyRequest,
+    { setSubmitting, setErrors, setStatus }: FormikProps
+  ) => {
+    // This shouldn't happen, but just in case.
+    if (!keyToEdit) {
+      return;
+    }
+
+    // Clear out status (used for general errors)
+    setStatus(null);
+    setSubmitting(true);
+
+    updateObjectStorageKey(keyToEdit.id, values)
+      .then(_ => {
+        setSubmitting(false);
+
+        // "Refresh" keys to display the newly updated key
+        paginationProps.request();
+
+        createOrEditDrawer.close();
+      })
+      .catch(errorResponse => {
+        setSubmitting(false);
+
+        const errors = getAPIErrorOrDefault(
+          errorResponse,
+          'There was an issue updating your Object Storage Key.'
         );
         const mappedErrors = getErrorMap(['label'], errors);
 
@@ -131,6 +184,27 @@ export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
       });
   };
 
+  const openDrawerForCreating = () => {
+    setMode('creating');
+    createOrEditDrawer.open();
+  };
+
+  const openDrawerForEditing = (objectStorageKey: Linode.ObjectStorageKey) => {
+    setMode('editing');
+    setKeyToEdit(objectStorageKey);
+    createOrEditDrawer.open();
+  };
+
+  const openRevokeDialog = (objectStorageKey: Linode.ObjectStorageKey) => {
+    setKeyToRevoke(objectStorageKey);
+    revokeKeysDialog.open();
+  };
+
+  const closeRevokeDialog = () => {
+    setRevokeErrors([]);
+    revokeKeysDialog.close();
+  };
+
   return (
     <React.Fragment>
       <Grid container justify="space-between" alignItems="flex-end">
@@ -146,7 +220,7 @@ export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
         </Grid>
         <Grid item>
           <AddNewLink
-            onClick={createDrawer.open}
+            onClick={openDrawerForCreating}
             label="Create an Object Storage Key"
           />
         </Grid>
@@ -154,10 +228,8 @@ export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
 
       <ObjectStorageKeyTable
         {...paginationProps}
-        openRevokeDialog={(objectStorageKey: Linode.ObjectStorageKey) => {
-          setKeyToRevoke(objectStorageKey);
-          revokeKeysDialog.open();
-        }}
+        openDrawerForEditing={openDrawerForEditing}
+        openRevokeDialog={openRevokeDialog}
       />
 
       <PaginationFooter
@@ -170,9 +242,11 @@ export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
       />
 
       <ObjectStorageDrawer
-        open={createDrawer.isOpen}
-        onClose={createDrawer.close}
-        onSubmit={handleSubmit}
+        open={createOrEditDrawer.isOpen}
+        onClose={createOrEditDrawer.close}
+        onSubmit={mode === 'creating' ? handleCreateKey : handleEditKey}
+        mode={mode}
+        objectStorageKey={keyToEdit ? keyToEdit : undefined}
       />
 
       <ObjectStorageKeyDisplayDialog
@@ -183,10 +257,7 @@ export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
       <ObjectStorageRevokeKeysDialog
         isOpen={revokeKeysDialog.isOpen}
         label={(keyToRevoke && keyToRevoke.label) || ''}
-        handleClose={() => {
-          setRevokeErrors([]);
-          revokeKeysDialog.close();
-        }}
+        handleClose={closeRevokeDialog}
         handleSubmit={handleRevokeKeys}
         isLoading={isRevoking}
         errors={revokeErrors}

--- a/src/features/Profile/APITokens/ObjectStorageKeys.tsx
+++ b/src/features/Profile/APITokens/ObjectStorageKeys.tsx
@@ -126,6 +126,13 @@ export const ObjectStorageKeys: React.StatelessComponent<Props> = props => {
 
     // Clear out status (used for general errors)
     setStatus(null);
+
+    // If the new label is the same as the old one, no need to make an API
+    // request. Just close the drawer and return early.
+    if (values.label === keyToEdit.label) {
+      return createOrEditDrawer.close();
+    }
+
     setSubmitting(true);
 
     updateObjectStorageKey(keyToEdit.id, values)

--- a/src/services/profile/objectStorageKeys.ts
+++ b/src/services/profile/objectStorageKeys.ts
@@ -9,7 +9,7 @@ import Request, {
 import { createObjectStorageKeysSchema } from './objectStorageKeys.schema';
 
 type Page<T> = Linode.ResourcePage<T>;
-export interface CreateObjectStorageKeyRequest {
+export interface ObjectStorageKeyRequest {
   label: string;
 }
 /**
@@ -30,10 +30,25 @@ export const getObjectStorageKeys = (params?: any, filters?: any) =>
  *
  * Creates an Object Storage key
  */
-export const createObjectStorageKeys = (data: CreateObjectStorageKeyRequest) =>
+export const createObjectStorageKeys = (data: ObjectStorageKeyRequest) =>
   Request<Linode.ObjectStorageKey>(
     setMethod('POST'),
     setURL(`${API_ROOT}beta/account/s3-keys`),
+    setData(data, createObjectStorageKeysSchema)
+  ).then(response => response.data);
+
+/**
+ * createObjectStorageKeys
+ *
+ * Creates an Object Storage key
+ */
+export const updateObjectStorageKey = (
+  id: number,
+  data: ObjectStorageKeyRequest
+) =>
+  Request<Linode.ObjectStorageKey>(
+    setMethod('PUT'),
+    setURL(`${API_ROOT}beta/account/s3-keys/${id}`),
     setData(data, createObjectStorageKeysSchema)
   ).then(response => response.data);
 

--- a/src/services/profile/objectStorageKeys.ts
+++ b/src/services/profile/objectStorageKeys.ts
@@ -38,9 +38,9 @@ export const createObjectStorageKeys = (data: ObjectStorageKeyRequest) =>
   ).then(response => response.data);
 
 /**
- * createObjectStorageKeys
+ * updateObjectStorageKeys
  *
- * Creates an Object Storage key
+ * Updates an Object Storage Key
  */
 export const updateObjectStorageKey = (
   id: number,


### PR DESCRIPTION
## Description

Adds a "Rename" option to the OBJ Key kebab menu. This opens the drawer and allows you to edit the label.

This completes the full feature set surrounding Object Storage Keys (for now, at least).

## Note to Reviewers

**To Test:**

1) Go to Profile > API Tokens > Object Storage Keys. 
2) Create keys, edit their label, revoke them, etc. 