### PR TITLE
M3-2659 Avoid Object Storage text wrap in primary menu on compact mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,7 +138,7 @@ const styles: StyleRulesCallback = theme => ({
   content: {
     flex: 1,
     [theme.breakpoints.up('md')]: {
-      marginLeft: theme.spacing.unit * 17 + 79 // 215
+      marginLeft: theme.spacing.unit * 15 + 95 // 215
     },
     [theme.breakpoints.up('xl')]: {
       marginLeft: theme.spacing.unit * 22 + 99 // 275

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -13,7 +13,7 @@ type ClassNames = 'menuPaper' | 'menuDocked';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   menuPaper: {
     height: '100%',
-    width: theme.spacing.unit * 17 + 79, // 215
+    width: theme.spacing.unit * 15 + 95, // 215
     backgroundColor: theme.bg.navy,
     left: 'inherit',
     boxShadow: 'none',


### PR DESCRIPTION
## Avoid "Object Storage" text wrap in primary menu on compact mode

below the XL breakpoint (1920px) the "Object Storage" link item wraps on compact mode. Should increase the width a little bit to avoid that.

## Type of Change
- Non breaking change ('update')
