### PR TITLE
M3-2597 re-order fields on monthly network transfer panels

### DIFF
--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -184,14 +184,14 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
               <Typography
                 className={classes.itemText + ' ' + classes.itemTextFirst}
               >
-                Free: <strong>{quota - used}</strong> GB
+                Total: <strong>{quota}</strong> GB
               </Typography>
               <Typography className={classes.itemText}>
                 Used: <strong>{used}</strong> GB
               </Typography>
               <Divider className={classes.divider} />
               <Typography className={classes.itemText}>
-                Total: <strong>{quota}</strong> GB
+                Free: <strong>{quota - used}</strong> GB
               </Typography>
             </Grid>
           </Grid>

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
@@ -139,14 +139,15 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
           <Typography
             className={classes.itemText + ' ' + classes.itemTextFirst}
           >
-            Free: <strong>{Math.floor(total - usedInGb)}</strong> GB
+            Total: <strong>{total}</strong> GB
           </Typography>
+
           <Typography className={classes.itemText}>
             Used: <strong>{usedInGb}</strong> GB
           </Typography>
           <Divider className={classes.divider} />
           <Typography className={classes.itemText}>
-            Total: <strong>{total}</strong> GB
+            Free: <strong>{Math.floor(total - usedInGb)}</strong> GB
           </Typography>
         </Grid>
       </Grid>


### PR DESCRIPTION
## Re-order fields on monthly network transfer panels

From Caker review, available space should be last: Total > Used >> Free

## Type of Change
- Non breaking change ('update')

## Applicable E2E Tests
N/A

## Note to Reviewers

- /dashboard
- /linode/{id}/summary

avail disk space in settings > adv configs has also been updated to reflect this [here](https://github.com/linode/manager/pull/4811)
