### PR TITLE
DOCS-112: Update - Added "nofail" to VolumeConfigForm.tsx 

### DIFF
--- a/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
@@ -376,7 +376,7 @@ export class VolumeDetail extends Page {
         expect(this.createFileSystemCommand.getAttribute('value')).toEqual(`mkfs.ext4 "/dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}"`);
         expect(this.createMountDirCommand.getAttribute('value')).toEqual(`mkdir "/mnt/${volumeLabel}"`);
         expect(this.mountCommand.getAttribute('value')).toEqual(`mount "/dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}" "/mnt/${volumeLabel}"`);
-        expect(this.mountOnBootCommand.getAttribute('value')).toEqual(`/dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel} /mnt/${volumeLabel} ext4 defaults,noatime 0 2`);
+        expect(this.mountOnBootCommand.getAttribute('value')).toEqual(`/dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel} /mnt/${volumeLabel} ext4 defaults,noatime,nofail 0 2`);
     }
 
     volumeRow(label){

--- a/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
@@ -82,7 +82,7 @@ const VolumeConfigDrawer: React.StatelessComponent<CombinedProps> = props => {
           className={classes.copyField}
           value={`${props.volumePath} /mnt/${
             props.volumeLabel
-          } ext4 defaults,noatime 0 2`}
+          } ext4 defaults,noatime,nofail 0 2`}
           data-qa-boot-mount
         />
       </div>


### PR DESCRIPTION
## Description
Added `nofail` to the default /etc/fstab entry given at creation of new volume.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers
This will allow Linodes to boot normally if there is an existing /etc/fstab entry for an unattached volume.