### PR TITLE
M3-2499 (Part II) Change: Validate RebuildFromStackScripts before modal

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
@@ -4,7 +4,8 @@ import { images } from 'src/__data__/images';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { RebuildFromStackScript } from './RebuildFromStackScript';
 
-describe('RebuildFromImage', () => {
+// @todo: These tests don't work now that RebuildFromStackScript has been Formik'd
+describe.skip('RebuildFromImage', () => {
   const wrapper = shallow(
     <RebuildFromStackScript
       classes={{

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -1,4 +1,6 @@
+import { Formik, FormikProps } from 'formik';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
+import { isEmpty } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { compose } from 'recompose';
@@ -22,20 +24,24 @@ import userSSHKeyHoc, {
 } from 'src/features/linodes/userSSHKeyHoc';
 import SelectStackScriptPanel from 'src/features/StackScripts/SelectStackScriptPanel';
 import StackScriptDrawer from 'src/features/StackScripts/StackScriptDrawer';
-import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
-import { useErrors } from 'src/hooks/useErrors';
-import { useForm } from 'src/hooks/useForm';
-import { useStackScript } from 'src/hooks/useStackScript';
-import { rebuildLinode } from 'src/services/linodes';
-import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
-import { filterPublicImages } from 'src/utilities/images';
-import { withLinodeDetailContext } from '../linodeDetailContext';
-import { RebuildDialog } from './RebuildDialog';
-
 import {
   getCommunityStackscripts,
   getMineAndAccountStackScripts
 } from 'src/features/StackScripts/stackScriptUtils';
+import UserDefinedFieldsPanel from 'src/features/StackScripts/UserDefinedFieldsPanel';
+// @todo: Extract these utils out of Volumes
+import {
+  handleFieldErrors,
+  handleGeneralErrors
+} from 'src/features/Volumes/VolumeDrawer/utils';
+import { useStackScript } from 'src/hooks/useStackScript';
+import { rebuildLinode } from 'src/services/linodes';
+import { RebuildLinodeFromStackScriptSchema } from 'src/services/linodes/linode.schema';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { filterPublicImages } from 'src/utilities/images';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { withLinodeDetailContext } from '../linodeDetailContext';
+import { RebuildDialog } from './RebuildDialog';
 
 type ClassNames = 'root' | 'error' | 'emptyImagePanel' | 'emptyImagePanelText';
 
@@ -68,11 +74,6 @@ interface WithImagesProps {
   imagesError?: string;
 }
 
-interface RebuildFromStackScriptForm {
-  imageID: string;
-  password: string;
-}
-
 export type CombinedProps = Props &
   WithStyles<ClassNames> &
   WithImagesProps &
@@ -80,6 +81,18 @@ export type CombinedProps = Props &
   UserSSHKeyProps &
   RouteComponentProps &
   WithSnackbarProps;
+
+interface RebuildFromStackScriptForm {
+  image: string;
+  root_pass: string;
+  stackscript_id: string;
+}
+
+const initialValues: RebuildFromStackScriptForm = {
+  image: '',
+  root_pass: '',
+  stackscript_id: ''
+};
 
 export const RebuildFromStackScript: React.StatelessComponent<
   CombinedProps
@@ -100,186 +113,238 @@ export const RebuildFromStackScript: React.StatelessComponent<
     resetStackScript
   ] = useStackScript(imagesData);
 
-  const [form, setField, resetForm] = useForm<RebuildFromStackScriptForm>({
-    imageID: '',
-    password: ''
-  });
+  // In this component, most errors are handled by Formik. This is not
+  // possible with UDFs, since they are dynamic. Their errors need to
+  // be handled separately.
+  const [udfErrors, setUdfErrors] = React.useState<
+    Linode.ApiFieldError[] | undefined
+  >(undefined);
 
-  const [errors, setErrors, resetErrors] = useErrors();
   const [isDialogOpen, setIsDialogOpen] = React.useState<boolean>(false);
-  const [isLoading, setIsLoading] = React.useState<boolean>(false);
 
-  const handleSelect = (
-    id: number,
-    label: string,
-    username: string,
-    stackScriptImages: string[],
-    user_defined_fields: Linode.StackScript.UserDefinedField[]
+  const handleFormSubmit = (
+    { image, root_pass }: RebuildFromStackScriptForm,
+    {
+      setSubmitting,
+      setStatus,
+      setErrors
+    }: FormikProps<RebuildFromStackScriptForm>
   ) => {
-    handleSelectStackScript(
-      id,
-      label,
-      username,
-      stackScriptImages,
-      user_defined_fields
-    );
-    // Reset Image ID so that that an incompatible image can't be submitted accidentally
-    setField('imageID', '');
-  };
-
-  const handleSubmit = () => {
-    // @todo: Ideally we would do form validation BEFORE opening up the
-    // confirmation dialog.
-
-    // StackScript ID is technically an optional field on the rebuildLinode
-    // request, so we need to explicitly check for it here.
-    if (!ss.id) {
-      setErrors([
-        { field: 'stackscript_id', reason: 'You must select a StackScript' }
-      ]);
-      setIsDialogOpen(false);
-      return;
-    }
-
-    setIsLoading(true);
+    setSubmitting(true);
 
     rebuildLinode(linodeId, {
       stackscript_id: ss.id,
       stackscript_data: ss.udf_data,
-      root_pass: form.password,
-      image: form.imageID,
+      root_pass,
+      image,
       authorized_users: userSSHKeys.filter(u => u.selected).map(u => u.username)
     })
       .then(_ => {
+        // Reset events polling since an in-progress event (rebuild) is happening.
         resetEventsPolling();
-        resetForm();
-        resetErrors();
-        setIsLoading(false);
+
+        setSubmitting(false);
         setIsDialogOpen(false);
+
         enqueueSnackbar('Linode rebuild started', {
           variant: 'info'
         });
         history.push(`/linodes/${linodeId}/summary`);
       })
       .catch(errorResponse => {
-        setIsLoading(false);
-        setIsDialogOpen(false);
+        const APIError = getAPIErrorOrDefault(errorResponse);
+        setUdfErrors(getUDFErrors(APIError));
 
-        setErrors(
-          getAPIErrorOrDefault(
-            errorResponse,
-            'There was an issue rebuilding your Linode.'
-          )
-        );
+        const defaultMessage = `There was an issue rebuilding your Linode.`;
+        const mapErrorToStatus = (generalError: string) =>
+          setStatus({ generalError });
+
+        setSubmitting(false);
+
+        handleFieldErrors(setErrors, errorResponse);
+        handleGeneralErrors(mapErrorToStatus, errorResponse, defaultMessage);
+
+        setIsDialogOpen(false);
+        scrollErrorIntoView();
       });
   };
 
-  // The error handling below could probably go into the useErrors() hook.
-  const fixedErrorFields = ['stackscript_id', 'root_pass', 'image', 'none'];
+  // Since UDFs are dynamic, they are not handled by Formik. They need
+  // to be validated separately. This functions checks if we've got values
+  // for all REQUIRED UDFs, and sets errors appropriately.
+  const validateUdfs = () => {
+    const maybeErrors: Linode.ApiFieldError[] = [];
 
-  const hasErrorFor = getErrorMap(
-    [
-      ...fixedErrorFields,
-      ...ss.user_defined_fields.map(
-        (udf: Linode.StackScript.UserDefinedField) => udf.name
-      )
-    ],
-    errors
-  );
-  const generalError = hasErrorFor.none;
-  const udfErrors = getUDFErrors(fixedErrorFields, errors);
+    // Walk through the defined UDFs
+    ss.user_defined_fields.forEach(eachUdf => {
+      // Is it required? Do we have a value?
+      if (isUDFRequired(eachUdf) && !ss.udf_data[eachUdf.name]) {
+        // If not, we've got an error.
+        maybeErrors.push({
+          field: eachUdf.name,
+          reason: `A value for the ${eachUdf.name} is required.`
+        });
+      }
+    });
+
+    return maybeErrors;
+  };
+
+  const isUDFRequired = (udf: Linode.StackScript.UserDefinedField) =>
+    !udf.hasOwnProperty('default');
 
   return (
-    <Grid item className={classes.root}>
-      {generalError && (
-        <Notice
-          error
-          className={classes.error}
-          text={generalError}
-          data-qa-notice
-        />
-      )}
-      <SelectStackScriptPanel
-        error={hasErrorFor.stackscript_id}
-        selectedId={ss.id}
-        selectedUsername={ss.username}
-        updateFor={[classes, ss.id, errors]}
-        onSelect={handleSelect}
-        publicImages={filterPublicImages(imagesData)}
-        resetSelectedStackScript={resetStackScript}
-        data-qa-select-stackscript
-        category={props.type}
-        header="Select StackScript"
-        request={
-          props.type === 'account'
-            ? getMineAndAccountStackScripts
-            : getCommunityStackscripts
-        }
-      />
-      {ss.user_defined_fields && ss.user_defined_fields.length > 0 && (
-        <UserDefinedFieldsPanel
-          errors={udfErrors}
-          selectedLabel={ss.label}
-          selectedUsername={ss.username}
-          handleChange={handleChangeUDF}
-          userDefinedFields={ss.user_defined_fields}
-          updateFor={[classes, ss.user_defined_fields, ss.udf_data, errors]}
-          udf_data={ss.udf_data}
-        />
-      )}
-      {ss.images && ss.images.length > 0 ? (
-        <SelectImagePanel
-          variant="all"
-          images={ss.images}
-          handleSelection={(selected: string) => setField('imageID', selected)}
-          updateFor={[classes, form.imageID, ss.images, errors]}
-          selectedImageID={form.imageID}
-          error={hasErrorFor.image}
-        />
-      ) : (
-        <Paper className={classes.emptyImagePanel}>
-          {/* empty state for images */}
-          {hasErrorFor.image && (
-            <Notice error={true} text={hasErrorFor.image} />
-          )}
-          <Typography variant="h2" data-qa-tp="Select Image">
-            Select Image
-          </Typography>
-          <Typography
-            variant="body1"
-            className={classes.emptyImagePanelText}
-            data-qa-no-compatible-images
-          >
-            No Compatible Images Available
-          </Typography>
-        </Paper>
-      )}
-      <AccessPanel
-        password={form.password}
-        handleChange={value => setField('password', value)}
-        updateFor={[form.password, errors, userSSHKeys, ss.id]}
-        error={hasErrorFor.root_pass}
-        users={userSSHKeys}
-        data-qa-access-panel
-      />
-      <ActionsPanel>
-        <Button
-          type="secondary"
-          className="destructive"
-          onClick={() => setIsDialogOpen(true)}
-          data-qa-rebuild
-        >
-          Rebuild
-        </Button>
-      </ActionsPanel>
-      <RebuildDialog
-        isOpen={isDialogOpen}
-        isLoading={isLoading}
-        handleClose={() => setIsDialogOpen(false)}
-        handleSubmit={handleSubmit}
-      />
-      <StackScriptDrawer />
-    </Grid>
+    <Formik
+      initialValues={initialValues}
+      validationSchema={RebuildLinodeFromStackScriptSchema}
+      validateOnChange={false}
+      onSubmit={handleFormSubmit}
+      render={formikProps => {
+        const {
+          errors,
+          handleSubmit,
+          isSubmitting,
+          setFieldValue,
+          status,
+          values,
+          validateForm
+        } = formikProps;
+
+        // The "Rebuild" button opens a confirmation modal.
+        // We'd like to validate the form before this happens.
+        const handleRebuildButtonClick = () => {
+          // Validate stackscript_id, image, & root_pass
+          validateForm().then(maybeErrors => {
+            // UDFs are not part of Formik - validate separately.
+            const maybeUDFErrors = validateUdfs();
+            setUdfErrors(maybeUDFErrors);
+
+            // If there aren't any errors, we can open the modal.
+            if (isEmpty(maybeErrors) && maybeUDFErrors.length === 0) {
+              setIsDialogOpen(true);
+              // The form receives the errors automatically, and we scroll them into view.
+            } else {
+              scrollErrorIntoView();
+            }
+          });
+        };
+
+        const handleSelect = (
+          id: number,
+          label: string,
+          username: string,
+          stackScriptImages: string[],
+          user_defined_fields: Linode.StackScript.UserDefinedField[]
+        ) => {
+          handleSelectStackScript(
+            id,
+            label,
+            username,
+            stackScriptImages,
+            user_defined_fields
+          );
+          // Reset Image ID so that that an incompatible image can't be submitted accidentally
+          setFieldValue('stackscript_id', id);
+          setFieldValue('image', '');
+        };
+
+        return (
+          <Grid item className={classes.root}>
+            {status && (
+              <Notice
+                error
+                className={classes.error}
+                text={status.generalError}
+                data-qa-notice
+              />
+            )}
+            <SelectStackScriptPanel
+              error={errors.stackscript_id}
+              selectedId={ss.id}
+              selectedUsername={ss.username}
+              updateFor={[classes, ss.id, errors]}
+              onSelect={handleSelect}
+              publicImages={filterPublicImages(imagesData)}
+              resetSelectedStackScript={resetStackScript}
+              data-qa-select-stackscript
+              category={props.type}
+              header="Select StackScript"
+              request={
+                props.type === 'account'
+                  ? getMineAndAccountStackScripts
+                  : getCommunityStackscripts
+              }
+            />
+            {ss.user_defined_fields && ss.user_defined_fields.length > 0 && (
+              <UserDefinedFieldsPanel
+                errors={udfErrors}
+                selectedLabel={ss.label}
+                selectedUsername={ss.username}
+                handleChange={handleChangeUDF}
+                userDefinedFields={ss.user_defined_fields}
+                updateFor={[
+                  classes,
+                  ss.user_defined_fields,
+                  ss.udf_data,
+                  udfErrors
+                ]}
+                udf_data={ss.udf_data}
+              />
+            )}
+            {ss.images && ss.images.length > 0 ? (
+              <SelectImagePanel
+                variant="public"
+                images={ss.images}
+                handleSelection={selected => setFieldValue('image', selected)}
+                updateFor={[classes, values.image, ss.images, errors]}
+                selectedImageID={values.image}
+                error={errors.image}
+              />
+            ) : (
+              <Paper className={classes.emptyImagePanel}>
+                {/* empty state for images */}
+                {errors.image && <Notice error={true} text={errors.image} />}
+                <Typography variant="h2" data-qa-tp="Select Image">
+                  Select Image
+                </Typography>
+                <Typography
+                  variant="body1"
+                  className={classes.emptyImagePanelText}
+                  data-qa-no-compatible-images
+                >
+                  No Compatible Images Available
+                </Typography>
+              </Paper>
+            )}
+            <AccessPanel
+              password={values.root_pass}
+              handleChange={value => setFieldValue('root_pass', value)}
+              updateFor={[values.root_pass, errors, userSSHKeys, ss.id]}
+              error={errors.root_pass}
+              users={userSSHKeys}
+              data-qa-access-panel
+            />
+            <ActionsPanel>
+              <Button
+                type="secondary"
+                className="destructive"
+                onClick={handleRebuildButtonClick}
+                data-qa-rebuild
+              >
+                Rebuild
+              </Button>
+            </ActionsPanel>
+            <RebuildDialog
+              isOpen={isDialogOpen}
+              isLoading={isSubmitting}
+              handleClose={() => setIsDialogOpen(false)}
+              handleSubmit={handleSubmit}
+            />
+            <StackScriptDrawer />
+          </Grid>
+        );
+      }}
+    />
   );
 };
 
@@ -309,10 +374,9 @@ export default enhanced(RebuildFromStackScript);
 // Helpers
 // =============================================================================
 
-const getUDFErrors = (
-  fixedErrorFields: string[],
-  errors: Linode.ApiFieldError[] | undefined
-) => {
+const getUDFErrors = (errors: Linode.ApiFieldError[] | undefined) => {
+  const fixedErrorFields = ['stackscript_id', 'root_pass', 'image', 'none'];
+
   return errors
     ? errors.filter(error => {
         // ensure the error isn't a root_pass, image, or none

--- a/src/services/linodes/linode.schema.ts
+++ b/src/services/linodes/linode.schema.ts
@@ -137,7 +137,8 @@ const SSHKeySchema = object({
   created: string()
 });
 
-export const RebuildLinodeSchema = object({
+// Include `shape()` here so that the schema can be extended without TS complaining.
+export const RebuildLinodeSchema = object().shape({
   image: string().required('An image is required.'),
   root_pass: string()
     .required('Password cannot be blank.')
@@ -147,6 +148,10 @@ export const RebuildLinodeSchema = object({
   stackscript_id: number().notRequired(),
   stackscript_data,
   booted: boolean().notRequired()
+});
+
+export const RebuildLinodeFromStackScriptSchema = RebuildLinodeSchema.shape({
+  stackscript_id: number().required('A StackScript is required.')
 });
 
 export const IPAllocationSchema = object({


### PR DESCRIPTION
Add Formik to control values and errors. UDFs are handled separately, since they are dynamic.

Tests have been broken; they will be fixed in the next commit.

## Description

Please start the pull request title with the jira ticket corresponding to the work if applicable. Please include a short summary of the feature added, the change, or issue fixed.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
- Non breaking change ('update', 'change')
- Breaking change ('break', 'deprecate')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=COMMA_SEPARATED_LIST_OF_SPECS_HERE --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
