### PR TITLE
Add: Prefix Length to the IPv6 Pools and Ranges

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -221,12 +221,6 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
       <TableRow key={ip.address} data-qa-ip={ip.address}>
         <TableCell parentColumn="Address" data-qa-ip-address>
           {ip.address}
-          {type === 'Link Local' && (
-            <React.Fragment>
-              <span style={{ margin: '0 5px 0 5px' }}>/</span>
-              {ip.prefix}
-            </React.Fragment>
-          )}
         </TableCell>
         <TableCell parentColumn="Default Gateway">{ip.gateway}</TableCell>
         <TableCell parentColumn="Reverse DNS" data-qa-rdns>

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -194,9 +194,13 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
 
     return (
       <TableRow key={range.range}>
-        <TableCell parentColumn="Address">{`${range.range}/${
-          range.prefix
-        }`}</TableCell>
+        <TableCell parentColumn="Address">
+          <React.Fragment>
+            {range.range}
+            <span style={{ margin: '0 5px 0 5px' }}>/</span>
+            {range.prefix}
+          </React.Fragment>
+        </TableCell>
         <TableCell />
         <TableCell />
         <TableCell parentColumn="Type">{type}</TableCell>
@@ -216,7 +220,13 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     return (
       <TableRow key={ip.address} data-qa-ip={ip.address}>
         <TableCell parentColumn="Address" data-qa-ip-address>
-          {ip.type !== 'ipv4' ? `${ip.address}/${ip.prefix}` : ip.address}
+          {ip.address}
+          {type === 'Link Local' && (
+            <React.Fragment>
+              <span style={{ margin: '0 5px 0 5px' }}>/</span>
+              {ip.prefix}
+            </React.Fragment>
+          )}
         </TableCell>
         <TableCell parentColumn="Default Gateway">{ip.gateway}</TableCell>
         <TableCell parentColumn="Reverse DNS" data-qa-rdns>

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -194,7 +194,9 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
 
     return (
       <TableRow key={range.range}>
-        <TableCell parentColumn="Address">{range.range}</TableCell>
+        <TableCell parentColumn="Address">{`${range.range}/${
+          range.prefix
+        }`}</TableCell>
         <TableCell />
         <TableCell />
         <TableCell parentColumn="Type">{type}</TableCell>
@@ -214,7 +216,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     return (
       <TableRow key={ip.address} data-qa-ip={ip.address}>
         <TableCell parentColumn="Address" data-qa-ip-address>
-          {ip.address}
+          {ip.type !== 'ipv4' ? `${ip.address}/${ip.prefix}` : ip.address}
         </TableCell>
         <TableCell parentColumn="Default Gateway">{ip.gateway}</TableCell>
         <TableCell parentColumn="Reverse DNS" data-qa-rdns>


### PR DESCRIPTION
## Description

Adds ipv6 prefix to each range table row

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/linodes/detail/networking.spec.js --browser=headlessChrome`

## Note to Reviewers
 
Only showing prefix for ipv6 range as per feedback from @asauber 