### PR TITLE
M3-2262 Change: Add "Unattached" or Linode label to Volumes

### DIFF
--- a/src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow.test.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow.test.tsx
@@ -4,16 +4,6 @@ import * as React from 'react';
 import { volumes } from 'src/__data__/volumes';
 import { VolumeDashboardRow } from './VolumeDashboardRow';
 
-const volumeWithLinodeLabel = {
-  ...volumes[2],
-  linodeLabel: 'thisLinode'
-};
-
-const unattachedVolume = {
-  ...volumes[0],
-  linodeLabel: ''
-};
-
 const classes = {
   root: '',
   icon: '',
@@ -26,7 +16,7 @@ const classes = {
 };
 const props = {
   classes,
-  volume: volumeWithLinodeLabel
+  volume: volumes[2]
 };
 
 const component = shallow(<VolumeDashboardRow {...props} />);
@@ -34,21 +24,13 @@ const component = shallow(<VolumeDashboardRow {...props} />);
 describe('Volumes dashboard card', () => {
   it.skip("should show the attached Linode's label for each Volume", () => {
     expect(
-      component
-        .find('[data-qa-attached-linode]')
-        .contains(volumeWithLinodeLabel.label)
+      component.find('[data-qa-attached-linode]').contains('Linode label') // @todo mock this
     ).toBeTruthy();
   });
 
   it('should show Unattached for each unattached Volume', () => {
-    const unattachedProps = { ...props, volume: unattachedVolume };
+    const unattachedProps = { ...props, volume: volumes[0] };
     const unattached = shallow(<VolumeDashboardRow {...unattachedProps} />);
-
-    expect(
-      unattached
-        .find('[data-qa-attached-linode]')
-        .contains(volumeWithLinodeLabel.label)
-    ).toBeFalsy();
     expect(
       unattached.find('[data-qa-attached-linode]').contains('Unattached')
     ).toBeTruthy();

--- a/src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow.test.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow.test.tsx
@@ -1,0 +1,56 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { volumes } from 'src/__data__/volumes';
+import { VolumeDashboardRow } from './VolumeDashboardRow';
+
+const volumeWithLinodeLabel = {
+  ...volumes[2],
+  linodeLabel: 'thisLinode'
+};
+
+const unattachedVolume = {
+  ...volumes[0],
+  linodeLabel: ''
+};
+
+const classes = {
+  root: '',
+  icon: '',
+  labelGridWrapper: '',
+  description: '',
+  labelCol: '',
+  moreCol: '',
+  actionsCol: '',
+  wrapHeader: ''
+};
+const props = {
+  classes,
+  volume: volumeWithLinodeLabel
+};
+
+const component = shallow(<VolumeDashboardRow {...props} />);
+
+describe('Volumes dashboard card', () => {
+  it.skip("should show the attached Linode's label for each Volume", () => {
+    expect(
+      component
+        .find('[data-qa-attached-linode]')
+        .contains(volumeWithLinodeLabel.label)
+    ).toBeTruthy();
+  });
+
+  it('should show Unattached for each unattached Volume', () => {
+    const unattachedProps = { ...props, volume: unattachedVolume };
+    const unattached = shallow(<VolumeDashboardRow {...unattachedProps} />);
+
+    expect(
+      unattached
+        .find('[data-qa-attached-linode]')
+        .contains(volumeWithLinodeLabel.label)
+    ).toBeFalsy();
+    expect(
+      unattached.find('[data-qa-attached-linode]').contains('Unattached')
+    ).toBeTruthy();
+  });
+});

--- a/src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import Hidden from 'src/components/core/Hidden';
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import TableCell from 'src/components/core/TableCell';
+import Typography from 'src/components/core/Typography';
+import EntityIcon from 'src/components/EntityIcon';
+import Grid from 'src/components/Grid';
+import TableRow from 'src/components/TableRow';
+import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
+
+type ClassNames =
+  | 'root'
+  | 'icon'
+  | 'labelGridWrapper'
+  | 'description'
+  | 'labelCol'
+  | 'moreCol'
+  | 'actionsCol'
+  | 'wrapHeader';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  icon: {
+    position: 'relative',
+    top: 3,
+    width: 40,
+    height: 40,
+    '& .circle': {
+      fill: theme.bg.offWhiteDT
+    },
+    '& .outerCircle': {
+      stroke: theme.bg.main
+    }
+  },
+  labelGridWrapper: {
+    paddingLeft: `${theme.spacing.unit / 2}px !important`,
+    paddingRight: `${theme.spacing.unit / 2}px !important`
+  },
+  description: {
+    paddingTop: theme.spacing.unit / 2
+  },
+  labelCol: {
+    width: '50%'
+  },
+  moreCol: {
+    width: '25%'
+  },
+  actionsCol: {
+    width: '10%'
+  },
+  wrapHeader: {
+    wordBreak: 'break-all'
+  }
+});
+
+interface Props {
+  volume: Linode.Volume;
+}
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const getLinodeLabel = (linodeId: number | null) => {
+  if (!linodeId) {
+    return null;
+  }
+  return 'Label';
+};
+
+export const VolumeDashboardRow: React.StatelessComponent<
+  CombinedProps
+> = props => {
+  const {
+    classes,
+    volume: { label, linode_id, region, size }
+  } = props;
+
+  const attachedLinodeLabel = getLinodeLabel(linode_id);
+
+  return (
+    <TableRow key={label} data-qa-volume={label}>
+      <TableCell className={classes.labelCol}>
+        <Grid container wrap="nowrap" alignItems="center">
+          <Grid item className="py0">
+            <EntityIcon variant="volume" />
+          </Grid>
+          <Grid item className={classes.labelGridWrapper}>
+            <Typography
+              role="header"
+              variant="h3"
+              className={classes.wrapHeader}
+              data-qa-label
+            >
+              {label}
+            </Typography>
+            <Typography className={classes.description}>{size} GiB</Typography>
+          </Grid>
+        </Grid>
+      </TableCell>
+      <Hidden xsDown>
+        <TableCell className={classes.moreCol} data-qa-attached-linode>
+          {attachedLinodeLabel ? (
+            <Link to={`/linodes/${linode_id}`}>{attachedLinodeLabel}</Link>
+          ) : (
+            <Typography>Unattached</Typography>
+          )}
+        </TableCell>
+        <TableCell className={classes.moreCol} data-qa-volume-region>
+          <RegionIndicator region={region} />
+        </TableCell>
+      </Hidden>
+    </TableRow>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(VolumeDashboardRow);

--- a/src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumeDashboardRow.tsx
@@ -13,6 +13,7 @@ import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import TableRow from 'src/components/TableRow';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
+import { getEntityByIDFromStore } from 'src/utilities/getEntityByIDFromStore';
 
 type ClassNames =
   | 'root'
@@ -64,11 +65,13 @@ interface Props {
 }
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const getLinodeLabel = (linodeId: number | null) => {
+export const getLinodeLabel = (linodeId: number | null) => {
+  /** default to null unless everything works */
   if (!linodeId) {
     return null;
   }
-  return 'Label';
+  const attachedLinode: any = getEntityByIDFromStore('linode', linodeId);
+  return attachedLinode ? attachedLinode.label : null;
 };
 
 export const VolumeDashboardRow: React.StatelessComponent<

--- a/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
@@ -1,5 +1,6 @@
 import { compose, take } from 'ramda';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { Subscription } from 'rxjs/Subscription';
 import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
@@ -191,34 +192,45 @@ class VolumesDashboardCard extends React.Component<CombinedProps, State> {
   renderData = (data: Linode.Volume[]) => {
     const { classes } = this.props;
 
-    return data.map(({ label, region, size, status }) => (
-      <TableRow key={label} data-qa-volume={label}>
-        <TableCell className={classes.labelCol}>
-          <Grid container wrap="nowrap" alignItems="center">
-            <Grid item className="py0">
-              <EntityIcon variant="volume" />
+    return data.map(({ label, linode_id, region, size, status }) => {
+      const attachedLinodeLabel = getLinodeLabel(linode_id);
+      return (
+        <TableRow key={label} data-qa-volume={label}>
+          <TableCell className={classes.labelCol}>
+            <Grid container wrap="nowrap" alignItems="center">
+              <Grid item className="py0">
+                <EntityIcon variant="volume" />
+              </Grid>
+              <Grid item className={classes.labelGridWrapper}>
+                <Typography
+                  role="header"
+                  variant="h3"
+                  className={classes.wrapHeader}
+                  data-qa-label
+                >
+                  {label}
+                </Typography>
+                <Typography className={classes.description}>
+                  {size} GiB
+                </Typography>
+              </Grid>
             </Grid>
-            <Grid item className={classes.labelGridWrapper}>
-              <Typography
-                variant="h3"
-                className={classes.wrapHeader}
-                data-qa-label
-              >
-                {label}
-              </Typography>
-              <Typography className={classes.description}>
-                {size} GiB
-              </Typography>
-            </Grid>
-          </Grid>
-        </TableCell>
-        <Hidden xsDown>
-          <TableCell className={classes.moreCol} data-qa-volume-region>
-            <RegionIndicator region={region} />
           </TableCell>
-        </Hidden>
-      </TableRow>
-    ));
+          <Hidden xsDown>
+            <TableCell>
+              {attachedLinodeLabel ? (
+                <Link to={`/linodes/${linode_id}`}>{attachedLinodeLabel}</Link>
+              ) : (
+                <Typography>Unattached</Typography>
+              )}
+            </TableCell>
+            <TableCell className={classes.moreCol} data-qa-volume-region>
+              <RegionIndicator region={region} />
+            </TableCell>
+          </Hidden>
+        </TableRow>
+      );
+    });
   };
 }
 
@@ -228,5 +240,12 @@ const enhanced = compose(styled);
 
 const isFoundInData = (id: number, data: Linode.Volume[] = []): boolean =>
   data.reduce((result, volume) => result || volume.id === id, false);
+
+const getLinodeLabel = (linodeId: number | null) => {
+  if (!linodeId) {
+    return null;
+  }
+  return 'Label';
+};
 
 export default enhanced(VolumesDashboardCard) as React.ComponentType<{}>;

--- a/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
@@ -1,8 +1,6 @@
 import { compose, take } from 'ramda';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { Subscription } from 'rxjs/Subscription';
-import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
@@ -11,65 +9,21 @@ import {
 } from 'src/components/core/styles';
 import Table from 'src/components/core/Table';
 import TableBody from 'src/components/core/TableBody';
-import TableCell from 'src/components/core/TableCell';
-import Typography from 'src/components/core/Typography';
-import EntityIcon from 'src/components/EntityIcon';
-import Grid from 'src/components/Grid';
-import TableRow from 'src/components/TableRow';
+
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 import { events$ } from 'src/events';
-import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
 import { getVolumes } from 'src/services/volumes';
 import DashboardCard from '../DashboardCard';
 import ViewAllLink from '../ViewAllLink';
+import VolumeDashboardRow from './VolumeDashboardRow';
 
-type ClassNames =
-  | 'root'
-  | 'icon'
-  | 'labelGridWrapper'
-  | 'description'
-  | 'labelCol'
-  | 'moreCol'
-  | 'actionsCol'
-  | 'wrapHeader';
+type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {},
-  icon: {
-    position: 'relative',
-    top: 3,
-    width: 40,
-    height: 40,
-    '& .circle': {
-      fill: theme.bg.offWhiteDT
-    },
-    '& .outerCircle': {
-      stroke: theme.bg.main
-    }
-  },
-  labelGridWrapper: {
-    paddingLeft: `${theme.spacing.unit / 2}px !important`,
-    paddingRight: `${theme.spacing.unit / 2}px !important`
-  },
-  description: {
-    paddingTop: theme.spacing.unit / 2
-  },
-  labelCol: {
-    width: '50%'
-  },
-  moreCol: {
-    width: '25%'
-  },
-  actionsCol: {
-    width: '10%'
-  },
-  wrapHeader: {
-    wordBreak: 'break-all'
-  }
+  root: {}
 });
-
 interface State {
   loading: boolean;
   errors?: Linode.ApiFieldError[];
@@ -79,7 +33,10 @@ interface State {
 
 type CombinedProps = WithStyles<ClassNames>;
 
-class VolumesDashboardCard extends React.Component<CombinedProps, State> {
+export class VolumesDashboardCard extends React.Component<
+  CombinedProps,
+  State
+> {
   state: State = {
     loading: true
   };
@@ -173,7 +130,12 @@ class VolumesDashboardCard extends React.Component<CombinedProps, State> {
     }
 
     if (data && data.length > 0) {
-      return this.renderData(data);
+      return data.map((volume, idx) => (
+        <VolumeDashboardRow
+          key={`volume-dashboard-row-${idx}`}
+          volume={volume}
+        />
+      ));
     }
 
     return this.renderEmpty();
@@ -188,50 +150,6 @@ class VolumesDashboardCard extends React.Component<CombinedProps, State> {
   );
 
   renderEmpty = () => <TableRowEmptyState colSpan={2} />;
-
-  renderData = (data: Linode.Volume[]) => {
-    const { classes } = this.props;
-
-    return data.map(({ label, linode_id, region, size, status }) => {
-      const attachedLinodeLabel = getLinodeLabel(linode_id);
-      return (
-        <TableRow key={label} data-qa-volume={label}>
-          <TableCell className={classes.labelCol}>
-            <Grid container wrap="nowrap" alignItems="center">
-              <Grid item className="py0">
-                <EntityIcon variant="volume" />
-              </Grid>
-              <Grid item className={classes.labelGridWrapper}>
-                <Typography
-                  role="header"
-                  variant="h3"
-                  className={classes.wrapHeader}
-                  data-qa-label
-                >
-                  {label}
-                </Typography>
-                <Typography className={classes.description}>
-                  {size} GiB
-                </Typography>
-              </Grid>
-            </Grid>
-          </TableCell>
-          <Hidden xsDown>
-            <TableCell className={classes.moreCol}>
-              {attachedLinodeLabel ? (
-                <Link to={`/linodes/${linode_id}`}>{attachedLinodeLabel}</Link>
-              ) : (
-                <Typography>Unattached</Typography>
-              )}
-            </TableCell>
-            <TableCell className={classes.moreCol} data-qa-volume-region>
-              <RegionIndicator region={region} />
-            </TableCell>
-          </Hidden>
-        </TableRow>
-      );
-    });
-  };
 }
 
 const styled = withStyles(styles);
@@ -240,12 +158,5 @@ const enhanced = compose(styled);
 
 const isFoundInData = (id: number, data: Linode.Volume[] = []): boolean =>
   data.reduce((result, volume) => result || volume.id === id, false);
-
-const getLinodeLabel = (linodeId: number | null) => {
-  if (!linodeId) {
-    return null;
-  }
-  return 'Label';
-};
 
 export default enhanced(VolumesDashboardCard) as React.ComponentType<{}>;

--- a/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
@@ -57,10 +57,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     paddingTop: theme.spacing.unit / 2
   },
   labelCol: {
-    width: '70%'
+    width: '50%'
   },
   moreCol: {
-    width: '30%'
+    width: '25%'
   },
   actionsCol: {
     width: '10%'
@@ -217,7 +217,7 @@ class VolumesDashboardCard extends React.Component<CombinedProps, State> {
             </Grid>
           </TableCell>
           <Hidden xsDown>
-            <TableCell>
+            <TableCell className={classes.moreCol}>
               {attachedLinodeLabel ? (
                 <Link to={`/linodes/${linode_id}`}>{attachedLinodeLabel}</Link>
               ) : (

--- a/src/features/Volumes/VolumeTableRow.test.tsx
+++ b/src/features/Volumes/VolumeTableRow.test.tsx
@@ -1,0 +1,61 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { volumes } from 'src/__data__/volumes';
+import { VolumeTableRow } from './VolumeTableRow';
+
+const volumeWithLinodeLabel = {
+  ...volumes[2],
+  linodeLabel: 'thisLinode'
+};
+
+const unattachedVolume = {
+  ...volumes[0],
+  linodeLabel: ''
+};
+
+const classes = {
+  root: '',
+  title: '',
+  labelCol: '',
+  labelStatusWrapper: '',
+  attachmentCol: '',
+  sizeCol: '',
+  pathCol: '',
+  volumesWrapper: '',
+  linodeVolumesWrapper: ''
+};
+
+const props = {
+  classes,
+  volume: volumeWithLinodeLabel,
+  isUpdating: false,
+  isVolumesLanding: true,
+  openForEdit: jest.fn(),
+  openForResize: jest.fn(),
+  openForClone: jest.fn(),
+  openForConfig: jest.fn(),
+  handleAttach: jest.fn(),
+  handleDetach: jest.fn(),
+  handleDelete: jest.fn()
+};
+
+const component = shallow(<VolumeTableRow {...props} />);
+
+describe('Volume table row', () => {
+  it("should show the attached Linode's label if present", () => {
+    expect(
+      component
+        .find('[data-qa-volume-cell-attachment]')
+        .contains(volumeWithLinodeLabel.linodeLabel)
+    ).toBeTruthy();
+  });
+
+  it('should show Unattached if the Volume is not attached to a Linode', () => {
+    const unattachedProps = { ...props, volume: unattachedVolume };
+    const unattached = shallow(<VolumeTableRow {...unattachedProps} />);
+    expect(
+      unattached.find('[data-qa-volume-cell-attachment]').contains('Unattached')
+    ).toBeTruthy();
+  });
+});

--- a/src/features/Volumes/VolumeTableRow.tsx
+++ b/src/features/Volumes/VolumeTableRow.tsx
@@ -113,7 +113,9 @@ const progressFromEvent = (e?: Linode.Event) => {
   return undefined;
 };
 
-const VolumeTableRow: React.StatelessComponent<CombinedProps> = props => {
+export const VolumeTableRow: React.StatelessComponent<
+  CombinedProps
+> = props => {
   const {
     classes,
     isUpdating,

--- a/src/features/Volumes/VolumeTableRow.tsx
+++ b/src/features/Volumes/VolumeTableRow.tsx
@@ -196,13 +196,15 @@ const VolumeTableRow: React.StatelessComponent<CombinedProps> = props => {
           parentColumn="Attached To"
           data-qa-volume-cell-attachment={volume.linodeLabel}
         >
-          {volume.linodeLabel && (
+          {volume.linodeLabel ? (
             <Link
               to={`/linodes/${volume.linode_id}`}
               className="link secondaryLink"
             >
               {volume.linodeLabel}
             </Link>
+          ) : (
+            <Typography>Unattached</Typography>
           )}
         </TableCell>
       )}


### PR DESCRIPTION
## Description

On both Dashboard and VolumesLanding, if a Volume is attached, it has a column with the Linode's label (which links to the Linode). If it is unattached, this column says "Unattached."
