### PR TITLE
M3-2678 Mobile Tables Titles

### DIFF
--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -34,7 +34,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   data: {
     [theme.breakpoints.down('sm')]: {
       textAlign: 'right',
-      wordBreak: 'break-all',
+      width: '100%',
       marginLeft: theme.spacing.unit * 3
     }
   },
@@ -86,9 +86,7 @@ class WrappedTableCell extends React.Component<CombinedProps> {
             <Hidden mdUp>
               <span>{parentColumn}</span>
             </Hidden>
-            <span className={`${classes.data} data`}>
-              {this.props.children}
-            </span>
+            <div className={`${classes.data} data`}>{this.props.children}</div>
           </React.Fragment>
         ) : (
           this.props.children


### PR DESCRIPTION
## Description

Adjustments to TableRow for mobile devices, specifically for Domains, NodeBalancers, and Volumes.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please view the ticket to see the exact bug, as this is not reproducible with chrome emulator. This would be best to test on an actual device or using XCode Simulator to replicate an accurate experience.
