### PR TITLE
M3-1696 Update: Linode detail permissions

### DIFF
--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -144,9 +144,13 @@ class Tag extends React.Component<CombinedProps, {}> {
           [classes.root]: true
         })}
         deleteIcon={
-          <Button data-qa-delete-tag className={classes.deleteButton}>
-            <Close />
-          </Button>
+          chipProps.onDelete ? (
+            <Button data-qa-delete-tag className={classes.deleteButton}>
+              <Close />
+            </Button>
+          ) : (
+            undefined
+          )
         }
         classes={{ label: classes.label, deletable: classes[colorVariant!] }}
         onClick={this.handleClick}

--- a/src/components/TagsPanel/TagsPanel.tsx
+++ b/src/components/TagsPanel/TagsPanel.tsx
@@ -413,11 +413,7 @@ class TagsPanel extends React.Component<CombinedProps, State> {
               onClick={this.toggleTagInput}
               className={classes.addButton}
               type="primary"
-<<<<<<< HEAD
-              disabled={loading}
-=======
-              disabled={disabled}
->>>>>>> Fix tags and name fields read-only state
+              disabled={loading || disabled}
             >
               <AddCircle data-qa-add-tag />
               <Typography>Add New Tag</Typography>

--- a/src/components/TagsPanel/TagsPanel.tsx
+++ b/src/components/TagsPanel/TagsPanel.tsx
@@ -148,6 +148,7 @@ interface State {
 export interface Props {
   tags: string[];
   updateTags: (tags: string[]) => Promise<void>;
+  disabled?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames> & InjectedNotistackProps;
@@ -192,10 +193,12 @@ class TagsPanel extends React.Component<CombinedProps, State> {
   }
 
   toggleTagInput = () => {
-    this.setState({
-      tagError: '',
-      isCreatingTag: !this.state.isCreatingTag
-    });
+    if (!this.props.disabled) {
+      this.setState({
+        tagError: '',
+        isCreatingTag: !this.state.isCreatingTag
+      });
+    }
   };
 
   handleDeleteTag = (label: string) => {
@@ -324,7 +327,7 @@ class TagsPanel extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { tags, classes } = this.props;
+    const { tags, classes, disabled } = this.props;
 
     const {
       isCreatingTag,
@@ -410,7 +413,11 @@ class TagsPanel extends React.Component<CombinedProps, State> {
               onClick={this.toggleTagInput}
               className={classes.addButton}
               type="primary"
+<<<<<<< HEAD
               disabled={loading}
+=======
+              disabled={disabled}
+>>>>>>> Fix tags and name fields read-only state
             >
               <AddCircle data-qa-add-tag />
               <Typography>Add New Tag</Typography>

--- a/src/components/TagsPanel/TagsPanel.tsx
+++ b/src/components/TagsPanel/TagsPanel.tsx
@@ -365,7 +365,7 @@ class TagsPanel extends React.Component<CombinedProps, State> {
                   key={eachTag}
                   label={eachTag}
                   tagLabel={eachTag}
-                  onDelete={this.handleDeleteTag}
+                  onDelete={disabled ? undefined : this.handleDeleteTag}
                   className={classes.tag}
                   loading={listDeletingTags.some(inProgressTag => {
                     /*

--- a/src/components/TagsPanel/TagsPanelItem.tsx
+++ b/src/components/TagsPanel/TagsPanelItem.tsx
@@ -17,7 +17,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 interface Props extends TagProps {
   tagLabel: string;
   loading: boolean;
-  onDelete: (tag: string) => void;
+  onDelete?: (tag: string) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -47,12 +47,12 @@ class TagsPanelItem extends React.Component<CombinedProps, {}> {
   };
 
   render() {
-    const { tagLabel, loading, ...restOfProps } = this.props;
+    const { tagLabel, loading, onDelete, ...restOfProps } = this.props;
     return (
       <Tag
         {...restOfProps}
         deleteIcon={this.renderIcon()}
-        onDelete={this.handleDelete}
+        onDelete={onDelete ? this.handleDelete : undefined}
         component={'button' as 'div'}
         colorVariant="lightBlue"
       />

--- a/src/features/Images/ImageSelect.tsx
+++ b/src/features/Images/ImageSelect.tsx
@@ -36,6 +36,7 @@ interface Props {
   isMulti?: boolean;
   helperText?: string;
   value?: Item | Item[];
+  disabled?: boolean;
   onSelect: (selected: Item<any> | Item<any>[]) => void;
 }
 
@@ -80,7 +81,8 @@ export class ImageSelect extends React.Component<CombinedProps, State> {
       imageFieldError,
       isMulti,
       onSelect,
-      value
+      value,
+      disabled
     } = this.props;
     const { renderedImages } = this.state;
     return (
@@ -99,7 +101,7 @@ export class ImageSelect extends React.Component<CombinedProps, State> {
               value={value}
               isMulti={Boolean(isMulti)}
               errorText={imageError || imageFieldError}
-              disabled={Boolean(imageError)}
+              disabled={disabled || Boolean(imageError)}
               onChange={onSelect}
               options={renderedImages as any}
               placeholder="Select an Image"

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -34,6 +34,8 @@ import withVolumesRequests, {
 import withLinodes from 'src/containers/withLinodes.container';
 import { BlockStorage } from 'src/documentation';
 import { resetEventsPolling } from 'src/events';
+import LinodePermissionsError from 'src/features/linodes/LinodesDetail/LinodePermissionsError';
+
 import {
   openForClone,
   openForConfig,
@@ -136,6 +138,7 @@ interface Props {
   linodeRegion?: string;
   linodeConfigs?: Linode.Config[];
   recentEvent?: Linode.Event;
+  readOnly?: boolean;
 }
 
 //
@@ -269,7 +272,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
       classes,
       volumesLoading,
       volumesError,
-      mappedVolumesDataWithLinodes
+      mappedVolumesDataWithLinodes,
+      readOnly
     } = this.props;
 
     if (volumesError) {
@@ -295,6 +299,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Volumes" />
+        {readOnly && <LinodePermissionsError />}
         <Grid
           container
           justify="space-between"
@@ -359,7 +364,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   };
 
   renderEmpty = () => {
-    const { linodeConfigs, linodeRegion } = this.props;
+    const { linodeConfigs, linodeRegion, readOnly } = this.props;
 
     if (regionsWithoutBlockStorage.some(region => region === linodeRegion)) {
       return (
@@ -394,13 +399,15 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Volumes" />
+        {readOnly && <LinodePermissionsError />}
         <Placeholder
           title="Add Block Storage!"
           copy={<EmptyCopy />}
           icon={VolumesIcon}
           buttonProps={{
             onClick: this.openCreateVolumeDrawer,
-            children: 'Add a Volume'
+            children: 'Add a Volume',
+            disabled: readOnly
           }}
         />
       </React.Fragment>

--- a/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/BackupTableRow.tsx
@@ -7,6 +7,7 @@ import LinodeBackupActionMenu from './LinodeBackupActionMenu';
 
 interface Props {
   backup: Linode.LinodeBackup;
+  disabled: boolean;
   handleRestore: (backup: Linode.LinodeBackup) => void;
   handleDeploy: (backup: Linode.LinodeBackup) => void;
 }
@@ -20,7 +21,7 @@ const BackupTableRow: React.StatelessComponent<Props> = props => {
   const onDeploy = () => {
     props.handleDeploy(props.backup);
   };
-  const { backup, handleRestore } = props;
+  const { backup, disabled, handleRestore } = props;
   return (
     <TableRow key={backup.id} data-qa-backup>
       <TableCell
@@ -51,6 +52,7 @@ const BackupTableRow: React.StatelessComponent<Props> = props => {
       <TableCell>
         <LinodeBackupActionMenu
           backup={backup}
+          disabled={disabled}
           onRestore={handleRestore}
           onDeploy={onDeploy}
         />

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -492,7 +492,8 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
   }: {
     backups: Linode.LinodeBackup[];
   }): JSX.Element | null => {
-    const { classes } = this.props;
+    const { classes, permissions } = this.props;
+    const disabled = isReadOnly(permissions);
 
     return (
       <React.Fragment>
@@ -513,6 +514,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
                 <BackupTableRow
                   key={idx}
                   backup={backup}
+                  disabled={disabled}
                   handleDeploy={this.handleDeploy}
                   handleRestore={this.handleRestore}
                 />

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
@@ -5,6 +5,7 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
   backup: Linode.LinodeBackup;
+  disabled: boolean;
   onRestore: (backup: Linode.LinodeBackup) => void;
   onDeploy: (backup: Linode.LinodeBackup) => void;
 }
@@ -13,7 +14,13 @@ type CombinedProps = Props & RouteComponentProps<{}>;
 
 class LinodeBackupActionMenu extends React.Component<CombinedProps> {
   createActions = () => {
-    const { backup, onRestore, onDeploy } = this.props;
+    const { backup, disabled, onRestore, onDeploy } = this.props;
+    const disabledProps = {
+      disabled,
+      tooltip: disabled
+        ? "You don't have permission to deploy from this Linode's backups"
+        : undefined
+    };
 
     return (closeMenu: Function): Action[] => {
       const actions = [
@@ -23,7 +30,8 @@ class LinodeBackupActionMenu extends React.Component<CombinedProps> {
             onRestore(backup);
             closeMenu();
             e.preventDefault();
-          }
+          },
+          ...disabledProps
         },
         {
           title: 'Deploy New Linode',
@@ -31,7 +39,8 @@ class LinodeBackupActionMenu extends React.Component<CombinedProps> {
             onDeploy(backup);
             closeMenu();
             e.preventDefault();
-          }
+          },
+          ...disabledProps
         }
       ];
       return actions;

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -73,6 +73,7 @@ interface Props {
   linodeRegion: string;
   linodeIPs: string[];
   linodeSharedIPs: string[];
+  readOnly?: boolean;
   refreshIPs: () => Promise<void>;
 }
 
@@ -210,7 +211,7 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
   };
 
   renderShareIPRow = (ip: string, idx: number) => {
-    const { classes } = this.props;
+    const { classes, readOnly } = this.props;
     return (
       <Grid container key={idx}>
         <Grid item xs={12}>
@@ -223,6 +224,7 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
             fullWidth={false}
             className={classes.ipField}
             data-qa-share-ip
+            disabled={readOnly}
           >
             {this.remainingChoices(ip).map(
               (ipChoice: string, choiceIdx: number) => (
@@ -239,6 +241,7 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
             onClick={this.onIPDelete(idx)}
             className={classes.remove}
             data-qa-remove-shared-ip
+            disabled={readOnly}
           />
         </Grid>
       </Grid>
@@ -309,13 +312,14 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
   };
 
   renderActions = () => {
+    const { readOnly } = this.props;
     const { submitting, loading } = this.state;
     const noChoices = this.state.ipChoices.length <= 1;
     return (
       <ActionsPanel>
         <Button
           loading={submitting}
-          disabled={loading || noChoices}
+          disabled={readOnly || loading || noChoices}
           onClick={this.onSubmit}
           type="primary"
           data-qa-submit
@@ -335,7 +339,7 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { classes, linodeIPs } = this.props;
+    const { classes, linodeIPs, readOnly } = this.props;
     const {
       errors,
       successMessage,
@@ -388,6 +392,7 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
                   <div className={classes.addNewButton}>
                     <AddNewLink
                       label="Add IP Address"
+                      disabled={readOnly}
                       onClick={this.addIPToShare}
                       left
                     />

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -24,6 +24,7 @@ import { ZONES } from 'src/constants';
 import { getLinodeIPs } from 'src/services/linodes';
 import { upsertLinode as _upsertLinode } from 'src/store/linodes/linodes.actions';
 import { withLinodeDetailContext } from '../linodeDetailContext';
+import LinodePermissionsError from '../LinodePermissionsError';
 import CreateIPv4Drawer from './CreateIPv4Drawer';
 import CreateIPv6Drawer from './CreateIPv6Drawer';
 import DeleteIPConfirm from './DeleteIPConfirm';
@@ -211,7 +212,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
   }
 
   renderIPRow(ip: Linode.IPAddress, type: IPTypes) {
-    const { classes } = this.props;
+    const { classes, readOnly } = this.props;
 
     return (
       <TableRow key={ip.address} data-qa-ip={ip.address}>
@@ -232,6 +233,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
             ipType={type}
             ipAddress={ip}
             onRemove={this.openRemoveIPDialog}
+            readOnly={readOnly}
           />
         </TableCell>
       </TableRow>
@@ -298,10 +300,9 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
 
   render() {
     const {
-      id: linodeID,
-      label: linodeLabel,
-      region: linodeRegion
-    } = this.props.linode;
+      readOnly,
+      linode: { id: linodeID, label: linodeLabel, region: linodeRegion }
+    } = this.props;
     const { linodeIPs, initialLoading, IPRequestError } = this.state;
     const firstPublicIPAddress = getFirstPublicIPv4FromResponse(linodeIPs);
 
@@ -323,6 +324,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment={`${linodeLabel} - Networking`} />
+        {readOnly && <LinodePermissionsError />}
         <LinodeNetworkingSummaryPanel
           linkLocal={path(['ipv6', 'link_local', 'address'], linodeIPs)}
           sshIPAddress={firstPublicIPAddress}
@@ -388,7 +390,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
   }
 
   renderIPv4 = () => {
-    const { classes } = this.props;
+    const { classes, readOnly } = this.props;
     const ipv4 = path<Linode.LinodeIPsResponseIPV4>(
       ['linodeIPs', 'ipv4'],
       this.state
@@ -423,7 +425,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
               <div>
                 <AddNewLink
                   onClick={this.openCreatePrivateIPv4Drawer}
-                  disabled={Boolean(this.hasPrivateIPAddress())}
+                  disabled={Boolean(this.hasPrivateIPAddress()) || readOnly}
                   label="Add Private IPv4"
                 />
               </div>
@@ -432,6 +434,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
           <Grid item>
             <AddNewLink
               onClick={this.openCreatePublicIPv4Drawer}
+              disabled={readOnly}
               label="Add Public IPv4"
             />
           </Grid>
@@ -469,7 +472,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
   };
 
   renderIPv6 = () => {
-    const { classes } = this.props;
+    const { classes, readOnly } = this.props;
     const ipv6 = path<Linode.LinodeIPsResponseIPV6>(
       ['linodeIPs', 'ipv6'],
       this.state
@@ -494,7 +497,11 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
             </Typography>
           </Grid>
           <Grid item>
-            <AddNewLink onClick={this.openCreateIPv6Drawer} label="Add IPv6" />
+            <AddNewLink
+              onClick={this.openCreateIPv6Drawer}
+              label="Add IPv6"
+              disabled={readOnly}
+            />
           </Grid>
         </Grid>
         <Paper style={{ padding: 0 }}>
@@ -529,7 +536,8 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
   renderNetworkActions = () => {
     const {
       classes,
-      linode: { id: linodeID, region: linodeRegion }
+      linode: { id: linodeID, region: linodeRegion },
+      readOnly
     } = this.props;
     const { linodeIPs } = this.state;
 
@@ -558,6 +566,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
             linodeRegion={linodeRegion}
             refreshIPs={this.refreshIPs}
             ipAddresses={[...publicIPs, ...privateIPs]}
+            readOnly={readOnly}
           />
           <IPSharingPanel
             linodeID={linodeID}
@@ -566,6 +575,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
             linodeRegion={linodeRegion}
             refreshIPs={this.refreshIPs}
             updateFor={[publicIPs, sharedIPs, linodeID, linodeRegion, classes]}
+            readOnly={readOnly}
           />
         </Grid>
       </Grid>
@@ -583,11 +593,13 @@ const getFirstPublicIPv4FromResponse = compose(
 
 interface ContextProps {
   linode: Linode.Linode;
+  readOnly: boolean;
 }
 
 const linodeContext = withLinodeDetailContext(({ linode }) => ({
   /** actually needs the whole linode for the purposes */
-  linode
+  linode,
+  readOnly: linode._permissions === 'read_only'
 }));
 
 interface DispatchProps {

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -9,6 +9,7 @@ interface Props {
   onRemove?: (ip: Linode.IPAddress) => void;
   ipType: IPTypes;
   ipAddress?: Linode.IPAddress;
+  readOnly?: boolean;
 }
 
 export type IPTypes =
@@ -23,10 +24,17 @@ type CombinedProps = Props & RouteComponentProps<{}>;
 
 class LinodeNetworkingActionMenu extends React.Component<CombinedProps> {
   createActions = () => {
-    const { onView, onEdit, onRemove, ipType, ipAddress } = this.props;
+    const {
+      onView,
+      onEdit,
+      onRemove,
+      ipType,
+      ipAddress,
+      readOnly
+    } = this.props;
 
     return (closeMenu: Function): Action[] => {
-      const actions = [
+      const actions: Action[] = [
         {
           title: 'View',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
@@ -53,7 +61,11 @@ class LinodeNetworkingActionMenu extends React.Component<CombinedProps> {
             onEdit(ipAddress);
             closeMenu();
             e.preventDefault();
-          }
+          },
+          disabled: readOnly,
+          tooltip: readOnly
+            ? "You don't have permissions to modify this Linode"
+            : undefined
         });
       }
 
@@ -64,7 +76,11 @@ class LinodeNetworkingActionMenu extends React.Component<CombinedProps> {
             onRemove(ipAddress);
             closeMenu();
             e.preventDefault();
-          }
+          },
+          disabled: readOnly,
+          tooltip: readOnly
+            ? "You don't have permissions to modify this Linode"
+            : undefined
         });
       }
 

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -87,6 +87,7 @@ interface Props {
   linodeID: number;
   linodeRegion: string;
   ipAddresses: string[];
+  readOnly?: boolean;
   refreshIPs: () => Promise<void>;
 }
 
@@ -261,7 +262,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
     renderLinodeSelect?: (s: Move) => JSX.Element,
     renderIPSelect?: (s: Swap) => JSX.Element
   ) => {
-    const { classes } = this.props;
+    const { classes, readOnly } = this.props;
     return (
       <Grid container key={state.sourceIP}>
         <Grid item xs={12}>
@@ -280,6 +281,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
             onChange={this.onModeChange(state.sourceIP)}
             fullWidth={false}
             data-qa-ip-transfer-action-menu
+            disabled={readOnly}
           >
             <MenuItem value="none">Select Action</MenuItem>
             <MenuItem value="move" data-qa-transfer-action="move">
@@ -297,11 +299,11 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
   };
 
   linodeSelect = ({ mode, sourceIP, selectedLinodeID }: Move) => {
-    const { classes } = this.props;
+    const { classes, readOnly } = this.props;
     return (
       <Grid item xs={12} className={classes.autoGridsm}>
         <Select
-          disabled={this.state.linodes.length === 1}
+          disabled={readOnly || this.state.linodes.length === 1}
           value={selectedLinodeID}
           onChange={this.onSelectedLinodeChange(sourceIP)}
           fullWidth={false}
@@ -317,11 +319,11 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
   };
 
   ipSelect = ({ sourceIP, selectedIP, selectedLinodesIPs }: Swap) => {
-    const { classes } = this.props;
+    const { classes, readOnly } = this.props;
     return (
       <Grid item xs={12} className={classes.autoGridsm}>
         <Select
-          disabled={selectedLinodesIPs.length === 1}
+          disabled={readOnly || selectedLinodesIPs.length === 1}
           value={selectedIP}
           fullWidth={false}
           onChange={this.onSelectedIPChange(sourceIP)}
@@ -483,13 +485,14 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
   };
 
   transferActions = () => {
+    const { readOnly } = this.props;
     return (
       <ActionsPanel>
         <Button
           loading={this.state.submitting}
           onClick={this.onSubmit}
           type="primary"
-          disabled={this.state.linodes.length === 0}
+          disabled={readOnly || this.state.linodes.length === 0}
           data-qa-ip-transfer-save
         >
           Save

--- a/src/features/linodes/LinodesDetail/LinodePermissionsError.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePermissionsError.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import Notice from 'src/components/Notice';
+
+const LinodePermissionsError = () => (
+  <Notice
+    error
+    text="You don't have permissions to modify this Linode. Please, contact account administrator for details."
+  />
+);
+
+export default LinodePermissionsError;

--- a/src/features/linodes/LinodesDetail/LinodePermissionsError.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePermissionsError.tsx
@@ -4,7 +4,7 @@ import Notice from 'src/components/Notice';
 const LinodePermissionsError = () => (
   <Notice
     error
-    text="You don't have permissions to modify this Linode. Please, contact account administrator for details."
+    text="You don't have permission to modify this Linode. Please contact an account administrator for details."
   />
 );
 

--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -114,7 +114,12 @@ interface Props {
   id: number;
   label: string;
   status: Linode.LinodeStatus;
+<<<<<<< HEAD
   noConfigs: boolean;
+=======
+  noImage: boolean;
+  disabled?: boolean;
+>>>>>>> M3-1696: configure permissions for editing linode
   recentEvent?: Linode.Event;
   openConfigDrawer: (
     config: Linode.Config[],
@@ -178,7 +183,11 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
   };
 
   render() {
+<<<<<<< HEAD
     const { status, classes, recentEvent, noConfigs } = this.props;
+=======
+    const { status, classes, recentEvent, noImage, disabled } = this.props;
+>>>>>>> M3-1696: configure permissions for editing linode
     const {
       menu: { anchorEl },
       bootOption,
@@ -250,6 +259,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
               onClick={this.toggleRebootDialog}
               className={classes.menuItem}
               data-qa-set-power="reboot"
+              disabled={disabled}
             >
               <div className={classes.menuItemInner}>
                 <EntityIcon
@@ -268,6 +278,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
               onClick={this.togglePowerDownDialog}
               className={classes.menuItem}
               data-qa-set-power="powerOff"
+              disabled={disabled}
             >
               <div className={classes.menuItemInner}>
                 <EntityIcon
@@ -286,7 +297,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
               onClick={this.powerOn}
               className={classes.menuItem}
               data-qa-set-power="powerOn"
-              disabled={noConfigs}
+              disabled={noConfigs || disabled}
               tooltip={
                 noConfigs
                   ? 'A config needs to be added before powering on a Linode'

--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -114,12 +114,8 @@ interface Props {
   id: number;
   label: string;
   status: Linode.LinodeStatus;
-<<<<<<< HEAD
   noConfigs: boolean;
-=======
-  noImage: boolean;
   disabled?: boolean;
->>>>>>> M3-1696: configure permissions for editing linode
   recentEvent?: Linode.Event;
   openConfigDrawer: (
     config: Linode.Config[],
@@ -183,11 +179,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
   };
 
   render() {
-<<<<<<< HEAD
-    const { status, classes, recentEvent, noConfigs } = this.props;
-=======
-    const { status, classes, recentEvent, noImage, disabled } = this.props;
->>>>>>> M3-1696: configure permissions for editing linode
+    const { status, classes, disabled, recentEvent, noConfigs } = this.props;
     const {
       menu: { anchorEl },
       bootOption,

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -10,6 +10,7 @@ import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
 import { withLinodeDetailContext } from '../linodeDetailContext';
+import LinodePermissionsError from '../LinodePermissionsError';
 import RebuildFromImage from './RebuildFromImage';
 import RebuildFromStackScript from './RebuildFromStackScript';
 
@@ -26,6 +27,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 interface ContextProps {
   linodeLabel: string;
+  permissions: Linode.GrantLevel;
 }
 type CombinedProps = WithStyles<ClassNames> & ContextProps;
 
@@ -40,7 +42,8 @@ const options = [
 ];
 
 const LinodeRebuild: React.StatelessComponent<CombinedProps> = props => {
-  const { classes, linodeLabel } = props;
+  const { classes, linodeLabel, permissions } = props;
+  const disabled = permissions === 'read_only';
 
   const [mode, setMode] = React.useState<MODES>('fromImage');
 
@@ -48,7 +51,13 @@ const LinodeRebuild: React.StatelessComponent<CombinedProps> = props => {
     <React.Fragment>
       <DocumentTitleSegment segment={`${linodeLabel} - Rebuild`} />
       <Paper className={classes.root}>
-        <Typography variant="h2" className={classes.title} data-qa-title>
+        {disabled && <LinodePermissionsError />}
+        <Typography
+          role="header"
+          variant="h2"
+          className={classes.title}
+          data-qa-title
+        >
           Rebuild
         </Typography>
         <Typography data-qa-rebuild-desc>
@@ -62,6 +71,7 @@ const LinodeRebuild: React.StatelessComponent<CombinedProps> = props => {
           defaultValue={options[0]}
           onChange={(selected: Item<MODES>) => setMode(selected.value)}
           isClearable={false}
+          disabled={disabled}
         />
       </Paper>
       {mode === 'fromImage' && <RebuildFromImage />}
@@ -76,7 +86,8 @@ const LinodeRebuild: React.StatelessComponent<CombinedProps> = props => {
 };
 
 const linodeContext = withLinodeDetailContext(({ linode }) => ({
-  linodeLabel: linode.label
+  linodeLabel: linode.label,
+  permissions: linode._permissions
 }));
 
 const styled = withStyles(styles);

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -43,6 +43,7 @@ interface WithImagesProps {
 
 interface ContextProps {
   linodeId: number;
+  permissions: Linode.GrantLevel;
 }
 
 export type CombinedProps = WithImagesProps &
@@ -62,8 +63,11 @@ export const RebuildFromImage: React.StatelessComponent<
     userSSHKeys,
     linodeId,
     enqueueSnackbar,
-    history
+    history,
+    permissions
   } = props;
+
+  const disabled = permissions === 'read_only';
 
   const [selectedImage, setSelectedImage] = React.useState<string>('');
   const [password, setPassword] = React.useState<string>('');
@@ -133,6 +137,7 @@ export const RebuildFromImage: React.StatelessComponent<
         selectedImageID={selectedImage}
         handleSelection={selected => setSelectedImage(selected)}
         data-qa-select-image
+        disabled={disabled}
       />
       <AccessPanel
         password={password}
@@ -141,6 +146,14 @@ export const RebuildFromImage: React.StatelessComponent<
         error={hasErrorFor.root_pass}
         users={userSSHKeys}
         data-qa-access-panel
+        passwordFieldDisabled={
+          disabled
+            ? {
+                disabled: true,
+                reason: "You don't have permissions to modify this Linode"
+              }
+            : undefined
+        }
       />
       <ActionsPanel>
         <Button
@@ -148,6 +161,7 @@ export const RebuildFromImage: React.StatelessComponent<
           className="destructive"
           onClick={() => setIsDialogOpen(true)}
           data-qa-rebuild
+          disabled={disabled}
         >
           Rebuild
         </Button>
@@ -165,7 +179,8 @@ export const RebuildFromImage: React.StatelessComponent<
 const styled = withStyles(styles);
 
 const linodeContext = withLinodeDetailContext(({ linode }) => ({
-  linodeId: linode.id
+  linodeId: linode.id,
+  permissions: linode._permissions
 }));
 
 const enhanced = compose<CombinedProps, {}>(

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -146,12 +146,10 @@ export const RebuildFromImage: React.StatelessComponent<
         error={hasErrorFor.root_pass}
         users={userSSHKeys}
         data-qa-access-panel
-        passwordFieldDisabled={
+        disabled={disabled}
+        disabledReason={
           disabled
-            ? {
-                disabled: true,
-                reason: "You don't have permissions to modify this Linode"
-              }
+            ? "You don't have permissions to modify this Linode"
             : undefined
         }
       />

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/SelectImagePanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/SelectImagePanel.tsx
@@ -30,19 +30,21 @@ export interface Props {
   selectedImageID: string | null;
   handleSelection: (id: string) => void;
   error?: string;
+  disabled?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const SelectImagePanel: React.StatelessComponent<CombinedProps> = props => {
-  const { images, error, handleSelection, selectedImageID } = props;
+  const { images, error, handleSelection, selectedImageID, disabled } = props;
 
   const { recommended, older } = groupImages(images);
   const myImages = getMyImages(images);
 
   const createImagePanels = imagePanelFactory(
     String(selectedImageID),
-    handleSelection
+    handleSelection,
+    disabled
   );
 
   const tabs = [
@@ -92,13 +94,15 @@ export default styled(RenderGuard<Props>(SelectImagePanel));
 // again.
 const imagePanelFactory = (
   selectedImageID: string,
-  handleSelection: (id: string) => void
+  handleSelection: (id: string) => void,
+  disabled?: boolean
 ) => (images: Linode.Image[] = []) =>
   images.map((image, idx) => (
     <SelectionCard
       key={idx}
       checked={image.id === String(selectedImageID)}
       onClick={() => handleSelection(image.id)}
+      disabled={disabled}
       renderIcon={() => {
         const className = image.vendor
           ? `fl-${distroIcons[image.vendor as string]}`

--- a/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
@@ -35,12 +35,21 @@ interface Props {
   counter?: number;
   slots: string[];
   rescue?: boolean;
+  disabled?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
-  const { devices, onChange, getSelected, slots, rescue, classes } = props;
+  const {
+    devices,
+    onChange,
+    getSelected,
+    slots,
+    rescue,
+    classes,
+    disabled
+  } = props;
 
   const counter = defaultTo(0, props.counter);
 
@@ -57,6 +66,7 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
               htmlFor={`rescueDevice_${slot}`}
               disableAnimation
               shrink={true}
+              disabled={disabled}
             >
               /dev/{slot}
             </InputLabel>
@@ -68,6 +78,7 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
                 name: `rescueDevice_${slot}`,
                 id: `rescueDevice_${slot}`
               }}
+              disabled={disabled}
             >
               <MenuItem value="none">None</MenuItem>
               {Object.entries(devices).map(([type, items]) => [
@@ -95,6 +106,7 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
             htmlFor={`rescueDevice_sdh`}
             disableAnimation
             shrink={true}
+            disabled={disabled}
           >
             /dev/sdh
           </InputLabel>

--- a/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
@@ -36,6 +36,7 @@ describe('LinodeRescue', () => {
         linodeRegion="us-east"
         volumesData={extendedVolumes}
         linodeLabel=""
+        permissions="read_write"
       />
     );
     const rescueComponentProps = component.instance().props;

--- a/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -24,6 +24,7 @@ import createDevicesFromStrings, {
   DevicesAsStrings
 } from 'src/utilities/createDevicesFromStrings';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import LinodePermissionsError from '../LinodePermissionsError';
 import DeviceSelection, {
   ExtendedDisk,
   ExtendedVolume
@@ -53,6 +54,7 @@ interface ContextProps {
   linodeRegion?: string;
   linodeLabel: string;
   linodeDisks?: ExtendedDisk[];
+  permissions: Linode.GrantLevel;
 }
 
 interface StateProps {
@@ -170,7 +172,14 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
 
   render() {
     const { devices } = this.state;
-    const { diskError, volumesError, classes, linodeLabel } = this.props;
+    const {
+      diskError,
+      volumesError,
+      classes,
+      linodeLabel,
+      permissions
+    } = this.props;
+    const disabled = permissions === 'read_only';
 
     if (diskError) {
       return (
@@ -194,7 +203,13 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
       <React.Fragment>
         <DocumentTitleSegment segment={`${linodeLabel} - Rescue`} />
         <Paper className={classes.root}>
-          <Typography variant="h2" className={classes.title} data-qa-title>
+          {disabled && <LinodePermissionsError />}
+          <Typography
+            role="header"
+            variant="h2"
+            className={classes.title}
+            data-qa-title
+          >
             Rescue
           </Typography>
           <Typography className={classes.intro}>
@@ -212,15 +227,21 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
             }
             counter={this.state.counter}
             rescue
+            disabled={disabled}
           />
           <AddNewLink
             onClick={this.incrementCounter}
             label="Add Disk"
-            disabled={this.state.counter >= 6}
+            disabled={disabled || this.state.counter >= 6}
             left
           />
           <ActionsPanel>
-            <Button onClick={this.onSubmit} type="primary" data-qa-submit>
+            <Button
+              onClick={this.onSubmit}
+              type="primary"
+              data-qa-submit
+              disabled={disabled}
+            >
               Submit
             </Button>
           </ActionsPanel>
@@ -236,7 +257,8 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeId: linode.id,
   linodeRegion: linode.region,
   linodeLabel: linode.label,
-  linodeDisks: linode._disks.map(disk => assoc('_id', `disk-${disk.id}`, disk))
+  linodeDisks: linode._disks.map(disk => assoc('_id', `disk-${disk.id}`, disk)),
+  permissions: linode._permissions
 }));
 
 const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({

--- a/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
@@ -78,13 +78,14 @@ interface Props {
   onValueChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   error?: string;
   endAdornment: string;
+  readOnly?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 class AlertSection extends React.Component<CombinedProps> {
   render() {
-    const { classes } = this.props;
+    const { classes, readOnly } = this.props;
 
     return (
       <React.Fragment>
@@ -101,6 +102,7 @@ class AlertSection extends React.Component<CombinedProps> {
                 <Toggle
                   checked={this.props.state}
                   onChange={this.props.onStateChange}
+                  disabled={readOnly}
                 />
               }
               label={this.props.title}
@@ -115,7 +117,7 @@ class AlertSection extends React.Component<CombinedProps> {
               label={this.props.textTitle}
               type="number"
               value={this.props.value}
-              disabled={!this.props.state}
+              disabled={!this.props.state || readOnly}
               InputProps={{
                 endAdornment: (
                   <InputAdornment position="end">

--- a/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.test.tsx
@@ -13,7 +13,8 @@ const props = {
   onImageChange: jest.fn(),
   password: '',
   onPasswordChange: jest.fn(),
-  userSSHKeys: []
+  userSSHKeys: [],
+  permissions: null
 };
 
 const component = shallow(<ImageAndPassword {...props} />);

--- a/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
@@ -69,12 +69,10 @@ export const ImageAndPassword: React.StatelessComponent<
         handleChange={onPasswordChange}
         error={passwordError}
         users={userSSHKeys}
-        passwordFieldDisabled={
+        disabled={disabled}
+        disabledReason={
           disabled
-            ? {
-                disabled: true,
-                reason: "You don't have permissions to modify this Linode"
-              }
+            ? "You don't have permissions to modify this Linode"
             : undefined
         }
       />

--- a/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
@@ -10,12 +10,18 @@ import AccessPanel, { UserSSHKeyObject } from 'src/components/AccessPanel';
 import { Item } from 'src/components/EnhancedSelect/Select';
 import withImages, { WithImages } from 'src/containers/withImages.container';
 import { ImageSelect } from 'src/features/Images';
+import { withLinodeDetailContext } from '../linodeDetailContext';
+import LinodePermissionsError from '../LinodePermissionsError';
 
 type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {}
 });
+
+interface ContextProps {
+  permissions: Linode.GrantLevel;
+}
 
 interface Props {
   onImageChange: (selected: Item<string>) => void;
@@ -28,7 +34,7 @@ interface Props {
   userSSHKeys: UserSSHKeyObject[];
 }
 
-type CombinedProps = Props & WithImages & WithStyles<ClassNames>;
+type CombinedProps = Props & ContextProps & WithImages & WithStyles<ClassNames>;
 
 export const ImageAndPassword: React.StatelessComponent<
   CombinedProps
@@ -41,16 +47,21 @@ export const ImageAndPassword: React.StatelessComponent<
     onPasswordChange,
     password,
     passwordError,
-    userSSHKeys
+    userSSHKeys,
+    permissions
   } = props;
+
+  const disabled = permissions === 'read_only';
 
   return (
     <React.Fragment>
+      {disabled && <LinodePermissionsError />}
       <ImageSelect
         images={images}
         imageError={imageError}
         imageFieldError={imageFieldError}
         onSelect={onImageChange}
+        disabled={disabled}
       />
       <AccessPanel
         noPadding
@@ -58,6 +69,14 @@ export const ImageAndPassword: React.StatelessComponent<
         handleChange={onPasswordChange}
         error={passwordError}
         users={userSSHKeys}
+        passwordFieldDisabled={
+          disabled
+            ? {
+                disabled: true,
+                reason: "You don't have permissions to modify this Linode"
+              }
+            : undefined
+        }
       />
     </React.Fragment>
   );
@@ -65,10 +84,15 @@ export const ImageAndPassword: React.StatelessComponent<
 
 const styled = withStyles(styles);
 
+const linodeContext = withLinodeDetailContext<ContextProps>(({ linode }) => ({
+  permissions: linode._permissions
+}));
+
 const enhanced = compose<CombinedProps, Props>(
   styled,
   withImages((ownProps, images, imagesLoading, imageError) => ({
     ...ownProps,
+    linodeContext,
     images,
     imagesLoading,
     imageError

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
@@ -9,6 +9,7 @@ interface Props {
   onBoot: (linodeId: number, configId: number, label: string) => void;
   config: Linode.Config;
   linodeId: number;
+  readOnly?: boolean;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}>;
@@ -37,6 +38,10 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
   };
 
   createConfigActions = () => (closeMenu: Function): Action[] => {
+    const { readOnly } = this.props;
+    const tooltip = readOnly
+      ? "You don't permissions to perform this action"
+      : undefined;
     const actions = [
       {
         title: 'Boot This Config',
@@ -44,7 +49,9 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
           e.preventDefault();
           this.handleBoot();
           closeMenu();
-        }
+        },
+        disabled: readOnly,
+        tooltip
       },
       {
         title: 'Edit',
@@ -60,7 +67,9 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
           e.preventDefault();
           this.handleDelete();
           closeMenu();
-        }
+        },
+        disabled: readOnly,
+        tooltip
       }
     ];
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
@@ -40,7 +40,7 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
   createConfigActions = () => (closeMenu: Function): Action[] => {
     const { readOnly } = this.props;
     const tooltip = readOnly
-      ? "You don't permissions to perform this action"
+      ? "You don't have permissions to perform this action"
       : undefined;
     const actions = [
       {

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
@@ -40,7 +40,7 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
   createConfigActions = () => (closeMenu: Function): Action[] => {
     const { readOnly } = this.props;
     const tooltip = readOnly
-      ? "You don't have permissions to perform this action"
+      ? "You don't have permission to perform this action"
       : undefined;
     const actions = [
       {
@@ -59,7 +59,9 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
           e.preventDefault();
           this.handleEdit();
           closeMenu();
-        }
+        },
+        disabled: readOnly,
+        tooltip
       },
       {
         title: 'Delete',

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -242,7 +242,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
   );
 
   renderForm = (errors?: Linode.ApiFieldError[]) => {
-    const { onClose, maxMemory, classes } = this.props;
+    const { onClose, maxMemory, classes, readOnly } = this.props;
 
     const {
       kernels,
@@ -304,6 +304,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             onChange={this.handleChangeLabel}
             errorText={errorFor('label')}
             errorGroup="linode-config-drawer"
+            disabled={readOnly}
           />
 
           <TextField
@@ -314,6 +315,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             rows={3}
             errorText={errorFor('comments')}
             errorGroup="linode-config-drawer"
+            disabled={readOnly}
           />
         </Grid>
 
@@ -327,7 +329,11 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
         >
           <Typography variant="h3">Virtual Machine</Typography>
           <FormControl component={'fieldset' as 'div'}>
-            <FormLabel htmlFor="virt_mode" component="label">
+            <FormLabel
+              htmlFor="virt_mode"
+              component="label"
+              disabled={readOnly}
+            >
               VM Mode
             </FormLabel>
             <RadioGroup
@@ -339,11 +345,13 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               <FormControlLabel
                 value="paravirt"
                 label="Paravirtulization"
+                disabled={readOnly}
                 control={<Radio />}
               />
               <FormControlLabel
                 value="fullvirt"
                 label="Full-virtulization"
+                disabled={readOnly}
                 control={<Radio />}
               />
             </RadioGroup>
@@ -375,6 +383,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               onChange={this.handleChangeKernel}
               errorText={errorFor('kernel')}
               errorGroup="linode-config-drawer"
+              disabled={readOnly}
             >
               <MenuItem value="none" disabled>
                 <em>Select a Kernel</em>
@@ -395,6 +404,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             updateFor={[run_level, classes]}
             fullWidth
             component={'fieldset' as 'div'}
+            disabled={readOnly}
           >
             <FormLabel htmlFor="run_level" component="label">
               Run Level
@@ -408,16 +418,19 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               <FormControlLabel
                 value="default"
                 label="Run Default Level"
+                disabled={readOnly}
                 control={<Radio />}
               />
               <FormControlLabel
                 value="single"
                 label="Single user mode"
+                disabled={readOnly}
                 control={<Radio />}
               />
               <FormControlLabel
                 value="binbash"
                 label="init=/bin/bash"
+                disabled={readOnly}
                 control={<Radio />}
               />
             </RadioGroup>
@@ -430,6 +443,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             onChange={this.handleMemoryLimitChange}
             helperText={`Max: ${maxMemory}`}
             errorText={errorFor('memory_limit')}
+            disabled={readOnly}
           />
         </Grid>
 
@@ -443,6 +457,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             onChange={this.handleDevicesChanges}
             getSelected={slot => pathOr('', [slot], this.state.fields.devices)}
             counter={99}
+            disabled={readOnly}
           />
 
           <FormControl fullWidth>
@@ -452,6 +467,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                 <Toggle
                   checked={useCustomRoot}
                   onChange={this.handleUseCustomRootChange}
+                  disabled={readOnly}
                 />
               }
             />
@@ -466,6 +482,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               autoFocus={useCustomRoot && true}
               errorText={errorFor('root_device')}
               errorGroup="linode-config-drawer"
+              disabled={readOnly}
             >
               {!useCustomRoot &&
                 [
@@ -509,6 +526,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                   <Toggle
                     checked={helpers.distro}
                     onChange={this.handleToggleDistroHelper}
+                    disabled={readOnly}
                   />
                 }
               />
@@ -519,6 +537,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                   <Toggle
                     checked={helpers.updatedb_disabled}
                     onChange={this.handleToggleUpdateDBHelper}
+                    disabled={readOnly}
                   />
                 }
               />
@@ -529,6 +548,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                   <Toggle
                     checked={helpers.modules_dep}
                     onChange={this.handleToggleModulesDepHelper}
+                    disabled={readOnly}
                   />
                 }
               />
@@ -539,6 +559,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                   <Toggle
                     checked={helpers.devtmpfs_automount}
                     onChange={this.handleToggleAutoMountHelper}
+                    disabled={readOnly}
                   />
                 }
               />
@@ -549,6 +570,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                   <Toggle
                     checked={helpers.network}
                     onChange={this.handleAuthConfigureNetworkHelper}
+                    disabled={readOnly}
                   />
                 }
               />
@@ -557,7 +579,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
         </Grid>
         <Grid item>
           <ActionsPanel>
-            <Button onClick={this.onSubmit} type="primary">
+            <Button onClick={this.onSubmit} type="primary" disabled={readOnly}>
               Submit
             </Button>
             <Button type="secondary" className="cancel" onClick={onClose}>
@@ -780,6 +802,7 @@ interface LinodeContextProps {
   createLinodeConfig: CreateLinodeConfig;
   updateLinodeConfig: UpdateLinodeConfig;
   getLinodeConfig: GetLinodeConfig;
+  readOnly: boolean;
 }
 
 const enhanced = compose<CombinedProps, Props>(
@@ -792,6 +815,7 @@ const enhanced = compose<CombinedProps, Props>(
         _id: `disk-${disk.id}`
       })),
       linodeId: linode.id,
+      readOnly: linode._permissions === 'read_only',
       createLinodeConfig,
       updateLinodeConfig,
       getLinodeConfig

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigs.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigs.tsx
@@ -98,7 +98,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { classes } = this.props;
+    const { classes, readOnly } = this.props;
 
     return (
       <React.Fragment>
@@ -112,6 +112,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
             <AddNewLink
               onClick={this.openConfigDrawerForCreation}
               label="Add a Configuration"
+              disabled={readOnly}
             />
           </Grid>
         </Grid>
@@ -325,6 +326,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
             onBoot={this.handleBoot}
             onEdit={this.openForEditing}
             onDelete={this.confirmDelete}
+            readOnly={this.props.readOnly}
           />
         </TableCell>
       </TableRow>
@@ -347,6 +349,7 @@ interface LinodeContext {
   linodeStatus: string;
   linodeTotalDisk: number;
   deleteLinodeConfig: DeleteLinodeConfig;
+  readOnly: boolean;
 }
 
 const linodeContext = withLinodeDetailContext<LinodeContext>(
@@ -358,6 +361,7 @@ const linodeContext = withLinodeDetailContext<LinodeContext>(
     linodeRegion: linode.region,
     linodeStatus: linode.status,
     linodeTotalDisk: linode.specs.disk,
+    readOnly: linode._permissions === 'read_only',
     deleteLinodeConfig
   })
 );

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskActionMenu.tsx
@@ -4,6 +4,7 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
   linodeStatus: string;
+  readOnly?: boolean;
   onRename: () => void;
   onResize: () => void;
   onImagize: () => void;
@@ -14,15 +15,21 @@ type CombinedProps = Props;
 
 class DiskActionMenu extends React.Component<CombinedProps> {
   createActions = () => (closeMenu: Function): Action[] => {
-    const { linodeStatus } = this.props;
-    const disabledProps =
+    const { linodeStatus, readOnly } = this.props;
+    let tooltip;
+    tooltip =
       linodeStatus === 'offline'
-        ? {}
-        : {
-            tooltip:
-              'Your Linode must be fully powered down in order to perform this action',
-            disabled: true
-          };
+        ? 'Your Linode must be fully powered down in order to perform this action'
+        : undefined;
+    tooltip = readOnly
+      ? "You don't permissions to perform this action"
+      : undefined;
+    const disabledProps = tooltip
+      ? {
+          tooltip,
+          disabled: true
+        }
+      : {};
     const actions = [
       {
         title: 'Rename',
@@ -30,7 +37,8 @@ class DiskActionMenu extends React.Component<CombinedProps> {
           e.preventDefault();
           this.props.onRename();
           closeMenu();
-        }
+        },
+        ...(readOnly ? disabledProps : {})
       },
       {
         title: 'Resize',
@@ -47,7 +55,8 @@ class DiskActionMenu extends React.Component<CombinedProps> {
           e.preventDefault();
           this.props.onImagize();
           closeMenu();
-        }
+        },
+        ...(readOnly ? disabledProps : {})
       },
       {
         title: 'Delete',

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDiskActionMenu.tsx
@@ -22,7 +22,7 @@ class DiskActionMenu extends React.Component<CombinedProps> {
         ? 'Your Linode must be fully powered down in order to perform this action'
         : undefined;
     tooltip = readOnly
-      ? "You don't permissions to perform this action"
+      ? "You don't have permissions to perform this action"
       : undefined;
     const disabledProps = tooltip
       ? {

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDisks.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeDisks.tsx
@@ -194,7 +194,8 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
       error,
       loading,
       linodeStatus,
-      linodeTotalDisk
+      linodeTotalDisk,
+      readOnly
     } = this.props;
 
     return (
@@ -214,6 +215,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
             <AddNewLink
               onClick={this.openDrawerForCreation}
               label="Add a Disk"
+              disabled={readOnly}
             />
           </Grid>
         </Grid>
@@ -266,6 +268,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
     error?: Error,
     data?: Linode.Disk[]
   ) => {
+    const { readOnly } = this.props;
     if (loading) {
       return <TableRowLoading colSpan={3} />;
     }
@@ -292,6 +295,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
             onResize={this.openDrawerForResize(disk)}
             onImagize={this.openImagizeDrawer(disk)}
             onDelete={this.openConfirmDelete(disk)}
+            readOnly={readOnly}
           />
         </TableCell>
       </TableRow>
@@ -728,6 +732,7 @@ interface LinodeContextProps {
   updateLinodeDisk: UpdateLinodeDisk;
   createLinodeDisk: CreateLinodeDisk;
   resizeLinodeDisk: ResizeLinodeDisk;
+  readOnly: boolean;
 }
 
 const linodeContext = withLinodeDetailContext(
@@ -744,7 +749,8 @@ const linodeContext = withLinodeDetailContext(
     deleteLinodeDisk,
     updateLinodeDisk,
     createLinodeDisk,
-    resizeLinodeDisk
+    resizeLinodeDisk,
+    readOnly: linode._permissions === 'read_only'
   })
 );
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettings.tsx
@@ -7,6 +7,7 @@ import {
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { LinodeDetailContextConsumer } from '../linodeDetailContext';
+import LinodePermissionsError from '../LinodePermissionsError';
 import LinodeAdvancedConfigurationsPanel from './LinodeAdvancedConfigurationsPanel';
 import LinodeSettingsAlertsPanel from './LinodeSettingsAlertsPanel';
 import LinodeSettingsDeletePanel from './LinodeSettingsDeletePanel';
@@ -35,9 +36,15 @@ const LinodeSettings: React.StatelessComponent<CombinedProps> = props => {
           return null;
         }
 
+        const permissionsError =
+          linode._permissions === 'read_only' ? (
+            <LinodePermissionsError />
+          ) : null;
+
         return (
           <React.Fragment>
             <DocumentTitleSegment segment={`${linode.label} - Settings`} />
+            {permissionsError}
             <Typography
               variant="h2"
               className={classes.title}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -14,6 +14,7 @@ import Typography from 'src/components/core/Typography';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import PanelErrorBoundary from 'src/components/PanelErrorBoundary';
 import { resetEventsPolling } from 'src/events';
+import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
 import {
   LinodeActionsProps,
   withLinodeActions
@@ -36,6 +37,7 @@ interface State {
 }
 
 type CombinedProps = Props &
+  ContextProps &
   LinodeActionsProps &
   RouteComponentProps<{}> &
   WithStyles<ClassNames>;
@@ -75,6 +77,7 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
   };
 
   render() {
+    const { readOnly } = this.props;
     return (
       <React.Fragment>
         <ExpansionPanel heading="Delete Linode">
@@ -84,6 +87,7 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
             style={{ marginBottom: 8 }}
             onClick={this.openDeleteDialog}
             data-qa-delete-linode
+            disabled={readOnly}
           >
             Delete
           </Button>
@@ -130,8 +134,17 @@ const styled = withStyles(styles);
 
 const errorBoundary = PanelErrorBoundary({ heading: 'Delete Linode' });
 
+interface ContextProps {
+  readOnly: boolean;
+}
+
+const linodeContext = withLinodeDetailContext<ContextProps>(({ linode }) => ({
+  readOnly: linode._permissions === 'read_only'
+}));
+
 const enhanced = compose<CombinedProps, Props>(
   errorBoundary,
+  linodeContext,
   withRouter,
   styled,
   withLinodeActions

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
@@ -78,6 +78,8 @@ class LinodeSettingsLabelPanel extends React.Component<CombinedProps, State> {
     const hasErrorFor = getAPIErrorFor({}, this.state.errors);
     const labelError = hasErrorFor('label');
     const { submitting } = this.state;
+    const { permissions } = this.props;
+    const disabled = permissions === 'read_only';
     const genericError =
       this.state.errors &&
       !labelError &&
@@ -96,7 +98,7 @@ class LinodeSettingsLabelPanel extends React.Component<CombinedProps, State> {
             <Button
               onClick={this.changeLabel}
               type="primary"
-              disabled={submitting && !labelError}
+              disabled={disabled || (submitting && !labelError)}
               loading={submitting && !labelError}
               data-qa-label-save
             >
@@ -116,6 +118,7 @@ class LinodeSettingsLabelPanel extends React.Component<CombinedProps, State> {
           errorGroup="linode-settings-label"
           error={Boolean(labelError)}
           data-qa-label
+          disabled={disabled}
         />
       </ExpansionPanel>
     );
@@ -129,11 +132,13 @@ const errorBoundary = PanelErrorBoundary({ heading: 'Linode Label' });
 interface ContextProps {
   linodeLabel: string;
   updateLinode: UpdateLinode;
+  permissions: Linode.GrantLevel;
 }
 
 const linodeContext = withLinodeDetailContext<ContextProps>(
   ({ linode, updateLinode }) => ({
     linodeLabel: linode.label,
+    permissions: linode._permissions,
     updateLinode
   })
 );

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -13,6 +13,7 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import PanelErrorBoundary from 'src/components/PanelErrorBoundary';
 import Toggle from 'src/components/Toggle';
+import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
 import {
   LinodeActionsProps,
   withLinodeActions
@@ -41,6 +42,7 @@ interface State {
 }
 
 type CombinedProps = Props &
+  ContextProps &
   LinodeActionsProps &
   RouteComponentProps<{}> &
   WithStyles<ClassNames>;
@@ -87,7 +89,9 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
 
   render() {
     const { currentStatus, submitting, success, errors } = this.state;
-    const { classes } = this.props;
+    const { classes, permissions } = this.props;
+
+    const disabled = permissions === 'read_only';
 
     return (
       <React.Fragment>
@@ -117,7 +121,7 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
                   />
                 }
                 label={currentStatus ? 'Enabled' : 'Disabled'}
-                disabled={submitting}
+                disabled={submitting || disabled}
               />
             </Grid>
             <Grid item xs={12} md={10} lg={8} xl={6}>
@@ -155,9 +159,18 @@ const styled = withStyles(styles);
 
 const errorBoundary = PanelErrorBoundary({ heading: 'Delete Linode' });
 
+interface ContextProps {
+  permissions: Linode.GrantLevel;
+}
+
+const linodeContext = withLinodeDetailContext<ContextProps>(({ linode }) => ({
+  permissions: linode._permissions
+}));
+
 export default compose(
   errorBoundary,
   withRouter,
   styled,
-  withLinodeActions
+  withLinodeActions,
+  linodeContext
 )(LinodeWatchdogPanel) as React.ComponentType<Props>;

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -8,6 +8,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import TagsPanel from 'src/components/TagsPanel';
 import styled, { StyleProps } from 'src/containers/SummaryPanels.styles';
@@ -155,11 +156,19 @@ class SummaryPanel extends React.Component<CombinedProps> {
           <Typography variant="h3" className={classes.title} data-qa-title>
             Tags
           </Typography>
-          <TagsPanel
-            tags={linodeTags}
-            updateTags={this.updateTags}
-            disabled={readOnly}
-          />
+          {readOnly ? (
+            <Tooltip title="You don't have permission to modify this Linode">
+              <div>
+                <TagsPanel
+                  tags={linodeTags}
+                  updateTags={this.updateTags}
+                  disabled
+                />
+              </div>
+            </Tooltip>
+          ) : (
+            <TagsPanel tags={linodeTags} updateTags={this.updateTags} />
+          )}
         </Paper>
       </div>
     );

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -98,7 +98,8 @@ class SummaryPanel extends React.Component<CombinedProps> {
       linodeIpv4,
       linodeIpv6,
       backupsEnabled,
-      mostRecentBackup
+      mostRecentBackup,
+      readOnly
     } = this.props;
 
     return (
@@ -154,7 +155,11 @@ class SummaryPanel extends React.Component<CombinedProps> {
           <Typography variant="h3" className={classes.title} data-qa-title>
             Tags
           </Typography>
-          <TagsPanel tags={linodeTags} updateTags={this.updateTags} />
+          <TagsPanel
+            tags={linodeTags}
+            updateTags={this.updateTags}
+            disabled={readOnly}
+          />
         </Paper>
       </div>
     );
@@ -177,6 +182,7 @@ interface LinodeContextProps {
   mostRecentBackup: string | null;
   linodeVolumes: Linode.Volume[];
   backupsEnabled: boolean;
+  readOnly: boolean;
 }
 
 const linodeContext = withLinodeDetailContext(({ linode }) => ({
@@ -187,7 +193,8 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeTags: linode.tags,
   linodeId: linode.id,
   backupsEnabled: linode.backups.enabled,
-  linodeVolumes: linode._volumes
+  linodeVolumes: linode._volumes,
+  readOnly: linode._permissions === 'read_only'
 }));
 
 const enhanced = compose<CombinedProps, {}>(

--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -115,11 +115,15 @@ const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
           linkText="Linodes"
           labelTitle={linode.label}
           labelOptions={{ linkTo: getLabelLink() }}
-          onEditHandlers={{
-            onEdit: handleSubmitLabelChange,
-            onCancel: resetEditableLabel,
-            errorText: editableLabelError
-          }}
+          onEditHandlers={
+            !disabled
+              ? {
+                  onEdit: handleSubmitLabelChange,
+                  onCancel: resetEditableLabel,
+                  errorText: editableLabelError
+                }
+              : undefined
+          }
         />
       </Grid>
       <Grid item className={classes.controls}>

--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -74,6 +74,8 @@ const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
     setEditableLabelError
   } = props;
 
+  const disabled = linode._permissions === 'read_only';
+
   const submitConfigChoice = () => {
     if (configDrawerSelected && configDrawerAction) {
       configDrawerAction(configDrawerSelected);
@@ -127,6 +129,7 @@ const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
           data-qa-launch-console
           disableFocusRipple={true}
           disableRipple={true}
+          disabled={disabled}
         >
           Launch Console
         </Button>
@@ -137,6 +140,7 @@ const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
           label={linode.label}
           noConfigs={linode._configs.length === 0}
           openConfigDrawer={openConfigDrawer}
+          disabled={disabled}
         />
       </Grid>
       <LinodeConfigSelectionDrawer

--- a/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -35,7 +35,8 @@ const LinodesDetailNavigation: React.StatelessComponent<
     linodeLabel,
     linodeConfigs,
     linodeId,
-    linodeRegion
+    linodeRegion,
+    readOnly
   } = props;
 
   const tabs = [
@@ -95,6 +96,7 @@ const LinodesDetailNavigation: React.StatelessComponent<
               linodeLabel={linodeLabel}
               linodeRegion={linodeRegion}
               linodeConfigs={linodeConfigs}
+              readOnly={readOnly}
               {...routeProps}
             />
           )}
@@ -145,6 +147,7 @@ interface ContextProps {
   linodeConfigs: Linode.Config[];
   linodeLabel: string;
   linodeRegion: string;
+  readOnly: boolean;
 }
 
 const enhanced = compose<CombinedProps, {}>(
@@ -153,7 +156,8 @@ const enhanced = compose<CombinedProps, {}>(
     linodeId: linode.id,
     linodeConfigs: linode._configs,
     linodeLabel: linode.label,
-    linodeRegion: linode.region
+    linodeRegion: linode.region,
+    readOnly: linode._permissions === 'read_only'
   }))
 );
 

--- a/src/features/linodes/LinodesDetail/maybeWithExtendedLinode.tsx
+++ b/src/features/linodes/LinodesDetail/maybeWithExtendedLinode.tsx
@@ -1,3 +1,4 @@
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { branch, compose, renderComponent } from 'recompose';
@@ -59,7 +60,10 @@ export default compose<InnerProps, OutterProps>(
           _events: eventsForLinode(events, linodeId),
           _configs: getLinodeConfigsForLinode(linodeConfigs, linodeId),
           _disks: getLinodeDisksForLinode(linodeDisks, linodeId),
-          _permissions: getPermissionsForLinode(profile, linodeId)
+          _permissions: getPermissionsForLinode(
+            pathOr(null, ['data'], profile),
+            linodeId
+          )
         }
       };
     }),

--- a/src/features/linodes/LinodesDetail/maybeWithExtendedLinode.tsx
+++ b/src/features/linodes/LinodesDetail/maybeWithExtendedLinode.tsx
@@ -7,6 +7,7 @@ import { eventsForLinode } from 'src/store/events/event.selectors';
 import { getLinodeConfigsForLinode } from 'src/store/linodes/config/config.selectors';
 import { getLinodeDisksForLinode } from 'src/store/linodes/disk/disk.selectors';
 import { findLinodeById } from 'src/store/linodes/linodes.selector';
+import { getPermissionsForLinode } from 'src/store/linodes/permissions/permissions.selector';
 import { getTypeById } from 'src/store/linodeType/linodeType.selector';
 import { getNotificationsForLinode } from 'src/store/notification/notification.selector';
 import { getVolumesForLinode } from 'src/store/volume/volume.selector';
@@ -43,7 +44,8 @@ export default compose<InnerProps, OutterProps>(
         notifications,
         types,
         linodeConfigs,
-        linodeDisks
+        linodeDisks,
+        profile
       } = __resources;
       const { linode, linodeId } = ownProps;
       const { type } = linode;
@@ -56,7 +58,8 @@ export default compose<InnerProps, OutterProps>(
           _type: getTypeById(types, type),
           _events: eventsForLinode(events, linodeId),
           _configs: getLinodeConfigsForLinode(linodeConfigs, linodeId),
-          _disks: getLinodeDisksForLinode(linodeDisks, linodeId)
+          _disks: getLinodeDisksForLinode(linodeDisks, linodeId),
+          _permissions: getPermissionsForLinode(profile, linodeId)
         }
       };
     }),

--- a/src/features/linodes/LinodesDetail/types.ts
+++ b/src/features/linodes/LinodesDetail/types.ts
@@ -5,4 +5,5 @@ export interface ExtendedLinode extends Linode.Linode {
   _notifications: Linode.Notification[];
   _volumes: Linode.Volume[];
   _type?: null | Linode.LinodeType;
+  _permissions: Linode.GrantLevel;
 }

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -83,8 +83,7 @@ class LinodeActionMenu extends React.Component<CombinedProps, State> {
     const readOnlyProps = readOnly
       ? {
           disabled: true,
-          tooltip:
-            readOnly && "You don't have permissions to modify this Linode"
+          tooltip: readOnly && "You don't have permission to modify this Linode"
         }
       : {};
 
@@ -119,6 +118,10 @@ class LinodeActionMenu extends React.Component<CombinedProps, State> {
         },
         {
           title: 'Resize',
+          disabled: readOnly,
+          tooltip: readOnly
+            ? "You don't have permission to modify this Linode."
+            : undefined,
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             sendEvent({
               category: 'Linode Action Menu Item',
@@ -156,6 +159,10 @@ class LinodeActionMenu extends React.Component<CombinedProps, State> {
         },
         {
           title: 'Delete',
+          disabled: readOnly,
+          tooltip: readOnly
+            ? "You don't have permission to delete this Linode."
+            : undefined,
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             sendEvent({
               category: 'Linode Action Menu Item',
@@ -180,7 +187,7 @@ class LinodeActionMenu extends React.Component<CombinedProps, State> {
             : noConfigs
             ? 'A config needs to be added before powering on a Linode'
             : readOnly
-            ? "You don't have permissions to modify this Linode"
+            ? "You don't have permission to modify this Linode"
             : undefined,
           onClick: e => {
             sendEvent({
@@ -197,6 +204,10 @@ class LinodeActionMenu extends React.Component<CombinedProps, State> {
         actions.unshift(
           {
             title: 'Reboot',
+            disabled: readOnly,
+            tooltip: readOnly
+              ? "You don't have permission to modify this Linode."
+              : undefined,
             onClick: (e: React.MouseEvent<HTMLElement>) => {
               sendEvent({
                 category: 'Linode Action Menu Item',
@@ -274,9 +285,9 @@ const mapStateToProps: MapState<StateProps, CombinedProps> = (
 
 const connected = connect(mapStateToProps);
 
-const enchanced = compose<CombinedProps, Props>(
+const enhanced = compose<CombinedProps, Props>(
   connected,
   withRouter
 );
 
-export default enchanced(LinodeActionMenu);
+export default enhanced(LinodeActionMenu);

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -1,3 +1,4 @@
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'recompose';
@@ -271,8 +272,10 @@ const mapStateToProps: MapState<StateProps, CombinedProps> = (
   ownProps
 ) => ({
   readOnly:
-    getPermissionsForLinode(state.__resources.profile, ownProps.linodeId) ===
-    'read_only'
+    getPermissionsForLinode(
+      pathOr(null, ['__resources', 'profile', 'data'], state),
+      ownProps.linodeId
+    ) === 'read_only'
 });
 
 const connected = connect(mapStateToProps);

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -118,10 +118,6 @@ class LinodeActionMenu extends React.Component<CombinedProps, State> {
         },
         {
           title: 'Resize',
-          disabled: readOnly,
-          tooltip: readOnly
-            ? "You don't have permission to modify this Linode."
-            : undefined,
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             sendEvent({
               category: 'Linode Action Menu Item',
@@ -159,10 +155,6 @@ class LinodeActionMenu extends React.Component<CombinedProps, State> {
         },
         {
           title: 'Delete',
-          disabled: readOnly,
-          tooltip: readOnly
-            ? "You don't have permission to delete this Linode."
-            : undefined,
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             sendEvent({
               category: 'Linode Action Menu Item',

--- a/src/store/linodes/permissions/permissions.selector.ts
+++ b/src/store/linodes/permissions/permissions.selector.ts
@@ -1,0 +1,14 @@
+import { pathOr } from 'ramda';
+import { State } from 'src/store/profile/profile.reducer';
+
+export const getPermissionsForLinode = (
+  profile: State,
+  linodeId: number
+): Linode.GrantLevel => {
+  const linodesGrants = pathOr([], ['data', 'grants', 'linode'], profile);
+  const linodeGrants = linodesGrants.find(
+    (grant: Linode.Grant) => grant.id === linodeId
+  );
+
+  return linodeGrants ? linodeGrants.permissions : 'read_write';
+};

--- a/src/store/linodes/permissions/permissions.selector.ts
+++ b/src/store/linodes/permissions/permissions.selector.ts
@@ -1,11 +1,13 @@
 import { pathOr } from 'ramda';
-import { State } from 'src/store/profile/profile.reducer';
 
 export const getPermissionsForLinode = (
-  profile: State,
+  profile: Linode.Profile | null,
   linodeId: number
 ): Linode.GrantLevel => {
-  const linodesGrants = pathOr([], ['data', 'grants', 'linode'], profile);
+  if (profile === null) {
+    return 'read_write';
+  } // Default to write access
+  const linodesGrants = pathOr([], ['grants', 'linode'], profile);
   const linodeGrants = linodesGrants.find(
     (grant: Linode.Grant) => grant.id === linodeId
   );


### PR DESCRIPTION
## Description

Disable things on Linode Detail if a user only has read access to that Linode. 

## Note to Reviewers

This is a rebuild of Russ's last PR, rebased and with a few additional fixes.

This is already a monstrous PR that's been reviewed multiple times, so I'm going to hold off on one small issue: from the Backups view, in a Backup's action menu, should we disable the "Deploy New Linode" button? I've asked the API team about this and will create a ticket based on what they say. It seems possible that the button should work even for a restricted user.

