### PR TITLE
M3-2107 Part I: Replace all pathOr<string>s with getErrorStringOrDefault

### DIFF
--- a/src/components/TagsPanel/TagsPanel.tsx
+++ b/src/components/TagsPanel/TagsPanel.tsx
@@ -1,7 +1,7 @@
 import AddCircle from '@material-ui/icons/AddCircle';
 import * as classNames from 'classnames';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { clone, pathOr } from 'ramda';
+import { clone } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
@@ -15,6 +15,7 @@ import Typography from 'src/components/core/Typography';
 import Select from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
 import { getTags } from 'src/services/tags';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import TagsPanelItem from './TagsPanelItem';
 
 type ClassNames =
@@ -314,14 +315,11 @@ class TagsPanel extends React.Component<CombinedProps, State> {
           });
         })
         .catch(e => {
-          this.setState({ loading: false });
-          const tagError = pathOr(
-            'Error while creating tag',
-            ['response', 'data', 'errors', 0, 'reason'],
-            e
+          const tagError = getErrorStringOrDefault(
+            e,
+            'Error while creating tag'
           );
-          // display the first error in the array or a generic one
-          this.setState({ tagError });
+          this.setState({ loading: false, tagError });
         });
     }
   };

--- a/src/features/Profile/AuthenticationSettings/TrustedDevicesDialog.tsx
+++ b/src/features/Profile/AuthenticationSettings/TrustedDevicesDialog.tsx
@@ -3,7 +3,6 @@ import {
   withStyles,
   WithStyles
 } from '@material-ui/core/styles';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 
@@ -16,6 +15,7 @@ import Typography from 'src/components/core/Typography';
 import withLoadingAndError, {
   Props as LoadingAndErrorProps
 } from 'src/components/withLoadingAndError';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 type ClassNames = 'root';
 
@@ -53,11 +53,9 @@ class TrustedDevicesDialog extends React.PureComponent<CombinedProps, {}> {
         this.props.refreshListOfDevices();
       })
       .catch(e => {
-        const defaultError = 'There was an issue removing this device.';
-        const errorString = pathOr(
-          defaultError,
-          ['response', 'data', 'errors', 0, 'reason'],
-          e
+        const errorString = getErrorStringOrDefault(
+          e,
+          'There was an issue removing this device.'
         );
         setErrorAndClearLoading(errorString);
       });

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/DisableTwoFactorDialog.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/DisableTwoFactorDialog.tsx
@@ -3,7 +3,6 @@ import {
   withStyles,
   WithStyles
 } from '@material-ui/core/styles';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 
@@ -16,6 +15,7 @@ import Typography from 'src/components/core/Typography';
 import withLoadingAndError, {
   Props as LoadingAndErrorProps
 } from 'src/components/withLoadingAndError';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 type ClassNames = 'root';
 
@@ -52,11 +52,9 @@ class DisableTwoFactorDialog extends React.PureComponent<CombinedProps, {}> {
         this.props.onSuccess();
       })
       .catch(e => {
-        const defaultError = 'There was an error disabling TFA.';
-        const errorString = pathOr(
-          defaultError,
-          ['response', 'data', 'errors', 0, 'reason'],
-          e
+        const errorString = getErrorStringOrDefault(
+          e,
+          'There was an error disabling TFA.'
         );
         setErrorAndClearLoading(errorString);
       });

--- a/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -21,7 +21,7 @@ import { getNodeBalancers } from 'src/services/nodebalancers';
 import { createSupportTicket, uploadAttachment } from 'src/services/support';
 import { getVolumes } from 'src/services/volumes';
 import composeState from 'src/utilities/composeState';
-import { getErrorMap } from 'src/utilities/errorUtils';
+import { getErrorMap, getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { getVersionString } from 'src/utilities/getVersionString';
 import AttachFileForm, { FileAttachment } from '../AttachFileForm';
 import { AttachmentError } from '../SupportTicketDetail/SupportTicketDetail';
@@ -307,12 +307,9 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
          * fail! Don't try to aggregate errors!
          */
         this.setState(set(lensPath(['files', idx, 'uploading']), false));
-        const error =
-          'There was an error attaching this file. Please try again.';
-        const newError = pathOr<string>(
-          error,
-          ['response', 'data', 'errors', 0, 'reason'],
-          attachmentErrors
+        const newError = getErrorStringOrDefault(
+          attachmentErrors,
+          'There was an error attaching this file. Please try again.'
         );
         return {
           ...accumulator,

--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
@@ -1,5 +1,4 @@
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -14,6 +13,7 @@ import {
   withTypes,
   WithTypes
 } from 'src/store/linodeType/linodeType.containers';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import MutateDrawer from '../MutateDrawer';
 import withMutationDrawerState, {
@@ -70,7 +70,7 @@ const MutationNotification: React.StatelessComponent<CombinedProps> = props => {
     openMutationDrawer();
 
     /*
-     * It's okay to disregard the possiblity of linode
+     * It's okay to disregard the possibility of linode
      * being undefined. The upgrade message won't appear unless
      * it's defined
      */
@@ -82,10 +82,9 @@ const MutationNotification: React.StatelessComponent<CombinedProps> = props => {
         });
       })
       .catch(errors => {
-        const e = pathOr(
-          'Mutation could not be initiated.',
-          ['response', 'data', 'errors', 0, 'reason'],
-          errors
+        const e = getErrorStringOrDefault(
+          errors,
+          'Mutation could not be initiated.'
         );
         mutationFailed(e);
       });

--- a/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { branch, compose, renderComponent } from 'recompose';
 import ErrorState from 'src/components/ErrorState';
 import { MapState } from 'src/store/types';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 interface OuterProps {
   configsError?: Linode.ApiFieldError[];
@@ -57,10 +58,9 @@ export default compose(
        * so we need to handle for both and look for the suspended message
        * in both paths
        */
-      const errorTextFromAxios = pathOr(
-        'Unable to load Linode',
-        ['response', 'data', 'errors', 0, 'reason'],
-        props.error
+      const errorTextFromAxios = getErrorStringOrDefault(
+        props.error,
+        'Unable to load Linode'
       );
 
       let errorText = pathOr(errorTextFromAxios, ['error', 0, 'reason'], props);

--- a/src/services/linodes/linodeActions.ts
+++ b/src/services/linodes/linodeActions.ts
@@ -179,7 +179,7 @@ export const cloneLinode = (sourceLinodeId: number, data: LinodeCloneData) => {
  * If any actions are currently running or queued, those actions must be completed
  * first before you can initiate a mutate.
  *
- * @param linodeId { number } The id of the Linode to retrieve stats data for.
+ * @param linodeId { number } The id of the Linode to be upgraded.
  */
 export const startMutation = (linodeID: number) => {
   return Request<{}>(

--- a/src/store/backupDrawer/index.ts
+++ b/src/store/backupDrawer/index.ts
@@ -6,6 +6,7 @@ import { enableBackups } from 'src/services/linodes';
 import { handleUpdate } from 'src/store/accountSettings/accountSettings.actions';
 import { updateMultipleLinodes } from 'src/store/linodes/linodes.actions';
 import { sendEvent } from 'src/utilities/analytics';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { ThunkActionCreator } from '../types';
 
 export interface BackupError {
@@ -229,10 +230,9 @@ export const gatherResponsesAndErrors = (
       ]
     }))
     .catch(error => {
-      const reason = pathOr(
-        'Backups could not be enabled for this Linode.',
-        ['response', 'data', 'errors', 0, 'reason'],
-        error
+      const reason = getErrorStringOrDefault(
+        error,
+        'Backups could not be enabled for this Linode.'
       );
       return {
         ...accumulator,
@@ -320,12 +320,9 @@ export const enableAutoEnroll: EnableAutoEnrollThunk = () => (
       dispatch(handleUpdate(response));
     })
     .catch(errors => {
-      const defaultError =
-        'Your account settings could not be updated. Please try again.';
-      const finalError = pathOr(
-        defaultError,
-        ['response', 'data', 'errors', 0, 'reason'],
-        errors
+      const finalError = getErrorStringOrDefault(
+        errors,
+        'Your account settings could not be updated. Please try again.'
       );
       dispatch(handleAutoEnrollError(finalError));
     });

--- a/src/store/tagImportDrawer/index.ts
+++ b/src/store/tagImportDrawer/index.ts
@@ -1,5 +1,5 @@
 import * as Bluebird from 'bluebird';
-import { isEmpty, pathOr } from 'ramda';
+import { isEmpty } from 'ramda';
 import { Action } from 'redux';
 import { ThunkAction, ThunkDispatch } from 'redux-thunk';
 import { ApplicationState } from 'src/store';
@@ -9,6 +9,7 @@ import getEntitiesWithGroupsToImport, {
   GroupImportProps
 } from 'src/store/selectors/getEntitiesWithGroupsToImport';
 import { ThunkActionCreator } from 'src/store/types';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { storage } from 'src/utilities/storage';
 import actionCreatorFactory from 'typescript-fsa';
 
@@ -173,12 +174,8 @@ const createAccumulator = <T extends Linode.Linode | Linode.Domain>(
       ...accumulator,
       success: [...accumulator.success, updatedEntity]
     }))
-    .catch((error: any) => {
-      const reason = pathOr(
-        'Error adding tag.',
-        ['response', 'data', 'errors', 0, 'reason'],
-        error
-      );
+    .catch(error => {
+      const reason = getErrorStringOrDefault(error, 'Error adding tag.');
       return {
         ...accumulator,
         errors: [


### PR DESCRIPTION
## Description

Searched for `['response', 'data', 'errors', 0, 'reason']` and replaced with `getErrorStringOrDefault`. End goal is to avoid passing Axios errors to components, and this single interface guarantees that any change we make won't break things.

## Type of Change
- Non breaking change ('update', 'change')


## Applicable E2E Tests

None
