### PR TITLE
Instruct user to run mongo if parallelRunners > 1 and CRED_STORE_MODE…

### DIFF
--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -57,7 +57,7 @@ const credStores = {
     mongolocal: new MongoCredStore('localhost')
 };
 
-let CRED_STORE_MODE = process.env.CRED_STORE_MODE;
+let CRED_STORE_MODE = process.env.CRED_STORE_MODE ? process.env.CRED_STORE_MODE : 'fs';
 console.log("process.env.CRED_STORE_MODE set to: " + CRED_STORE_MODE);
 
 if (!(CRED_STORE_MODE in credStores)) {

--- a/e2e/utils/fs-cred-store.js
+++ b/e2e/utils/fs-cred-store.js
@@ -12,7 +12,7 @@ class FSCredStore extends CredStore {
     constructor(credsFile, shouldCleanupUsingAPI, browser) {
         super(shouldCleanupUsingAPI, browser);
         this.credsFile = credsFile;
-        console.log(this);
+        //console.log(this);
     }
 
     _readCredsFile() {

--- a/e2e/utils/mongo-cred-store.js
+++ b/e2e/utils/mongo-cred-store.js
@@ -11,7 +11,7 @@ class MongoCredStore extends CredStore {
 
     constructor(dbHost, shouldCleanupUsingAPI, browser) {
         super(shouldCleanupUsingAPI, browser);
-        console.log("connecting to mongodb host: " + dbHost);
+        //console.log("connecting to mongodb host: " + dbHost);
 
         // Connection URL
         this.dbUrl = 'mongodb://' + dbHost + ':27017';
@@ -19,7 +19,7 @@ class MongoCredStore extends CredStore {
         // Database Name
         this.dbName = 'test-credentials';
         this.collectionName = 'users';
-        console.log(this);
+        //console.log(this);
     }
 
     // return MongoClient for use in chained promises


### PR DESCRIPTION
… set to fs

## Description

If user has CRED_STORE_MODE set to fs (which is the default) and parallelRunners is set to more than 1, error out with a helpful message instructing the user to set CRED_STORE_MODE to 'mongolocal' and provides CLI for running mongo locally via docker.

## Type of Change
- Non-breaking change

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=COMMA_SEPARATED_LIST_OF_SPECS_HERE --browser=headlessChrome`

## Note to Reviewers

Remove CRED_STORE_MODE env var from `.env` or set to `fs`.  Make sure you have more than one user configured in your `.env`.  Then run `source .env && yarn e2e --smoke`.  You should see output similar to the following:

```
yarn run v1.13.0
$ npx wdio ./e2e/config/wdio.conf.js --smoke
parallel runners: 2
process.env.CRED_STORE_MODE set to: fs

onPrepare
***** Can't use filesystem cred store when parallelRunners > 1.
***** Set CRED_STORE_MODE=mongolocal in .env and launch mongodb by running: docker run -d -p 27017:27017 mongo
error Command failed with exit code 1.
```

Change CRED_STORE_MODE to `mongolocal`, launch mongo by running ` docker run -d -p 27017:27017 mongo` and re-run tests.  They should all run.  (And hopefully pass!)