### PR TITLE
M3-2603 Update to Linode List - Plan details

### DIFF
--- a/src/utilities/getLinodeDescription.ts
+++ b/src/utilities/getLinodeDescription.ts
@@ -11,7 +11,13 @@ export const linodeDescription = (
 ) => {
   const imageDesc = safeGetImageLabel(images, imageId);
   const typeDesc = typeLabelLong(typeLabel, memory, disk, vcpus);
-  return `${imageDesc} ${typeDesc}`;
+
+  // Check if we return an empty string for imageDesc if the slug is nonexsistent
+  if (imageDesc === '') {
+    return `${typeDesc}`;
+  } else {
+    return `${imageDesc}, ${typeDesc}`;
+  }
 };
 
 export default linodeDescription;

--- a/src/utilities/getLinodeDescription.ts
+++ b/src/utilities/getLinodeDescription.ts
@@ -11,7 +11,7 @@ export const linodeDescription = (
 ) => {
   const imageDesc = safeGetImageLabel(images, imageId);
   const typeDesc = typeLabelLong(typeLabel, memory, disk, vcpus);
-  return `${imageDesc}, ${typeDesc}`;
+  return `${imageDesc} ${typeDesc}`;
 };
 
 export default linodeDescription;

--- a/src/utilities/safeGetImageLabel/safeGetImageLabel.test.ts
+++ b/src/utilities/safeGetImageLabel/safeGetImageLabel.test.ts
@@ -6,11 +6,11 @@ describe('safeGetImageLabel', () => {
     expect(safeGetImageLabel(images, null)).toBe('');
   });
 
-  it('should return "Unknown Image," if the slug does not exist in the image data', () => {
-    expect(safeGetImageLabel(images, 'duhhhhhhhhhh')).toBe('Unknown Image,');
+  it('should return "Unknown Image" if the slug does not exist in the image data', () => {
+    expect(safeGetImageLabel(images, 'duhhhhhhhhhh')).toBe('Unknown Image');
   });
 
-  it('should return "Fedora 23,"', () => {
-    expect(safeGetImageLabel(images, 'linode/Fedora23')).toBe('Fedora 23,');
+  it('should return "Fedora 23"', () => {
+    expect(safeGetImageLabel(images, 'linode/Fedora23')).toBe('Fedora 23');
   });
 });

--- a/src/utilities/safeGetImageLabel/safeGetImageLabel.test.ts
+++ b/src/utilities/safeGetImageLabel/safeGetImageLabel.test.ts
@@ -2,15 +2,15 @@ import { images } from 'src/__data__/images';
 import { safeGetImageLabel } from './safeGetImageLabel';
 
 describe('safeGetImageLabel', () => {
-  it('should return "No Image" if no slug provided', () => {
-    expect(safeGetImageLabel(images, null)).toBe('No Image');
+  it('should return an empty string if no slug provided', () => {
+    expect(safeGetImageLabel(images, null)).toBe('');
   });
 
-  it('should return "Unknown Image" if the slug does not exist in the image data', () => {
-    expect(safeGetImageLabel(images, 'duhhhhhhhhhh')).toBe('Unknown Image');
+  it('should return "Unknown Image," if the slug does not exist in the image data', () => {
+    expect(safeGetImageLabel(images, 'duhhhhhhhhhh')).toBe('Unknown Image,');
   });
 
-  it('should return "Fedora 23"', () => {
-    expect(safeGetImageLabel(images, 'linode/Fedora23')).toBe('Fedora 23');
+  it('should return "Fedora 23,"', () => {
+    expect(safeGetImageLabel(images, 'linode/Fedora23')).toBe('Fedora 23,');
   });
 });

--- a/src/utilities/safeGetImageLabel/safeGetImageLabel.ts
+++ b/src/utilities/safeGetImageLabel/safeGetImageLabel.ts
@@ -2,7 +2,7 @@
  * returns either the Image label or "Unknown Image," depending on whether the image can
  * be found in the API data
  *
- * If no slug is available, returns "no image."
+ * If no slug is available, return an empty string so nothing will display in the description.
  *
  * @param { Linode.Image[] } images - list of Linode Images, both deprecated and non-deprecated
  * @param { string | null } slug - image slug that belongs to the Linode instance
@@ -12,8 +12,8 @@ export const safeGetImageLabel = (
   slug: string | null
 ): string => {
   if (!slug) {
-    return 'No Image';
+    return '';
   }
   const iv = images.find(i => i.id === slug);
-  return iv ? iv.label : 'Unknown Image';
+  return iv ? iv.label + ',' : 'Unknown Image,';
 };

--- a/src/utilities/safeGetImageLabel/safeGetImageLabel.ts
+++ b/src/utilities/safeGetImageLabel/safeGetImageLabel.ts
@@ -15,5 +15,5 @@ export const safeGetImageLabel = (
     return '';
   }
   const iv = images.find(i => i.id === slug);
-  return iv ? iv.label + ',' : 'Unknown Image,';
+  return iv ? iv.label : 'Unknown Image';
 };


### PR DESCRIPTION
## Description

Previously if there wasn't a provided image slug, we were returning 'No Image'. Now, we will display nothing if the image slug does not exist. The check for `Unknown Image` is still present though.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

This impacts both dashboard and linodes list views.
