### PR TITLE
M3-2618 Fix user events dropdown items styles

### DIFF
--- a/src/features/TopMenu/UserEventsMenu/UserEventsListItem.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsListItem.tsx
@@ -8,7 +8,13 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 
-type ClassNames = 'root' | 'title' | 'content' | 'unread' | 'pointer';
+type ClassNames =
+  | 'root'
+  | 'title'
+  | 'content'
+  | 'unread'
+  | 'pointer'
+  | 'noLink';
 
 const styles: StyleRulesCallback<ClassNames> = theme => {
   const {
@@ -24,10 +30,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
       transition: theme.transitions.create(['border-color', 'opacity']),
       outline: 0,
       '&:hover, &:focus': {
-        backgroundColor: theme.palette.primary.main,
-        '& $title, & $content': {
-          color: 'white'
-        }
+        backgroundColor: 'transparent'
       }
     },
     title: {
@@ -36,10 +39,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
     content: {
       ...theme.typography.body1
     },
-    unread: {
-      backgroundColor: theme.bg.main,
-      opacity: 1
-    },
+    unread: {},
     warning: {
       borderLeftColor: status.warningDark
     },
@@ -47,8 +47,19 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
       borderLeftColor: status.successDark
     },
     pointer: {
+      '&:hover, &:focus': {
+        backgroundColor: theme.palette.primary.main,
+        '& $title, & $content': {
+          color: 'white'
+        }
+      },
       '& > h3': {
         lineHeight: '1.2'
+      }
+    },
+    noLink: {
+      '& $title': {
+        opacity: '.5'
       }
     }
   };
@@ -83,7 +94,8 @@ const userEventsListItem: React.StatelessComponent<CombinedProps> = props => {
         {
           [classes.root]: true,
           [classes.unread]: error || warning || success,
-          [classes.pointer]: Boolean(onClick)
+          [classes.pointer]: Boolean(onClick),
+          [classes.noLink]: Boolean(!onClick)
         },
         className
       )}


### PR DESCRIPTION
## Fix user events dropdown items styles

The styles for user events drop down needed to be updated as there was hover states for items that had no link. I also made sure these no links items had less opacity in order to differentiate them from clickable events.

<img width="438" alt="Screen Shot 2019-04-03 at 3 21 22 PM" src="https://user-images.githubusercontent.com/205353/55506750-3afd4900-5624-11e9-9fdf-4769ea84aefe.png">

updated version ^