### PR TITLE
Add: M3-2694 Scroll-to logic for Disks and Configs page changes

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -537,11 +537,7 @@ const MyComponent: React.FC<ReduxStateProps> = (props) => {
             count={count}
             page={page}
             pageSize={pageSize}
-            /* 
-              handlePageChange takes an optional boolean argument of 
-              whether you want to auto scroll-to-top
-            */
-            handlePageChange={handlePageChange()}
+            handlePageChange={handlePageChange}
             handleSizeChange={handlePageSizeChange}
           />
         </React.Fragment>

--- a/src/components/Paginate.ts
+++ b/src/components/Paginate.ts
@@ -20,7 +20,7 @@ const createDiplayPage = <T extends any>(page: number, pageSize: number) => (
 };
 
 export interface PaginationProps extends State {
-  handlePageChange: (shouldScrollToTop?: boolean) => (page: number) => void;
+  handlePageChange: (page: number) => void;
   handlePageSizeChange: (pageSize: number) => void;
   data: any[];
   count: number;
@@ -45,11 +45,9 @@ export default class Paginate extends React.Component<Props, State> {
     pageSize: storage.pageSize.get()
   };
 
-  handlePageChange = (shouldScrollToTop: boolean = true) => (page: number) => {
+  handlePageChange = (page: number) => {
     const { scrollToRef } = this.props;
-    if (shouldScrollToTop) {
-      scrollTo(scrollToRef);
-    }
+    scrollTo(scrollToRef);
     this.setState({ page });
   };
 

--- a/src/components/core/RootRef.ts
+++ b/src/components/core/RootRef.ts
@@ -1,0 +1,8 @@
+import RootRef, {
+  RootRefProps as _RootRefProps
+} from '@material-ui/core/RootRef';
+
+/* tslint:disable-next-line:no-empty-interface */
+export interface RootRefProps extends _RootRefProps {}
+
+export default RootRef;

--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -761,7 +761,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                             </Paper>
                             <PaginationFooter
                               count={count}
-                              handlePageChange={handlePageChange()}
+                              handlePageChange={handlePageChange}
                               handleSizeChange={handlePageSizeChange}
                               page={page}
                               pageSize={pageSize}

--- a/src/features/Domains/ListDomains.tsx
+++ b/src/features/Domains/ListDomains.tsx
@@ -89,7 +89,7 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
             count={count}
             page={page}
             pageSize={pageSize}
-            handlePageChange={handlePageChange()}
+            handlePageChange={handlePageChange}
             handleSizeChange={handlePageSizeChange}
             eventCategory="domains landing"
           />

--- a/src/features/Domains/ListGroupedDomains.tsx
+++ b/src/features/Domains/ListGroupedDomains.tsx
@@ -141,7 +141,7 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
                           >
                             <PaginationFooter
                               count={count}
-                              handlePageChange={handlePageChange()}
+                              handlePageChange={handlePageChange}
                               handleSizeChange={handlePageSizeChange}
                               pageSize={pageSize}
                               page={page}

--- a/src/features/Images/ImagesLanding.tsx
+++ b/src/features/Images/ImagesLanding.tsx
@@ -381,7 +381,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
                   </Paper>
                   <PaginationFooter
                     count={count}
-                    handlePageChange={handlePageChange()}
+                    handlePageChange={handlePageChange}
                     handleSizeChange={handlePageSizeChange}
                     page={page}
                     pageSize={pageSize}

--- a/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
@@ -142,7 +142,7 @@ const ListGroupedNodeBalancers: React.StatelessComponent<
                             count={count}
                             page={page}
                             pageSize={pageSize}
-                            handlePageChange={handlePageChange()}
+                            handlePageChange={handlePageChange}
                             handleSizeChange={handlePageSizeChange}
                             eventCategory="nodebalancers landing"
                           />

--- a/src/features/NodeBalancers/NodeBalancersLanding/ListNodeBalancers.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/ListNodeBalancers.tsx
@@ -73,7 +73,7 @@ const ListNodeBalancers: React.StatelessComponent<CombinedProps> = props => {
             count={count}
             page={page}
             pageSize={pageSize}
-            handlePageChange={handlePageChange()}
+            handlePageChange={handlePageChange}
             handleSizeChange={handlePageSizeChange}
             eventCategory="nodebalancers landing"
           />

--- a/src/features/ObjectStorage/Buckets/ListBuckets.tsx
+++ b/src/features/ObjectStorage/Buckets/ListBuckets.tsx
@@ -180,7 +180,7 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
             count={count}
             page={page}
             pageSize={pageSize}
-            handlePageChange={handlePageChange()}
+            handlePageChange={handlePageChange}
             handleSizeChange={handlePageSizeChange}
             eventCategory="object storage landing"
           />

--- a/src/features/Volumes/ListGroupedVolumes.tsx
+++ b/src/features/Volumes/ListGroupedVolumes.tsx
@@ -130,7 +130,7 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
                           >
                             <PaginationFooter
                               count={count}
-                              handlePageChange={handlePageChange()}
+                              handlePageChange={handlePageChange}
                               handleSizeChange={handlePageSizeChange}
                               pageSize={pageSize}
                               page={page}

--- a/src/features/Volumes/ListVolumes.tsx
+++ b/src/features/Volumes/ListVolumes.tsx
@@ -77,7 +77,7 @@ const ListVolumes: React.StatelessComponent<CombinedProps> = props => {
             count={count}
             page={page}
             pageSize={pageSize}
-            handlePageChange={handlePageChange()}
+            handlePageChange={handlePageChange}
             handleSizeChange={handlePageSizeChange}
             eventCategory="volumes landing"
           />

--- a/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectLinodePanel.tsx
@@ -115,7 +115,7 @@ class SelectLinodePanel extends React.Component<CombinedProps> {
                 </Paper>
                 <PaginationFooter
                   count={count}
-                  handlePageChange={handlePageChange()}
+                  handlePageChange={handlePageChange}
                   handleSizeChange={handlePageSizeChange}
                   page={page}
                   pageSize={pageSize}

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -86,13 +86,15 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
     configDrawer: this.defaultConfigDrawerState
   };
 
+  configsPanel = React.createRef();
+
   render() {
     const { classes, readOnly } = this.props;
 
     return (
       <React.Fragment>
         <Grid container justify="space-between" alignItems="flex-end">
-          <Grid item>
+          <Grid item innerRef={this.configsPanel}>
             <Typography variant="h3" className={classes.headline}>
               Configuration
             </Typography>
@@ -255,7 +257,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
 
   linodeConfigsTable = () => {
     return (
-      <Paginate data={this.props.configs}>
+      <Paginate data={this.props.configs} scrollToRef={this.configsPanel}>
         {({
           data: paginatedData,
           handlePageChange,
@@ -285,7 +287,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
                 count={count}
                 page={page}
                 pageSize={pageSize}
-                handlePageChange={handlePageChange(false)}
+                handlePageChange={handlePageChange}
                 handleSizeChange={handlePageSizeChange}
                 eventCategory="linode configs"
               />

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -5,6 +5,7 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import RootRef from 'src/components/core/RootRef';
 import {
   StyleRulesCallback,
   withStyles,
@@ -94,11 +95,13 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <Grid container justify="space-between" alignItems="flex-end">
-          <Grid item innerRef={this.configsPanel}>
-            <Typography variant="h3" className={classes.headline}>
-              Configuration
-            </Typography>
-          </Grid>
+          <RootRef rootRef={this.configsPanel}>
+            <Grid item>
+              <Typography variant="h3" className={classes.headline}>
+                Configuration
+              </Typography>
+            </Grid>
+          </RootRef>
           <Grid item className={classes.addNewWrapper}>
             <AddNewLink
               onClick={this.openConfigDrawerForCreation}

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -6,6 +6,7 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import RootRef from 'src/components/core/RootRef';
 import {
   StyleRulesCallback,
   withStyles,
@@ -177,11 +178,13 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <Grid container justify="space-between" alignItems="flex-end">
-          <Grid item innerRef={this.disksHeader}>
-            <Typography variant="h3" className={classes.headline}>
-              Disks
-            </Typography>
-          </Grid>
+          <RootRef rootRef={this.disksHeader}>
+            <Grid item>
+              <Typography variant="h3" className={classes.headline}>
+                Disks
+              </Typography>
+            </Grid>
+          </RootRef>
           <Grid item className={classes.addNewWrapper}>
             <AddNewLink
               onClick={this.openDrawerForCreation}

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -126,39 +126,46 @@ type CombinedProps = UserSSHKeyProps &
   WithStyles<ClassNames> &
   WithSnackbarProps;
 
-class LinodeDisks extends React.Component<CombinedProps, State> {
-  static defaultDrawerState: DrawerState = {
-    open: false,
-    submitting: false,
-    mode: 'create',
-    errors: undefined,
-    maximumSize: 0,
-    fields: {
-      label: '',
-      filesystem: 'ext4',
-      size: 0
-    }
-  };
-
-  static defaultImagizeDrawerState: ImagizeDrawerState = {
-    open: false,
-    description: '',
+const defaultDrawerState: DrawerState = {
+  open: false,
+  submitting: false,
+  mode: 'create',
+  errors: undefined,
+  maximumSize: 0,
+  fields: {
     label: '',
-    disk: undefined
-  };
+    filesystem: 'ext4',
+    size: 0
+  }
+};
 
-  static defaultConfirmDeleteState: ConfirmDeleteState = {
-    open: false,
-    id: undefined,
-    label: undefined,
-    submitting: false
-  };
+const defaultImagizeDrawerState: ImagizeDrawerState = {
+  open: false,
+  description: '',
+  label: '',
+  disk: undefined
+};
 
-  state: State = {
-    drawer: LinodeDisks.defaultDrawerState,
-    imagizeDrawer: LinodeDisks.defaultImagizeDrawerState,
-    confirmDelete: LinodeDisks.defaultConfirmDeleteState
-  };
+const defaultConfirmDeleteState: ConfirmDeleteState = {
+  open: false,
+  id: undefined,
+  label: undefined,
+  submitting: false
+};
+
+class LinodeDisks extends React.Component<CombinedProps, State> {
+  private disksHeader: React.RefObject<any>;
+  constructor(props: CombinedProps) {
+    super(props);
+
+    this.disksHeader = React.createRef();
+
+    this.state = {
+      drawer: defaultDrawerState,
+      imagizeDrawer: defaultImagizeDrawerState,
+      confirmDelete: defaultConfirmDeleteState
+    };
+  }
 
   errorState = (
     <ErrorState errorText="There was an error loading disk images." />
@@ -170,7 +177,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <Grid container justify="space-between" alignItems="flex-end">
-          <Grid item>
+          <Grid item innerRef={this.disksHeader}>
             <Typography variant="h3" className={classes.headline}>
               Disks
             </Typography>
@@ -183,7 +190,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
             />
           </Grid>
         </Grid>
-        <Paginate data={disks}>
+        <Paginate data={disks} scrollToRef={this.disksHeader}>
           {({
             data: paginatedData,
             handlePageChange,
@@ -219,7 +226,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
                   page={page}
                   pageSize={pageSize}
                   count={count}
-                  handlePageChange={handlePageChange(false)}
+                  handlePageChange={handlePageChange}
                   handleSizeChange={handlePageSizeChange}
                   eventCategory="linode disks"
                 />
@@ -353,7 +360,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
 
   openImagizeDrawer = (disk: Linode.Disk) => () => {
     this.setImagizeDrawer({
-      ...LinodeDisks.defaultImagizeDrawerState,
+      ...defaultImagizeDrawerState,
       open: true,
       disk
     });
@@ -475,7 +482,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
 
     resizeLinodeDisk(diskId, size)
       .then(data => {
-        this.setDrawer(LinodeDisks.defaultDrawerState);
+        this.setDrawer(defaultDrawerState);
         this.props.enqueueSnackbar(`Disk queued for resizing.`, {
           variant: 'info'
         });
@@ -520,7 +527,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
         : undefined
     })
       .then(_ => {
-        this.setDrawer(LinodeDisks.defaultDrawerState);
+        this.setDrawer(defaultDrawerState);
       })
       .catch(error => {
         const errors = path<Linode.ApiFieldError[]>(
@@ -549,7 +556,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
 
     updateLinodeDisk(diskId, { label })
       .then(_ => {
-        this.setDrawer(LinodeDisks.defaultDrawerState);
+        this.setDrawer(defaultDrawerState);
       })
       .catch(error => {
         const errors = path<Linode.ApiFieldError[]>(

--- a/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -147,7 +147,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<
                       <Grid item xs={12}>
                         <PaginationFooter
                           count={count}
-                          handlePageChange={handlePageChange()}
+                          handlePageChange={handlePageChange}
                           handleSizeChange={handlePageSizeChange}
                           pageSize={pageSize}
                           page={page}
@@ -217,7 +217,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<
                             >
                               <PaginationFooter
                                 count={count}
-                                handlePageChange={handlePageChange()}
+                                handlePageChange={handlePageChange}
                                 handleSizeChange={handlePageSizeChange}
                                 pageSize={pageSize}
                                 page={page}

--- a/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -71,7 +71,7 @@ const DisplayLinodes: React.StatelessComponent<CombinedProps> = props => {
               {
                 <PaginationFooter
                   count={data.length}
-                  handlePageChange={handlePageChange()}
+                  handlePageChange={handlePageChange}
                   handleSizeChange={handlePageSizeChange}
                   pageSize={pageSize}
                   page={page}


### PR DESCRIPTION
## Description

Scrolls to the header of the paginated data for disks and configs

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## Note to Reviewers

Have lots of disks and configs and start switching pages