### PR TITLE
Fix: Error Views on Linode and NodeBalancer Detail

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/TablesPanel.tsx
@@ -201,7 +201,11 @@ class TablesPanel extends React.Component<CombinedProps, State> {
           ['reason'],
           errorResponse[0]
         );
-        this.setState({ loadingStats: false, statsError });
+
+        /** only show an error if stats aren't already loaded */
+        return !this.state.stats
+          ? this.setState({ loadingStats: false, statsError })
+          : this.setState({ loadingStats: false });
       });
   };
 

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -295,7 +295,11 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           ['reason'],
           errorResponse[0]
         );
-        this.setState({ dataIsLoading: false, statsError: errorText });
+
+        /** only show an error if stats aren't already loaded */
+        return !this.state.stats
+          ? this.setState({ dataIsLoading: false, statsError: errorText })
+          : this.setState({ dataIsLoading: false });
       });
   };
 


### PR DESCRIPTION
## Description

This PR fixes 3 issues

1. Previously, if a stats request on Linode Detail succeeded and the next one failed, an error view would appear
2. Previously, if a stats request on NodeBalancer Detail succeeded and the next one failed, an error view would appear
3. If the NodeBalancer detail polling first succeeded and the next one failed, an error view would appear.

Basically, we should not be removing the data state even if a subsequent request fails.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A