### PR TITLE
Fix: Volume Attachment Always Shows Error

### DIFF
--- a/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -76,7 +76,7 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
         handleChange(selected ? selected.value : null)
       }
       errorText={getErrorStringOrDefault(
-        generalError || linodeError || linodesError || []
+        generalError || linodeError || linodesError || ''
       )}
     />
   );


### PR DESCRIPTION
## Description

Volume attachment drawer was always showing an error because the default was an empty array and `![] === false` in JS

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A