### PR TITLE
M3-2705 Volumes tables style updates

### DIFF
--- a/src/components/ActionMenu/ActionMenu.tsx
+++ b/src/components/ActionMenu/ActionMenu.tsx
@@ -127,7 +127,7 @@ export class ActionMenu extends React.Component<CombinedProps, State> {
     }
 
     return (
-      <div className={classes.root}>
+      <div className={`${classes.root} action-menu`}>
         <IconButton
           aria-owns={anchorEl ? 'action-menu' : undefined}
           aria-expanded={anchorEl ? true : undefined}

--- a/src/features/Volumes/SortableVolumesTableHeader.tsx
+++ b/src/features/Volumes/SortableVolumesTableHeader.tsx
@@ -13,7 +13,6 @@ import TableSortCell from 'src/components/TableSortCell';
 type ClassNames =
   | 'root'
   | 'labelCol'
-  | 'tagsCol'
   | 'regionCol'
   | 'attachmentCol'
   | 'sizeCol'
@@ -29,7 +28,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   linodeVolumesWrapper: {
     '& $labelCol': {
       width: '20%',
-      minWidth: 200
+      minWidth: 150
     },
     '& $sizeCol': {
       width: '15%',
@@ -37,26 +36,21 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     },
     '& $pathCol': {
       width: '55%',
-      minWidth: 350
+      minWidth: 150
     }
-  },
-  tagsCol: {
-    width: '10%',
-    minWidth: 150,
-    paddingLeft: 65
   },
   regionCol: {
     width: '20%',
-    minWidth: 150
+    minWidth: 75
   },
   labelCol: {
     width: '20%',
-    minWidth: 150,
+    minWidth: 75,
     paddingLeft: theme.spacing.unit * 2 + 49
   },
   attachmentCol: {
     width: '15%',
-    minWidth: 150
+    minWidth: 75
   },
   sizeCol: {
     width: '10%',
@@ -64,7 +58,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   pathCol: {
     width: '25%',
-    minWidth: 250
+    minWidth: 100
   }
 });
 
@@ -105,7 +99,6 @@ const SortableTableHeader: React.StatelessComponent<CombinedProps> = props => {
         >
           Label
         </TableSortCell>
-        <TableCell className={classes.tagsCol}>Tags</TableCell>
         {isVolumesLanding && (
           <TableSortCell
             className={classes.regionCol}

--- a/src/features/Volumes/VolumeTableRow.test.tsx
+++ b/src/features/Volumes/VolumeTableRow.test.tsx
@@ -24,7 +24,8 @@ const classes = {
   sizeCol: '',
   pathCol: '',
   volumesWrapper: '',
-  linodeVolumesWrapper: ''
+  linodeVolumesWrapper: '',
+  systemPath: ''
 };
 
 const props = {

--- a/src/features/Volumes/VolumeTableRow.tsx
+++ b/src/features/Volumes/VolumeTableRow.tsx
@@ -12,7 +12,6 @@ import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
 import TableCell from 'src/components/TableCell';
-import TagsCell from 'src/components/TagsCell';
 import { formatRegion } from 'src/utilities';
 import VolumesActionMenu from './VolumesActionMenu';
 import { ExtendedVolume } from './VolumesLanding';
@@ -26,7 +25,8 @@ type ClassNames =
   | 'sizeCol'
   | 'pathCol'
   | 'volumesWrapper'
-  | 'linodeVolumesWrapper';
+  | 'linodeVolumesWrapper'
+  | 'systemPath';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
@@ -71,6 +71,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   pathCol: {
     width: '25%',
     minWidth: 250
+  },
+  systemPath: {
+    wordBreak: 'break-all'
   }
 });
 
@@ -157,7 +160,6 @@ export const VolumeTableRow: React.StatelessComponent<
           </Grid>
         </Grid>
       </TableCell>
-      <TagsCell tags={volume.tags} />
       <TableCell colSpan={5}>
         <LinearProgress value={progressFromEvent(volume.recentEvent)} />
       </TableCell>
@@ -182,7 +184,6 @@ export const VolumeTableRow: React.StatelessComponent<
           </Grid>
         </Grid>
       </TableCell>
-      <TagsCell tags={volume.tags} />
       {isVolumesLanding && (
         <TableCell parentColumn="Region" data-qa-volume-region>
           {region}
@@ -191,7 +192,11 @@ export const VolumeTableRow: React.StatelessComponent<
       <TableCell parentColumn="Size" data-qa-volume-size>
         {size} GiB
       </TableCell>
-      <TableCell parentColumn="File System Path" data-qa-fs-path>
+      <TableCell
+        parentColumn="File System Path"
+        data-qa-fs-path
+        className={classes.systemPath}
+      >
         {filesystemPath}
       </TableCell>
       {isVolumesLanding && (

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -678,7 +678,7 @@ const RenderLoading = () => {
 const RenderError = () => {
   return (
     <TableRowError
-      colSpan={7}
+      colSpan={6}
       message="There was an error loading your volumes. Please try again later"
     />
   );

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1069,6 +1069,11 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
           borderBottom: `2px solid ${primaryColors.divider}`,
           '&:last-child': {
             paddingRight: spacingUnit + 2
+          },
+          '& .action-menu': {
+            [breakpoints.down('sm')]: {
+              width: '100%'
+            }
           }
         },
         head: {


### PR DESCRIPTION
## Volumes tables style updates

The volumes landing table was problematic as the content would make it scrollable and hide the action menu at certain breakpoints. So i had to wrap/break the system path strings. I made sure to keep in check the volumes table on the linodes detail as well

## Type of Change
- Non breaking change ('update', 'change')

<img width="980" alt="Screen Shot 2019-04-22 at 4 49 31 PM" src="https://user-images.githubusercontent.com/205353/56738584-e89edc00-673a-11e9-99ae-9aadb956d58b.png">

