### PR TITLE
M3-2633: Linodes in "Create From Backups" say "Unknown Plan" 

### DIFF
--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -180,6 +180,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
       accountBackupsEnabled,
       classes,
       errors,
+      imagesData,
       privateIPEnabled,
       selectedBackupID,
       selectedDiskSize,
@@ -231,7 +232,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                 error={hasErrorFor('linode_id')}
                 linodes={ramdaCompose(
                   (linodes: Linode.LinodeWithBackups[]) =>
-                    extendLinodes(linodes),
+                    extendLinodes(linodes, imagesData, typesData),
                   filterLinodesWithBackups
                 )(linodesWithBackups!)}
                 selectedLinodeID={selectedLinodeID}


### PR DESCRIPTION
## Description

**This bug only exists on the `develop` branch. It's not in production**.

To reproduce the issue: 

1) Check out the develop branch. 
2) Have a Linode with Backups. 
3) Go to Create Linode > My Images > Backups. 
4) Observe: "Unknown Plan" is present on each Linode.keywords in the pull request title.

The `extendLinodes()` function needed `images` and `types` to work properly,. 