### PR TITLE
M3-2645 Fix Select Image

### DIFF
--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -144,13 +144,11 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   componentDidMount() {
     const params = getParamsFromUrl(this.props.location.search);
     if (params && params !== {}) {
+      console.log(params.backupID);
       this.setState({
         // This set is for creating from a Backup
         selectedBackupID: params.backupID,
-        selectedLinodeID: params.linodeID,
-
-        // This is for coming from ImagesLanding (where a private Image will be preselected)
-        selectedImageID: params.imageID
+        selectedLinodeID: params.linodeID
       });
     }
     this.setState({ appInstancesLoading: true });

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -144,7 +144,6 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   componentDidMount() {
     const params = getParamsFromUrl(this.props.location.search);
     if (params && params !== {}) {
-      console.log(params.backupID);
       this.setState({
         // This set is for creating from a Backup
         selectedBackupID: params.backupID,

--- a/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectImagePanel.tsx
@@ -22,6 +22,8 @@ import Panel from './Panel';
 import PrivateImages from './PrivateImages';
 import PublicImages from './PublicImages';
 
+import { getParamFromUrl } from 'src/utilities/queryParams';
+
 interface Props {
   images: Linode.Image[];
   title?: string;
@@ -75,70 +77,90 @@ export const getMyImages = compose<any, any, any>(
 
 type CombinedProps = Props;
 
-const CreateFromImage: React.StatelessComponent<CombinedProps> = props => {
-  const {
-    images,
-    error,
-    handleSelection,
-    disabled,
-    title,
-    variant,
-    selectedImageID
-  } = props;
-  const publicImages = getPublicImages(images);
-  const olderPublicImages = getOlderPublicImages(images);
-  const myImages = getMyImages(images);
+class CreateFromImage extends React.PureComponent<CombinedProps> {
+  componentDidMount() {
+    const imageIDFromURL = getParamFromUrl(location.search, 'imageID');
+    if (!!imageIDFromURL) {
+      this.props.handleSelection(imageIDFromURL);
+    }
+  }
 
-  const Public = (
-    <Panel error={error} title={title}>
-      <PublicImages
-        images={publicImages}
-        oldImages={olderPublicImages}
-        disabled={disabled}
-        handleSelection={handleSelection}
-        selectedImageID={selectedImageID}
-      />
-    </Panel>
-  );
+  Public = () => {
+    const {
+      images,
+      error,
+      handleSelection,
+      disabled,
+      title,
+      selectedImageID
+    } = this.props;
+    const publicImages = getPublicImages(images);
+    const olderPublicImages = getOlderPublicImages(images);
+    return (
+      <Panel error={error} title={title}>
+        <PublicImages
+          images={publicImages}
+          oldImages={olderPublicImages}
+          disabled={disabled}
+          handleSelection={handleSelection}
+          selectedImageID={selectedImageID}
+        />
+      </Panel>
+    );
+  };
 
-  const Private = (
-    <Panel error={error} title={title}>
-      <PrivateImages
-        images={myImages}
-        disabled={disabled}
-        handleSelection={handleSelection}
-        selectedImageID={selectedImageID}
-      />
-    </Panel>
-  );
+  Private = () => {
+    const {
+      images,
+      error,
+      handleSelection,
+      disabled,
+      title,
+      selectedImageID
+    } = this.props;
+    const myImages = getMyImages(images);
+    return (
+      <Panel error={error} title={title}>
+        <PrivateImages
+          images={myImages}
+          disabled={disabled}
+          handleSelection={handleSelection}
+          selectedImageID={selectedImageID}
+        />
+      </Panel>
+    );
+  };
 
-  const tabs = [
+  tabs = [
     {
       title: 'Public Images',
-      render: () => Public
+      render: () => this.Public()
     },
     {
       title: 'My Images',
-      render: () => Private
+      render: () => this.Private()
     }
   ];
 
-  switch (variant) {
-    case 'private':
-      return Private;
-    case 'public':
-      return Public;
-    case 'all':
-    default:
-      return (
-        <TabbedPanel
-          error={error}
-          header="Select Image"
-          tabs={tabs}
-          initTab={props.initTab}
-        />
-      );
+  render() {
+    const { error, variant } = this.props;
+    switch (variant) {
+      case 'private':
+        return this.Private();
+      case 'public':
+        return this.Public();
+      case 'all':
+      default:
+        return (
+          <TabbedPanel
+            error={error}
+            header="Select Image"
+            tabs={this.tabs}
+            initTab={this.props.initTab}
+          />
+        );
+    }
   }
-};
+}
 
 export default RenderGuard<Props>(CreateFromImage);


### PR DESCRIPTION
## Description

Fixes issue where Linode Image was being un-selected on cDM if no `imageID` query param existed in the URL

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

To run relavant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/create/create-linode.spec.js,e2e/specs/create/smoke-configure-linode.spec.js --browser=headlessChrome`

^^^ You will get failures, but the tests are fixed in https://github.com/linode/manager/pull/4772/files. If you rebase with that branch, you'll see the tests pass