### PR TITLE
E2E - Revert cleanup in before hook

### DIFF
--- a/e2e/config/wdio.axe.conf.js
+++ b/e2e/config/wdio.axe.conf.js
@@ -34,7 +34,6 @@ exports.config = merge(wdioMaster.config, {
     seleniumInstallArgs: seleniumSettings,
     seleniumArgs: seleniumSettings,
     onPrepare: () => {},
-    beforeSession: () => {},
     before: function(caps, specs) {
         // Load up our custom commands
         require('babel-register');

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -1,6 +1,6 @@
 require('dotenv').config();
 
-const { readFileSync } = require('fs');
+const { readFileSync, unlinkSync } = require('fs');
 const { argv } = require('yargs');
 
 const FSCredStore = require('../utils/fs-cred-store');
@@ -259,8 +259,10 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      * @param {Array.<String>} specs List of spec file paths that are to be run
      */
-    // beforeSession: function (config, capabilities, specs) {
-    // },
+    beforeSession: function (config, capabilities, specs) {
+        console.log("beforeSession");
+        return credStore.cleanupAccounts(false, 10);
+    },
     /**
      * Gets executed before test execution begins. At this point you can access to all global
      * variables like `browser`. It is the perfect place to define custom commands.
@@ -311,11 +313,6 @@ exports.config = {
         });
         console.log("creds are");
         console.log(creds);
-
-        browser.call(() => {
-            return credStore.cleanupAccounts(10, false);
-        });
-
         credStore.login(creds.username, creds.password, false);
     },
     /**

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -251,6 +251,7 @@ exports.config = {
                 console.error("***** MAKE SURE MONGO IS RUNNING, do: docker run -d -p 27017:27017 mongo *****");
             }
         });
+        credStore.cleanupAccounts();
     },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you
@@ -259,10 +260,8 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      * @param {Array.<String>} specs List of spec file paths that are to be run
      */
-    beforeSession: function (config, capabilities, specs) {
-        console.log("beforeSession");
-        return credStore.cleanupAccounts(false, 10);
-    },
+    // beforeSession: function (config, capabilities, specs) {
+    // },
     /**
      * Gets executed before test execution begins. At this point you can access to all global
      * variables like `browser`. It is the perfect place to define custom commands.

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -251,7 +251,6 @@ exports.config = {
                 console.error("***** MAKE SURE MONGO IS RUNNING, do: docker run -d -p 27017:27017 mongo *****");
             }
         });
-        credStore.cleanupAccounts();
     },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you

--- a/e2e/setup/cleanup.js
+++ b/e2e/setup/cleanup.js
@@ -48,18 +48,18 @@ exports.removeAllLinodes = token => {
    where Volumes fail to be removed if they were
    attached to a recently deleted linode
 */
-exports.pause = (volumesResponse, timeOut) => {
+exports.pause = (volumesResponse) => {
     return new Promise((resolve, reject) => {
-        setTimeout(() => resolve(volumesResponse, timeOut), timeOut ? timeOut : 21000);
+        setTimeout(() => resolve(volumesResponse), 21000);
     });
 }
 
-exports.removeAllVolumes = (token, timeOut) => {
+exports.removeAllVolumes = token => {
     
     const endpoint = '/volumes';
 
-    return getAxiosInstance(token).get(endpoint).then((volumesResponse) => {
-        return exports.pause(volumesResponse, timeOut).then(res => {
+    return getAxiosInstance(token).get(endpoint).then(volumesResponse => {
+        return exports.pause(volumesResponse).then(res => {
             volumes = res.data.data;
             if (volumes.length > 0) {
                 return Promise.all(
@@ -126,14 +126,14 @@ exports.deleteAll = (token, user) => {
     return iterateEndpointsAndRemove();
 }
 
-exports.resetAccounts = (credsArray, timeOut) => {
+exports.resetAccounts = (credsArray) => {
     return Promise.all(
         credsArray.map((cred) => {
             return exports.removeAllLinodes(cred.token)
             .then((res) => {
                 console.log("removed all linodes")
                 console.log(res);
-                return exports.removeAllVolumes(cred.token, timeOut)
+                return exports.removeAllVolumes(cred.token)
             })
             .then((res) => {
                 console.log("removed all volumes")

--- a/e2e/setup/cleanup.js
+++ b/e2e/setup/cleanup.js
@@ -28,7 +28,7 @@ const getAxiosInstance = (token) => {
 }
 
 exports.removeAllLinodes = token => {
-
+    
     const linodesEndpoint = '/linode/instances';
 
     return getAxiosInstance(token).get(linodesEndpoint)
@@ -50,12 +50,12 @@ exports.removeAllLinodes = token => {
 */
 exports.pause = (volumesResponse, timeOut) => {
     return new Promise((resolve, reject) => {
-        setTimeout(() => resolve(volumesResponse), timeOut);
+        setTimeout(() => resolve(volumesResponse, timeOut), timeOut ? timeOut : 21000);
     });
 }
 
 exports.removeAllVolumes = (token, timeOut) => {
-
+    
     const endpoint = '/volumes';
 
     return getAxiosInstance(token).get(endpoint).then((volumesResponse) => {

--- a/e2e/utils/cred-store.js
+++ b/e2e/utils/cred-store.js
@@ -10,7 +10,7 @@ class CredStore {
         this.browser = browser;
         this.shouldCleanupUsingAPI = shouldCleanupUsingAPI;
     }
-
+    
     setBrowser(browser) {
         //console.log("setting browser to:");
         //console.log(browser);
@@ -24,13 +24,7 @@ class CredStore {
         throw "CredStore.getAllCreds() needs to be implemented in child class";
     }
 
-    /*
-        Account cleanup gets a default timeout of 21 seconds
-        Timeout is used to wait on removing volumes after removing linodes
-        If a linode with a volume attached is removed, the volume will still appear
-        as attached to the linode for a few seconds and will throw errors on attempts to remove
-    */
-    cleanupAccounts(timeOut=21000) {
+    cleanupAccounts(timeOut) {
         if (this.shouldCleanupUsingAPI) {
             console.log("cleaning up user resources via API");
             return this.getAllCreds().then((credCollection) => {
@@ -45,7 +39,7 @@ class CredStore {
 
     login(username, password, shouldStoreToken = false) {
         console.log("logging in for user: " + username);
-
+        
         let browser = this.browser;
 
         browser.url(constants.routes.linodes);
@@ -54,19 +48,19 @@ class CredStore {
         } catch (err) {
             console.log(browser.getSource());
         }
-
+    
         browser.waitForVisible('#password', constants.wait.long);
         browser.jsClick('#username');
         browser.trySetValue('#username', username);
         browser.jsClick('#password');
         browser.trySetValue('#password', password);
 
-
+        
         let url = browser.getUrl();
 
         const loginButton = url.includes('dev') ? '.btn#submit' : '[data-qa-sign-in] input';
         const letsGoButton = url.includes('dev') ? '.btn#submit' : '[data-qa-welcome-button]';
-
+    
         // Helper to check if on the Authorize 3rd Party App
         const isOauthAuthPage = () => {
             /**
@@ -80,24 +74,24 @@ class CredStore {
                 return false;
             }
         }
-
+    
         // Helper to check if CSRF error is displayed on the page
         const csrfErrorExists = () => {
             const sourceIncludesCSRF = browser.getSource().includes('CSRF');
             return sourceIncludesCSRF;
         };
-
+    
         // Click the Login button
         browser.click(loginButton);
-
+    
         const onOauthPage = isOauthAuthPage();
         const csrfError = csrfErrorExists();
-
+    
         // If on the authorize page, click the authorize button
         if (onOauthPage) {
             $('.form-actions>.btn').click();
         }
-
+    
         // If still on the login page, check for a form error
         if (csrfError) {
             // Attempt to Login after encountering the CSRF Error
@@ -105,7 +99,7 @@ class CredStore {
             browser.trySetValue('#username', username);
             $(loginButton).click();
         }
-
+    
         // Wait for the add entity menu to exist
         try {
             browser.waitForExist('[data-qa-add-new-menu-button]', constants.wait.normal);
@@ -114,15 +108,15 @@ class CredStore {
             console.error(`Current URL is:\n${browser.getUrl()}`);
             console.error(`Page source: \n ${browser.getSource()}`);
         }
-
+    
         // Wait for the welcome modal to display, click it once it appears
         if (browser.waitForVisible('[role="dialog"]')) {
             browser.click(letsGoButton);
             browser.waitForVisible('[role="dialog"]', constants.wait.long, true)
         }
-
+    
         browser.waitForVisible('[data-qa-add-new-menu-button]', constants.wait.long);
-
+    
         // TODO fix storeToken implementation
         //if (shouldStoreToken) {
         //    this.storeToken(username);
@@ -137,7 +131,7 @@ class CredStore {
 
         this would replace personal access tokens provided via env vars in favor of the access token
         created when logging in.
-
+        
         we can rework token handling in a followup feature branch.
      */
     getTokenFromLocalStorage() {

--- a/e2e/utils/cred-store.js
+++ b/e2e/utils/cred-store.js
@@ -24,12 +24,12 @@ class CredStore {
         throw "CredStore.getAllCreds() needs to be implemented in child class";
     }
 
-    cleanupAccounts(timeOut) {
+    cleanupAccounts() {
         if (this.shouldCleanupUsingAPI) {
             console.log("cleaning up user resources via API");
             return this.getAllCreds().then((credCollection) => {
                 console.log(credCollection);
-                return resetAccounts(credCollection, timeOut);
+                return resetAccounts(credCollection);
             });
         } else {
             console.log("not cleaning up resources via API");

--- a/e2e/utils/fs-cred-store.js
+++ b/e2e/utils/fs-cred-store.js
@@ -8,7 +8,7 @@ const CredStore = require('./cred-store');
  * on the local filesystem.
  */
 class FSCredStore extends CredStore {
-
+    
     constructor(credsFile, shouldCleanupUsingAPI, browser) {
         super(shouldCleanupUsingAPI, browser);
         this.credsFile = credsFile;
@@ -55,7 +55,7 @@ class FSCredStore extends CredStore {
             if (!currentUser.isPresetToken) {
                 currentUser.token = this.getTokenFromLocalStorage();
             }
-
+    
             return this._writeCredsFile(credCollection);
         })
     }
@@ -75,7 +75,7 @@ class FSCredStore extends CredStore {
                 if (!cred.inUse) {
                     credCollection[i].inUse = true;
                     credCollection[i].spec = specFile;
-
+                    
                     this.browser.options.testUser = credCollection[i].username;
                     return true;
                 }
@@ -86,7 +86,7 @@ class FSCredStore extends CredStore {
 
     checkinCreds(specFile) {
         console.log("checkinCreds: " + specFile);
-
+        
         return this._readCredsFile().then((credCollection) => {
             const creds = credCollection.find((cred, i) => {
                 if (cred.spec === specFile) {
@@ -117,7 +117,7 @@ class FSCredStore extends CredStore {
                 setCredCollection('MANAGER_USER', `_${i}`);
             }
         }
-
+        
         console.log("adding users:");
         console.log(credCollection);
         return this._writeCredsFile(credCollection);
@@ -127,15 +127,12 @@ class FSCredStore extends CredStore {
         return this._readCredsFile();
     }
 
-    cleanupAccounts(timeOut, runningOnComplete=true) {
+    cleanupAccounts(noCredDel, timeOut) {
         return super.cleanupAccounts(timeOut)
         .catch((err) => console.log(err))
         .then(() => {
             return new Promise((resolve, reject) => {
-                if (!runningOnComplete) {
-                    // Nothing else to do if not running from onComplete
-                    resolve(true)
-                } else {
+                noCredDel !== false ?
                     unlink(this.credsFile, (err) => {
                         if (err) {
                             reject(err);
@@ -143,8 +140,8 @@ class FSCredStore extends CredStore {
                             resolve(this.credsFile);
                         }
                     })
-                }
-            });
+                : resolve(this.credsFile);
+            });            
         })
     }
 }
@@ -152,9 +149,9 @@ class FSCredStore extends CredStore {
 if (process.argv[2] == "test-fs") {
 
     console.log("running fs credential tests");
-
+    
     let mockTestConfig = {"host":"selenium","port":4444,"sync":true,"specs":["./e2e/specs/search/smoke-search.spec.js"],"suites":{},"exclude":["./e2e/specs/accessibility/*.spec.js"],"logLevel":"silent","coloredLogs":true,"deprecationWarnings":false,"baseUrl":"http://localhost:3000","bail":0,"waitforInterval":500,"waitforTimeout":30000,"framework":"jasmine","reporters":["spec","junit"],"reporterOptions":{"junit":{"outputDir":"./e2e/test-results"}},"maxInstances":1,"maxInstancesPerCapability":100,"connectionRetryTimeout":90000,"connectionRetryCount":3,"debug":false,"execArgv":null,"mochaOpts":{"timeout":10000},"jasmineNodeOpts":{"defaultTimeoutInterval":600000},"before":[null],"beforeSession":[],"beforeSuite":[],"beforeHook":[],"beforeTest":[],"beforeCommand":[],"afterCommand":[],"afterTest":[],"afterHook":[],"afterSuite":[],"afterSession":[],"after":[null],"onError":[],"onReload":[],"beforeFeature":[],"beforeScenario":[],"beforeStep":[],"afterFeature":[],"afterScenario":[],"afterStep":[],"mountebankConfig":{"proxyConfig":{"imposterPort":"8088","imposterProtocol":"https","imposterName":"Linode-API","proxyHost":"https://api.linode.com/v4","mutualAuth":true}},"testUser":"","watch":false};
-
+    
     let credStore = new FSCredStore("/tmp/e2e-users.js", false);
 
     // assumes env var config for 2 test users, see .env or .env.example

--- a/e2e/utils/fs-cred-store.js
+++ b/e2e/utils/fs-cred-store.js
@@ -127,20 +127,18 @@ class FSCredStore extends CredStore {
         return this._readCredsFile();
     }
 
-    cleanupAccounts(noCredDel, timeOut) {
-        return super.cleanupAccounts(timeOut)
+    cleanupAccounts() {
+        return super.cleanupAccounts()
         .catch((err) => console.log(err))
         .then(() => {
             return new Promise((resolve, reject) => {
-                noCredDel !== false ?
-                    unlink(this.credsFile, (err) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(this.credsFile);
-                        }
-                    })
-                : resolve(this.credsFile);
+                unlink(this.credsFile, (err) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(this.credsFile);
+                    }
+                })
             });            
         })
     }

--- a/e2e/utils/mongo-cred-store.js
+++ b/e2e/utils/mongo-cred-store.js
@@ -4,7 +4,7 @@ const CredStore = require('./cred-store');
 
 /**
  * Takes test user creds from environment variables and manages them in via a mongodb.
- *
+ * 
  * Designed to be used when running e2e tests via docker compose (see integration-test.yml).
  */
 class MongoCredStore extends CredStore {
@@ -36,7 +36,7 @@ class MongoCredStore extends CredStore {
         let mongo = null;
 
         return this._connect().then((mongoClient) => {
-
+            
             console.log("populating creds");
             mongo = mongoClient;
 
@@ -45,15 +45,15 @@ class MongoCredStore extends CredStore {
                 [{key: {inUse: 1, username: 1, spec: 1}}]
             );
 
-        }).then((result) => {
+        }).then((result) => {            
             console.log("initiailized users index");
-
+            
             const setCredCollection = (userKey, userIndex) => {
-
+        
                 const setEnvToken = process.env[`MANAGER_OAUTH${userIndex}`];
                 const token = setEnvToken ? setEnvToken : '';
-                const tokenFlag = token !== '';
-
+                const tokenFlag = token !== ''; 
+                
                 let userRecord = {
                     username: process.env[`${userKey}${userIndex}`],
                     password: process.env[`MANAGER_PASS${userIndex}`],
@@ -62,13 +62,13 @@ class MongoCredStore extends CredStore {
                     spec: '',
                     isPresetToken: tokenFlag
                 };
-
+                
                 const collection = mongo.db(this.dbName).collection(this.collectionName);
                 return collection.insertOne(userRecord).then(() => userRecord);
             }
-
+        
             const users = [setCredCollection('MANAGER_USER', '')];
-
+            
             if (userCount > 1) {
                 for (let i = 2; i <= userCount; i++ ) {
                     users.push(setCredCollection('MANAGER_USER', `_${i}`));
@@ -83,7 +83,7 @@ class MongoCredStore extends CredStore {
             });
             console.log("closing mongo client for populating creds");
             return mongo.close();
-        })
+        })        
     }
 
     // fetches all available creds
@@ -108,19 +108,19 @@ class MongoCredStore extends CredStore {
                 { $set: { inUse: true, spec: specToRun } },
                 { returnOriginal: false }
             )
-
+            
         })
         .then((result) => {
             console.log("checked out creds");
             const creds = result.value;
-
+            
             this.browser.options.testUser = creds.username;
 
             return mongo.close().then((r) => { return creds; });
         })
         .catch((err) => {
             console.log("error checking out creds for spec: " + specToRun);
-            console.log(err);
+            console.log(err);            
         });
     }
 
@@ -130,14 +130,14 @@ class MongoCredStore extends CredStore {
         let mongo = null;
         return this._connect().then((mongoClient) => {
             mongo = mongoClient;
-
+            
             return mongo.db(this.dbName).collection(this.collectionName)
             .findOneAndUpdate(
                 { spec: specThatRan },
                 { $set: { inUse: false, spec: '' } },
                 { returnOriginal: false }
             );
-
+            
         })
         .then((result) => {
             console.log("checked in creds");
@@ -146,8 +146,8 @@ class MongoCredStore extends CredStore {
         })
         .catch((err) => {
             console.log("error checking in creds for spec: " + specThatRan);
-            console.log(err);
-        });
+            console.log(err);            
+        });        
     }
 
     readToken(username) {
@@ -168,8 +168,8 @@ class MongoCredStore extends CredStore {
         throw "MongoCredStore.storeToken not implemented. See comments in utils/cred-store.js.";
     }
 
-    cleanupAccounts(timeout) {
-        return super.cleanupAccounts(timeout)
+    cleanupAccounts() {        
+        return super.cleanupAccounts()
         .catch((err) => console.log(err))
         .then((users) => {
             let mongo = null;
@@ -197,7 +197,7 @@ if (process.argv[2] == "test-mongo") {
     // NOTE: test below requires mongo to be running locally via
     //   docker run -d -p 27017:27017 mongo
     console.log("running mongo credential tests");
-
+    
     let mockTestConfig = {"host":"selenium","port":4444,"sync":true,"specs":["./e2e/specs/search/smoke-search.spec.js"],"suites":{},"exclude":["./e2e/specs/accessibility/*.spec.js"],"logLevel":"silent","coloredLogs":true,"deprecationWarnings":false,"baseUrl":"http://localhost:3000","bail":0,"waitforInterval":500,"waitforTimeout":30000,"framework":"jasmine","reporters":["spec","junit"],"reporterOptions":{"junit":{"outputDir":"./e2e/test-results"}},"maxInstances":1,"maxInstancesPerCapability":100,"connectionRetryTimeout":90000,"connectionRetryCount":3,"debug":false,"execArgv":null,"mochaOpts":{"timeout":10000},"jasmineNodeOpts":{"defaultTimeoutInterval":600000},"before":[null],"beforeSession":[],"beforeSuite":[],"beforeHook":[],"beforeTest":[],"beforeCommand":[],"afterCommand":[],"afterTest":[],"afterHook":[],"afterSuite":[],"afterSession":[],"after":[null],"onError":[],"onReload":[],"beforeFeature":[],"beforeScenario":[],"beforeStep":[],"afterFeature":[],"afterScenario":[],"afterStep":[],"mountebankConfig":{"proxyConfig":{"imposterPort":"8088","imposterProtocol":"https","imposterName":"Linode-API","proxyHost":"https://api.linode.com/v4","mutualAuth":true}},"testUser":"","watch":false};
     let mongoCredStore = new MongoCredStore("localhost", false);
 


### PR DESCRIPTION
## Description

Reverts calling `credStore.cleanupAccounts` in the before hook of the test framework.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=COMMA_SEPARATED_LIST_OF_SPECS_HERE --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
