### PR TITLE
M3-2702 Fix: errorUtils bug

### DIFF
--- a/src/__data__/axios.ts
+++ b/src/__data__/axios.ts
@@ -3,3 +3,18 @@ export const mockAxiosError = {
   name: 'hello world',
   message: 'error'
 };
+
+export const mockAxiosErrorWithAPIErrorContent = {
+  config: {},
+  name: 'hello world',
+  message: 'error',
+  response: {
+    status: 0,
+    statusText: 'status',
+    headers: null,
+    config: {},
+    data: {
+      errors: [{ field: 'Error', reason: 'A reason' }]
+    }
+  }
+};

--- a/src/features/ObjectStorage/ListBuckets.tsx
+++ b/src/features/ObjectStorage/ListBuckets.tsx
@@ -1,4 +1,3 @@
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -25,6 +24,7 @@ import bucketRequestsContainer, {
 } from 'src/containers/bucketRequests.container';
 import useOpenClose from 'src/hooks/useOpenClose';
 import { DeleteBucketRequest } from 'src/store/bucket/bucket.requests';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import BucketTableRow from './BucketTableRow';
 
 type ClassNames = 'root' | 'label';
@@ -88,12 +88,7 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
         // We're not worried about field errors here, so just grab the text
         // of the first error in the response.
 
-        // @todo: change this code when getErrorStringOrDefault is ironed out.
-        const errorText = pathOr(
-          'Error removing bucket.',
-          ['response', 'data', 'errors', 0, 'reason'],
-          e
-        );
+        const errorText = getErrorStringOrDefault(e, 'Error removing bucket.');
 
         setError(errorText);
       });

--- a/src/features/ObjectStorage/ListBuckets.tsx
+++ b/src/features/ObjectStorage/ListBuckets.tsx
@@ -84,12 +84,7 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
       })
       .catch(e => {
         setIsLoading(false);
-
-        // We're not worried about field errors here, so just grab the text
-        // of the first error in the response.
-
         const errorText = getErrorStringOrDefault(e, 'Error removing bucket.');
-
         setError(errorText);
       });
   };

--- a/src/utilities/errorUtils.test.ts
+++ b/src/utilities/errorUtils.test.ts
@@ -1,4 +1,7 @@
-import { mockAxiosError } from 'src/__data__/axios';
+import {
+  mockAxiosError,
+  mockAxiosErrorWithAPIErrorContent
+} from 'src/__data__/axios';
 import { getAPIErrorOrDefault, getErrorStringOrDefault } from './errorUtils';
 
 const error = [{ field: 'a field', reason: 'a reason' }];
@@ -49,6 +52,14 @@ describe('Error handling utilities', () => {
 
     it('should just return the string if you pass it a string', () => {
       expect(getErrorStringOrDefault('a', 'b')).toBe('a');
+    });
+
+    it('should access response.data.errors if passed an AxiosError', () => {
+      expect(
+        getErrorStringOrDefault(mockAxiosErrorWithAPIErrorContent)
+      ).toMatch(
+        mockAxiosErrorWithAPIErrorContent.response.data.errors[0].reason
+      );
     });
   });
 });

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -66,13 +66,14 @@ export const handleUnauthorizedErrors = (
 };
 
 export const getErrorStringOrDefault = (
-  errors: Linode.ApiFieldError[] | string,
+  errors: Linode.ApiFieldError[] | AxiosError | string,
   defaultError: string = 'An unexpected error occurred.'
 ): string => {
   if (typeof errors === 'string') {
     return errors;
   }
-  return pathOr<string>(defaultError, [0, 'reason'], errors);
+  const apiErrors = pathOr(errors, ['response', 'data', 'errors'], errors);
+  return pathOr<string>(defaultError, [0, 'reason'], apiErrors);
 };
 
 /**


### PR DESCRIPTION
## Description

`getErrorStringOrDefault` wasn't properly handling AxiosErrors, but was being passed them in several components. Handled this case in the function rather than adjust the consumers.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Also addressed the @todo in ListBuckets that was waiting on this change.