### PR TITLE
Adding patch to log errors in jasmine test setup

### DIFF
--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -116,7 +116,7 @@ exports.config = {
     sync: true,
     //
     // Level of logging verbosity: silent | verbose | command | data | result | error
-    logLevel: argv.logLevel ? argv.logLevel : 'silent',
+    logLevel: argv.logLevel ? argv.logLevel : 'error',
     //
     // Enables colors for log output.
     coloredLogs: true,
@@ -200,7 +200,8 @@ exports.config = {
         // an assertion fails.
         expectationResultHandler: function(passed, assertion) {
             // do something
-        }
+        },
+        stopOnSpecFailure: true
     },
 
     mountebankConfig: {
@@ -249,7 +250,6 @@ exports.config = {
      * @param {Array.<String>} specs List of spec file paths that are to be run
      */
     before: function (capabilities, specs) {
-        console.log("before");
         // Load up our custom commands
         require('@babel/register');
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "moment-timezone": "^0.5.16",
     "notistack": "^0.4.1",
     "novnc-node": "^0.5.3",
+    "patch-package": "^6.1.0",
+    "postinstall-postinstall": "^2.0.0",
     "pretty-bytes": "^5.1.0",
     "promise": "8.0.1",
     "promise.prototype.finally": "^3.1.0",
@@ -81,6 +83,7 @@
     "zxcvbn": "^4.4.2"
   },
   "scripts": {
+    "postinstall": "patch-package",
     "axe": "npx wdio ./e2e/config/wdio.axe.conf.js",
     "format": "prettier 'src/**/*.{ts,tsx}' --write",
     "compare": "./scripts/jira-changelog.sh",

--- a/patches/wdio-jasmine-framework+0.3.8.patch
+++ b/patches/wdio-jasmine-framework+0.3.8.patch
@@ -1,0 +1,39 @@
+diff --git a/node_modules/wdio-jasmine-framework/build/adapter.js b/node_modules/wdio-jasmine-framework/build/adapter.js
+index 399da8a..399ce33 100644
+--- a/node_modules/wdio-jasmine-framework/build/adapter.js
++++ b/node_modules/wdio-jasmine-framework/build/adapter.js
+@@ -71,6 +71,15 @@ var DEFAULT_TIMEOUT_INTERVAL = 60000;
+  * Jasmine 2.x runner
+  */
+ 
++class HookError extends Error {
++    constructor(message) {
++      super(message);
++      this.name = 'HookError';
++    }
++}
++
++var _hookException = null;
++
+ var JasmineAdapter = function () {
+     function JasmineAdapter(cid, config) {
+         var specs = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
+@@ -162,6 +171,7 @@ var JasmineAdapter = function () {
+                                             return specFn.call(this).then(function () {
+                                                 return done();
+                                             }, function (e) {
++                                                _hookException = new HookError(e.stack);
+                                                 return done.fail(e);
+                                             });
+                                         };
+@@ -242,6 +252,10 @@ var JasmineAdapter = function () {
+                             case 25:
+                                 result = _context.sent;
+                                 _context.next = 28;
++                                if (_hookException != null) {
++                                    console.error(_hookException);
++                                    _hookException = null;
++                                }
+                                 return _get__('executeHooksWithArgs')(this.config.after, [result, this.capabilities, this.specs]);
+ 
+                             case 28:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2782,6 +2782,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -6978,6 +6983,14 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 find@^0.2.8:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/find/-/find-0.2.9.tgz#4b73f1ff9e56ad91b76e716407fe5ffe6554bb8c"
@@ -7162,6 +7175,15 @@ fs-extra@^0.30.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^5.0.0:
   version "5.0.0"
@@ -9695,6 +9717,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -11530,6 +11559,25 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+patch-package@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.1.0.tgz#80985dc5c2042c42bcf34c8c35622ce95e5c16dc"
+  integrity sha512-YbnG+p2d96E5A/WJ7kNJRWegpxyN7L0BWZ7FnYwC3ighfD2nr3vZYvl33oJmL9ZrFEP1bhQvJPV6iKHdRIro7A==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    update-notifier "^2.5.0"
+
 path-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -11873,6 +11921,11 @@ postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.5, postcss@^7.0.6:
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postinstall-postinstall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postinstall-postinstall/-/postinstall-postinstall-2.0.0.tgz#7ba6711b4420575c4f561638836a81faad47f43f"
+  integrity sha512-3f6qWexsHiT4WKtZc5DRb0FPLilHtARi5KpY4fqban/DJNn8/YhZH8U7dVKVz51WbOxEnR31gV+qYQhvEdHtdQ==
 
 precinct@^6.1.1:
   version "6.1.1"
@@ -13279,7 +13332,7 @@ rgbcolor@^1.0.1:
   resolved "https://registry.yarnpkg.com/rgbcolor/-/rgbcolor-1.0.1.tgz#d6505ecdb304a6595da26fa4b43307306775945d"
   integrity sha1-1lBezbMEplldom+ktDMHMGd1lF0=
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
+rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
@@ -15171,7 +15224,7 @@ upath@^1.0.5, upath@^1.1.0:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
   integrity sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==
 
-update-notifier@^2.3.0:
+update-notifier@^2.3.0, update-notifier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
   integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==


### PR DESCRIPTION
## Description

Patches wdio-jasmine-framework to log exceptions in test hooks so they're not swallowed.

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relavant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/search/search-tags.spec.js --browser=headlessChrome`

Make sure test runs and passes.

## Note to Reviewers

If sufficiently motivated, drop the following code into an `example.spec.js` file:

```
describe('test suite 1', () => {
    let b = false;
    beforeAll(() => {        
        throw new Error("problem in beforeAll");
        b = true;
    });
    it('test case 1', () => {
        console.log("test case 1");
        expect(b).toBe(true);
    });
    it('test case 2', () => {
        console.log("test case 2");
        expect(b).toBe(true);
    });
});
```

Then do `yarn e2e --spec=example.spec.js --browser=headlessChrome` and verify you get a stacktrace in your log similar to:

```
{ HookError: Error: problem in beforeAll
    at UserContext.<anonymous> (/Users/bschmaus/code/manager/e2e/specs/tmp/ex-test.spec.js:6:15)
    at new Promise (<anonymous>)
    at new F (/Users/bschmaus/code/manager/node_modules/babel-runtime/node_modules/core-js/library/modules/_export.js:36:28)
    at /Users/bschmaus/code/manager/node_modules/wdio-jasmine-framework/build/adapter.js:174:66
    at <anonymous> name: 'HookError' }
```

Note that if you run the same example spec in `develop` (or any other branch without the patch) you won't see that the exception occurred and will just see assertion failures from the test cases.