### PR TITLE
M3-2620 Adjust spacing for add buttons for domain records

### DIFF
--- a/src/components/IconTextLink/IconTextLink.tsx
+++ b/src/components/IconTextLink/IconTextLink.tsx
@@ -18,7 +18,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     padding: theme.spacing.unit + theme.spacing.unit / 2,
     color: theme.palette.primary.main,
     transition: theme.transitions.create(['color']),
-    margin: `0 -${theme.spacing.unit + theme.spacing.unit / 2}px 4px 0`,
+    margin: `0 -${theme.spacing.unit + theme.spacing.unit / 2}px 2px 0`,
     minHeight: 'auto',
     '&:hover': {
       color: theme.palette.primary.light,
@@ -48,8 +48,6 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     fontSize: 18,
     marginRight: theme.spacing.unit + 1,
     color: theme.palette.primary.main,
-    position: 'relative',
-    top: 2,
     '& .border': {
       transition: theme.transitions.create(['color'])
     }

--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -63,7 +63,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   linkContainer: {
     position: 'relative',
-    top: 10,
+    top: theme.spacing.unit + 2,
     [theme.breakpoints.down('xs')]: {
       top: -10,
       '& button': {


### PR DESCRIPTION
## Adjust spacing for add buttons for domain records (compact mode)

Buttons were too close to the table on compact mode

<img width="208" alt="Screen Shot 2019-04-05 at 4 23 47 PM" src="https://user-images.githubusercontent.com/205353/55654370-3751f980-57bf-11e9-9893-9588db18ae72.png">
