### PR TITLE
Paypal Sentry Reporting

### DIFF
--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -385,7 +385,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
         return response.checkout_token;
       })
       .catch(errorResponse => {
-        /** For senty purposes only */
+        /** For sentry purposes only */
         const cleanedError = getAPIErrorOrDefault(
           errorResponse,
           'Something went wrong with the call to Linode /v4/account/paypal. See tags for USD info'

--- a/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -20,6 +20,7 @@
  *
  */
 
+import { captureException, configureScope } from '@sentry/browser';
 import * as classNames from 'classnames';
 import { pathOr } from 'ramda';
 import * as React from 'react';
@@ -384,6 +385,21 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
         return response.checkout_token;
       })
       .catch(errorResponse => {
+        /** For senty purposes only */
+        const cleanedError = getAPIErrorOrDefault(
+          errorResponse,
+          'Something went wrong with the call to Linode /v4/account/paypal. See tags for USD info'
+        )[0].reason;
+
+        /**
+         * Send the error off to sentry with the USD amount in the tags
+         */
+        configureScope(scope => {
+          scope.setExtra('Raw USD', usd);
+          scope.setExtra('USD converted to number', (+usd).toFixed(2));
+        });
+        captureException(cleanedError);
+
         this.setState({
           isStagingPaypalPayment: false,
           paypalPaymentFailed: true


### PR DESCRIPTION
## Description

Send some more useful data to Sentry in the event of a Paypal failure

## Type of Change
- Non breaking change ('update', 'change')

Please reach out if you need access to sentry, but this is what the error looks like:

![Screen Shot 2019-04-04 at 9 49 54 AM](https://user-images.githubusercontent.com/7387001/55560811-08ecf500-56bf-11e9-9d9f-f88aa5a85d84.png)
![Screen Shot 2019-04-04 at 9 50 03 AM](https://user-images.githubusercontent.com/7387001/55560827-130ef380-56bf-11e9-9109-eac8f712e20a.png)

