### PR TITLE
M3-2673 Add: e2e tests for volume actions

### DIFF
--- a/e2e/config/custom-commands.js
+++ b/e2e/config/custom-commands.js
@@ -18,6 +18,7 @@ const {
     getLinodeImage,
     createDomain,
     createNodeBalancer,
+    removeLinode,
 } = require('../setup/setup');
 
 const {
@@ -82,6 +83,12 @@ exports.browserCommands = () => {
             .then(res => res)
             .catch(err => err);
     });
+    
+    browser.addCommand('removeLinode', function async(token, linodeId) {
+        return removeLinode(token, linodeId)
+            .then(res => res)
+            .catch(err => console.error(err));
+    })
 
     browser.addCommand('removeAllLinodes', function async(token) {
         return removeAllLinodes(token)

--- a/e2e/config/selenium-config.js
+++ b/e2e/config/selenium-config.js
@@ -4,7 +4,7 @@ module.exports = {
   version: '3.4.0',
   drivers: {
     chrome: {
-      version: '2.42',
+      version: '74.0.3729.6',
       arch: process.arch,
       baseURL: 'https://chromedriver.storage.googleapis.com'
     },

--- a/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
@@ -329,13 +329,10 @@ export class VolumeDetail extends Page {
         const volumes = this.volumeCell;
         const vLabel = this.volumeCellLabel;
         const vSize = this.volumeCellSize;
-        const vFsPath = this.volumeFsPath;
-
         const volumesDisplayed = volumes.map((v) => {
-            return [v.$(vLabel.selector).getText(),
-            v.$(vSize.selector).getText()]
+            return v.$(vLabel.selector).getText()
         });
-        expect(volumesDisplayed).toContain([volume.label, volume.size]);
+        expect(volumesDisplayed).toContain(volume.label);
     }
 
     assertActionMenuItems(attached=true) {

--- a/e2e/pageobjects/page.js
+++ b/e2e/pageobjects/page.js
@@ -26,6 +26,7 @@ export default class Page {
     get progressBar() { return $('[data-qa-circle-progress]'); }
     get actionMenu() { return $('[data-qa-action-menu]'); }
     get actionMenuItem() { return $('[data-qa-action-menu-item]'); }
+    get actionMenuItems() { return $$('[data-qa-action-menu-item]'); }
     get selectOptions() { return $$('[data-qa-option]'); }
     get selectOption() { return $('[data-qa-option]') };
     get multiOption() { return $('[data-qa-multi-option]'); }

--- a/e2e/pageobjects/volumes.page.js
+++ b/e2e/pageobjects/volumes.page.js
@@ -67,13 +67,18 @@ class Volumes extends Page {
 
         // Wait for progress bars to not display on volume detail pages
         if (!browser.getUrl().includes('/linodes')) {
-            browser.waitForVisible(`[data-qa-volume-cell-attachment="${linodeLabel}"]`,constants.wait.minute, true);
+            browser.waitForVisible(`[data-qa-volume-cell-attachment="${linodeLabel}"]`, constants.wait.minute, true);
         }
     }
 
     isAttached(volumeElement) {
-        const attached = volumeElement.$(this.volumeAttachment.selector).getText() !== '' ? true : false;
+        const attached = volumeElement.$(this.volumeAttachment.selector).getText() !== 'Unattached';
         return attached;
+    }
+
+    getVolumeElement(volumeLabel) {
+        const volumeId = this.getVolumeId(volumeLabel);
+        return $(`[data-qa-volume-cell="${volumeId}"]`);
     }
 }
 

--- a/e2e/pageobjects/volumes.page.js
+++ b/e2e/pageobjects/volumes.page.js
@@ -11,6 +11,7 @@ class Volumes extends Page {
     get volumeAttachment() { return $('[data-qa-volume-cell-attachment]'); }
     get copyToolTip() { return $('[data-qa-copy-tooltip]'); }
     get configHelpMessages() { $$('[data-qa-config-help-msg]'); }
+    get actionMenu() { return $('[data-qa-action-menu]'); }
 
     baseElemsDisplay(initial) {
         if (initial) {

--- a/e2e/setup/cleanup.js
+++ b/e2e/setup/cleanup.js
@@ -3,8 +3,6 @@ require('dotenv').config();
 const https = require('https');
 const axios = require('axios');
 const API_ROOT = process.env.REACT_APP_API_ROOT;
-const { isEmpty } = require('lodash');
-const { readFileSync, unlink } = require('fs');
 
 
 function removeEntity(token, entity, endpoint) {

--- a/e2e/setup/setup.js
+++ b/e2e/setup/setup.js
@@ -226,6 +226,18 @@ exports.removeNodebalancer = (token, nodeBalancerId) => {
     });
 }
 
+exports.removeLinode = (token, linodeId) => {
+    return new Promise((resolve, reject) => {
+        const endpoint = `/linode/instances/${linodeId}`;
+        return getAxiosInstance(token).delete(endpoint)
+            .then(response => resolve(response.data))
+            .catch(error => {
+                console.error('Error', error);
+                reject(error);
+            });
+    });
+}
+
 exports.createNodeBalancer = (token, label, region, tags) => {
     return new Promise((resolve,reject) => {
         const endpoint = '/nodebalancers';

--- a/e2e/specs/volumes/volume-actions.spec.js
+++ b/e2e/specs/volumes/volume-actions.spec.js
@@ -46,13 +46,23 @@ describe("Volumes Landing - Volume Actions", () => {
     expect(Volumes.volumeCell.length).toBeGreaterThan(0);
   });
 
-  it("should have basic actions", () => {
-    const attachedVolume = VolumeDetail.volumeRow(volumeEast.label).$('..');
-    browser.debug();
-    attachedVolume.$(VolumeDetail.actionMenu.selector).click();
-    const basicActions = ['Show Configuration', 'Edit Volume', 'Resize', 'Clone'];
+  it("an unattached Volume should have the correct actions", () => {
+    const unattachedVolumeId = Volumes.getVolumeId(volumeEast.label);
+    const unattachedVolume = $(`[data-qa-volume-cell="${unattachedVolumeId}"]`);
+    unattachedVolume.$(VolumeDetail.actionMenu.selector).click();
+    const basicActions = ['Show Configuration', 'Edit Volume', 'Resize', 'Clone', 'Attach', 'Delete'];
     const actionsDisplayed = Volumes.actionMenuItems.map(action => action.getText());
-    // expect(basicActions.sort()).toEqual(actionsDisplayed.sort());
+    basicActions.forEach(action => {
+      expect(actionsDisplayed).toContain(action);
+    });
+  });
+
+  it("an attached Volume should have the correct actions", () => {
+    const unattachedVolumeId = Volumes.getVolumeId(volumeEast.label);
+    const unattachedVolume = $(`[data-qa-volume-cell="${unattachedVolumeId}"]`);
+    unattachedVolume.$(VolumeDetail.actionMenu.selector).click();
+    const basicActions = ['Show Configuration', 'Edit Volume', 'Resize', 'Clone', 'Detach'];
+    const actionsDisplayed = Volumes.actionMenuItems.map(action => action.getText());
     basicActions.forEach(action => {
       expect(actionsDisplayed).toContain(action);
     });

--- a/e2e/specs/volumes/volume-actions.spec.js
+++ b/e2e/specs/volumes/volume-actions.spec.js
@@ -43,11 +43,14 @@ describe("Volumes Landing - Volume Actions", () => {
     Volumes.baseElemsDisplay();
     VolumeDetail.assertVolumeInTable(volumeEast);
     VolumeDetail.assertVolumeInTable(volumeEastAttached);
+    const attached = Volumes.getVolumeElement(volumeEastAttached.label);
+    const unattached = Volumes.getVolumeElement(volumeEast.label);
+    expect(Volumes.isAttached(attached)).toBeTruthy();
+    expect(Volumes.isAttached(unattached)).toBeFalsy();
   });
 
   it("an unattached Volume should have the correct actions", () => {
-    const unattachedVolumeId = Volumes.getVolumeId(volumeEast.label);
-    const unattachedVolume = $(`[data-qa-volume-cell="${unattachedVolumeId}"]`);
+    const unattachedVolume = Volumes.getVolumeElement(volumeEast.label)
     unattachedVolume.$(VolumeDetail.actionMenu.selector).click();
     const basicActions = ['Show Configuration', 'Edit Volume', 'Resize', 'Clone', 'Attach', 'Delete'];
     const actionsDisplayed = Volumes.actionMenuItems.map(action => action.getText());
@@ -60,8 +63,7 @@ describe("Volumes Landing - Volume Actions", () => {
   });
 
   it("an attached Volume should have the correct actions", () => {
-    const attachedVolumeId = Volumes.getVolumeId(volumeEastAttached.label);
-    const attachedVolume = $(`[data-qa-volume-cell="${attachedVolumeId}"]`);
+    const attachedVolume = Volumes.getVolumeElement(volumeEastAttached.label);
     browser.waitForExist('[data-qa-backdrop]', constants.wait.normal, true);
 
     attachedVolume.$(VolumeDetail.actionMenu.selector).click();

--- a/e2e/specs/volumes/volume-actions.spec.js
+++ b/e2e/specs/volumes/volume-actions.spec.js
@@ -1,4 +1,5 @@
 const { constants } = require('../../constants');
+
 import {
   timestamp,
   apiCreateLinode,
@@ -9,6 +10,7 @@ import {
 } from '../../utils/common';
 
 import Volumes from '../../pageobjects/volumes.page';
+import VolumeDetail from '../../pageobjects/linode-detail/linode-detail-volume.page';
 
 describe("Volumes Landing - Volume Actions", () => {
   const testVolume = {
@@ -41,10 +43,18 @@ describe("Volumes Landing - Volume Actions", () => {
   it("should list the Volumes on the Volumes landing page", () => {
     browser.url(constants.routes.volumes);
     Volumes.baseElemsDisplay();
-    expect(Volumes.volumeCell.length).toBe(2);
+    expect(Volumes.volumeCell.length).toBeGreaterThan(0);
   });
 
   it("should have basic actions", () => {
-    VolumeDetail.selectActionMenuItemV2(VolumeDetail.volumeCellElem.selector, 'Detach');
+    const attachedVolume = VolumeDetail.volumeRow(volumeEast.label).$('..');
+    browser.debug();
+    attachedVolume.$(VolumeDetail.actionMenu.selector).click();
+    const basicActions = ['Show Configuration', 'Edit Volume', 'Resize', 'Clone'];
+    const actionsDisplayed = Volumes.actionMenuItems.map(action => action.getText());
+    // expect(basicActions.sort()).toEqual(actionsDisplayed.sort());
+    basicActions.forEach(action => {
+      expect(actionsDisplayed).toContain(action);
+    });
   });
 });

--- a/e2e/specs/volumes/volume-actions.spec.js
+++ b/e2e/specs/volumes/volume-actions.spec.js
@@ -4,6 +4,8 @@ import {
   timestamp,
   apiCreateLinode,
   apiDeleteLinode,
+  apiDeleteAllLinodes,
+  apiDeleteAllVolumes,
   createVolumes,
 } from '../../utils/common';
 
@@ -41,6 +43,11 @@ describe("Volumes Landing - Volume Actions", () => {
     }
   });
 
+  afterAll(() => {
+    apiDeleteAllLinodes();
+    apiDeleteAllVolumes();
+  });
+
   it("should list the Volumes on the Volumes landing page", () => {
     browser.url(constants.routes.volumes);
     Volumes.baseElemsDisplay();
@@ -48,8 +55,8 @@ describe("Volumes Landing - Volume Actions", () => {
     VolumeDetail.assertVolumeInTable(volumeEastAttached);
     const attached = Volumes.getVolumeElement(volumeEastAttached.label);
     const unattached = Volumes.getVolumeElement(volumeEast.label);
-    expect(Volumes.isAttached(attached)).toBeTruthy();
-    expect(Volumes.isAttached(unattached)).toBeFalsy();
+    expect(Volumes.isAttached(attached)).toBe(true);
+    expect(Volumes.isAttached(unattached)).toBe(false);
   });
 
   it("an unattached Volume should have the correct actions", () => {
@@ -92,7 +99,7 @@ describe("Volumes Landing - Volume Actions", () => {
     apiDeleteLinode(linode.id);
     browser.pause(1000);
     const wasAttached = Volumes.getVolumeElement(volumeEastAttached.label);
-    expect(Volumes.isAttached(wasAttached)).toBeFalsy();
+    expect(Volumes.isAttached(wasAttached)).toBe(false);
 
     wasAttached.$(VolumeDetail.actionMenu.selector).click();
     const actionsDisplayed = Volumes.actionMenuItems.map(action => action.getText());

--- a/e2e/specs/volumes/volume-actions.spec.js
+++ b/e2e/specs/volumes/volume-actions.spec.js
@@ -1,0 +1,50 @@
+const { constants } = require('../../constants');
+import {
+  timestamp,
+  apiCreateLinode,
+  createVolumes,
+  apiDeleteAllLinodes,
+  apiDeleteAllVolumes,
+  checkEnvironment,
+} from '../../utils/common';
+
+import Volumes from '../../pageobjects/volumes.page';
+
+describe("Volumes Landing - Volume Actions", () => {
+  const testVolume = {
+    label: `AutoVolume${timestamp()}`,
+    size: 100,
+    tags: `AutoTag${timestamp()}`
+  };
+
+  const volumeEast = {
+    label: `testEast${timestamp()}`
+  }
+
+  const volumeCentral = {
+      region: 'us-central',
+      label: `testWest${timestamp()}`
+  }
+
+  const testLinode = `AutoLinodeEast${timestamp()}`;
+
+  beforeAll(() => {
+    const environment = process.env.REACT_APP_API_ROOT;
+    if (environment.includes('dev') || environment.includes('testing')){
+        createVolumes([volumeEast]);
+    } else{
+      createVolumes([volumeEast,volumeCentral]);
+    }
+    apiCreateLinode(testLinode);
+  });
+
+  it("should list the Volumes on the Volumes landing page", () => {
+    browser.url(constants.routes.volumes);
+    Volumes.baseElemsDisplay();
+    expect(Volumes.volumeCell.length).toBe(2);
+  });
+
+  it("should have basic actions", () => {
+    VolumeDetail.selectActionMenuItemV2(VolumeDetail.volumeCellElem.selector, 'Detach');
+  });
+});

--- a/e2e/utils/common.js
+++ b/e2e/utils/common.js
@@ -7,8 +7,6 @@ const {
     removeImage,
     getPublicKeys,
     removePublicKey,
-    updateUserProfile,
-    getUserProfile
 } = require('../setup/setup');
 
 import ConfigureLinode from '../pageobjects/configure-linode';
@@ -71,6 +69,12 @@ export const apiCreateLinode = (linodeLabel=false, privateIp=false, tags=[], typ
 
     return linode;
 }
+
+export const apiDeleteLinode = (linodeId) => {
+    const token = readToken(browser.options.testUser);
+    browser.removeLinode(token, linodeId);
+}
+
  export const apiCreateMultipleLinodes = (arrayOfLinodeCreateObj) => {
     let linodes = [];
     const token = readToken(browser.options.testUser);
@@ -150,7 +154,6 @@ export const createNodeBalancer = () => {
 export const removeNodeBalancers = (doNotDeleteLinodes) => {
     const token = readToken(browser.options.testUser);
     if(!doNotDeleteLinodes){
-        console.log('here');
         apiDeleteAllLinodes();
     }
     const availableNodeBalancers = browser.getNodeBalancers(token);

--- a/src/features/Volumes/VolumeTableRow.tsx
+++ b/src/features/Volumes/VolumeTableRow.tsx
@@ -202,7 +202,7 @@ export const VolumeTableRow: React.StatelessComponent<
       {isVolumesLanding && (
         <TableCell
           parentColumn="Attached To"
-          data-qa-volume-cell-attachment={volume.linodeLabel}
+          data-qa-volume-cell-attachment={volume.linodeLabel || 'Unattached'}
         >
           {volume.linodeLabel ? (
             <Link


### PR DESCRIPTION
## Description

I wanted to add a test for M3-2534, where the actions menu on VolumesLanding wasn't being updated after a Linode (to which a Volume was attached) was deleted. Turns out we didn't have any tests for that page, so added a few smoke tests as well.


## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --file e2e/specs/volumes/volume-actions.spec.js --browser=headlessChrome`

## Note to Reviewers

There's still a `browser.pause(1000)` in here that I don't like, and ~10% of the time the "View Configuration" action (and only that action) is an empty string, which I've been unable to work out.