### PR TITLE
M3-2679 Fix Typography for new Activity Feed and update tests

### DIFF
--- a/src/components/DateTimeDisplay/DateTimeDisplay.test.tsx
+++ b/src/components/DateTimeDisplay/DateTimeDisplay.test.tsx
@@ -12,7 +12,12 @@ describe('DateTimeDisplay component', () => {
   describe('Non-humanized dates', () => {
     it('should be displayed in 24-hour ISO format', () => {
       component.setProps({ value: APIDate, humanizeCutoff: undefined });
-      expect(component.text()).toContain('2018-07-20 04:23:17');
+      expect(
+        component
+          .find('WithStyles(Typography)')
+          .children()
+          .text()
+      ).toContain('2018-07-20 04:23:17');
     });
   });
 
@@ -22,7 +27,12 @@ describe('DateTimeDisplay component', () => {
         value: moment().subtract(5, 'minutes'),
         humanizeCutoff: 'day'
       });
-      expect(component.text()).toContain('5 minutes ago');
+      expect(
+        component
+          .find('WithStyles(Typography)')
+          .children()
+          .text()
+      ).toContain('5 minutes ago');
     });
     it('should output ISO strings if the date is older than the cutoff', () => {
       const almostOneWeek = moment().subtract(6, 'days');
@@ -30,9 +40,19 @@ describe('DateTimeDisplay component', () => {
         value: almostOneWeek,
         humanizeCutoff: 'month'
       });
-      expect(component.text()).toContain('6 days ago');
+      expect(
+        component
+          .find('WithStyles(Typography)')
+          .children()
+          .text()
+      ).toContain('6 days ago');
       component.setProps({ humanizeCutoff: 'day' });
-      expect(component.text()).toContain(almostOneWeek.year());
+      expect(
+        component
+          .find('WithStyles(Typography)')
+          .children()
+          .text()
+      ).toContain(almostOneWeek.year());
     });
     it('should always output formatted text if humanizedCutoff is set to never', () => {
       const aLongTimeAgo = moment().subtract(10, 'years');
@@ -40,7 +60,12 @@ describe('DateTimeDisplay component', () => {
         value: aLongTimeAgo,
         humanizeCutoff: 'never'
       });
-      expect(component.text()).toContain('10 years ago');
+      expect(
+        component
+          .find('WithStyles(Typography)')
+          .children()
+          .text()
+      ).toContain('10 years ago');
     });
   });
 });

--- a/src/components/DateTimeDisplay/DateTimeDisplay.tsx
+++ b/src/components/DateTimeDisplay/DateTimeDisplay.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Typography from 'src/components/core/Typography';
 import formatDate, { TimeInterval } from 'src/utilities/formatDate';
 
 export interface Props {
@@ -15,7 +16,7 @@ export const DateTimeDisplay: React.StatelessComponent<
   const { format, humanizeCutoff, value } = props;
   return (
     <React.Fragment>
-      {formatDate(value, { format, humanizeCutoff })}
+      <Typography>{formatDate(value, { format, humanizeCutoff })}</Typography>
     </React.Fragment>
   );
 };

--- a/src/components/DateTimeDisplay/DateTimeDisplay.tsx
+++ b/src/components/DateTimeDisplay/DateTimeDisplay.tsx
@@ -16,7 +16,9 @@ export const DateTimeDisplay: React.StatelessComponent<
   const { format, humanizeCutoff, value } = props;
   return (
     <React.Fragment>
-      <Typography>{formatDate(value, { format, humanizeCutoff })}</Typography>
+      <Typography component="span">
+        {formatDate(value, { format, humanizeCutoff })}
+      </Typography>
     </React.Fragment>
   );
 };

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -46,7 +46,7 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
       data-qa-activity-row
     >
       <Grid item>
-        <Typography variant={'inherit'}>{message}</Typography>
+        <Typography>{message}</Typography>
       </Grid>
       <Grid item>
         <DateTimeDisplay value={event.created} humanizeCutoff={'month'} />


### PR DESCRIPTION
## Fix Typography for new Activity Feed and update tests

Typography was not properly setup for activity items and related dates. `variant="inherit"` is not to be used. better to leave the default (which is no variant)

## Type of Change
- Bug fix ('fix')