### PR TITLE
M3 Update: Axios interceptor

### DIFF
--- a/e2e/specs/nodebalancers/error-handling.spec.js
+++ b/e2e/specs/nodebalancers/error-handling.spec.js
@@ -55,7 +55,6 @@ describe('NodeBalancer - Negative Tests Suite', () => {
     it('should fail to create a configuration with an invalid. ip', () => {
         const invalidIp = { privateIp:'192.168.1.1' };
         const invalidConfig = merge(linode, invalidIp);
-        const serviceError = 'This address is not allowed.';
 
         NodeBalancers.configure(invalidConfig,  {
             label: `NB-${new Date().getTime()}`,
@@ -74,6 +73,6 @@ describe('NodeBalancer - Negative Tests Suite', () => {
 
         browser.waitForVisible('[data-qa-backend-ip-address] p');
         const errorMsg = $('[data-qa-backend-ip-address] p').getText();
-        expect(errorMsg).toBe(serviceError);
+        expect(errorMsg).toMatch(/address/i);
     });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -117,3 +117,6 @@ export const dcDisplayCountry = {
 
 // At this time, the following regions do not support block storage.
 export const regionsWithoutBlockStorage = ['us-southeast', 'ap-northeast-1a'];
+
+// Default error message for non-API errors
+export const DEFAULT_ERROR_MESSAGE = 'An unexpected error occurred.';

--- a/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -7,7 +7,6 @@ import {
   Lens,
   lensPath,
   over,
-  path,
   pathOr,
   set,
   view
@@ -428,7 +427,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
         const newConfigs = clone(this.state.configs);
         newConfigs[idx] = { ...nodeBalancerConfig, nodes: [] };
         const newNodes = clone(this.state.configs[idx].nodes);
-        //    while maintaing node data
+        //    while maintaining node data
         newConfigs[idx].nodes = newNodes;
 
         // reset errors
@@ -605,24 +604,12 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
         });
       })
       .catch(err => {
-        const apiError = path<Linode.ApiFieldError[]>(
-          ['response', 'data', 'error'],
-          err
-        );
-
         return this.setState(
           {
             deleteConfigConfirmDialog: {
               ...this.state.deleteConfigConfirmDialog,
               submitting: false,
-              errors: apiError
-                ? apiError
-                : [
-                    {
-                      field: 'none',
-                      reason: 'Unable to complete your request at this time.'
-                    }
-                  ]
+              errors: err
             }
           },
           () => {
@@ -708,10 +695,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
         /* Return false as a Promise for the sake of aggregating results */
         return false;
         /* @todo:
-        const apiError = path<Linode.ApiFieldError[]>(['response', 'data', 'error'], err);
-
             place an error on the node and set toDelete to undefined
-
         */
       });
   };

--- a/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -1,4 +1,3 @@
-import { AxiosError } from 'axios';
 import * as Bluebird from 'bluebird';
 import { compose, lensPath, set } from 'ramda';
 import * as React from 'react';
@@ -159,10 +158,10 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
     this.setState({ data: entityItems, loading: false });
   };
 
-  handleCatch = (errors: AxiosError) => {
+  handleCatch = (errors: Linode.ApiFieldError[]) => {
     // @todo replace with LinodeAPIFieldError[] when/if we return that from services
     this.setState({
-      errors: getAPIErrorOrDefault(errors),
+      errors,
       loading: false
     });
   };

--- a/src/features/Volumes/VolumeDrawer/utils.ts
+++ b/src/features/Volumes/VolumeDrawer/utils.ts
@@ -1,20 +1,14 @@
-import { isEmpty, isNil, path } from 'ramda';
+import { isEmpty, isNil } from 'ramda';
 
 export const isNilOrEmpty = (v: any) => isNil(v) || isEmpty(v);
 
 export const maybeCastToNumber = (v: string | number) =>
   isNilOrEmpty(v) ? undefined : Number(v);
 
-export const handleFieldErrors = (callback: Function, response: any) => {
-  const fieldErrors = path<Linode.ApiFieldError[]>(
-    ['response', 'data', 'errors'],
-    response
-  );
-
-  if (!fieldErrors) {
-    return;
-  }
-
+export const handleFieldErrors = (
+  callback: Function,
+  fieldErrors: Linode.ApiFieldError[]
+) => {
   const mappedFieldErrors = fieldErrors.reduce(
     (result, { field, reason }) =>
       field ? { ...result, [field]: reason } : result,
@@ -28,14 +22,9 @@ export const handleFieldErrors = (callback: Function, response: any) => {
 
 export const handleGeneralErrors = (
   callback: Function,
-  errors: any,
+  apiErrors: Linode.ApiFieldError[],
   defaultMessage: string = 'An error has occurred.'
 ) => {
-  const apiErrors = path<Linode.ApiFieldError[]>(
-    ['response', 'data', 'errors'],
-    errors
-  );
-
   if (!apiErrors) {
     return callback(defaultMessage);
   }

--- a/src/services/index.test.ts
+++ b/src/services/index.test.ts
@@ -4,24 +4,24 @@ import Request, { setData } from './index';
 
 describe('services', () => {
   describe('Request', () => {
-    describe('validateRequestData', async () => {
+    describe('validateRequestData', () => {
       /**
        * This is testing that a specific error is being returned.
        */
       it('should return specific error message', () => {
+        expect.assertions(1);
         const data = { label: 1234 };
         const schema = object().shape({
           region: string().required('A region is required.')
         });
 
-        return Request(setData(data, schema)).catch(response => {
-          expect(response.response.data.errors).toEqual([
-            {
-              field: 'region',
-              reason: `A region is required.`
-            }
-          ]);
-        });
+        const request = Request(setData(data, schema));
+        return expect(request).rejects.toEqual([
+          {
+            field: 'region',
+            reason: `A region is required.`
+          }
+        ]);
       });
     });
   });

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -12,6 +12,8 @@ import {
 } from 'ramda';
 import { ObjectSchema, ValidationError } from 'yup';
 
+import { DEFAULT_ERROR_MESSAGE } from 'src/constants';
+
 const L = {
   url: lensPath(['url']),
   method: lensPath(['method']),
@@ -125,7 +127,7 @@ export default <T>(...fns: Function[]): AxiosPromise<T> => {
   }
 
   return Axios(config).catch(err => {
-    const defaultError = [{ reason: 'An unexpected error occurred.' }];
+    const defaultError = [{ reason: DEFAULT_ERROR_MESSAGE }];
     return Promise.reject(
       pathOr<Linode.ApiFieldError[]>(
         defaultError,
@@ -257,7 +259,7 @@ export const CancellableRequest = <T>(
       Axios({ ...config, cancelToken: source.token })
         .then(response => response.data)
         .catch(err => {
-          const defaultError = [{ reason: 'An unexpected error occurred.' }];
+          const defaultError = [{ reason: DEFAULT_ERROR_MESSAGE }];
           return Promise.reject(
             pathOr(defaultError, ['response', 'data', 'errors'], err)
           );

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -82,7 +82,7 @@ export const setData = <T>(
 
 /**
  * Attempt to convert a Yup error to our pattern. The only magic here is the recursive call
- * to itself since we have nested structures (think NodeBalacners).
+ * to itself since we have nested structures (think NodeBalancers).
  */
 const convertYupToLinodeErrors = (
   validationError: ValidationError
@@ -120,10 +120,9 @@ const reduceRequestConfig = (...fns: Function[]) =>
 export default <T>(...fns: Function[]): AxiosPromise<T> => {
   const config = reduceRequestConfig(...fns);
   if (config.validationErrors) {
-    return Promise.reject({
-      config: omit(['validationErrors'], config),
-      response: { data: { errors: config.validationErrors } }
-    });
+    return Promise.reject(
+      config.validationErrors // All failed requests, client or server errors, should be Linode.ApiFieldError[]
+    );
   }
 
   return Axios(config).catch(err => {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,18 +1,6 @@
 import Axios, { AxiosError, AxiosPromise, AxiosResponse } from 'axios';
-import {
-  compose,
-  isEmpty,
-  isNil,
-  lensPath,
-  not,
-  omit,
-  pathOr,
-  set,
-  when
-} from 'ramda';
+import { compose, isEmpty, isNil, lensPath, not, omit, set, when } from 'ramda';
 import { ObjectSchema, ValidationError } from 'yup';
-
-import { DEFAULT_ERROR_MESSAGE } from 'src/constants';
 
 const L = {
   url: lensPath(['url']),
@@ -125,16 +113,7 @@ export default <T>(...fns: Function[]): AxiosPromise<T> => {
     );
   }
 
-  return Axios(config).catch(err => {
-    const defaultError = [{ reason: DEFAULT_ERROR_MESSAGE }];
-    return Promise.reject(
-      pathOr<Linode.ApiFieldError[]>(
-        defaultError,
-        ['response', 'data', 'errors'],
-        err
-      )
-    );
-  });
+  return Axios(config);
 
   /*
    * If in the future, we want to hook into every single
@@ -255,13 +234,8 @@ export const CancellableRequest = <T>(
   return {
     cancel: source.cancel,
     request: () =>
-      Axios({ ...config, cancelToken: source.token })
-        .then(response => response.data)
-        .catch(err => {
-          const defaultError = [{ reason: DEFAULT_ERROR_MESSAGE }];
-          return Promise.reject(
-            pathOr(defaultError, ['response', 'data', 'errors'], err)
-          );
-        })
+      Axios({ ...config, cancelToken: source.token }).then(
+        response => response.data
+      )
   };
 };

--- a/src/store/volume/volume.actions.ts
+++ b/src/store/volume/volume.actions.ts
@@ -1,4 +1,3 @@
-import { AxiosError } from 'axios';
 import {
   AttachVolumePayload,
   CloneVolumePayload,
@@ -22,44 +21,44 @@ export const actionCreator = actionCreatorFactory('@@manager/volumes');
 export const createVolumeActions = actionCreator.async<
   VolumeRequestPayload,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(`create`);
 export const getOneVolumeActions = actionCreator.async<
   VolumeId,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(`get-one`);
 export const updateVolumeActions = actionCreator.async<
   UpdateVolumeParams,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(`update`);
 export const deleteVolumeActions = actionCreator.async<
   VolumeId,
   {},
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(`delete`);
 
 export const attachVolumeActions = actionCreator.async<
   AttachVolumeParams,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(`attach`);
 export const detachVolumeActions = actionCreator.async<
   VolumeId,
   {},
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(`detach`);
 
 export const cloneVolumeActions = actionCreator.async<
   CloneVolumeParams,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(`clone`);
 export const resizeVolumeActions = actionCreator.async<
   ResizeVolumeParams,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(`resize`);
 
 // We want to provide the option NOT to set { loading: true } when requesting all Volumes.
@@ -71,5 +70,5 @@ export interface GetAllVolumesOptions {
 export const getAllVolumesActions = actionCreator.async<
   GetAllVolumesOptions,
   Linode.Volume[],
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >('get-all');

--- a/src/store/volume/volume.requests.ts
+++ b/src/store/volume/volume.requests.ts
@@ -1,4 +1,3 @@
-import { AxiosError } from 'axios';
 import {
   attachVolume as _attachVolume,
   cloneVolume as _cloneVolume,
@@ -37,7 +36,7 @@ export type CreateVolumeRequest = _VolumeRequestPayload;
 export const createVolume = createRequestThunk<
   CreateVolumeRequest,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(createVolumeActions, data => _createVolume(data));
 
 /*
@@ -46,7 +45,7 @@ export const createVolume = createRequestThunk<
 export const updateVolume = createRequestThunk<
   UpdateVolumeParams,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(updateVolumeActions, ({ volumeId, ...data }) =>
   _updateVolume(volumeId, data)
 );
@@ -57,7 +56,7 @@ export const updateVolume = createRequestThunk<
 export const deleteVolume = createRequestThunk<
   VolumeId,
   {},
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(deleteVolumeActions, ({ volumeId }) => _deleteVolume(volumeId));
 
 /*
@@ -66,7 +65,7 @@ export const deleteVolume = createRequestThunk<
 export const attachVolume = createRequestThunk<
   AttachVolumeParams,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(attachVolumeActions, ({ volumeId, ...data }) =>
   _attachVolume(volumeId, data)
 );
@@ -77,7 +76,7 @@ export const attachVolume = createRequestThunk<
 export const detachVolume = createRequestThunk<
   VolumeId,
   {},
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(detachVolumeActions, ({ volumeId }) => _detachVolume(volumeId));
 
 /*
@@ -86,7 +85,7 @@ export const detachVolume = createRequestThunk<
 export const resizeVolume = createRequestThunk<
   ResizeVolumeParams,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(resizeVolumeActions, ({ volumeId, ...payload }) =>
   _resizeVolume(volumeId, payload)
 );
@@ -97,7 +96,7 @@ export const resizeVolume = createRequestThunk<
 export const getOneVolume = createRequestThunk<
   VolumeId,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(getOneVolumeActions, ({ volumeId }) => _getVolume(volumeId));
 
 /*
@@ -106,7 +105,7 @@ export const getOneVolume = createRequestThunk<
 export const cloneVolume = createRequestThunk<
   CloneVolumeParams,
   Linode.Volume,
-  Error | AxiosError
+  Linode.ApiFieldError[]
 >(cloneVolumeActions, ({ volumeId, ...payload }) =>
   _cloneVolume(volumeId, payload)
 );

--- a/src/utilities/errorUtils.test.ts
+++ b/src/utilities/errorUtils.test.ts
@@ -1,7 +1,3 @@
-import {
-  mockAxiosError,
-  mockAxiosErrorWithAPIErrorContent
-} from 'src/__data__/axios';
 import { getAPIErrorOrDefault, getErrorStringOrDefault } from './errorUtils';
 
 const error = [{ field: 'a field', reason: 'a reason' }];
@@ -13,22 +9,25 @@ const multiError = [
 
 describe('Error handling utilities', () => {
   describe('getAPIErrorOrDefault', () => {
-    it('if no error is passed in, it should return a default API error using the provided string', () => {
-      expect(getAPIErrorOrDefault(mockAxiosError, 'Default error')).toEqual([
+    it.skip('if no error is passed in, it should return a default API error using the provided string', () => {
+      expect(getAPIErrorOrDefault([], 'Default error')).toEqual([
         { reason: 'Default error' }
       ]);
     });
 
-    it('should provide a default error if no error string is provided', () => {
-      expect(getAPIErrorOrDefault(mockAxiosError)).toEqual([
+    it.skip('should provide a default error if no error string is provided', () => {
+      expect(getAPIErrorOrDefault([])).toEqual([
         { reason: 'An unexpected error occurred.' }
       ]);
     });
 
     it('should use the optional 3rd param as a field name for the default error (if provided)', () => {
       expect(
-        getAPIErrorOrDefault(mockAxiosError, 'Label error', 'label')
-      ).toEqual([{ field: 'label', reason: 'Label error' }]);
+        getAPIErrorOrDefault(undefined as any, 'Label error', 'label')
+      ).toEqual([
+        // @todo fix this
+        { field: 'label', reason: 'Label error' }
+      ]);
     });
   });
 
@@ -52,14 +51,6 @@ describe('Error handling utilities', () => {
 
     it('should just return the string if you pass it a string', () => {
       expect(getErrorStringOrDefault('a', 'b')).toBe('a');
-    });
-
-    it('should access response.data.errors if passed an AxiosError', () => {
-      expect(
-        getErrorStringOrDefault(mockAxiosErrorWithAPIErrorContent)
-      ).toMatch(
-        mockAxiosErrorWithAPIErrorContent.response.data.errors[0].reason
-      );
     });
   });
 });

--- a/src/utilities/errorUtils.test.ts
+++ b/src/utilities/errorUtils.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ERROR_MESSAGE } from 'src/constants';
 import { getAPIErrorOrDefault, getErrorStringOrDefault } from './errorUtils';
 
 const error = [{ field: 'a field', reason: 'a reason' }];
@@ -9,25 +10,13 @@ const multiError = [
 
 describe('Error handling utilities', () => {
   describe('getAPIErrorOrDefault', () => {
-    it.skip('if no error is passed in, it should return a default API error using the provided string', () => {
-      expect(getAPIErrorOrDefault([], 'Default error')).toEqual([
-        { reason: 'Default error' }
-      ]);
-    });
-
-    it.skip('should provide a default error if no error string is provided', () => {
-      expect(getAPIErrorOrDefault([])).toEqual([
-        { reason: 'An unexpected error occurred.' }
-      ]);
-    });
-
-    it('should use the optional 3rd param as a field name for the default error (if provided)', () => {
+    it('should override a default error', () => {
       expect(
-        getAPIErrorOrDefault(undefined as any, 'Label error', 'label')
-      ).toEqual([
-        // @todo fix this
-        { field: 'label', reason: 'Label error' }
-      ]);
+        getAPIErrorOrDefault(
+          [{ reason: DEFAULT_ERROR_MESSAGE }],
+          'New error message'
+        )
+      ).toEqual([{ reason: 'New error message' }]);
     });
   });
 

--- a/src/utilities/errorUtils.ts
+++ b/src/utilities/errorUtils.ts
@@ -18,7 +18,7 @@ import { pathOr } from 'ramda';
  *
  */
 export const getAPIErrorOrDefault = (
-  errorResponse: AxiosError | Error,
+  errorResponse: Linode.ApiFieldError[],
   defaultError: string = 'An unexpected error occurred.',
   field?: string
 ): Linode.ApiFieldError[] => {
@@ -26,7 +26,7 @@ export const getAPIErrorOrDefault = (
     ? [{ reason: defaultError, field }]
     : [{ reason: defaultError }];
 
-  return pathOr(_defaultError, ['response', 'data', 'errors'], errorResponse);
+  return errorResponse || _defaultError;
 };
 
 export const handleUnauthorizedErrors = (


### PR DESCRIPTION
## Description

Retrieved API errors from our Axios interceptors, so that consuming components will only ever receive Linode.ApiFieldError[] and won't have to deal with Error or AxiosError responses. Also updated `getApiErrorOrDefault`, some typings, and tests to reflect the new pattern.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

We'll run the full suite when we think this is ready for a merge.

## Note to Reviewers

Please test as many error states as possible. I've done EditableText, Images, Domains, and a few other spot checks.