### PR TITLE
M3-1388 Update: Use EnhancedSelect for selecting Linodes

### DIFF
--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -196,7 +196,7 @@ export const retrieveGlobalSettings = () => {
 export const checkEnvironment = () => {
     const environment = process.env.REACT_APP_API_ROOT;
     if (environment.includes('dev') || environment.includes('testing')) {
-        pending('Feature not available in Testing or Dev environmnet');
+        pending('Feature not available in Testing or Dev environment');
     }
 }
 

--- a/src/containers/withLinodes.container.ts
+++ b/src/containers/withLinodes.container.ts
@@ -1,17 +1,17 @@
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 
-type MapProps<TOutter, TInner> = (
-  ownProps: TOutter,
+type MapProps<TOuter, TInner> = (
+  ownProps: TOuter,
   linodes: Linode.Linode[],
   loading: boolean,
   error?: Linode.ApiFieldError[]
 ) => TInner;
 
-export default <TInner extends {}, TOutter extends {}>(
-  mapToProps: MapProps<TOutter, TInner>
+export default <TInner extends {}, TOuter extends {}>(
+  mapToProps: MapProps<TOuter, TInner>
 ) =>
-  connect((state: ApplicationState, ownProps: TOutter) => {
+  connect((state: ApplicationState, ownProps: TOuter) => {
     const { loading, error, entities } = state.__resources.linodes;
 
     return mapToProps(ownProps, entities, loading, error);

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -106,6 +106,10 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       this.setState({ disks: this.props.disks });
     }
 
+    if (!this.props.selectedLinode && prevProps.selectedLinode) {
+      this.setState({ disks: [] });
+    }
+
     if (
       this.props.selectedLinode &&
       this.props.selectedLinode !== prevProps.selectedLinode

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -127,7 +127,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
             this.setState({ disks: filteredDisks });
           }
         })
-        .catch(error => {
+        .catch(_ => {
           if (!this.mounted) {
             return;
           }

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -17,7 +17,7 @@ import { resetEventsPolling } from 'src/events';
 import DiskSelect from 'src/features/linodes/DiskSelect';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
 import { createImage, updateImage } from 'src/services/images';
-import { getLinodeDisks, getLinodes } from 'src/services/linodes';
+import { getLinodeDisks } from 'src/services/linodes';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 
@@ -46,18 +46,17 @@ export interface Props {
   // Only used from LinodeDisks to pre-populate the selected Disk
   disks?: Linode.Disk[];
   selectedDisk: string | null;
-  selectedLinode?: string;
   onClose: () => void;
-  onSuccess: () => void;
-  changeLinode: (e: React.ChangeEvent<HTMLInputElement>) => void;
   changeDisk: (disk: string | null) => void;
+  selectedLinode: number | null;
+  onSuccess: () => void;
+  changeLinode: (linodeId: number) => void;
   changeLabel: (e: React.ChangeEvent<HTMLInputElement>) => void;
   changeDescription: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 interface State {
   disks: Linode.Disk[];
-  linodes: string[][];
   notice?: string;
   errors?: Linode.ApiFieldError[];
 }
@@ -84,7 +83,6 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
   mounted: boolean = false;
   state = {
     disks: [],
-    linodes: [],
     errors: undefined,
     notice: undefined
   };
@@ -103,13 +101,6 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
   }
 
   componentDidUpdate(prevProps: CombinedProps, prevState: State) {
-    /** Is opening... */
-    if (prevProps.open === false && this.props.open === true) {
-      this.updateLinodes();
-      // Reset the disks on drawer open
-      this.setState({ disks: [] });
-    }
-
     if (this.props.disks && !equals(this.props.disks, prevProps.disks)) {
       // for the 'imagizing' mode
       this.setState({ disks: this.props.disks });
@@ -119,7 +110,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       this.props.selectedLinode &&
       this.props.selectedLinode !== prevProps.selectedLinode
     ) {
-      getLinodeDisks(Number(this.props.selectedLinode))
+      getLinodeDisks(this.props.selectedLinode)
         .then(response => {
           if (!this.mounted) {
             return;
@@ -203,7 +194,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       case modes.CREATING:
       case modes.IMAGIZING:
         createImage(Number(selectedDisk), label, safeDescription)
-          .then(response => {
+          .then(_ => {
             if (!this.mounted) {
               return;
             }
@@ -245,19 +236,6 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
     }
   };
 
-  updateLinodes() {
-    getLinodes({ page: 1 }).then(response => {
-      if (!this.mounted) {
-        return;
-      }
-
-      const linodeChoices = response.data.map(linode => {
-        return [`${linode.id}`, linode.label];
-      });
-      this.setState({ linodes: linodeChoices });
-    });
-  }
-
   checkRequirements = () => {
     // When creating an image, disable the submit button until a Linode,
     // disk, and label are selected. When editing, only a label is required.
@@ -291,7 +269,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
       changeDescription,
       classes
     } = this.props;
-    const { disks, linodes, notice } = this.state;
+    const { disks, notice } = this.state;
     const { errors } = this.state;
 
     const requirementsMet = this.checkRequirements();
@@ -324,11 +302,10 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
 
         {[modes.CREATING, modes.RESTORING].includes(mode) && (
           <LinodeSelect
-            linodes={linodes}
-            selectedLinode={selectedLinode || 'none'}
+            selectedLinode={selectedLinode}
             linodeError={linodeError}
             handleChange={changeLinode}
-            updateFor={[linodes, selectedLinode, linodeError, classes]}
+            updateFor={[selectedLinode, linodeError, classes]}
           />
         )}
 

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -291,7 +291,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
     }
 
     /** Error State */
-    if (imagesError instanceof Error) {
+    if (imagesError) {
       return this.renderError(imagesError);
     }
 
@@ -408,7 +408,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
     );
   }
 
-  renderError = (e: Error) => {
+  renderError = (_: Linode.ApiFieldError[]) => {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Images" />

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -55,8 +55,8 @@ interface State {
     imageID?: string;
     label?: string;
     description?: string;
-    selectedLinode?: string;
     selectedDisk: string | null;
+    selectedLinode?: number;
   };
   removeDialog: {
     open: boolean;
@@ -200,13 +200,22 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
       });
   };
 
-  changeSelectedLinode = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (this.state.imageDrawer.selectedLinode !== e.target.value) {
+  changeSelectedLinode = (linodeId: number | null) => {
+    if (!linodeId) {
       this.setState({
         imageDrawer: {
           ...this.state.imageDrawer,
           selectedDisk: null,
-          selectedLinode: e.target.value
+          selectedLinode: undefined
+        }
+      });
+    }
+    if (this.state.imageDrawer.selectedLinode !== linodeId) {
+      this.setState({
+        imageDrawer: {
+          ...this.state.imageDrawer,
+          selectedDisk: null,
+          selectedLinode: linodeId!
         }
       });
     }

--- a/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -133,7 +133,7 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
       linode_id: Number(selectedLinode),
       config_id: Number(selectedConfig) || undefined
     })
-      .then(response => {
+      .then(_ => {
         resetEventsPolling();
         this.handleClose();
       })
@@ -153,7 +153,7 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { open, volumeLabel, disabled, readOnly } = this.props;
+    const { open, volumeLabel, disabled, linodeRegion, readOnly } = this.props;
     const { configs, selectedLinode, selectedConfig, errors } = this.state;
 
     const hasErrorFor = getAPIErrorsFor(this.errorResources, errors);
@@ -176,6 +176,7 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
         )}
         <LinodeSelect
           selectedLinode={selectedLinode}
+          region={linodeRegion}
           handleChange={this.changeSelectedLinode}
           linodeError={linodeError}
           generalError={generalError}

--- a/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -8,6 +8,7 @@ import {
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import withLinodes from 'src/containers/withLinodes.container';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 type ClassNames = 'root';
 
@@ -18,7 +19,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 interface WithLinodesProps {
   linodesData: Linode.Linode[];
   linodesLoading: boolean;
-  linodesError?: string;
+  linodesError?: Linode.ApiFieldError[];
 }
 
 interface Props {
@@ -74,7 +75,9 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
       onChange={(selected: Item<number> | null) =>
         handleChange(selected ? selected.value : null)
       }
-      errorText={generalError || linodeError || linodesError}
+      errorText={getErrorStringOrDefault(
+        generalError || linodeError || linodesError || []
+      )}
     />
   );
 };


### PR DESCRIPTION
## Description

Replace the ImagesLanding LinodeSelect with one that uses our enhanced select. Previously you could only choose from the first page of Linodes when creating an Image; now you get everything in the store as an option, and can search as well.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

None

## Note to Reviewers

There are other places in the app where this could be useful, we can add them later. This component is already used in VolumeAttachmentDrawer so that's been updated, but other places include VolumeCreateForm [...todo figure out all the remaining places]
