### PR TITLE
M3-1913 Remove IPV6 addresses and tag columns from rows

### DIFF
--- a/src/components/CopyTooltip/CopyTooltip.tsx
+++ b/src/components/CopyTooltip/CopyTooltip.tsx
@@ -35,7 +35,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   root: {
     position: 'relative',
-    padding: 2,
+    padding: 4,
     transition: theme.transitions.create(['background-color']),
     borderRadius: 4,
     color: theme.color.grey1,

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
@@ -92,8 +92,7 @@ const NodeBalancersLandingTableRows: React.StatelessComponent<
             </TableCell>
             <TagsCell tags={nodeBalancer.tags} />
             <TableCell parentColumn="Node Status" data-qa-node-status>
-              <span>{nodesUp} up</span> <br />
-              <span>{nodesDown} down</span>
+              <span>{nodesUp} up</span> - <span>{nodesDown} down</span>
             </TableCell>
             <TableCell parentColumn="Transferred" data-qa-transferred>
               {convertMegabytesTo(nodeBalancer.transfer.total)}
@@ -114,12 +113,9 @@ const NodeBalancersLandingTableRows: React.StatelessComponent<
                 </React.Fragment>
               ))}
             </TableCell>
-            <TableCell parentColumn="IP Addresses" data-qa-nodebalancer-ips>
+            <TableCell parentColumn="IP Address" data-qa-nodebalancer-ips>
               <div className={classes.ipsWrapper}>
                 <IPAddress ips={[nodeBalancer.ipv4]} copyRight showMore />
-                {nodeBalancer.ipv6 && (
-                  <IPAddress ips={[nodeBalancer.ipv6]} copyRight showMore />
-                )}
               </div>
             </TableCell>
             <TableCell parentColumn="Region" data-qa-region>

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
@@ -10,19 +10,14 @@ import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
-import TagsCell from 'src/components/TagsCell';
 import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
 import { convertMegabytesTo } from 'src/utilities/convertMegabytesTo';
 import NodeBalancerActionMenu from './NodeBalancerActionMenu';
 
-type ClassNames = 'ip' | 'tagWrapper' | 'ipsWrapper' | 'icon';
+type ClassNames = 'tagWrapper' | 'ipsWrapper' | 'icon';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  ip: {
-    width: '30%',
-    minWidth: 200
-  },
   tagWrapper: {
     marginTop: theme.spacing.unit / 2,
     '& [class*="MuiChip"]': {
@@ -90,7 +85,6 @@ const NodeBalancersLandingTableRows: React.StatelessComponent<
                 </Grid>
               </Grid>
             </TableCell>
-            <TagsCell tags={nodeBalancer.tags} />
             <TableCell parentColumn="Node Status" data-qa-node-status>
               <span>{nodesUp} up</span> - <span>{nodesDown} down</span>
             </TableCell>

--- a/src/features/NodeBalancers/NodeBalancersLanding/SortableTableHead.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/SortableTableHead.tsx
@@ -90,7 +90,7 @@ const SortableTableHead: React.StatelessComponent<CombinedProps> = props => {
         <TableCell className={classes.transferred}>Transferred</TableCell>
         <TableCell className={classes.ports}>Ports</TableCell>
         <TableCell className={classes.ip} noWrap>
-          IP Addresses
+          IP Address
         </TableCell>
         <TableSortCell
           className={classes.region}

--- a/src/features/NodeBalancers/NodeBalancersLanding/SortableTableHead.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/SortableTableHead.tsx
@@ -14,50 +14,35 @@ type ClassNames =
   | 'ip'
   | 'nameCell'
   | 'nodeStatus'
-  | 'tags'
   | 'ports'
-  | 'tagGroup'
-  | 'title'
   | 'transferred'
   | 'region';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  ip: {
-    width: '30%',
-    minWidth: 200
-  },
   nameCell: {
-    width: '15%',
+    width: '20%',
     minWidth: 150,
     paddingLeft: theme.spacing.unit * 2 + 49
+  },
+  nodeStatus: {
+    width: '15%',
+    minWidth: 100
+  },
+  transferred: {
+    width: '15%',
+    minWidth: 100
+  },
+  ports: {
+    width: '15%',
+    minWidth: 50
+  },
+  ip: {
+    width: '15%',
+    minWidth: 200
   },
   region: {
     width: '15%',
     minWidth: 150
-  },
-  tags: {
-    width: '10%',
-    minWidth: 100,
-    textAlign: 'center'
-  },
-  nodeStatus: {
-    width: '10%',
-    minWidth: 100
-  },
-  ports: {
-    width: '10%',
-    minWidth: 50
-  },
-  tagGroup: {
-    flexDirection: 'row-reverse',
-    marginBottom: theme.spacing.unit - 2
-  },
-  title: {
-    marginBottom: theme.spacing.unit * 2
-  },
-  transferred: {
-    width: '10%',
-    minWidth: 100
   }
 });
 
@@ -81,9 +66,6 @@ const SortableTableHead: React.StatelessComponent<CombinedProps> = props => {
         >
           Name
         </TableSortCell>
-        <TableCell className={classes.tags} noWrap>
-          Tags
-        </TableCell>
         <TableCell className={classes.nodeStatus} noWrap>
           Node Status
         </TableCell>

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -67,7 +67,6 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   icon: {
     '& svg': {
-      top: 1,
       width: 12,
       height: 12
     }
@@ -78,14 +77,15 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   ipLink: {
     color: theme.palette.primary.main,
+    top: -1,
     position: 'relative',
     display: 'inline-block',
-    width: 28,
     transition: theme.transitions.create(['color'])
   },
   hide: {
     [theme.breakpoints.up('md')]: {
-      // Hide until the component is hovered, when props.showCopyOnHover is true (only on desktop)
+      // Hide until the component is hovered,
+      // when props.showCopyOnHover is true (only on desktop)
       opacity: 0
     },
     transition: theme.transitions.create(['opacity']),

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -84,7 +84,10 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     transition: theme.transitions.create(['color'])
   },
   hide: {
-    opacity: 0, // Hide until the component is hovered, when props.showCopyOnHover is true
+    [theme.breakpoints.up('md')]: {
+      // Hide until the component is hovered, when props.showCopyOnHover is true (only on desktop)
+      opacity: 0
+    },
     transition: theme.transitions.create(['opacity']),
     '&:focus': {
       opacity: 1

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
@@ -64,7 +64,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     padding: 4
   },
   ipCell: {
-    width: '25%',
+    width: '15%',
     [theme.breakpoints.down('sm')]: {
       width: '100%'
     }
@@ -80,7 +80,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     }
   },
   regionCell: {
-    width: '10%',
+    width: '15%',
     [theme.breakpoints.down('sm')]: {
       width: '100%'
     }

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -4,7 +4,6 @@ import Flag from 'src/assets/icons/flag.svg';
 import Tooltip from 'src/components/core/Tooltip';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
-import TagsCell from 'src/components/TagsCell';
 import { LinodeConfigSelectionDrawerCallback } from 'src/features/LinodeConfigSelectionDrawer';
 import { linodeInTransition } from 'src/features/linodes/transitions';
 import hasMutationAvailable, {
@@ -123,7 +122,6 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = props => {
         aria-label={label}
       >
         {!loading && headCell}
-        <TagsCell tags={tags} />
         <LinodeRowBackupCell
           linodeId={id}
           backupsEnabled={backups.enabled || false}

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -130,13 +130,12 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = props => {
           mostRecentBackup={mostRecentBackup || ''}
         />
         <TableCell
-          parentColumn="IP Addresses"
+          parentColumn="IP Address"
           className={classes.ipCell}
           data-qa-ips
         >
           <div className={classes.ipCellWrapper}>
             <IPAddress ips={ipv4} copyRight showCopyOnHover />
-            <IPAddress ips={[ipv6]} copyRight showCopyOnHover />
           </div>
         </TableCell>
         <TableCell

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -38,6 +38,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     paddingTop: theme.spacing.unit / 4
   },
   root: {
+    width: '40%',
     '& h3': {
       transition: theme.transitions.create(['color'])
     },

--- a/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -15,7 +15,7 @@ type ClassNames = 'root' | 'label' | 'tagHeader';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   label: {
-    paddingLeft: theme.spacing.unit * 4 + 33
+    paddingLeft: theme.spacing.unit * 2 + 49
   },
   tagHeader: {
     textAlign: 'center'
@@ -42,15 +42,6 @@ const SortableTableHead: React.StatelessComponent<combinedProps> = props => {
           className={classes.label}
         >
           Linode
-        </TableSortCell>
-        <TableSortCell
-          label="tags"
-          direction={order}
-          active={isActive('tags')}
-          handleClick={handleOrderChange}
-          className={classes.tagHeader}
-        >
-          Tags
         </TableSortCell>
         <TableSortCell
           noWrap

--- a/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -67,7 +67,7 @@ const SortableTableHead: React.StatelessComponent<combinedProps> = props => {
           handleClick={handleOrderChange}
           direction={order}
         >
-          IP Addresses
+          IP Address
         </TableSortCell>
         <TableSortCell
           label="region"


### PR DESCRIPTION
## Remove IPV6 addresses and tag columns from rows

Per the Caker review, we get rid of the tag column and IPV6 listing in the table rows for both linodes and nodeBalancers. I updated col widths accordingly and styled a few regressions.

## Type of Change
- Non breaking change ('update')

## Applicable E2E Tests

N/A
