### PR TITLE
M3-2631: Fix TSLint warnings

### DIFF
--- a/src/components/PaginationControls/PageNumbers.tsx
+++ b/src/components/PaginationControls/PageNumbers.tsx
@@ -65,10 +65,8 @@ class PageNumbers extends React.PureComponent<Props & StyleProps> {
             {eachPage}
           </PageNumber>
         ))}
-        {/**
-         * if we have more than 5 pages and we're on a page that is
-         * not one of the last 5 pages, show " ... lastPage# "
-         */
+        {/* if we have more than 5 pages and we're on a page that is
+        not one of the last 5 pages, show " ... lastPage# " */
         numOfPages > 5 && currentPage <= numOfPages - 4 ? (
           <React.Fragment>
             <div className={classes.ellipses}>

--- a/src/components/StatusIndicator/index.ts
+++ b/src/components/StatusIndicator/index.ts
@@ -1,2 +1,3 @@
 import { Props as _Props } from './StatusIndicator';
+// tslint:disable-next-line
 export interface Props extends _Props {}

--- a/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -38,7 +38,7 @@ const formatDescription = (desc?: string) => {
   return descChunks.reduce((acc, chunk, i) => {
     const delimiter = i === nameIndex ? ' - \n' : ' - '; // insert line break before long entity name
     if (i === 0) {
-      return chunk; // avoid inserting delimeter for the first element
+      return chunk; // avoid inserting delimiter for the first element
     }
     return acc + delimiter + chunk;
   }, '');
@@ -147,7 +147,7 @@ const addTitle = (doc: jsPDF, title: string) => {
   doc.setFontStyle('normal');
 };
 
-interface pdfResult {
+interface PdfResult {
   status: 'success' | 'error';
   error?: Error;
 }
@@ -156,7 +156,7 @@ export const printInvoice = (
   account: Linode.Account,
   invoice: Linode.Invoice,
   items: Linode.InvoiceItem[]
-): pdfResult => {
+): PdfResult => {
   try {
     const itemsPerPage = 18;
     const date = formatDate(invoice.date, { format: 'YYYY-MM-DD' });
@@ -260,7 +260,6 @@ export const printInvoice = (
       status: 'success'
     };
   } catch (e) {
-    console.error(e);
     reportException(Error('Error while generating Invoice PDF.'), e);
     return {
       status: 'error',
@@ -272,7 +271,7 @@ export const printInvoice = (
 export const printPayment = (
   account: Linode.Account,
   payment: Linode.Payment
-): pdfResult => {
+): PdfResult => {
   try {
     const date = formatDate(payment.date, { format: 'YYYY-MM-DD' });
     const paymentId = payment.id;
@@ -355,7 +354,6 @@ export const printPayment = (
       status: 'success'
     };
   } catch (e) {
-    console.error(e);
     reportException(Error('Error while generating Payment PDF.'), e);
     return {
       status: 'error',

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -151,12 +151,12 @@ class DomainDetail extends React.Component<CombinedProps, State> {
     if (!domainId) {
       return;
     }
-
     getAllWithArguments<Linode.DomainRecord>(getDomainRecords)([+domainId])
       .then(({ data }) => {
         this.setState({ records: data });
+        throw new Error();
       })
-      .catch(console.error);
+      .catch(e => this.setState({ error: e }));
   };
 
   updateDomain = () => {
@@ -172,8 +172,9 @@ class DomainDetail extends React.Component<CombinedProps, State> {
     getDomain(+domainId)
       .then((data: Linode.Domain) => {
         this.setState({ domain: data });
+        throw new Error();
       })
-      .catch(console.error);
+      .catch(e => this.setState({ error: e }));
   };
 
   handleUpdateTags = (tagsList: string[]) => {

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -154,9 +154,9 @@ class DomainDetail extends React.Component<CombinedProps, State> {
     getAllWithArguments<Linode.DomainRecord>(getDomainRecords)([+domainId])
       .then(({ data }) => {
         this.setState({ records: data });
-        throw new Error();
       })
-      .catch(e => this.setState({ error: e }));
+      // tslint:disable-next-line
+      .catch(console.error);
   };
 
   updateDomain = () => {
@@ -172,9 +172,9 @@ class DomainDetail extends React.Component<CombinedProps, State> {
     getDomain(+domainId)
       .then((data: Linode.Domain) => {
         this.setState({ domain: data });
-        throw new Error();
       })
-      .catch(e => this.setState({ error: e }));
+      // tslint:disable-next-line
+      .catch(console.error);
   };
 
   handleUpdateTags = (tagsList: string[]) => {

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -222,8 +222,8 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
   ];
 
   render() {
-    const matches = (p: string) =>
-      Boolean(matchPath(this.props.location.pathname, { path: p }));
+    const matches = (pathName: string) =>
+      Boolean(matchPath(this.props.location.pathname, { path: pathName }));
     const {
       match: { path, url },
       classes

--- a/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/src/features/Profile/APITokens/APITokenTable.tsx
@@ -462,13 +462,13 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
         </TableCell>
         <TableCell parentColumn="Expires">
           <Typography variant="body1" data-qa-token-expiry>
-            {/**
-             * The expiry time of tokens that never expire are returned from the API as
-             * 200 years in the future, so we just need to check that they're at least
-             * 100 years into the future to safely assume they never expire.
-             *
-             * The expiry time of apps that don't expire until revoked come back as 'null'.
-             * In this case, we display an expiry time of "never" as well.
+            {/*
+             The expiry time of tokens that never expire are returned from the API as
+             200 years in the future, so we just need to check that they're at least
+             100 years into the future to safely assume they never expire.
+
+             The expiry time of apps that don't expire until revoked come back as 'null'.
+             In this case, we display an expiry time of "never" as well.
              */
             isWayInTheFuture(token.expiry) || token.expiry === null ? (
               'never'

--- a/src/features/Profile/AuthenticationSettings/ResetPassword.tsx
+++ b/src/features/Profile/AuthenticationSettings/ResetPassword.tsx
@@ -11,9 +11,7 @@ import { LOGIN_ROOT } from 'src/constants';
 
 type ClassNames = 'root' | 'button';
 
-interface Props {}
-
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = WithStyles<ClassNames>;
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {

--- a/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -17,9 +17,10 @@ import UserEventsListItem, {
 const reportUnfoundEvent = (event: Linode.Event) =>
   process.env.NODE_ENV === 'production'
     ? captureException
-    : console.log('Unknown API event received.', {
+    : // tslint:disable-next-line
+      console.log('Unknown API event received.', {
         extra: { event }
-      }); /* tslint:disable-line */
+      });
 
 const reportEventError = (e: Linode.Event, err: Error) =>
   process.env.NODE_ENV === 'production'

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -200,7 +200,7 @@ export const RebuildFromStackScript: React.StatelessComponent<
         />
       )}
       <SelectStackScriptPanel
-        error={hasErrorFor['stackscript_id']}
+        error={hasErrorFor.stackscript_id}
         selectedId={ss.id}
         selectedUsername={ss.username}
         updateFor={[classes, ss.id, errors]}

--- a/src/features/linodes/LinodesDetail/initLinode.ts
+++ b/src/features/linodes/LinodesDetail/initLinode.ts
@@ -1,9 +1,9 @@
 import { connect } from 'react-redux';
 import { compose, lifecycle } from 'recompose';
-import { getLinode } from 'src/store/linodes/linode.requests';
+import { getLinode as _getLinode } from 'src/store/linodes/linode.requests';
 import { GetLinodeRequest } from 'src/store/linodes/linodes.actions';
 
-interface OutterProps {
+interface OuterProps {
   linodeId: number;
 }
 
@@ -11,12 +11,12 @@ interface OutterProps {
  * Get the Linode on mount and on linodeId change.
  */
 
-export default compose<OutterProps, {}>(
+export default compose<OuterProps, {}>(
   connect(
     undefined,
-    { getLinode }
+    { getLinode: _getLinode }
   ),
-  lifecycle<OutterProps & { getLinode: GetLinodeRequest }, void>({
+  lifecycle<OuterProps & { getLinode: GetLinodeRequest }, void>({
     componentDidMount() {
       const { linodeId, getLinode } = this.props;
       getLinode({ linodeId });
@@ -25,7 +25,7 @@ export default compose<OutterProps, {}>(
       const { linodeId: prevLinodeId } = prevProps;
       const { linodeId } = this.props;
       if (linodeId !== prevLinodeId) {
-        getLinode({ linodeId });
+        _getLinode({ linodeId });
       }
     }
   })

--- a/src/services/linodes/getLinodeInfo.ts
+++ b/src/services/linodes/getLinodeInfo.ts
@@ -4,7 +4,7 @@ import Request, { setMethod, setParams, setURL, setXFilter } from '../index';
 
 type Page<T> = Linode.ResourcePage<T>;
 type Type = Linode.LinodeType;
-type Stats = {
+interface Stats {
   data: Linode.Stats;
 }
 

--- a/src/store/events/event.helpers.test.ts
+++ b/src/store/events/event.helpers.test.ts
@@ -280,8 +280,6 @@ describe('event.helpers', () => {
         }
       ]);
     });
-
-    describe('when updating an event', () => {});
   });
 
   describe('updateInProgressEvents', () => {

--- a/src/store/events/event.helpers.ts
+++ b/src/store/events/event.helpers.ts
@@ -13,7 +13,6 @@ type Event = ExtendedEvent;
 export const epoch = new Date(`1970-01-01T00:00:00.000`).getTime();
 
 /**
-
  * Safely find an entity in a list of entities returning the index.
  * Will return -1 if the index is not found.
  *

--- a/src/store/events/event.reducer.test.ts
+++ b/src/store/events/event.reducer.test.ts
@@ -75,12 +75,5 @@ describe('events.reducer', () => {
         });
       });
     });
-
-    describe('UPDATE_EVENTS_AS_SEEN', () => {});
-  });
-
-  describe('async', () => {
-    describe('getEvents', () => {});
-    describe('markAllSeen', () => {});
   });
 });

--- a/src/utilities/isCreditCardExpired.ts
+++ b/src/utilities/isCreditCardExpired.ts
@@ -20,7 +20,7 @@ const expirationDateFromString = (expDate: string /* MM/YYYY */) => {
 };
 
 export const hasExpirationPassedFor = (today: Date = new Date()) => (
-  expDate: string /** MM/YYYY*/
+  expDate: string /** MM/YYYY */
 ) => {
   return today >= expirationDateFromString(expDate);
 };


### PR DESCRIPTION
## Description

** **Please read the notes at the bottom of this description.** **

Fixes the following tslint warnings:

```
WARNING: src/components/PaginationControls/PageNumbers.tsx:69:1 - asterisks in jsdoc must be aligned
WARNING: src/components/PaginationControls/PageNumbers.tsx:70:1 - asterisks in jsdoc must be aligned
WARNING: src/components/PaginationControls/PageNumbers.tsx:71:1 - asterisks in jsdoc must be aligned
WARNING: src/components/StatusIndicator/index.ts:2:18 - An interface declaring no members is equivalent to its supertype.
WARNING: src/features/Billing/PdfGenerator/PdfGenerator.ts:150:11 - Class name must be in pascal case
WARNING: src/features/Billing/PdfGenerator/PdfGenerator.ts:263:5 - Calls to 'console.error' are not allowed.
WARNING: src/features/Billing/PdfGenerator/PdfGenerator.ts:358:5 - Calls to 'console.error' are not allowed.
WARNING: src/features/Domains/DomainDetail.tsx:159:14 - Calls to 'console.error' are not allowed.
WARNING: src/features/Domains/DomainDetail.tsx:176:14 - Calls to 'console.error' are not allowed.
WARNING: src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx:225:22 - Shadowed name: 'p'
WARNING: src/features/Profile/APITokens/APITokenTable.tsx:466:1 - asterisks in jsdoc must be aligned
WARNING: src/features/Profile/APITokens/APITokenTable.tsx:467:1 - asterisks in jsdoc must be aligned
WARNING: src/features/Profile/APITokens/APITokenTable.tsx:468:1 - asterisks in jsdoc must be aligned
WARNING: src/features/Profile/APITokens/APITokenTable.tsx:469:1 - asterisks in jsdoc must be aligned
WARNING: src/features/Profile/APITokens/APITokenTable.tsx:470:1 - asterisks in jsdoc must be aligned
WARNING: src/features/Profile/APITokens/APITokenTable.tsx:471:1 - asterisks in jsdoc must be aligned
WARNING: src/features/Profile/APITokens/APITokenTable.tsx:472:1 - asterisks in jsdoc must be aligned
WARNING: src/features/Profile/AuthenticationSettings/ResetPassword.tsx:14:11 - An empty interface is equivalent to `{}`.
WARNING: src/features/TopMenu/UserEventsMenu/UserEventsList.tsx:20:7 - Calls to 'console.log' are not allowed.
WARNING: src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx:203:28 - object access via string literals is disallowed
WARNING: src/features/linodes/LinodesDetail/initLinode.ts:21:25 - Shadowed name: 'getLinode'
WARNING: src/services/linodes/getLinodeInfo.ts:7:6 - Use an interface instead of a type literal.
WARNING: src/store/events/event.helpers.test.ts:284:46 - block is empty
WARNING: src/store/events/event.helpers.ts:16:1 - asterisks in jsdoc must be aligned
WARNING: src/store/events/event.helpers.ts:16:1 - jsdoc is not formatted correctly on this line
WARNING: src/store/events/event.reducer.test.ts:79:45 - block is empty
WARNING: src/store/events/event.reducer.test.ts:83:33 - block is empty
WARNING: src/store/events/event.reducer.test.ts:84:35 - block is empty
WARNING: src/utilities/isCreditCardExpired.ts:23:19 - jsdoc is not formatted correctly on this line
```


## Note to Reviewers

**To test,** Run `yarn lint`. There should be no errors.

In particular, please check the changes in `DomainDetail.tsx`. All we were doing in `catch` blocks was `console.error`. It was really old code, so I changed it to actually set the error to state.

Also, JSDoc-style comments within JSX don't play well with Prettier and TSLint, so we should avoid these in the future.
