### PR TITLE
M3-2680 Update IP address listing on card view and styling

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -135,12 +135,12 @@ class SummaryPanel extends React.Component<CombinedProps> {
           </Typography>
           <div className={classes.section}>
             <IPAddress ips={linodeIpv4} copyRight showAll />
+            {linodeIpv6 && (
+              <div className={classes.section}>
+                <IPAddress ips={[linodeIpv6]} copyRight showAll />
+              </div>
+            )}
           </div>
-          {linodeIpv6 && (
-            <div className={classes.section}>
-              <IPAddress ips={[linodeIpv6]} copyRight showAll />
-            </div>
-          )}
         </Paper>
         <Paper className={classes.summarySection} style={{ paddingBottom: 24 }}>
           <Typography variant="h3" className={classes.title} data-qa-title>

--- a/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -53,7 +53,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   multipleAddresses: {
     '&:not(:last-child)': {
-      marginBottom: theme.spacing.unit
+      marginBottom: theme.spacing.unit / 2
     }
   },
   left: {

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -172,8 +172,8 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
               <RegionIndicator region={region} />
             </div>
             <div className={classes.cardSection} data-qa-ips>
-              <IPAddress ips={ipv4} copyRight showMore />
-              <IPAddress ips={[ipv6]} copyRight showMore />
+              <IPAddress ips={ipv4} copyRight showAll />
+              <IPAddress ips={[ipv6]} copyRight showAll />
             </div>
             <div className={classes.cardSection} data-qa-image>
               {imageLabel}


### PR DESCRIPTION
## Update IP address listing on card view and styling

In order to get a consistent experience from list view to card view, it makes sense to list all IP addresses on card view to be able to copy the addresses quickly without the use of the pop-up.
Updated margins as well

## Type of Change
- Non breaking change ('update')
