### PR TITLE
M3-2701 Update MUI selects to use react-select

### DIFF
--- a/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
+++ b/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
@@ -166,13 +166,6 @@ class Example extends React.Component<{}, State> {
           createNew={this.createNew}
         />
         <Select
-          variant="async"
-          loadOptions={this.loadOptions}
-          label="Async Select"
-          value={valueAsync}
-          onChange={this.handleChangeAsync}
-        />
-        <Select
           loadOptions={this.loadOptions}
           label="Small Select"
           value={valueAsync}

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -1,7 +1,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import ReactSelect from 'react-select';
-import Async, { AsyncProps } from 'react-select/lib/Async';
 import CreatableSelect, {
   Props as CreatableSelectProps
 } from 'react-select/lib/Creatable';
@@ -299,7 +298,7 @@ export interface EnhancedSelectProps {
   isClearable?: boolean;
   isMulti?: boolean;
   isLoading?: boolean;
-  variant?: 'async' | 'creatable';
+  variant?: 'creatable';
   value?: Item | Item[] | null;
   label?: string;
   placeholder?: string;
@@ -387,13 +386,9 @@ class Select extends React.PureComponent<CombinedProps, {}> {
 
     // If async, pass loadOptions instead of options. A Select can't be both Creatable and Async.
     // (AsyncCreatable exists, but we have not adapted it.)
-    type PossibleProps = BaseSelectProps | CreatableProps | AsyncProps<any>;
+    type PossibleProps = BaseSelectProps | CreatableProps;
     const BaseSelect: React.ComponentClass<PossibleProps> =
-      variant === 'creatable'
-        ? CreatableSelect
-        : variant === 'async'
-        ? Async
-        : ReactSelect;
+      variant === 'creatable' ? CreatableSelect : ReactSelect;
 
     return (
       <BaseSelect
@@ -403,10 +398,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
         isSearchable
         blurInputOnSelect={blurInputOnSelect}
         isLoading={isLoading}
-        defaultOptions
-        cacheOptions={false}
         filterOption={filterOption}
-        loadOptions={loadOptions}
         isMulti={isMulti}
         isDisabled={disabled}
         classes={classes}

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -39,7 +39,9 @@ type ClassNames =
   | 'selectedMenuItem'
   | 'medium'
   | 'small'
-  | 'noMarginTop';
+  | 'noMarginTop'
+  | 'inline'
+  | 'hideLabel';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   '@keyframes dash': {
@@ -213,18 +215,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   suggestionItem: {
     padding: theme.spacing.unit
   },
-  // suggestionIcon: {
-  //   '& svg': {
-  //     width: '40px',
-  //     height: '40px'
-  //   },
-  //   '& .circle': {
-  //     fill: theme.bg.offWhiteDT
-  //   },
-  //   '& .outerCircle': {
-  //     stroke: theme.bg.main
-  //   }
-  // },
   suggestionTitle: {
     fontSize: '1rem',
     color: theme.palette.text.primary,
@@ -270,6 +260,17 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   noMarginTop: {
     marginTop: 0
+  },
+  inline: {
+    display: 'inline-flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    '& label': {
+      marginRight: theme.spacing.unit
+    }
+  },
+  hideLabel: {
+    '& label': { ...theme.visually.hidden }
   }
 });
 
@@ -326,6 +327,8 @@ export interface EnhancedSelectProps {
   small?: boolean;
   guidance?: string | React.ReactNode;
   noMarginTop?: boolean;
+  inline?: boolean;
+  hideLabel?: boolean;
 }
 
 // Material-UI versions of several React-Select components.
@@ -384,6 +387,8 @@ class Select extends React.PureComponent<CombinedProps, {}> {
       medium,
       small,
       noMarginTop,
+      inline,
+      hideLabel,
       ...restOfProps
     } = this.props;
 
@@ -434,7 +439,9 @@ class Select extends React.PureComponent<CombinedProps, {}> {
           className: classNames({
             [classes.medium]: medium,
             [classes.small]: small,
-            [classes.noMarginTop]: noMarginTop
+            [classes.noMarginTop]: noMarginTop,
+            [classes.inline]: inline,
+            [classes.hideLabel]: hideLabel
           })
         }}
         value={value}

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -336,6 +336,7 @@ export interface EnhancedSelectProps {
   noMarginTop?: boolean;
   inline?: boolean;
   hideLabel?: boolean;
+  errorGroup?: string;
 }
 
 // Material-UI versions of several React-Select components.
@@ -396,6 +397,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
       noMarginTop,
       inline,
       hideLabel,
+      errorGroup,
       ...restOfProps
     } = this.props;
 

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -132,6 +132,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
         backgroundColor: theme.bg.white
       }
     },
+    '& .react-select__option--is-disabled': {
+      opacity: '.5',
+      cursor: 'initial'
+    },
     '& .react-select__single-value': {
       color: theme.palette.text.primary,
       overflow: 'initial'

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -36,7 +36,10 @@ type ClassNames =
   | 'suggestionDescription'
   | 'resultContainer'
   | 'tagContainer'
-  | 'selectedMenuItem';
+  | 'selectedMenuItem'
+  | 'medium'
+  | 'small'
+  | 'noMarginTop';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   '@keyframes dash': {
@@ -254,9 +257,15 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       }
     }
   },
+  medium: {
+    minHeight: 40
+  },
   small: {
     minHeight: 35,
     minWidth: 'auto'
+  },
+  noMarginTop: {
+    marginTop: 0
   }
 });
 
@@ -309,8 +318,10 @@ export interface EnhancedSelectProps {
   onInputChange?: (inputValue: string, actionMeta: ActionMeta) => void;
   loadOptions?: (inputValue: string) => Promise<Item | Item[]> | undefined;
   filterOption?: (option: Item, inputValue: string) => boolean | null;
+  medium?: boolean;
   small?: boolean;
   guidance?: string | React.ReactNode;
+  noMarginTop?: boolean;
 }
 
 // Material-UI versions of several React-Select components.
@@ -366,7 +377,9 @@ class Select extends React.PureComponent<CombinedProps, {}> {
       onMenuClose,
       onBlur,
       blurInputOnSelect,
+      medium,
       small,
+      noMarginTop,
       ...restOfProps
     } = this.props;
 
@@ -414,7 +427,11 @@ class Select extends React.PureComponent<CombinedProps, {}> {
           InputLabelProps: {
             shrink: true
           },
-          className: small && classes.small
+          className: classNames({
+            [classes.medium]: medium,
+            [classes.small]: small,
+            [classes.noMarginTop]: noMarginTop
+          })
         }}
         value={value}
         onBlur={onBlur}

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -89,7 +89,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     },
     '& .react-select__group-heading': {
       textTransform: 'initial',
-      fontSize: '.9rem'
+      fontSize: '1rem',
+      color: theme.color.headline,
+      fontFamily: theme.font.bold,
+      paddingLeft: 10,
+      paddingRight: 10
     },
     '& .react-select__menu-list': {
       padding: theme.spacing.unit / 2,

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -266,7 +266,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     flexDirection: 'row',
     alignItems: 'center',
     '& label': {
-      marginRight: theme.spacing.unit
+      marginRight: theme.spacing.unit,
+      whiteSpace: 'nowrap',
+      position: 'relative',
+      top: 1
     }
   },
   hideLabel: {

--- a/src/components/IconTextLink/IconTextLink.tsx
+++ b/src/components/IconTextLink/IconTextLink.tsx
@@ -53,7 +53,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     }
   },
   left: {
-    left: theme.spacing.unit + theme.spacing.unit / 2
+    left: -(theme.spacing.unit + theme.spacing.unit / 2)
   },
   label: {
     whiteSpace: 'nowrap'

--- a/src/components/PaginationFooter/PaginationFooter.tsx
+++ b/src/components/PaginationFooter/PaginationFooter.tsx
@@ -5,9 +5,8 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
-import MenuItem from 'src/components/MenuItem';
-import Select from 'src/components/Select';
 import PaginationControls from '../PaginationControls';
 
 type ClassNames = 'root' | 'padded';
@@ -38,9 +37,15 @@ interface Props extends PaginationProps {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
+const options = [
+  { label: 'Show 25', value: 25 },
+  { label: 'Show 50', value: 50 },
+  { label: 'Show 75', value: 75 },
+  { label: 'Show 100', value: 100 }
+];
+
 class PaginationFooter extends React.PureComponent<CombinedProps> {
-  handleSizeChange = (e: React.ChangeEvent<HTMLSelectElement>) =>
-    this.props.handleSizeChange(+e.target.value);
+  handleSizeChange = (e: Item) => this.props.handleSizeChange(+e.value);
 
   render() {
     const {
@@ -56,6 +61,10 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
     if (count <= 25) {
       return null;
     }
+
+    const defaultPagination = options.find(eachOption => {
+      return eachOption.value === pageSize;
+    });
 
     return (
       <Grid
@@ -78,16 +87,11 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
         </Grid>
         <Grid item>
           <Select
-            value={pageSize}
+            options={options}
+            defaultValue={defaultPagination}
             onChange={this.handleSizeChange}
-            disableUnderline
-            pagination
-          >
-            <MenuItem value={25}>Show 25</MenuItem>
-            <MenuItem value={50}>Show 50</MenuItem>
-            <MenuItem value={75}>Show 75</MenuItem>
-            <MenuItem value={100}>Show 100</MenuItem>
-          </Select>
+            isClearable={false}
+          />
         </Grid>
       </Grid>
     );

--- a/src/components/PaginationFooter/PaginationFooter.tsx
+++ b/src/components/PaginationFooter/PaginationFooter.tsx
@@ -91,6 +91,8 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
             defaultValue={defaultPagination}
             onChange={this.handleSizeChange}
             isClearable={false}
+            noMarginTop
+            medium
           />
         </Grid>
       </Grid>

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -14,6 +14,7 @@ type CSSClasses = 'root' | 'checked' | 'disabled' | 'warning' | 'error';
 const styles: StyleRulesCallback<CSSClasses> = theme => ({
   root: {
     color: '#ccc',
+    padding: '4px 10px',
     transition: theme.transitions.create(['color']),
     '& .defaultFill': {
       transition: theme.transitions.create(['fill'])

--- a/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
+++ b/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
@@ -10,9 +10,9 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import Grid from 'src/components/Grid';
-import MenuItem from 'src/components/MenuItem';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { withAccount } from 'src/features/Billing/context';
@@ -89,12 +89,12 @@ class UpdateCreditCardPanel extends React.Component<CombinedProps, State> {
     });
   };
 
-  handleExpiryMonthChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    this.setState({ expiry_month: +e.target.value });
+  handleExpiryMonthChange = (e: Item<string>) => {
+    this.setState({ expiry_month: +e.value });
   };
 
-  handleExpiryYearChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    this.setState({ expiry_year: +e.target.value });
+  handleExpiryYearChange = (e: Item<string>) => {
+    this.setState({ expiry_year: +e.value });
   };
 
   submitForm = () => {
@@ -168,6 +168,16 @@ class UpdateCreditCardPanel extends React.Component<CombinedProps, State> {
     );
     const generalError = hasErrorFor('none');
 
+    const defaultMonth = UpdateCreditCardPanel.monthMenuItems.find(
+      eachMonth => {
+        return eachMonth.value === this.state.expiry_month;
+      }
+    );
+
+    const defaultYear = UpdateCreditCardPanel.yearMenuItems.find(eachYear => {
+      return eachYear.value === this.state.expiry_year;
+    });
+
     return (
       <ExpansionPanel heading="Update Credit Card" actions={this.renderActions}>
         <Grid container>
@@ -226,29 +236,25 @@ class UpdateCreditCardPanel extends React.Component<CombinedProps, State> {
                 </Grid>
 
                 <Grid item className={classes.fullWidthMobile}>
-                  <TextField
-                    required
-                    select
+                  <Select
+                    options={UpdateCreditCardPanel.monthMenuItems}
                     label="Expiration Month"
-                    value={this.state.expiry_month}
+                    defaultValue={defaultMonth}
                     onChange={this.handleExpiryMonthChange}
                     errorText={hasErrorFor('expiry_month')}
-                  >
-                    {UpdateCreditCardPanel.monthMenuItems}
-                  </TextField>
+                    isClearable={false}
+                  />
                 </Grid>
 
                 <Grid item className={classes.fullWidthMobile}>
-                  <TextField
-                    required
-                    select
+                  <Select
+                    options={UpdateCreditCardPanel.yearMenuItems}
                     label="Expiration Year"
-                    value={this.state.expiry_year}
+                    defaultValue={defaultYear}
                     onChange={this.handleExpiryYearChange}
                     errorText={hasErrorFor('expiry_year')}
-                  >
-                    {UpdateCreditCardPanel.yearMenuItems}
-                  </TextField>
+                    isClearable={false}
+                  />
                 </Grid>
               </Grid>
             </div>
@@ -278,17 +284,14 @@ class UpdateCreditCardPanel extends React.Component<CombinedProps, State> {
   static yearMenuItems = range(
     UpdateCreditCardPanel.currentYear,
     UpdateCreditCardPanel.currentYear + 20
-  ).map((v: number) => (
-    <MenuItem key={v} value={v}>
-      {v}
-    </MenuItem>
-  ));
+  ).map((v: any) => {
+    return { label: v, value: v };
+  });
 
-  static monthMenuItems = range(1, 13).map((v: number) => (
-    <MenuItem key={v} value={v}>
-      {String(v).padStart(2, '0')}
-    </MenuItem>
-  ));
+  static monthMenuItems = range(1, 13).map((v: any) => {
+    const label = String(v).padStart(2, '0');
+    return { label, value: v };
+  });
 }
 
 const styled = withStyles(styles);

--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -19,7 +19,6 @@ import {
 } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import MenuItem from 'src/components/MenuItem';
 import Notice from 'src/components/Notice';
 import {
   default as _TextField,
@@ -318,57 +317,64 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     );
   };
 
-  ProtocolField = () => (
-    <TextField
-      select
-      label="Protocol"
-      value={defaultTo(
-        DomainRecordDrawer.defaultFieldsState(this.props).protocol,
-        (this.state.fields as EditableRecordFields).protocol
-      )}
-      onChange={e => this.setProtocol(e.target.value)}
-      data-qa-protocol
-    >
-      <MenuItem value="tcp" data-qa-protocol-options>
-        tcp
-      </MenuItem>
-      <MenuItem value="udp" data-qa-protocol-options>
-        udp
-      </MenuItem>
-      <MenuItem value="xmpp" data-qa-protocol-options>
-        xmpp
-      </MenuItem>
-      <MenuItem value="tls" data-qa-protocol-options>
-        tls
-      </MenuItem>
-      <MenuItem value="smtp" data-qa-protocol-options>
-        smtp
-      </MenuItem>
-    </TextField>
-  );
+  ProtocolField = () => {
+    const protocolOptions = [
+      { label: 'tcp', value: 'tcp' },
+      { label: 'udp', value: 'udp' },
+      { label: 'xmpp', value: 'xmpp' },
+      { label: 'tls', value: 'tls' },
+      { label: 'smtp', value: 'smtp' }
+    ];
 
-  TagField = () => (
-    <TextField
-      label="Tag"
-      select
-      value={defaultTo(
-        DomainRecordDrawer.defaultFieldsState(this.props).tag,
-        (this.state.fields as EditableRecordFields).tag
-      )}
-      onChange={e => this.setTag(e.target.value)}
-      data-qa-caa-tag
-    >
-      <MenuItem value="issue" data-qa-caa-tags>
-        issue
-      </MenuItem>
-      <MenuItem value="issuewild" data-qa-caa-tags>
-        issuewild
-      </MenuItem>
-      <MenuItem value="iodef" data-qa-caa-tags>
-        iodef
-      </MenuItem>
-    </TextField>
-  );
+    const defaultProtocol = protocolOptions.find(eachProtocol => {
+      return (
+        eachProtocol.value ===
+        defaultTo(
+          DomainRecordDrawer.defaultFieldsState(this.props).protocol,
+          (this.state.fields as EditableRecordFields).protocol
+        )
+      );
+    });
+
+    return (
+      <Select
+        options={protocolOptions}
+        label="Protocol"
+        defaultValue={defaultProtocol}
+        onChange={(e: Item) => this.setProtocol(e.value)}
+        data-qa-protocol
+        isClearable={false}
+      />
+    );
+  };
+
+  TagField = () => {
+    const tagOptions = [
+      { label: 'issue', value: 'issue' },
+      { label: 'issuewild', value: 'issuewild' },
+      { label: 'iodef', value: 'iodef' }
+    ];
+
+    const defaultTag = tagOptions.find(eachTag => {
+      return (
+        eachTag.value ===
+        defaultTo(
+          DomainRecordDrawer.defaultFieldsState(this.props).tag,
+          (this.state.fields as EditableRecordFields).tag
+        )
+      );
+    });
+    return (
+      <Select
+        label="Tag"
+        options={tagOptions}
+        defaultValue={defaultTag || tagOptions[0]}
+        onChange={(e: Item) => this.setTag(e.value)}
+        data-qa-caa-tag
+        isClearable={false}
+      />
+    );
+  };
 
   DomainTransferField = () => (
     <TextField

--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -18,6 +18,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import MenuItem from 'src/components/MenuItem';
 import Notice from 'src/components/Notice';
 import {
@@ -240,29 +241,35 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     <this.MSSelect label="Retry Rate" field="retry_sec" fn={this.setRetrySec} />
   );
 
-  ExpireField = () => (
-    <TextField
-      label="Expire Rate"
-      select
-      value={defaultTo(
-        DomainRecordDrawer.defaultFieldsState(this.props).expire_sec,
-        (this.state.fields as EditableDomainFields).expire_sec
-      )}
-      onChange={e => this.setExpireSec(+e.target.value)}
-      data-qa-expire-rate
-    >
-      <MenuItem value={0}>Default</MenuItem>
-      <MenuItem value={604800} data-qa-expire-options>
-        1 week
-      </MenuItem>
-      <MenuItem value={1209600} data-qa-expire-options>
-        2 weeks
-      </MenuItem>
-      <MenuItem value={2419200} data-qa-expire-options>
-        4 weeks
-      </MenuItem>
-    </TextField>
-  );
+  ExpireField = () => {
+    const rateOptions = [
+      { label: 'Default', value: 0 },
+      { label: '1 week', value: 604800 },
+      { label: '2 weeks', value: 1209600 },
+      { label: '4 weeks', value: 2419200 }
+    ];
+
+    const defaultRate = rateOptions.find(eachRate => {
+      return (
+        eachRate.value ===
+        defaultTo(
+          DomainRecordDrawer.defaultFieldsState(this.props).expire_sec,
+          (this.state.fields as EditableDomainFields).expire_sec
+        )
+      );
+    });
+
+    return (
+      <Select
+        options={rateOptions}
+        label="Expire Rate"
+        defaultValue={defaultRate}
+        onChange={(e: Item) => this.setExpireSec(+e.value)}
+        data-qa-expire-rate
+        isClearable={false}
+      />
+    );
+  };
 
   MSSelect = ({
     label,
@@ -272,56 +279,44 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     label: string;
     field: keyof EditableRecordFields | keyof EditableDomainFields;
     fn: (v: number) => void;
-  }) => (
-    <TextField
-      label={label}
-      select
-      value={defaultTo(
-        DomainRecordDrawer.defaultFieldsState(this.props)[field],
-        this.state.fields[field]
-      )}
-      onChange={e => fn(+e.target.value)}
-      data-qa-domain-select={label}
-    >
-      <MenuItem value={0}>Default</MenuItem>
-      <MenuItem value={300} data-qa-options>
-        5 minutes
-      </MenuItem>
-      <MenuItem value={3600} data-qa-options>
-        1 hour
-      </MenuItem>
-      <MenuItem value={7200} data-qa-options>
-        2 hours
-      </MenuItem>
-      <MenuItem value={14400} data-qa-options>
-        4 hours
-      </MenuItem>
-      <MenuItem value={28800} data-qa-options>
-        8 hours
-      </MenuItem>
-      <MenuItem value={57600} data-qa-options>
-        16 hours
-      </MenuItem>
-      <MenuItem value={86400} data-qa-options>
-        1 day
-      </MenuItem>
-      <MenuItem value={172800} data-qa-options>
-        2 days
-      </MenuItem>
-      <MenuItem value={345600} data-qa-options>
-        4 days
-      </MenuItem>
-      <MenuItem value={604800} data-qa-options>
-        1 week
-      </MenuItem>
-      <MenuItem value={1209600} data-qa-options>
-        2 weeks
-      </MenuItem>
-      <MenuItem value={2419200} data-qa-options>
-        4 weeks
-      </MenuItem>
-    </TextField>
-  );
+  }) => {
+    const MSSelectOptions = [
+      { label: 'Default', value: 0 },
+      { label: '5 minutes', value: 300 },
+      { label: '1 hour', value: 3600 },
+      { label: '2 hours', value: 7200 },
+      { label: '4 hours', value: 14400 },
+      { label: '8 hours', value: 28800 },
+      { label: '16 hours', value: 57600 },
+      { label: '1 day', value: 86400 },
+      { label: '2 days', value: 172800 },
+      { label: '4 days', value: 345600 },
+      { label: '1 week', value: 604800 },
+      { label: '2 weeks', value: 1209600 },
+      { label: '4 weeks', value: 2419200 }
+    ];
+
+    const defaultOption = MSSelectOptions.find(eachOption => {
+      return (
+        eachOption.value ===
+        defaultTo(
+          DomainRecordDrawer.defaultFieldsState(this.props)[field],
+          this.state.fields[field]
+        )
+      );
+    });
+
+    return (
+      <Select
+        options={MSSelectOptions}
+        label={label}
+        defaultValue={defaultOption}
+        onChange={(e: Item) => fn(+e.value)}
+        data-qa-domain-select={label}
+        isClearable={false}
+      />
+    );
+  };
 
   ProtocolField = () => (
     <TextField

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -1232,7 +1232,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   alignItems="center"
                 >
                   <Grid item>
-                    <ActionsPanel>
+                    <ActionsPanel style={{ paddingLeft: 0 }}>
                       {forEdit && (
                         <Button
                           type="primary"

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -16,6 +16,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
@@ -186,8 +187,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
 
   static defaultProps: Partial<Props> = {};
 
-  onAlgorithmChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    this.props.onAlgorithmChange(e.target.value);
+  onAlgorithmChange = (e: Item<string>) =>
+    this.props.onAlgorithmChange(e.value);
 
   onCheckPassiveChange = (
     e: React.ChangeEvent<HTMLInputElement>,
@@ -218,13 +219,11 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
   onPrivateKeyChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.props.onPrivateKeyChange(e.target.value);
 
-  onProtocolChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  onProtocolChange = (e: Item<string>) => {
     const { healthCheckType } = this.props;
-    const {
-      target: { value: protocol }
-    } = e;
+    const { value: protocol } = e;
 
-    this.props.onProtocolChange(e.target.value);
+    this.props.onProtocolChange(e.value);
 
     if (
       protocol === 'tcp' &&
@@ -240,8 +239,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     }
   };
 
-  onSessionStickinessChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    this.props.onSessionStickinessChange(e.target.value);
+  onSessionStickinessChange = (e: Item<string>) =>
+    this.props.onSessionStickinessChange(e.value);
 
   onSslCertificateChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.props.onSslCertificateChange(e.target.value);
@@ -687,6 +686,24 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
 
     const globalFormError = hasErrorFor('none');
 
+    const protocolOptions = [
+      { label: 'TCP', value: 'tcp' },
+      { label: 'HTTP', value: 'http' },
+      { label: 'HTTPS', value: 'https' }
+    ];
+
+    const algOptions = [
+      { label: 'Round Robin', value: 'roundrobin' },
+      { label: 'Least Connections', value: 'leastconn' },
+      { label: 'Source', value: 'source' }
+    ];
+
+    const sessionOptions = [
+      { label: 'None', value: 'none' },
+      { label: 'Table', value: 'table' },
+      { label: 'HTTP Cookie', value: 'http_cookie' }
+    ];
+
     return (
       <Grid item xs={12}>
         <Paper className={classes.root} data-qa-label-header>
@@ -722,12 +739,12 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   Port Configuration
                 </Typography>
               </Grid>
-              <Grid item xs={6} sm={4} md={3} lg={2}>
+              <Grid item xs={6} md={3}>
                 <TextField
                   type="number"
                   label="Port"
                   required
-                  value={port || ''}
+                  defaultValue={port || ''}
                   onChange={this.onPortChange}
                   errorText={hasErrorFor('port') || hasErrorFor('configs')}
                   errorGroup={forEdit ? `${configIdx}` : undefined}
@@ -737,28 +754,20 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 />
                 <FormHelperText>Listen on this port</FormHelperText>
               </Grid>
-              <Grid item xs={6} sm={4} md={3} lg={2}>
-                <TextField
+              <Grid item xs={6} md={3}>
+                <Select
+                  options={protocolOptions}
                   label="Protocol"
-                  value={protocol}
-                  select
+                  defaultValue={protocolOptions[0]}
                   onChange={this.onProtocolChange}
                   errorText={hasErrorFor('protocol')}
-                  errorGroup={forEdit ? `${configIdx}` : undefined}
+                  // errorGroup={forEdit ? `${configIdx}` : undefined}
                   data-qa-protocol-select
-                  small
                   disabled={disabled}
-                >
-                  <MenuItem value="tcp" data-qa-option="tcp">
-                    TCP
-                  </MenuItem>
-                  <MenuItem value="http" data-qa-option="http">
-                    HTTP
-                  </MenuItem>
-                  <MenuItem value="https" data-qa-option="https">
-                    HTTPS
-                  </MenuItem>
-                </TextField>
+                  noMarginTop
+                  small
+                  isClearable={false}
+                />
               </Grid>
 
               {protocol === 'https' && (
@@ -809,28 +818,20 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 </Grid>
               )}
 
-              <Grid item xs={6} sm={4} md={3} lg={2}>
-                <TextField
+              <Grid item xs={6} md={3}>
+                <Select
+                  options={algOptions}
                   label="Algorithm"
-                  value={algorithm}
-                  select
+                  defaultValue={algOptions[0]}
                   onChange={this.onAlgorithmChange}
                   errorText={hasErrorFor('algorithm')}
-                  errorGroup={forEdit ? `${configIdx}` : undefined}
+                  // errorGroup={forEdit ? `${configIdx}` : undefined}
                   data-qa-algorithm-select
                   small
                   disabled={disabled}
-                >
-                  <MenuItem value="roundrobin" data-qa-option="roundrobin">
-                    Round Robin
-                  </MenuItem>
-                  <MenuItem value="leastconn" data-qa-option="leastconn">
-                    Least Connections
-                  </MenuItem>
-                  <MenuItem value="source" data-qa-option="source">
-                    Source
-                  </MenuItem>
-                </TextField>
+                  isClearable={false}
+                  noMarginTop
+                />
                 <FormHelperText>
                   Roundrobin. Least connections assigns connections to the
                   backend with the least connections. Source uses the client's
@@ -838,28 +839,20 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 </FormHelperText>
               </Grid>
 
-              <Grid item xs={6} sm={4} md={3} lg={2}>
-                <TextField
+              <Grid item xs={6} md={3}>
+                <Select
+                  options={sessionOptions}
                   label="Session Stickiness"
-                  value={sessionStickiness}
-                  select
+                  defaultValue={sessionOptions[1]}
                   onChange={this.onSessionStickinessChange}
                   errorText={hasErrorFor('stickiness')}
-                  errorGroup={forEdit ? `${configIdx}` : undefined}
+                  // errorGroup={forEdit ? `${configIdx}` : undefined}
                   data-qa-session-stickiness-select
                   small
                   disabled={disabled}
-                >
-                  <MenuItem value="none" data-qa-option="none">
-                    None
-                  </MenuItem>
-                  <MenuItem value="table" data-qa-option="table">
-                    Table
-                  </MenuItem>
-                  <MenuItem value="http_cookie" data-qa-option="http_cookie">
-                    HTTP Cookie
-                  </MenuItem>
-                </TextField>
+                  isClearable={false}
+                  noMarginTop
+                />
                 <FormHelperText>
                   Route subsequent requests from the client to the same backend
                 </FormHelperText>

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -210,8 +210,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
   onHealthCheckTimeoutChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.props.onHealthCheckTimeoutChange(e.target.value);
 
-  onHealthCheckTypeChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    this.props.onHealthCheckTypeChange(e.target.value);
+  onHealthCheckTypeChange = (e: Item<string>) =>
+    this.props.onHealthCheckTypeChange(e.value);
 
   onPortChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.props.onPortChange(e.target.value);
@@ -406,6 +406,32 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
 
     const conditionalText = this.displayProtocolText(protocol);
 
+    const typeOptions = [
+      {
+        label: 'None',
+        value: 'none'
+      },
+      {
+        label: 'TCP Connection',
+        value: 'connection',
+        isDisabled: protocol === 'http' || protocol === 'https'
+      },
+      {
+        label: 'HTTP Status',
+        value: 'http',
+        disabled: protocol === 'tcp'
+      },
+      {
+        label: 'HTTP Body',
+        value: 'http_body',
+        disabled: protocol === 'tcp'
+      }
+    ];
+
+    const defaultType = typeOptions.find(eachType => {
+      return eachType.value === healthCheckType;
+    });
+
     return (
       <Grid item xs={12} md={4} xl={2}>
         <Grid container>
@@ -430,33 +456,19 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
             xs={12}
           >
             <Grid item xs={12}>
-              <TextField
+              <Select
+                options={typeOptions}
                 label="Type"
-                value={healthCheckType}
-                select
+                defaultValue={defaultType || typeOptions[0]}
                 onChange={this.onHealthCheckTypeChange}
                 errorText={hasErrorFor('check')}
-                errorGroup={forEdit ? `${configIdx}` : undefined}
+                // errorGroup={forEdit ? `${configIdx}` : undefined}
                 data-qa-active-check-select
                 small
                 disabled={disabled}
-              >
-                <MenuItem value="none">None</MenuItem>
-                <MenuItem
-                  value="connection"
-                  disabled={protocol === 'http' || protocol === 'https'}
-                >
-                  TCP Connection
-                </MenuItem>
-
-                <MenuItem value="http" disabled={protocol === 'tcp'}>
-                  HTTP Status
-                </MenuItem>
-
-                <MenuItem value="http_body" disabled={protocol === 'tcp'}>
-                  HTTP Body
-                </MenuItem>
-              </TextField>
+                isClearable={false}
+                noMarginTop
+              />
               <FormHelperText>
                 Active health checks proactively check the health of back-end
                 nodes. {conditionalText}
@@ -490,6 +502,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   errorGroup={forEdit ? `${configIdx}` : undefined}
                   data-qa-active-check-interval
                   disabled={disabled}
+                  small
                 />
                 <FormHelperText>
                   Seconds between health check probes
@@ -520,6 +533,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   errorGroup={forEdit ? `${configIdx}` : undefined}
                   data-qa-active-check-timeout
                   disabled={disabled}
+                  small
                 />
                 <FormHelperText>
                   Seconds to wait before considering the probe a failure. 1-30.
@@ -549,6 +563,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   }}
                   data-qa-active-check-attempts
                   disabled={disabled}
+                  small
                 />
                 <FormHelperText>
                   Number of failed probes before taking a node out of rotation.
@@ -576,6 +591,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                     errorText={hasErrorFor('check_path')}
                     errorGroup={forEdit ? `${configIdx}` : undefined}
                     disabled={disabled}
+                    small
                   />
                 </Grid>
               )}
@@ -600,6 +616,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                     errorText={hasErrorFor('check_body')}
                     errorGroup={forEdit ? `${configIdx}` : undefined}
                     disabled={disabled}
+                    small
                   />
                 </Grid>
               )}
@@ -692,17 +709,29 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
       { label: 'HTTPS', value: 'https' }
     ];
 
+    const defaultProtocol = protocolOptions.find(eachProtocol => {
+      return eachProtocol.value === protocol;
+    });
+
     const algOptions = [
       { label: 'Round Robin', value: 'roundrobin' },
       { label: 'Least Connections', value: 'leastconn' },
       { label: 'Source', value: 'source' }
     ];
 
+    const defaultAlg = algOptions.find(eachAlg => {
+      return eachAlg.value === algorithm;
+    });
+
     const sessionOptions = [
       { label: 'None', value: 'none' },
       { label: 'Table', value: 'table' },
       { label: 'HTTP Cookie', value: 'http_cookie' }
     ];
+
+    const defaultSession = sessionOptions.find(eachSession => {
+      return eachSession.value === sessionStickiness;
+    });
 
     return (
       <Grid item xs={12}>
@@ -758,7 +787,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 <Select
                   options={protocolOptions}
                   label="Protocol"
-                  defaultValue={protocolOptions[0]}
+                  defaultValue={defaultProtocol || protocolOptions[0]}
                   onChange={this.onProtocolChange}
                   errorText={hasErrorFor('protocol')}
                   // errorGroup={forEdit ? `${configIdx}` : undefined}
@@ -822,7 +851,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 <Select
                   options={algOptions}
                   label="Algorithm"
-                  defaultValue={algOptions[0]}
+                  defaultValue={defaultAlg || algOptions[0]}
                   onChange={this.onAlgorithmChange}
                   errorText={hasErrorFor('algorithm')}
                   // errorGroup={forEdit ? `${configIdx}` : undefined}
@@ -843,7 +872,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 <Select
                   options={sessionOptions}
                   label="Session Stickiness"
-                  defaultValue={sessionOptions[1]}
+                  defaultValue={defaultSession || sessionOptions[1]}
                   onChange={this.onSessionStickinessChange}
                   errorText={hasErrorFor('stickiness')}
                   // errorGroup={forEdit ? `${configIdx}` : undefined}

--- a/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -462,7 +462,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 defaultValue={defaultType || typeOptions[0]}
                 onChange={this.onHealthCheckTypeChange}
                 errorText={hasErrorFor('check')}
-                // errorGroup={forEdit ? `${configIdx}` : undefined}
+                errorGroup={forEdit ? `${configIdx}` : undefined}
                 data-qa-active-check-select
                 small
                 disabled={disabled}
@@ -790,7 +790,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   defaultValue={defaultProtocol || protocolOptions[0]}
                   onChange={this.onProtocolChange}
                   errorText={hasErrorFor('protocol')}
-                  // errorGroup={forEdit ? `${configIdx}` : undefined}
+                  errorGroup={forEdit ? `${configIdx}` : undefined}
                   data-qa-protocol-select
                   disabled={disabled}
                   noMarginTop
@@ -854,7 +854,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   defaultValue={defaultAlg || algOptions[0]}
                   onChange={this.onAlgorithmChange}
                   errorText={hasErrorFor('algorithm')}
-                  // errorGroup={forEdit ? `${configIdx}` : undefined}
+                  errorGroup={forEdit ? `${configIdx}` : undefined}
                   data-qa-algorithm-select
                   small
                   disabled={disabled}
@@ -875,7 +875,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   defaultValue={defaultSession || sessionOptions[1]}
                   onChange={this.onSessionStickinessChange}
                   errorText={hasErrorFor('stickiness')}
-                  // errorGroup={forEdit ? `${configIdx}` : undefined}
+                  errorGroup={forEdit ? `${configIdx}` : undefined}
                   data-qa-session-stickiness-select
                   small
                   disabled={disabled}

--- a/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -4,8 +4,6 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import FormControl from 'src/components/core/FormControl';
 import FormHelperText from 'src/components/core/FormHelperText';
-import InputLabel from 'src/components/core/InputLabel';
-import MenuItem from 'src/components/core/MenuItem';
 import {
   StyleRulesCallback,
   withStyles,
@@ -16,8 +14,8 @@ import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Radio from 'src/components/Radio';
-import Select from 'src/components/Select';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TextField from 'src/components/TextField';
@@ -181,8 +179,8 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
     this.props.onChange('label', e.target.value);
   };
 
-  handleExpiryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    this.props.onChange('expiry', e.target.value);
+  handleExpiryChange = (e: Item<string>) => {
+    this.props.onChange('expiry', e.value);
   };
 
   // return whether all scopes selected in the create token flow are the same
@@ -382,6 +380,14 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
 
     const errorFor = getAPIErrorFor(this.errorResources, errors);
 
+    const expiryList = expiryTups.map((expiryTup: Expiry) => {
+      return { label: expiryTup[0], value: expiryTup[1] };
+    });
+
+    const defaultExpiry = expiryList.find(eachOption => {
+      return eachOption.value === expiry;
+    });
+
     return (
       <Drawer
         title={
@@ -404,18 +410,15 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
         )}
         {mode === 'create' && (
           <FormControl>
-            <InputLabel htmlFor="expiry">Expiry</InputLabel>
             <Select
-              value={expiry || expiryTups[0][1]}
+              options={expiryList}
+              defaultValue={defaultExpiry || expiryTups[0][1]}
               onChange={this.handleExpiryChange}
-              inputProps={{ name: 'expiry', id: 'expiry' }}
-            >
-              {expiryTups.map((expiryTup: Expiry) => (
-                <MenuItem key={expiryTup[0]} value={expiryTup[1]}>
-                  {expiryTup[0]}
-                </MenuItem>
-              ))}
-            </Select>
+              name="expiry"
+              id="expiry"
+              label="Expiry"
+              isClearable={false}
+            />
           </FormControl>
         )}
         {mode === 'view' && (

--- a/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -86,7 +86,6 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
   };
 
   handleTimezoneChange = (timezone: Item) => {
-    console.log(timezone);
     if (timezone) {
       this.setState(set(lensPath(['updatedTimezone']), timezone));
     } else {

--- a/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -86,6 +86,7 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
   };
 
   handleTimezoneChange = (timezone: Item) => {
+    console.log(timezone);
     if (timezone) {
       this.setState(set(lensPath(['updatedTimezone']), timezone));
     } else {
@@ -140,6 +141,10 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
     const generalError = hasErrorFor('none');
     const timezoneError = hasErrorFor('timezone');
 
+    const defaultTimeZone = timezoneList.find(eachZone => {
+      return eachZone.label === timezoneDisplay;
+    });
+
     return (
       <React.Fragment>
         <Paper className={classes.root}>
@@ -162,16 +167,17 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
           {generalError && <Notice error text={generalError} />}
           <Typography variant="body1" data-qa-copy>
             This setting converts the dates and times displayed in the Linode
-            Manager to a timezone of your choice. Your current timezone is:{' '}
-            <strong>{timezoneDisplay}</strong>.
+            Manager to a timezone of your choice.{' '}
           </Typography>
           <React.Fragment>
             <Select
               options={timezoneList}
-              placeholder={'Choose a timezone.'}
+              placeholder={'Choose a timezone'}
               errorText={timezoneError}
               onChange={this.handleTimezoneChange}
               data-qa-tz-select
+              defaultValue={defaultTimeZone}
+              isClearable={false}
             />
             <ActionsPanel>
               <Button

--- a/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/src/features/Profile/LishSettings/LishSettings.tsx
@@ -6,7 +6,6 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import FormControl from 'src/components/core/FormControl';
-import FormHelperText from 'src/components/core/FormHelperText';
 import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
@@ -164,11 +163,8 @@ class LishSettings extends React.Component<CombinedProps, State> {
                   onChange={this.onListAuthMethodChange}
                   label="Authentication Mode"
                   isClearable={false}
+                  errorText={authMethodError}
                 />
-
-                {authMethodError && (
-                  <FormHelperText error>{authMethodError}</FormHelperText>
-                )}
               </FormControl>
               {Array.from(Array(authorizedKeysCount)).map((value, idx) => (
                 <div className={classes.sshWrap} key={idx}>

--- a/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/src/features/Profile/LishSettings/LishSettings.tsx
@@ -7,7 +7,6 @@ import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import FormControl from 'src/components/core/FormControl';
 import FormHelperText from 'src/components/core/FormHelperText';
-import InputLabel from 'src/components/core/InputLabel';
 import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
@@ -17,9 +16,8 @@ import {
 import Typography from 'src/components/core/Typography';
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import MenuItem from 'src/components/MenuItem';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
-import Select from 'src/components/Select';
 import TextField from 'src/components/TextField';
 import { LISH } from 'src/documentation';
 import { updateProfile } from 'src/services/profile';
@@ -122,6 +120,25 @@ class LishSettings extends React.Component<CombinedProps, State> {
     const authMethodError = hasErrorFor('lish_auth_method');
     const authorizedKeysError = hasErrorFor('authorized_keys');
 
+    const modeOptions = [
+      {
+        label: 'Allow both password and key authentication',
+        value: 'password_keys'
+      },
+      {
+        label: 'Allow key authentication only',
+        value: 'keys_only'
+      },
+      {
+        label: 'Disable Lish',
+        value: 'disabled'
+      }
+    ];
+
+    const defaultMode = modeOptions.find(eachMode => {
+      return eachMode.value === lishAuthMethod;
+    });
+
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Lish" />
@@ -139,31 +156,19 @@ class LishSettings extends React.Component<CombinedProps, State> {
           {loading ? null : (
             <React.Fragment>
               <FormControl className={classes.modeControl}>
-                <InputLabel
-                  htmlFor="mode-select"
-                  disableAnimation
-                  shrink={true}
-                >
-                  Authentication Mode
-                </InputLabel>
-                <div>
-                  <Select
-                    inputProps={{ name: 'mode-select', id: 'mode-select' }}
-                    value={lishAuthMethod}
-                    onChange={this.onListAuthMethodChange}
-                  >
-                    <MenuItem value={'password_keys'}>
-                      Allow both password and key authentication
-                    </MenuItem>
-                    <MenuItem value={'keys_only'}>
-                      Allow key authentication only
-                    </MenuItem>
-                    <MenuItem value={'disabled'}>Disable Lish</MenuItem>
-                  </Select>
-                  {authMethodError && (
-                    <FormHelperText error>{authMethodError}</FormHelperText>
-                  )}
-                </div>
+                <Select
+                  options={modeOptions}
+                  name="mode-select"
+                  id="mode-select"
+                  defaultValue={defaultMode}
+                  onChange={this.onListAuthMethodChange}
+                  label="Authentication Mode"
+                  isClearable={false}
+                />
+
+                {authMethodError && (
+                  <FormHelperText error>{authMethodError}</FormHelperText>
+                )}
               </FormControl>
               {Array.from(Array(authorizedKeysCount)).map((value, idx) => (
                 <div className={classes.sshWrap} key={idx}>
@@ -252,8 +257,8 @@ class LishSettings extends React.Component<CombinedProps, State> {
       });
   };
 
-  onListAuthMethodChange = (e: React.ChangeEvent<HTMLSelectElement>) =>
-    this.setState({ lishAuthMethod: e.target.value });
+  onListAuthMethodChange = (e: Item<string>) =>
+    this.setState({ lishAuthMethod: e.value });
 
   onPublicKeyChange = (idx: number) => (
     e: React.ChangeEvent<HTMLInputElement>

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -40,7 +40,8 @@ type ClassNames =
   | 'grantTable'
   | 'selectAll'
   | 'tableSubheading'
-  | 'permSelect';
+  | 'permSelect'
+  | 'setAll';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   topGrid: {
@@ -88,6 +89,14 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   selectAll: {
     cursor: 'pointer'
+  },
+  setAll: {
+    width: 300,
+    marginTop: theme.spacing.unit / 2,
+    '& .react-select__menu': {
+      maxWidth: 153,
+      right: 0
+    }
   }
 });
 
@@ -722,6 +731,8 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               label="Set all permissions to:"
               isClearable={false}
               inline
+              className={classes.setAll}
+              noMarginTop
             />
           </Grid>
         </Grid>

--- a/src/features/Users/UserPermissions.tsx
+++ b/src/features/Users/UserPermissions.tsx
@@ -5,7 +5,6 @@ import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
 import Divider from 'src/components/core/Divider';
 import FormControlLabel from 'src/components/core/FormControlLabel';
-import MenuItem from 'src/components/core/MenuItem';
 import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
@@ -17,10 +16,10 @@ import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
-import Select from 'src/components/Select';
 import SelectionCard from 'src/components/SelectionCard';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
@@ -677,19 +676,30 @@ class UserPermissions extends React.Component<CombinedProps, State> {
     );
   };
 
-  setAllEntitiesTo = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value === 'null' ? null : e.target.value;
+  setAllEntitiesTo = (e: Item) => {
+    const value = e.value === 'null' ? null : e.value;
     this.entityPerms.map((entity: Linode.GrantType) =>
       this.entitySetAllTo(entity, value as Linode.GrantLevel)()
     );
     this.setState({
-      setAllPerm: e.target.value as 'null' | 'read_only' | 'read_write'
+      setAllPerm: e.value as 'null' | 'read_only' | 'read_write'
     });
   };
 
   renderSpecificPerms = () => {
     const { classes } = this.props;
     const { grants, success, setAllPerm, saving } = this.state;
+
+    const permOptions = [
+      { label: 'None', value: 'null' },
+      { label: 'Read Only', value: 'read_only' },
+      { label: 'Read Write', value: 'read_write' }
+    ];
+
+    const defaultPerm = permOptions.find(eachPerm => {
+      return eachPerm.value === setAllPerm;
+    });
+
     return (
       <Paper className={classes.globalSection} data-qa-entity-section>
         <Grid container justify="space-between" alignItems="center">
@@ -701,23 +711,18 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               Specific Permissions
             </Typography>
           </Grid>
+
           <Grid item>
-            <Grid container alignItems="center" className={classes.permSelect}>
-              <Grid item>
-                <Typography>Set all permissions to:</Typography>
-              </Grid>
-              <Grid item>
-                <Select
-                  value={setAllPerm}
-                  onChange={this.setAllEntitiesTo}
-                  inputProps={{ name: 'setall', id: 'setall' }}
-                >
-                  <MenuItem value="null">None</MenuItem>
-                  <MenuItem value="read_only">Read Only</MenuItem>
-                  <MenuItem value="read_write">Read Write</MenuItem>
-                </Select>
-              </Grid>
-            </Grid>
+            <Select
+              options={permOptions}
+              defaultValue={defaultPerm}
+              onChange={this.setAllEntitiesTo}
+              name="setall"
+              id="setall"
+              label="Set all permissions to:"
+              isClearable={false}
+              inline
+            />
           </Grid>
         </Grid>
         <div className={classes.section}>

--- a/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -13,9 +13,8 @@ import {
   withStyles
 } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
-import MenuItem from 'src/components/MenuItem';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
-import Select from 'src/components/Select';
 import withVolumesRequests, {
   VolumesRequests
 } from 'src/containers/volumesRequests.container';
@@ -104,8 +103,8 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
     }
   };
 
-  changeSelectedConfig = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    this.setState({ selectedConfig: e.target.value });
+  changeSelectedConfig = (e: Item<string>) => {
+    this.setState({ selectedConfig: e.value });
   };
 
   handleClose = () => {
@@ -172,6 +171,15 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
     const configError = hasErrorFor('config_id');
     const generalError = hasErrorFor('none');
 
+    const configList =
+      configs &&
+      configs.map(el => {
+        return {
+          label: el[1],
+          value: el[0]
+        };
+      });
+
     return (
       <Drawer
         open={open}
@@ -212,21 +220,16 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
               Config
             </InputLabel>
             <Select
-              value={selectedConfig || ''}
+              options={configList}
+              defaultValue={selectedConfig || ''}
               onChange={this.changeSelectedConfig}
-              inputProps={{ name: 'config', id: 'config' }}
-              error={Boolean(configError)}
+              name="config"
+              id="config"
+              errorText={linodeError}
               disabled={disabled || readOnly}
-            >
-              {configs &&
-                configs.map(el => {
-                  return (
-                    <MenuItem key={el[0]} value={el[0]}>
-                      {el[1]}
-                    </MenuItem>
-                  );
-                })}
-            </Select>
+              label="Config"
+              isClearable={false}
+            />
             {Boolean(configError) && (
               <FormHelperText error>{configError}</FormHelperText>
             )}

--- a/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -119,8 +119,6 @@ class ConfigSelect extends React.Component<CombinedProps, State> {
         return { label, value: v };
       });
 
-    console.log('now:' + value);
-
     return (
       <FormControl fullWidth>
         <Select

--- a/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -119,12 +119,14 @@ class ConfigSelect extends React.Component<CombinedProps, State> {
         return { label, value: v };
       });
 
+    console.log('now:' + value);
+
     return (
       <FormControl fullWidth>
         <Select
           options={configList}
           name={name}
-          value={value}
+          defaultValue={configList[0]}
           onChange={(e: Item) => {
             onChange(+e.value);
           }}
@@ -132,6 +134,9 @@ class ConfigSelect extends React.Component<CombinedProps, State> {
           id={name}
           label="Config"
           errorText={error}
+          noMarginTop
+          isClearable={false}
+          placeholder="Select a Config"
           {...rest}
         />
       </FormControl>

--- a/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/ConfigSelect.tsx
@@ -5,10 +5,7 @@ import {
 } from '@material-ui/core/styles';
 import * as React from 'react';
 import FormControl from 'src/components/core/FormControl';
-import FormHelperText from 'src/components/core/FormHelperText';
-import InputLabel from 'src/components/core/InputLabel';
-import MenuItem from 'src/components/core/MenuItem';
-import Select from 'src/components/Select';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import { getLinodeConfigs } from 'src/services/linodes';
 
 type ClassNames = 'root';
@@ -112,41 +109,31 @@ class ConfigSelect extends React.Component<CombinedProps, State> {
     const { error, onChange, name, onBlur, value, ...rest } = this.props;
     const { loading, configs } = this.state;
 
-    const hasError = Boolean(error);
-
     if (!loading && configs.length <= 1) {
       return null;
     }
 
+    const configList =
+      configs &&
+      configs.map(([v, label]) => {
+        return { label, value: v };
+      });
+
     return (
       <FormControl fullWidth>
-        <InputLabel
-          htmlFor={name}
-          disableAnimation
-          shrink={true}
-          error={hasError}
-        >
-          Config
-        </InputLabel>
         <Select
+          options={configList}
           name={name}
           value={value}
-          onChange={e => {
-            onChange(+e.target.value);
+          onChange={(e: Item) => {
+            onChange(+e.value);
           }}
           onBlur={onBlur}
-          inputProps={{ name, id: name }}
-          error={hasError}
+          id={name}
+          label="Config"
+          errorText={error}
           {...rest}
-        >
-          {configs &&
-            configs.map(([v, label]) => (
-              <MenuItem key={v} value={v}>
-                {label}
-              </MenuItem>
-            ))}
-        </Select>
-        {hasError && <FormHelperText error>{error}</FormHelperText>}
+        />
       </FormControl>
     );
   }

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
@@ -189,7 +189,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               error={touched.region ? errors.region : undefined}
               name="region"
               onBlur={handleBlur}
-              onChange={handleChange}
+              onChange={value => setFieldValue('region', value)}
               value={values.region}
               shouldOnlyDisplayRegionsWithBlockStorage={true}
               disabled={disabled}

--- a/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
@@ -182,7 +182,7 @@ export class LinodeSelect extends React.Component<CombinedProps, State> {
       : linodes;
 
     return (
-      <FormControl fullWidth>
+      <>
         <EnhancedSelect
           onBlur={onBlur}
           name={name}
@@ -203,7 +203,7 @@ export class LinodeSelect extends React.Component<CombinedProps, State> {
             Only Linodes in the selected region are displayed.
           </FormHelperText>
         )}
-      </FormControl>
+      </>
     );
   }
 }

--- a/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
@@ -1,7 +1,6 @@
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import _Option from 'react-select/lib/components/Option';
-import FormControl from 'src/components/core/FormControl';
 import FormHelperText from 'src/components/core/FormHelperText';
 import {
   StyleRulesCallback,

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.test.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.test.tsx
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { regionsWithoutBlockStorage } from 'src/constants';
+import { formatRegion } from 'src/utilities';
 import { RegionSelect } from './RegionSelect';
 
 const regionsData: Linode.Region[] = [
@@ -8,6 +9,11 @@ const regionsData: Linode.Region[] = [
   { id: 'us-west', country: 'US' },
   { id: 'ap-northeast-1a', country: 'JP' }
 ];
+
+const regionList = regionsData.map(eachRegion => {
+  const label = formatRegion('' + eachRegion.id);
+  return { label, value: eachRegion.id };
+});
 
 describe('Region Select', () => {
   const wrapper = shallow(
@@ -26,18 +32,18 @@ describe('Region Select', () => {
     expect(wrapper).toHaveLength(1);
   });
   it('includes all regions by default.', () => {
-    regionsData.forEach(region => {
-      expect(
-        wrapper.find(`[data-qa-attach-to-region="${region.id}"]`)
-      ).toHaveLength(1);
+    regionsData.forEach(() => {
+      expect(wrapper.find('WithStyles(Select)').prop('options')).toEqual(
+        regionList
+      );
     });
   });
   it('disables regions without block storage if prop specified', () => {
     wrapper.setProps({ shouldOnlyDisplayRegionsWithBlockStorage: true });
     regionsWithoutBlockStorage.forEach(region => {
-      expect(
-        wrapper.find(`[data-qa-attach-to-region="${region}"]`)
-      ).toHaveLength(0);
+      expect(wrapper.find('WithStyles(Select)').prop('options')).not.toEqual(
+        regionList
+      );
     });
   });
 });

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
@@ -7,7 +7,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import Select from 'src/components/EnhancedSelect/Select';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import regionsContainer, {
   DefaultProps as WithRegions
 } from 'src/containers/regions.container';
@@ -24,7 +24,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 interface Props {
   error?: string;
   name: string;
-  onChange: any;
+  onChange: (value: string) => void;
   onBlur: (e: any) => void;
   value: any;
   shouldOnlyDisplayRegionsWithBlockStorage?: boolean;
@@ -39,7 +39,6 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
     onChange,
     onBlur,
     regionsData,
-    value,
     shouldOnlyDisplayRegionsWithBlockStorage: shouldOnlyDisplayRegionsWithBlockStorage,
     disabled
   } = props;
@@ -56,14 +55,14 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
   return (
     <FormControl fullWidth>
       <Select
-        value={value}
         options={regionList}
         placeholder="All Regions"
-        onChange={onChange}
+        onChange={(item: Item<string>) => onChange(item.value)}
         onBlur={onBlur}
         data-qa-select-region
         disabled={disabled}
         label="Region"
+        isClearable={false}
       />
       {error && <FormHelperText error>{error}</FormHelperText>}
       {!error && shouldOnlyDisplayRegionsWithBlockStorage && (

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import FormControl from 'src/components/core/FormControl';
 import FormHelperText from 'src/components/core/FormHelperText';
 import {
   StyleRulesCallback,

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
@@ -62,8 +62,8 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
         disabled={disabled}
         label="Region"
         isClearable={false}
+        errorText={error}
       />
-      {error && <FormHelperText error>{error}</FormHelperText>}
       {!error && shouldOnlyDisplayRegionsWithBlockStorage && (
         <FormHelperText data-qa-volume-region>
           The datacenter where the new volume should be created. Only regions

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
@@ -53,7 +53,7 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
   });
 
   return (
-    <FormControl fullWidth>
+    <>
       <Select
         options={regionList}
         placeholder="All Regions"
@@ -71,7 +71,7 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
           supporting block storage are displayed.
         </FormHelperText>
       )}
-    </FormControl>
+    </>
   );
 };
 

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
@@ -2,14 +2,12 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import FormControl from 'src/components/core/FormControl';
 import FormHelperText from 'src/components/core/FormHelperText';
-import InputLabel from 'src/components/core/InputLabel';
 import {
   StyleRulesCallback,
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import MenuItem from 'src/components/MenuItem';
-import Select from 'src/components/Select';
+import Select from 'src/components/EnhancedSelect/Select';
 import regionsContainer, {
   DefaultProps as WithRegions
 } from 'src/containers/regions.container';
@@ -26,7 +24,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 interface Props {
   error?: string;
   name: string;
-  onChange: (e: React.ChangeEvent<any>) => void;
+  onChange: any;
   onBlur: (e: any) => void;
   value: any;
   shouldOnlyDisplayRegionsWithBlockStorage?: boolean;
@@ -42,7 +40,6 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
     onBlur,
     regionsData,
     value,
-    name,
     shouldOnlyDisplayRegionsWithBlockStorage: shouldOnlyDisplayRegionsWithBlockStorage,
     disabled
   } = props;
@@ -51,41 +48,23 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
     ? regionsData.filter(region => doesRegionSupportBlockStorage(region.id))
     : regionsData;
 
+  const regionList = regions.map(eachRegion => {
+    const label = formatRegion('' + eachRegion.id);
+    return { label, value: eachRegion.id };
+  });
+
   return (
     <FormControl fullWidth>
-      <InputLabel
-        htmlFor="region"
-        disableAnimation
-        shrink={true}
-        disabled={disabled}
-      >
-        Region
-      </InputLabel>
       <Select
         value={value}
-        name={name}
+        options={regionList}
         placeholder="All Regions"
         onChange={onChange}
         onBlur={onBlur}
-        inputProps={{ name: 'region', id: 'region' }}
         data-qa-select-region
         disabled={disabled}
-      >
-        <MenuItem key="none" value="none">
-          All Regions
-        </MenuItem>
-        {regions.map(eachRegion => {
-          return (
-            <MenuItem
-              data-qa-attach-to-region={eachRegion.id}
-              key={eachRegion.id}
-              value={eachRegion.id}
-            >
-              {formatRegion('' + eachRegion.id)}
-            </MenuItem>
-          );
-        })}
-      </Select>
+        label="Region"
+      />
       {error && <FormHelperText error>{error}</FormHelperText>}
       {!error && shouldOnlyDisplayRegionsWithBlockStorage && (
         <FormHelperText data-qa-volume-region>

--- a/src/features/Volumes/VolumeDrawer/SizeField.tsx
+++ b/src/features/Volumes/VolumeDrawer/SizeField.tsx
@@ -42,7 +42,7 @@ const SizeField: React.StatelessComponent<CombinedProps> = ({
     : undefined;
 
   return (
-    <FormControl fullWidth>
+    <>
       <TextField
         data-qa-size
         errorText={error}
@@ -60,7 +60,7 @@ const SizeField: React.StatelessComponent<CombinedProps> = ({
         {...rest}
       />
       <FormHelperText>The size of the new volume in GiB</FormHelperText>
-    </FormControl>
+    </>
   );
 };
 

--- a/src/features/Volumes/VolumeDrawer/SizeField.tsx
+++ b/src/features/Volumes/VolumeDrawer/SizeField.tsx
@@ -4,7 +4,6 @@ import {
   WithStyles
 } from '@material-ui/core/styles';
 import * as React from 'react';
-import FormControl from 'src/components/core/FormControl';
 import FormHelperText from 'src/components/core/FormHelperText';
 import InputAdornment from 'src/components/core/InputAdornment';
 import TextField from 'src/components/TextField';

--- a/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
@@ -15,10 +15,10 @@ type ClassNames = 'root' | 'copySection' | 'copyField';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   copySection: {
-    marginTop: theme.spacing.unit * 2
+    marginTop: theme.spacing.unit * 3
   },
   copyField: {
-    marginTop: theme.spacing.unit
+    marginTop: theme.spacing.unit / 2
   }
 });
 

--- a/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -78,6 +78,7 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
       errorText={getErrorStringOrDefault(
         generalError || linodeError || linodesError || ''
       )}
+      isClearable={false}
     />
   );
 };

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -13,8 +13,6 @@ import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import FormControl from 'src/components/core/FormControl';
 import FormHelperText from 'src/components/core/FormHelperText';
-import InputLabel from 'src/components/core/InputLabel';
-import MenuItem from 'src/components/core/MenuItem';
 import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
@@ -28,13 +26,13 @@ import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import Currency from 'src/components/Currency';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ErrorState from 'src/components/ErrorState';
 import Notice from 'src/components/Notice';
 import Placeholder from 'src/components/Placeholder';
 import PromiseLoader, {
   PromiseLoaderResponse
 } from 'src/components/PromiseLoader';
-import Select from 'src/components/Select';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TextField from 'src/components/TextField';
@@ -413,20 +411,20 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
     });
   };
 
-  handleSelectBackupWindow = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  handleSelectBackupWindow = (e: Item) => {
     this.setState({
       settingsForm: {
         ...this.state.settingsForm,
-        window: e.target.value as Linode.Window
+        window: e.value as Linode.Window
       }
     });
   };
 
-  handleSelectBackupTime = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  handleSelectBackupTime = (e: Item) => {
     this.setState({
       settingsForm: {
         ...this.state.settingsForm,
-        day: e.target.value as Linode.Day
+        day: e.value as Linode.Day
       }
     });
   };
@@ -625,6 +623,24 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
       getErrorFor('backups.schedule.window') ||
       getErrorFor('backups.schedule.day');
 
+    const timeSelection = this.windows.map((window: Linode.Window[]) => {
+      const label = window[0];
+      return { label, value: window[1] };
+    });
+
+    const daySelection = this.days.map((day: string[]) => {
+      const label = day[0];
+      return { label, value: day[1] };
+    });
+
+    const defaultTimeSelection = timeSelection.find(eachOption => {
+      return eachOption.value === settingsForm.window;
+    });
+
+    const defaultDaySelection = daySelection.find(eachOption => {
+      return eachOption.value === settingsForm.day;
+    });
+
     return (
       <React.Fragment>
         <Paper className={classes.paper}>
@@ -641,38 +657,31 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
             selected day is when the backup is promoted to the weekly slot.
           </Typography>
           <FormControl className={classes.chooseTime}>
-            <InputLabel htmlFor="window">Time of Day</InputLabel>
             <Select
-              value={settingsForm.window}
+              options={timeSelection}
               onChange={this.handleSelectBackupWindow}
-              inputProps={{ name: 'window', id: 'window' }}
               data-qa-time-select
-            >
-              {this.windows.map((window: Linode.Window[]) => (
-                <MenuItem key={window[0]} value={window[1]}>
-                  {window[0]}
-                </MenuItem>
-              ))}
-            </Select>
+              label="Time of Day"
+              placeholder="Choose a time"
+              isClearable={false}
+              defaultValue={defaultTimeSelection}
+              name="Time of Day"
+            />
             <FormHelperText>
               Windows displayed in {this.props.timezone}
             </FormHelperText>
           </FormControl>
 
           <FormControl>
-            <InputLabel htmlFor="day">Day of Week</InputLabel>
             <Select
-              value={settingsForm.day}
+              options={daySelection}
+              defaultValue={defaultDaySelection}
               onChange={this.handleSelectBackupTime}
-              inputProps={{ name: 'day', id: 'day' }}
               data-qa-weekday-select
-            >
-              {this.days.map((day: string[]) => (
-                <MenuItem key={day[0]} value={day[1]}>
-                  {day[0]}
-                </MenuItem>
-              ))}
-            </Select>
+              label="Day of Week"
+              placeholder="Choose a day"
+              isClearable={false}
+            />
           </FormControl>
           <ActionsPanel className={classes.scheduleAction}>
             <Button

--- a/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -72,6 +72,7 @@ type ClassNames =
   | 'snapshotGeneralError'
   | 'scheduleAction'
   | 'chooseTime'
+  | 'chooseDay'
   | 'cancelButton';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
@@ -108,6 +109,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   chooseTime: {
     marginRight: theme.spacing.unit * 2
+  },
+  chooseDay: {
+    minWidth: 150
   },
   cancelButton: {
     marginBottom: theme.spacing.unit
@@ -666,13 +670,14 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
               isClearable={false}
               defaultValue={defaultTimeSelection}
               name="Time of Day"
+              noMarginTop
             />
             <FormHelperText>
               Windows displayed in {this.props.timezone}
             </FormHelperText>
           </FormControl>
 
-          <FormControl>
+          <FormControl className={classes.chooseDay}>
             <Select
               options={daySelection}
               defaultValue={defaultDaySelection}
@@ -681,6 +686,7 @@ class LinodeBackup extends React.Component<CombinedProps, State> {
               label="Day of Week"
               placeholder="Choose a day"
               isClearable={false}
+              noMarginTop
             />
           </FormControl>
           <ActionsPanel className={classes.scheduleAction}>

--- a/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -13,9 +13,8 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
-import MenuItem from 'src/components/MenuItem';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
-import Select from 'src/components/Select';
 import withProfile, { ProfileProps } from 'src/containers/profile.container';
 import { getLinodes, restoreBackup } from 'src/services/linodes';
 import { getPermissionsForLinode } from 'src/store/linodes/permissions/permissions.selector.ts';
@@ -129,8 +128,8 @@ export class RestoreToLinodeDrawer extends React.Component<
       });
   };
 
-  handleSelectLinode = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    this.setState({ selectedLinode: e.target.value });
+  handleSelectLinode = (e: Item<string>) => {
+    this.setState({ selectedLinode: e.value });
   };
 
   handleToggleOverwrite = () => {
@@ -159,6 +158,13 @@ export class RestoreToLinodeDrawer extends React.Component<
     const readOnly = canEditLinode(profile || null, Number(selectedLinode));
     const selectError = Boolean(linodeError) || readOnly;
 
+    const linodeList =
+      linodes &&
+      linodes.map(l => {
+        const label = l[1];
+        return { label, value: l[0] };
+      });
+
     return (
       <Drawer
         open={open}
@@ -175,23 +181,13 @@ export class RestoreToLinodeDrawer extends React.Component<
             Linode
           </InputLabel>
           <Select
-            value={selectedLinode || ''}
+            defaultValue={selectedLinode || ''}
+            options={linodeList}
             onChange={this.handleSelectLinode}
-            inputProps={{ name: 'linode', id: 'linode' }}
-            error={selectError}
-          >
-            <MenuItem value="none" disabled>
-              Select a Linode
-            </MenuItem>
-            {linodes &&
-              linodes.map(l => {
-                return (
-                  <MenuItem data-qa-restore-options key={l[0]} value={l[0]}>
-                    {l[1]}
-                  </MenuItem>
-                );
-              })}
-          </Select>
+            errorText={linodeError}
+            placeholder="Select a Linode"
+            isClearable={false}
+          />
           {selectError && (
             <FormHelperText error>
               {linodeError || "You don't have permission to edit this Linode."}

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -10,12 +10,11 @@ import {
   withStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
-import MenuItem from 'src/components/MenuItem';
 import RenderGuard from 'src/components/RenderGuard';
-import Select from 'src/components/Select';
 import TextField from 'src/components/TextField';
 import { getLinodes } from 'src/services/linodes';
 import { shareAddresses } from 'src/services/networking';
@@ -30,6 +29,7 @@ type ClassNames =
   | 'noIPsMessage'
   | 'networkActionText'
   | 'removeCont'
+  | 'addNewIP'
   | 'remove';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
@@ -61,6 +61,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     [theme.breakpoints.down('xs')]: {
       width: '100%'
     }
+  },
+  addNewIP: {
+    marginLeft: -(theme.spacing.unit + theme.spacing.unit / 2)
   },
   remove: {
     [theme.breakpoints.down('xs')]: {
@@ -176,12 +179,12 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
     );
   };
 
-  onIPSelect = (ipIdx: number) => (e: React.ChangeEvent<HTMLSelectElement>) => {
+  onIPSelect = (ipIdx: number) => (e: Item<string>) => {
     if (ipIdx === undefined) {
       return;
     }
     const newIPsToShare = clone(this.state.ipsToShare);
-    newIPsToShare[+ipIdx] = e.target.value;
+    newIPsToShare[+ipIdx] = e.value;
     if (!this.mounted) {
       return;
     }
@@ -213,6 +216,20 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
 
   renderShareIPRow = (ip: string, idx: number) => {
     const { classes, readOnly } = this.props;
+
+    const ipList = this.remainingChoices(ip).map((ipChoice: string) => {
+      const label = `${ipChoice} ${
+        this.state.ipChoiceLabels[ipChoice] !== undefined
+          ? this.state.ipChoiceLabels[ipChoice]
+          : ''
+      }`;
+      return { label, value: ipChoice };
+    });
+
+    const defaultIP = ipList.find(eachIP => {
+      return eachIP.value === ip;
+    });
+
     return (
       <Grid container key={idx}>
         <Grid item xs={12}>
@@ -220,21 +237,15 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
         </Grid>
         <Grid item xs={12} sm={10}>
           <Select
-            value={ip}
+            defaultValue={defaultIP}
+            options={ipList}
             onChange={this.onIPSelect(idx)}
-            fullWidth={false}
             className={classes.ipField}
             data-qa-share-ip
             disabled={readOnly}
-          >
-            {this.remainingChoices(ip).map(
-              (ipChoice: string, choiceIdx: number) => (
-                <MenuItem data-ip-idx={idx} key={choiceIdx} value={ipChoice}>
-                  {ipChoice} {this.state.ipChoiceLabels[ipChoice]}
-                </MenuItem>
-              )
-            )}
-          </Select>
+            isClearable={false}
+            placeholder="Select an IP"
+          />
         </Grid>
         <Grid item className={classes.removeCont}>
           <Button
@@ -394,7 +405,7 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
                       label="Add IP Address"
                       disabled={readOnly}
                       onClick={this.addIPToShare}
-                      left
+                      className={classes.addNewIP}
                     />
                   </div>
                 )}

--- a/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
@@ -1,14 +1,12 @@
 import { defaultTo } from 'ramda';
 import * as React from 'react';
 import FormControl from 'src/components/core/FormControl';
-import InputLabel from 'src/components/core/InputLabel';
 import {
   StyleRulesCallback,
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import MenuItem from 'src/components/MenuItem';
 import { titlecase } from 'src/features/linodes/presentation';
 
 type ClassNames = 'root';
@@ -58,10 +56,13 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
       {slots.map((slot, idx) => {
         const deviceList = Object.entries(devices).map(([type, items]) => {
           const device = titlecase(type);
-          return { label: device, value: device };
-          // ...(items as any[]).map(({ _id, label }) => {
-          //   return { label, value: _id };
-          // })
+          return {
+            label: device,
+            value: type,
+            options: (items as any[]).map(({ _id, label }) => {
+              return { label, value: _id };
+            })
+          };
         });
 
         return counter < idx ? null : (
@@ -70,41 +71,32 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
             key={slot}
             fullWidth
           >
-            <InputLabel
-              htmlFor={`rescueDevice_${slot}`}
-              disableAnimation
-              shrink={true}
-              disabled={disabled}
-            >
-              /dev/{slot}
-            </InputLabel>
             <Select
               options={deviceList}
               defaultValue={getSelected(slot) || 'none'}
               onChange={(e: Item<string>) => onChange(slot, e.value)}
               disabled={disabled}
               placeholder={'None'}
+              isClearable={false}
+              label={`/dev/${slot}`}
+              noMarginTop
             />
           </FormControl>
         );
       })}
       {rescue && (
         <FormControl fullWidth>
-          <InputLabel
-            htmlFor={`rescueDevice_sdh`}
-            disableAnimation
-            shrink={true}
-            disabled={disabled}
-          >
-            /dev/sdh
-          </InputLabel>
           <Select
             disabled
-            value={'finnix'}
-            inputProps={{ name: `rescueDevice_sdh`, id: `rescueDevice_sdh` }}
-          >
-            <MenuItem value="finnix">Finnix Media</MenuItem>
-          </Select>
+            onChange={() => onChange}
+            options={[]}
+            defaultValue={'finnix'}
+            name="rescueDevice_sdh"
+            id="rescueDevice_sdh"
+            label="/dev/sdh"
+            placeholder="Finnix Media"
+            noMarginTop
+          />
         </FormControl>
       )}
     </React.Fragment>

--- a/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
@@ -7,8 +7,8 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import MenuItem from 'src/components/MenuItem';
-import Select from 'src/components/Select';
 import { titlecase } from 'src/features/linodes/presentation';
 
 type ClassNames = 'root';
@@ -56,6 +56,14 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
   return (
     <React.Fragment>
       {slots.map((slot, idx) => {
+        const deviceList = Object.entries(devices).map(([type, items]) => {
+          const device = titlecase(type);
+          return { label: device, value: device };
+          // ...(items as any[]).map(({ _id, label }) => {
+          //   return { label, value: _id };
+          // })
+        });
+
         return counter < idx ? null : (
           <FormControl
             updateFor={[getSelected(slot), classes]}
@@ -71,32 +79,12 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
               /dev/{slot}
             </InputLabel>
             <Select
-              fullWidth
-              value={getSelected(slot) || 'none'}
-              onChange={e => onChange(slot, e.target.value)}
-              inputProps={{
-                name: `rescueDevice_${slot}`,
-                id: `rescueDevice_${slot}`
-              }}
+              options={deviceList}
+              defaultValue={getSelected(slot) || 'none'}
+              onChange={(e: Item<string>) => onChange(slot, e.value)}
               disabled={disabled}
-            >
-              <MenuItem value="none">None</MenuItem>
-              {Object.entries(devices).map(([type, items]) => [
-                <MenuItem
-                  className="selectHeader"
-                  disabled
-                  key={type}
-                  data-qa-type={titlecase(type)}
-                >
-                  {titlecase(type)}
-                </MenuItem>,
-                ...(items as any[]).map(({ _id, label }) => (
-                  <MenuItem key={_id} value={_id} data-qa-option={label}>
-                    {label}
-                  </MenuItem>
-                ))
-              ])}
-            </Select>
+              placeholder={'None'}
+            />
           </FormControl>
         );
       })}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -24,9 +24,9 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
-import MenuItem from 'src/components/MenuItem';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
 import TextField from 'src/components/TextField';
@@ -278,6 +278,21 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       volumes: this.props.volumes
     };
 
+    const kernelList = kernels.map(eachKernel => {
+      return { label: eachKernel.label, value: eachKernel.id };
+    });
+
+    const pathsOptions = [
+      { label: '/dev/sda', value: '/dev/sda' },
+      { label: '/dev/sdb', value: '/dev/sdc' },
+      { label: '/dev/sdc', value: '/dev/sdc' },
+      { label: '/dev/sdd', value: '/dev/sdd' },
+      { label: '/dev/sde', value: '/dev/sde' },
+      { label: '/dev/sdf', value: '/dev/sdf' },
+      { label: '/dev/sdg', value: '/dev/sdg' },
+      { label: '/dev/sdh', value: '/dev/sdh' }
+    ];
+
     return (
       <React.Fragment>
         {generalError && (
@@ -375,28 +390,16 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
         >
           <Typography variant="h3">Boot Settings</Typography>
           {kernels && (
-            <TextField
-              label="Kernel"
-              select={true}
-              value={kernel}
+            <Select
+              options={kernelList}
+              label="Select a Kernel"
+              defaultValue={kernel}
               onChange={this.handleChangeKernel}
               errorText={errorFor('kernel')}
-              errorGroup="linode-config-drawer"
+              // errorGroup="linode-config-drawer"
               disabled={readOnly}
-            >
-              <MenuItem value="none" disabled>
-                <em>Select a Kernel</em>
-              </MenuItem>
-              {kernels.map(eachKernel => (
-                <MenuItem
-                  // Can't use ID for key until DBA-162 is closed.
-                  key={`${eachKernel.id}-${eachKernel.label}`}
-                  value={eachKernel.id}
-                >
-                  {eachKernel.label}
-                </MenuItem>
-              ))}
-            </TextField>
+              isClearable={false}
+            />
           )}
 
           <FormControl
@@ -470,35 +473,31 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                 />
               }
             />
-
-            <TextField
-              label={`${useCustomRoot ? 'Custom ' : ''}Root Device`}
-              value={root_device}
-              onChange={this.handleRootDeviceChange}
-              inputProps={{ name: 'root_device', id: 'root_device' }}
-              select={!useCustomRoot}
-              fullWidth
-              autoFocus={useCustomRoot && true}
-              errorText={errorFor('root_device')}
-              errorGroup="linode-config-drawer"
-              disabled={readOnly}
-            >
-              {!useCustomRoot &&
-                [
-                  '/dev/sda',
-                  '/dev/sdb',
-                  '/dev/sdc',
-                  '/dev/sdd',
-                  '/dev/sde',
-                  '/dev/sdf',
-                  '/dev/sdg',
-                  '/dev/sdh'
-                ].map(path => (
-                  <MenuItem key={path} value={path}>
-                    {path}
-                  </MenuItem>
-                ))}
-            </TextField>
+            {!useCustomRoot ? (
+              <Select
+                options={pathsOptions}
+                label="Root Device"
+                defaultValue={root_device}
+                onChange={this.handleRootDeviceChange}
+                name="root_device"
+                id="root_device"
+                errorText={errorFor('root_device')}
+                disabled={readOnly}
+                isClearable={false}
+              />
+            ) : (
+              <TextField
+                label="Custom"
+                value={root_device}
+                onChange={this.handleRootDeviceChangeTextfield}
+                inputProps={{ name: 'root_device', id: 'root_device' }}
+                fullWidth
+                autoFocus={true}
+                errorText={errorFor('root_device')}
+                errorGroup="linode-config-drawer"
+                disabled={readOnly}
+              />
+            )}
           </FormControl>
         </Grid>
 
@@ -710,7 +709,10 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
       helpers: { ...this.state.fields.helpers, distro: result }
     });
 
-  handleRootDeviceChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+  handleRootDeviceChange = (e: Item<string>) =>
+    this.updateField({ root_device: e.value || '' });
+
+  handleRootDeviceChangeTextfield = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.updateField({ root_device: e.target.value || '' });
 
   handleUseCustomRootChange = (e: any, useCustomRoot: boolean) =>
@@ -735,8 +737,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
   handleChangeComments = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.updateField({ comments: e.target.value || '' });
 
-  handleChangeKernel = (e: React.ChangeEvent<HTMLSelectElement>) =>
-    this.updateField({ kernel: e.target.value });
+  handleChangeKernel = (e: Item<string>) =>
+    this.updateField({ kernel: e.value });
 
   handleChangeLabel = (e: React.ChangeEvent<HTMLInputElement>) =>
     this.updateField({ label: e.target.value || '' });

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -396,7 +396,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               defaultValue={kernel}
               onChange={this.handleChangeKernel}
               errorText={errorFor('kernel')}
-              // errorGroup="linode-config-drawer"
+              errorGroup="linode-config-drawer"
               disabled={readOnly}
               isClearable={false}
             />

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -357,7 +357,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
           </FormControl>
         </Grid>
 
-        <Divider className={classes.divider} />
+        <Divider className={classes.divider} style={{ marginTop: 0 }} />
 
         <Grid
           item

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -226,6 +226,7 @@ class LinodeSettingsPasswordPanel extends React.Component<
           value={selectedDisk}
           data-qa-select-linode
           disabled={disabled}
+          isClearable={false}
         />
         <PasswordInput
           autoComplete="new-password"

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -19,9 +19,7 @@ import { ExtendedEvent } from 'src/store/events/event.helpers';
 type ClassNames = 'root' | 'header' | 'viewMore';
 
 const styles: StyleRulesCallback<ClassNames> = (theme: Theme) => ({
-  root: {
-    marginBottom: theme.spacing.unit * 4
-  },
+  root: {},
   header: {
     marginBottom: theme.spacing.unit * 2
   },

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -23,46 +23,14 @@ describe('LinodeSummary', () => {
         graphControls: '',
         graphTitle: '',
         graphSelectTitle: '',
-        totalTraffic: ''
+        totalTraffic: '',
+        chartSelect: ''
       }}
       typesData={[]}
     />
   );
 
-  it('should include "Last 24 Hours" as the first option', () => {
-    expect(
-      wrapper
-        .find('WithStyles(MenuItem)')
-        .at(0)
-        .children()
-        .text()
-    ).toBe('Last 24 Hours');
-    expect(
-      wrapper
-        .find('WithStyles(MenuItem)')
-        .at(0)
-        .props().value
-    ).toBe('24');
-  });
-
-  it('should include "Last 30 Days" as the second option', () => {
-    const currentMonth = new Date().getMonth() + 1;
-    const currentYear = new Date().getFullYear();
-
-    const paddedCurrentMonth = currentMonth.toString().padStart(2, '0');
-
-    expect(
-      wrapper
-        .find('WithStyles(MenuItem)')
-        .at(1)
-        .children()
-        .text()
-    ).toBe('Last 30 Days');
-    expect(
-      wrapper
-        .find('WithStyles(MenuItem)')
-        .at(1)
-        .props().value
-    ).toBe(`${currentYear} ${paddedCurrentMonth}`);
+  it('should have a select menu for the graphs', () => {
+    expect(wrapper.find('[data-qa-item="chartRange"]')).toHaveLength(1);
   });
 });

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -717,7 +717,6 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                   hideLabel
                   className={classes.chartSelect}
                   isClearable={false}
-                  menuIsOpen={true}
                   data-qa-item="chartRange"
                 />
               </div>

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -3,9 +3,6 @@ import { map, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'recompose';
-import FormControl from 'src/components/core/FormControl';
-import InputLabel from 'src/components/core/InputLabel';
-import MenuItem from 'src/components/core/MenuItem';
 import {
   StyleRulesCallback,
   withStyles,
@@ -13,9 +10,9 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import LineGraph from 'src/components/LineGraph';
-import Select from 'src/components/Select';
 import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
 import { displayType, typeLabelLong } from 'src/features/linodes/presentation';
 import { getLinodeStats, getLinodeStatsByDate } from 'src/services/linodes';
@@ -46,6 +43,7 @@ type ClassNames =
   | 'sidebar'
   | 'headerWrapper'
   | 'chart'
+  | 'chartSelect'
   | 'leftLegend'
   | 'bottomLegend'
   | 'graphTitle'
@@ -120,6 +118,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => {
     },
     totalTraffic: {
       margin: '12px'
+    },
+    chartSelect: {
+      maxWidth: 150
     }
   };
 };
@@ -157,7 +158,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
     dataIsLoading: false
   };
 
-  rangeSelectOptions: (typeof MenuItem)[] = [];
+  rangeSelectOptions: Item[] = [];
 
   constructor(props: CombinedProps) {
     super(props);
@@ -214,11 +215,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           : `${testYear}-${testMonth}-01`;
     } while (moment(formattedTestDate).diff(creationFirstOfMonth) >= 0);
     (this.rangeSelectOptions as Linode.TodoAny) = options.map(option => {
-      return (
-        <MenuItem key={option[0]} value={option[0]}>
-          {option[1]}
-        </MenuItem>
-      );
+      return { label: option[1], value: option[0] };
     });
   }
 
@@ -299,8 +296,8 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
       });
   };
 
-  handleChartRangeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const value = e.target.value;
+  handleChartRangeChange = (e: Item<string>) => {
+    const value = e.value;
     this.setState({ rangeSelection: value }, () => {
       this.getStats();
     });
@@ -655,12 +652,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
   render() {
     const { linodeData: linode, classes, typesData } = this.props;
 
-    const {
-      dataIsLoading,
-      statsError,
-      rangeSelection,
-      isTooEarlyForGraphData
-    } = this.state;
+    const { dataIsLoading, statsError, isTooEarlyForGraphData } = this.state;
 
     // Shared props for all stats charts
     const chartProps = {
@@ -714,19 +706,20 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
 
             <Grid item className="py0">
               <div className={classes.graphControls}>
-                <FormControl>
-                  <InputLabel htmlFor="chartRange" disableAnimation hidden>
-                    Select Time Range
-                  </InputLabel>
-                  <Select
-                    value={rangeSelection}
-                    onChange={this.handleChartRangeChange}
-                    inputProps={{ name: 'chartRange', id: 'chartRange' }}
-                    small
-                  >
-                    {this.rangeSelectOptions}
-                  </Select>
-                </FormControl>
+                <Select
+                  options={this.rangeSelectOptions}
+                  defaultValue={this.rangeSelectOptions[0]}
+                  onChange={this.handleChartRangeChange}
+                  name="chartRange"
+                  id="chartRange"
+                  small
+                  label="Select Time Range"
+                  hideLabel
+                  className={classes.chartSelect}
+                  isClearable={false}
+                  menuIsOpen={true}
+                  data-qa-item="chartRange"
+                />
               </div>
             </Grid>
 

--- a/src/index.css
+++ b/src/index.css
@@ -108,6 +108,16 @@ body.searchOverlay #main-content {
   height: 100%;
 }
 
+.visually-hidden {
+  /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
+}
+
 .tac {
   text-align: center;
 }

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -44,6 +44,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     '@keyframes dash': any;
     bg: any;
     color: any;
+    visually: any;
     font?: any;
     animateCircleIcon?: any;
     notificationList: any;
@@ -56,6 +57,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
     '@keyframes dash'?: any;
     bg?: any;
     color?: any;
+    visually?: any;
     font?: any;
     animateCircleIcon?: any;
     notificationList?: any;
@@ -105,6 +107,24 @@ const iconCircleAnimation = {
     transition: 'fill .2s ease-in-out .2s, stroke .2s ease-in-out .2s',
     stroke: 'white'
   }
+};
+
+const visuallyVisible = {
+  /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+  position: 'relative',
+  height: 'auto',
+  width: 'auto',
+  overflow: 'initial',
+  clip: 'none'
+};
+
+const visuallyHidden = {
+  /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+  position: 'absolute !important',
+  height: 1,
+  width: 1,
+  overflow: 'hidden',
+  clip: 'rect(1px, 1px, 1px, 1px)'
 };
 
 const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
@@ -277,6 +297,10 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
         fontSize: '1.075rem',
         lineHeight: '1.5rem'
       }
+    },
+    visually: {
+      visible: visuallyVisible,
+      hidden: visuallyHidden
     },
     overrides: {
       MuiAppBar: {

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -657,6 +657,14 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
           marginLeft: -(spacingUnit + 3)
         }
       },
+      MuiFormGroup: {
+        root: {
+          '&[role="radiogroup"]': {
+            marginTop: spacingUnit,
+            marginBottom: spacingUnit * 2
+          }
+        }
+      },
       MuiFormLabel: {
         root: {
           color: '#555',


### PR DESCRIPTION
## Update MUI selects to use react-select

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

The following selects have been replaced:

- volume drawer > region select (edit, create volume)
- time of day and day selects on /linodes/[id]/backup
- pagination select
- restore backup drawer select (/linodes/[id]/backup > restore)
- IP transfer selects /linodes/[id]/networking > IP transfer
- IP sharing selects /linodes/[id]/networking > IP sharing
- Linode rescue selects
- Linode summary charts select (need a better test)
- API drawer token select
- Profile > Lish
- volumes attach drawer
- advanced config drawer
- domain drawers selects
- account CC update selects
- create a ticket selects