### PR TITLE
Dropdown fields in OCA creation screen get cut off

### DIFF
--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -60,7 +60,7 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
     const isOptional = field.hasOwnProperty('default');
     if (isMultiSelect(field)) {
       return (
-        <Grid item xs={12} sm={6} md={4} key={field.name}>
+        <Grid item xs={12} lg={5} key={field.name}>
           <UserDefinedMultiSelect
             key={field.name}
             field={field}
@@ -75,7 +75,7 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
     }
     if (isOneSelect(field)) {
       return (
-        <Grid item xs={12} sm={6} md={4} key={field.name}>
+        <Grid item xs={12} lg={5} key={field.name}>
           <UserDefinedSelect
             field={field}
             updateFormState={handleChange}
@@ -90,7 +90,7 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
     }
     if (isPasswordField(field.name)) {
       return (
-        <Grid item xs={12} sm={6} md={4} key={field.name}>
+        <Grid item xs={12} lg={5} key={field.name}>
           <UserDefinedText
             updateFormState={handleChange}
             isPassword={true}
@@ -105,7 +105,7 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
       );
     }
     return (
-      <Grid item xs={12} sm={6} md={4} key={field.name}>
+      <Grid item xs={12} lg={5} key={field.name}>
         <UserDefinedText
           updateFormState={handleChange}
           field={field}


### PR DESCRIPTION
## Description

Some UDFs were getting cutoff depending on screen size. To test, go to linode create flow, and select an OCA that has selects, such as CSGO or minecraft. You should observe the right border of the selects is no longer being cutoff no matter your screen size. 

## Type of Change
- Bug fix ('fix', 'repair', 'bug')