### PR TITLE
M3-2642 Fix: chart timezone

### DIFF
--- a/patches/chart.js+2.7.3.patch
+++ b/patches/chart.js+2.7.3.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/chart.js/src/scales/scale.time.js b/node_modules/chart.js/src/scales/scale.time.js
+index 2496a48..a80dd68 100644
+--- a/node_modules/chart.js/src/scales/scale.time.js
++++ b/node_modules/chart.js/src/scales/scale.time.js
+@@ -692,11 +692,12 @@ module.exports = function() {
+ 		},
+ 
+ 		convertTicksToLabels: function(ticks) {
++			var offset = this.options.time.offset;
+ 			var labels = [];
+ 			var i, ilen;
+ 
+ 			for (i = 0, ilen = ticks.length; i < ilen; ++i) {
+-				labels.push(this.tickFormatFunction(moment(ticks[i].value), i, ticks));
++				labels.push(this.tickFormatFunction(moment(moment(ticks[i].value).utc()).utcOffset(offset), i, ticks));
+ 			}
+ 
+ 			return labels;

--- a/patches/chart.js+2.7.3.patch
+++ b/patches/chart.js+2.7.3.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/chart.js/src/scales/scale.time.js b/node_modules/chart.js/src/scales/scale.time.js
-index 2496a48..a80dd68 100644
+index 2496a48..b96ccf5 100644
 --- a/node_modules/chart.js/src/scales/scale.time.js
 +++ b/node_modules/chart.js/src/scales/scale.time.js
-@@ -692,11 +692,12 @@ module.exports = function() {
+@@ -692,11 +692,16 @@ module.exports = function() {
  		},
  
  		convertTicksToLabels: function(ticks) {
@@ -12,7 +12,11 @@ index 2496a48..a80dd68 100644
  
  			for (i = 0, ilen = ticks.length; i < ilen; ++i) {
 -				labels.push(this.tickFormatFunction(moment(ticks[i].value), i, ticks));
-+				labels.push(this.tickFormatFunction(moment(moment(ticks[i].value).utc()).utcOffset(offset), i, ticks));
++				if (offset) {
++					labels.push(this.tickFormatFunction(moment(moment(ticks[i].value).utc()).utcOffset(offset), i, ticks));
++				} else {
++					labels.push(this.tickFormatFunction(moment(ticks[i].value), i, ticks));
++				}
  			}
  
  			return labels;

--- a/src/components/LineGraph/LineGraph.stories.tsx
+++ b/src/components/LineGraph/LineGraph.stories.tsx
@@ -23,8 +23,25 @@ const mockData = [
 ];
 
 storiesOf('Line Graph', module)
-  .add('Current Day', () => <LineGraph showToday={true} data={mockData} />)
-  .add('Multiple Days', () => <LineGraph showToday={false} data={mockData} />)
+  .add('Current Day', () => (
+    <LineGraph
+      showToday={true}
+      data={mockData}
+      timezone={'America/Los_Angeles'}
+    />
+  ))
+  .add('Multiple Days', () => (
+    <LineGraph
+      showToday={false}
+      data={mockData}
+      timezone={'America/Los_Angeles'}
+    />
+  ))
   .add('Fixed Max Y Axis', () => (
-    <LineGraph showToday={false} data={mockData} suggestedMax={7000} />
+    <LineGraph
+      showToday={false}
+      data={mockData}
+      suggestedMax={7000}
+      timezone={'America/Los_Angeles'}
+    />
   ));

--- a/src/components/LineGraph/LineGraph.tsx
+++ b/src/components/LineGraph/LineGraph.tsx
@@ -32,7 +32,7 @@ interface Props {
   showToday: boolean;
   suggestedMax?: number;
   data: DataSet[];
-  timezone?: string;
+  timezone: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -107,9 +107,6 @@ const lineOptions: ChartData<any> = {
 };
 
 const parseInTimeZone = curry((timezone: string, utcMoment: any) => {
-  if (!timezone) {
-    return moment(utcMoment);
-  }
   return moment(utcMoment).tz(timezone);
 });
 

--- a/src/components/LineGraph/LineGraph.tsx
+++ b/src/components/LineGraph/LineGraph.tsx
@@ -1,4 +1,5 @@
-import { clone } from 'ramda';
+import * as moment from 'moment-timezone';
+import { clone, curry } from 'ramda';
 import * as React from 'react';
 import { ChartData, Line } from 'react-chartjs-2';
 import {
@@ -31,6 +32,7 @@ interface Props {
   showToday: boolean;
   suggestedMax?: number;
   data: DataSet[];
+  timezone?: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -104,10 +106,23 @@ const lineOptions: ChartData<any> = {
   pointHitRadius: 10
 };
 
+const parseInTimeZone = curry((timezone: string, utcMoment: any) => {
+  if (!timezone) {
+    return moment(utcMoment);
+  }
+  const offset = moment.tz(timezone).utcOffset();
+  return moment(utcMoment).utcOffset(offset);
+});
+
 class LineGraph extends React.Component<CombinedProps, {}> {
   getChartOptions = (suggestedMax?: number) => {
     const finalChartOptions = clone(chartOptions);
-    const { showToday } = this.props;
+    const { showToday, timezone } = this.props;
+    const parser = parseInTimeZone(timezone || '');
+    finalChartOptions.scales.xAxes[0].time.parser = parser;
+    finalChartOptions.scales.xAxes[0].time.offset = moment
+      .tz(timezone || '')
+      .utcOffset();
 
     if (showToday) {
       finalChartOptions.scales.xAxes[0].time.displayFormats = {

--- a/src/components/LineGraph/LineGraph.tsx
+++ b/src/components/LineGraph/LineGraph.tsx
@@ -110,8 +110,7 @@ const parseInTimeZone = curry((timezone: string, utcMoment: any) => {
   if (!timezone) {
     return moment(utcMoment);
   }
-  const offset = moment.tz(timezone).utcOffset();
-  return moment(utcMoment).utcOffset(offset);
+  return moment(utcMoment).tz(timezone);
 });
 
 class LineGraph extends React.Component<CombinedProps, {}> {

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -1,5 +1,7 @@
 import { pathOr } from 'ramda';
 import * as React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
 import Paper from 'src/components/core/Paper';
 import {
@@ -13,6 +15,7 @@ import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
 import MetricsDisplay from 'src/features/linodes/LinodesDetail/LinodeSummary/MetricsDisplay';
 import { getNodeBalancerStats } from 'src/services/nodebalancers';
+import { ApplicationState } from 'src/store';
 import {
   formatBitsPerSecond,
   formatNumber,
@@ -117,7 +120,7 @@ interface State {
   statsError?: string;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props & StateProps & WithStyles<ClassNames>;
 
 const statsFetchInterval = 30000;
 
@@ -219,7 +222,7 @@ class TablesPanel extends React.Component<CombinedProps, State> {
     statsError: string | undefined,
     loadingStats: boolean
   ) => {
-    const { classes } = this.props;
+    const { classes, timezone } = this.props;
     const { stats } = this.state;
     const data = pathOr([[]], ['data', 'connections'], stats);
 
@@ -245,6 +248,7 @@ class TablesPanel extends React.Component<CombinedProps, State> {
               connections/sec
             </div>
             <LineGraph
+              timezone={timezone}
               showToday={true}
               data={[
                 {
@@ -280,7 +284,7 @@ class TablesPanel extends React.Component<CombinedProps, State> {
     statsError: string | undefined,
     loadingStats: boolean
   ) => {
-    const { classes } = this.props;
+    const { classes, timezone } = this.props;
     const { stats } = this.state;
     const trafficIn = pathOr([[]], ['data', 'traffic', 'in'], stats);
     const trafficOut = pathOr([[]], ['data', 'traffic', 'out'], stats);
@@ -300,6 +304,7 @@ class TablesPanel extends React.Component<CombinedProps, State> {
           <div className={classes.chart}>
             <div className={classes.leftLegend}>bits/sec</div>
             <LineGraph
+              timezone={timezone}
               showToday={true}
               data={[
                 {
@@ -359,6 +364,19 @@ class TablesPanel extends React.Component<CombinedProps, State> {
   }
 }
 
+interface StateProps {
+  timezone: string;
+}
+
+const withTimezone = connect((state: ApplicationState, ownProps) => ({
+  timezone: pathOr('UTC', ['__resources', 'profile', 'data', 'timezone'], state)
+}));
+
 const styled = withStyles(styles);
 
-export default styled(TablesPanel);
+const enhanced = compose<CombinedProps, Props>(
+  styled,
+  withTimezone
+);
+
+export default enhanced(TablesPanel);

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -10,6 +10,7 @@ describe('LinodeSummary', () => {
       linodeCreated="2018-11-01T00:00:00"
       linodeId={1234}
       linodeData={linodes[0]}
+      timezone={'America/Los_Angeles'}
       classes={{
         main: '',
         sidebar: '',

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -290,7 +290,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
   renderCPUChart = () => {
     const { rangeSelection, stats } = this.state;
-    const { classes } = this.props;
+    const { classes, timezone } = this.props;
     const data = pathOr([], ['data', 'cpu'], stats);
 
     const metrics = getMetrics(data);
@@ -301,6 +301,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         <div className={classes.chart}>
           <div className={classes.leftLegend}>CPU %</div>
           <LineGraph
+            timezone={timezone}
             chartHeight={chartHeight}
             showToday={rangeSelection === '24'}
             data={[
@@ -333,7 +334,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
   };
 
   renderIPv4TrafficChart = () => {
-    const { classes } = this.props;
+    const { classes, timezone } = this.props;
     const { rangeSelection, stats } = this.state;
 
     const v4Data = {
@@ -376,6 +377,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         <div className={classes.chart}>
           <div className={classes.leftLegend}>bits/sec</div>
           <LineGraph
+            timezone={timezone}
             chartHeight={chartHeight}
             showToday={rangeSelection === '24'}
             data={[
@@ -456,7 +458,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
   };
 
   renderIPv6TrafficChart = () => {
-    const { classes } = this.props;
+    const { classes, timezone } = this.props;
     const { rangeSelection, stats } = this.state;
 
     const data = {
@@ -485,6 +487,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         <div className={classes.chart}>
           <div className={classes.leftLegend}>bits/sec</div>
           <LineGraph
+            timezone={timezone}
             chartHeight={chartHeight}
             showToday={rangeSelection === '24'}
             data={[
@@ -565,7 +568,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
   };
 
   renderDiskIOChart = () => {
-    const { classes } = this.props;
+    const { classes, timezone } = this.props;
     const { rangeSelection, stats } = this.state;
 
     const data = {
@@ -582,6 +585,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
             blocks/sec
           </div>
           <LineGraph
+            timezone={timezone}
             chartHeight={chartHeight}
             showToday={rangeSelection === '24'}
             data={[
@@ -744,10 +748,12 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
 
 interface WithTypesProps {
   typesData: Linode.LinodeType[];
+  timezone: string;
 }
 
 const withTypes = connect((state: ApplicationState, ownProps) => ({
-  typesData: state.__resources.types.entities
+  typesData: state.__resources.types.entities,
+  timezone: pathOr('UTC', ['__resources', 'profile', 'data', 'timezone'], state)
 }));
 
 const enhanced = compose<CombinedProps, {}>(


### PR DESCRIPTION
## Description

Displays the charts in LinodeSummary using the user's timezone.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

I had to patch-package to make this work, so it's entirely possible the cure is worse than the disease. Longer term we can and probably should switch to Rechart or something similar that gives us more control. Future versions of Chart.js are also expected to include this functionality.