### PR TITLE
M3-2704 change: Validate presence of images during StackScript update

### DIFF
--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -192,12 +192,6 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
 
     const { history } = this.props;
 
-    if (selectedImages.length < 1) {
-      return this.setState({
-        errors: [{ field: 'images', reason: 'An image is required.' }]
-      });
-    }
-
     const payload = {
       script,
       label: labelText,

--- a/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -192,6 +192,12 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
 
     const { history } = this.props;
 
+    if (selectedImages.length < 1) {
+      return this.setState({
+        errors: [{ field: 'images', reason: 'An image is required.' }]
+      });
+    }
+
     const payload = {
       script,
       label: labelText,

--- a/src/services/stackscripts/stackscripts.schema.ts
+++ b/src/services/stackscripts/stackscripts.schema.ts
@@ -19,7 +19,9 @@ export const updateStackScriptSchema = object({
   label: string()
     .min(3, 'Label must be between 3 and 128 characters.')
     .max(128, 'Label must be between 3 and 128 characters.'),
-  images: array().of(string()),
+  images: array()
+    .of(string())
+    .min(1, 'An image is required.'),
   description: string(),
   is_public: boolean(),
   rev_note: string()

--- a/src/services/stackscripts/stackscripts.schema.ts
+++ b/src/services/stackscripts/stackscripts.schema.ts
@@ -19,7 +19,9 @@ export const updateStackScriptSchema = object({
   label: string()
     .min(3, 'Label must be between 3 and 128 characters.')
     .max(128, 'Label must be between 3 and 128 characters.'),
-  images: array().of(string()),
+  images: array()
+    .of(string())
+    .required('An image is required.'),
   description: string(),
   is_public: boolean(),
   rev_note: string()

--- a/src/services/stackscripts/stackscripts.schema.ts
+++ b/src/services/stackscripts/stackscripts.schema.ts
@@ -19,9 +19,7 @@ export const updateStackScriptSchema = object({
   label: string()
     .min(3, 'Label must be between 3 and 128 characters.')
     .max(128, 'Label must be between 3 and 128 characters.'),
-  images: array()
-    .of(string())
-    .required('An image is required.'),
+  images: array().of(string()),
   description: string(),
   is_public: boolean(),
   rev_note: string()


### PR DESCRIPTION
## Description

There is currently an API bug where StackScript Images are not being validated on PUT. Images actually should be required, so I updated the our client-side schema to check that `images` is not empty when updating a StackScript.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Try editing a StackScript – specifically, adding/removing images.