### PR TITLE
Add: Update Events Landing in Real-Time

### DIFF
--- a/src/__data__/events.ts
+++ b/src/__data__/events.ts
@@ -9,7 +9,7 @@ export const events: Linode.Event[] = [
     action: 'linode_reboot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11241778,
@@ -27,7 +27,7 @@ export const events: Linode.Event[] = [
     action: 'linode_reboot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11241778,
@@ -45,7 +45,7 @@ export const events: Linode.Event[] = [
     action: 'linode_reboot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11241778,
@@ -63,7 +63,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11642886,
@@ -81,7 +81,7 @@ export const events: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11642886,
@@ -99,7 +99,7 @@ export const events: Linode.Event[] = [
     action: 'linode_reboot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11241778,
@@ -117,7 +117,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -135,7 +135,7 @@ export const events: Linode.Event[] = [
     action: 'linode_delete',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -153,7 +153,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -171,7 +171,7 @@ export const events: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -189,7 +189,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -207,7 +207,7 @@ export const events: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -225,7 +225,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -243,7 +243,7 @@ export const events: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -261,7 +261,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -279,7 +279,7 @@ export const events: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -297,7 +297,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -315,7 +315,7 @@ export const events: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -333,7 +333,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -351,7 +351,7 @@ export const events: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -369,7 +369,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -387,7 +387,7 @@ export const events: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -405,7 +405,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -423,7 +423,7 @@ export const events: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -441,7 +441,7 @@ export const events: Linode.Event[] = [
     action: 'linode_shutdown',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -462,7 +462,7 @@ export const uniqueEvents: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -480,7 +480,7 @@ export const uniqueEvents: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,
@@ -501,7 +501,7 @@ export const reduxEvent: ExtendedEvent = {
   action: 'linode_boot',
   read: false,
   percent_complete: 100,
-  username: 'coolguymarty',
+  username: 'test',
   rate: null,
   entity: {
     id: 11440645,

--- a/src/__data__/events.ts
+++ b/src/__data__/events.ts
@@ -1,3 +1,5 @@
+import { ExtendedEvent } from 'src/store/events/event.helpers';
+
 export const events: Linode.Event[] = [
   {
     id: 18029754,
@@ -451,48 +453,9 @@ export const events: Linode.Event[] = [
   }
 ];
 
-export const dupeEvents: Linode.Event[] = [
-  {
-    id: 1234,
-    time_remaining: 50,
-    seen: true,
-    created: '2018-12-02T20:23:43',
-    action: 'linode_boot',
-    read: false,
-    percent_complete: 100,
-    username: 'coolguymarty',
-    rate: null,
-    entity: {
-      id: 11440645,
-      label: 'linode11440645',
-      type: 'linode',
-      url: '/v4/linode/instances/11440645'
-    },
-    status: 'finished'
-  },
-  {
-    id: 1234,
-    time_remaining: 0,
-    seen: true,
-    created: '2018-12-02T20:23:43',
-    action: 'linode_boot',
-    read: false,
-    percent_complete: 100,
-    username: 'coolguymarty',
-    rate: null,
-    entity: {
-      id: 11440645,
-      label: 'linode11440645',
-      type: 'linode',
-      url: '/v4/linode/instances/11440645'
-    },
-    status: 'scheduled'
-  }
-];
-
 export const uniqueEvents: Linode.Event[] = [
   {
-    id: 1234,
+    id: 1231234,
     time_remaining: 50,
     seen: true,
     created: '2018-12-02T20:23:43',
@@ -528,3 +491,23 @@ export const uniqueEvents: Linode.Event[] = [
     status: 'finished'
   }
 ];
+
+export const reduxEvent: ExtendedEvent = {
+  _initial: false,
+  id: 123551234,
+  time_remaining: 50,
+  seen: true,
+  created: '2018-12-02T20:23:43',
+  action: 'linode_boot',
+  read: false,
+  percent_complete: 100,
+  username: 'coolguymarty',
+  rate: null,
+  entity: {
+    id: 11440645,
+    label: 'linode11440645',
+    type: 'linode',
+    url: '/v4/linode/instances/11440645'
+  },
+  status: 'finished'
+};

--- a/src/components/EntityIcon/EntityIcon.tsx
+++ b/src/components/EntityIcon/EntityIcon.tsx
@@ -104,7 +104,8 @@ const EntityIcon: React.StatelessComponent<CombinedProps> = props => {
     size,
     className,
     marginTop,
-    stopAnimation
+    stopAnimation,
+    ...rest
   } = props;
 
   const iconSize = size
@@ -147,6 +148,7 @@ const EntityIcon: React.StatelessComponent<CombinedProps> = props => {
       data-qa-entity-status={status || 'undefined'}
       data-qa-is-loading={loading || 'false'}
       aria-label={`${variant} is ${finalStatus}`}
+      {...rest}
     >
       <Icon
         className={classNames({

--- a/src/features/Events/Event.helpers.test.ts
+++ b/src/features/Events/Event.helpers.test.ts
@@ -1,4 +1,4 @@
-import { dupeEvents, uniqueEvents } from 'src/__data__/events';
+import { reduxEvent, uniqueEvents } from 'src/__data__/events';
 import {
   filterUniqueEvents,
   percentCompleteHasUpdated,
@@ -19,7 +19,7 @@ const nextTime = '1556810370715';
 
 describe('Utility Functions', () => {
   it('should filter out unique events', () => {
-    expect(filterUniqueEvents(dupeEvents)).toHaveLength(1);
+    expect(filterUniqueEvents([reduxEvent, reduxEvent])).toHaveLength(1);
     expect(filterUniqueEvents(uniqueEvents)).toHaveLength(2);
   });
 

--- a/src/features/Events/Event.helpers.test.ts
+++ b/src/features/Events/Event.helpers.test.ts
@@ -1,0 +1,25 @@
+import { dupeEvents, uniqueEvents } from 'src/__data__/events';
+import { filterUniqueEvents, percentCompleteHasUpdated } from './Event.helpers';
+
+describe('Utility Functions', () => {
+  it('should filter out unique events', () => {
+    expect(filterUniqueEvents(dupeEvents)).toHaveLength(1);
+    expect(filterUniqueEvents(uniqueEvents)).toHaveLength(2);
+  });
+
+  it('should return true if percent complete has changed', () => {
+    const inProgressEvents: Record<number, number> = {
+      123: 50
+    };
+    const prevInProgressEvents: Record<number, number> = {
+      123: 79
+    };
+    expect(
+      percentCompleteHasUpdated(inProgressEvents, inProgressEvents)
+    ).toBeFalsy();
+    expect(
+      percentCompleteHasUpdated(inProgressEvents, prevInProgressEvents)
+    ).toBeTruthy();
+    expect(percentCompleteHasUpdated(inProgressEvents, {})).toBeTruthy();
+  });
+});

--- a/src/features/Events/Event.helpers.test.ts
+++ b/src/features/Events/Event.helpers.test.ts
@@ -1,5 +1,21 @@
 import { dupeEvents, uniqueEvents } from 'src/__data__/events';
-import { filterUniqueEvents, percentCompleteHasUpdated } from './Event.helpers';
+import {
+  filterUniqueEvents,
+  percentCompleteHasUpdated,
+  shouldUpdateEvents
+} from './Event.helpers';
+
+const inProgressEvents = {
+  1234: 50,
+  1235: 20
+};
+
+const nextInProgressEvents = {
+  1234: 80
+};
+
+const mostRecentEventTime = '1556810353941';
+const nextTime = '1556810370715';
 
 describe('Utility Functions', () => {
   it('should filter out unique events', () => {
@@ -8,18 +24,69 @@ describe('Utility Functions', () => {
   });
 
   it('should return true if percent complete has changed', () => {
-    const inProgressEvents: Record<number, number> = {
-      123: 50
-    };
-    const prevInProgressEvents: Record<number, number> = {
-      123: 79
-    };
     expect(
       percentCompleteHasUpdated(inProgressEvents, inProgressEvents)
     ).toBeFalsy();
     expect(
-      percentCompleteHasUpdated(inProgressEvents, prevInProgressEvents)
+      percentCompleteHasUpdated(inProgressEvents, nextInProgressEvents)
     ).toBeTruthy();
     expect(percentCompleteHasUpdated(inProgressEvents, {})).toBeTruthy();
+  });
+
+  it('should update events if most recent event time has changed', () => {
+    expect(
+      shouldUpdateEvents(
+        {
+          inProgressEvents,
+          mostRecentEventTime
+        },
+        {
+          inProgressEvents,
+          mostRecentEventTime: nextTime
+        }
+      )
+    ).toBeTruthy();
+  });
+
+  it('should update if event progress has updated', () => {
+    expect(
+      shouldUpdateEvents(
+        {
+          inProgressEvents,
+          mostRecentEventTime
+        },
+        {
+          inProgressEvents: nextInProgressEvents,
+          mostRecentEventTime
+        }
+      )
+    ).toBeTruthy();
+    expect(
+      shouldUpdateEvents(
+        {
+          inProgressEvents,
+          mostRecentEventTime
+        },
+        {
+          inProgressEvents: {},
+          mostRecentEventTime
+        }
+      )
+    ).toBeTruthy();
+  });
+
+  it('should not update if nothing has changed', () => {
+    expect(
+      shouldUpdateEvents(
+        {
+          inProgressEvents,
+          mostRecentEventTime
+        },
+        {
+          inProgressEvents,
+          mostRecentEventTime
+        }
+      )
+    ).toBeFalsy();
   });
 });

--- a/src/features/Events/Event.helpers.ts
+++ b/src/features/Events/Event.helpers.ts
@@ -1,0 +1,48 @@
+/**
+ * The point of this function is to ensure we don't have an activity stream
+ * that looks like:
+ *
+ * Linode hello_world has been booted
+ * Linode hello_world has been created
+ * Linode hello_world is scheduled to be booted
+ * Linode hello_world is scheduled to be created
+ *
+ * Basically, we're creating a cache and only adding to the cache if the Event
+ * ID doesn't already exist in the cache. This ensures that "has been created"
+ * events will replace the "is scheduled to" events
+ */
+export const filterUniqueEvents = (events: Linode.Event[]) => {
+  return events.reduce((acc, event) => {
+    const foundEventInAcc = acc.some(
+      (eachAccumEvent: Linode.Event) => eachAccumEvent.id === event.id
+    );
+    return foundEventInAcc ? acc : [...acc, event];
+  }, []);
+};
+
+/**
+ * Takes in the inProgressEvents which are sourced from Redux. These are a key-value
+ * pair where the key is the ID of the event in progress and the value is the percent_complete
+ * So it ends up comparing the values similar to
+ *
+ * {
+ *    1234: 50
+ * }
+ *
+ * and
+ *
+ * {
+ *   1234: 79
+ * }
+ *
+ * the "50" and the "79" are the things being compared
+ */
+export const percentCompleteHasUpdated = (
+  prevEventsInProgress: Record<number, number>,
+  nextEventsInProgress: Record<number, number>
+) => {
+  return Object.keys(prevEventsInProgress).some(
+    eachEventID =>
+      prevEventsInProgress[eachEventID] !== nextEventsInProgress[eachEventID]
+  );
+};

--- a/src/features/Events/Event.helpers.ts
+++ b/src/features/Events/Event.helpers.ts
@@ -1,3 +1,5 @@
+import { equals } from 'ramda';
+
 /**
  * The point of this function is to ensure we don't have an activity stream
  * that looks like:
@@ -44,5 +46,26 @@ export const percentCompleteHasUpdated = (
   return Object.keys(prevEventsInProgress).some(
     eachEventID =>
       prevEventsInProgress[eachEventID] !== nextEventsInProgress[eachEventID]
+  );
+};
+
+interface Payload {
+  mostRecentEventTime: string;
+  inProgressEvents: Record<number, number>;
+}
+
+/**
+ * shouldComponentUpdate logic to determine if the list of events should update
+ *
+ * This is abstracted because it's shared logic between the EventsLanding the Activity Summary
+ */
+export const shouldUpdateEvents = (prevProps: Payload, nextProps: Payload) => {
+  return (
+    !equals(prevProps.mostRecentEventTime, nextProps.mostRecentEventTime) ||
+    (!equals(prevProps.inProgressEvents, nextProps.inProgressEvents) ||
+      percentCompleteHasUpdated(
+        prevProps.inProgressEvents,
+        nextProps.inProgressEvents
+      ))
   );
 };

--- a/src/features/Events/EventRow.test.tsx
+++ b/src/features/Events/EventRow.test.tsx
@@ -11,8 +11,7 @@ const props: RowProps = {
     root: '',
     message: ''
   },
-  linkTarget: jest.fn(),
-  isEventsLandingForEntity: false
+  linkTarget: jest.fn()
 };
 
 describe('EventRow component', () => {
@@ -28,21 +27,21 @@ describe('EventRow component', () => {
   });
 
   it("should only render an entity icon if it's not an events page for a specific entity", () => {
-    row.setProps({ isEventsLandingForEntity: true });
+    row.setProps({ entityId: 1 });
     expect(row.find('[data-qa-entity-icon]')).toHaveLength(0);
 
-    row.setProps({ isEventsLandingForEntity: false });
+    row.setProps({ entityId: 0 });
     expect(row.find('[data-qa-entity-icon]')).toHaveLength(1);
   });
 
   it("should only include a link if it's not an events page for a specific entity", () => {
-    row.setProps({ isEventsLandingForEntity: true });
+    row.setProps({ entityId: 1 });
     let tableRowProps: any = row
       .find('WithStyles(withRouter(TableRow))')
       .props();
     expect(tableRowProps.rowLink).toBe(undefined);
 
-    row.setProps({ isEventsLandingForEntity: false });
+    row.setProps({ entityId: 0 });
     tableRowProps = row.find('WithStyles(withRouter(TableRow))').props();
     expect(tableRowProps.rowLink).toBeDefined();
   });

--- a/src/features/Events/EventRow.tsx
+++ b/src/features/Events/EventRow.tsx
@@ -36,7 +36,7 @@ interface ExtendedEvent extends Linode.Event {
 
 interface Props {
   event: ExtendedEvent;
-  isEventsLandingForEntity: boolean;
+  entityId?: number;
 }
 
 export const onUnfound = (event: ExtendedEvent) => {
@@ -48,7 +48,7 @@ export const onUnfound = (event: ExtendedEvent) => {
 type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{}>;
 
 export const EventRow: React.StatelessComponent<CombinedProps> = props => {
-  const { event, isEventsLandingForEntity, classes } = props;
+  const { event, entityId, classes } = props;
   const type = pathOr<string>('linode', ['entity', 'type'], event);
   const id = pathOr<string | number>(-1, ['entity', 'id'], event);
   const entity = getEntityByIDFromStore(type, id);
@@ -65,7 +65,7 @@ export const EventRow: React.StatelessComponent<CombinedProps> = props => {
     message: eventMessageGenerator(event, onUnfound),
     status: pathOr(undefined, ['status'], entity),
     type,
-    isEventsLandingForEntity,
+    entityId,
     classes
   };
 
@@ -74,7 +74,7 @@ export const EventRow: React.StatelessComponent<CombinedProps> = props => {
 
 export interface RowProps extends WithStyles<ClassNames> {
   message?: string | void;
-  isEventsLandingForEntity: boolean;
+  entityId?: number;
   linkTarget?: (e: React.MouseEvent<HTMLElement>) => void;
   type: 'linode' | 'domain' | 'nodebalancer' | 'stackscript' | 'volume';
   status?: string;
@@ -84,7 +84,7 @@ export interface RowProps extends WithStyles<ClassNames> {
 export const Row: React.StatelessComponent<RowProps> = props => {
   const {
     classes,
-    isEventsLandingForEntity,
+    entityId,
     linkTarget,
     message,
     status,
@@ -100,15 +100,14 @@ export const Row: React.StatelessComponent<RowProps> = props => {
   }
 
   return (
-    <TableRow
-      rowLink={isEventsLandingForEntity ? undefined : (linkTarget as any)}
-    >
+    <TableRow rowLink={entityId ? undefined : (linkTarget as any)}>
       {/** We don't use the event argument, so typing isn't critical here. */}
       {/* Only display entity icon on the Global EventsLanding page */}
-      {!isEventsLandingForEntity && (
+      {!entityId && (
         <TableCell data-qa-event-icon-cell compact>
-          <Hidden smDown data-qa-entity-icon>
+          <Hidden smDown>
             <EntityIcon
+              data-qa-entity-icon
               variant={type}
               status={status}
               size={28}

--- a/src/features/Events/EventsLanding.test.ts
+++ b/src/features/Events/EventsLanding.test.ts
@@ -1,9 +1,103 @@
-// import { reducer } from './EventsLanding';
+import { reduxEvent, uniqueEvents } from 'src/__data__/events';
+import { reducer, ReducerActions, ReducerState } from './EventsLanding';
+
+const someEvent: Linode.Event[] = [
+  {
+    id: 1234,
+    time_remaining: 50,
+    seen: true,
+    created: '2018-12-02T20:23:43',
+    action: 'linode_boot',
+    read: false,
+    percent_complete: 100,
+    username: 'coolguymarty',
+    rate: null,
+    entity: {
+      id: 11440645,
+      label: 'linode11440645',
+      type: 'linode',
+      url: '/v4/linode/instances/11440645'
+    },
+    status: 'finished'
+  }
+];
+
+const currentState: ReducerState = {
+  reactStateEvents: uniqueEvents,
+  eventsFromRedux: [],
+  inProgressEvents: { 123: 50 },
+  mostRecentEventTime: 'hello world'
+};
+
+const appendPayload: ReducerActions = {
+  type: 'append',
+  payload: currentState
+};
+
+const prependPayloadNoChange: ReducerActions = {
+  type: 'prepend',
+  payload: currentState
+};
 
 describe('utility functions', () => {
-  it('should append new events to the list of events when the "append" type is invoked', () => {});
+  it(`should append new events and filter out duplicates to the list of events
+   when the "append" type is invoked`, () => {
+    expect(reducer(currentState, appendPayload)).toEqual(appendPayload.payload);
+    expect(
+      reducer(currentState, {
+        ...appendPayload,
+        payload: {
+          ...appendPayload.payload,
+          reactStateEvents: [...someEvent, ...someEvent]
+        }
+      })
+    ).toEqual({
+      ...currentState,
+      reactStateEvents: [...uniqueEvents, ...someEvent]
+    });
+    expect(reducer(currentState, appendPayload)).not.toEqual({
+      ...currentState,
+      reactStateEvents: [...uniqueEvents, ...uniqueEvents]
+    });
+  });
 
-  it('should prepend new events to the list of events when the "prepend" type is invoked', () => {
-    return;
+  it('should prepend new events to the list of events and filter out duplicates when the "prepend" type is invoked', () => {
+    expect(
+      reducer(currentState, {
+        ...prependPayloadNoChange,
+        payload: {
+          ...prependPayloadNoChange.payload,
+          mostRecentEventTime: 'ahhhhhhhh',
+          eventsFromRedux: [reduxEvent]
+        }
+      })
+    ).toEqual({
+      reactStateEvents: [reduxEvent, ...uniqueEvents],
+      eventsFromRedux: [reduxEvent],
+      inProgressEvents: {
+        123: 50
+      },
+      mostRecentEventTime: 'ahhhhhhhh'
+    });
+
+    expect(
+      reducer(currentState, {
+        ...prependPayloadNoChange,
+        payload: {
+          ...prependPayloadNoChange.payload,
+          inProgressEvents: { 123: 70 },
+          eventsFromRedux: [reduxEvent]
+        }
+      })
+    ).toEqual({
+      reactStateEvents: [reduxEvent, ...uniqueEvents],
+      eventsFromRedux: [reduxEvent],
+      inProgressEvents: { 123: 70 },
+      mostRecentEventTime: 'hello world'
+    });
+  });
+
+  it('should not prepend when inProgress and mostRecentEventTime has changed', () => {
+    expect(reducer(currentState, prependPayloadNoChange)).toEqual(currentState);
   });
 });

--- a/src/features/Events/EventsLanding.test.ts
+++ b/src/features/Events/EventsLanding.test.ts
@@ -10,7 +10,7 @@ const someEvent: Linode.Event[] = [
     action: 'linode_boot',
     read: false,
     percent_complete: 100,
-    username: 'coolguymarty',
+    username: 'test',
     rate: null,
     entity: {
       id: 11440645,

--- a/src/features/Events/EventsLanding.test.ts
+++ b/src/features/Events/EventsLanding.test.ts
@@ -1,0 +1,9 @@
+// import { reducer } from './EventsLanding';
+
+describe('utility functions', () => {
+  it('should append new events to the list of events when the "append" type is invoked', () => {});
+
+  it('should prepend new events to the list of events when the "prepend" type is invoked', () => {
+    return;
+  });
+});

--- a/src/features/Events/EventsLanding.tsx
+++ b/src/features/Events/EventsLanding.tsx
@@ -1,5 +1,5 @@
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { compose as rCompose, concat, uniq } from 'ramda';
+import { compose as rCompose, concat, equals, uniq } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import Waypoint from 'react-waypoint';
@@ -25,6 +25,8 @@ import { ApplicationState } from 'src/store';
 import { setDeletedEvents } from 'src/store/events/event.helpers';
 import areEntitiesLoading from 'src/store/selectors/entitiesLoading';
 
+import { ExtendedEvent } from 'src/store/events/event.helpers';
+import { filterUniqueEvents, percentCompleteHasUpdated } from './Event.helpers';
 import EventRow from './EventRow';
 
 type ClassNames = 'root' | 'header' | 'labelCell' | 'timeCell' | 'noMoreEvents';
@@ -51,7 +53,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 interface Props {
   getEventsRequest?: typeof getEvents;
-  isEventsLandingForEntity?: boolean;
+  // isEventsLandingForEntity?: boolean;
+  entityId?: number;
   errorMessage?: string; // Custom error message (for an entity's Activity page, for example)
 }
 
@@ -67,14 +70,105 @@ const appendToEvents = (oldEvents: Linode.Event[], newEvents: Linode.Event[]) =>
     setDeletedEvents // Add a _deleted entry for each new event
   )(newEvents);
 
+interface ReducerState {
+  inProgressEvents: Record<number, number>;
+  eventsFromRedux: ExtendedEvent[];
+  reactStateEvents: Linode.Event[];
+}
+
+interface ReducerActions {
+  type: 'append' | 'prepend';
+  payload: {
+    inProgressEvents: Record<number, number>;
+    eventsFromRedux: ExtendedEvent[];
+    reactStateEvents: Linode.Event[];
+    entityId?: number;
+  };
+}
+
+const reducer: React.Reducer<ReducerState, ReducerActions> = (
+  state,
+  action
+) => {
+  const {
+    payload: {
+      eventsFromRedux: nextReduxEvents,
+      inProgressEvents: nextInProgressEvents,
+      reactStateEvents: nextReactEvents,
+      entityId
+    }
+  } = action;
+
+  switch (action.type) {
+    case 'prepend':
+      if (
+        !equals(state.inProgressEvents, nextInProgressEvents) ||
+        percentCompleteHasUpdated(nextInProgressEvents, state.inProgressEvents)
+      ) {
+        return {
+          eventsFromRedux: nextReduxEvents,
+          inProgressEvents: nextInProgressEvents,
+          reactStateEvents: filterUniqueEvents([
+            /* 
+              Pop new events from Redux on the top of the event stream, with some conditions
+            */
+            ...nextReduxEvents.filter(eachEvent => {
+              return (
+                /** all events from Redux will have this flag as a boolean value */
+                !eachEvent._initial &&
+                /**
+                 * so here we're basically determining whether or not
+                 * an entityID prop was passed, and if so, only show the events
+                 * that pertain to that entity. This is useful because it helps
+                 * us show only relevant events on the Linode Activity panel, for example
+                 */
+                (typeof entityId === 'undefined' ||
+                  (eachEvent.entity && eachEvent.entity.id === entityId))
+              );
+            }),
+            /* 
+            at this point, the state is populated with events from the cDM 
+            request (which don't include the "_initial flag"), but it might also
+            contain events from Redux as well. We only want the ones where the "_initial" 
+            flag doesn't exist
+            */
+            ...nextReactEvents.filter(
+              eachEvent => typeof eachEvent._initial === 'undefined'
+            )
+          ])
+        };
+      }
+      return {
+        eventsFromRedux: nextReduxEvents,
+        reactStateEvents: nextReactEvents,
+        inProgressEvents: nextInProgressEvents
+      };
+    case 'append':
+    default:
+      return {
+        reactStateEvents: nextReactEvents,
+        eventsFromRedux: nextReduxEvents,
+        inProgressEvents: nextInProgressEvents
+      };
+  }
+};
+
 export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
-  const [events, setEvents] = React.useState<Linode.Event[]>([]);
   const [loading, setLoading] = React.useState<boolean>(false);
   const [loadMoreEvents, setLoadMoreEvents] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>(undefined);
   const [currentPage, setCurrentPage] = React.useState<number>(1);
   const [isRequesting, setRequesting] = React.useState<boolean>(false);
   const [initialLoaded, setInitialLoaded] = React.useState<boolean>(false);
+
+  const [events, dispatch] = React.useReducer<ReducerState, ReducerActions>(
+    reducer,
+    {
+      inProgressEvents: props.inProgressEvents,
+      eventsFromRedux: props.eventsFromRedux,
+      reactStateEvents: []
+    }
+  );
 
   const getNext = () => {
     if (isRequesting) {
@@ -100,7 +194,19 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
   ) => {
     setCurrentPage(currentPage + 1);
     setLoadMoreEvents(true);
-    setEvents(appendToEvents(events, response.data));
+    /** append our events to component state */
+    dispatch({
+      type: 'append',
+      payload: {
+        eventsFromRedux: props.eventsFromRedux,
+        reactStateEvents: appendToEvents(
+          events.reactStateEvents,
+          response.data
+        ),
+        entityId: props.entityId,
+        inProgressEvents: props.inProgressEvents
+      }
+    });
     setLoading(false);
     setRequesting(false);
     setError(undefined);
@@ -125,18 +231,31 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
       });
   }, []);
 
-  const {
-    classes,
-    entitiesLoading,
-    isEventsLandingForEntity,
-    errorMessage
-  } = props;
+  /**
+   * For the purposes of concat-ing the events from Redux and React state
+   * so we can display events in real-time
+   */
+  React.useEffect(() => {
+    const { eventsFromRedux, inProgressEvents } = props;
+    /** in this case, we're getting new events from Redux, so we want to prepend */
+    dispatch({
+      type: 'prepend',
+      payload: {
+        eventsFromRedux,
+        inProgressEvents,
+        reactStateEvents: events.reactStateEvents,
+        entityId: props.entityId
+      }
+    });
+  }, [props.eventsFromRedux, props.inProgressEvents]);
+
+  const { classes, entitiesLoading, errorMessage, entityId } = props;
   const isLoading = loading || entitiesLoading;
 
   return (
     <>
       {/* Only display this title on the main Events landing page */}
-      {!isEventsLandingForEntity && (
+      {!entityId && (
         <Typography variant="h1" className={classes.header}>
           Events
         </Typography>
@@ -146,9 +265,7 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
           <TableHead>
             <TableRow>
               {/* Cell for icon (global EventsLanding only) */}
-              {!isEventsLandingForEntity && (
-                <TableCell style={{ padding: 0, width: '1%' }} />
-              )}
+              {!entityId && <TableCell style={{ padding: 0, width: '1%' }} />}
               <TableCell
                 data-qa-events-subject-header
                 className={classes.labelCell}
@@ -167,10 +284,10 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
             {renderTableBody(
               isLoading,
               isRequesting,
-              isEventsLandingForEntity,
               errorMessage,
+              entityId,
               error,
-              events
+              events.reactStateEvents
             )}
           </TableBody>
         </Table>
@@ -194,8 +311,8 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
 export const renderTableBody = (
   loading: boolean,
   isRequesting: boolean,
-  isEventsLandingForEntity: boolean = false,
   errorMessage = 'There was an error retrieving the events on your account.',
+  entityId?: number,
   error?: string,
   events?: Linode.Event[]
 ) => {
@@ -222,9 +339,9 @@ export const renderTableBody = (
       <>
         {events.map((thisEvent, idx) => (
           <EventRow
+            entityId={entityId}
             key={`event-list-item-${idx}`}
             event={thisEvent}
-            isEventsLandingForEntity={isEventsLandingForEntity}
           />
         ))}
         {isRequesting && <TableRowLoading colSpan={12} transparent />}
@@ -237,10 +354,14 @@ const styled = withStyles(styles);
 
 interface StateProps {
   entitiesLoading: boolean;
+  inProgressEvents: Record<number, number>;
+  eventsFromRedux: ExtendedEvent[];
 }
 
 const mapStateToProps = (state: ApplicationState) => ({
-  entitiesLoading: areEntitiesLoading(state.__resources)
+  entitiesLoading: areEntitiesLoading(state.__resources),
+  inProgressEvents: state.events.inProgressEvents,
+  eventsFromRedux: state.events.events
 });
 
 const connected = connect(mapStateToProps);

--- a/src/features/Events/EventsLanding.tsx
+++ b/src/features/Events/EventsLanding.tsx
@@ -70,7 +70,7 @@ const appendToEvents = (oldEvents: Linode.Event[], newEvents: Linode.Event[]) =>
     setDeletedEvents // Add a _deleted entry for each new event
   )(newEvents);
 
-interface ReducerState {
+export interface ReducerState {
   inProgressEvents: Record<number, number>;
   eventsFromRedux: ExtendedEvent[];
   reactStateEvents: Linode.Event[];
@@ -85,7 +85,7 @@ interface Payload {
   entityId?: number;
 }
 
-interface ReducerActions {
+export interface ReducerActions {
   type: 'append' | 'prepend';
   payload: Payload;
 }
@@ -161,7 +161,10 @@ export const reducer: React.Reducer<ReducerState, ReducerActions> = (
     case 'append':
     default:
       return {
-        reactStateEvents: nextReactEvents,
+        reactStateEvents: appendToEvents(
+          state.reactStateEvents,
+          nextReactEvents
+        ),
         eventsFromRedux: nextReduxEvents,
         inProgressEvents: nextInProgressEvents,
         mostRecentEventTime: nextMostRecentEventTime
@@ -216,10 +219,7 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
       type: 'append',
       payload: {
         eventsFromRedux: props.eventsFromRedux,
-        reactStateEvents: appendToEvents(
-          events.reactStateEvents,
-          response.data
-        ),
+        reactStateEvents: response.data,
         entityId: props.entityId,
         inProgressEvents: props.inProgressEvents,
         mostRecentEventTime: props.mostRecentEventTime

--- a/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.test.tsx
@@ -15,6 +15,6 @@ describe('LinodeActivity', () => {
     const props: any = wrapper
       .find('[data-qa-events-landing-for-linode]')
       .props();
-    expect(props.isEventsLandingForEntity).toBe(true);
+    expect(props.entityId).toBe(123);
   });
 });

--- a/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeActivity/LinodeActivity.tsx
@@ -24,7 +24,7 @@ type CombinedProps = WithStyles<ClassNames> & StateProps;
 export const LinodeActivity: React.StatelessComponent<
   CombinedProps
 > = props => {
-  const { classes } = props;
+  const { classes, linodeID } = props;
 
   return (
     <React.Fragment>
@@ -36,10 +36,10 @@ export const LinodeActivity: React.StatelessComponent<
         Activity Feed
       </Typography>
       <EventsLanding
+        entityId={linodeID}
         getEventsRequest={(params: any = {}) =>
           getEventsForEntity(params, 'linode', props.linodeID)
         }
-        isEventsLandingForEntity={true}
         errorMessage="There was an error retrieving activity for this Linode."
         data-qa-events-landing-for-linode
       />

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
@@ -1,12 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import {
-  ActivitySummary,
-  filterUniqueEvents,
-  percentCompleteHasUpdated
-} from './ActivitySummary';
-
-import { dupeEvents, uniqueEvents } from 'src/__data__/events';
+import { ActivitySummary } from './ActivitySummary';
 
 const requests = require.requireMock('src/services/account');
 
@@ -29,29 +23,6 @@ const props = {
 const component = shallow(<ActivitySummary {...props} />);
 
 describe('ActivitySummary component', () => {
-  describe('Utility Functions', () => {
-    it('should filter out unique events', () => {
-      expect(filterUniqueEvents(dupeEvents)).toHaveLength(1);
-      expect(filterUniqueEvents(uniqueEvents)).toHaveLength(2);
-    });
-
-    it('should return true if percent complete has changed', () => {
-      const inProgressEvents: Record<number, number> = {
-        123: 50
-      };
-      const prevInProgressEvents: Record<number, number> = {
-        123: 79
-      };
-      expect(
-        percentCompleteHasUpdated(inProgressEvents, inProgressEvents)
-      ).toBeFalsy();
-      expect(
-        percentCompleteHasUpdated(inProgressEvents, prevInProgressEvents)
-      ).toBeTruthy();
-      expect(percentCompleteHasUpdated(inProgressEvents, {})).toBeTruthy();
-    });
-  });
-
   it('should render', () => {
     expect(component).toHaveLength(1);
   });

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.test.tsx
@@ -14,6 +14,7 @@ const props = {
   linodeId: 123456,
   eventsFromRedux: [],
   inProgressEvents: [],
+  mostRecentEventTime: '',
   classes: {
     root: '',
     header: '',

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -1,4 +1,3 @@
-import { equals } from 'ramda';
 import * as React from 'react';
 import Grid from 'src/components/core/Grid';
 import Paper from 'src/components/core/Paper';
@@ -16,7 +15,7 @@ import ActivitySummaryContent from './ActivitySummaryContent';
 
 import {
   filterUniqueEvents,
-  percentCompleteHasUpdated
+  shouldUpdateEvents
 } from 'src/features/Events/Event.helpers';
 import { ExtendedEvent } from 'src/store/events/event.helpers';
 
@@ -39,6 +38,7 @@ interface Props {
   linodeId: number;
   inProgressEvents: Record<number, number>;
   eventsFromRedux: ExtendedEvent[];
+  mostRecentEventTime: string;
 }
 
 interface State {
@@ -57,11 +57,28 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
   };
 
   componentDidUpdate(prevProps: CombinedProps) {
+    /**
+     * This condition checks either the most recent event time has changed OR
+     * if the in progress events have changed or that the in-progress events have new percentages
+     *
+     * This is necessary because we have 2 types of events: ones that have percent and ones that
+     * don't.
+     *
+     * Events that don't have a percentage won't affect the inProgressEvents state, which is why
+     * we're checking the mostRecentEvent time becasue that will update when we get a new event
+     *
+     * That being said, mostRecentEventTime will NOT be updated when a event's percentage updates
+     */
     if (
-      !equals(this.props.inProgressEvents, prevProps.inProgressEvents) ||
-      percentCompleteHasUpdated(
-        this.props.inProgressEvents,
-        prevProps.inProgressEvents
+      shouldUpdateEvents(
+        {
+          mostRecentEventTime: prevProps.mostRecentEventTime,
+          inProgressEvents: prevProps.inProgressEvents
+        },
+        {
+          mostRecentEventTime: this.props.mostRecentEventTime,
+          inProgressEvents: this.props.inProgressEvents
+        }
       )
     ) {
       this.setState({

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -14,6 +14,10 @@ import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { getEventsForEntity } from 'src/utilities/getEventsForEntity';
 import ActivitySummaryContent from './ActivitySummaryContent';
 
+import {
+  filterUniqueEvents,
+  percentCompleteHasUpdated
+} from 'src/features/Events/Event.helpers';
 import { ExtendedEvent } from 'src/store/events/event.helpers';
 
 type ClassNames = 'root' | 'header' | 'viewMore';
@@ -52,7 +56,7 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
     events: []
   };
 
-  componentDidUpdate(prevProps: CombinedProps, prevState: State) {
+  componentDidUpdate(prevProps: CombinedProps) {
     if (
       !equals(this.props.inProgressEvents, prevProps.inProgressEvents) ||
       percentCompleteHasUpdated(
@@ -138,55 +142,6 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
     );
   }
 }
-
-/**
- * The point of this function is to ensure we don't have an activity stream
- * that looks like:
- *
- * Linode hello_world has been booted
- * Linode hello_world has been created
- * Linode hello_world is scheduled to be booted
- * Linode hello_world is scheduled to be created
- *
- * Basically, we're creating a cache and only adding to the cache if the Event
- * ID doesn't already exist in the cache. This ensures that "has been created"
- * events will replace the "is scheduled to" events
- */
-export const filterUniqueEvents = (events: Linode.Event[]) => {
-  return events.reduce((acc, event) => {
-    const foundEventInAcc = acc.some(
-      (eachAccumEvent: Linode.Event) => eachAccumEvent.id === event.id
-    );
-    return foundEventInAcc ? acc : [...acc, event];
-  }, []);
-};
-
-/**
- * Takes in the inProgressEvents which are sourced from Redux. These are a key-value
- * pair where the key is the ID of the event in progress and the value is the percent_complete
- * So it ends up comparing the values similar to
- *
- * {
- *    1234: 50
- * }
- *
- * and
- *
- * {
- *   1234: 79
- * }
- *
- * the "50" and the "79" are the things being compared
- */
-export const percentCompleteHasUpdated = (
-  prevEventsInProgress: Record<number, number>,
-  nextEventsInProgress: Record<number, number>
-) => {
-  return Object.keys(prevEventsInProgress).some(
-    eachEventID =>
-      prevEventsInProgress[eachEventID] !== nextEventsInProgress[eachEventID]
-  );
-};
 
 const styled = withStyles(styles);
 

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.test.tsx
@@ -7,6 +7,7 @@ import { LinodeSummary } from './LinodeSummary';
 describe('LinodeSummary', () => {
   const wrapper = shallow(
     <LinodeSummary
+      mostRecentEventTime=""
       events={[]}
       inProgressEvents={[]}
       linodeCreated="2018-11-01T00:00:00"

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -709,6 +709,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
                 eventsFromRedux={this.props.events}
                 linodeId={linode.id}
                 inProgressEvents={this.props.inProgressEvents}
+                mostRecentEventTime={this.props.mostRecentEventTime}
               />
             </Grid>
 
@@ -773,6 +774,7 @@ interface WithTypesProps {
   timezone: string;
   inProgressEvents: Record<number, number>;
   events: ExtendedEvent[];
+  mostRecentEventTime: string;
 }
 
 const withTypes = connect((state: ApplicationState, ownProps) => ({
@@ -783,7 +785,8 @@ const withTypes = connect((state: ApplicationState, ownProps) => ({
     state
   ),
   inProgressEvents: state.events.inProgressEvents,
-  events: state.events.events
+  events: state.events.events,
+  mostRecentEventTime: state.events.mostRecentEventTime
 }));
 
 const enhanced = compose<CombinedProps, {}>(

--- a/src/store/events/event.helpers.test.ts
+++ b/src/store/events/event.helpers.test.ts
@@ -102,7 +102,7 @@ describe('event.helpers', () => {
           action: 'linode_delete',
           read: false,
           percent_complete: 100,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: {
             id: 11440645,
@@ -120,7 +120,7 @@ describe('event.helpers', () => {
           action: 'linode_boot',
           read: false,
           percent_complete: 100,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: {
             id: 11440645,
@@ -141,7 +141,7 @@ describe('event.helpers', () => {
           action: 'linode_delete',
           read: false,
           percent_complete: 100,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: {
             id: 11440645,
@@ -160,7 +160,7 @@ describe('event.helpers', () => {
           action: 'linode_boot',
           read: false,
           percent_complete: 100,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: {
             id: 11440645,
@@ -189,7 +189,7 @@ describe('event.helpers', () => {
           action: 'linode_delete',
           read: false,
           percent_complete: 100,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: null,
           status: 'finished'
@@ -202,7 +202,7 @@ describe('event.helpers', () => {
           action: 'linode_shutdown',
           read: false,
           percent_complete: 60,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: null,
           status: 'started'
@@ -215,7 +215,7 @@ describe('event.helpers', () => {
           action: 'linode_boot',
           read: false,
           percent_complete: 100,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: null,
           status: 'finished'
@@ -230,7 +230,7 @@ describe('event.helpers', () => {
           action: 'linode_shutdown',
           read: false,
           percent_complete: 70,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: null,
           status: 'started'
@@ -247,7 +247,7 @@ describe('event.helpers', () => {
           action: 'linode_delete',
           read: false,
           percent_complete: 100,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: null,
           status: 'finished'
@@ -260,7 +260,7 @@ describe('event.helpers', () => {
           action: 'linode_shutdown',
           read: false,
           percent_complete: 70,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: null,
           status: 'started'
@@ -273,7 +273,7 @@ describe('event.helpers', () => {
           action: 'linode_boot',
           read: false,
           percent_complete: 100,
-          username: 'coolguymarty',
+          username: 'test',
           rate: null,
           entity: null,
           status: 'finished'

--- a/src/store/events/event.reducer.test.ts
+++ b/src/store/events/event.reducer.test.ts
@@ -23,7 +23,7 @@ describe('events.reducer', () => {
             action: 'linode_reboot',
             read: false,
             percent_complete: 100,
-            username: 'coolguymarty',
+            username: 'test',
             rate: null,
             entity: {
               id: 11241778,
@@ -41,7 +41,7 @@ describe('events.reducer', () => {
             action: 'linode_shutdown',
             read: false,
             percent_complete: 80,
-            username: 'coolguymarty',
+            username: 'test',
             rate: null,
             entity: {
               id: 11642886,

--- a/src/store/middleware/combineEventsMiddleware.ts
+++ b/src/store/middleware/combineEventsMiddleware.ts
@@ -33,8 +33,11 @@ const eventsMiddlewareFactory = (
       /**
        * We can bail immediately if there is no associated entity since we need an entity
        * to update the store.
+       *
+       * but we still need to dispatch the action to add the event to the store
        */
       if (!isEntityEvent(event)) {
+        next(action);
         return;
       }
 


### PR DESCRIPTION
## Description

Adds similar logic from the activity summary to the events landing page so we can update the list of events with new events from Redux as they come down.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## Note to Reviewers

`useReducer` is basically acting as `shouldComponentUpdate`

https://reactjs.org/docs/hooks-reference.html#usereducer