### PR TITLE
M3-2661 Make beta tag for CA Tab blue on both themes

### DIFF
--- a/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -354,7 +354,11 @@ export class LinodeCreate extends React.PureComponent<
       title: (
         <div style={{ display: 'flex', alignItems: 'center' }}>
           One-Click Apps{' '}
-          <Chip label="beta" style={{ marginLeft: 8, cursor: 'pointer' }} />
+          <Chip
+            color="primary"
+            label="beta"
+            style={{ marginLeft: 8, cursor: 'pointer' }}
+          />
         </div>
       ),
       type: 'fromApp',


### PR DESCRIPTION
## Description

Making beta tag blue regardless of theme so it is more apparent to users. 

## Type of Change
- Non breaking change ('update', 'change')

