### PR TITLE
Hide label for Bucket Table on mobile

### DIFF
--- a/src/features/ObjectStorage/ListBuckets.tsx
+++ b/src/features/ObjectStorage/ListBuckets.tsx
@@ -46,7 +46,7 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
       }) => (
         <React.Fragment>
           <Paper>
-            <Table aria-label="List of your Buckets">
+            <Table removeLabelonMobile aria-label="List of your Buckets">
               <TableHead>
                 <TableRow>
                   <TableSortCell


### PR DESCRIPTION
## Description

It was missing a `removeLabelonMobile` prop.