### PR TITLE
M3-2718 Reverse sorting arrows for sortable tables

### DIFF
--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1180,6 +1180,12 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
         icon: {
           opacity: 1,
           marginTop: 2
+        },
+        iconDirectionDesc: {
+          transform: 'rotate(180deg)'
+        },
+        iconDirectionAsc: {
+          transform: 'rotate(0deg)'
         }
       },
       MuiTooltip: {


### PR DESCRIPTION
## Reverse sorting arrows for sortable tables

On a sortable table cell:

- Arrow should be pointing up for ascending order
- Arrow should be pointing down for descending order.

## Type of Change
- Bug fix ('fix')
