### PR TITLE
OBJ-149: Pluralize number of items in buckets.

### DIFF
--- a/src/features/ObjectStorage/BucketTableRow.test.tsx
+++ b/src/features/ObjectStorage/BucketTableRow.test.tsx
@@ -78,4 +78,30 @@ describe('BucketTableRow', () => {
     expect(actionMenuProps.cluster).toBe('a-cluster');
     expect(actionMenuProps.onRemove).toBe(mockOnRemove);
   });
+
+  it('should correctly pluralize the number of items in the bucket', () => {
+    wrapper.setProps({ objects: 0 });
+    expect(
+      wrapper
+        .find('[data-qa-num-objects]')
+        .childAt(0)
+        .text()
+    ).toBe('0 items');
+
+    wrapper.setProps({ objects: 1 });
+    expect(
+      wrapper
+        .find('[data-qa-num-objects]')
+        .childAt(0)
+        .text()
+    ).toBe('1 item');
+
+    wrapper.setProps({ objects: 24 });
+    expect(
+      wrapper
+        .find('[data-qa-num-objects]')
+        .childAt(0)
+        .text()
+    ).toBe('24 items');
+  });
 });

--- a/src/features/ObjectStorage/BucketTableRow.tsx
+++ b/src/features/ObjectStorage/BucketTableRow.tsx
@@ -87,7 +87,7 @@ export const BucketTableRow: React.StatelessComponent<
         </Grid>
         <Grid>
           <Typography variant="body2" data-qa-num-objects>
-            {objects} items
+            {`${objects} ${objects === 1 ? 'item' : 'items'}`}
           </Typography>
         </Grid>
       </TableCell>


### PR DESCRIPTION
## Description

I forgot to do this in the original implementation.

<img width="254" alt="Screen Shot 2019-04-22 at 3 51 08 PM" src="https://user-images.githubusercontent.com/16911484/56524168-e825fb80-6516-11e9-877b-4c8a576d8863.png">

## Note to Reviewers

To test, go the the Object Storage landing page and look at buckets with different numbers of items. 