### PR TITLE
M3-2134 Change: Use EnhancedSelect for DiskSelect component

### DIFF
--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -305,7 +305,7 @@ export interface EnhancedSelectProps {
   placeholder?: string;
   errorText?: string;
   styleOverrides?: StylesConfig;
-  onChange: (selected: Item | Item[], actionMeta: ActionMeta) => void;
+  onChange: (selected: Item | Item[] | null, actionMeta: ActionMeta) => void;
   createNew?: (inputValue: string) => void;
   onInputChange?: (inputValue: string, actionMeta: ActionMeta) => void;
   loadOptions?: (inputValue: string) => Promise<Item | Item[]> | undefined;

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -138,7 +138,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
             this.setState({
               errors: [
                 {
-                  field: 'disk',
+                  field: 'disk_id',
                   reason: 'Could not retrieve disks for this Linode.'
                 }
               ]

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -49,7 +49,7 @@ export interface Props {
   onClose: () => void;
   onSuccess: () => void;
   changeLinode: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  changeDisk: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  changeDisk: (disk: string) => void;
   changeLabel: (e: React.ChangeEvent<HTMLInputElement>) => void;
   changeDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -44,12 +44,12 @@ export interface Props {
   imageID?: string;
   label?: string;
   disks?: Linode.Disk[];
-  selectedDisk?: string;
+  selectedDisk: string | null;
   selectedLinode?: string;
   onClose: () => void;
   onSuccess: () => void;
   changeLinode: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  changeDisk: (disk: string) => void;
+  changeDisk: (disk: string | null) => void;
   changeLabel: (e: React.ChangeEvent<HTMLInputElement>) => void;
   changeDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
@@ -261,7 +261,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
     // When restoring to an existing Linode, the Linode select is the only field.
     const { mode, selectedDisk, selectedLinode } = this.props;
 
-    const isDiskSelected = selectedDisk && selectedDisk !== 'none';
+    const isDiskSelected = Boolean(selectedDisk);
 
     switch (mode) {
       case modes.CREATING:
@@ -332,7 +332,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
         {[modes.CREATING, modes.IMAGIZING].includes(mode) && (
           <>
             <DiskSelect
-              selectedDisk={selectedDisk || 'none'}
+              selectedDisk={selectedDisk}
               disks={disks}
               diskError={diskError}
               handleChange={changeDisk}

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -43,6 +43,7 @@ export interface Props {
   description?: string;
   imageID?: string;
   label?: string;
+  // Only used from LinodeDisks to pre-populate the selected Disk
   disks?: Linode.Disk[];
   selectedDisk: string | null;
   selectedLinode?: string;
@@ -105,6 +106,8 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
     /** Is opening... */
     if (prevProps.open === false && this.props.open === true) {
       this.updateLinodes();
+      // Reset the disks on drawer open
+      this.setState({ disks: [] });
     }
 
     if (this.props.disks && !equals(this.props.disks, prevProps.disks)) {

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -203,9 +203,9 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
     }
   };
 
-  changeSelectedDisk = (e: React.ChangeEvent<HTMLInputElement>) => {
+  changeSelectedDisk = (disk: string) => {
     this.setState({
-      imageDrawer: { ...this.state.imageDrawer, selectedDisk: e.target.value }
+      imageDrawer: { ...this.state.imageDrawer, selectedDisk: disk }
     });
   };
 
@@ -333,9 +333,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
                           <TableCell data-qa-image-created-header>
                             Created
                           </TableCell>
-                          <TableCell data-qa-expiry-header>
-                            Expires
-                          </TableCell>
+                          <TableCell data-qa-expiry-header>Expires</TableCell>
                           <TableSortCell
                             active={orderBy === 'size'}
                             label={'size'}

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -56,7 +56,7 @@ interface State {
     label?: string;
     description?: string;
     selectedLinode?: string;
-    selectedDisk?: string;
+    selectedDisk: string | null;
   };
   removeDialog: {
     open: boolean;
@@ -80,7 +80,8 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
       open: false,
       mode: 'edit',
       label: '',
-      description: ''
+      description: '',
+      selectedDisk: null
     },
     removeDialog: {
       open: false,
@@ -100,7 +101,13 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
 
   openForCreate = () => {
     this.setState({
-      imageDrawer: { open: true, mode: 'create', label: '', description: '' }
+      imageDrawer: {
+        open: true,
+        mode: 'create',
+        label: '',
+        description: '',
+        selectedDisk: null
+      }
     });
   };
 
@@ -130,7 +137,8 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
         mode: 'edit',
         description,
         imageID,
-        label
+        label,
+        selectedDisk: null
       }
     });
   };
@@ -140,7 +148,8 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
       imageDrawer: {
         open: true,
         mode: 'restore',
-        imageID
+        imageID,
+        selectedDisk: null
       }
     });
   };
@@ -196,14 +205,14 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
       this.setState({
         imageDrawer: {
           ...this.state.imageDrawer,
-          selectedDisk: 'none',
+          selectedDisk: null,
           selectedLinode: e.target.value
         }
       });
     }
   };
 
-  changeSelectedDisk = (disk: string) => {
+  changeSelectedDisk = (disk: string | null) => {
     this.setState({
       imageDrawer: { ...this.state.imageDrawer, selectedDisk: disk }
     });

--- a/src/features/linodes/DiskSelect/DiskSelect.tsx
+++ b/src/features/linodes/DiskSelect/DiskSelect.tsx
@@ -18,7 +18,7 @@ interface Props {
   generalError?: string;
   diskError?: string;
   disks: Linode.Disk[];
-  selectedDisk?: string;
+  selectedDisk: string | null;
   disabled?: boolean;
   handleChange: (disk: string | null) => void;
 }
@@ -31,7 +31,7 @@ const disksToOptions = (disks: Linode.Disk[]): Item<string>[] => {
 
 const diskFromValue = (
   disks: Item<string>[],
-  diskId?: string
+  diskId: string | null
 ): Item<string> | undefined => {
   if (!diskId) {
     return;

--- a/src/features/linodes/DiskSelect/DiskSelect.tsx
+++ b/src/features/linodes/DiskSelect/DiskSelect.tsx
@@ -1,15 +1,12 @@
 import { compose } from 'ramda';
 import * as React from 'react';
-import FormControl from 'src/components/core/FormControl';
-import FormHelperText from 'src/components/core/FormHelperText';
 import {
   StyleRulesCallback,
   WithStyles,
   withStyles
 } from 'src/components/core/styles';
-import MenuItem from 'src/components/MenuItem';
+import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
 import RenderGuard from 'src/components/RenderGuard';
-import TextField from 'src/components/TextField';
 
 type ClassNames = 'root';
 
@@ -23,47 +20,35 @@ interface Props {
   disks: Linode.Disk[];
   selectedDisk?: string;
   disabled?: boolean;
-  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleChange: (disk: string) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
+const disksToOptions = (disks: Linode.Disk[]): Item<string>[] => {
+  return disks.map(disk => ({ label: disk.label, value: String(disk.id) }));
+};
+
 const DiskSelect: React.StatelessComponent<CombinedProps> = props => {
+  const {
+    disabled,
+    disks,
+    diskError,
+    generalError,
+    handleChange,
+    selectedDisk
+  } = props;
+  const options = disksToOptions(disks);
   return (
-    <FormControl fullWidth>
-      <TextField
-        value={props.selectedDisk || 'none'}
-        onChange={props.handleChange}
-        inputProps={{ name: 'linode', id: 'linode' }}
-        error={Boolean(props.diskError)}
-        disabled={props.disabled}
-        select
-        data-qa-disk-select
-        label="Disk"
-      >
-        <MenuItem value="none" disabled>
-          Select a Disk
-        </MenuItem>
-        {props.disks &&
-          props.disks.map(disk => {
-            return (
-              <MenuItem
-                key={disk.id}
-                value={'' + disk.id}
-                data-qa-disk-menu-item={disk.label}
-              >
-                {disk.label}
-              </MenuItem>
-            );
-          })}
-      </TextField>
-      {Boolean(props.diskError) && (
-        <FormHelperText error>{props.diskError}</FormHelperText>
-      )}
-      {Boolean(props.generalError) && (
-        <FormHelperText error>{props.generalError}</FormHelperText>
-      )}
-    </FormControl>
+    <EnhancedSelect
+      label={'Disk'}
+      placeholder={'Select a Disk'}
+      disabled={disabled}
+      options={options}
+      value={selectedDisk}
+      onChange={(newDisk: Item<string>) => handleChange(newDisk.value)}
+      errorText={generalError || diskError}
+    />
   );
 };
 

--- a/src/features/linodes/DiskSelect/DiskSelect.tsx
+++ b/src/features/linodes/DiskSelect/DiskSelect.tsx
@@ -32,11 +32,12 @@ const disksToOptions = (disks: Linode.Disk[]): Item<string>[] => {
 const diskFromValue = (
   disks: Item<string>[],
   diskId: string | null
-): Item<string> | undefined => {
+): Item<string> | null => {
   if (!diskId) {
-    return;
+    return null;
   }
-  return disks.find(thisDisk => thisDisk.value === diskId);
+  const thisDisk = disks.find(disk => disk.value === diskId);
+  return thisDisk ? thisDisk : null;
 };
 
 const DiskSelect: React.StatelessComponent<CombinedProps> = props => {

--- a/src/features/linodes/DiskSelect/DiskSelect.tsx
+++ b/src/features/linodes/DiskSelect/DiskSelect.tsx
@@ -1,12 +1,12 @@
-import { compose } from 'ramda';
 import * as React from 'react';
+import { compose } from 'recompose';
 import {
   StyleRulesCallback,
   WithStyles,
   withStyles
 } from 'src/components/core/styles';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
-import RenderGuard from 'src/components/RenderGuard';
+import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 
 type ClassNames = 'root';
 
@@ -29,6 +29,16 @@ const disksToOptions = (disks: Linode.Disk[]): Item<string>[] => {
   return disks.map(disk => ({ label: disk.label, value: String(disk.id) }));
 };
 
+const diskFromValue = (
+  disks: Item<string>[],
+  diskId?: string
+): Item<string> | undefined => {
+  if (!diskId) {
+    return;
+  }
+  return disks.find(thisDisk => thisDisk.value === diskId);
+};
+
 const DiskSelect: React.StatelessComponent<CombinedProps> = props => {
   const {
     disabled,
@@ -45,7 +55,7 @@ const DiskSelect: React.StatelessComponent<CombinedProps> = props => {
       placeholder={'Select a Disk'}
       disabled={disabled}
       options={options}
-      value={selectedDisk}
+      value={diskFromValue(options, selectedDisk)}
       onChange={(newDisk: Item<string>) => handleChange(newDisk.value)}
       errorText={generalError || diskError}
     />
@@ -54,7 +64,7 @@ const DiskSelect: React.StatelessComponent<CombinedProps> = props => {
 
 const styled = withStyles(styles);
 
-export default compose<any, any, any>(
+export default compose<CombinedProps, Props & RenderGuardProps>(
   styled,
   RenderGuard
 )(DiskSelect);

--- a/src/features/linodes/DiskSelect/DiskSelect.tsx
+++ b/src/features/linodes/DiskSelect/DiskSelect.tsx
@@ -20,7 +20,7 @@ interface Props {
   disks: Linode.Disk[];
   selectedDisk?: string;
   disabled?: boolean;
-  handleChange: (disk: string) => void;
+  handleChange: (disk: string | null) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -56,7 +56,9 @@ const DiskSelect: React.StatelessComponent<CombinedProps> = props => {
       disabled={disabled}
       options={options}
       value={diskFromValue(options, selectedDisk)}
-      onChange={(newDisk: Item<string>) => handleChange(newDisk.value)}
+      onChange={(newDisk: Item<string> | null) =>
+        handleChange(newDisk ? newDisk.value : null)
+      }
       errorText={generalError || diskError}
     />
   );


### PR DESCRIPTION
## Description

Please start the pull request title with the jira ticket corresponding to the work if applicable. Please include a short summary of the feature added, the change, or issue fixed.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

The only instance of this component lives in ImagesDrawer. If there's anywhere else in the app where disks are selected in a dropdown (by themselves, we already have a specialized thingy for disks & volumes), please flag it for me.