### PR TITLE
Update: M3-2394 Add Account Creation Date to Summary Panel

### DIFF
--- a/src/__data__/account.ts
+++ b/src/__data__/account.ts
@@ -1,4 +1,5 @@
 export const account: Linode.Account = {
+  active_since: 'hello world',
   address_2: 'apt b2',
   email: 'mmckenna@linode.com',
   first_name: 'Marty',

--- a/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.test.tsx
+++ b/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.test.tsx
@@ -19,7 +19,8 @@ describe('SummaryPanel', () => {
     tax_id: '',
     country: '',
     balance: 0,
-    balance_uninvoiced: 0
+    balance_uninvoiced: 0,
+    active_since: 'hello world'
   };
 
   const mockClasses: any = {

--- a/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
+++ b/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
@@ -12,6 +12,7 @@ import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import ErrorState from 'src/components/ErrorState';
 import styled, { StyleProps } from 'src/containers/SummaryPanels.styles';
+import { formatDate } from 'src/utilities/formatDate';
 import isCreditCardExpired from 'src/utilities/isCreditCardExpired';
 import { withAccount } from '../../context';
 
@@ -97,7 +98,8 @@ export class SummaryPanel extends React.Component<CombinedProps, {}> {
         credit_card: { expiry, last_four },
         city,
         state,
-        zip
+        zip,
+        active_since
       },
       balance,
       balance_uninvoiced,
@@ -143,6 +145,10 @@ export class SummaryPanel extends React.Component<CombinedProps, {}> {
           <div className={classes.section} data-qa-contact-phone>
             <strong>Phone Number:&nbsp;</strong>
             {phone ? phone : 'None'}
+          </div>
+          <div className={classes.section}>
+            <strong>Active Since:&nbsp;</strong>
+            {formatDate(active_since)}
           </div>
         </Paper>
 

--- a/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
+++ b/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
@@ -10,9 +10,9 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
+import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import ErrorState from 'src/components/ErrorState';
 import styled, { StyleProps } from 'src/containers/SummaryPanels.styles';
-import { formatDate } from 'src/utilities/formatDate';
 import isCreditCardExpired from 'src/utilities/isCreditCardExpired';
 import { withAccount } from '../../context';
 
@@ -148,7 +148,7 @@ export class SummaryPanel extends React.Component<CombinedProps, {}> {
           </div>
           <div className={classes.section}>
             <strong>Active Since:&nbsp;</strong>
-            {formatDate(active_since)}
+            <DateTimeDisplay value={active_since} format="MMMM D, YYYY" />
           </div>
         </Paper>
 

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -8,6 +8,7 @@ namespace Linode {
   }
 
   export interface Account {
+    active_since: string;
     address_2: string;
     email: string;
     first_name: string;


### PR DESCRIPTION
## Description

Adds Account Creation date to the account summary panel

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A