### PR TITLE
M30-2107 Phase 2: more error handling

### DIFF
--- a/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -16,7 +16,7 @@ import { withAccount } from 'src/features/Billing/context';
 import { Requestable } from 'src/requestableContext';
 import { updateAccountInfo } from 'src/services/account';
 import composeState from 'src/utilities/composeState';
-import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 import CountryData, { Region } from './countryRegionData';
@@ -120,25 +120,25 @@ class UpdateContactInformationPanel extends React.Component<
     const { classes } = this.props;
     const { fields, submissionErrors, success } = this.state;
 
-    const hasErrorFor = getAPIErrorFor(
-      {
-        address_1: 'address',
-        address_2: 'address 2',
-        city: 'city',
-        company: 'company',
-        country: 'country',
-        email: 'email',
-        first_name: 'first name',
-        last_name: 'last name',
-        phone: 'phone',
-        state: 'state / province',
-        tax_id: 'tax ID',
-        zip: 'zip / postal code'
-      },
+    const errorMap = getErrorMap(
+      [
+        'address_1',
+        'address_2',
+        'city',
+        'country',
+        'company',
+        'email',
+        'first_name',
+        'last_name',
+        'phone',
+        'state',
+        'tax_id',
+        'zip'
+      ],
       submissionErrors
     );
 
-    const generalError = hasErrorFor('none');
+    const generalError = errorMap.none;
 
     const countryResults = CountryData.map(country => {
       return {
@@ -195,14 +195,14 @@ class UpdateContactInformationPanel extends React.Component<
         <Grid
           item
           xs={12}
-          updateFor={[fields.company, hasErrorFor('company'), classes]}
+          updateFor={[fields.company, errorMap.company, classes]}
         >
           <Grid container>
             <Grid item xs={12} sm={6}>
               <TextField
                 label="Company Name"
                 value={defaultTo(account.company, fields.company)}
-                errorText={hasErrorFor('company')}
+                errorText={errorMap.company}
                 onChange={this.updateCompany}
                 data-qa-company
               />
@@ -214,13 +214,13 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.email, hasErrorFor('email'), classes]}
+          updateFor={[fields.email, errorMap.email, classes]}
         >
           <TextField
             label="Email"
             type="email"
             value={defaultTo(account.email, fields.email)}
-            errorText={hasErrorFor('email')}
+            errorText={errorMap.email}
             onChange={this.updateEmail}
             data-qa-contact-email
           />
@@ -230,13 +230,13 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.phone, hasErrorFor('phone'), classes]}
+          updateFor={[fields.phone, errorMap.phone, classes]}
         >
           <TextField
             label="Phone Number"
             type="tel"
             value={defaultTo(account.phone, fields.phone)}
-            errorText={hasErrorFor('phone')}
+            errorText={errorMap.phone}
             onChange={this.updatePhone}
             data-qa-contact-phone
           />
@@ -246,12 +246,12 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.first_name, hasErrorFor('first_name'), classes]}
+          updateFor={[fields.first_name, errorMap.first_name, classes]}
         >
           <TextField
             label="First Name"
             value={defaultTo(account.first_name, fields.first_name)}
-            errorText={hasErrorFor('first_name')}
+            errorText={errorMap.first_name}
             onChange={this.updateFirstName}
             data-qa-contact-first-name
           />
@@ -261,12 +261,12 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.last_name, hasErrorFor('last_name'), classes]}
+          updateFor={[fields.last_name, errorMap.last_name, classes]}
         >
           <TextField
             label="Last Name"
             value={defaultTo(account.last_name, fields.last_name)}
-            errorText={hasErrorFor('last_name')}
+            errorText={errorMap.last_name}
             onChange={this.updateLastName}
             data-qa-contact-last-name
           />
@@ -276,12 +276,12 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.address_1, hasErrorFor('address_1'), classes]}
+          updateFor={[fields.address_1, errorMap.address_1, classes]}
         >
           <TextField
             label="Address"
             value={defaultTo(account.address_1, fields.address_1)}
-            errorText={hasErrorFor('address_1')}
+            errorText={errorMap.address_1}
             onChange={this.updateAddress1}
             data-qa-contact-address-1
           />
@@ -291,12 +291,12 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.address_2, hasErrorFor('address2'), classes]}
+          updateFor={[fields.address_2, errorMap.address2, classes]}
         >
           <TextField
             label="Address 2"
             value={defaultTo(account.address_2, fields.address_2)}
-            errorText={hasErrorFor('address_2')}
+            errorText={errorMap.address_2}
             onChange={this.updateAddress2}
             data-qa-contact-address-2
           />
@@ -306,12 +306,12 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.city, hasErrorFor('city'), classes]}
+          updateFor={[fields.city, errorMap.city, classes]}
         >
           <TextField
             label="City"
             value={defaultTo(account.city, fields.city)}
-            errorText={hasErrorFor('city')}
+            errorText={errorMap.city}
             onChange={this.updateCity}
             data-qa-contact-city
           />
@@ -325,9 +325,9 @@ class UpdateContactInformationPanel extends React.Component<
             fields.state,
             fields.zip,
             fields.country,
-            hasErrorFor('state'),
-            hasErrorFor('zip'),
-            hasErrorFor('country'),
+            errorMap.state,
+            errorMap.zip,
+            errorMap.country,
             classes
           ]}
         >
@@ -335,7 +335,7 @@ class UpdateContactInformationPanel extends React.Component<
             <Grid item xs={12} sm={7}>
               <EnhancedSelect
                 label="State / Province"
-                errorText={hasErrorFor('state')}
+                errorText={errorMap.state}
                 onChange={this.updateState}
                 data-qa-contact-province
                 placeholder="Select a State"
@@ -354,7 +354,7 @@ class UpdateContactInformationPanel extends React.Component<
               <TextField
                 label="Zip / Postal Code"
                 value={defaultTo(account.zip, fields.zip)}
-                errorText={hasErrorFor('zip')}
+                errorText={errorMap.zip}
                 onChange={this.updateZip}
                 data-qa-contact-post-code
               />
@@ -366,11 +366,11 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.country, hasErrorFor('country'), classes]}
+          updateFor={[fields.country, errorMap.country, classes]}
         >
           <EnhancedSelect
             label="Country"
-            errorText={hasErrorFor('country')}
+            errorText={errorMap.country}
             onChange={this.updateCountry}
             data-qa-contact-country
             placeholder="Select a Country"
@@ -388,12 +388,12 @@ class UpdateContactInformationPanel extends React.Component<
           item
           xs={12}
           sm={6}
-          updateFor={[fields.tax_id, hasErrorFor('tax_id'), classes]}
+          updateFor={[fields.tax_id, errorMap.tax_id, classes]}
         >
           <TextField
             label="Tax ID"
             value={defaultTo(account.tax_id, fields.tax_id)}
-            errorText={hasErrorFor('tax_id')}
+            errorText={errorMap.tax_id}
             onChange={this.updateTaxID}
             data-qa-contact-tax-id
           />
@@ -509,18 +509,12 @@ class UpdateContactInformationPanel extends React.Component<
         });
       })
       .catch(response => {
-        const fallbackError = [
-          {
-            reason: 'Unable to save your contact information. Please try again.'
-          }
-        ];
         this.setState(
           {
             submitting: false,
-            submissionErrors: pathOr(
-              fallbackError,
-              ['response', 'data', 'errors'],
-              response
+            submissionErrors: getAPIErrorOrDefault(
+              response,
+              'Unable to save your contact information. Please try again.'
             )
           },
           () => {

--- a/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
+++ b/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
@@ -1,4 +1,4 @@
-import { compose, pathOr, range, take, takeLast } from 'ramda';
+import { compose, range, take, takeLast } from 'ramda';
 import * as React from 'react';
 import NumberFormat from 'react-number-format';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -17,6 +17,7 @@ import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { withAccount } from 'src/features/Billing/context';
 import { saveCreditCard } from 'src/services/account';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import isCreditCardExpired from 'src/utilities/isCreditCardExpired';
 
@@ -121,11 +122,7 @@ class UpdateCreditCardPanel extends React.Component<CombinedProps, State> {
       .catch(error => {
         this.setState({
           submitting: false,
-          errors: pathOr(
-            [{ reason: 'Unable to update credit card.' }],
-            ['response', 'data', 'errors'],
-            error
-          )
+          errors: getAPIErrorOrDefault(error, 'Unable to update credit card.')
         });
       });
   };

--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -30,6 +30,7 @@ import {
   withDomainActions
 } from 'src/store/domains/domains.container';
 import defaultNumeric from 'src/utilities/defaultNumeric';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
@@ -107,7 +108,7 @@ interface NumberFieldProps extends _TextFieldProps {
 
 class DomainRecordDrawer extends React.Component<CombinedProps, State> {
   /**
-   * the defaultFieldState is used to prepopulate the drawer with either
+   * the defaultFieldState is used to pre-populate the drawer with either
    * editable data or defaults.
    */
   static defaultFieldsState = (props: Partial<CombinedProps>) => ({
@@ -374,7 +375,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     </TextField>
   );
 
-  DomainTrainsferField = () => (
+  DomainTransferField = () => (
     <TextField
       multiline
       label="Domain Transfers"
@@ -392,25 +393,10 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
   );
 
   handleSubmissionErrors = (errorResponse: any) => {
-    const errors = path<Linode.ApiFieldError[]>(['response', 'data', 'errors'])(
-      errorResponse
-    );
-    if (errors) {
-      this.setState({ errors, submitting: false }, () => {
-        scrollErrorIntoView();
-      });
-      return;
-    }
-
-    this.setState(
-      {
-        submitting: false,
-        errors: [{ reason: 'An unknown error has occured.', field: '_unknown' }]
-      },
-      () => {
-        scrollErrorIntoView();
-      }
-    );
+    const errors = getAPIErrorOrDefault(errorResponse);
+    this.setState({ errors, submitting: false }, () => {
+      scrollErrorIntoView();
+    });
   };
 
   handleRecordSubmissionSuccess = () => {
@@ -551,7 +537,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         (idx: number) => (
           <this.TextField field="soa_email" label="SOA Email" key={idx} />
         ),
-        (idx: number) => <this.DomainTrainsferField key={idx} />,
+        (idx: number) => <this.DomainTransferField key={idx} />,
         (idx: number) => <this.DefaultTTLField key={idx} />,
         (idx: number) => <this.RefreshRateField key={idx} />,
         (idx: number) => <this.RetryRateField key={idx} />,

--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -6,7 +6,6 @@ import {
   isEmpty,
   lensPath,
   over,
-  path,
   pathOr,
   prepend,
   propEq
@@ -36,6 +35,10 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import { deleteDomainRecord } from 'src/services/domains';
+import {
+  getAPIErrorOrDefault,
+  getErrorStringOrDefault
+} from 'src/utilities/errorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import ActionMenu from './DomainRecordActionMenu';
 import Drawer from './DomainRecordDrawer';
@@ -242,17 +245,13 @@ class DomainRecords extends React.Component<CombinedProps, State> {
         }));
       })
       .catch(errorResponse => {
-        const errors = path<Linode.ApiFieldError[]>(
-          ['response', 'data', 'errors'],
-          errorResponse
-        );
-        if (errors) {
-          this.updateConfirmDialog(c => ({
-            ...c,
-            submitting: false,
-            errors
-          }));
-        }
+        const errors = getAPIErrorOrDefault(errorResponse);
+        console.log(errors);
+        this.updateConfirmDialog(c => ({
+          ...c,
+          submitting: false,
+          errors
+        }));
       });
     this.updateConfirmDialog(c => ({ ...c, submitting: true }));
   };
@@ -784,6 +783,11 @@ class DomainRecords extends React.Component<CombinedProps, State> {
           onClose={this.handleCloseDialog}
           title="Confirm Deletion"
           actions={this.renderDialogActions}
+          error={
+            confirmDialog.errors
+              ? getErrorStringOrDefault(confirmDialog.errors)
+              : undefined
+          }
         >
           Are you sure you want to delete this record?
         </ConfirmationDialog>

--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -246,7 +246,6 @@ class DomainRecords extends React.Component<CombinedProps, State> {
       })
       .catch(errorResponse => {
         const errors = getAPIErrorOrDefault(errorResponse);
-        console.log(errors);
         this.updateConfirmDialog(c => ({
           ...c,
           submitting: false,

--- a/src/features/Domains/DomainZoneImportDrawer.tsx
+++ b/src/features/Domains/DomainZoneImportDrawer.tsx
@@ -1,4 +1,3 @@
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -11,6 +10,7 @@ import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import LinodeTextField from 'src/components/TextField';
 import { importZone } from 'src/services/domains';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 
 type ClassNames = 'root';
@@ -138,14 +138,10 @@ class DomainZoneImportDrawer extends React.Component<CombinedProps, State> {
       .then(data => {
         this.props.onSuccess(data);
       })
-      .catch((error: Linode.ApiFieldError) => {
-        const err: Linode.ApiFieldError[] = [
-          { field: 'none', reason: 'An unexpected error has ocurred.' }
-        ];
-
+      .catch(error => {
         this.setState({
           submitting: false,
-          errors: pathOr(err, ['response', 'data', 'errors'], error)
+          errors: getAPIErrorOrDefault(error)
         });
       });
   };

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -1,5 +1,4 @@
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -26,6 +25,7 @@ import {
   withLinodeDetailContext
 } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
 import { linodeReboot } from 'src/services/linodes';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import LinodeConfigActionMenu from '../LinodeSettings/LinodeConfigActionMenu';
 import LinodeConfigDrawer from '../LinodeSettings/LinodeConfigDrawer';
 
@@ -203,10 +203,9 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
         resetEventsPolling();
       })
       .catch(errorResponse => {
-        const errors = pathOr(
-          [{ reason: `Error booting ${label}` }],
-          ['response', 'data', 'errors'],
-          errorResponse
+        const errors = getAPIErrorOrDefault(
+          errorResponse,
+          `Error booting ${label}`
         );
         errors.map((error: Linode.ApiFieldError) => {
           this.props.enqueueSnackbar(error.reason, {

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -1,5 +1,4 @@
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router';
@@ -25,6 +24,7 @@ import { linodeInTransition } from 'src/features/linodes/transitions';
 import { resizeLinode } from 'src/services/linodes';
 import { ApplicationState } from 'src/store';
 import { withNotifications } from 'src/store/notification/notification.containers';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import LinodePermissionsError from '../LinodePermissionsError';
 
 type ClassNames = 'root' | 'title' | 'subTitle' | 'currentPlanContainer';
@@ -129,10 +129,9 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
         history.push(`/linodes/${linodeId}/summary`);
       })
       .catch(errorResponse => {
-        pathOr(
-          [{ reason: 'There was an issue resizing your Linode.' }],
-          ['response', 'data', 'errors'],
-          errorResponse
+        getAPIErrorOrDefault(
+          errorResponse,
+          'There was an issue resizing your Linode.'
         ).forEach((err: Linode.ApiFieldError) =>
           enqueueSnackbar(err.reason, {
             variant: 'error'

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -1,5 +1,6 @@
-import { compose, lensPath, pathOr, set } from 'ramda';
+import { compose, lensPath, set } from 'ramda';
 import * as React from 'react';
+import { compose as rCompose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import {
@@ -15,6 +16,7 @@ import {
   LinodeActionsProps,
   withLinodeActions
 } from 'src/store/linodes/linode.containers';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import AlertSection from './AlertSection';
 
@@ -266,10 +268,9 @@ class LinodeSettingsAlertsPanel extends React.Component<CombinedProps, State> {
       .catch(error => {
         this.setState({
           submitting: false,
-          errors: pathOr(
-            [{ reason: 'Unable to update alerts thresholds.' }],
-            ['response', 'data', 'errors'],
-            error
+          errors: getAPIErrorOrDefault(
+            error,
+            'Unable to update alerts thresholds.'
           )
         });
       });
@@ -318,7 +319,7 @@ const linodeContext = withLinodeDetailContext<ContextProps>(({ linode }) => ({
   permissions: linode._permissions
 }));
 
-export default compose(
+export default rCompose<CombinedProps, Props>(
   errorBoundary,
   linodeContext,
   styled,


### PR DESCRIPTION
## Description

Trying to keep these PRs manageable. Started replacing `['response', 'data', 'errors']` with `getApiErrorOrDefault`, but there's more variation with these so I had to fix some things. 

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.
