### PR TITLE
Change: M3-2696 Update Activity Stream Based on Events

### DIFF
--- a/src/__data__/events.ts
+++ b/src/__data__/events.ts
@@ -450,3 +450,81 @@ export const events: Linode.Event[] = [
     status: 'finished'
   }
 ];
+
+export const dupeEvents: Linode.Event[] = [
+  {
+    id: 1234,
+    time_remaining: 50,
+    seen: true,
+    created: '2018-12-02T20:23:43',
+    action: 'linode_boot',
+    read: false,
+    percent_complete: 100,
+    username: 'coolguymarty',
+    rate: null,
+    entity: {
+      id: 11440645,
+      label: 'linode11440645',
+      type: 'linode',
+      url: '/v4/linode/instances/11440645'
+    },
+    status: 'finished'
+  },
+  {
+    id: 1234,
+    time_remaining: 0,
+    seen: true,
+    created: '2018-12-02T20:23:43',
+    action: 'linode_boot',
+    read: false,
+    percent_complete: 100,
+    username: 'coolguymarty',
+    rate: null,
+    entity: {
+      id: 11440645,
+      label: 'linode11440645',
+      type: 'linode',
+      url: '/v4/linode/instances/11440645'
+    },
+    status: 'scheduled'
+  }
+];
+
+export const uniqueEvents: Linode.Event[] = [
+  {
+    id: 1234,
+    time_remaining: 50,
+    seen: true,
+    created: '2018-12-02T20:23:43',
+    action: 'linode_boot',
+    read: false,
+    percent_complete: 100,
+    username: 'coolguymarty',
+    rate: null,
+    entity: {
+      id: 11440645,
+      label: 'linode11440645',
+      type: 'linode',
+      url: '/v4/linode/instances/11440645'
+    },
+    status: 'finished'
+  },
+  {
+    id: 17950407,
+    time_remaining: 0,
+    seen: true,
+    created: '2018-12-02T20:23:43',
+    action: 'linode_boot',
+    read: false,
+    percent_complete: 100,
+    username: 'coolguymarty',
+    rate: null,
+    entity: {
+      id: 11440645,
+      label: 'linode11440645',
+      type: 'linode',
+      url: '/v4/linode/instances/11440645'
+    },
+    status: 'finished'
+  }
+];

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
@@ -1,5 +1,12 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import {
+  ActivitySummary,
+  filterUniqueEvents,
+  percentCompleteHasUpdated
+} from './ActivitySummary';
+
+import { dupeEvents, uniqueEvents } from 'src/__data__/events';
 
 const requests = require.requireMock('src/services/account');
 
@@ -8,8 +15,6 @@ requests.getEvents = jest.fn(() => Promise.resolve([]));
 jest.mock('src/services/account', () => ({
   getEvents: () => jest.fn()
 }));
-
-import { ActivitySummary } from './ActivitySummary';
 
 const props = {
   linodeId: 123456,
@@ -24,6 +29,29 @@ const props = {
 const component = shallow(<ActivitySummary {...props} />);
 
 describe('ActivitySummary component', () => {
+  describe('Utility Functions', () => {
+    it('should filter out unique events', () => {
+      expect(filterUniqueEvents(dupeEvents)).toHaveLength(1);
+      expect(filterUniqueEvents(uniqueEvents)).toHaveLength(2);
+    });
+
+    it('should return true if percent complete has changed', () => {
+      const inProgressEvents: Record<number, number> = {
+        123: 50
+      };
+      const prevInProgressEvents: Record<number, number> = {
+        123: 79
+      };
+      expect(
+        percentCompleteHasUpdated(inProgressEvents, inProgressEvents)
+      ).toBeFalsy();
+      expect(
+        percentCompleteHasUpdated(inProgressEvents, prevInProgressEvents)
+      ).toBeTruthy();
+      expect(percentCompleteHasUpdated(inProgressEvents, {})).toBeTruthy();
+    });
+  });
+
   it('should render', () => {
     expect(component).toHaveLength(1);
   });

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
@@ -13,6 +13,8 @@ import { ActivitySummary } from './ActivitySummary';
 
 const props = {
   linodeId: 123456,
+  eventsFromRedux: [],
+  inProgressEvents: [],
   classes: {
     root: '',
     header: '',

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -41,7 +41,6 @@ interface State {
   loading: boolean;
   error?: string;
   events: Linode.Event[];
-  initialEventsLength: number;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -50,8 +49,7 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
   state: State = {
     loading: true,
     error: undefined,
-    events: [],
-    initialEventsLength: this.props.eventsFromRedux.length
+    events: []
   };
 
   componentDidUpdate(prevProps: CombinedProps, prevState: State) {
@@ -63,13 +61,21 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
             of the activity stream. Make sure they're events after the ones
             we got from page load and ones that match the Linode ID
           */
-          ...this.props.eventsFromRedux.filter((eachEvent, index) => {
+          ...this.props.eventsFromRedux.filter(eachEvent => {
             return (
-              index < this.state.initialEventsLength &&
-              (eachEvent.entity && eachEvent.entity.id === this.props.linodeId)
+              !eachEvent._initial &&
+              (eachEvent.entity &&
+                eachEvent.entity.id === this.props.linodeId &&
+                eachEvent.entity.type === 'linode')
             );
           }),
-          ...this.state.events
+          /* 
+            at this point, the state is populated with events from Redux and events from the cDM request
+            and we only want the ones where the "_initial" flag doesn't exist
+          */
+          ...this.state.events.filter(
+            eachEvent => typeof eachEvent._initial === 'undefined'
+          )
         ]
       });
     }

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -1,3 +1,4 @@
+import { equals } from 'ramda';
 import * as React from 'react';
 import Grid from 'src/components/core/Grid';
 import Paper from 'src/components/core/Paper';
@@ -12,6 +13,8 @@ import ViewAllLink from 'src/components/ViewAllLink';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { getEventsForEntity } from 'src/utilities/getEventsForEntity';
 import ActivitySummaryContent from './ActivitySummaryContent';
+
+import { ExtendedEvent } from 'src/store/events/event.helpers';
 
 type ClassNames = 'root' | 'header' | 'viewMore';
 
@@ -30,12 +33,15 @@ const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
 
 interface Props {
   linodeId: number;
+  inProgressEvents: Record<number, boolean>;
+  eventsFromRedux: ExtendedEvent[];
 }
 
 interface State {
   loading: boolean;
   error?: string;
   events: Linode.Event[];
+  initialEventsLength: number;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -44,14 +50,36 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
   state: State = {
     loading: true,
     error: undefined,
-    events: []
+    events: [],
+    initialEventsLength: this.props.eventsFromRedux.length
   };
+
+  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
+    if (!equals(this.props.inProgressEvents, prevProps.inProgressEvents)) {
+      this.setState({
+        events: [
+          /* 
+            make sure that we're popping new related events to the top
+            of the activity stream. Make sure they're events after the ones
+            we got from page load and ones that match the Linode ID
+          */
+          ...this.props.eventsFromRedux.filter((eachEvent, index) => {
+            return (
+              index < this.state.initialEventsLength &&
+              (eachEvent.entity && eachEvent.entity.id === this.props.linodeId)
+            );
+          }),
+          ...this.state.events
+        ]
+      });
+    }
+  }
 
   componentDidMount() {
     getEventsForEntity({}, 'linode', this.props.linodeId)
       .then(response => {
         this.setState({
-          events: response.data.slice(0, 5),
+          events: response.data,
           loading: false
         });
       })
@@ -86,7 +114,7 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
         </Grid>
         <Paper className={classes.root}>
           <ActivitySummaryContent
-            events={events}
+            events={events.slice(0, 5)}
             error={error}
             loading={loading}
           />

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -7,6 +7,8 @@ import { LinodeSummary } from './LinodeSummary';
 describe('LinodeSummary', () => {
   const wrapper = shallow(
     <LinodeSummary
+      events={[]}
+      inProgressEvents={[]}
       linodeCreated="2018-11-01T00:00:00"
       linodeId={1234}
       linodeData={linodes[0]}

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -37,6 +37,8 @@ import StatsPanel from './StatsPanel';
 import SummaryPanel from './SummaryPanel';
 import TotalTraffic, { TotalTrafficProps } from './TotalTraffic';
 
+import { ExtendedEvent } from 'src/store/events/event.helpers';
+
 setUpCharts();
 
 type ClassNames =
@@ -693,7 +695,11 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
             </Grid>
 
             <Grid item>
-              <ActivitySummary linodeId={linode.id} />
+              <ActivitySummary
+                eventsFromRedux={this.props.events}
+                linodeId={linode.id}
+                inProgressEvents={this.props.inProgressEvents}
+              />
             </Grid>
 
             <Grid item className="py0">
@@ -755,11 +761,19 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
 interface WithTypesProps {
   typesData: Linode.LinodeType[];
   timezone: string;
+  inProgressEvents: Record<number, boolean>;
+  events: ExtendedEvent[];
 }
 
 const withTypes = connect((state: ApplicationState, ownProps) => ({
   typesData: state.__resources.types.entities,
-  timezone: pathOr('UTC', ['__resources', 'profile', 'data', 'timezone'], state)
+  timezone: pathOr(
+    'UTC',
+    ['__resources', 'profile', 'data', 'timezone'],
+    state
+  ),
+  inProgressEvents: state.events.inProgressEvents,
+  events: state.events.events
 }));
 
 const enhanced = compose<CombinedProps, {}>(

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -761,7 +761,7 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
 interface WithTypesProps {
   typesData: Linode.LinodeType[];
   timezone: string;
-  inProgressEvents: Record<number, boolean>;
+  inProgressEvents: Record<number, number>;
   events: ExtendedEvent[];
 }
 

--- a/src/store/events/event.helpers.test.ts
+++ b/src/store/events/event.helpers.test.ts
@@ -291,7 +291,7 @@ describe('event.helpers', () => {
     });
 
     it('should do nothing if there are no in-progress events', () => {
-      const inProgressEvents = { '999': true };
+      const inProgressEvents = { '999': 23 };
       const events = [
         {
           id: 1,
@@ -307,7 +307,7 @@ describe('event.helpers', () => {
         }
       ];
       const result = updateInProgressEvents(inProgressEvents, events);
-      expect(result).toEqual({ '999': true });
+      expect(result).toEqual({ '999': 23 });
     });
 
     it('should add in-progress events to the Map', () => {
@@ -328,7 +328,7 @@ describe('event.helpers', () => {
       ];
       const result = updateInProgressEvents(inProgressEvents, events);
 
-      expect(result).toEqual({ '2': true });
+      expect(result).toEqual({ '2': 60 });
     });
   });
 });

--- a/src/store/events/event.helpers.ts
+++ b/src/store/events/event.helpers.ts
@@ -131,9 +131,12 @@ export const isEntityEvent = (e: Linode.Event): e is Linode.EntityEvent =>
  * If an event is "completed" it is removed from the inProgressEvents map.
  * Otherwise the inProgressEvents is unchanged.
  *
+ * @retuns { [key: number]: number } inProgressEvents: key value pair, where the
+ * key will be the ID of the event and the value will be the percent_complete
+ *
  */
 export const updateInProgressEvents = (
-  inProgressEvents: Record<number, boolean>,
+  inProgressEvents: Record<number, number>,
   event: Pick<Event, 'percent_complete' | 'id'>[]
 ) => {
   return event.reduce((result, e) => {
@@ -143,7 +146,9 @@ export const updateInProgressEvents = (
       return omit([key], result);
     }
 
-    return isInProgressEvent(e) ? { ...result, [key]: true } : result;
+    return isInProgressEvent(e)
+      ? { ...result, [key]: e.percent_complete }
+      : result;
   }, inProgressEvents);
 };
 

--- a/src/store/events/event.reducer.test.ts
+++ b/src/store/events/event.reducer.test.ts
@@ -71,7 +71,7 @@ describe('events.reducer', () => {
         });
 
         it('should update the inProgressEvents', () => {
-          expect(state).toHaveProperty('inProgressEvents', { 18022171: true });
+          expect(state).toHaveProperty('inProgressEvents', { 18022171: 80 });
         });
       });
     });

--- a/src/store/events/event.reducer.ts
+++ b/src/store/events/event.reducer.ts
@@ -14,7 +14,7 @@ export interface State {
   events: ExtendedEvent[];
   mostRecentEventTime: number;
   countUnseenEvents: number;
-  inProgressEvents: Record<number, boolean>;
+  inProgressEvents: Record<number, number>;
 }
 
 export const defaultState: State = {


### PR DESCRIPTION
## Description

Subscribes to Redux state to update events automatically in the Activity Stream without needing a refresh.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## Note to Reviewers

This does not affect the events landing.......yet. This is simple a POC that will also affect that view if this approach is received well.