### PR TITLE
M3-2562 Change: Don't use last Stats reading, because sometimes it's wrong

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -16,6 +16,7 @@ import LineGraph from 'src/components/LineGraph';
 import MetricsDisplay from 'src/features/linodes/LinodesDetail/LinodeSummary/MetricsDisplay';
 import { getNodeBalancerStats } from 'src/services/nodebalancers';
 import { ApplicationState } from 'src/store';
+import { initAll } from 'src/utilities/initAll';
 import {
   formatBitsPerSecond,
   formatNumber,
@@ -184,7 +185,7 @@ class TablesPanel extends React.Component<CombinedProps, State> {
           return;
         }
         this.setState({
-          stats: response,
+          stats: initAll(response),
           loadingStats: false,
           statsError: undefined
         });

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -185,6 +185,8 @@ class TablesPanel extends React.Component<CombinedProps, State> {
           return;
         }
         this.setState({
+          // Occasionally the last reading of each stats reading is incorrect, so we drop
+          // the last element of each array in the stats response.
           stats: initAll(response),
           loadingStats: false,
           statsError: undefined

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
@@ -46,7 +46,7 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
     getLinodeStatsByDate(linodeId, year, month)
       .then(resp => {
         this.setState({
-          used: getMonthlyTraffic(resp.data.data),
+          used: getMonthlyTraffic(resp.data),
           loading: false
         });
       })

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -255,6 +255,8 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
         this.setState({ statsLoadError: undefined });
         this.setState({
+          // Occasionally the last reading of each stats reading is incorrect, so we drop
+          // the last element of each array in the stats response.
           stats: initAll(response),
           dataIsLoading: false
         });

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -1,5 +1,5 @@
 import * as moment from 'moment';
-import { init as ramdaInit, map, pathOr } from 'ramda';
+import { map, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'recompose';
@@ -21,6 +21,7 @@ import { displayType, typeLabelLong } from 'src/features/linodes/presentation';
 import { getLinodeStats, getLinodeStatsByDate } from 'src/services/linodes';
 import { ApplicationState } from 'src/store';
 import { setUpCharts } from 'src/utilities/charts';
+import { initAll } from 'src/utilities/initAll';
 import { isRecent } from 'src/utilities/isRecent';
 import {
   formatBitsPerSecond,
@@ -144,38 +145,6 @@ const chartHeight = 300;
 
 const statsFetchInterval = 30000;
 
-// Sometimes the last data pair on a given stat is incorrectly returned by the API as 0.
-// The way we're avoiding the problems this causes is by dropping the last element of each
-// stats array.
-const applyInitToAllStats = (stats: Linode.Stats) => {
-  // Wrap Ramda's `init` function with the typing we want.
-  const init = (list: [number, number][]) => ramdaInit<[number, number]>(list);
-
-  const { cpu, netv4, netv6, io } = stats.data;
-  return {
-    title: stats.title,
-    data: {
-      cpu: init(cpu),
-      netv4: {
-        in: init(netv4.in),
-        out: init(netv4.out),
-        private_in: init(netv4.private_in),
-        private_out: init(netv4.private_out)
-      },
-      netv6: {
-        in: init(netv6.in),
-        out: init(netv6.out),
-        private_in: init(netv6.private_in),
-        private_out: init(netv6.private_out)
-      },
-      io: {
-        io: init(io.io),
-        swap: init(io.swap)
-      }
-    }
-  };
-};
-
 export class LinodeSummary extends React.Component<CombinedProps, State> {
   statsInterval?: number = undefined;
   mounted: boolean = false;
@@ -286,7 +255,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
         this.setState({ statsLoadError: undefined });
         this.setState({
-          stats: applyInitToAllStats(response),
+          stats: initAll(response),
           dataIsLoading: false
         });
       })

--- a/src/services/linodes/getLinodeInfo.ts
+++ b/src/services/linodes/getLinodeInfo.ts
@@ -4,9 +4,6 @@ import Request, { setMethod, setParams, setURL, setXFilter } from '../index';
 
 type Page<T> = Linode.ResourcePage<T>;
 type Type = Linode.LinodeType;
-interface Stats {
-  data: Linode.Stats;
-}
 
 /**
  * getLinodeStats
@@ -16,10 +13,10 @@ interface Stats {
  * @param linodeId { number } The id of the Linode to retrieve stats data for.
  */
 export const getLinodeStats = (linodeId: number) =>
-  Request<Stats>(
+  Request<Linode.Stats>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/stats`),
     setMethod('GET')
-  );
+  ).then(response => response.data);
 
 /**
  * getLinodeStats
@@ -37,10 +34,10 @@ export const getLinodeStatsByDate = (
   year: string,
   month: string
 ) =>
-  Request<Stats>(
+  Request<Linode.Stats>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/stats/${year}/${month}`),
     setMethod('GET')
-  );
+  ).then(response => response.data);
 
 /**
  * getLinodeKernels

--- a/src/types/Linode.ts
+++ b/src/types/Linode.ts
@@ -212,20 +212,24 @@ namespace Linode {
   export type KebabAction = BootAction | 'delete';
 
   interface NetStats {
-    in: number[][];
-    out: number[][];
-    private_in: number[][];
-    private_out: number[][];
+    in: [number, number][];
+    out: [number, number][];
+    private_in: [number, number][];
+    private_out: [number, number][];
+  }
+
+  export interface StatsData {
+    cpu: [number, number][];
+    io: {
+      io: [number, number][];
+      swap: [number, number][];
+    };
+    netv4: NetStats;
+    netv6: NetStats;
   }
 
   export interface Stats {
     title: string;
-    cpu: number[][];
-    io: {
-      io: number[][];
-      swap: number[][];
-    };
-    netv4: NetStats;
-    netv6: NetStats;
+    data: StatsData;
   }
 }

--- a/src/utilities/initAll.test.ts
+++ b/src/utilities/initAll.test.ts
@@ -1,0 +1,32 @@
+import { initAll } from './initAll';
+
+describe('initAll', () => {
+  it('removes the last element of every found array', () => {
+    const obj = {
+      x: [1, 2, 3],
+      y: {
+        z: [1, 2, 3]
+      }
+    };
+    expect(initAll(obj).x).toEqual([1, 2]);
+    expect(initAll(obj).y.z).toEqual([1, 2]);
+  });
+
+  it('leaves non-arrays untouched', () => {
+    const obj = {
+      a: null,
+      b: undefined,
+      c: true,
+      d: 1,
+      e: 'hello',
+      f: new Date(),
+      g: () => null,
+      h: { x: {} }
+    };
+    expect(initAll(obj)).toEqual(obj);
+  });
+
+  it('works with a single array', () => {
+    expect(initAll([1, 2, 3])).toEqual([1, 2]);
+  });
+});

--- a/src/utilities/initAll.ts
+++ b/src/utilities/initAll.ts
@@ -1,0 +1,13 @@
+import { init, keys, map } from 'ramda';
+
+// Recursively applies Ramda's `init` function to every array found in the input.
+// I.e. initAll({ x: { y: [1, 2] }} ) == { x: { y: [1] } }
+export const initAll = (element: any): any => {
+  if (Array.isArray(element)) {
+    return init(element);
+    // Check for length of Object.keys, because Dates and null are objects too
+  } else if (typeof element === 'object' && keys(element).length > 0) {
+    return map(initAll, element);
+  }
+  return element;
+};

--- a/src/utilities/statMetrics.tsx
+++ b/src/utilities/statMetrics.tsx
@@ -122,7 +122,7 @@ export const getTotalTraffic = (
   };
 };
 
-export const getMonthlyTraffic = (stats: Linode.Stats) => {
+export const getMonthlyTraffic = (stats: Linode.StatsData) => {
   const getTrafficSum = (records: number[][]) =>
     records.reduce((acc, record) => {
       return acc + record[1];


### PR DESCRIPTION
## Description

Occasionally the last reading of each stats array is incorrectly `0`. So we ignore it.

See the ticket (and comments) for more details.

I opted to use a recursive helper function here so that it's flexible and could be used easily with both Linodes and NodeBalancers. I'm open to feedback though if this approach is too magical. See my first commit on this PR for a more declarative version.

I also fixed some typing issues with the services library.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

To test, view a Linode with graph data. Look at the `/stats` request in Dev Tools and verify that we're not displaying the last element of each of the stats arrays. Repeat with a NodeBalancer.
