### PR TITLE
M3-2614 Remove the word Summary from the Linode Creation flow

### DIFF
--- a/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -324,6 +324,13 @@ class FromAppsContent extends React.PureComponent<CombinedProps> {
                 displaySections.push(typeDisplayInfo);
               }
 
+              if (label) {
+                displaySections.push({
+                  title: 'Linode Label',
+                  details: label
+                });
+              }
+
               if (
                 hasBackups &&
                 typeDisplayInfo &&
@@ -348,7 +355,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps> {
 
               return (
                 <CheckoutBar
-                  heading={`${label || 'Linode'} Summary`}
+                  heading="Linode Summary"
                   calculatedPrice={calculatedPrice}
                   isMakingRequest={formIsSubmitting}
                   disabled={formIsSubmitting || userCannotCreateLinode}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -320,6 +320,13 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                   displaySections.push(typeDisplayInfo);
                 }
 
+                if (label) {
+                  displaySections.push({
+                    title: 'Linode Label',
+                    details: label
+                  });
+                }
+
                 if (
                   hasBackups &&
                   typeDisplayInfo &&
@@ -344,7 +351,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
 
                 return (
                   <CheckoutBar
-                    heading={`${label || 'Linode'} Summary`}
+                    heading="Linode Summary"
                     calculatedPrice={calculatedPrice}
                     isMakingRequest={isGettingBackups}
                     disabled={disabled}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -260,6 +260,13 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
                 displaySections.push(typeDisplayInfo);
               }
 
+              if (this.props.label) {
+                displaySections.push({
+                  title: 'Linode Label',
+                  details: this.props.label
+                });
+              }
+
               if (
                 hasBackups &&
                 typeDisplayInfo &&
@@ -285,7 +292,7 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
               return (
                 <CheckoutBar
                   data-qa-checkout-bar
-                  heading={`${this.props.label || 'Linode'} Summary`}
+                  heading="Linode Summary"
                   calculatedPrice={calculatedPrice}
                   isMakingRequest={this.props.formIsSubmitting}
                   disabled={

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -192,6 +192,13 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
                     displaySections.push(typeInfo);
                   }
 
+                  if (label) {
+                    displaySections.push({
+                      title: 'Linode Label',
+                      details: label
+                    });
+                  }
+
                   if (hasBackups && typeInfo && typeInfo.backupsMonthly) {
                     displaySections.push(
                       renderBackupsDisplaySection(
@@ -208,7 +215,7 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
 
                   return (
                     <CheckoutBar
-                      heading={`${label || 'Linode'} Summary`}
+                      heading="Linode Summary"
                       calculatedPrice={calculatedPrice}
                       isMakingRequest={this.props.formIsSubmitting}
                       disabled={

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -353,6 +353,13 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
                 displaySections.push(typeDisplayInfo);
               }
 
+              if (label) {
+                displaySections.push({
+                  title: 'Linode Label',
+                  details: label
+                });
+              }
+
               if (hasBackups && typeDisplayInfo && backupsMonthlyPrice) {
                 displaySections.push(
                   renderBackupsDisplaySection(
@@ -369,7 +376,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
 
               return (
                 <CheckoutBar
-                  heading={`${label || 'Linode'} Summary`}
+                  heading="Linode Summary"
                   calculatedPrice={calculatedPrice}
                   isMakingRequest={this.props.formIsSubmitting}
                   disabled={this.props.formIsSubmitting || disabled}


### PR DESCRIPTION
## Description

Summary header is now static, adding label as a display section underneath by order of section within the create flow. 

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

<img width="309" alt="Screen Shot 2019-04-04 at 12 10 00 PM" src="https://user-images.githubusercontent.com/2565527/55571176-fc729780-56d2-11e9-82e5-ead70b497269.png">

