### PR TITLE
M3-2648 Change: Display reserved IPs in IPv4 table (Linode Detail)

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -400,7 +400,17 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
       return null;
     }
 
-    const { private: privateIPs, public: publicIPs, shared: sharedIPs } = ipv4;
+    const {
+      private: privateIPs,
+      public: publicIPs,
+      shared: sharedIPs,
+      reserved: reservedIPs
+    } = ipv4;
+
+    // `ipv4.reserved` contains both Public and Private IPs, so we use the `public` field to differentiate.
+    // Splitting them into two arrays so we can order as desired (Public, then Private).
+    const publicReservedIps = reservedIPs.filter(ip => ip.public);
+    const privateReservedIps = reservedIPs.filter(ip => !ip.public);
 
     return (
       <React.Fragment>
@@ -460,6 +470,12 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
               )}
               {privateIPs.map((ip: Linode.IPAddress) =>
                 this.renderIPRow(ip, 'Private')
+              )}
+              {publicReservedIps.map((ip: Linode.IPAddress) =>
+                this.renderIPRow(ip, 'Public Reserved')
+              )}
+              {privateReservedIps.map((ip: Linode.IPAddress) =>
+                this.renderIPRow(ip, 'Private Reserved')
               )}
               {sharedIPs.map((ip: Linode.IPAddress) =>
                 this.renderIPRow(ip, 'Shared')

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -15,6 +15,8 @@ interface Props {
 export type IPTypes =
   | 'SLAAC'
   | 'Public'
+  | 'Public Reserved'
+  | 'Private Reserved'
   | 'Private'
   | 'Shared'
   | 'Link Local'
@@ -46,14 +48,15 @@ class LinodeNetworkingActionMenu extends React.Component<CombinedProps> {
       ];
 
       /**
-       * can only edit if we're not dealing with
-       * either a private IP or Link Local IP
+       * can only edit if we're not dealing private IPs, link local, or reserved IPs
        */
       if (
         onEdit &&
         ipAddress &&
         ipType !== 'Private' &&
-        ipType !== 'Link Local'
+        ipType !== 'Link Local' &&
+        ipType !== 'Public Reserved' &&
+        ipType !== 'Private Reserved'
       ) {
         actions.push({
           title: 'Edit RDNS',

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -48,7 +48,7 @@ class LinodeNetworkingActionMenu extends React.Component<CombinedProps> {
       ];
 
       /**
-       * can only edit if we're not dealing private IPs, link local, or reserved IPs
+       * can only edit if we're not dealing with private IPs, link local, or reserved IPs
        */
       if (
         onEdit &&

--- a/src/types/Linode.ts
+++ b/src/types/Linode.ts
@@ -141,6 +141,7 @@ namespace Linode {
     public: IPAddress[];
     private: IPAddress[];
     shared: IPAddress[];
+    reserved: IPAddress[];
   }
 
   export interface LinodeIPsResponseIPV6 {


### PR DESCRIPTION
The API now returns reserved IPv4 addresses (used in cross data-center migrations). 

In this PR, they've been added to the IPv4 table in Linode Details -> Networking.

## Description

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

To test:

1) Have a Linode with a pending migration.
2) Navigate to Linode Detail -> Networking.
3) Observe: reserved IPs appear in the IPv4 table.

Reserved IPs cannot be deleted, and RDNS cannot be edited. `Public Reserved` and `Private Reserved` are both possible.
