### PR TITLE
M3-2693 Fix: disk action menu tooltip logic

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
@@ -19,11 +19,11 @@ class DiskActionMenu extends React.Component<CombinedProps> {
     let tooltip;
     tooltip =
       linodeStatus === 'offline'
-        ? 'Your Linode must be fully powered down in order to perform this action'
-        : undefined;
+        ? undefined
+        : 'Your Linode must be fully powered down in order to perform this action';
     tooltip = readOnly
       ? "You don't have permissions to perform this action"
-      : undefined;
+      : tooltip;
     const disabledProps = tooltip
       ? {
           tooltip,


### PR DESCRIPTION
## Description

This fixes the logic which will disable the Resize/Delete disk options and display a tooltip when a Linode is powered on. It will also show a tooltip when the user is ReadOnly

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
