### PR TITLE
Adds Labels and Port to NodeBalancer Delete Modals

### DIFF
--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -108,6 +108,7 @@ interface State {
     submitting: boolean;
     errors?: Linode.ApiFieldError[];
     idxToDelete?: number;
+    portToDelete?: number;
   };
 }
 
@@ -152,7 +153,8 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
     submitting: false,
     open: false,
     errors: undefined,
-    idxToDelete: undefined
+    idxToDelete: undefined,
+    portToDelete: undefined
   };
 
   static defaultDeleteNodeConfirmDialogState = {
@@ -942,14 +944,15 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
 
   onSaveConfig = (idx: number) => () => this.saveConfig(idx);
 
-  onDeleteConfig = (idx: number) => () => {
+  onDeleteConfig = (idx: number, port: number) => () => {
     this.setState({
       deleteConfigConfirmDialog: {
         ...clone(
           NodeBalancerConfigurations.defaultDeleteConfigConfirmDialogState
         ),
         open: true,
-        idxToDelete: idx
+        idxToDelete: idx,
+        portToDelete: port
       }
     });
   };
@@ -1024,7 +1027,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
           configIdx={idx}
           onSave={this.onSaveConfig(idx)}
           submitting={configSubmitting[idx]}
-          onDelete={this.onDeleteConfig(idx)}
+          onDelete={this.onDeleteConfig(idx, config.port)}
           errors={configErrors[idx]}
           nodeMessage={panelNodeMessages[idx]}
           algorithm={view(L.algorithmLens, this.state)}
@@ -1157,7 +1160,9 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
 
         <ConfirmationDialog
           onClose={this.onCloseConfirmation}
-          title="Confirm Deletion"
+          title={`Delete this configuration on port ${
+            this.state.deleteConfigConfirmDialog.portToDelete
+          }?`}
           error={this.confirmationConfigError()}
           actions={this.renderConfigConfirmationActions}
           open={this.state.deleteConfigConfirmDialog.open}

--- a/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
@@ -74,7 +74,7 @@ interface Props {
   orderBy: string;
   order: 'asc' | 'desc';
   handleOrderChange: (orderBy: string, order?: 'asc' | 'desc') => void;
-  toggleDialog: (id: number) => void;
+  toggleDialog: (id: number, label: string) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;

--- a/src/features/NodeBalancers/NodeBalancersLanding/ListNodeBalancers.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/ListNodeBalancers.tsx
@@ -39,7 +39,7 @@ interface Props {
   orderBy: string;
   order: 'asc' | 'desc';
   handleOrderChange: (orderBy: string, order?: 'asc' | 'desc') => void;
-  toggleDialog: (id: number) => void;
+  toggleDialog: (id: number, label: string) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerActionMenu.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerActionMenu.tsx
@@ -5,14 +5,15 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
   nodeBalancerId: number;
-  toggleDialog: (nodeBalancerId: number) => void;
+  toggleDialog: (nodeBalancerId: number, label: string) => void;
+  label: string;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}>;
 
 class NodeBalancerActionMenu extends React.Component<CombinedProps> {
   createLinodeActions = () => {
-    const { nodeBalancerId, history, toggleDialog } = this.props;
+    const { nodeBalancerId, history, toggleDialog, label } = this.props;
 
     return (closeMenu: Function): Action[] => {
       const actions = [
@@ -44,7 +45,7 @@ class NodeBalancerActionMenu extends React.Component<CombinedProps> {
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             e.preventDefault();
-            toggleDialog(nodeBalancerId);
+            toggleDialog(nodeBalancerId, label);
             closeMenu();
           }
         }

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -94,6 +94,7 @@ interface DeleteConfirmDialogState {
 interface State {
   deleteConfirmDialog: DeleteConfirmDialogState;
   selectedNodeBalancerId?: number;
+  selectedNodeBalancerLabel: string;
 }
 
 type CombinedProps = WithNodeBalancerActions &
@@ -116,7 +117,8 @@ export class NodeBalancersLanding extends React.Component<
   };
 
   state: State = {
-    deleteConfirmDialog: NodeBalancersLanding.defaultDeleteConfirmDialogState
+    deleteConfirmDialog: NodeBalancersLanding.defaultDeleteConfirmDialogState,
+    selectedNodeBalancerLabel: ''
   };
 
   pollInterval: number;
@@ -139,9 +141,10 @@ export class NodeBalancersLanding extends React.Component<
 
   static docs = [NodeBalancerGettingStarted, NodeBalancerReference];
 
-  toggleDialog = (nodeBalancerId: number) => {
+  toggleDialog = (nodeBalancerId: number, label: string) => {
     this.setState({
       selectedNodeBalancerId: nodeBalancerId,
+      selectedNodeBalancerLabel: label,
       deleteConfirmDialog: {
         ...this.state.deleteConfirmDialog,
         open: !this.state.deleteConfirmDialog.open
@@ -292,7 +295,7 @@ export class NodeBalancersLanding extends React.Component<
         </OrderBy>
         <ConfirmationDialog
           onClose={this.closeConfirmationDialog}
-          title="Confirm Deletion"
+          title={`Delete ${this.state.selectedNodeBalancerLabel}?`}
           error={(this.state.deleteConfirmDialog.errors || [])
             .map(e => e.reason)
             .join(',')}

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
@@ -44,7 +44,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 interface Props {
   data: Linode.NodeBalancerWithConfigs[];
-  toggleDialog: (id: number) => void;
+  toggleDialog: (id: number, label: string) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -119,6 +119,7 @@ const NodeBalancersLandingTableRows: React.StatelessComponent<
               <NodeBalancerActionMenu
                 nodeBalancerId={nodeBalancer.id}
                 toggleDialog={toggleDialog}
+                label={nodeBalancer.label}
               />
             </TableCell>
           </TableRow>


### PR DESCRIPTION
## Description

1. Adds NodeBalancer Label to NB Delete Modal
2. Adds NodeBalancer Config port to NB Config Delete Modal

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/nodebalancers/configurations.spec.js,e2e/specs/nodebalancers/list.spec.js --browser=headlessChrome`