### PR TITLE
M3-OCA-664 Add: e2e test for Create from StackScript 

### DIFF
--- a/e2e/specs/create/create-linode-from-stackscript.spec.js
+++ b/e2e/specs/create/create-linode-from-stackscript.spec.js
@@ -54,9 +54,12 @@ describe('Create Linode - Create from StackScript Suite', () => {
       constants.wait.normal
     );
     ConfigureLinode.selectFirstStackScript().click();
-    ConfigureLinode.stackScriptRows.find(row =>
-      row.$('[data-qa-radio="true"]')
+
+    const checkedRows = ConfigureLinode.stackScriptRows.filter(
+      row => row.$('[data-qa-radio]').getAttribute('data-qa-radio') === 'true'
     );
+
+    expect(checkedRows.length).toEqual(1);
   });
 
   it('should display an error when creating without selecting a region', () => {

--- a/e2e/specs/create/create-linode-from-stackscript.spec.js
+++ b/e2e/specs/create/create-linode-from-stackscript.spec.js
@@ -4,140 +4,167 @@ import ConfigureStackScripts from '../../pageobjects/configure-stackscript.page'
 import ConfigureLinode from '../../pageobjects/configure-linode';
 import ListLinodes from '../../pageobjects/list-linodes';
 import {
-    timestamp,
-    waitForLinodeStatus,
-    apiDeleteAllLinodes,
-    apiDeleteMyStackScripts
-  } from '../../utils/common';
+  timestamp,
+  waitForLinodeStatus,
+  apiDeleteAllLinodes,
+  apiDeleteMyStackScripts
+} from '../../utils/common';
 
 describe('Create Linode - Create from StackScript Suite', () => {
+  beforeAll(() => {
+    browser.url(constants.routes.create.linode);
+    ConfigureLinode.baseDisplay();
+  });
 
-    beforeAll(() => {
-        browser.url(constants.routes.create.linode);
-        ConfigureLinode.baseDisplay();
-    });
+  afterAll(() => {
+    apiDeleteAllLinodes();
+  });
 
-    afterAll(() => {
-       apiDeleteAllLinodes();
-    });
+  afterEach(() => {
+    apiDeleteMyStackScripts();
+  });
 
-    afterEach(() => {
-        apiDeleteMyStackScripts();
-    })
+  it('should change tab to create from stackscript', () => {
+    ConfigureLinode.createFrom('My Images');
+    ConfigureLinode.createFrom('Account StackScripts');
+  });
 
-    it('should change tab to create from stackscript', () => {
-        ConfigureLinode.createFrom('My Images');
-        ConfigureLinode.createFrom('Account StackScripts');
-        ConfigureLinode.stackScriptsBaseElemsDisplay(ConfigureLinode.createFromMyStackScript);
-    });
+  it('should display stackscript table', () => {
+    ConfigureLinode.createFrom('One-Click');
+    ConfigureLinode.createFrom('Community StackScripts');
+    ConfigureLinode.stackScriptTableDisplay();
+  });
 
-    it('should display stackscript table', () => {
-        ConfigureLinode.createFrom('One-Click');
-        ConfigureLinode.createFrom('Community StackScripts');
-        ConfigureLinode.stackScriptTableDisplay();
-    });
+  it('should display community stackscripts', () => {
+    ConfigureLinode.stackScriptMetadataDisplay();
+  });
 
-    it('should display community stackscripts', () => {
-        ConfigureLinode.stackScriptMetadataDisplay();
-    });
+  it('should fail to create without selecting a stackscript', () => {
+    const noticeMsg = 'You must select a StackScript';
 
-    it('should fail to create without selecting a stackscript', () => {
-        const noticeMsg = 'You must select a StackScript';
+    ConfigureLinode.deploy.click();
+    ConfigureLinode.waitForNotice(noticeMsg);
+  });
 
-        ConfigureLinode.deploy.click();
-        ConfigureLinode.waitForNotice(noticeMsg);
-    });
+  //   it('should work amazingly ', () => {
+  //     ConfigureLinode.createFrom('One-Click');
+  //     ConfigureLinode.createFrom('Community StackScripts');
+  //     ConfigureLinode.stackScriptMetadataDisplay();
+  //     ConfigureLinode.selectFirstStackScript().click();
+  //     expect(
+  //       ConfigureLinode.stackScriptRows.find(row =>
+  //         row.$('[data-qa-radio="true"]')
+  //       )
+  //     );
+  //   });
 
-    it('should display an error when creating without selecting a region', () => {
-        const regionErr = 'Region is required.';
+  it('should display an error when creating without selecting a region', () => {
+    const regionErr = 'Region is required.';
 
-        /** create the stackscript */
-        ConfigureStackScripts.createStackScriptNoUDFs()
+    /** create the stackscript */
+    ConfigureStackScripts.createStackScriptNoUDFs();
 
-        /** navigate to the Account StackScripts tab */
-        $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(constants.wait.normal)
-        browser.url(constants.routes.create.linode);
-        ConfigureLinode.createFrom('My Images');
-        ConfigureLinode.createFrom('Account StackScripts');
+    /** navigate to the Account StackScripts tab */
+    $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(
+      constants.wait.normal
+    );
+    browser.url(constants.routes.create.linode);
+    ConfigureLinode.createFrom('My Images');
+    ConfigureLinode.createFrom('Account StackScripts');
 
-        /** Select the first one in the list */
-        ConfigureLinode.selectFirstStackScript().waitForVisible(constants.wait.normal);
-        ConfigureLinode.selectFirstStackScript().click();
+    /** Select the first one in the list */
+    ConfigureLinode.selectFirstStackScript().waitForVisible(
+      constants.wait.normal
+    );
+    ConfigureLinode.selectFirstStackScript().click();
 
-        ConfigureLinode.deploy.click();
-        ConfigureLinode.waitForNotice(regionErr, constants.wait.normal);
-    });
+    ConfigureLinode.deploy.click();
+    ConfigureLinode.waitForNotice(regionErr, constants.wait.normal);
+  });
 
-    it('should display an error when creating without selecting a plan', () => {
-        const planError = 'Plan is required.';
+  it('should display an error when creating without selecting a plan', () => {
+    const planError = 'Plan is required.';
 
-        /** create the stackscript */
-        ConfigureStackScripts.createStackScriptNoUDFs()
+    /** create the stackscript */
+    ConfigureStackScripts.createStackScriptNoUDFs();
 
-        /** navigate to the Account StackScripts tab */
-        $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(constants.wait.normal)
-        browser.url(constants.routes.create.linode);
-        ConfigureLinode.createFrom('My Images');
-        ConfigureLinode.createFrom('Account StackScripts');
+    /** navigate to the Account StackScripts tab */
+    $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(
+      constants.wait.normal
+    );
+    browser.url(constants.routes.create.linode);
+    ConfigureLinode.createFrom('My Images');
+    ConfigureLinode.createFrom('Account StackScripts');
 
-        /** Select the first one in the list */
-        ConfigureLinode.selectFirstStackScript().waitForVisible(constants.wait.normal);
-        ConfigureLinode.selectFirstStackScript().click();
-        ConfigureLinode.regions[0].click();
-        ConfigureLinode.deploy.click();
-        ConfigureLinode.waitForNotice(planError, constants.wait.normal)
-    });
+    /** Select the first one in the list */
+    ConfigureLinode.selectFirstStackScript().waitForVisible(
+      constants.wait.normal
+    );
+    ConfigureLinode.selectFirstStackScript().click();
+    ConfigureLinode.regions[0].click();
+    ConfigureLinode.deploy.click();
+    ConfigureLinode.waitForNotice(planError, constants.wait.normal);
+  });
 
-    it('should display user-defined fields on selection of a stackscript containing UD fields', () => {
+  it('should display user-defined fields on selection of a stackscript containing UD fields', () => {
+    /** create the stackscript */
+    ConfigureStackScripts.createStackScriptWithRequiredUDFs();
 
-        /** create the stackscript */
-        ConfigureStackScripts.createStackScriptWithRequiredUDFs()
+    /** navigate to the Account StackScripts tab */
+    $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(
+      constants.wait.normal
+    );
+    browser.url(constants.routes.create.linode);
+    ConfigureLinode.createFrom('My Images');
+    ConfigureLinode.createFrom('Account StackScripts');
 
-        /** navigate to the Account StackScripts tab */
-        $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(constants.wait.normal)
-        browser.url(constants.routes.create.linode);
-        ConfigureLinode.createFrom('My Images');
-        ConfigureLinode.createFrom('Account StackScripts');
+    ConfigureLinode.selectFirstStackScript().waitForVisible(
+      constants.wait.normal
+    );
+    ConfigureLinode.selectFirstStackScript().click();
+    ConfigureLinode.userDefinedFieldsHeader.waitForVisible(
+      constants.wait.normal
+    );
+  });
 
-        ConfigureLinode.selectFirstStackScript().waitForVisible(constants.wait.normal);
-        ConfigureLinode.selectFirstStackScript().click();
-        ConfigureLinode.userDefinedFieldsHeader.waitForVisible(constants.wait.normal);
-    });
+  it('should create from stackscript', () => {
+    /** create the stackscript */
+    ConfigureStackScripts.createStackScriptNoUDFs();
 
-    it('should create from stackscript', () => {
+    /** navigate to the Account StackScripts tab */
+    $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(
+      constants.wait.normal
+    );
+    browser.url(constants.routes.create.linode);
+    ConfigureLinode.createFrom('My Images');
+    ConfigureLinode.createFrom('Account StackScripts');
 
-        /** create the stackscript */
-        ConfigureStackScripts.createStackScriptNoUDFs();
+    ConfigureLinode.selectFirstStackScript().waitForVisible(
+      constants.wait.normal
+    );
+    ConfigureLinode.selectFirstStackScript().click();
 
-        /** navigate to the Account StackScripts tab */
-        $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(constants.wait.normal)
-        browser.url(constants.routes.create.linode);
-        ConfigureLinode.createFrom('My Images');
-        ConfigureLinode.createFrom('Account StackScripts');
+    ConfigureLinode.regions[0].click();
+    ConfigureLinode.plans[0].click();
+    /** image is already pre-selected */
+    // ConfigureLinode.images[0].click();
 
-        ConfigureLinode.selectFirstStackScript().waitForVisible(constants.wait.normal);
-        ConfigureLinode.selectFirstStackScript().click();
+    const imageName = ConfigureLinode.images[0]
+      .$('[data-qa-select-card-subheading]')
+      .getText();
 
-        ConfigureLinode.regions[0].click();
-        ConfigureLinode.plans[0].click();
-        /** image is already pre-selected */
-        // ConfigureLinode.images[0].click();
+    ConfigureLinode.randomPassword();
 
-        const imageName = ConfigureLinode.images[0].$('[data-qa-select-card-subheading]').getText();
+    const linodeLabel = `${timestamp()}`;
+    ConfigureLinode.label.setValue(linodeLabel);
 
-        ConfigureLinode.randomPassword();
+    ConfigureLinode.deploy.click();
 
-        const linodeLabel = `${timestamp()}`;
-        ConfigureLinode.label.setValue(linodeLabel);
-
-        ConfigureLinode.deploy.click();
-
-        /**
-         * at this point, we've been redirected to the Linodes detail page
-         * and we should see the editable text on the screen
-         */
-        $('[data-qa-editable-text]').waitForVisible(constants.wait.normal)
-        expect($('[data-qa-editable-text]').getText()).toBe(linodeLabel)
-
-    });
+    /**
+     * at this point, we've been redirected to the Linodes detail page
+     * and we should see the editable text on the screen
+     */
+    $('[data-qa-editable-text]').waitForVisible(constants.wait.normal);
+    expect($('[data-qa-editable-text]').getText()).toBe(linodeLabel);
+  });
 });

--- a/e2e/specs/create/create-linode-from-stackscript.spec.js
+++ b/e2e/specs/create/create-linode-from-stackscript.spec.js
@@ -46,17 +46,18 @@ describe('Create Linode - Create from StackScript Suite', () => {
     ConfigureLinode.waitForNotice(noticeMsg);
   });
 
-  //   it('should work amazingly ', () => {
-  //     ConfigureLinode.createFrom('One-Click');
-  //     ConfigureLinode.createFrom('Community StackScripts');
-  //     ConfigureLinode.stackScriptMetadataDisplay();
-  //     ConfigureLinode.selectFirstStackScript().click();
-  //     expect(
-  //       ConfigureLinode.stackScriptRows.find(row =>
-  //         row.$('[data-qa-radio="true"]')
-  //       )
-  //     );
-  //   });
+  it('should select a stackscript if the associated table row is clicked', () => {
+    ConfigureLinode.createFrom('One-Click');
+    ConfigureLinode.createFrom('Community StackScripts');
+    ConfigureLinode.stackScriptTableDisplay();
+    ConfigureLinode.selectFirstStackScript().waitForVisible(
+      constants.wait.normal
+    );
+    ConfigureLinode.selectFirstStackScript().click();
+    ConfigureLinode.stackScriptRows.find(row =>
+      row.$('[data-qa-radio="true"]')
+    );
+  });
 
   it('should display an error when creating without selecting a region', () => {
     const regionErr = 'Region is required.';


### PR DESCRIPTION
## Description

Adding an e2e that checks that upon clicking anywhere on a stackscript table row, that stackscript will be selected.

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --file e2e/specs/create/create-linode-from-stackscript.spec.js --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
