### PR TITLE
M3-2606 Unbold most of the things in compact mode

### DIFF
--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -62,7 +62,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     marginRight: theme.spacing.unit,
     whiteSpace: 'nowrap',
     float: 'right',
-    fontFamily: 'LatoWebBold'
+    fontFamily: theme.font.bold
   },
   hidden: {
     height: 0,

--- a/src/components/CircleProgress/CircleProgress.tsx
+++ b/src/components/CircleProgress/CircleProgress.tsx
@@ -90,7 +90,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   valueInside: {
     position: 'absolute',
-    marginTop: theme.spacing.unit / 2
+    marginTop: 4
   },
   hasValueInside: {},
   green: {

--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -23,7 +23,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     color: theme.palette.primary.main,
     position: 'relative',
     left: theme.spacing.unit,
-    opacity: 0
+    opacity: 0,
+    width: 14,
+    height: 14
   },
   absoluteIcon: {
     display: 'inline',

--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -53,7 +53,10 @@ const styles: StyleRulesCallback = theme => {
     },
     important: {
       backgroundColor: theme.bg.white,
-      padding: theme.spacing.unit * 2
+      padding: theme.spacing.unit * 2,
+      '& $noticeText': {
+        fontFamily: theme.font.normal
+      }
     },
     inner: {
       width: '100%'
@@ -66,7 +69,8 @@ const styles: StyleRulesCallback = theme => {
     noticeText: {
       color: theme.palette.text.primary,
       fontSize: '1rem',
-      lineHeight: 1.2
+      lineHeight: 1.2,
+      fontFamily: 'LatoWebBold' // we keep this bold at all times
     },
     error: {
       borderLeft: `5px solid ${status.errorDark}`,

--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -65,7 +65,6 @@ const styles: StyleRulesCallback = theme => {
     },
     noticeText: {
       color: theme.palette.text.primary,
-      fontFamily: 'LatoWebBold',
       fontSize: '1rem',
       lineHeight: 1.2
     },

--- a/src/components/Placeholder/Placeholder.tsx
+++ b/src/components/Placeholder/Placeholder.tsx
@@ -46,11 +46,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     '&.animate': {
       animation: 'scaleIn .5s ease-in-out'
     },
-    width: '150px',
-    height: '150px',
+    width: '120px',
+    height: '120px',
     [theme.breakpoints.up('md')]: {
-      width: '225px',
-      height: '225px'
+      width: '150px',
+      height: '150px'
     },
     '& .outerCircle': {
       fill: theme.color.absWhite,
@@ -66,14 +66,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     }
   },
   title: {
-    textAlign: 'center',
-    fontFamily: 'LatoWebBold',
-    fontSize: '2.188rem',
-    lineHeight: '3.75rem',
-    [theme.breakpoints.up('md')]: {
-      fontSize: '2.5rem',
-      lineHeight: '4rem'
-    }
+    textAlign: 'center'
   },
   button: {
     marginBottom: theme.spacing.unit * 4
@@ -106,7 +99,11 @@ const Placeholder: React.StatelessComponent<CombinedProps> = props => {
         {Icon && <Icon className={`${classes.icon} ${animate && 'animate'}`} />}
       </Grid>
       <Grid item xs={12}>
-        <Typography className={classes.title} data-qa-placeholder-title>
+        <Typography
+          className={classes.title}
+          data-qa-placeholder-title
+          variant="h1"
+        >
           {title}
         </Typography>
       </Grid>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -113,7 +113,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   linkItem: {
     transition: theme.transitions.create(['color']),
     color: '#C9CACB',
-    fontFamily: theme.font.bold
+    fontFamily: 'LatoWebBold' // we keep this bold at all times
   },
   active: {
     transition: 'border-color .7s ease-in-out',

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -113,7 +113,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   linkItem: {
     transition: theme.transitions.create(['color']),
     color: '#C9CACB',
-    fontFamily: 'LatoWebBold'
+    fontFamily: theme.font.bold
   },
   active: {
     transition: 'border-color .7s ease-in-out',

--- a/src/components/SelectionCard/SelectionCard.tsx
+++ b/src/components/SelectionCard/SelectionCard.tsx
@@ -88,7 +88,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     }
   },
   heading: {
-    fontFamily: 'LatoWebBold',
+    fontFamily: theme.font.bold,
     fontSize: '1rem',
     color: theme.color.headline
   },

--- a/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
+++ b/src/components/ShowMoreExpansion/ShowMoreExpansion.tsx
@@ -17,7 +17,7 @@ const styles: StyleRulesCallback = theme => ({
     backgroundColor: 'transparent !important',
     display: 'flex',
     alignItems: 'center',
-    fontFamily: 'LatoWebBold',
+    fontFamily: theme.font.bold,
     width: 'auto',
     color: theme.color.headline,
     transition: theme.transitions.create('color'),

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -31,8 +31,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       '& tbody > tr': {
         marginBottom: 0,
         '& > td:first-child': {
-          backgroundColor: theme.bg.tableHeader,
-          fontFamily: 'LatoWebBold'
+          backgroundColor: theme.bg.tableHeader
         }
       },
       '& tr': {

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -73,7 +73,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   used: {
     fontSize: '1.5rem',
-    fontFamily: 'LatoWebBold',
+    fontFamily: theme.font.bold,
     color: theme.color.green
   },
   quota: {

--- a/src/features/Dashboard/ViewAllLink.tsx
+++ b/src/features/Dashboard/ViewAllLink.tsx
@@ -31,7 +31,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     marginRight: theme.spacing.unit / 2
   },
   countNumber: {
-    fontFamily: 'LatoWebBold'
+    fontFamily: theme.font.bold
   }
 });
 

--- a/src/features/Domains/ListDomains.tsx
+++ b/src/features/Domains/ListDomains.tsx
@@ -20,7 +20,7 @@ type ClassNames = 'root' | 'label';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   label: {
-    paddingLeft: theme.spacing.unit * 2 + 49
+    paddingLeft: theme.spacing.unit * 3 + 41
   }
 });
 

--- a/src/features/Events/EventsLanding.tsx
+++ b/src/features/Events/EventsLanding.tsx
@@ -137,7 +137,7 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
               <TableCell style={{ padding: 0, width: '1%' }} />
               <TableCell
                 data-qa-events-subject-header
-                style={{ minWidth: 200 }}
+                style={{ minWidth: 200, paddingLeft: 10 }}
               >
                 Event
               </TableCell>

--- a/src/features/Help/Panels/PopularPosts.tsx
+++ b/src/features/Help/Panels/PopularPosts.tsx
@@ -33,17 +33,13 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   wrapper: {},
   postTitle: {
-    ...theme.typography.body1,
-    marginBottom: theme.spacing.unit
+    marginBottom: theme.spacing.unit * 2
   },
   post: {
-    marginBottom: theme.spacing.unit / 2
+    marginBottom: theme.spacing.unit / 2,
+    ...theme.typography.body1
   },
   postLink: {
-    color: theme.color.headline,
-    fontSize: '1rem',
-    fontFamily: 'LatoWebBold',
-    lineHeight: '1.2em',
     '&:hover': {
       textDecoration: 'underline'
     }

--- a/src/features/Help/Panels/SearchItem.tsx
+++ b/src/features/Help/Panels/SearchItem.tsx
@@ -34,7 +34,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   source: {
     marginTop: theme.spacing.unit / 2,
-    fontFamily: 'LatoWebBold'
+    color: theme.color.headline
   },
   row: {
     display: 'flex',

--- a/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -77,7 +77,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     marginTop: theme.spacing.unit * 3
   },
   selectCell: {
-    fontFamily: 'LatoWebBold',
+    fontFamily: 'LatoWebBold', // we keep this bold at all times
     fontSize: '.9rem'
   },
   accessCell: {

--- a/src/features/Support/ExpandableTicketPanel.tsx
+++ b/src/features/Support/ExpandableTicketPanel.tsx
@@ -73,7 +73,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   userName: {
     whiteSpace: 'nowrap',
-    fontFamily: 'LatoWebBold',
+    fontFamily: 'LatoWebBold', // we keep this bold at all times
     color: theme.color.headline
   },
   paper: {

--- a/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
@@ -60,7 +60,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   count: {
     color: 'white',
-    fontFamily: 'LatoWebBold',
+    fontFamily: 'LatoWebBold', // we keep this bold at all times
     display: 'block',
     fontSize: '.7rem',
     lineHeight: 0,

--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationListItem.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationListItem.tsx
@@ -66,7 +66,7 @@ const styles: StyleRulesCallback = theme => {
     },
     noticeText: {
       color: theme.palette.text.primary,
-      fontFamily: 'LatoWebBold'
+      fontFamily: theme.font.bold
     },
     critical: {
       borderLeft: `5px solid ${status.errorDark}`

--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationsList.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationsList.tsx
@@ -14,7 +14,7 @@ type ClassNames = 'emptyText';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   emptyText: {
     padding: `${theme.spacing.unit * 2}px ${theme.spacing.unit * 3}px`,
-    fontFamily: 'LatoWebBold'
+    fontFamily: theme.font.bold
   }
 });
 

--- a/src/features/linodes/LinodesCreate/AddonsPanel.tsx
+++ b/src/features/linodes/LinodesCreate/AddonsPanel.tsx
@@ -55,7 +55,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   label: {
     '& > span:last-child': {
       color: theme.color.headline,
-      fontFamily: 'LatoWebBold',
+      fontFamily: theme.font.bold,
       fontSize: '1rem',
       lineHeight: '1.2em',
       [theme.breakpoints.up('md')]: {

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -19,6 +19,7 @@ describe('LinodeSummary', () => {
         bottomLegend: '',
         graphControls: '',
         graphTitle: '',
+        graphSelectTitle: '',
         totalTraffic: ''
       }}
       typesData={[]}

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -44,6 +44,7 @@ type ClassNames =
   | 'leftLegend'
   | 'bottomLegend'
   | 'graphTitle'
+  | 'graphSelectTitle'
   | 'graphControls'
   | 'totalTraffic';
 
@@ -99,6 +100,12 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
     },
     graphTitle: {
       marginRight: theme.spacing.unit * 2
+    },
+    graphSelectTitle: {
+      marginRight: theme.spacing.unit,
+      position: 'relative',
+      color: theme.color.headline,
+      top: -1
     },
     graphControls: {
       display: 'flex',
@@ -670,7 +677,10 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
               </Grid>
               <Grid item className="py0">
                 <div className={classes.graphControls}>
-                  <Typography variant="h3" className={classes.graphTitle}>
+                  <Typography
+                    variant="body1"
+                    className={classes.graphSelectTitle}
+                  >
                     Graphs
                   </Typography>
                   <FormControl style={{ marginTop: 0 }}>

--- a/src/features/linodes/LinodesLanding/LinodeCard.style.ts
+++ b/src/features/linodes/LinodesLanding/LinodeCard.style.ts
@@ -61,10 +61,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     }
   },
   cardHeader: {
-    fontFamily: 'LatoWebBold',
+    fontFamily: theme.font.bold,
     color: 'black',
     marginLeft: theme.spacing.unit,
-    // This is necessary for text to ellipsis responsively without the need for a hard set width value that won't play well with flexbox.
+    // This is necessary for text to ellipsis responsively
+    // without the need for a hard set width value that won't play well with flexbox.
     minWidth: 0
   },
   cardContent: {

--- a/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
+++ b/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
@@ -58,7 +58,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     }
   },
   title: {
-    fontFamily: 'LatoWebBold',
+    fontFamily: theme.font.bold,
     textAlign: 'center'
   }
 });

--- a/src/features/linodes/LinodesLanding/ToggleBox.tsx
+++ b/src/features/linodes/LinodesLanding/ToggleBox.tsx
@@ -27,7 +27,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     borderStyle: 'solid',
     borderColor: theme.color.boxShadow,
     borderRadius: 0,
-    fontFamily: 'LatoWebBold',
+    fontFamily: theme.font.bold,
     textTransform: 'inherit',
     width: 80,
     minWidth: 80,

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -227,13 +227,13 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
       h2: {
         color: primaryColors.headline,
         fontSize: '1.125rem',
-        fontFamily: 'LatoWebBold',
+        fontFamily: spacingUnit === 4 ? 'LatoWeb' : 'LatoWebBold',
         lineHeight: '1.5rem'
       },
       h3: {
         color: primaryColors.headline,
         fontSize: '1rem',
-        fontFamily: 'LatoWebBold',
+        fontFamily: spacingUnit === 4 ? 'LatoWeb' : 'LatoWebBold',
         lineHeight: '1rem'
       },
       body1: {
@@ -283,7 +283,7 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
           borderRadius: 0,
           fontSize: '1rem',
           lineHeight: 1,
-          fontFamily: 'LatoWebBold',
+          fontFamily: spacingUnit === 4 ? 'LatoWeb' : 'LatoWebBold',
           color: primaryColors.main,
           padding: `${spacingUnit * 2}px ${spacingUnit * 3 +
             spacingUnit / 2}px ${spacingUnit * 2}px`,
@@ -620,7 +620,7 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
       MuiFormLabel: {
         root: {
           color: '#555',
-          fontFamily: 'LatoWebBold',
+          fontFamily: spacingUnit === 4 ? 'LatoWeb' : 'LatoWebBold',
           fontSize: '.9rem',
           marginBottom: 2,
           '&$focused': {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -82,6 +82,11 @@ const primaryColors = {
   white: '#fff'
 };
 
+const primaryFonts = {
+  normal: '"LatoWeb", sans-serif',
+  bold: '"LatoWebBold", sans-serif'
+};
+
 const iconCircleAnimation = {
   '& .circle': {
     fill: primaryColors.main,
@@ -187,8 +192,8 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
       disabledText: '#c9cacb'
     },
     font: {
-      normal: '"LatoWeb", sans-serif',
-      bold: spacingUnit === 4 ? 'LatoWeb' : 'LatoWebBold'
+      normal: primaryFonts.normal,
+      bold: spacingUnit === 4 ? primaryFonts.normal : primaryFonts.bold
     },
     animateCircleIcon: {
       ...iconCircleAnimation
@@ -218,13 +223,13 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
     },
     typography: {
       useNextVariants: true,
-      fontFamily: '"LatoWeb", sans-serif',
+      fontFamily: primaryFonts.normal,
       fontSize: 16,
       h1: {
         color: primaryColors.headline,
         fontSize: '1.25rem',
         lineHeight: '1.75rem',
-        fontFamily: 'LatoWebBold',
+        fontFamily: primaryFonts.bold,
         [breakpoints.up('lg')]: {
           fontSize: '1.5rem',
           lineHeight: '1.875rem'
@@ -233,13 +238,13 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
       h2: {
         color: primaryColors.headline,
         fontSize: '1.125rem',
-        fontFamily: spacingUnit === 4 ? 'LatoWeb' : 'LatoWebBold',
+        fontFamily: spacingUnit === 4 ? primaryFonts.normal : primaryFonts.bold,
         lineHeight: '1.5rem'
       },
       h3: {
         color: primaryColors.headline,
         fontSize: '1rem',
-        fontFamily: spacingUnit === 4 ? 'LatoWeb' : 'LatoWebBold',
+        fontFamily: spacingUnit === 4 ? primaryFonts.normal : primaryFonts.bold,
         lineHeight: '1rem'
       },
       body1: {
@@ -289,7 +294,8 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
           borderRadius: 0,
           fontSize: '1rem',
           lineHeight: 1,
-          fontFamily: spacingUnit === 4 ? 'LatoWeb' : 'LatoWebBold',
+          fontFamily:
+            spacingUnit === 4 ? primaryFonts.normal : primaryFonts.bold,
           color: primaryColors.main,
           padding: `${spacingUnit * 2}px ${spacingUnit * 3 +
             spacingUnit / 2}px ${spacingUnit * 2}px`,
@@ -626,7 +632,8 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
       MuiFormLabel: {
         root: {
           color: '#555',
-          fontFamily: spacingUnit === 4 ? 'LatoWeb' : 'LatoWebBold',
+          fontFamily:
+            spacingUnit === 4 ? primaryFonts.normal : primaryFonts.bold,
           fontSize: '.9rem',
           marginBottom: 2,
           '&$focused': {
@@ -786,7 +793,7 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
           },
           '&.selectHeader': {
             opacity: 1,
-            fontFamily: 'LatoWebBold',
+            fontFamily: primaryFonts.bold,
             fontSize: '1rem',
             color: primaryColors.text
           }
@@ -831,7 +838,7 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
       MuiMenuItem: {
         root: {
           height: 'auto',
-          fontFamily: 'LatoWeb',
+          fontFamily: primaryFonts.normal,
           fontSize: '.9rem',
           whiteSpace: 'initial',
           textOverflow: 'initial',
@@ -1026,7 +1033,7 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
             minWidth: 75
           },
           '&$selected, &$selected:hover': {
-            fontFamily: 'LatoWebBold',
+            fontFamily: primaryFonts.bold,
             color: primaryColors.headline
           },
           '&:hover': {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -44,6 +44,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     '@keyframes dash': any;
     bg: any;
     color: any;
+    font?: any;
     animateCircleIcon?: any;
     notificationList: any;
     status: any;
@@ -55,6 +56,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     '@keyframes dash'?: any;
     bg?: any;
     color?: any;
+    font?: any;
     animateCircleIcon?: any;
     notificationList?: any;
     status?: any;
@@ -183,6 +185,10 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
       drawerBackdrop: 'rgba(255, 255, 255, 0.5)',
       label: '#555',
       disabledText: '#c9cacb'
+    },
+    font: {
+      normal: '"LatoWeb", sans-serif',
+      bold: spacingUnit === 4 ? 'LatoWeb' : 'LatoWebBold'
     },
     animateCircleIcon: {
       ...iconCircleAnimation

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -784,7 +784,6 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
             backgroundColor: 'transparent',
             color: primaryColors.main
           },
-
           '&.selectHeader': {
             opacity: 1,
             fontFamily: 'LatoWebBold',


### PR DESCRIPTION
## Unbold most of the things in compact mode

In conjunction with the compact mode, we need to de-emphasize most UI elements by removing their bolding in order to offer more clarity to thew page and help with the overall hierarchy. This was done by implementing a new `theme.font.bold` in `themeFactory` that keeps the bolding for the normal theme but turns it off when the compact more is activated.

## Type of Change
- Non breaking change ('update')

## Applicable E2E Tests
 N/A
