### PR TITLE
M3-2602 List all IP Addresses in summary panel

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -134,11 +134,11 @@ class SummaryPanel extends React.Component<CombinedProps> {
             IP Addresses
           </Typography>
           <div className={classes.section}>
-            <IPAddress ips={linodeIpv4} copyRight showMore />
+            <IPAddress ips={linodeIpv4} copyRight showAll />
           </div>
           {linodeIpv6 && (
             <div className={classes.section}>
-              <IPAddress ips={[linodeIpv6]} copyRight showMore />
+              <IPAddress ips={[linodeIpv6]} copyRight showAll />
             </div>
           )}
         </Paper>

--- a/src/features/linodes/LinodesLanding/IPAddress.test.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.test.tsx
@@ -14,6 +14,7 @@ const classes = {
   right: '',
   icon: '',
   row: '',
+  multipleAddresses: '',
   ip: '',
   ipLink: '',
   hide: 'hide'
@@ -24,7 +25,8 @@ const component = shallow(
 );
 
 describe('IPAddress', () => {
-  it('should render without error and display and IP address', () => {
+  it('should render without error and display one IP address if showAll is false', () => {
+    component.setProps({ showMore: true, showAll: false });
     const rendered = component.find('[data-qa-ip-main]');
     const ipText = rendered.text();
 
@@ -32,7 +34,8 @@ describe('IPAddress', () => {
     expect(ipText).toBe('8.8.8.8');
   });
 
-  it('should not display ShowMore button unless the showMore prop is passed', () => {
+  it('should not display ShowMore button unless the showMore prop is true', () => {
+    component.setProps({ showMore: false, showAll: false });
     expect(component.find('[data-qa-ip-more]')).toHaveLength(0);
   });
 

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -15,6 +15,7 @@ type CSSClasses =
   | 'right'
   | 'icon'
   | 'row'
+  | 'multipleAddresses'
   | 'ip'
   | 'ipLink'
   | 'hide';
@@ -49,6 +50,11 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     display: 'flex',
     alignItems: 'flex-start',
     width: '100%'
+  },
+  multipleAddresses: {
+    '&:not(:last-child)': {
+      marginBottom: theme.spacing.unit
+    }
   },
   left: {
     marginLeft: theme.spacing.unit
@@ -91,6 +97,7 @@ interface Props {
   copyRight?: boolean;
   showCopyOnHover?: boolean;
   showMore?: boolean;
+  showAll?: boolean;
 }
 
 const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
@@ -134,9 +141,12 @@ export class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
   };
 
   renderIP = (ip: string, copyRight?: Boolean, key?: number) => {
-    const { classes } = this.props;
+    const { classes, showAll } = this.props;
     return (
-      <div key={key} className={classes.row}>
+      <div
+        key={key}
+        className={`${classes.row} ${showAll && classes.multipleAddresses}`}
+      >
         <div className={`${classes.ip} ${'ip xScroll'}`} data-qa-ip-main>
           {ip}
         </div>
@@ -146,16 +156,21 @@ export class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
   };
 
   render() {
-    const { classes, ips, copyRight, showMore } = this.props;
+    const { classes, ips, copyRight, showMore, showAll } = this.props;
 
     const formattedIPS = ips
       .map(ip => ip.replace('/64', ''))
       .sort(sortIPAddress);
 
     return (
-      <div className={`dif ${classes.root}`}>
-        {this.renderIP(formattedIPS[0], copyRight)}
-        {formattedIPS.length > 1 && showMore && (
+      <div className={`${!showAll && 'dif'} ${classes.root}`}>
+        {!showAll && showMore
+          ? this.renderIP(formattedIPS[0], copyRight)
+          : formattedIPS.map((a, i) => {
+              return this.renderIP(a, copyRight, i);
+            })}
+
+        {formattedIPS.length > 1 && showMore && !showAll && (
           <ShowMore
             items={tail(formattedIPS)}
             render={(ipsAsArray: string[]) => {

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -164,7 +164,7 @@ export class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
 
     return (
       <div className={`${!showAll && 'dif'} ${classes.root}`}>
-        {!showAll && showMore
+        {!showAll
           ? this.renderIP(formattedIPS[0], copyRight)
           : formattedIPS.map((a, i) => {
               return this.renderIP(a, copyRight, i);


### PR DESCRIPTION
## List all IP Addresses in summary panel

We want to show all IP addresses on the sidebar component of the Linode listing page. Added a showAll prop in order to do that. The summary panel is the only place where we want to do that. The table rows should remain identical.

## Type of Change
- Non breaking change ('update')
