### PR TITLE
M3-2514 Update focus states for clickable rows

### DIFF
--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -94,12 +94,16 @@ class TableRow extends React.Component<CombinedProps> {
     return (
       <_TableRow
         onClick={(e: any) => rowLink && this.rowClick(e, rowLink)}
+        onKeyUp={(e: any) =>
+          rowLink && e.keyCode === 13 && this.rowClick(e, rowLink)
+        }
         hover={rowLink !== undefined}
         role={role}
         className={classNames(className, {
           [classes.root]: true
         })}
         {...rest}
+        tabIndex={rowLink ? 0 : -1}
       >
         {this.props.children}
       </_TableRow>

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -1,7 +1,6 @@
 import { compose, prop, sortBy, take } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
@@ -141,34 +140,28 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
     return data.map(({ id, domain, type, status }) => (
       <TableRow key={domain} rowLink={`/domains/${id}/records`}>
         <TableCell className={classes.labelCol}>
-          <Link
-            onClick={e => this.handleRowClick(e, id, domain, type)}
-            to={`/domains/${id}/records`}
-            className={'black nu block'}
-          >
-            <Grid container wrap="nowrap" alignItems="center">
-              <Grid item className="py0">
-                <EntityIcon
-                  variant="domain"
-                  status={status}
-                  marginTop={1}
-                  loading={status === 'edit_mode'}
-                />
-              </Grid>
-              <Grid item className={classes.labelGridWrapper}>
-                <div className={classes.labelStatusWrapper}>
-                  <Typography
-                    variant="h3"
-                    className={classes.wrapHeader}
-                    data-qa-label
-                  >
-                    {domain}
-                  </Typography>
-                </div>
-                <Typography className={classes.description}>{type}</Typography>
-              </Grid>
+          <Grid container wrap="nowrap" alignItems="center">
+            <Grid item className="py0">
+              <EntityIcon
+                variant="domain"
+                status={status}
+                marginTop={1}
+                loading={status === 'edit_mode'}
+              />
             </Grid>
-          </Link>
+            <Grid item className={classes.labelGridWrapper}>
+              <div className={classes.labelStatusWrapper}>
+                <Typography
+                  variant="h3"
+                  className={classes.wrapHeader}
+                  data-qa-label
+                >
+                  {domain}
+                </Typography>
+              </div>
+              <Typography className={classes.description}>{type}</Typography>
+            </Grid>
+          </Grid>
         </TableCell>
         <TableCell className={classes.actionsCol} />
       </TableRow>

--- a/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -1,6 +1,5 @@
 import { compose, take } from 'ramda';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { Subscription } from 'rxjs/Subscription';
 import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
@@ -194,25 +193,23 @@ class NodeBalancersDashboardCard extends React.Component<CombinedProps, State> {
     return data.map(({ id, label, region, hostname }) => (
       <TableRow key={label} rowLink={`/nodebalancers/${id}`}>
         <TableCell className={classes.labelCol}>
-          <Link to={`/nodebalancers/${id}`} className={'black nu block'}>
-            <Grid container wrap="nowrap" alignItems="center">
-              <Grid item className="py0">
-                <EntityIcon variant="nodebalancer" />
-              </Grid>
-              <Grid item className={classes.labelGridWrapper}>
-                <Typography
-                  variant="h3"
-                  className={classes.wrapHeader}
-                  data-qa-label
-                >
-                  {label}
-                </Typography>
-                <Typography className={classes.description}>
-                  {hostname}
-                </Typography>
-              </Grid>
+          <Grid container wrap="nowrap" alignItems="center">
+            <Grid item className="py0">
+              <EntityIcon variant="nodebalancer" />
             </Grid>
-          </Link>
+            <Grid item className={classes.labelGridWrapper}>
+              <Typography
+                variant="h3"
+                className={classes.wrapHeader}
+                data-qa-label
+              >
+                {label}
+              </Typography>
+              <Typography className={classes.description}>
+                {hostname}
+              </Typography>
+            </Grid>
+          </Grid>
         </TableCell>
         <Hidden xsDown>
           <TableCell className={classes.moreCol} data-qa-node-region>

--- a/src/features/Domains/DomainTableRow.tsx
+++ b/src/features/Domains/DomainTableRow.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import {
   StyleRulesCallback,
   WithStyles,
@@ -98,28 +97,26 @@ const DomainTableRow: React.StatelessComponent<CombinedProps> = props => {
       }
     >
       <TableCell parentColumn="Domain" data-qa-domain-label>
-        <Link to={`/domains/${id}`} onClick={e => handleRowClick(e, props)}>
-          <Grid container wrap="nowrap" alignItems="center">
-            <Grid item className="py0">
-              <EntityIcon
-                variant="domain"
-                status={status}
-                marginTop={1}
-                loading={status === 'edit_mode'}
-              />
-            </Grid>
-            <Grid item className={classes.domainCellContainer}>
-              <div className={classes.labelStatusWrapper}>
-                <Typography variant="h3" data-qa-label>
-                  {domain}
-                </Typography>
-              </div>
-              <div className={classes.tagWrapper}>
-                <Tags tags={tags} />
-              </div>
-            </Grid>
+        <Grid container wrap="nowrap" alignItems="center">
+          <Grid item className="py0">
+            <EntityIcon
+              variant="domain"
+              status={status}
+              marginTop={1}
+              loading={status === 'edit_mode'}
+            />
           </Grid>
-        </Link>
+          <Grid item className={classes.domainCellContainer}>
+            <div className={classes.labelStatusWrapper}>
+              <Typography variant="h3" data-qa-label>
+                {domain}
+              </Typography>
+            </div>
+            <div className={classes.tagWrapper}>
+              <Tags tags={tags} />
+            </div>
+          </Grid>
+        </Grid>
       </TableCell>
       <TableCell parentColumn="Type" data-qa-domain-type>
         {type}

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
@@ -81,16 +81,14 @@ const NodeBalancersLandingTableRows: React.StatelessComponent<
             aria-label={nodeBalancer.label}
           >
             <TableCell parentColumn="Name" data-qa-nodebalancer-label>
-              <Link to={`/nodebalancers/${nodeBalancer.id}`}>
-                <Grid container wrap="nowrap" alignItems="center">
-                  <Grid item className="py0">
-                    <EntityIcon variant="nodebalancer" marginTop={1} />
-                  </Grid>
-                  <Grid item>
-                    <Typography variant="h3">{nodeBalancer.label}</Typography>
-                  </Grid>
+              <Grid container wrap="nowrap" alignItems="center">
+                <Grid item className="py0">
+                  <EntityIcon variant="nodebalancer" marginTop={1} />
                 </Grid>
-              </Link>
+                <Grid item>
+                  <Typography variant="h3">{nodeBalancer.label}</Typography>
+                </Grid>
+              </Grid>
             </TableCell>
             <TagsCell tags={nodeBalancer.tags} />
             <TableCell parentColumn="Node Status" data-qa-node-status>

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
 import {
   StyleRulesCallback,
@@ -28,7 +27,6 @@ type ClassNames =
   | 'labelRow'
   | 'labelStatusWrapper'
   | 'dashboard'
-  | 'labelGridWrapper'
   | 'wrapHeader';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
@@ -72,9 +70,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     flexFlow: 'row nowrap',
     alignItems: 'center'
   },
-  labelGridWrapper: {
-    padding: `${theme.spacing.unit}px ${theme.spacing.unit / 2}px !important`
-  },
   wrapHeader: {
     wordBreak: 'break-all'
   }
@@ -113,7 +108,6 @@ type CombinedProps = Props &
 const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
   const {
     // linode props
-    id,
     label,
     status,
     memory,
@@ -142,41 +136,40 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
 
   return (
     <TableCell className={classes.root} style={style} rowSpan={loading ? 2 : 1}>
-      <Link to={`/linodes/${id}`} className={classes.link}>
-        <Grid container wrap="nowrap" alignItems="center">
-          <Grid item className="py0">
-            <EntityIcon
-              variant="linode"
-              status={status}
-              loading={linodeInTransition(status, recentEvent)}
-              marginTop={1}
-            />
-          </Grid>
-          <Grid item className={classes.labelGridWrapper}>
-            <div className={loading ? classes.labelWrapper : ''}>
-              {recentEvent && linodeInTransition(status, recentEvent) && (
-                <ProgressDisplay
-                  className={classes.loadingStatus}
-                  text={transitionText(status, recentEvent)}
-                  progress={recentEvent.percent_complete}
-                />
-              )}
-              <div className={classes.labelStatusWrapper}>
-                <Typography
-                  variant="h3"
-                  className={classes.wrapHeader}
-                  data-qa-label
-                >
-                  {label}
-                </Typography>
-              </div>
-              <Typography className={classes.linodeDescription}>
-                {description}
+      <Grid container wrap="nowrap" alignItems="center">
+        <Grid item className="py0">
+          <EntityIcon
+            variant="linode"
+            status={status}
+            loading={linodeInTransition(status, recentEvent)}
+            marginTop={1}
+          />
+        </Grid>
+        <Grid item>
+          <div className={loading ? classes.labelWrapper : ''}>
+            {recentEvent && linodeInTransition(status, recentEvent) && (
+              <ProgressDisplay
+                className={classes.loadingStatus}
+                text={transitionText(status, recentEvent)}
+                progress={recentEvent.percent_complete}
+              />
+            )}
+            <div className={classes.labelStatusWrapper}>
+              <Typography
+                variant="h3"
+                className={classes.wrapHeader}
+                data-qa-label
+              >
+                {label}
               </Typography>
             </div>
-          </Grid>
+            <Typography className={classes.linodeDescription}>
+              {description}
+            </Typography>
+          </div>
         </Grid>
-      </Link>
+      </Grid>
+      {/* </Link> */}
     </TableCell>
   );
 };

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1124,7 +1124,7 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
           '&:before': {
             borderLeftColor: 'white'
           },
-          '&:hover': {
+          '&:hover, &:focus': {
             '&$hover': {
               backgroundColor: '#fbfbfb',
               '&:before': {


### PR DESCRIPTION
## Update focus states for clickable rows

We previously had extra links in the clickable rows to make sure we could add a focus when tabbing through. This adds duplication and weird focus styles and needed a cleanup. I removed them and added tabIndex on the rows that have links as well as matching focus styles with hover styles as well as making sure clicking enter on the keyboard acts as a click.
 
## Type of Change
- Non breaking change ('update')

## Applicable E2E Tests

N/A

## Note to Reviewers

to test on entity clickable rows both in landing pages and dashboard (linodes, nodeBalancers & domains)