### PR TITLE
M3-2616 Keeping Checkout bar fixed at md breakpoint+

### DIFF
--- a/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/src/components/CheckoutBar/CheckoutBar.tsx
@@ -29,7 +29,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
     minHeight: '24px',
     minWidth: '24px',
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.down('sm')]: {
       position: 'relative !important',
       left: '0 !important',
       bottom: '0 !important',
@@ -48,7 +48,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   sidebarTitle: {
     fontSize: '1.5rem',
-    color: theme.color.green
+    color: theme.color.green,
+    wordBreak: 'break-word'
   },
   detail: {
     fontSize: '.8rem',

--- a/src/components/SelectionCard/SelectionCard.tsx
+++ b/src/components/SelectionCard/SelectionCard.tsx
@@ -227,7 +227,7 @@ class SelectionCard extends React.PureComponent<CombinedProps, {}> {
         item
         xs={12}
         sm={6}
-        md={4}
+        lg={4}
         xl={3}
         tabIndex={0}
         className={classNames({

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -39,7 +39,7 @@ type ClassNames = 'sidebar' | 'emptyImagePanel' | 'emptyImagePanelText';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   sidebar: {
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up('md')]: {
       marginTop: '-130px !important'
     }
   },

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -37,7 +37,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   main: {},
   sidebar: {
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up('md')]: {
       marginTop: '-130px !important'
     }
   }

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -36,12 +36,12 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   main: {},
   sidebarPrivate: {
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up('md')]: {
       marginTop: '-130px !important'
     }
   },
   sidebarPublic: {
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up('md')]: {
       marginTop: '0 !important'
     }
   }

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -36,7 +36,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   main: {},
   sidebar: {
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up('md')]: {
       marginTop: '-130px !important'
     }
   }

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -44,7 +44,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   main: {},
   sidebar: {
-    [theme.breakpoints.up('lg')]: {
+    [theme.breakpoints.up('md')]: {
       marginTop: '-130px !important'
     }
   },

--- a/src/index.css
+++ b/src/index.css
@@ -244,6 +244,7 @@ a.black:not(.nu):active {
   flex-basis: 100%;
   margin-top: 24px !important;
 }
+
 @media (min-width: 960px) {
   .mlMain {
     max-width: 70%;
@@ -254,7 +255,7 @@ a.black:not(.nu):active {
     top: 0;
     align-self: flex-start;
     max-width: 30%;
-    padding: 8px 24px !important;
+    padding: 8px !important;
     margin-top: 0 !important;
   }
 }
@@ -265,6 +266,7 @@ a.black:not(.nu):active {
   }
   .mlSidebar {
     max-width: 21.2%;
+    padding: 8px 24px !important;
   }
 }
 .p0 {

--- a/src/index.css
+++ b/src/index.css
@@ -244,19 +244,27 @@ a.black:not(.nu):active {
   flex-basis: 100%;
   margin-top: 24px !important;
 }
+@media (min-width: 960px) {
+  .mlMain {
+    max-width: 70%;
+    flex-basis: 70%;
+  }
+  .mlSidebar {
+    position: sticky;
+    top: 0;
+    align-self: flex-start;
+    max-width: 30%;
+    padding: 8px 24px !important;
+    margin-top: 0 !important;
+  }
+}
 @media (min-width: 1280px) {
   .mlMain {
     max-width: 78.8%;
     flex-basis: 78.8%;
   }
   .mlSidebar {
-    position: sticky;
-    top: 0;
-    align-self: flex-start;
     max-width: 21.2%;
-    max-width: 21.2%;
-    padding: 8px 24px !important;
-    margin-top: 0 !important;
   }
 }
 .p0 {


### PR DESCRIPTION
## Description

Keeping checkout bar fixed at medium breakpoint + instead of only at larger screens. I also added a word break to the summary title so text won't overflow. 

## Type of Change
- Non breaking change ('update', 'change')
