### PR TITLE
OBJ-158 Change: Force-delete buckets

### DIFF
--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -2,7 +2,7 @@
 
 # Confirm Branch includes M3 Ticket
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-BRANCH_INCLUDES_TICKET=$(git rev-parse --abbrev-ref HEAD | egrep -i '(M3-[0-9]*)|feature|develop|master|release-.*')
+BRANCH_INCLUDES_TICKET=$(git rev-parse --abbrev-ref HEAD | egrep -i '(M3-[0-9]*)|feature|develop|master|release-.*|OBJ.*')
 RED='\033[0;31m'
 
 if [ $BRANCH_INCLUDES_TICKET ]

--- a/src/features/ObjectStorage/Buckets/BucketActionMenu.test.tsx
+++ b/src/features/ObjectStorage/Buckets/BucketActionMenu.test.tsx
@@ -29,6 +29,6 @@ describe('BucketActionMenu', () => {
     );
 
     fireEvent.click(getAllByText('Delete')[0]);
-    expect(mockOnRemove).toHaveBeenCalledWith('a-cluster', 'my-test-bucket');
+    expect(mockOnRemove).toHaveBeenCalled();
   });
 });

--- a/src/features/ObjectStorage/Buckets/BucketActionMenu.tsx
+++ b/src/features/ObjectStorage/Buckets/BucketActionMenu.tsx
@@ -2,23 +2,18 @@ import * as React from 'react';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 export interface Props {
-  onRemove: (cluster: string, bucketLabel: string) => void;
+  onRemove: () => void;
   bucketLabel: string;
   cluster: string;
 }
 
 export const BucketActionMenu: React.StatelessComponent<Props> = props => {
-  const handleRemove = () => {
-    const { bucketLabel, cluster, onRemove } = props;
-    onRemove(cluster, bucketLabel);
-  };
-
   const createActions = () => (closeMenu: Function): Action[] => {
     return [
       {
         title: 'Delete',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
-          handleRemove();
+          props.onRemove();
           closeMenu();
           e.preventDefault();
         }

--- a/src/features/ObjectStorage/Buckets/BucketTableRow.tsx
+++ b/src/features/ObjectStorage/Buckets/BucketTableRow.tsx
@@ -31,7 +31,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 });
 
 interface BucketTableRowProps extends Linode.Bucket {
-  onRemove: (cluster: string, bucketLabel: string) => void;
+  onRemove: () => void;
 }
 
 type CombinedProps = BucketTableRowProps & WithStyles<ClassNames>;

--- a/src/features/ObjectStorage/Buckets/ListBuckets.test.tsx
+++ b/src/features/ObjectStorage/Buckets/ListBuckets.test.tsx
@@ -6,7 +6,7 @@ import { ListBuckets } from './ListBuckets';
 describe('ListBuckets', () => {
   const wrapper = shallow(
     <ListBuckets
-      classes={{ root: '', label: '' }}
+      classes={{ root: '', label: '', confirmationCopy: '' }}
       data={buckets}
       orderBy="label"
       order="asc"

--- a/src/features/ObjectStorage/Buckets/ListBuckets.tsx
+++ b/src/features/ObjectStorage/Buckets/ListBuckets.tsx
@@ -133,7 +133,7 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
         </Typography>
       ) : (
         <Typography>
-          Deleting a bucket is permanent and can't be undone.{' '}
+          Deleting a bucket is permanent and can't be undone.
         </Typography>
       )}
       <Typography className={classes.confirmationCopy}>

--- a/src/features/ObjectStorage/Buckets/ListBuckets.tsx
+++ b/src/features/ObjectStorage/Buckets/ListBuckets.tsx
@@ -231,7 +231,6 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
           <ConfirmationDialog
             open={removeBucketConfirmationDialog.isOpen}
             onClose={() => {
-              setBucketToRemove(undefined);
               removeBucketConfirmationDialog.close();
             }}
             title={

--- a/src/features/ObjectStorage/Buckets/ListBuckets.tsx
+++ b/src/features/ObjectStorage/Buckets/ListBuckets.tsx
@@ -77,7 +77,9 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
     setIsLoading(true);
 
     const { cluster, label } = bucketToRemove;
-    deleteBucket({ cluster, label })
+    // Passing in `force: 1` as a param to delete ALL items within
+    // the bucket before deleting the bucket itself.
+    deleteBucket({ cluster, label, params: { force: 1 } })
       .then(() => {
         removeBucketConfirmationDialog.close();
         setIsLoading(false);

--- a/src/features/ObjectStorage/Buckets/ListBuckets.tsx
+++ b/src/features/ObjectStorage/Buckets/ListBuckets.tsx
@@ -117,38 +117,31 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
     </ActionsPanel>
   );
 
-  const deleteBucketConfirmationMessage = () => {
-    if (!bucketToRemove) {
-      return null;
-    }
-
-    const { label, size, objects } = bucketToRemove;
-    const maybePluralizedObject = objects === 1 ? 'object' : 'objects';
-
-    return (
-      <React.Fragment>
-        {size > 0 ? (
-          <Typography>
-            This bucket contains{' '}
-            <strong>
-              {objects} {maybePluralizedObject}
-            </strong>{' '}
-            totalling <strong>{readableBytes(size).formatted}</strong> that will
-            be deleted along with the bucket. Deleting a bucket is permanent and
-            can't be undone.
-          </Typography>
-        ) : (
-          <Typography>
-            Deleting a bucket is permanent and can't be undone.{' '}
-          </Typography>
-        )}
-        <Typography className={classes.confirmationCopy}>
-          To confirm deletion, type the name of the bucket ({label}) in the
-          field below:
+  const deleteBucketConfirmationMessage = bucketToRemove ? (
+    <React.Fragment>
+      {bucketToRemove.size > 0 ? (
+        <Typography>
+          This bucket contains{' '}
+          <strong>
+            {bucketToRemove.objects}{' '}
+            {bucketToRemove.objects === 1 ? 'object' : 'objects'}
+          </strong>{' '}
+          totalling{' '}
+          <strong>{readableBytes(bucketToRemove.size).formatted}</strong> that
+          will be deleted along with the bucket. Deleting a bucket is permanent
+          and can't be undone.
         </Typography>
-      </React.Fragment>
-    );
-  };
+      ) : (
+        <Typography>
+          Deleting a bucket is permanent and can't be undone.{' '}
+        </Typography>
+      )}
+      <Typography className={classes.confirmationCopy}>
+        To confirm deletion, type the name of the bucket ({bucketToRemove.label}
+        ) in the field below:
+      </Typography>
+    </React.Fragment>
+  ) : null;
 
   return (
     <Paginate data={data} pageSize={25}>
@@ -241,7 +234,7 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
             actions={actions}
             error={error}
           >
-            <Typography>{deleteBucketConfirmationMessage()}</Typography>
+            {deleteBucketConfirmationMessage}
             <TextField
               onChange={e => setConfirmBucketName(e.target.value)}
               expand

--- a/src/services/objectStorage/buckets.ts
+++ b/src/services/objectStorage/buckets.ts
@@ -18,6 +18,7 @@ export interface BucketRequestPayload {
 export interface DeleteBucketRequestPayload {
   cluster: string;
   label: string;
+  params?: { force: number };
 }
 
 /**
@@ -53,11 +54,18 @@ export const createBucket = (data: BucketRequestPayload) =>
  *
  * Removes a Bucket from your account.
  *
- * @param bucketId { number } The ID of the bucket to delete.
+ * NOTE: By default, attempting to delete a non-empty bucket
+ * will result in an error. Passing `force: 1` as a param will
+ * delete every item in the bucket, then delete the bucket itself.
  *
  */
-export const deleteBucket = ({ cluster, label }: DeleteBucketRequestPayload) =>
+export const deleteBucket = ({
+  cluster,
+  label,
+  params
+}: DeleteBucketRequestPayload) =>
   Request<Linode.Bucket>(
     setURL(`${API_ROOT}beta/object-storage/buckets/${cluster}/${label}`),
+    setParams(params),
     setMethod('DELETE')
   );


### PR DESCRIPTION
## Description

TODO:

- [x] Add appropriate UX warning user all items will be deleted.

By default, the API returns an error when attempting to delete a bucket with items in it.

A new API feature allows a `force` option, which recursively deletes every item in the bucket, and then deletes the bucket itself.

This PR uses the `force` option when deleting a bucket from the landing page.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Attempt to delete a bucket with objects in it. It should work. 