### PR TITLE
Remove Volumes From MaybeRenderError

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -486,7 +486,7 @@ interface StateProps {
   settingsError?: Linode.ApiFieldError[] | Error;
   typesError?: Linode.ApiFieldError[];
   regionsError?: Linode.ApiFieldError[];
-  volumesError?: Linode.ApiFieldError[] | Error;
+  volumesError?: Linode.ApiFieldError[];
   bucketsError?: Error | Linode.ApiFieldError[];
   userId?: number;
   username: string;
@@ -505,7 +505,9 @@ const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => ({
   settingsError: state.__resources.accountSettings.error,
   typesError: state.__resources.types.error,
   regionsError: state.__resources.regions.error,
-  volumesError: state.__resources.volumes.error,
+  volumesError: state.__resources.volumes.error
+    ? state.__resources.volumes.error.read
+    : undefined,
   bucketsError: state.__resources.buckets.error,
   userId: path(['data', 'uid'], state.__resources.profile),
   username: pathOr('', ['data', 'username'], state.__resources.profile),

--- a/src/containers/volumes.container.ts
+++ b/src/containers/volumes.container.ts
@@ -13,15 +13,15 @@ export interface Props {
   volumesError?: EntityError;
 }
 
-export default <TInner extends {}, TOutter extends {}>(
+export default <TInner extends {}, TOuter extends {}>(
   mapVolumesToProps: (
-    ownProps: TOutter,
+    ownProps: TOuter,
     volumesData: VolumesData,
     volumesLoading: boolean,
     volumesError?: EntityError
   ) => TInner
 ) =>
-  connect((state: ApplicationState, ownProps: TOutter) => {
+  connect((state: ApplicationState, ownProps: TOuter) => {
     const { items, itemsById } = state.__resources.volumes;
 
     const volumesData = { items, itemsById };

--- a/src/containers/volumes.container.ts
+++ b/src/containers/volumes.container.ts
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
+import { EntityError } from 'src/store/types';
 
 interface VolumesData {
   items: string[];
@@ -9,7 +10,7 @@ interface VolumesData {
 export interface Props {
   volumesData: VolumesData;
   volumesLoading: boolean;
-  volumesError?: Error;
+  volumesError?: EntityError;
 }
 
 export default <TInner extends {}, TOutter extends {}>(
@@ -17,7 +18,7 @@ export default <TInner extends {}, TOutter extends {}>(
     ownProps: TOutter,
     volumesData: VolumesData,
     volumesLoading: boolean,
-    volumesError?: Error
+    volumesError?: EntityError
   ) => TInner
 ) =>
   connect((state: ApplicationState, ownProps: TOutter) => {

--- a/src/features/Volumes/VolumeDrawer/EditVolumeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/EditVolumeForm.tsx
@@ -74,7 +74,7 @@ const RenameVolumeForm: React.StatelessComponent<CombinedProps> = props => {
             onClose();
           })
           .catch(errorResponse => {
-            const defaultMessage = `Unable to rename this volume at this time. Please try again later.`;
+            const defaultMessage = `Unable to edit this Volume at this time. Please try again later.`;
             const mapErrorToStatus = (generalError: string) =>
               setStatus({ generalError });
 

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -674,6 +674,6 @@ export default compose<CombinedProps, Props>(
 
 const RenderError = () => {
   return (
-    <ErrorState errorText="There was an error loading your volumes. Please try again later" />
+    <ErrorState errorText="There was an error loading your Volumes. Please try again later" />
   );
 };

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -6,7 +6,6 @@ import { compose } from 'recompose';
 import { bindActionCreators } from 'redux';
 import VolumesIcon from 'src/assets/addnewmenu/volume.svg';
 import AddNewLink from 'src/components/AddNewLink';
-import CircleProgress from 'src/components/CircleProgress';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import {
   StyleRulesCallback,
@@ -20,7 +19,6 @@ import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
 import { PaginationProps } from 'src/components/Pagey';
 import Placeholder from 'src/components/Placeholder';
-import TableRowError from 'src/components/TableRowError';
 import Toggle from 'src/components/Toggle';
 import { regionsWithoutBlockStorage } from 'src/constants';
 import _withEvents, { EventsProps } from 'src/containers/events.container';
@@ -47,6 +45,8 @@ import DestructiveVolumeDialog from './DestructiveVolumeDialog';
 import ListGroupedVolumes from './ListGroupedVolumes';
 import ListVolumes from './ListVolumes';
 import VolumeAttachmentDrawer from './VolumeAttachmentDrawer';
+
+import ErrorState from 'src/components/ErrorState';
 
 type ClassNames =
   | 'root'
@@ -269,18 +269,13 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   render() {
     const {
       classes,
-      volumesLoading,
       volumesError,
       mappedVolumesDataWithLinodes,
       readOnly
     } = this.props;
 
-    if (volumesError) {
+    if (volumesError && volumesError.read) {
       return <RenderError />;
-    }
-
-    if (volumesLoading) {
-      return <RenderLoading />;
     }
 
     // If this is the Volumes tab on a Linode, we want ONLY the Volumes attached to this Linode.
@@ -652,34 +647,33 @@ export default compose<CombinedProps, Props>(
       linodesError
     })
   ),
-  withVolumes((ownProps: CombinedProps, volumesData, volumesLoading) => {
-    const mappedData = volumesData.items.map(id => volumesData.itemsById[id]);
-    const mappedVolumesDataWithLinodes = mappedData.map(volume => {
-      const volumeWithLinodeData = addAttachedLinodeInfoToVolume(
-        volume,
-        ownProps.linodesData
-      );
-      return addRecentEventToVolume(volumeWithLinodeData, ownProps.eventsData);
-    });
-    return {
-      ...ownProps,
-      volumesData,
-      mappedVolumesDataWithLinodes,
-      volumesLoading
-    };
-  }),
+  withVolumes(
+    (ownProps: CombinedProps, volumesData, volumesLoading, volumesError) => {
+      const mappedData = volumesData.items.map(id => volumesData.itemsById[id]);
+      const mappedVolumesDataWithLinodes = mappedData.map(volume => {
+        const volumeWithLinodeData = addAttachedLinodeInfoToVolume(
+          volume,
+          ownProps.linodesData
+        );
+        return addRecentEventToVolume(
+          volumeWithLinodeData,
+          ownProps.eventsData
+        );
+      });
+      return {
+        ...ownProps,
+        volumesData,
+        mappedVolumesDataWithLinodes,
+        volumesLoading,
+        volumesError
+      };
+    }
+  ),
   withSnackbar
 )(VolumesLanding);
 
-const RenderLoading = () => {
-  return <CircleProgress />;
-};
-
 const RenderError = () => {
   return (
-    <TableRowError
-      colSpan={6}
-      message="There was an error loading your volumes. Please try again later"
-    />
+    <ErrorState errorText="There was an error loading your volumes. Please try again later" />
   );
 };

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -23,6 +23,8 @@ import { formatRegion } from 'src/utilities';
 import { withLinodeDetailContext } from '../linodeDetailContext';
 import LinodeNetSummary from './LinodeNetSummary';
 
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
+
 type ClassNames = 'region' | 'volumeLink' | 'regionInner';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
@@ -93,6 +95,7 @@ class SummaryPanel extends React.Component<CombinedProps> {
     const {
       classes,
       linodeVolumes,
+      linodeVolumesError,
       linodeTags,
       linodeId,
       linodeRegion,
@@ -114,13 +117,19 @@ class SummaryPanel extends React.Component<CombinedProps> {
             className={classes.section}
             data-qa-volumes={linodeVolumes.length}
           >
-            Volumes:&#160;
-            <Link
-              className={classes.volumeLink}
-              to={`/linodes/${linodeId}/volumes`}
-            >
-              {linodeVolumes.length}
-            </Link>
+            <Typography>
+              Volumes:&#160;
+              {linodeVolumesError ? (
+                getErrorStringOrDefault(linodeVolumesError)
+              ) : (
+                <Link
+                  className={classes.volumeLink}
+                  to={`/linodes/${linodeId}/volumes`}
+                >
+                  {linodeVolumes.length}
+                </Link>
+              )}
+            </Typography>
           </div>
           <div className={`${classes.section}`}>
             {formatRegion(linodeRegion)}
@@ -190,6 +199,7 @@ interface LinodeContextProps {
   linodeTags: string[];
   mostRecentBackup: string | null;
   linodeVolumes: Linode.Volume[];
+  linodeVolumesError?: Linode.ApiFieldError[];
   backupsEnabled: boolean;
   readOnly: boolean;
 }
@@ -203,6 +213,7 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeId: linode.id,
   backupsEnabled: linode.backups.enabled,
   linodeVolumes: linode._volumes,
+  linodeVolumesError: linode._volumesError,
   readOnly: linode._permissions === 'read_only'
 }));
 

--- a/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -22,7 +22,6 @@ const collectErrors: MapState<InnerProps, OuterProps> = (
   const {
     linodes,
     types,
-    volumes,
     notifications,
     linodeConfigs,
     linodeDisks
@@ -34,8 +33,6 @@ const collectErrors: MapState<InnerProps, OuterProps> = (
       typesError ||
       linodes.error ||
       types.error ||
-      // @todo remove this patch
-      (volumes.error && volumes.lastUpdated === 0 ? volumes.error : false) ||
       notifications.error ||
       linodeConfigs.error ||
       linodeDisks.error

--- a/src/features/linodes/LinodesDetail/maybeWithExtendedLinode.tsx
+++ b/src/features/linodes/LinodesDetail/maybeWithExtendedLinode.tsx
@@ -54,7 +54,8 @@ export default compose<InnerProps, OutterProps>(
       return {
         linode: {
           ...linode,
-          _volumes: getVolumesForLinode(volumes, linodeId),
+          _volumes: getVolumesForLinode(volumes.itemsById, linodeId),
+          _volumesError: volumes.error ? volumes.error.read : undefined,
           _notifications: getNotificationsForLinode(notifications, linodeId),
           _type: getTypeById(types, type),
           _events: eventsForLinode(events, linodeId),

--- a/src/features/linodes/LinodesDetail/types.ts
+++ b/src/features/linodes/LinodesDetail/types.ts
@@ -4,6 +4,7 @@ export interface ExtendedLinode extends Linode.Linode {
   _events: Linode.Event[];
   _notifications: Linode.Notification[];
   _volumes: Linode.Volume[];
+  _volumesError: Linode.ApiFieldError[];
   _type?: null | Linode.LinodeType;
   _permissions: Linode.GrantLevel;
 }

--- a/src/store/store.helpers.test.ts
+++ b/src/store/store.helpers.test.ts
@@ -80,6 +80,7 @@ describe('store.helpers', () => {
     it('should update state with error and complete loading', () => {
       expect(result).toEqual({
         ...createDefaultState(),
+        loading: false,
         error: [{ reason: 'Something bad happened.' }]
       });
     });

--- a/src/store/store.helpers.ts
+++ b/src/store/store.helpers.ts
@@ -23,7 +23,7 @@ export const onGetAllSuccess = <E extends Entity, S>(
   items: E[],
   state: S,
   update: (e: E) => E = i => i
-): MappedEntityState<E> =>
+): S =>
   Object.assign({}, state, {
     loading: false,
     lastUpdated: Date.now(),
@@ -34,12 +34,17 @@ export const onGetAllSuccess = <E extends Entity, S>(
     )
   });
 
-export const onError = <S = {}>(error: Linode.ApiFieldError[], state: S) =>
-  Object.assign({}, state, { error });
+export const onError = <S = {}, E = Linode.ApiFieldError[] | undefined>(
+  error: E,
+  state: S
+) => Object.assign({}, state, { error, loading: false });
 
-export const createDefaultState = <E extends Entity>(
-  override: Partial<MappedEntityState<E>> = {}
-): MappedEntityState<E> => ({
+export const createDefaultState = <
+  E extends Entity,
+  O = Linode.ApiFieldError[] | undefined
+>(
+  override: Partial<MappedEntityState<E, O>> = {}
+): MappedEntityState<E, O> => ({
   itemsById: {},
   items: [],
   loading: true,
@@ -48,24 +53,33 @@ export const createDefaultState = <E extends Entity>(
   ...override
 });
 
-export const onDeleteSuccess = <E extends Entity>(
+export const onDeleteSuccess = <
+  E extends Entity,
+  O = Linode.ApiFieldError[] | undefined
+>(
   id: string | number,
-  state: MappedEntityState<E>
-): MappedEntityState<E> => {
+  state: MappedEntityState<E, O>
+): MappedEntityState<E, O> => {
   return removeMany([String(id)], state);
 };
 
-export const onCreateOrUpdate = <E extends Entity>(
+export const onCreateOrUpdate = <
+  E extends Entity,
+  O = Linode.ApiFieldError[] | undefined
+>(
   entity: E,
-  state: MappedEntityState<E>
-): MappedEntityState<E> => {
+  state: MappedEntityState<E, O>
+): MappedEntityState<E, O> => {
   return addMany([entity], state);
 };
 
-export const removeMany = <E extends Entity>(
+export const removeMany = <
+  E extends Entity,
+  O = Linode.ApiFieldError[] | undefined
+>(
   list: string[],
-  state: MappedEntityState<E>
-): MappedEntityState<E> => {
+  state: MappedEntityState<E, O>
+): MappedEntityState<E, O> => {
   const itemsById = omit(list, state.itemsById);
 
   return {
@@ -75,10 +89,13 @@ export const removeMany = <E extends Entity>(
   };
 };
 
-export const addMany = <E extends Entity>(
+export const addMany = <
+  E extends Entity,
+  O = Linode.ApiFieldError[] | undefined
+>(
   list: E[],
-  state: MappedEntityState<E>
-): MappedEntityState<E> => {
+  state: MappedEntityState<E, O>
+): MappedEntityState<E, O> => {
   const itemsById = list.reduce(
     (map, item) => ({ ...map, [item.id]: item }),
     state.itemsById

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -13,6 +13,13 @@ export type ThunkResult<T> = ThunkAction<
   Action
 >;
 
+export interface EntityError {
+  read?: Linode.ApiFieldError[];
+  create?: Linode.ApiFieldError[];
+  delete?: Linode.ApiFieldError[];
+  update?: Linode.ApiFieldError[];
+}
+
 export type ThunkActionCreator<T> = ActionCreator<ThunkResult<T>>;
 
 export type ThunkDispatch = _ThunkDispatch<ApplicationState, undefined, Action>;
@@ -33,8 +40,11 @@ export type TypeOfID<T> = T extends HasNumericID ? number : string;
 
 export type EntityMap<T> = Record<string, T>;
 
-export interface MappedEntityState<T extends Entity> {
-  error?: Error;
+export interface MappedEntityState<
+  T extends Entity,
+  E = Linode.ApiFieldError[] | undefined
+> {
+  error?: E;
   items: string[];
   itemsById: EntityMap<T>;
   lastUpdated: number;

--- a/src/store/volume/volume.actions.ts
+++ b/src/store/volume/volume.actions.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import {
   AttachVolumePayload,
   CloneVolumePayload,
@@ -21,44 +22,44 @@ export const actionCreator = actionCreatorFactory('@@manager/volumes');
 export const createVolumeActions = actionCreator.async<
   VolumeRequestPayload,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(`create`);
 export const getOneVolumeActions = actionCreator.async<
   VolumeId,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(`get-one`);
 export const updateVolumeActions = actionCreator.async<
   UpdateVolumeParams,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(`update`);
 export const deleteVolumeActions = actionCreator.async<
   VolumeId,
   {},
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(`delete`);
 
 export const attachVolumeActions = actionCreator.async<
   AttachVolumeParams,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(`attach`);
 export const detachVolumeActions = actionCreator.async<
   VolumeId,
   {},
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(`detach`);
 
 export const cloneVolumeActions = actionCreator.async<
   CloneVolumeParams,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(`clone`);
 export const resizeVolumeActions = actionCreator.async<
   ResizeVolumeParams,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(`resize`);
 
 // We want to provide the option NOT to set { loading: true } when requesting all Volumes.
@@ -70,5 +71,5 @@ export interface GetAllVolumesOptions {
 export const getAllVolumesActions = actionCreator.async<
   GetAllVolumesOptions,
   Linode.Volume[],
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >('get-all');

--- a/src/store/volume/volume.reducer.ts
+++ b/src/store/volume/volume.reducer.ts
@@ -18,9 +18,22 @@ import {
   updateVolumeActions
 } from './volume.actions';
 
-export type State = MappedEntityState<Linode.Volume>;
+import { EntityError } from 'src/store/types';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
-export const defaultState: State = createDefaultState<Linode.Volume>();
+export type State = MappedEntityState<Linode.Volume, EntityError>;
+
+export const defaultState: State = createDefaultState<
+  Linode.Volume,
+  EntityError
+>({
+  error: {
+    create: undefined,
+    update: undefined,
+    delete: undefined,
+    read: undefined
+  }
+});
 
 const reducer: Reducer<State> = (state = defaultState, action) => {
   /*
@@ -28,11 +41,16 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
    **/
   if (isType(action, createVolumeActions.done)) {
     const { result } = action.payload;
-    return onCreateOrUpdate(result, state);
+    return onCreateOrUpdate<Linode.Volume, EntityError>(result, state);
   }
   if (isType(action, createVolumeActions.failed)) {
     const { error } = action.payload;
-    return onError(error, state);
+    return onError<MappedEntityState<Linode.Volume, EntityError>, EntityError>(
+      {
+        create: getAPIErrorOrDefault(error)
+      },
+      state
+    );
   }
 
   /*
@@ -40,11 +58,16 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
    **/
   if (isType(action, updateVolumeActions.done)) {
     const { result } = action.payload;
-    return onCreateOrUpdate(result, state);
+    return onCreateOrUpdate<Linode.Volume, EntityError>(result, state);
   }
   if (isType(action, updateVolumeActions.failed)) {
     const { error } = action.payload;
-    return onError(error, state);
+    return onError<MappedEntityState<Linode.Volume, EntityError>, EntityError>(
+      {
+        update: getAPIErrorOrDefault(error)
+      },
+      state
+    );
   }
 
   /*
@@ -52,11 +75,16 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
    **/
   if (isType(action, deleteVolumeActions.done)) {
     const { params } = action.payload;
-    return onDeleteSuccess<Linode.Volume>(params.volumeId, state);
+    return onDeleteSuccess<Linode.Volume, EntityError>(params.volumeId, state);
   }
   if (isType(action, deleteVolumeActions.failed)) {
     const { error } = action.payload;
-    return onError(error, state);
+    return onError<MappedEntityState<Linode.Volume, EntityError>, EntityError>(
+      {
+        delete: getAPIErrorOrDefault(error)
+      },
+      state
+    );
   }
 
   /*
@@ -64,7 +92,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
    */
   if (isType(action, getOneVolumeActions.done)) {
     const { result } = action.payload;
-    return onCreateOrUpdate(result, state);
+    return onCreateOrUpdate<Linode.Volume, EntityError>(result, state);
   }
 
   /*
@@ -77,16 +105,24 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       action
     );
     if (shouldSetLoading) {
-      return onStart(state);
+      return onStart<MappedEntityState<Linode.Volume, EntityError>>(state);
     }
   }
   if (isType(action, getAllVolumesActions.done)) {
     const { result } = action.payload;
-    return onGetAllSuccess(result, state);
+    return onGetAllSuccess<
+      Linode.Volume,
+      MappedEntityState<Linode.Volume, EntityError>
+    >(result, state);
   }
   if (isType(action, getAllVolumesActions.failed)) {
     const { error } = action.payload;
-    return onError(error, state);
+    return onError<MappedEntityState<Linode.Volume, EntityError>, EntityError>(
+      {
+        read: getAPIErrorOrDefault(error)
+      },
+      state
+    );
   }
 
   return state;

--- a/src/store/volume/volume.requests.ts
+++ b/src/store/volume/volume.requests.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import {
   attachVolume as _attachVolume,
   cloneVolume as _cloneVolume,
@@ -36,7 +37,7 @@ export type CreateVolumeRequest = _VolumeRequestPayload;
 export const createVolume = createRequestThunk<
   CreateVolumeRequest,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(createVolumeActions, data => _createVolume(data));
 
 /*
@@ -45,7 +46,7 @@ export const createVolume = createRequestThunk<
 export const updateVolume = createRequestThunk<
   UpdateVolumeParams,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(updateVolumeActions, ({ volumeId, ...data }) =>
   _updateVolume(volumeId, data)
 );
@@ -56,7 +57,7 @@ export const updateVolume = createRequestThunk<
 export const deleteVolume = createRequestThunk<
   VolumeId,
   {},
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(deleteVolumeActions, ({ volumeId }) => _deleteVolume(volumeId));
 
 /*
@@ -65,7 +66,7 @@ export const deleteVolume = createRequestThunk<
 export const attachVolume = createRequestThunk<
   AttachVolumeParams,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(attachVolumeActions, ({ volumeId, ...data }) =>
   _attachVolume(volumeId, data)
 );
@@ -76,7 +77,7 @@ export const attachVolume = createRequestThunk<
 export const detachVolume = createRequestThunk<
   VolumeId,
   {},
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(detachVolumeActions, ({ volumeId }) => _detachVolume(volumeId));
 
 /*
@@ -85,7 +86,7 @@ export const detachVolume = createRequestThunk<
 export const resizeVolume = createRequestThunk<
   ResizeVolumeParams,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(resizeVolumeActions, ({ volumeId, ...payload }) =>
   _resizeVolume(volumeId, payload)
 );
@@ -96,7 +97,7 @@ export const resizeVolume = createRequestThunk<
 export const getOneVolume = createRequestThunk<
   VolumeId,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(getOneVolumeActions, ({ volumeId }) => _getVolume(volumeId));
 
 /*
@@ -105,7 +106,7 @@ export const getOneVolume = createRequestThunk<
 export const cloneVolume = createRequestThunk<
   CloneVolumeParams,
   Linode.Volume,
-  Linode.ApiFieldError[]
+  Error | AxiosError
 >(cloneVolumeActions, ({ volumeId, ...payload }) =>
   _cloneVolume(volumeId, payload)
 );

--- a/src/store/volume/volume.selector.ts
+++ b/src/store/volume/volume.selector.ts
@@ -1,6 +1,7 @@
-import { State } from './volume.reducer';
-
-export const getVolumesForLinode = (state: State, linodeId: number) =>
-  Object.values(state.itemsById).filter(
+export const getVolumesForLinode = (
+  itemsById: Record<string, Linode.Volume>,
+  linodeId: number
+) =>
+  Object.values(itemsById).filter(
     ({ linode_id }) => linode_id && linode_id === linodeId
   );

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -18,7 +18,7 @@ import { pathOr } from 'ramda';
  *
  */
 export const getAPIErrorOrDefault = (
-  errorResponse: AxiosError,
+  errorResponse: AxiosError | Error,
   defaultError: string = 'An unexpected error occurred.',
   field?: string
 ): Linode.ApiFieldError[] => {


### PR DESCRIPTION
## Description

Removes Volumes from the `maybeRenderError` component.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## Note to Reviewers

New volumes error state in Redux looks like the following: 

```
{
  read: Linode.APIFieldError[],
  create: Linode.APIFieldError[],
  update: Linode.APIFieldError[],
  delete: Linode.APIFieldError[]
}
```

### How it Works

First of all, the requests from the services library still return `AxiosError`. They are not converted to `Linode.APIFieldError[]` until we get to the reducer

So:

1. Service function request runs
2. Rejects with `AxiosError`
3. Redux Action is invoked with `AxiosError`
4. In the reducer, `getAPIErrorOrDefault()` is invoked with the `AxiosError`
5. Redux State is set: `{ error: { read: getAPIErrorOrDefault(myError) } }`

### Please Please Note

All the functions in `store.helpers.ts` are backwards compatible. The error type argument defaults to `Linode.APIFieldError[]` but if you want to apply this new logic to another Entity, you will have to implicitly tell the function that it should take an `EntityError`

Look at this line as an example:

https://github.com/linode/manager/compare/develop...martinmckenna:M3-maybe-render-error?expand=1#diff-d845fd14ea6de0c61642a89e997580efR44

### How to apply elsewhere

Applying elsewhere should require a few steps

1. Change `whatever.actions.ts` error type to be `Error | AxiosError`
2. Change `whatever.requests.ts` error type to be `Error | AxiosError`
3. Change function invocations in `whatever.reducer.ts` to accept `EntityError` as a second type argument
     * i.e `onError<MappedEntityState<Linode.Volume, EntityError>, EntityError>`
4. Change consuming components to use the correct error states from Redux