### PR TITLE
Password Helper Text Display Issue

### DIFF
--- a/src/components/AccessPanel/AccessPanel.tsx
+++ b/src/components/AccessPanel/AccessPanel.tsx
@@ -100,6 +100,7 @@ interface Props {
   className?: string;
   small?: boolean;
   isOptional?: boolean;
+  hideHelperText?: boolean;
 }
 
 export interface UserSSHKeyObject {
@@ -130,7 +131,8 @@ class AccessPanel extends React.Component<CombinedProps> {
       hideStrengthLabel,
       className,
       small,
-      isOptional
+      isOptional,
+      hideHelperText
     } = this.props;
 
     return (
@@ -157,6 +159,7 @@ class AccessPanel extends React.Component<CombinedProps> {
             placeholder={placeholder || 'Enter a password.'}
             onChange={this.handleChange}
             hideStrengthLabel={hideStrengthLabel}
+            hideHelperText={hideHelperText}
           />
           {users && users.length > 0 && this.renderUserSSHKeyTable(users)}
         </div>

--- a/src/components/PasswordInput/PasswordInput.tsx
+++ b/src/components/PasswordInput/PasswordInput.tsx
@@ -17,7 +17,7 @@ type Props = TextFieldProps & {
   required?: boolean;
   disabledReason?: string;
   hideStrengthLabel?: boolean;
-  showHelperText?: boolean;
+  hideHelperText?: boolean;
 };
 
 interface State {
@@ -75,7 +75,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
       required,
       disabledReason,
       hideStrengthLabel,
-      showHelperText,
+      hideHelperText,
       ...rest
     } = this.props;
 
@@ -99,7 +99,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
             />
           </Grid>
         </Grid>
-        {showHelperText && (
+        {!hideHelperText && (
           <Typography variant="body1" className={classes.infoText}>
             Password must be at least 6 characters and contain each of the
             following characters: uppercase, lowercase, numeric, and special

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
@@ -70,6 +70,7 @@ class UserDefinedText extends React.Component<CombinedProps, {}> {
         hideStrengthLabel
         className={!isOptional ? classes.accessPanel : ''}
         isOptional={isOptional}
+        hideHelperText
       />
     );
   };


### PR DESCRIPTION
## Description

Hiding password helper text for UDF passwords only (root password for create linode should display helper text)

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Can view UDF Passwords by viewing a StackScript that has those fields (search for 'basic security' and select the first option)
