### PR TITLE
M3-2677 TESTS: Cleanup account data on test initialization

### DIFF
--- a/e2e/config/wdio.axe.conf.js
+++ b/e2e/config/wdio.axe.conf.js
@@ -34,6 +34,7 @@ exports.config = merge(wdioMaster.config, {
     seleniumInstallArgs: seleniumSettings,
     seleniumArgs: seleniumSettings,
     onPrepare: () => {},
+    beforeSession: () => {},
     before: function(caps, specs) {
         // Load up our custom commands
         require('babel-register');

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -251,6 +251,7 @@ exports.config = {
                 console.error("***** MAKE SURE MONGO IS RUNNING, do: docker run -d -p 27017:27017 mongo *****");
             }
         });
+        credStore.cleanupAccounts();
     },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 
-const { readFileSync, unlinkSync } = require('fs');
+const { readFileSync } = require('fs');
 const { argv } = require('yargs');
 
 const FSCredStore = require('../utils/fs-cred-store');
@@ -259,10 +259,8 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      * @param {Array.<String>} specs List of spec file paths that are to be run
      */
-    beforeSession: function (config, capabilities, specs) {
-        console.log("beforeSession");
-        return credStore.cleanupAccounts(false, 10);
-    },
+    // beforeSession: function (config, capabilities, specs) {
+    // },
     /**
      * Gets executed before test execution begins. At this point you can access to all global
      * variables like `browser`. It is the perfect place to define custom commands.
@@ -313,6 +311,11 @@ exports.config = {
         });
         console.log("creds are");
         console.log(creds);
+
+        browser.call(() => {
+            return credStore.cleanupAccounts(10, false);
+        });
+
         credStore.login(creds.username, creds.password, false);
     },
     /**

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -251,7 +251,6 @@ exports.config = {
                 console.error("***** MAKE SURE MONGO IS RUNNING, do: docker run -d -p 27017:27017 mongo *****");
             }
         });
-        credStore.cleanupAccounts();
     },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you
@@ -260,8 +259,10 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      * @param {Array.<String>} specs List of spec file paths that are to be run
      */
-    // beforeSession: function (config, capabilities, specs) {
-    // },
+    beforeSession: function (config, capabilities, specs) {
+        console.log("beforeSession");
+        return credStore.cleanupAccounts(false, 10);
+    },
     /**
      * Gets executed before test execution begins. At this point you can access to all global
      * variables like `browser`. It is the perfect place to define custom commands.

--- a/e2e/setup/cleanup.js
+++ b/e2e/setup/cleanup.js
@@ -48,18 +48,18 @@ exports.removeAllLinodes = token => {
    where Volumes fail to be removed if they were
    attached to a recently deleted linode
 */
-exports.pause = (volumesResponse) => {
+exports.pause = (volumesResponse, timeOut) => {
     return new Promise((resolve, reject) => {
-        setTimeout(() => resolve(volumesResponse), 21000);
+        setTimeout(() => resolve(volumesResponse, timeOut), timeOut ? timeOut : 21000);
     });
 }
 
-exports.removeAllVolumes = token => {
+exports.removeAllVolumes = (token, timeOut) => {
     
     const endpoint = '/volumes';
 
-    return getAxiosInstance(token).get(endpoint).then(volumesResponse => {
-        return exports.pause(volumesResponse).then(res => {
+    return getAxiosInstance(token).get(endpoint).then((volumesResponse) => {
+        return exports.pause(volumesResponse, timeOut).then(res => {
             volumes = res.data.data;
             if (volumes.length > 0) {
                 return Promise.all(
@@ -126,14 +126,14 @@ exports.deleteAll = (token, user) => {
     return iterateEndpointsAndRemove();
 }
 
-exports.resetAccounts = (credsArray) => {
+exports.resetAccounts = (credsArray, timeOut) => {
     return Promise.all(
         credsArray.map((cred) => {
             return exports.removeAllLinodes(cred.token)
             .then((res) => {
                 console.log("removed all linodes")
                 console.log(res);
-                return exports.removeAllVolumes(cred.token)
+                return exports.removeAllVolumes(cred.token, timeOut)
             })
             .then((res) => {
                 console.log("removed all volumes")

--- a/e2e/setup/cleanup.js
+++ b/e2e/setup/cleanup.js
@@ -28,7 +28,7 @@ const getAxiosInstance = (token) => {
 }
 
 exports.removeAllLinodes = token => {
-    
+
     const linodesEndpoint = '/linode/instances';
 
     return getAxiosInstance(token).get(linodesEndpoint)
@@ -50,12 +50,12 @@ exports.removeAllLinodes = token => {
 */
 exports.pause = (volumesResponse, timeOut) => {
     return new Promise((resolve, reject) => {
-        setTimeout(() => resolve(volumesResponse, timeOut), timeOut ? timeOut : 21000);
+        setTimeout(() => resolve(volumesResponse), timeOut);
     });
 }
 
 exports.removeAllVolumes = (token, timeOut) => {
-    
+
     const endpoint = '/volumes';
 
     return getAxiosInstance(token).get(endpoint).then((volumesResponse) => {

--- a/e2e/utils/cred-store.js
+++ b/e2e/utils/cred-store.js
@@ -24,12 +24,12 @@ class CredStore {
         throw "CredStore.getAllCreds() needs to be implemented in child class";
     }
 
-    cleanupAccounts() {
+    cleanupAccounts(timeOut) {
         if (this.shouldCleanupUsingAPI) {
             console.log("cleaning up user resources via API");
             return this.getAllCreds().then((credCollection) => {
                 console.log(credCollection);
-                return resetAccounts(credCollection);
+                return resetAccounts(credCollection, timeOut);
             });
         } else {
             console.log("not cleaning up resources via API");

--- a/e2e/utils/fs-cred-store.js
+++ b/e2e/utils/fs-cred-store.js
@@ -127,18 +127,20 @@ class FSCredStore extends CredStore {
         return this._readCredsFile();
     }
 
-    cleanupAccounts() {
-        return super.cleanupAccounts()
+    cleanupAccounts(noCredDel, timeOut) {
+        return super.cleanupAccounts(timeOut)
         .catch((err) => console.log(err))
         .then(() => {
             return new Promise((resolve, reject) => {
-                unlink(this.credsFile, (err) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(this.credsFile);
-                    }
-                })
+                noCredDel !== false ?
+                    unlink(this.credsFile, (err) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve(this.credsFile);
+                        }
+                    })
+                : resolve(this.credsFile);
             });            
         })
     }

--- a/e2e/utils/fs-cred-store.js
+++ b/e2e/utils/fs-cred-store.js
@@ -8,7 +8,7 @@ const CredStore = require('./cred-store');
  * on the local filesystem.
  */
 class FSCredStore extends CredStore {
-    
+
     constructor(credsFile, shouldCleanupUsingAPI, browser) {
         super(shouldCleanupUsingAPI, browser);
         this.credsFile = credsFile;
@@ -55,7 +55,7 @@ class FSCredStore extends CredStore {
             if (!currentUser.isPresetToken) {
                 currentUser.token = this.getTokenFromLocalStorage();
             }
-    
+
             return this._writeCredsFile(credCollection);
         })
     }
@@ -75,7 +75,7 @@ class FSCredStore extends CredStore {
                 if (!cred.inUse) {
                     credCollection[i].inUse = true;
                     credCollection[i].spec = specFile;
-                    
+
                     this.browser.options.testUser = credCollection[i].username;
                     return true;
                 }
@@ -86,7 +86,7 @@ class FSCredStore extends CredStore {
 
     checkinCreds(specFile) {
         console.log("checkinCreds: " + specFile);
-        
+
         return this._readCredsFile().then((credCollection) => {
             const creds = credCollection.find((cred, i) => {
                 if (cred.spec === specFile) {
@@ -117,7 +117,7 @@ class FSCredStore extends CredStore {
                 setCredCollection('MANAGER_USER', `_${i}`);
             }
         }
-        
+
         console.log("adding users:");
         console.log(credCollection);
         return this._writeCredsFile(credCollection);
@@ -127,12 +127,15 @@ class FSCredStore extends CredStore {
         return this._readCredsFile();
     }
 
-    cleanupAccounts(noCredDel, timeOut) {
+    cleanupAccounts(timeOut, runningOnComplete=true) {
         return super.cleanupAccounts(timeOut)
         .catch((err) => console.log(err))
         .then(() => {
             return new Promise((resolve, reject) => {
-                noCredDel !== false ?
+                if (!runningOnComplete) {
+                    // Nothing else to do if not running from onComplete
+                    resolve(true)
+                } else {
                     unlink(this.credsFile, (err) => {
                         if (err) {
                             reject(err);
@@ -140,8 +143,8 @@ class FSCredStore extends CredStore {
                             resolve(this.credsFile);
                         }
                     })
-                : resolve(this.credsFile);
-            });            
+                }
+            });
         })
     }
 }
@@ -149,9 +152,9 @@ class FSCredStore extends CredStore {
 if (process.argv[2] == "test-fs") {
 
     console.log("running fs credential tests");
-    
+
     let mockTestConfig = {"host":"selenium","port":4444,"sync":true,"specs":["./e2e/specs/search/smoke-search.spec.js"],"suites":{},"exclude":["./e2e/specs/accessibility/*.spec.js"],"logLevel":"silent","coloredLogs":true,"deprecationWarnings":false,"baseUrl":"http://localhost:3000","bail":0,"waitforInterval":500,"waitforTimeout":30000,"framework":"jasmine","reporters":["spec","junit"],"reporterOptions":{"junit":{"outputDir":"./e2e/test-results"}},"maxInstances":1,"maxInstancesPerCapability":100,"connectionRetryTimeout":90000,"connectionRetryCount":3,"debug":false,"execArgv":null,"mochaOpts":{"timeout":10000},"jasmineNodeOpts":{"defaultTimeoutInterval":600000},"before":[null],"beforeSession":[],"beforeSuite":[],"beforeHook":[],"beforeTest":[],"beforeCommand":[],"afterCommand":[],"afterTest":[],"afterHook":[],"afterSuite":[],"afterSession":[],"after":[null],"onError":[],"onReload":[],"beforeFeature":[],"beforeScenario":[],"beforeStep":[],"afterFeature":[],"afterScenario":[],"afterStep":[],"mountebankConfig":{"proxyConfig":{"imposterPort":"8088","imposterProtocol":"https","imposterName":"Linode-API","proxyHost":"https://api.linode.com/v4","mutualAuth":true}},"testUser":"","watch":false};
-    
+
     let credStore = new FSCredStore("/tmp/e2e-users.js", false);
 
     // assumes env var config for 2 test users, see .env or .env.example

--- a/e2e/utils/mongo-cred-store.js
+++ b/e2e/utils/mongo-cred-store.js
@@ -4,7 +4,7 @@ const CredStore = require('./cred-store');
 
 /**
  * Takes test user creds from environment variables and manages them in via a mongodb.
- * 
+ *
  * Designed to be used when running e2e tests via docker compose (see integration-test.yml).
  */
 class MongoCredStore extends CredStore {
@@ -36,7 +36,7 @@ class MongoCredStore extends CredStore {
         let mongo = null;
 
         return this._connect().then((mongoClient) => {
-            
+
             console.log("populating creds");
             mongo = mongoClient;
 
@@ -45,15 +45,15 @@ class MongoCredStore extends CredStore {
                 [{key: {inUse: 1, username: 1, spec: 1}}]
             );
 
-        }).then((result) => {            
+        }).then((result) => {
             console.log("initiailized users index");
-            
+
             const setCredCollection = (userKey, userIndex) => {
-        
+
                 const setEnvToken = process.env[`MANAGER_OAUTH${userIndex}`];
                 const token = setEnvToken ? setEnvToken : '';
-                const tokenFlag = token !== ''; 
-                
+                const tokenFlag = token !== '';
+
                 let userRecord = {
                     username: process.env[`${userKey}${userIndex}`],
                     password: process.env[`MANAGER_PASS${userIndex}`],
@@ -62,13 +62,13 @@ class MongoCredStore extends CredStore {
                     spec: '',
                     isPresetToken: tokenFlag
                 };
-                
+
                 const collection = mongo.db(this.dbName).collection(this.collectionName);
                 return collection.insertOne(userRecord).then(() => userRecord);
             }
-        
+
             const users = [setCredCollection('MANAGER_USER', '')];
-            
+
             if (userCount > 1) {
                 for (let i = 2; i <= userCount; i++ ) {
                     users.push(setCredCollection('MANAGER_USER', `_${i}`));
@@ -83,7 +83,7 @@ class MongoCredStore extends CredStore {
             });
             console.log("closing mongo client for populating creds");
             return mongo.close();
-        })        
+        })
     }
 
     // fetches all available creds
@@ -108,19 +108,19 @@ class MongoCredStore extends CredStore {
                 { $set: { inUse: true, spec: specToRun } },
                 { returnOriginal: false }
             )
-            
+
         })
         .then((result) => {
             console.log("checked out creds");
             const creds = result.value;
-            
+
             this.browser.options.testUser = creds.username;
 
             return mongo.close().then((r) => { return creds; });
         })
         .catch((err) => {
             console.log("error checking out creds for spec: " + specToRun);
-            console.log(err);            
+            console.log(err);
         });
     }
 
@@ -130,14 +130,14 @@ class MongoCredStore extends CredStore {
         let mongo = null;
         return this._connect().then((mongoClient) => {
             mongo = mongoClient;
-            
+
             return mongo.db(this.dbName).collection(this.collectionName)
             .findOneAndUpdate(
                 { spec: specThatRan },
                 { $set: { inUse: false, spec: '' } },
                 { returnOriginal: false }
             );
-            
+
         })
         .then((result) => {
             console.log("checked in creds");
@@ -146,8 +146,8 @@ class MongoCredStore extends CredStore {
         })
         .catch((err) => {
             console.log("error checking in creds for spec: " + specThatRan);
-            console.log(err);            
-        });        
+            console.log(err);
+        });
     }
 
     readToken(username) {
@@ -168,8 +168,8 @@ class MongoCredStore extends CredStore {
         throw "MongoCredStore.storeToken not implemented. See comments in utils/cred-store.js.";
     }
 
-    cleanupAccounts() {        
-        return super.cleanupAccounts()
+    cleanupAccounts(timeout) {
+        return super.cleanupAccounts(timeout)
         .catch((err) => console.log(err))
         .then((users) => {
             let mongo = null;
@@ -197,7 +197,7 @@ if (process.argv[2] == "test-mongo") {
     // NOTE: test below requires mongo to be running locally via
     //   docker run -d -p 27017:27017 mongo
     console.log("running mongo credential tests");
-    
+
     let mockTestConfig = {"host":"selenium","port":4444,"sync":true,"specs":["./e2e/specs/search/smoke-search.spec.js"],"suites":{},"exclude":["./e2e/specs/accessibility/*.spec.js"],"logLevel":"silent","coloredLogs":true,"deprecationWarnings":false,"baseUrl":"http://localhost:3000","bail":0,"waitforInterval":500,"waitforTimeout":30000,"framework":"jasmine","reporters":["spec","junit"],"reporterOptions":{"junit":{"outputDir":"./e2e/test-results"}},"maxInstances":1,"maxInstancesPerCapability":100,"connectionRetryTimeout":90000,"connectionRetryCount":3,"debug":false,"execArgv":null,"mochaOpts":{"timeout":10000},"jasmineNodeOpts":{"defaultTimeoutInterval":600000},"before":[null],"beforeSession":[],"beforeSuite":[],"beforeHook":[],"beforeTest":[],"beforeCommand":[],"afterCommand":[],"afterTest":[],"afterHook":[],"afterSuite":[],"afterSession":[],"after":[null],"onError":[],"onReload":[],"beforeFeature":[],"beforeScenario":[],"beforeStep":[],"afterFeature":[],"afterScenario":[],"afterStep":[],"mountebankConfig":{"proxyConfig":{"imposterPort":"8088","imposterProtocol":"https","imposterName":"Linode-API","proxyHost":"https://api.linode.com/v4","mutualAuth":true}},"testUser":"","watch":false};
     let mongoCredStore = new MongoCredStore("localhost", false);
 


### PR DESCRIPTION
## Cleanup account data on test initialization

We often get test failures because of data that was not cleaned up from a previous test. Let's run the tearDown script on initialization and see of that helps

## Type of Change
- Non breaking change ('update')
