### PR TITLE
M3-2692 Change: messaging in UserEventsList for deleted entities

### DIFF
--- a/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -59,11 +59,9 @@ export const UserEventsList: React.StatelessComponent<
             reportUnfoundEvent as any,
             reportEventError
           );
-          const content = event._deleted
-            ? `Deleted ${moment(`${event.created}Z`).fromNow()} by ${
-                event.username
-              }`
-            : `${moment(`${event.created}Z`).fromNow()} by ${event.username}`;
+          const content = `${moment(`${event.created}Z`).fromNow()} by ${
+            event.username
+          }`;
 
           const success = event.status !== 'failed' && !event.seen;
           const error = event.status === 'failed';


### PR DESCRIPTION
## Description

See this exchange from https://github.com/linode/manager/pull/4181:

<img width="785" alt="Screen Shot 2019-04-18 at 2 29 06 PM" src="https://user-images.githubusercontent.com/16911484/56382903-813ad680-61e6-11e9-8776-eb791abe64d6.png">

**Now that we're greying out events of deleted entities, we can safely remove this logic.**

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
