### PR TITLE
M3-2666 Update scroll buttons styles for mobile tabs

### DIFF
--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1093,6 +1093,16 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
             position: 'absolute',
             bottom: 6,
             zIndex: 2,
+            left: -9,
+            '& svg': {
+              backgroundColor: 'rgba(232, 232, 232, .9)',
+              height: 39,
+              width: 38,
+              padding: '7px 4px',
+              borderRadius: '50%'
+            }
+          },
+          '& $scrollButtons:last-child': {
             '& svg': {
               backgroundColor: 'rgba(232, 232, 232, .9)',
               height: 39,


### PR DESCRIPTION
## Update scroll buttons styles for mobile tabs

Small update to style the right scroll tab button the same as the scroll left one for consistency as we are entering the world of many tab items on linode details

## Type of Change
- Non breaking change ('update')
