### PR TITLE
M3-2298 Add: event stream summary

### DIFF
--- a/src/components/ViewAllLink/ViewAllLink.tsx
+++ b/src/components/ViewAllLink/ViewAllLink.tsx
@@ -14,6 +14,7 @@ interface Props {
   link: string;
   count?: number;
   external?: boolean;
+  className?: any;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -36,7 +37,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 });
 
 const ViewAllLink: React.StatelessComponent<CombinedProps> = props => {
-  const { classes, count, text, link, external } = props;
+  const { classes, count, text, link, external, className } = props;
   return (
     <>
       {count && (
@@ -51,10 +52,13 @@ const ViewAllLink: React.StatelessComponent<CombinedProps> = props => {
       {!external ? (
         <Link
           to={link}
-          className={classNames({
-            [classes.link]: true,
-            [classes.noCount]: !count
-          })}
+          className={classNames(
+            {
+              [classes.link]: true,
+              [classes.noCount]: !count
+            },
+            className
+          )}
           data-qa-view-all-link
         >
           {text}

--- a/src/components/ViewAllLink/index.ts
+++ b/src/components/ViewAllLink/index.ts
@@ -1,0 +1,2 @@
+import ViewAllLink from './ViewAllLink';
+export default ViewAllLink;

--- a/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
+++ b/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
@@ -9,9 +9,9 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import ViewAllLink from 'src/components/ViewAllLink';
 import { parseString } from 'xml2js';
 import DashboardCard from '../DashboardCard';
-import ViewAllLink from '../ViewAllLink';
 
 const parseXMLStringPromise = (str: string) =>
   new Promise((resolve, reject) =>

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -17,15 +17,14 @@ import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
+import ViewAllLink from 'src/components/ViewAllLink';
 import { ApplicationState } from 'src/store';
 import { openForEditing } from 'src/store/domainDrawer';
-
 import {
   isEntityEvent,
   isInProgressEvent
 } from 'src/store/events/event.helpers';
 import DashboardCard from '../DashboardCard';
-import ViewAllLink from '../ViewAllLink';
 
 type ClassNames =
   | 'root'

--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -16,6 +16,7 @@ import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
+import ViewAllLink from 'src/components/ViewAllLink';
 import LinodeRowHeadCell from 'src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
 import { ApplicationState } from 'src/store';
@@ -24,7 +25,6 @@ import {
   isInProgressEvent
 } from 'src/store/events/event.helpers';
 import DashboardCard from '../DashboardCard';
-import ViewAllLink from '../ViewAllLink';
 
 type ClassNames =
   | 'root'

--- a/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -18,11 +18,11 @@ import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
+import ViewAllLink from 'src/components/ViewAllLink';
 import { events$ } from 'src/events';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
 import { getNodeBalancers } from 'src/services/nodebalancers';
 import DashboardCard from '../DashboardCard';
-import ViewAllLink from '../ViewAllLink';
 
 type ClassNames =
   | 'root'

--- a/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
@@ -13,10 +13,10 @@ import TableBody from 'src/components/core/TableBody';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
+import ViewAllLink from 'src/components/ViewAllLink';
 import { events$ } from 'src/events';
 import { getVolumes } from 'src/services/volumes';
 import DashboardCard from '../DashboardCard';
-import ViewAllLink from '../ViewAllLink';
 import VolumeDashboardRow from './VolumeDashboardRow';
 
 type ClassNames = 'root';

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -16,7 +16,7 @@ type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
-    padding: theme.spacing.unit * 2,
+    padding: theme.spacing.unit * 1.5,
     borderBottom: `1px solid ${theme.palette.divider}`
   }
 });

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+import {
+  StyleRulesCallback,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import DateTimeDisplay from 'src/components/DateTimeDisplay';
+import Grid from 'src/components/Grid';
+import eventMessageGenerator from 'src/eventMessageGenerator';
+import { onUnfound } from 'src/features/Events/EventRow';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {
+    padding: theme.spacing.unit * 2,
+    borderBottom: `1px solid ${theme.palette.divider}`
+  }
+});
+
+interface Props {
+  event: Linode.Event;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
+  const { classes, event } = props;
+
+  const message = eventMessageGenerator(event, onUnfound);
+
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <Grid
+      className={classes.root}
+      container
+      direction={'row'}
+      justify={'space-between'}
+      alignItems={'center'}
+    >
+      <Grid item>
+        <Typography variant={'inherit'}>{event.action}</Typography>
+      </Grid>
+      <Grid item>
+        <DateTimeDisplay value={event.created} humanizeCutoff={'month'} />
+      </Grid>
+    </Grid>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(ActivityRow);

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -16,7 +16,7 @@ type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
-    padding: theme.spacing.unit * 1.5,
+    padding: theme.spacing.unit,
     borderBottom: `1px solid ${theme.palette.divider}`
   }
 });

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -43,6 +43,7 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
       direction={'row'}
       justify={'space-between'}
       alignItems={'center'}
+      data-qa-activity-row
     >
       <Grid item>
         <Typography variant={'inherit'}>{message}</Typography>

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -45,7 +45,7 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
       alignItems={'center'}
     >
       <Grid item>
-        <Typography variant={'inherit'}>{event.action}</Typography>
+        <Typography variant={'inherit'}>{message}</Typography>
       </Grid>
       <Grid item>
         <DateTimeDisplay value={event.created} humanizeCutoff={'month'} />

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
@@ -15,7 +15,8 @@ const props = {
   linodeId: 123456,
   classes: {
     root: '',
-    header: ''
+    header: '',
+    viewMore: ''
   }
 };
 const component = shallow(<ActivitySummary {...props} />);

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
@@ -1,0 +1,34 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+const requests = require.requireMock('src/services/account');
+
+requests.getEvents = jest.fn(() => Promise.resolve([]));
+
+jest.mock('src/services/account', () => ({
+  getEvents: () => jest.fn()
+}));
+
+import { ActivitySummary } from './ActivitySummary';
+
+const props = {
+  linodeId: 123456,
+  classes: {
+    root: '',
+    header: ''
+  }
+};
+const component = shallow(<ActivitySummary {...props} />);
+
+describe('ActivitySummary component', () => {
+  it('should render', () => {
+    expect(component).toHaveLength(1);
+  });
+
+  it("should request the Linode's events on load", () => {
+    expect(requests.getEvents).toHaveBeenCalledWith(
+      {},
+      { 'entity.id': 123456, 'entity.type': 'linode' }
+    );
+  });
+});

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import Grid from 'src/components/core/Grid';
+import Paper from 'src/components/core/Paper';
+import {
+  StyleRulesCallback,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+
+import ActivityRow from './ActivityRow';
+
+// mocking
+import { events } from 'src/__data__/events';
+const mockEvents = events.slice(0, 5);
+
+type ClassNames = 'root' | 'header';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {
+    marginBottom: theme.spacing.unit * 2
+  },
+  header: {
+    marginBottom: theme.spacing.unit * 2
+  }
+});
+
+type CombinedProps = WithStyles<ClassNames>;
+
+export const ActivitySummary: React.StatelessComponent<
+  CombinedProps
+> = props => {
+  const { classes } = props;
+  return (
+    <>
+      <Grid container alignItems={'center'} justify={'space-between'}>
+        <Grid item>
+          <Typography className={classes.header} variant="h2">
+            Activity Feed
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Link to="/activity">View More Activity</Link>
+        </Grid>
+      </Grid>
+      <Paper className={classes.root}>
+        {mockEvents.map((event, idx) => (
+          <ActivityRow event={event} key={`activity-summary-row-${idx}`} />
+        ))}
+      </Paper>
+    </>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(ActivitySummary);

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -29,56 +29,68 @@ interface Props {
   linodeId: number;
 }
 
+interface State {
+  loading: boolean;
+  error?: string;
+  events: Linode.Event[];
+}
+
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const ActivitySummary: React.StatelessComponent<
-  CombinedProps
-> = props => {
-  const [events, setEvents] = React.useState<Linode.Event[]>([]);
-  const [error, setError] = React.useState<string | undefined>(undefined);
-  const [loading, setLoading] = React.useState<boolean>(true);
+export class ActivitySummary extends React.Component<CombinedProps, State> {
+  state: State = {
+    loading: true,
+    error: undefined,
+    events: []
+  };
 
-  React.useEffect(() => {
-    getEvents({}, { 'entity.type': 'linode', 'entity.id': props.linodeId })
+  componentDidMount() {
+    getEvents({}, { 'entity.type': 'linode', 'entity.id': this.props.linodeId })
       .then(response => {
-        setEvents(response.data.slice(0, 5));
+        this.setState({
+          events: response.data.slice(0, 5),
+          loading: false
+        });
       })
       .catch(err => {
-        setError(
-          getErrorStringOrDefault(
+        this.setState({
+          error: getErrorStringOrDefault(
             err,
             "Couldn't retrieve events for this Linode."
-          )
-        );
+          ),
+          loading: false
+        });
       });
-    setLoading(false);
-  }, []);
-  const { classes, linodeId } = props;
-  return (
-    <>
-      <Grid
-        container
-        alignItems={'center'}
-        justify={'space-between'}
-        className={classes.header}
-      >
-        <Grid item>
-          <Typography variant="h2">Activity Feed</Typography>
+  }
+  render() {
+    const { classes, linodeId } = this.props;
+    const { events, error, loading } = this.state;
+    return (
+      <>
+        <Grid
+          container
+          alignItems={'center'}
+          justify={'space-between'}
+          className={classes.header}
+        >
+          <Grid item>
+            <Typography variant="h2">Activity Feed</Typography>
+          </Grid>
+          <Grid item>
+            <Link to={`/linodes/${linodeId}/activity`}>View More Activity</Link>
+          </Grid>
         </Grid>
-        <Grid item>
-          <Link to={`/linodes/${linodeId}/activity`}>View More Activity</Link>
-        </Grid>
-      </Grid>
-      <Paper className={classes.root}>
-        <ActivitySummaryContent
-          events={events}
-          error={error}
-          loading={loading}
-        />
-      </Paper>
-    </>
-  );
-};
+        <Paper className={classes.root}>
+          <ActivitySummaryContent
+            events={events}
+            error={error}
+            loading={loading}
+          />
+        </Paper>
+      </>
+    );
+  }
+}
 
 const styled = withStyles(styles);
 

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -41,12 +41,9 @@ export const ActivitySummary: React.StatelessComponent<
   const [loading, setLoading] = React.useState<boolean>(true);
 
   React.useEffect(() => {
-    getEvents(
-      { pageSize: 5 },
-      { 'entity.type': 'linode', 'entity.id': props.linodeId }
-    )
+    getEvents({}, { 'entity.type': 'linode', 'entity.id': props.linodeId })
       .then(response => {
-        setEvents(response.data);
+        setEvents(response.data.slice(0, 5));
         setLoading(false);
       })
       .catch(err => {

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -9,8 +9,8 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import { getEvents } from 'src/services/account';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
+import { getEventsForEntity } from 'src/utilities/getEventsForEntity';
 
 import ActivitySummaryContent from './ActivitySummaryContent';
 
@@ -45,7 +45,7 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
   };
 
   componentDidMount() {
-    getEvents({}, { 'entity.type': 'linode', 'entity.id': this.props.linodeId })
+    getEventsForEntity({}, 'linode', this.props.linodeId)
       .then(response => {
         this.setState({
           events: response.data.slice(0, 5),

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -14,7 +14,7 @@ import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 import ActivitySummaryContent from './ActivitySummaryContent';
 
-type ClassNames = 'root' | 'header' | 'emptyState';
+type ClassNames = 'root' | 'header';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
@@ -22,9 +22,6 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   },
   header: {
     marginBottom: theme.spacing.unit * 2
-  },
-  emptyState: {
-    padding: theme.spacing.unit * 2
   }
 });
 
@@ -45,7 +42,6 @@ export const ActivitySummary: React.StatelessComponent<
     getEvents({}, { 'entity.type': 'linode', 'entity.id': props.linodeId })
       .then(response => {
         setEvents(response.data.slice(0, 5));
-        setLoading(false);
       })
       .catch(err => {
         setError(

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -20,7 +20,7 @@ type ClassNames = 'root' | 'header';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
-    marginBottom: theme.spacing.unit * 2
+    marginBottom: theme.spacing.unit * 4
   },
   header: {
     marginBottom: theme.spacing.unit * 2
@@ -62,11 +62,14 @@ export const ActivitySummary: React.StatelessComponent<
   const { classes, linodeId } = props;
   return (
     <>
-      <Grid container alignItems={'center'} justify={'space-between'}>
+      <Grid
+        container
+        alignItems={'center'}
+        justify={'space-between'}
+        className={classes.header}
+      >
         <Grid item>
-          <Typography className={classes.header} variant="h2">
-            Activity Feed
-          </Typography>
+          <Typography variant="h2">Activity Feed</Typography>
         </Grid>
         <Grid item>
           <Link to={`/linodes/${linodeId}/activity`}>View More Activity</Link>
@@ -94,7 +97,7 @@ const renderContentLoadingOrError = (
 
   if (events.length === 0) {
     return (
-      <Typography variant="caption">
+      <Typography variant="body2">
         No recent activity for this Linode.
       </Typography>
     );

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import Grid from 'src/components/core/Grid';
 import Paper from 'src/components/core/Paper';
 import {
@@ -9,12 +8,12 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import ViewAllLink from 'src/components/ViewAllLink';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { getEventsForEntity } from 'src/utilities/getEventsForEntity';
-
 import ActivitySummaryContent from './ActivitySummaryContent';
 
-type ClassNames = 'root' | 'header';
+type ClassNames = 'root' | 'header' | 'viewMore';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
@@ -22,6 +21,10 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   },
   header: {
     marginBottom: theme.spacing.unit * 2
+  },
+  viewMore: {
+    position: 'relative',
+    top: 2
   }
 });
 
@@ -67,17 +70,18 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
     const { events, error, loading } = this.state;
     return (
       <>
-        <Grid
-          container
-          alignItems={'center'}
-          justify={'space-between'}
-          className={classes.header}
-        >
+        <Grid container alignItems={'center'} className={classes.header}>
           <Grid item>
             <Typography variant="h2">Activity Feed</Typography>
           </Grid>
           <Grid item>
-            <Link to={`/linodes/${linodeId}/activity`}>View More Activity</Link>
+            <Typography>
+              <ViewAllLink
+                text="View More Activity"
+                link={`/linodes/${linodeId}/activity`}
+                className={classes.viewMore}
+              />
+            </Typography>
           </Grid>
         </Grid>
         <Paper className={classes.root}>

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import CircleProgress from 'src/components/CircleProgress';
 import Grid from 'src/components/core/Grid';
 import Paper from 'src/components/core/Paper';
 import {
@@ -10,13 +9,12 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import ErrorState from 'src/components/ErrorState';
 import { getEvents } from 'src/services/account';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
-import ActivityRow from './ActivityRow';
+import ActivitySummaryContent from './ActivitySummaryContent';
 
-type ClassNames = 'root' | 'header';
+type ClassNames = 'root' | 'header' | 'emptyState';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   root: {
@@ -24,6 +22,9 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
   },
   header: {
     marginBottom: theme.spacing.unit * 2
+  },
+  emptyState: {
+    padding: theme.spacing.unit * 2
   }
 });
 
@@ -73,36 +74,14 @@ export const ActivitySummary: React.StatelessComponent<
         </Grid>
       </Grid>
       <Paper className={classes.root}>
-        {renderContentLoadingOrError(events, loading, error)}
+        <ActivitySummaryContent
+          events={events}
+          error={error}
+          loading={loading}
+        />
       </Paper>
     </>
   );
-};
-
-const renderContentLoadingOrError = (
-  events: Linode.Event[],
-  loading: boolean,
-  error?: string
-) => {
-  if (error) {
-    return <ErrorState errorText={error} />;
-  }
-
-  if (loading) {
-    return <CircleProgress />;
-  }
-
-  if (events.length === 0) {
-    return (
-      <Typography variant="body2">
-        No recent activity for this Linode.
-      </Typography>
-    );
-  }
-
-  return events.map((event, idx) => (
-    <ActivityRow event={event} key={`activity-summary-row-${idx}`} />
-  ));
 };
 
 const styled = withStyles(styles);

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.test.tsx
@@ -1,0 +1,40 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { events } from 'src/__data__/events';
+
+import { ActivitySummaryContent } from './ActivitySummaryContent';
+
+const props = {
+  loading: true,
+  events: [],
+  classes: {
+    root: '',
+    emptyState: ''
+  }
+};
+
+const component = shallow(<ActivitySummaryContent {...props} />);
+
+describe('ActivitySummaryContent', () => {
+  it('should render a loading spinner when loading', () => {
+    expect(component.find('[data-qa-activity-loading]')).toHaveLength(1);
+  });
+
+  it('should render an error state when there is an error', () => {
+    component.setProps({ error: 'An error' });
+    expect(component.find('[data-qa-activity-error]')).toHaveLength(1);
+  });
+
+  it('should render an empty state when there are no events', () => {
+    component.setProps({ error: undefined, loading: false });
+    expect(component.find('[data-qa-activity-empty]')).toHaveLength(1);
+  });
+
+  it('should render an ActivityRow for each event when there are events', () => {
+    component.setProps({ events });
+    expect(component.find('[data-qa-activity-row]')).toHaveLength(
+      events.length
+    );
+  });
+});

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import CircleProgress from 'src/components/CircleProgress';
+import Grid from 'src/components/core/Grid';
 import {
   StyleRulesCallback,
   Theme,
@@ -38,14 +39,20 @@ export const ActivitySummaryContent: React.StatelessComponent<
   }
 
   if (loading) {
-    return <CircleProgress mini />;
+    return (
+      <Grid container alignContent="center" justify="center">
+        <CircleProgress mini />
+      </Grid>
+    );
   }
 
   if (events.length === 0) {
     return (
-      <Typography className={classes.emptyState} variant="body2">
-        No recent activity for this Linode.
-      </Typography>
+      <Grid container alignContent="center" justify="center">
+        <Typography className={classes.emptyState} variant="body2">
+          No recent activity for this Linode.
+        </Typography>
+      </Grid>
     );
   }
 

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+
+import CircleProgress from 'src/components/CircleProgress';
+import {
+  StyleRulesCallback,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import ErrorState from 'src/components/ErrorState';
+
+import ActivityRow from './ActivityRow';
+
+type ClassNames = 'root' | 'emptyState';
+
+const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
+  root: {},
+  emptyState: {
+    padding: theme.spacing.unit * 2
+  }
+});
+
+interface Props {
+  error?: string;
+  loading: boolean;
+  events: Linode.Event[];
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export const ActivitySummaryContent: React.StatelessComponent<
+  CombinedProps
+> = props => {
+  const { classes, error, loading, events } = props;
+  if (error) {
+    return <ErrorState errorText={error} />;
+  }
+
+  if (loading) {
+    return <CircleProgress />;
+  }
+
+  if (events.length === 0) {
+    return (
+      <Typography className={classes.emptyState} variant="body2">
+        No recent activity for this Linode.
+      </Typography>
+    );
+  }
+
+  return (
+    <>
+      {events.map((event, idx) => (
+        <ActivityRow event={event} key={`activity-summary-row-${idx}`} />
+      ))}
+    </>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(ActivitySummaryContent);

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.tsx
@@ -38,7 +38,7 @@ export const ActivitySummaryContent: React.StatelessComponent<
   }
 
   if (loading) {
-    return <CircleProgress />;
+    return <CircleProgress mini />;
   }
 
   if (events.length === 0) {

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummaryContent.tsx
@@ -35,12 +35,17 @@ export const ActivitySummaryContent: React.StatelessComponent<
 > = props => {
   const { classes, error, loading, events } = props;
   if (error) {
-    return <ErrorState errorText={error} />;
+    return <ErrorState data-qa-activity-error errorText={error} />;
   }
 
   if (loading) {
     return (
-      <Grid container alignContent="center" justify="center">
+      <Grid
+        container
+        alignContent="center"
+        justify="center"
+        data-qa-activity-loading
+      >
         <CircleProgress mini />
       </Grid>
     );
@@ -48,7 +53,12 @@ export const ActivitySummaryContent: React.StatelessComponent<
 
   if (events.length === 0) {
     return (
-      <Grid container alignContent="center" justify="center">
+      <Grid
+        container
+        alignContent="center"
+        justify="center"
+        data-qa-activity-empty
+      >
         <Typography className={classes.emptyState} variant="body2">
           No recent activity for this Linode.
         </Typography>
@@ -59,7 +69,11 @@ export const ActivitySummaryContent: React.StatelessComponent<
   return (
     <>
       {events.map((event, idx) => (
-        <ActivityRow event={event} key={`activity-summary-row-${idx}`} />
+        <ActivityRow
+          event={event}
+          key={`activity-summary-row-${idx}`}
+          data-qa-activity-row
+        />
       ))}
     </>
   );

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -110,7 +110,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
     },
     graphControls: {
       display: 'flex',
-      alignItems: 'center'
+      alignItems: 'center',
+      marginTop: theme.spacing.unit * 2,
+      marginBottom: theme.spacing.unit * 2
     },
     totalTraffic: {
       margin: '12px'
@@ -676,32 +678,29 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                   {longLabel}
                 </Typography>
               </Grid>
-              <Grid item className="py0">
-                <div className={classes.graphControls}>
-                  <Typography
-                    variant="body1"
-                    className={classes.graphSelectTitle}
-                  >
-                    Graphs
-                  </Typography>
-                  <FormControl style={{ marginTop: 0 }}>
-                    <InputLabel htmlFor="chartRange" disableAnimation hidden>
-                      Select Time Range
-                    </InputLabel>
-                    <Select
-                      value={rangeSelection}
-                      onChange={this.handleChartRangeChange}
-                      inputProps={{ name: 'chartRange', id: 'chartRange' }}
-                      small
-                    >
-                      {this.rangeSelectOptions}
-                    </Select>
-                  </FormControl>
-                </div>
-              </Grid>
             </Grid>
 
-            <ActivitySummary linodeId={linode.id} />
+            <Grid item>
+              <ActivitySummary linodeId={linode.id} />
+            </Grid>
+
+            <Grid item className="py0">
+              <div className={classes.graphControls}>
+                <FormControl>
+                  <InputLabel htmlFor="chartRange" disableAnimation hidden>
+                    Select Time Range
+                  </InputLabel>
+                  <Select
+                    value={rangeSelection}
+                    onChange={this.handleChartRangeChange}
+                    inputProps={{ name: 'chartRange', id: 'chartRange' }}
+                    small
+                  >
+                    {this.rangeSelectOptions}
+                  </Select>
+                </FormControl>
+              </div>
+            </Grid>
 
             <StatsPanel
               title="CPU Usage"

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -1,7 +1,8 @@
 import * as moment from 'moment';
-import { compose, map, pathOr } from 'ramda';
+import { map, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { compose } from 'recompose';
 import FormControl from 'src/components/core/FormControl';
 import InputLabel from 'src/components/core/InputLabel';
 import MenuItem from 'src/components/core/MenuItem';
@@ -16,10 +17,7 @@ import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
 import Select from 'src/components/Select';
 import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
-import {
-  displayType,
-  typeLabelDetails
-} from 'src/features/linodes/presentation';
+import { displayType, typeLabelLong } from 'src/features/linodes/presentation';
 import { getLinodeStats, getLinodeStatsByDate } from 'src/services/linodes';
 import { ApplicationState } from 'src/store';
 import { setUpCharts } from 'src/utilities/charts';
@@ -654,9 +652,8 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
       return null;
     }
 
-    const label = displayType(linode.type, typesData || []);
-
-    const details = typeLabelDetails(
+    const longLabel = typeLabelLong(
+      displayType(linode.type, typesData || []),
       linode.specs.memory,
       linode.specs.disk,
       linode.specs.vcpus
@@ -680,11 +677,8 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
             >
               <Grid item className="py0">
                 <Typography variant="h2" className={classes.graphTitle}>
-                  {label}
+                  {longLabel}
                 </Typography>
-              </Grid>
-              <Grid item>
-                <Typography variant="h3">{details}</Typography>
               </Grid>
             </Grid>
 
@@ -756,7 +750,7 @@ const withTypes = connect((state: ApplicationState, ownProps) => ({
   typesData: state.__resources.types.entities
 }));
 
-const enhanced = compose(
+const enhanced = compose<CombinedProps, {}>(
   styled,
   withTypes,
   linodeContext

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -29,6 +29,7 @@ import {
   getMetrics,
   getTotalTraffic
 } from 'src/utilities/statMetrics';
+import ActivitySummary from './ActivitySummary';
 import MetricsDisplay from './MetricsDisplay';
 import StatsPanel from './StatsPanel';
 import SummaryPanel from './SummaryPanel';
@@ -699,6 +700,8 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 </div>
               </Grid>
             </Grid>
+
+            <ActivitySummary />
 
             <StatsPanel
               title="CPU Usage"

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -16,7 +16,10 @@ import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
 import Select from 'src/components/Select';
 import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
-import { displayType, typeLabelLong } from 'src/features/linodes/presentation';
+import {
+  displayType,
+  typeLabelDetails
+} from 'src/features/linodes/presentation';
 import { getLinodeStats, getLinodeStatsByDate } from 'src/services/linodes';
 import { ApplicationState } from 'src/store';
 import { setUpCharts } from 'src/utilities/charts';
@@ -651,8 +654,9 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
       return null;
     }
 
-    const longLabel = typeLabelLong(
-      displayType(linode.type, typesData || []),
+    const label = displayType(linode.type, typesData || []);
+
+    const details = typeLabelDetails(
       linode.specs.memory,
       linode.specs.disk,
       linode.specs.vcpus
@@ -670,13 +674,17 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
             <Grid
               container
               justify="space-between"
-              alignItems="center"
+              alignItems="flex-start"
               className={classes.headerWrapper}
+              direction="column"
             >
               <Grid item className="py0">
                 <Typography variant="h2" className={classes.graphTitle}>
-                  {longLabel}
+                  {label}
                 </Typography>
+              </Grid>
+              <Grid item>
+                <Typography variant="h3">{details}</Typography>
               </Grid>
             </Grid>
 

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -701,7 +701,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
               </Grid>
             </Grid>
 
-            <ActivitySummary />
+            <ActivitySummary linodeId={linode.id} />
 
             <StatsPanel
               title="CPU Usage"


### PR DESCRIPTION
## Description

Add a Activity Feed section to LinodeDetail/summary


## Applicable E2E Tests

None

## Note to Reviewers

I also updated the layout of LinodeDetailSummary to match the new-ish design (see ticket for link to Invision)