### PR TITLE
M3-2655 Fix: Routing on Support Ticket pages

### DIFF
--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.test.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.test.tsx
@@ -59,7 +59,7 @@ describe('Support Ticket Detail', () => {
     it('contains linkTo prop when open', () => {
       expect(breadcrumbProps.linkTo).toEqual({
         pathname: '/support/tickets',
-        state: { openFromRedirect: true }
+        search: 'type=open'
       });
     });
 
@@ -71,7 +71,7 @@ describe('Support Ticket Detail', () => {
       breadcrumbProps = wrapper.find('[data-qa-breadcrumb]').props();
       expect(breadcrumbProps.linkTo).toEqual({
         pathname: '/support/tickets',
-        state: { openFromRedirect: false }
+        search: 'type=closed'
       });
     });
 

--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -135,10 +135,10 @@ export class SupportTicketDetail extends React.Component<CombinedProps, State> {
 
   componentDidMount() {
     this.mounted = true;
-    const { history } = this.props;
+    const { history, location } = this.props;
     this.loadTicketAndReplies();
     // Clear any state that was passed from React Router so errors don't persist after reload.
-    history.push({ state: {} });
+    history.replace(location.pathname, {});
   }
 
   componentDidUpdate(prevProps: CombinedProps, prevState: State) {
@@ -343,12 +343,9 @@ export class SupportTicketDetail extends React.Component<CombinedProps, State> {
           <Grid item className={classes.titleWrapper}>
             <Breadcrumb
               linkTo={{
-                pathname: '/support/tickets',
-                // If the ticket is "open" or "new", the "Open Tickets" tab
-                // should be active on when we go back to SupportTicketsLanding
-                state: {
-                  openFromRedirect: ['open', 'new'].includes(ticket.status)
-                }
+                pathname: `/support/tickets`,
+                // If we're viewing a `Closed` ticket, the Breadcrumb link should take us to `Closed` tickets.
+                search: `type=${ticket.status === 'closed' ? 'closed' : 'open'}`
               }}
               linkText="Support Tickets"
               labelTitle={`#${ticket.id}: ${ticket.summary}`}

--- a/src/features/Support/SupportTickets/SupportTicketsLanding.test.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketsLanding.test.tsx
@@ -1,9 +1,10 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
-import { SupportTicketsLanding } from './SupportTicketsLanding';
-
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import {
+  getSelectedTabFromQueryString,
+  SupportTicketsLanding
+} from './SupportTicketsLanding';
 
 describe('Support Tickets Landing', () => {
   const component = shallow(
@@ -25,5 +26,25 @@ describe('Support Tickets Landing', () => {
   it('icon text link text should read "Open New Ticket"', () => {
     const iconText = component.find('[data-qa-open-ticket-link]').prop('label');
     expect(iconText).toBe('Open New Ticket');
+  });
+});
+
+describe('getSelectedTabFromQueryString utility function', () => {
+  it('should return 0 if ?type=open', () => {
+    const url = 'cloud.linode.com/support/tickets?type=open';
+    expect(getSelectedTabFromQueryString(url)).toBe(0);
+  });
+
+  it('should return 1 if ?type=closed', () => {
+    const url = 'cloud.linode.com/support/tickets?type=closed';
+    expect(getSelectedTabFromQueryString(url)).toBe(1);
+  });
+
+  it('should return 0 if type is unrecognized or not defined', () => {
+    let url = 'cloud.linode.com/support/tickets?type=unknown';
+    expect(getSelectedTabFromQueryString(url)).toBe(0);
+
+    url = 'cloud.linode.com/support/tickets';
+    expect(getSelectedTabFromQueryString(url)).toBe(0);
   });
 });


### PR DESCRIPTION
## Description

The browser's back button wasn't working correctly on Support Ticket Details, because we were pushing a extra item to history to clear its `state`. I changed this to the `history.replace` method to achieve the same thing without the extraneous history item. 

I also made a change so that clicking on a tab ("Open" or "Closed") is reflected in browser history. The downside is that this results in a double render, which I haven't found a way around. This problem exists elsewhere in the app, so I'll create a ticket to address it site-wide.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Please test all Support Ticket functionality: Browser back/forward buttons, Breadcrumb Component links, etc.