### PR TITLE
M3-1842 Change: Use browser timezone when logged in as customer

### DIFF
--- a/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
+++ b/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
@@ -12,6 +12,7 @@ describe('Email change form', () => {
       username="exampleuser"
       email="me@this.com"
       timezone="America/Barbados"
+      isLoggedInAsCustomer={false}
       actions={{
         updateProfile: update
       }}

--- a/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
+++ b/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
@@ -12,7 +12,7 @@ describe('Email change form', () => {
       username="exampleuser"
       email="me@this.com"
       timezone="America/Barbados"
-      isLoggedInAsCustomer={false}
+      loggedInAsCustomer={false}
       actions={{
         updateProfile: update
       }}

--- a/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -47,7 +47,7 @@ export class DisplaySettings extends React.Component<CombinedProps, State> {
     const {
       actions,
       email,
-      isLoggedInAsCustomer,
+      loggedInAsCustomer,
       loading,
       timezone,
       username
@@ -71,7 +71,7 @@ export class DisplaySettings extends React.Component<CombinedProps, State> {
             <TimezoneForm
               timezone={timezone}
               updateProfile={actions.updateProfile}
-              isLoggedInAsCustomer={isLoggedInAsCustomer}
+              loggedInAsCustomer={loggedInAsCustomer}
             />
           </React.Fragment>
         )}
@@ -89,7 +89,7 @@ interface StateProps {
   username?: string;
   email?: string;
   timezone: string;
-  isLoggedInAsCustomer: boolean;
+  loggedInAsCustomer: boolean;
 }
 
 const mapStateToProps: MapState<StateProps, {}> = state => {
@@ -99,9 +99,9 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
     username: path(['data', 'username'], profile),
     email: path(['data', 'email'], profile),
     timezone: defaultTimezone(profile),
-    isLoggedInAsCustomer: pathOr(
+    loggedInAsCustomer: pathOr(
       false,
-      ['authentication', 'isLoggedInAsCustomer'],
+      ['authentication', 'loggedInAsCustomer'],
       state
     )
   };

--- a/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -44,7 +44,14 @@ export class DisplaySettings extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { email, loading, timezone, username, actions } = this.props;
+    const {
+      actions,
+      email,
+      isLoggedInAsCustomer,
+      loading,
+      timezone,
+      username
+    } = this.props;
 
     if (!email || !username) {
       return null;
@@ -64,6 +71,7 @@ export class DisplaySettings extends React.Component<CombinedProps, State> {
             <TimezoneForm
               timezone={timezone}
               updateProfile={actions.updateProfile}
+              isLoggedInAsCustomer={isLoggedInAsCustomer}
             />
           </React.Fragment>
         )}
@@ -81,6 +89,7 @@ interface StateProps {
   username?: string;
   email?: string;
   timezone: string;
+  isLoggedInAsCustomer: boolean;
 }
 
 const mapStateToProps: MapState<StateProps, {}> = state => {
@@ -89,7 +98,12 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
     loading: profile.loading,
     username: path(['data', 'username'], profile),
     email: path(['data', 'email'], profile),
-    timezone: defaultTimezone(profile)
+    timezone: defaultTimezone(profile),
+    isLoggedInAsCustomer: pathOr(
+      false,
+      ['authentication', 'isLoggedInAsCustomer'],
+      state
+    )
   };
 };
 

--- a/src/features/Profile/DisplaySettings/TimezoneForm.test.tsx
+++ b/src/features/Profile/DisplaySettings/TimezoneForm.test.tsx
@@ -14,11 +14,21 @@ describe('Timezone change form', () => {
       }}
       timezone={'Pacific/Niue'}
       updateProfile={updateProfile}
+      isLoggedInAsCustomer={true}
     />
   );
 
   it('should render .', () => {
     expect(component).toHaveLength(1);
+  });
+
+  it('should show a message if an admin is logged in as a customer', () => {
+    expect(component.find('[data-qa-admin-notice]')).toHaveLength(1);
+  });
+
+  it('should not show a message if the user is logged in normally', () => {
+    component.setProps({ isLoggedInAsCustomer: false });
+    expect(component.find('[data-qa-admin-notice]')).toHaveLength(0);
   });
 
   xit("should include text with the user's current time zone", () => {

--- a/src/features/Profile/DisplaySettings/TimezoneForm.test.tsx
+++ b/src/features/Profile/DisplaySettings/TimezoneForm.test.tsx
@@ -14,7 +14,7 @@ describe('Timezone change form', () => {
       }}
       timezone={'Pacific/Niue'}
       updateProfile={updateProfile}
-      isLoggedInAsCustomer={true}
+      loggedInAsCustomer={true}
     />
   );
 
@@ -27,7 +27,7 @@ describe('Timezone change form', () => {
   });
 
   it('should not show a message if the user is logged in normally', () => {
-    component.setProps({ isLoggedInAsCustomer: false });
+    component.setProps({ loggedInAsCustomer: false });
     expect(component.find('[data-qa-admin-notice]')).toHaveLength(0);
   });
 

--- a/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -33,7 +33,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 interface Props {
   timezone: string;
-  isLoggedInAsCustomer: boolean;
+  loggedInAsCustomer: boolean;
   updateProfile: (v: Linode.Profile) => void;
 }
 
@@ -123,7 +123,7 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { classes, isLoggedInAsCustomer, timezone } = this.props;
+    const { classes, loggedInAsCustomer, timezone } = this.props;
     const { errors, submitting, success } = this.state;
     const timezoneDisplay = pathOr(
       timezone,
@@ -145,12 +145,20 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
         <Paper className={classes.root}>
           {success && <Notice success text={success} />}
           {generalError && <Notice error text={generalError} />}
-          {isLoggedInAsCustomer && (
-            <Notice
-              warning
+          {loggedInAsCustomer && (
+            <div
+              style={{
+                backgroundColor: 'pink',
+                padding: '1em',
+                marginBottom: '0.5em',
+                textAlign: 'center'
+              }}
               data-qa-admin-notice
-              text={`While you are logged in as a customer, all times, dates, and graphs will be displayed in your browser's timezone (${timezone}).`}
-            />
+            >
+              <Typography style={{ fontSize: '1.2em', color: 'black' }}>
+                {`While you are logged in as a customer, all times, dates, and graphs will be displayed in your browser's timezone (${timezone}).`}
+              </Typography>
+            </div>
           )}
           <Typography variant="body1" data-qa-copy>
             This setting converts the dates and times displayed in the Linode

--- a/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -33,6 +33,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 interface Props {
   timezone: string;
+  isLoggedInAsCustomer: boolean;
   updateProfile: (v: Linode.Profile) => void;
 }
 
@@ -122,7 +123,7 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { classes, timezone } = this.props;
+    const { classes, isLoggedInAsCustomer, timezone } = this.props;
     const { errors, submitting, success } = this.state;
     const timezoneDisplay = pathOr(
       timezone,
@@ -144,6 +145,13 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
         <Paper className={classes.root}>
           {success && <Notice success text={success} />}
           {generalError && <Notice error text={generalError} />}
+          {isLoggedInAsCustomer && (
+            <Notice
+              warning
+              data-qa-admin-notice
+              text={`While you are logged in as a customer, all times, dates, and graphs will be displayed in your browser's timezone (${timezone}).`}
+            />
+          )}
           <Typography variant="body1" data-qa-copy>
             This setting converts the dates and times displayed in the Linode
             Manager to a timezone of your choice. Your current timezone is:{' '}

--- a/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -143,8 +143,6 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <Paper className={classes.root}>
-          {success && <Notice success text={success} />}
-          {generalError && <Notice error text={generalError} />}
           {loggedInAsCustomer && (
             <div
               style={{
@@ -160,6 +158,8 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
               </Typography>
             </div>
           )}
+          {success && <Notice success text={success} />}
+          {generalError && <Notice error text={generalError} />}
           <Typography variant="body1" data-qa-copy>
             This setting converts the dates and times displayed in the Linode
             Manager to a timezone of your choice. Your current timezone is:{' '}

--- a/src/store/profile/profile.requests.ts
+++ b/src/store/profile/profile.requests.ts
@@ -1,4 +1,6 @@
+import { pathOr } from 'ramda';
 import { getMyGrants, getProfile } from 'src/services/profile';
+import { ApplicationState } from 'src/store';
 import { ThunkActionCreator } from 'src/store/types';
 import { getProfileActions } from './profile.actions';
 
@@ -12,15 +14,33 @@ const maybeRequestGrants: (
   return getMyGrants().then(grants => ({ ...profile, grants }));
 };
 
+export const getTimezone = (state: ApplicationState, timezone: string) => {
+  const isLoggedInAsCustomer = pathOr(
+    false,
+    ['authentication', 'loggedInAsCustomer'],
+    state
+  );
+  /** If logged in as customer (from Admin), use the browser's local time instead of the
+   *  value in profile. Otherwise, use the user's chosen value.
+   */
+  return isLoggedInAsCustomer
+    ? Intl.DateTimeFormat().resolvedOptions().timeZone
+    : timezone;
+};
+
 export const requestProfile: ThunkActionCreator<
   Promise<Linode.Profile>
-> = () => dispatch => {
+> = () => (dispatch, getState) => {
   const { started, done, failed } = getProfileActions;
 
   dispatch(started());
 
   return getProfile()
     .then(response => response.data)
+    .then(profile => ({
+      ...profile,
+      timezone: getTimezone(getState(), profile.timezone)
+    }))
     .then(maybeRequestGrants)
     .then(response => {
       dispatch(done({ result: response }));

--- a/src/utilities/formatDate.ts
+++ b/src/utilities/formatDate.ts
@@ -31,7 +31,7 @@ export const shouldHumanize = (
    */
   const diff = Math.abs(+moment.duration(moment().diff(time)));
   /**
-   * Humanize the date if th difference between the current date and provided date
+   * Humanize the date if the difference between the current date and provided date
    * is lower than the cutoff
    */
   return diff <= +duration;
@@ -49,8 +49,12 @@ export const formatDate = (
   let time;
 
   /** get the timezone from redux and use it as the moment timezone */
-  const reduxProfile = store.getState().__resources.profile;
-  const userTimezone = pathOr('GMT', ['data', 'timezone'], reduxProfile);
+  const state = store.getState();
+  const userTimezone = pathOr(
+    'GMT',
+    ['__resources', 'profile', 'data', 'timezone'],
+    state
+  );
 
   try {
     // Unknown error was causing this to crash in rare situations.
@@ -58,7 +62,7 @@ export const formatDate = (
   } catch (e) {
     // Better to return a blank date than an error or incorrect information.
     reportException(e);
-    return 'Error getting datetime';
+    return 'Error getting date';
   }
   const formattedTime = shouldHumanize(time, options.humanizeCutoff)
     ? time.fromNow()


### PR DESCRIPTION
## Description

Using the `isLoggedInAsCustomer` value from Redux, set the timezone (also in Redux) to the browser's timezone when logged in as customer.


## Type of Change
- Non breaking change ('update', 'change')


## Applicable E2E Tests

None

## Note to Reviewers

You'll have to use devenv (or use some clever method to capture the redirect urls from linode/admin): http://localhost:3000/admin/callback#access_token=ec592ecb23e08bbcc0c8008b0898858436df564e04e8975603fdfbe1238e4406&destination=linodes&token_type=Admin&expires_in=7200

I had trouble getting to a place in Manager where the time display was visible and not humanized (in devenv, that is), but the current timezone is displayed at /profile/display. Vagrant (the user you're impersonating) is set to GMT, your browser is likely EDT.