### PR TITLE
M3-2688 Fix: Deploy new Linode from backup

### DIFF
--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -227,6 +227,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
         selectedLinodeID: id,
         selectedDiskSize: diskSize,
         selectedTypeID: undefined,
+        selectedBackupID: undefined,
         selectedRegionID
       });
     }

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -58,6 +58,7 @@ import { allocatePrivateIP } from 'src/utilities/allocateIPAddress';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendCreateLinodeEvent } from 'src/utilities/ga';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+import { getRegionIDFromLinodeID } from './utilities';
 
 type StackScript = Linode.StackScript.Response;
 
@@ -116,14 +117,6 @@ const defaultState: State = {
   formIsSubmitting: false,
   errors: undefined,
   appInstancesLoading: false
-};
-
-const getRegionIDFromLinodeID = (
-  linodes: Linode.Linode[],
-  id: number
-): string | undefined => {
-  const thisLinode = linodes.find(linode => linode.id === id);
-  return thisLinode ? thisLinode.region : undefined;
 };
 
 const trimOneClickFromLabel = (script: StackScript) => {

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -28,7 +28,7 @@ import {
   WithDisplayData,
   WithLinodesTypesRegionsAndImages
 } from '../types';
-import { extendLinodes } from '../utilities';
+import { extendLinodes, getRegionIDFromLinodeID } from '../utilities';
 import { renderBackupsDisplaySection } from './utils';
 
 type ClassNames = 'root' | 'main' | 'sidebar';
@@ -158,6 +158,15 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     });
   };
 
+  // Find regionID from the selectedLinodeID, and update the parent state.
+  updateRegion() {
+    const regionID = getRegionIDFromLinodeID(
+      this.props.linodesData,
+      +this.props.selectedLinodeID!
+    );
+    this.props.updateRegionID(regionID || '');
+  }
+
   componentWillUnmount() {
     this.mounted = false;
   }
@@ -167,6 +176,13 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
     this.getLinodesWithBackups(this.props.linodesData);
     // If there is a selected Linode ID (from props), make sure its information
     // is set to state as if it had been selected manually.
+    this.updateRegion();
+  }
+
+  componentDidUpdate(prevProps: CombinedProps) {
+    if (prevProps.selectedLinodeID !== this.props.selectedLinodeID) {
+      this.updateRegion();
+    }
   }
 
   render() {
@@ -354,7 +370,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
                     heading="Linode Summary"
                     calculatedPrice={calculatedPrice}
                     isMakingRequest={isGettingBackups}
-                    disabled={disabled}
+                    disabled={this.props.formIsSubmitting || disabled}
                     onDeploy={this.createLinode}
                     displaySections={displaySections}
                     {...props}

--- a/src/features/linodes/LinodesCreate/utilities.test.ts
+++ b/src/features/linodes/LinodesCreate/utilities.test.ts
@@ -1,8 +1,12 @@
 import { extendedTypes } from 'src/__data__/ExtendedType';
 import { images } from 'src/__data__/images';
-import { linode1 } from 'src/__data__/linodes';
+import { linode1, linode2 } from 'src/__data__/linodes';
 
-import { extendLinodes, formatLinodeSubheading } from './utilities';
+import {
+  extendLinodes,
+  formatLinodeSubheading,
+  getRegionIDFromLinodeID
+} from './utilities';
 
 describe('Extend Linode', () => {
   it('should create an array of Extended Linodes from an array of Linodes', () => {
@@ -13,11 +17,19 @@ describe('Extend Linode', () => {
     ]);
   });
 
-  it('should concat image and type data, seperated by a comma', () => {
+  it('should concat image and type data, separated by a comma', () => {
     const withImage = formatLinodeSubheading('test', 'test');
     const withoutImage = formatLinodeSubheading('test');
 
     expect(withImage).toEqual(['test, test']);
     expect(withoutImage).toEqual(['test']);
+  });
+});
+
+describe('getRegionIDFromLinodeID', () => {
+  it('returns the regionID from the given Linodes and Linode ID', () => {
+    expect(getRegionIDFromLinodeID([linode1, linode2], 2020425)).toBe(
+      'us-east-1a'
+    );
   });
 });

--- a/src/features/linodes/LinodesCreate/utilities.ts
+++ b/src/features/linodes/LinodesCreate/utilities.ts
@@ -36,3 +36,11 @@ export const formatLinodeSubheading = (
     : `${typeLabel}`;
   return [subheading];
 };
+
+export const getRegionIDFromLinodeID = (
+  linodes: Linode.Linode[],
+  id: number
+): string | undefined => {
+  const thisLinode = linodes.find(linode => linode.id === id);
+  return thisLinode ? thisLinode.region : undefined;
+};


### PR DESCRIPTION
## Description

Previously `regionID` wasn't being selected when `selectedLinodeID` was being set with a query param (i.e. clicking "Deploy new Linode" on a backup).

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Please check all functionality in Create Linodes, especially from backups.
