### PR TITLE
LKE-473 List Kubernetes clusters

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -2,7 +2,7 @@
 
 # Confirm Branch includes M3 Ticket
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-BRANCH_INCLUDES_TICKET=$(git rev-parse --abbrev-ref HEAD | egrep -i '(M3-[0-9]*)|feature|develop|master|release-.*')
+BRANCH_INCLUDES_TICKET=$(git rev-parse --abbrev-ref HEAD | egrep -i '(M3-[0-9]*)|feature|develop|master|release-.*|LKE.*')
 RED='\033[0;31m'
 
 if [ $BRANCH_INCLUDES_TICKET ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ import { getAllVolumes } from 'src/store/volume/volume.requests';
 import composeState from 'src/utilities/composeState';
 import { notifications } from 'src/utilities/storage';
 import WelcomeBanner from 'src/WelcomeBanner';
-import { isObjectStorageEnabled } from './constants';
+import { isKubernetesEnabled, isObjectStorageEnabled } from './constants';
 import BucketDrawer from './features/ObjectStorage/Buckets/BucketDrawer';
 import { requestClusters } from './store/clusters/clusters.actions';
 import {
@@ -385,7 +385,7 @@ export class App extends React.Component<CombinedProps, State> {
                               component={ObjectStorage}
                             />
                           )}
-                          {true && ( //@todo add feature flagging
+                          {isKubernetesEnabled && (
                             <Route path="/kubernetes" component={Kubernetes} />
                           )}
                           <Route path="/account" component={Account} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,10 @@ const Images = DefaultLoader({
   loader: () => import('src/features/Images')
 });
 
+const Kubernetes = DefaultLoader({
+  loader: () => import('src/features/Kubernetes/ClusterList')
+});
+
 const ObjectStorage = DefaultLoader({
   loader: () => import('src/features/ObjectStorage')
 });
@@ -380,6 +384,9 @@ export class App extends React.Component<CombinedProps, State> {
                               path="/object-storage"
                               component={ObjectStorage}
                             />
+                          )}
+                          {true && ( //@todo add feature flagging
+                            <Route path="/kubernetes" component={Kubernetes} />
                           )}
                           <Route path="/account" component={Account} />
                           <Route

--- a/src/__data__/kubernetes.ts
+++ b/src/__data__/kubernetes.ts
@@ -1,0 +1,80 @@
+export const clusters: Linode.KubernetesCluster[] = [
+  {
+    tags: ['spam', 'eggs'],
+    region: 'us-central',
+    label: 'cluster-1',
+    node_pools: [
+      {
+        type: 'g6-standard-4',
+        count: 2,
+        id: 69,
+        linodes: [
+          {
+            id: 103,
+            status: 'ready'
+          },
+          {
+            id: 104,
+            status: 'ready'
+          }
+        ],
+        lkeid: 35
+      },
+      {
+        type: 'g6-standard-8',
+        count: 1,
+        id: 70,
+        linodes: [
+          {
+            id: 105,
+            status: 'ready'
+          }
+        ],
+        lkeid: 35
+      }
+    ],
+    created: '2019-04-29 18:02:17',
+    id: '35',
+    status: 'running',
+    version: '1.13.5'
+  },
+  {
+    tags: ['spam', 'eggs'],
+    region: 'us-central',
+    label: 'cluster-2',
+    node_pools: [
+      {
+        type: 'g6-standard-4',
+        count: 2,
+        id: 69,
+        linodes: [
+          {
+            id: 103,
+            status: 'ready'
+          },
+          {
+            id: 104,
+            status: 'ready'
+          }
+        ],
+        lkeid: 35
+      },
+      {
+        type: 'g6-standard-8',
+        count: 1,
+        id: 70,
+        linodes: [
+          {
+            id: 105,
+            status: 'ready'
+          }
+        ],
+        lkeid: 35
+      }
+    ],
+    created: '2019-04-29 18:02:17',
+    id: '34',
+    status: 'running',
+    version: '1.13.5'
+  }
+];

--- a/src/components/OrderBy.ts
+++ b/src/components/OrderBy.ts
@@ -51,7 +51,7 @@ export const sortData = (orderBy: string, order: Order) =>
             : eachValue
         );
     }
-    /** basically, if orderByProp exists, do a pathOr with that insteead */
+    /** basically, if orderByProp exists, do a pathOr with that instead */
     const aValue = pathOr(0, !!orderByProp ? orderByProp : [orderBy], a);
     const bValue = pathOr(0, !!orderByProp ? orderByProp : [orderBy], b);
 

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -274,6 +274,15 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
       });
     }
 
+    if (true) {
+      // @todo add feature flagging
+      primaryLinks.push({
+        display: 'Kubernetes',
+        href: '/kubernetes',
+        key: 'kubernetes'
+      });
+    }
+
     // if (canAccessNodeBalancers) {
     primaryLinks.push({
       display: 'NodeBalancers',

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -16,7 +16,7 @@ import {
   WithTheme
 } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
-import { isObjectStorageEnabled } from 'src/constants';
+import { isKubernetesEnabled, isObjectStorageEnabled } from 'src/constants';
 import { MapState } from 'src/store/types';
 import { sendEvent } from 'src/utilities/analytics';
 import AdditionalMenuItems from './AdditionalMenuItems';
@@ -274,15 +274,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
       });
     }
 
-    if (true) {
-      // @todo add feature flagging
-      primaryLinks.push({
-        display: 'Kubernetes',
-        href: '/kubernetes',
-        key: 'kubernetes'
-      });
-    }
-
     // if (canAccessNodeBalancers) {
     primaryLinks.push({
       display: 'NodeBalancers',
@@ -302,6 +293,14 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
       key: 'longview'
     });
     // }
+
+    if (isKubernetesEnabled) {
+      primaryLinks.push({
+        display: 'Kubernetes',
+        href: '/kubernetes',
+        key: 'kubernetes'
+      });
+    }
 
     if (isManagedAccount) {
       primaryLinks.push({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,12 +32,15 @@ export const OAUTH_TOKEN_REFRESH_TIMEOUT = LOGIN_SESSION_LIFETIME_MS / 2;
 /** Google Analytics and Tag Manager */
 export const GA_ID = process.env.REACT_APP_GA_ID;
 export const GTM_ID = process.env.REACT_APP_GTM_ID;
-/** for hardcoding token used for API Requests. Example: "Bearer 1234" */
+/** for hard-coding token used for API Requests. Example: "Bearer 1234" */
 export const ACCESS_TOKEN = process.env.REACT_APP_ACCESS_TOKEN;
 
 // Features
 export const isObjectStorageEnabled =
   process.env.REACT_APP_IS_OBJECT_STORAGE_ENABLED === 'true';
+
+export const isKubernetesEnabled =
+  process.env.REACT_APP_KUBERNETES_ENABLED === 'true';
 
 export const DISABLE_EVENT_THROTTLE =
   Boolean(process.env.REACT_APP_DISABLE_EVENT_THROTTLE) || false;

--- a/src/features/Kubernetes/ClusterList/ClusterList.test.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.test.tsx
@@ -1,0 +1,69 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { clusters } from 'src/__data__/kubernetes';
+import { ClusterContent, ClusterList } from './ClusterList';
+
+const props = {
+  classes: {
+    root: '',
+    title: ''
+  }
+};
+
+const contentProps = {
+  loading: true,
+  data: []
+};
+
+const component = shallow(<ClusterList {...props} />);
+const contentComponent = shallow(<ClusterContent {...contentProps} />);
+
+const isLoading = (container: any) =>
+  container.find('[data-qa-cluster-loading]');
+const hasError = (container: any) => container.find('[data-qa-cluster-error]');
+const isEmpty = (container: any) => container.find('[data-qa-cluster-empty]');
+const hasContent = (container: any) => container.find('[data-qa-cluster-row]');
+
+describe('ClusterRow component', () => {
+  describe('ClusterContent loading/error/empty states', () => {
+    it('should have a loading state', () => {
+      expect(isLoading(contentComponent)).toHaveLength(1);
+      expect(hasError(contentComponent)).toHaveLength(0);
+      expect(isEmpty(contentComponent)).toHaveLength(0);
+      expect(hasContent(contentComponent)).toHaveLength(0);
+    });
+
+    it('should have an error state', () => {
+      contentComponent.setProps({ loading: false, error: 'An error' });
+      expect(isLoading(contentComponent)).toHaveLength(0);
+      expect(hasError(contentComponent)).toHaveLength(1);
+      expect(isEmpty(contentComponent)).toHaveLength(0);
+      expect(hasContent(contentComponent)).toHaveLength(0);
+    });
+
+    it('should have an empty state', () => {
+      contentComponent.setProps({ loading: false, error: undefined, data: [] });
+      expect(isLoading(contentComponent)).toHaveLength(0);
+      expect(hasError(contentComponent)).toHaveLength(0);
+      expect(isEmpty(contentComponent)).toHaveLength(1);
+      expect(hasContent(contentComponent)).toHaveLength(0);
+    });
+
+    it('should display content', () => {
+      contentComponent.setProps({
+        loading: false,
+        error: undefined,
+        data: clusters
+      });
+      expect(isLoading(contentComponent)).toHaveLength(0);
+      expect(hasError(contentComponent)).toHaveLength(0);
+      expect(isEmpty(contentComponent)).toHaveLength(0);
+      expect(hasContent(contentComponent)).toHaveLength(clusters.length);
+    });
+  });
+
+  it.skip('should render', () => {
+    expect(component).toHaveLength(1);
+  });
+});

--- a/src/features/Kubernetes/ClusterList/ClusterList.test.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.test.tsx
@@ -7,7 +7,8 @@ import { ClusterContent, ClusterList } from './ClusterList';
 const props = {
   classes: {
     root: '',
-    title: ''
+    title: '',
+    labelHeader: ''
   }
 };
 

--- a/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -36,7 +36,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 type CombinedProps = WithStyles<ClassNames>;
 
-const ClusterList: React.FunctionComponent<CombinedProps> = props => {
+export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
   const { classes } = props;
   const [clusters, setClusters] = React.useState<Linode.KubernetesCluster[]>(
     []
@@ -179,16 +179,16 @@ interface ContentProps {
 export const ClusterContent: React.FunctionComponent<ContentProps> = props => {
   const { data, error, loading } = props;
   if (error) {
-    return <TableRowError message={error} colSpan={12} />;
+    return <TableRowError data-qa-cluster-error message={error} colSpan={12} />;
   }
 
   if (loading) {
-    return <TableRowLoading colSpan={12} />;
+    return <TableRowLoading data-qa-cluster-loading colSpan={12} />;
   }
 
   if (data.length === 0) {
     return (
-      <TableRow>
+      <TableRow data-qa-cluster-empty>
         <TableCell>You don't have any Kubernetes Clusters.</TableCell>
       </TableRow>
     );
@@ -197,7 +197,11 @@ export const ClusterContent: React.FunctionComponent<ContentProps> = props => {
   return (
     <>
       {data.map((cluster, idx) => (
-        <ClusterRow key={`kubernetes-cluster-list-${idx}`} cluster={cluster} />
+        <ClusterRow
+          data-qa-cluster-row
+          key={`kubernetes-cluster-list-${idx}`}
+          cluster={cluster}
+        />
       ))}
     </>
   );

--- a/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -36,24 +36,30 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 type CombinedProps = WithStyles<ClassNames>;
 
-
 const ClusterList: React.FunctionComponent<CombinedProps> = props => {
   const { classes } = props;
-  const [clusters, setClusters] = React.useState<Linode.KubernetesCluster[]>([]);
+  const [clusters, setClusters] = React.useState<Linode.KubernetesCluster[]>(
+    []
+  );
   const [loading, setLoading] = React.useState<boolean>(false);
-  const [error, setError] = React.useState<string|undefined>(undefined);
+  const [error, setError] = React.useState<string | undefined>(undefined);
 
   React.useEffect(() => {
     setLoading(true);
     getKubernetesClusters()
-      .then((response) => {
+      .then(response => {
         setClusters(response.data);
         setLoading(false);
       })
-      .catch((err) => {
+      .catch(err => {
         setLoading(false);
-        setError(getErrorStringOrDefault(err));
-      })
+        setError(
+          getErrorStringOrDefault(
+            err,
+            'There was an error loading your Kubernetes Clusters.'
+          )
+        );
+      });
   }, []);
 
   return (
@@ -74,14 +80,18 @@ const ClusterList: React.FunctionComponent<CombinedProps> = props => {
         <Grid item>
           <Grid container alignItems="flex-end">
             <Grid item className="pt0">
-              <AddNewLink disabled={true} onClick={() => null} label="Add a Cluster" />
+              <AddNewLink
+                disabled={true}
+                onClick={() => null}
+                label="Add a Cluster"
+              />
             </Grid>
           </Grid>
         </Grid>
       </Grid>
-      <OrderBy data={[]} orderBy={'label'} order={'asc'}>
-        {({ handleOrderChange, order, orderBy }) => (
-          <Paginate data={clusters}>
+      <OrderBy data={clusters} orderBy={'label'} order={'asc'}>
+        {({ data: orderedData, handleOrderChange, order, orderBy }) => (
+          <Paginate data={orderedData}>
             {({
               data,
               count,
@@ -113,9 +123,15 @@ const ClusterList: React.FunctionComponent<CombinedProps> = props => {
                         >
                           Version
                         </TableSortCell>
-                        <TableCell data-qa-kubernetes-clusters-created-header>
+                        <TableSortCell
+                          active={orderBy === 'created'}
+                          label={'created'}
+                          direction={order}
+                          handleClick={handleOrderChange}
+                          data-qa-kubernetes-clusters-created-header
+                        >
                           Created
-                        </TableCell>
+                        </TableSortCell>
                         <TableSortCell
                           active={orderBy === 'region'}
                           label={'region'}
@@ -129,7 +145,11 @@ const ClusterList: React.FunctionComponent<CombinedProps> = props => {
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      <ClusterContent loading={loading} error={error} data={data} />
+                      <ClusterContent
+                        loading={loading}
+                        error={error}
+                        data={data}
+                      />
                     </TableBody>
                   </Table>
                 </Paper>
@@ -147,7 +167,7 @@ const ClusterList: React.FunctionComponent<CombinedProps> = props => {
         )}
       </OrderBy>
     </React.Fragment>
-  )
+  );
 };
 
 interface ContentProps {
@@ -156,18 +176,22 @@ interface ContentProps {
   data: Linode.KubernetesCluster[];
 }
 
-const ClusterContent:React.FunctionComponent<ContentProps> = (props) => {
+export const ClusterContent: React.FunctionComponent<ContentProps> = props => {
   const { data, error, loading } = props;
   if (error) {
-    return <TableRowError message={error} colSpan={12} />
+    return <TableRowError message={error} colSpan={12} />;
   }
 
   if (loading) {
-    return <TableRowLoading colSpan={12} />
+    return <TableRowLoading colSpan={12} />;
   }
 
   if (data.length === 0) {
-    return <TableRow><TableCell>You don't have any Kubernetes Clusters.</TableCell></TableRow>;
+    return (
+      <TableRow>
+        <TableCell>You don't have any Kubernetes Clusters.</TableCell>
+      </TableRow>
+    );
   }
 
   return (
@@ -176,8 +200,8 @@ const ClusterContent:React.FunctionComponent<ContentProps> = (props) => {
         <ClusterRow key={`kubernetes-cluster-list-${idx}`} cluster={cluster} />
       ))}
     </>
-  )
-}
+  );
+};
 
 const styled = withStyles(styles);
 

--- a/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -26,12 +26,15 @@ import { getKubernetesClusters } from 'src/services/kubernetes';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import ClusterRow from './ClusterRow';
 
-type ClassNames = 'root' | 'title';
+type ClassNames = 'root' | 'title' | 'labelHeader';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   title: {
     marginBottom: theme.spacing.unit + theme.spacing.unit / 2
+  },
+  labelHeader: {
+    paddingLeft: theme.spacing.unit * 2 + 49
   }
 });
 
@@ -111,6 +114,7 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
                           label={'label'}
                           direction={order}
                           handleClick={handleOrderChange}
+                          className={classes.labelHeader}
                           data-qa-kubernetes-clusters-name-header
                         >
                           Cluster Label
@@ -120,7 +124,7 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
                           label={'version'}
                           direction={order}
                           handleClick={handleOrderChange}
-                          data-qa-kubernetes-clusters-name-header
+                          data-qa-kubernetes-clusters-version-header
                         >
                           Version
                         </TableSortCell>
@@ -138,7 +142,7 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
                           label={'region'}
                           direction={order}
                           handleClick={handleOrderChange}
-                          data-qa-kubernetes-clusters-size-header
+                          data-qa-kubernetes-clusters-region-header
                         >
                           Region
                         </TableSortCell>

--- a/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -1,9 +1,146 @@
 import * as React from 'react';
+import 'rxjs/add/operator/filter';
+import { Subscription } from 'rxjs/Subscription';
+import ActionsPanel from 'src/components/ActionsPanel';
+import AddNewLink from 'src/components/AddNewLink';
+import Button from 'src/components/Button';
+import CircleProgress from 'src/components/CircleProgress';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Paper from 'src/components/core/Paper';
+import {
+  StyleRulesCallback,
+  WithStyles,
+  withStyles
+} from 'src/components/core/styles';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/core/TableRow';
+import Typography from 'src/components/core/Typography';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import ErrorState from 'src/components/ErrorState';
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
+import OrderBy from 'src/components/OrderBy';
+import Paginate from 'src/components/Paginate';
+import PaginationFooter from 'src/components/PaginationFooter';
+import Placeholder from 'src/components/Placeholder';
+import Table from 'src/components/Table';
+import TableCell from 'src/components/TableCell';
+import TableSortCell from 'src/components/TableSortCell';
+import { Images } from 'src/documentation';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 interface Props {}
 
-const ClusterList: React.FunctionComponent<Props> = props => {
-  return <div>Kubernetes Clusters!</div>;
+type ClassNames = 'root' | 'title';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  title: {
+    marginBottom: theme.spacing.unit + theme.spacing.unit / 2
+  }
+});
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const ClusterList: React.FunctionComponent<CombinedProps> = props => {
+  const { classes } = props;
+  return (
+    <React.Fragment>
+      <DocumentTitleSegment segment="Images" />
+      <Grid
+        container
+        justify="space-between"
+        alignItems="flex-end"
+        updateFor={[classes]}
+        style={{ paddingBottom: 0 }}
+      >
+        <Grid item>
+          <Typography variant="h1" data-qa-title className={classes.title}>
+            Kubernetes Clusters
+          </Typography>
+        </Grid>
+        <Grid item>
+          <Grid container alignItems="flex-end">
+            <Grid item className="pt0">
+              <AddNewLink disabled={true} onClick={() => null} label="Add a Cluster" />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+      <OrderBy data={[]} orderBy={'label'} order={'asc'}>
+        {({ data: orderedData, handleOrderChange, order, orderBy }) => (
+          <Paginate data={orderedData}>
+            {({
+              data,
+              count,
+              handlePageChange,
+              handlePageSizeChange,
+              page,
+              pageSize
+            }) => (
+              <>
+                <Paper>
+                  <Table aria-label="List of Your Kubernetes Clusters">
+                    <TableHead>
+                      <TableRow>
+                        <TableSortCell
+                          active={orderBy === 'label'}
+                          label={'label'}
+                          direction={order}
+                          handleClick={handleOrderChange}
+                          data-qa-kubernetes-clusters-name-header
+                        >
+                          Cluster Label
+                        </TableSortCell>
+                        <TableSortCell
+                          active={orderBy === 'version'}
+                          label={'version'}
+                          direction={order}
+                          handleClick={handleOrderChange}
+                          data-qa-kubernetes-clusters-name-header
+                        >
+                          Version
+                        </TableSortCell>
+                        <TableCell data-qa-kubernetes-clusters-created-header>
+                          Created
+                        </TableCell>
+                        <TableSortCell
+                          active={orderBy === 'region'}
+                          label={'region'}
+                          direction={order}
+                          handleClick={handleOrderChange}
+                          data-qa-kubernetes-clusters-size-header
+                        >
+                          Region
+                        </TableSortCell>
+                        <TableCell />
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {data.map((image, idx) => (
+                        <div>Hi</div>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </Paper>
+                <PaginationFooter
+                  count={count}
+                  handlePageChange={handlePageChange()}
+                  handleSizeChange={handlePageSizeChange}
+                  page={page}
+                  pageSize={pageSize}
+                  eventCategory="kubernetes landing"
+                />
+              </>
+            )}
+          </Paginate>
+        )}
+      </OrderBy>
+    </React.Fragment>
+  )
 };
 
-export default ClusterList;
+const styled = withStyles(styles);
+
+export default styled(ClusterList);

--- a/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -160,7 +160,7 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
                 </Paper>
                 <PaginationFooter
                   count={count}
-                  handlePageChange={handlePageChange()}
+                  handlePageChange={handlePageChange}
                   handleSizeChange={handlePageSizeChange}
                   page={page}
                   pageSize={pageSize}

--- a/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+interface Props {}
+
+const ClusterList: React.FunctionComponent<Props> = props => {
+  return <div>Kubernetes Clusters!</div>;
+};
+
+export default ClusterList;

--- a/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -82,7 +82,7 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
             <Grid item className="pt0">
               <AddNewLink
                 disabled={true}
-                onClick={() => null}
+                onClick={() => null} // @todo enable creation flow
                 label="Add a Cluster"
               />
             </Grid>

--- a/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -18,6 +18,7 @@ import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 import TableSortCell from 'src/components/TableSortCell';
@@ -188,9 +189,11 @@ export const ClusterContent: React.FunctionComponent<ContentProps> = props => {
 
   if (data.length === 0) {
     return (
-      <TableRow data-qa-cluster-empty>
-        <TableCell>You don't have any Kubernetes Clusters.</TableCell>
-      </TableRow>
+      <TableRowEmptyState
+        data-qa-cluster-empty
+        message={"You don't have any Kubernetes Clusters."}
+        colSpan={12}
+      />
     );
   }
 

--- a/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
@@ -8,7 +8,8 @@ const props = {
   cluster: clusters[0],
   classes: {
     root: '',
-    label: ''
+    label: '',
+    clusterDescription: ''
   }
 };
 

--- a/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterRow.test.tsx
@@ -1,0 +1,36 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { clusters } from 'src/__data__/kubernetes';
+import { ClusterRow } from './ClusterRow';
+
+const props = {
+  cluster: clusters[0],
+  classes: {
+    root: '',
+    label: ''
+  }
+};
+
+const component = shallow(<ClusterRow {...props} />);
+
+describe('ClusterRow component', () => {
+  it('should render without crashing', () => {
+    expect(component).toHaveLength(1);
+  });
+
+  it('should render the cluster version', () => {
+    const version = component.find('[data-qa-cluster-version]');
+    expect(version.contains(clusters[0].version)).toBeTruthy();
+  });
+
+  it('should render the cluster label', () => {
+    const label = component.find('[data-qa-cluster-label]');
+    expect(label.contains(clusters[0].label)).toBeTruthy();
+  });
+
+  it('should render the region', () => {
+    const region = component.find('[data-qa-cluster-region]');
+    expect(region.contains(clusters[0].region)).toBeTruthy();
+  });
+});

--- a/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -37,13 +37,13 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = props => {
       >
         {cluster.label}
       </TableCell>
-      <TableCell parentColumn="Version" data-qa-cluster-date>
+      <TableCell parentColumn="Version" data-qa-cluster-version>
         {cluster.version}
       </TableCell>
       <TableCell parentColumn="Created" data-qa-cluster-date>
         <DateTimeDisplay value={cluster.created} humanizeCutoff="month" />
       </TableCell>
-      <TableCell parentColumn="Region" data-qa-cluster-size>
+      <TableCell parentColumn="Region" data-qa-cluster-region>
         {cluster.region}
       </TableCell>
     </TableRow>

--- a/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -5,9 +5,8 @@ import {
   withStyles
 } from 'src/components/core/styles';
 import TableRow from 'src/components/core/TableRow';
+import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import TableCell from 'src/components/TableCell';
-import { formatDate } from 'src/utilities/format-date-iso8601';
-
 
 type ClassNames = 'root' | 'label';
 
@@ -27,7 +26,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
+export const ClusterRow: React.FunctionComponent<CombinedProps> = props => {
   const { classes, cluster } = props;
   return (
     <TableRow key={cluster.id} data-qa-cluster-cell={cluster.id}>
@@ -42,14 +41,14 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
         {cluster.version}
       </TableCell>
       <TableCell parentColumn="Created" data-qa-cluster-date>
-        {formatDate(cluster.created)}
+        <DateTimeDisplay value={cluster.created} humanizeCutoff="month" />
       </TableCell>
       <TableCell parentColumn="Region" data-qa-cluster-size>
         {cluster.region}
       </TableCell>
-  </TableRow>
-  )
-}
+    </TableRow>
+  );
+};
 
 const styled = withStyles(styles);
 

--- a/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -5,18 +5,24 @@ import {
   withStyles
 } from 'src/components/core/styles';
 import TableRow from 'src/components/core/TableRow';
+import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
+import EntityIcon from 'src/components/EntityIcon';
+import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 
-type ClassNames = 'root' | 'label';
+type ClassNames = 'root' | 'label' | 'clusterDescription';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   label: {
-    width: '30%',
+    width: '50%',
     [theme.breakpoints.down('sm')]: {
       width: '100%'
     }
+  },
+  clusterDescription: {
+    paddingTop: theme.spacing.unit / 2
   }
 });
 
@@ -35,7 +41,18 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = props => {
         className={classes.label}
         data-qa-cluster-label
       >
-        {cluster.label}
+        <Grid container wrap="nowrap" alignItems="center">
+          <Grid item className="py0">
+            <EntityIcon variant="linode" marginTop={1} />
+          </Grid>
+          <Grid item>
+            <Typography variant="h3">{cluster.label}</Typography>
+            {/* @todo add cluster description when available */}
+            {/* <Typography className={classes.clusterDescription}>
+              64 CPUs
+            </Typography> */}
+          </Grid>
+        </Grid>
       </TableCell>
       <TableCell parentColumn="Version" data-qa-cluster-version>
         {cluster.version}

--- a/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import {
+  StyleRulesCallback,
+  WithStyles,
+  withStyles
+} from 'src/components/core/styles';
+import TableRow from 'src/components/core/TableRow';
+import TableCell from 'src/components/TableCell';
+import { formatDate } from 'src/utilities/format-date-iso8601';
+
+
+type ClassNames = 'root' | 'label';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  label: {
+    width: '30%',
+    [theme.breakpoints.down('sm')]: {
+      width: '100%'
+    }
+  }
+});
+
+interface Props {
+  cluster: Linode.KubernetesCluster;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export const ClusterRow: React.FunctionComponent<CombinedProps> = (props) => {
+  const { classes, cluster } = props;
+  return (
+    <TableRow key={cluster.id} data-qa-cluster-cell={cluster.id}>
+      <TableCell
+        parentColumn="Cluster Label"
+        className={classes.label}
+        data-qa-cluster-label
+      >
+        {cluster.label}
+      </TableCell>
+      <TableCell parentColumn="Version" data-qa-cluster-date>
+        {cluster.version}
+      </TableCell>
+      <TableCell parentColumn="Created" data-qa-cluster-date>
+        {formatDate(cluster.created)}
+      </TableCell>
+      <TableCell parentColumn="Region" data-qa-cluster-size>
+        {cluster.region}
+      </TableCell>
+  </TableRow>
+  )
+}
+
+const styled = withStyles(styles);
+
+export default styled(ClusterRow);

--- a/src/features/Kubernetes/ClusterList/index.tsx
+++ b/src/features/Kubernetes/ClusterList/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ClusterList';

--- a/src/services/kubernetes/index.ts
+++ b/src/services/kubernetes/index.ts
@@ -1,0 +1,1 @@
+export * from './kubernetes';

--- a/src/services/kubernetes/kubernetes.ts
+++ b/src/services/kubernetes/kubernetes.ts
@@ -1,0 +1,23 @@
+import { API_ROOT } from 'src/constants';
+import Request, {
+  setMethod,
+  setParams,
+  setURL,
+  setXFilter
+} from '../index';
+
+type Page<T> = Linode.ResourcePage<T>;
+
+/**
+ * getKubernetesClusters
+ *
+ * Gets a list of a user's Kubernetes clusters
+ */
+export const getKubernetesClusters = (params?: any, filters?: any) =>
+  Request<Page<Linode.KubernetesCluster>>(
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filters),
+    setURL(`${API_ROOT}/lke/clusters`)
+  ).then(response => response.data);
+

--- a/src/types/Kubernetes.ts
+++ b/src/types/Kubernetes.ts
@@ -1,0 +1,11 @@
+namespace Linode {
+  export interface KubernetesCluster {
+    created: string;
+    region: string;
+    tags: string[];
+    status: string; // @todo enum this
+    label: string;
+    version: string;
+    id: string;
+  }
+}

--- a/src/types/Kubernetes.ts
+++ b/src/types/Kubernetes.ts
@@ -7,5 +7,6 @@ namespace Linode {
     label: string;
     version: string;
     id: string;
+    node_pools: any[]; // @todo type this
   }
 }


### PR DESCRIPTION
## Description

Add a list of Kubernetes clusters at `/kubernetes`. Almost entirely boilerplate of the sort we use on all landing pages. See Notes for details.

## Type of Change
- Non breaking change ('update', 'change')


## Applicable E2E Tests

None

## Note to Reviewers

- Add `REACT_APP_KUBERNETES_ENABLED='true'` to your `.env` file
- Follow KB steps for setting up devenv to work with the new LKE API (PM for link)
- To test pagination, you'll have to run Anton's `post-cluster.sh` script a bunch of times, maybe swapping a few values (version, label, created) here and there.
- Only routing/landing page; Add a Cluster button is present but disabled.
- Data management is a little up in the air; the comps make it look like we'll be grouping by tag here, which means that we'll need to Redux this (or at least getAll on page load), and use the Paginated component. I used that component here but I'm not getting all yet, bc we might end up paginating through the API with Pagey.
- No action menu yet bc no actions are possible yet