### PR TITLE
M3-2703 Lish tabs style updates

### DIFF
--- a/src/features/Lish/Lish.tsx
+++ b/src/features/Lish/Lish.tsx
@@ -27,7 +27,17 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     margin: 0
   },
   tabRoot: {
-    minWidth: '50%'
+    margin: 0,
+    flexBasis: '50%',
+    transition: theme.transitions.create('background-color'),
+    '&[aria-selected="true"]': {
+      backgroundColor: theme.palette.primary.main,
+      color: 'white',
+      '&:hover': {
+        backgroundColor: theme.palette.primary.light,
+        color: 'white'
+      }
+    }
   },
   progress: {
     height: 'auto'
@@ -188,8 +198,7 @@ class Lish extends React.Component<CombinedProps, State> {
           className={classes.tabs}
           indicatorColor="primary"
           textColor="primary"
-          variant="scrollable"
-          scrollButtons="on"
+          scrollButtons="off"
         >
           {this.tabs.map(tab => (
             <Tab

--- a/src/index.css
+++ b/src/index.css
@@ -315,3 +315,7 @@ button::-moz-focus-inner {
 .no-transition *::after {
   transition: none !important;
 }
+
+.terminal {
+  padding: 24px;
+}


### PR DESCRIPTION
## Lish tabs style updates

Tabs were showing the scrollbar by default so that is fixed. I also updated the active tab state to make it more clear as well as adding some padding to the lish console itself. Should improve the UX quite a bit.

## Type of Change
- Non breaking change ('update')