### PR TITLE
OBJ-151 Fix: Pre-selected region and rename "Remove" buckets

### DIFF
--- a/src/features/ObjectStorage/ClusterSelect.test.tsx
+++ b/src/features/ObjectStorage/ClusterSelect.test.tsx
@@ -8,6 +8,7 @@ describe('ClusterSelect', () => {
 
   const wrapper = shallow(
     <ClusterSelect
+      selectedCluster="a-cluster"
       onChange={onChangeMock}
       onBlur={onBlurMock}
       clustersData={[]}

--- a/src/features/ObjectStorage/ClusterSelect.tsx
+++ b/src/features/ObjectStorage/ClusterSelect.tsx
@@ -7,6 +7,7 @@ import clustersContainer, {
 import { formatRegion } from 'src/utilities';
 
 interface Props {
+  selectedCluster: string;
   onChange: (value: string) => void;
   onBlur: (e: any) => void;
   error?: string;
@@ -14,12 +15,25 @@ interface Props {
 
 type CombinedProps = Props & StateProps;
 export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
-  const { error, onChange, onBlur, clustersData, clustersError } = props;
+  const {
+    selectedCluster,
+    error,
+    onChange,
+    onBlur,
+    clustersData,
+    clustersError
+  } = props;
 
   const options: Item<string>[] = clustersData.map(eachCluster => ({
     value: eachCluster.id,
     label: formatRegion(eachCluster.region)
   }));
+
+  // If there's only one option, we want it to selected by default.
+  // If it isn't already selected, call `onChange` with it so Formik knows about it.
+  if (options.length === 1 && selectedCluster !== options[0].value) {
+    onChange(options[0].value);
+  }
 
   // Error could be: 1. General Clusters error, 2. Field error, 3. Nothing
   const errorText = clustersError

--- a/src/features/ObjectStorage/CreateBucketForm.tsx
+++ b/src/features/ObjectStorage/CreateBucketForm.tsx
@@ -114,6 +114,7 @@ export const CreateBucketForm: React.StatelessComponent<
               error={touched.cluster ? errors.cluster : undefined}
               onBlur={handleBlur}
               onChange={value => setFieldValue('cluster', value)}
+              selectedCluster={values.cluster}
             />
 
             <BucketsActionPanel


### PR DESCRIPTION
## Description

In the Create Bucket drawer, React-Select knew about the default value, but Formik (in the parent component) didn't.

## Type of Change
- Bug fix

## Applicable E2E Tests
None

## Note to Reviewers
Check the bucket creation drawer. Try changing clusters/regions, etc.