### PR TITLE
M3-2322 Fix: Pagination Footer numbering

### DIFF
--- a/src/components/PaginationControls/PageNumbers.tsx
+++ b/src/components/PaginationControls/PageNumbers.tsx
@@ -15,6 +15,18 @@ interface Props {
   handlePageClick: (n: number) => void;
 }
 
+// This component handles page numbering for the pagination footer.
+// The first and last page are always shown, and depending on the number
+// of pages (and the selected page number), ellipses may be shown.
+//
+// Examples: ("*" denotes selected page)
+// 1 2 *3* 4 5 6
+// 1 2 3 *4* 5 ... 7
+// 1 ... 3 4 *5* 6 7
+// 1 ... 5 6 *7* 8 9 ... 11
+//
+// On smaller viewports, only 3 page numbers are shown in the middle,
+// so the last example becomes 1 ... 6 *7* 8 ... 11
 class PageNumbers extends React.PureComponent<Props & StyleProps> {
   forceRefresh = debounce(400, false, () => {
     /**

--- a/src/components/PaginationControls/PageNumbers.tsx
+++ b/src/components/PaginationControls/PageNumbers.tsx
@@ -15,6 +15,8 @@ interface Props {
   handlePageClick: (n: number) => void;
 }
 
+export type CombinedProps = Props & StyleProps;
+
 // This component handles page numbering for the pagination footer.
 // The first and last page are always shown, and depending on the number
 // of pages (and the selected page number), ellipses may be shown.
@@ -27,7 +29,7 @@ interface Props {
 //
 // On smaller viewports, only 3 page numbers are shown in the middle,
 // so the last example becomes 1 ... 6 *7* 8 ... 11
-class PageNumbers extends React.PureComponent<Props & StyleProps> {
+export class PageNumbers extends React.PureComponent<CombinedProps> {
   forceRefresh = debounce(400, false, () => {
     /**
      * forcing update because we want the shown page numbers to update
@@ -58,6 +60,7 @@ class PageNumbers extends React.PureComponent<Props & StyleProps> {
             <PageNumber
               number={1}
               data-qa-page-to={1}
+              data-testid={1}
               disabled={currentPage === 1}
               aria-label={`Page 1`}
               {...rest}
@@ -67,7 +70,7 @@ class PageNumbers extends React.PureComponent<Props & StyleProps> {
             {/* We want an ellipsis here, unless the first element of pageNumbers is 2, because
              "1 ... 2" is incorrect. */}
             {pageNumbers[0] !== 2 && (
-              <div className={classes.ellipses}>
+              <div data-testid="leading-ellipsis" className={classes.ellipses}>
                 <span className={classes.ellipsesInner}>...</span>
               </div>
             )}
@@ -77,6 +80,7 @@ class PageNumbers extends React.PureComponent<Props & StyleProps> {
           <PageNumber
             number={eachPage}
             data-qa-page-to={eachPage}
+            data-testid={eachPage}
             key={eachPage}
             disabled={eachPage === currentPage}
             aria-label={`Page ${eachPage}`}
@@ -92,13 +96,14 @@ class PageNumbers extends React.PureComponent<Props & StyleProps> {
             {/* We want an ellipsis here, unless the last element of pageNumbers is equal to
             numPages-1, because "6 ... 7" is incorrect. */}
             {pageNumbers[pageNumbers.length - 1] !== numOfPages - 1 && (
-              <div className={classes.ellipses}>
+              <div data-testid="trailing-ellipsis" className={classes.ellipses}>
                 <span className={classes.ellipsesInner}>...</span>
               </div>
             )}
             <PageNumber
               number={numOfPages}
               data-qa-page-to={numOfPages}
+              data-testid={numOfPages}
               disabled={currentPage === numOfPages}
               aria-label={`Page ${numOfPages}`}
               {...rest}

--- a/src/components/PaginationControls/PageNumbers.tsx
+++ b/src/components/PaginationControls/PageNumbers.tsx
@@ -34,10 +34,14 @@ class PageNumbers extends React.PureComponent<Props & StyleProps> {
 
   render() {
     const { numOfPages, currentPage, classes, ...rest } = this.props;
+
+    const pageNumbers = pageNumbersToRender(currentPage, numOfPages);
+
     return (
       <React.Fragment>
-        {/** display "1 ... " if we're on a page higher than 5 */
-        currentPage >= 5 ? (
+        {/* We always want to start with "1", so if it isn't already the first
+        element in pageNumbers, add it here. */}
+        {pageNumbers[0] !== 1 && (
           <React.Fragment>
             <PageNumber
               number={1}
@@ -48,12 +52,16 @@ class PageNumbers extends React.PureComponent<Props & StyleProps> {
             >
               1
             </PageNumber>
-            <div className={classes.ellipses}>
-              <span className={classes.ellipsesInner}>...</span>
-            </div>
+            {/* We want an ellipsis here, unless the first element of pageNumbers is 2, because
+             "1 ... 2" is incorrect. */}
+            {pageNumbers[0] !== 2 && (
+              <div className={classes.ellipses}>
+                <span className={classes.ellipsesInner}>...</span>
+              </div>
+            )}
           </React.Fragment>
-        ) : null}
-        {pageNumbersToRender(currentPage, numOfPages).map(eachPage => (
+        )}
+        {pageNumbers.map(eachPage => (
           <PageNumber
             number={eachPage}
             data-qa-page-to={eachPage}
@@ -65,13 +73,17 @@ class PageNumbers extends React.PureComponent<Props & StyleProps> {
             {eachPage}
           </PageNumber>
         ))}
-        {/* if we have more than 5 pages and we're on a page that is
-        not one of the last 5 pages, show " ... lastPage# " */
-        numOfPages > 5 && currentPage <= numOfPages - 4 ? (
+        {/* We always want to end with the last page, so if it isn't already the last
+        element in pageNumbers, add it here. */}
+        {pageNumbers[pageNumbers.length - 1] !== numOfPages && (
           <React.Fragment>
-            <div className={classes.ellipses}>
-              <span className={classes.ellipsesInner}>...</span>
-            </div>
+            {/* We want an ellipsis here, unless the last element of pageNumbers is equal to
+            numPages-1, because "6 ... 7" is incorrect. */}
+            {pageNumbers[pageNumbers.length - 1] !== numOfPages - 1 && (
+              <div className={classes.ellipses}>
+                <span className={classes.ellipsesInner}>...</span>
+              </div>
+            )}
             <PageNumber
               number={numOfPages}
               data-qa-page-to={numOfPages}
@@ -82,7 +94,7 @@ class PageNumbers extends React.PureComponent<Props & StyleProps> {
               {numOfPages}
             </PageNumber>
           </React.Fragment>
-        ) : null}
+        )}
       </React.Fragment>
     );
   }


### PR DESCRIPTION
## Description

There are a few problems with the page numbering of our pagination footer:

<img width="392" alt="Screen Shot 2019-04-30 at 7 36 15 AM" src="https://user-images.githubusercontent.com/16911484/56959221-b9adaf00-6b1a-11e9-9266-20b5a1b8ab44.png">

<img width="403" alt="Screen Shot 2019-04-30 at 7 35 59 AM" src="https://user-images.githubusercontent.com/16911484/56959216-b6b2be80-6b1a-11e9-8284-39f9430da389.png">

This PR attempts to fix these issues.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Test multiple pages with varying page numbers. Click on each page number and ensure the sequence makes sense. Here's where you can find different page numbering combinations:

**11 pages:** Test Account 1 - Linodes
**7 pages:** Test Account 1 – Domains
**6 pages:** Test Account 9 – Domains (remove one domain to make it 5 pages)