### PR TITLE
OBJ-152: Change Object Storage placement in the Primary Nav

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -266,6 +266,14 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     primaryLinks.push({ display: 'Volumes', href: '/volumes', key: 'volumes' });
     // }
 
+    if (isObjectStorageEnabled) {
+      primaryLinks.push({
+        display: 'Object Storage',
+        href: '/object-storage',
+        key: 'objectStorage'
+      });
+    }
+
     // if (canAccessNodeBalancers) {
     primaryLinks.push({
       display: 'NodeBalancers',
@@ -305,14 +313,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     // if(canAccessImages){
     primaryLinks.push({ display: 'Images', href: '/images', key: 'images' });
     // }
-
-    if (isObjectStorageEnabled) {
-      primaryLinks.push({
-        display: 'Object Storage',
-        href: '/object-storage',
-        key: 'objectStorage'
-      });
-    }
 
     if (hasAccountAccess) {
       primaryLinks.push({


### PR DESCRIPTION
The previous positioning was only temporary. Now the placement has been decided on.

<img width="208" alt="Screen Shot 2019-04-25 at 2 47 06 PM" src="https://user-images.githubusercontent.com/16911484/56760359-03884500-6769-11e9-9bdc-578b031fb475.png">


## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests
None. 