### PR TITLE
M3-2502 Update: polling for NodeBalancer node status

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -35,6 +35,7 @@ import {
   withNodeBalancerActions,
   WithNodeBalancerActions
 } from 'src/store/nodeBalancer/nodeBalancer.containers';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { NodeBalancerProvider } from './context';
@@ -109,7 +110,12 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
           this.props.clearLoadingAndErrors();
         })
         .catch(error => {
-          this.props.setErrorAndClearLoading(error);
+          this.props.setErrorAndClearLoading(
+            getErrorStringOrDefault(
+              error,
+              'There was an error loading your NodeBalancer.'
+            )
+          );
         });
     });
 

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-router-dom';
 import { compose } from 'recompose';
 import Breadcrumb from 'src/components/Breadcrumb';
+import CircleProgress from 'src/components/CircleProgress';
 import AppBar from 'src/components/core/AppBar';
 import {
   StyleRulesCallback,
@@ -21,9 +22,10 @@ import Tabs from 'src/components/core/Tabs';
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
-import PromiseLoader, {
-  PromiseLoaderResponse
-} from 'src/components/PromiseLoader/PromiseLoader';
+import withLoadingAndError, {
+  LoadingAndErrorHandlers,
+  LoadingAndErrorState
+} from 'src/components/withLoadingAndError';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import {
   getNodeBalancer,
@@ -59,18 +61,13 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 });
 
 const defaultError = [
-  { reason: 'An unknown error occured while updating NodeBalancer.' }
+  { reason: 'An unknown error occurred while updating NodeBalancer.' }
 ];
 
 type RouteProps = RouteComponentProps<{ nodeBalancerId?: string }>;
 
-interface PreloadedProps {
-  nodeBalancer: PromiseLoaderResponse<Linode.ExtendedNodeBalancer>;
-}
-
 interface State {
-  nodeBalancer: Linode.ExtendedNodeBalancer;
-  error?: Error;
+  nodeBalancer?: Linode.ExtendedNodeBalancer;
   ApiError: Linode.ApiFieldError[] | undefined;
   labelInput?: string;
 }
@@ -78,20 +75,20 @@ interface State {
 type CombinedProps = WithNodeBalancerActions &
   InjectedNotistackProps &
   RouteProps &
-  PreloadedProps &
+  LoadingAndErrorHandlers &
+  LoadingAndErrorState &
   WithStyles<ClassNames>;
 
-const preloaded = PromiseLoader<CombinedProps>({
-  nodeBalancer: ({
-    match: {
-      params: { nodeBalancerId }
-    }
-  }) => {
-    if (!nodeBalancerId) {
-      return Promise.reject(new Error('nodeBalancerId param not set.'));
-    }
+class NodeBalancerDetail extends React.Component<CombinedProps, State> {
+  state: State = {
+    nodeBalancer: undefined,
+    ApiError: undefined
+  };
 
-    return getNodeBalancer(+nodeBalancerId).then(nodeBalancer => {
+  pollInterval: number;
+
+  requestNodeBalancer = (nodeBalancerId: number) =>
+    getNodeBalancer(+nodeBalancerId).then(nodeBalancer => {
       return getNodeBalancerConfigs(nodeBalancer.id)
         .then(({ data: configs }) => {
           return {
@@ -107,22 +104,38 @@ const preloaded = PromiseLoader<CombinedProps>({
             }, [])
           };
         })
-        .catch(e => []);
+        .then((response: Linode.ExtendedNodeBalancer) => {
+          this.setState({ nodeBalancer: response });
+          this.props.clearLoadingAndErrors();
+        })
+        .catch(error => {
+          this.props.setErrorAndClearLoading(error);
+        });
     });
+
+  componentDidMount() {
+    const { nodeBalancerId } = this.props.match.params;
+
+    // On initial load only, we want a loading state.
+    this.props.setLoadingAndClearErrors();
+    if (!nodeBalancerId) {
+      this.props.setErrorAndClearLoading('NodeBalancer ID param not set.');
+      return;
+    }
+    this.requestNodeBalancer(+nodeBalancerId);
+
+    // Update NB information every 30 seconds, so that we have an accurate picture of nodes
+    this.pollInterval = window.setInterval(
+      () => this.requestNodeBalancer(+nodeBalancerId),
+      30 * 1000
+    );
   }
-});
 
-class NodeBalancerDetail extends React.Component<CombinedProps, State> {
-  state: State = {
-    nodeBalancer: pathOr(undefined, ['response'], this.props.nodeBalancer),
-    error: pathOr(undefined, ['error'], this.props.nodeBalancer),
-    ApiError: undefined
-  };
+  componentWillUnmount() {
+    clearInterval(this.pollInterval);
+  }
 
-  handleTabChange = (
-    event: React.ChangeEvent<HTMLDivElement>,
-    value: number
-  ) => {
+  handleTabChange = (_: React.ChangeEvent<HTMLDivElement>, value: number) => {
     const { history } = this.props;
     const routeName = this.tabs[value].routeNames[0];
     history.push(`${routeName}`);
@@ -133,6 +146,11 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
     const {
       nodeBalancerActions: { updateNodeBalancer }
     } = this.props;
+
+    // This should never actually happen, but TypeScript is expecting a Promise here.
+    if (nodeBalancer === undefined) {
+      return Promise.resolve();
+    }
 
     return updateNodeBalancer({ nodeBalancerId: nodeBalancer.id, label })
       .then(() => {
@@ -165,6 +183,10 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
       nodeBalancerActions: { updateNodeBalancer }
     } = this.props;
 
+    if (nodeBalancer === undefined) {
+      return;
+    }
+
     return updateNodeBalancer({ nodeBalancerId: nodeBalancer.id, tags }).then(
       () => {
         this.setState({
@@ -178,7 +200,7 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
   cancelUpdate = () => {
     this.setState({
       ApiError: undefined,
-      labelInput: this.state.nodeBalancer.label
+      labelInput: pathOr('', ['label'], this.state.nodeBalancer)
     });
   };
 
@@ -226,9 +248,16 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
       Boolean(matchPath(this.props.location.pathname, { path: pathName }));
     const {
       match: { path, url },
-      classes
+      classes,
+      error,
+      loading
     } = this.props;
-    const { error, nodeBalancer } = this.state;
+    const { nodeBalancer } = this.state;
+
+    /** Loading State */
+    if (loading) {
+      return <CircleProgress />;
+    }
 
     /** Empty State */
     if (!nodeBalancer) {
@@ -349,7 +378,7 @@ class NodeBalancerDetail extends React.Component<CombinedProps, State> {
 
 const styled = withStyles(styles);
 const reloaded = reloadableWithRouter<
-  PreloadedProps,
+  CombinedProps,
   { nodeBalancerId?: number }
 >((routePropsOld, routePropsNew) => {
   return (
@@ -362,7 +391,7 @@ export default compose(
   setDocs(NodeBalancerDetail.docs),
   reloaded,
   styled,
-  preloaded,
   withSnackbar,
-  withNodeBalancerActions
+  withNodeBalancerActions,
+  withLoadingAndError
 )(NodeBalancerDetail);

--- a/src/services/nodebalancers/configNodes.ts
+++ b/src/services/nodebalancers/configNodes.ts
@@ -36,12 +36,6 @@ export interface NodeBalancerConfigNode {
   weight: number;
 }
 
-// interface IDontKnowWhatThisIs {
-//   /* for the sake of local operations */
-//   modifyStatus?: 'new' | 'delete' | 'update';
-//   errors?: Linode.ApiFieldError[];
-// }
-
 /**
  * getNodeBalancerConfigNodes
  *
@@ -65,8 +59,7 @@ export const getNodeBalancerConfigNodes = (
 /**
  * getNodeBalancerConfigNode
  *
- * Returns a paginated list of nodes for the specified NodeBalancer configuration profile.
- * These are the backends that will be sent traffic for this port.
+ * Returns details about a specific node for the given NodeBalancer configuration profile.
  *
  * @param nodeBalancerId { number } The ID of the NodeBalancer the config belongs to.
  * @param configId { number } The configuration profile to retrieve nodes for.

--- a/src/store/store.helpers.ts
+++ b/src/store/store.helpers.ts
@@ -92,7 +92,7 @@ export const addMany = <E extends Entity>(
 };
 
 /**
- * Generates a list of entites added to an existing list, and a list of entities removed from an existing list.
+ * Generates a list of entities added to an existing list, and a list of entities removed from an existing list.
  */
 export const getAddRemoved = <E extends Entity>(
   existingList: E[] = [],


### PR DESCRIPTION
## Description

Add polling for NodeBalancers on NB landing and detail pages. This keeps the "Nodes: 1 up, 2 down" status indicators in both locations up to date.

## Type of Change
- Non breaking change ('update', 'change')


## Applicable E2E Tests

None

## Note to Reviewers

- prod-test-004 is set up with a NodeBalancer & 5 nodes. Just open a new tab and boot/shutdown any of the `example-instance` Linodes, then wait a bit.
- Current interval is 30 seconds; feedback welcome.
- I used the existing `getAllNodeBalancersWithConfigs` Thunk, since it's safe and reuses existing logic. We might be able to slightly lower network usage by only getting configs for NBs already in Redux state but I didn't think this was worth it.
- NodeBalancerDetail has a NodeBalancerContext but I'm not completely clear what it's doing. I pulled out the PromiseLoader/preloaded business, and everything seems to hold together, but it's a complicated component so let me know if I missed something.