### PR TITLE
Change: M3-2669 Paginate Disks and Configs with Paginate Render Props Component

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -528,7 +528,16 @@ const MyComponent: React.FC<PaginationProps & OtherProps> = (props) => {
 }
 ```
 
-Now, each time you change a page, the appropriate page will be requested.
+Now, each time you change a page, the appropriate page will be requested. `<Pagey />` also gives you access to a bunch of other props that might help for other tasks you're attempting to accomplish, namely:
+
+| Prop Name | Type | Description
+| --------- | ---- | ---------- |
+| onDelete  | () => void | Helper function that should be invoked when you're deleting items from the list. This will ensure no redundant requests are made |
+| Order | 'asc' or 'desc' | What order in which the data is being sorted. |
+| handleSearch | (filter?: any) => void | Helper function to re-invoke the base request with new filters |
+| searching | boolean | is the handleSeach Promise in-progress |
+| handleOrderChange | (sortBy: string, order: 'asc' or 'desc' = 'asc', page: number = 1) | Helper function to change the sort and sort order of the base request |
+| isSorting | boolean | is the handleOrderChange in-progress |
 
 ### Toasts
 

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -533,11 +533,11 @@ Now, each time you change a page, the appropriate page will be requested. `<Page
 | Prop Name | Type | Description
 | --------- | ---- | ---------- |
 | onDelete  | () => void | Helper function that should be invoked when you're deleting items from the list. This will ensure no redundant requests are made |
-| Order | 'asc' or 'desc' | What order in which the data is being sorted. |
+| order | 'asc' or 'desc' | What order in which the data is being sorted. |
 | handleSearch | (filter?: any) => void | Helper function to re-invoke the base request with new filters |
 | searching | boolean | is the handleSeach Promise in-progress |
-| handleOrderChange | (sortBy: string, order: 'asc' or 'desc' = 'asc', page: number = 1) | Helper function to change the sort and sort order of the base request |
-| isSorting | boolean | is the handleOrderChange in-progress |
+| handleOrderChange | (sortBy: string, order: 'asc' or 'desc' = 'asc', page: number = 1) => void | Helper function to change the sort and sort order of the base request |
+| isSorting | boolean | is the handleOrderChange Promise in-progress |
 
 ### Toasts
 

--- a/src/components/Paginate.ts
+++ b/src/components/Paginate.ts
@@ -20,7 +20,7 @@ const createDiplayPage = <T extends any>(page: number, pageSize: number) => (
 };
 
 export interface PaginationProps extends State {
-  handlePageChange: (page: number) => void;
+  handlePageChange: (shouldScrollToTop?: boolean) => (page: number) => void;
   handlePageSizeChange: (pageSize: number) => void;
   data: any[];
   count: number;
@@ -45,9 +45,11 @@ export default class Paginate extends React.Component<Props, State> {
     pageSize: storage.pageSize.get()
   };
 
-  handlePageChange = (page: number) => {
+  handlePageChange = (shouldScrollToTop: boolean = true) => (page: number) => {
     const { scrollToRef } = this.props;
-    scrollTo(scrollToRef);
+    if (shouldScrollToTop) {
+      scrollTo(scrollToRef);
+    }
     this.setState({ page });
   };
 

--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -763,7 +763,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                             </Paper>
                             <PaginationFooter
                               count={count}
-                              handlePageChange={handlePageChange}
+                              handlePageChange={handlePageChange()}
                               handleSizeChange={handlePageSizeChange}
                               page={page}
                               pageSize={pageSize}

--- a/src/features/Domains/ListDomains.tsx
+++ b/src/features/Domains/ListDomains.tsx
@@ -89,7 +89,7 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
             count={count}
             page={page}
             pageSize={pageSize}
-            handlePageChange={handlePageChange}
+            handlePageChange={handlePageChange()}
             handleSizeChange={handlePageSizeChange}
             eventCategory="domains landing"
           />

--- a/src/features/Domains/ListGroupedDomains.tsx
+++ b/src/features/Domains/ListGroupedDomains.tsx
@@ -141,7 +141,7 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
                           >
                             <PaginationFooter
                               count={count}
-                              handlePageChange={handlePageChange}
+                              handlePageChange={handlePageChange()}
                               handleSizeChange={handlePageSizeChange}
                               pageSize={pageSize}
                               page={page}

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -372,7 +372,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
                   </Paper>
                   <PaginationFooter
                     count={count}
-                    handlePageChange={handlePageChange}
+                    handlePageChange={handlePageChange()}
                     handleSizeChange={handlePageSizeChange}
                     page={page}
                     pageSize={pageSize}

--- a/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
@@ -142,7 +142,7 @@ const ListGroupedNodeBalancers: React.StatelessComponent<
                             count={count}
                             page={page}
                             pageSize={pageSize}
-                            handlePageChange={handlePageChange}
+                            handlePageChange={handlePageChange()}
                             handleSizeChange={handlePageSizeChange}
                             eventCategory="nodebalancers landing"
                           />

--- a/src/features/NodeBalancers/NodeBalancersLanding/ListNodeBalancers.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/ListNodeBalancers.tsx
@@ -73,7 +73,7 @@ const ListNodeBalancers: React.StatelessComponent<CombinedProps> = props => {
             count={count}
             page={page}
             pageSize={pageSize}
-            handlePageChange={handlePageChange}
+            handlePageChange={handlePageChange()}
             handleSizeChange={handlePageSizeChange}
             eventCategory="nodebalancers landing"
           />

--- a/src/features/ObjectStorage/ListBuckets.tsx
+++ b/src/features/ObjectStorage/ListBuckets.tsx
@@ -97,7 +97,7 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
             count={count}
             page={page}
             pageSize={pageSize}
-            handlePageChange={handlePageChange}
+            handlePageChange={handlePageChange()}
             handleSizeChange={handlePageSizeChange}
             eventCategory="object storage landing"
           />

--- a/src/features/Volumes/ListGroupedVolumes.tsx
+++ b/src/features/Volumes/ListGroupedVolumes.tsx
@@ -130,7 +130,7 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
                           >
                             <PaginationFooter
                               count={count}
-                              handlePageChange={handlePageChange}
+                              handlePageChange={handlePageChange()}
                               handleSizeChange={handlePageSizeChange}
                               pageSize={pageSize}
                               page={page}

--- a/src/features/Volumes/ListVolumes.tsx
+++ b/src/features/Volumes/ListVolumes.tsx
@@ -77,7 +77,7 @@ const ListVolumes: React.StatelessComponent<CombinedProps> = props => {
             count={count}
             page={page}
             pageSize={pageSize}
-            handlePageChange={handlePageChange}
+            handlePageChange={handlePageChange()}
             handleSizeChange={handlePageSizeChange}
             eventCategory="volumes landing"
           />

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -115,7 +115,7 @@ class SelectLinodePanel extends React.Component<CombinedProps> {
                 </Paper>
                 <PaginationFooter
                   count={count}
-                  handlePageChange={handlePageChange}
+                  handlePageChange={handlePageChange()}
                   handleSizeChange={handlePageSizeChange}
                   page={page}
                   pageSize={pageSize}

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeAdvancedConfigurationsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeAdvancedConfigurationsPanel.tsx
@@ -36,25 +36,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 type CombinedProps = LinodeContextProps & WithStyles<ClassNames>;
 
-interface State {
-  loaded: boolean;
-}
-
-class LinodeAdvancedConfigurationsPanel extends React.Component<
-  CombinedProps,
-  State
+class LinodeAdvancedConfigurationsPanel extends React.PureComponent<
+  CombinedProps
 > {
-  state: State = {
-    loaded: false
-  };
-
-  componentDidMount = () => {
-    this.setState({ loaded: true });
-  };
-
   render() {
     const { classes, disks, linodeTotalDisk } = this.props;
-    const { loaded } = this.state;
 
     return (
       <Grid container>
@@ -63,19 +49,15 @@ class LinodeAdvancedConfigurationsPanel extends React.Component<
             Advanced Configurations
           </Typography>
           <Paper className={classes.paper}>
-            <LinodeConfigs active={loaded} />
+            <LinodeConfigs />
           </Paper>
           <Paper className={classes.paper}>
-            <LinodeDisks active={loaded} />
+            <LinodeDisks />
           </Paper>
         </Grid>
         <Grid item xs={12} md={5} lg={3} className={classes.sidebar}>
           <Paper className={classes.paper}>
-            <LinodeDiskSpace
-              disks={disks}
-              loading={!loaded}
-              totalDiskSpace={linodeTotalDisk}
-            />
+            <LinodeDiskSpace disks={disks} totalDiskSpace={linodeTotalDisk} />
           </Paper>
         </Grid>
       </Grid>
@@ -84,8 +66,8 @@ class LinodeAdvancedConfigurationsPanel extends React.Component<
 }
 
 interface LinodeContextProps {
-  linodeTotalDisk?: number;
-  disks: Linode.Disk[] | undefined;
+  linodeTotalDisk: number;
+  disks: Linode.Disk[];
 }
 
 const linodeContext = withLinodeDetailContext(({ linode }) => ({

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskSpace.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskSpace.test.tsx
@@ -15,8 +15,6 @@ const component = shallow(
       textOuter: '',
       code: ''
     }}
-    loading={true}
-    error={new Error('hello world')}
     disks={disks}
     totalDiskSpace={100}
   />
@@ -25,28 +23,6 @@ const component = shallow(
 describe('LinodeDiskSpace', () => {
   it('should add up the space in each disk', () => {
     expect(addUsedDiskSpace(disks)).toBe(25600);
-  });
-
-  it('should render Loading state if loading prop is true', () => {
-    expect(component.find('DiskSpaceLoading')).toHaveLength(1);
-  });
-
-  it('should render error state if error prop is true and loading prop is false', () => {
-    component.setProps({ loading: false });
-    expect(component.find('WithStyles(ErrorState)')).toHaveLength(1);
-  });
-
-  it(`should render main content if loading is false and error prop is undefined and
-  disks prop is defined`, () => {
-    component.setProps({ error: undefined });
-    expect(component.children().length).toBeTruthy();
-  });
-
-  it(`should render null if data, error, and totalDiskSpace are 
-    undefined and loading is false`, () => {
-    component.setProps({ disks: undefined });
-    component.setProps({ totalDiskSpace: undefined });
-    expect(component.children().length).toBeFalsy();
   });
 
   describe('percentages', () => {

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskSpace.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskSpace.tsx
@@ -8,7 +8,6 @@ import * as React from 'react';
 import BarPercent from 'src/components/BarPercent';
 import Divider from 'src/components/core/Divider';
 import Typography from 'src/components/core/Typography';
-import ErrorState from 'src/components/ErrorState';
 
 type ClassNames =
   | 'root'
@@ -45,34 +44,15 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 });
 
 interface Props {
-  loading: boolean;
-  disks?: Linode.Disk[];
-  error?: Error;
-  totalDiskSpace?: number;
+  disks: Linode.Disk[];
+  totalDiskSpace: number;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 export class LinodeDiskSpace extends React.PureComponent<CombinedProps> {
   render() {
-    const { loading, error, disks, totalDiskSpace, classes } = this.props;
-
-    if (loading) {
-      return <DiskSpaceLoading />;
-    }
-
-    if (error) {
-      return (
-        <ErrorState
-          cozy
-          errorText="There was an error loading your storage statistics"
-        />
-      );
-    }
-
-    if (!disks || !totalDiskSpace) {
-      return null;
-    }
+    const { disks, totalDiskSpace, classes } = this.props;
 
     const usedDiskSpace = addUsedDiskSpace(disks);
 
@@ -136,16 +116,3 @@ export const addUsedDiskSpace = (disks: Linode.Disk[]) => {
 const styled = withStyles(styles);
 
 export default styled(LinodeDiskSpace);
-
-class DiskSpaceLoading extends React.PureComponent<{}> {
-  render() {
-    return (
-      <BarPercent
-        isFetchingValue={true}
-        loadingText="Loading your storage statistics..."
-        max={0}
-        value={0}
-      />
-    );
-  }
-}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -91,7 +91,6 @@ interface Props {
   open: boolean;
   linodeConfigId?: number;
   onClose: () => void;
-  onSuccess: () => void;
 }
 
 interface State {
@@ -630,7 +629,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       return updateLinodeConfig(linodeConfigId, configData)
         .then(_ => {
           this.props.onClose();
-          this.props.onSuccess();
         })
         .catch(error => {
           this.setState({
@@ -647,7 +645,6 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     return createLinodeConfig(configData)
       .then(_ => {
         this.props.onClose();
-        this.props.onSuccess();
       })
       .catch(error =>
         this.setState({

--- a/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -147,7 +147,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<
                       <Grid item xs={12}>
                         <PaginationFooter
                           count={count}
-                          handlePageChange={handlePageChange}
+                          handlePageChange={handlePageChange()}
                           handleSizeChange={handlePageSizeChange}
                           pageSize={pageSize}
                           page={page}
@@ -217,7 +217,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<
                             >
                               <PaginationFooter
                                 count={count}
-                                handlePageChange={handlePageChange}
+                                handlePageChange={handlePageChange()}
                                 handleSizeChange={handlePageSizeChange}
                                 pageSize={pageSize}
                                 page={page}

--- a/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -71,7 +71,7 @@ const DisplayLinodes: React.StatelessComponent<CombinedProps> = props => {
               {
                 <PaginationFooter
                   count={data.length}
-                  handlePageChange={handlePageChange}
+                  handlePageChange={handlePageChange()}
                   handleSizeChange={handlePageSizeChange}
                   pageSize={pageSize}
                   page={page}

--- a/src/store/linodes/config/config.requests.ts
+++ b/src/store/linodes/config/config.requests.ts
@@ -69,7 +69,9 @@ export const getAllLinodeConfigs: ThunkActionCreator<Promise<Entity[]>> = (
   const { linodeId } = params;
   const { started, done, failed } = getAllLinodeConfigsActions;
   dispatch(started(params));
-  const req = getAll<Entity>(() => _getLinodeConfigs(linodeId));
+  const req = getAll<Entity>((configParams?: any, filter?: any) =>
+    _getLinodeConfigs(linodeId, configParams, filter)
+  );
 
   try {
     const { data } = await req();

--- a/src/store/linodes/disk/disk.requests.ts
+++ b/src/store/linodes/disk/disk.requests.ts
@@ -69,7 +69,9 @@ export const getAllLinodeDisks: ThunkActionCreator<Promise<Entity[]>> = (
   const { linodeId } = params;
   const { started, done, failed } = getAllLinodeDisksActions;
   dispatch(started(params));
-  const req = getAll<Entity>(() => _getLinodeDisks(linodeId));
+  const req = getAll<Entity>((diskParams: any, filter: any) =>
+    _getLinodeDisks(linodeId, diskParams, filter)
+  );
 
   try {
     const { data } = await req();


### PR DESCRIPTION
## Description

Remove Pagey from Disks and Configs panel in favor of Paginate render-props component

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## Note to Reviewers

Also removed the auto scroll-to-top from disks and configs because they don't have their own dedicated pages, so it would make sense. We should implement some sort of scroll-to-id feature, similar to `scrollToError`