### PR TITLE
M3-2757 Add: abuse ticket banner

### DIFF
--- a/src/__data__/notifications.ts
+++ b/src/__data__/notifications.ts
@@ -1,0 +1,31 @@
+export const mockNotification: Linode.Notification = {
+  entity: {
+    url: 'doesnt/matter/',
+    type: 'linode',
+    label: 'my-linode',
+    id: 8675309
+  },
+  label: "Here's a notification!",
+  message: 'Something something... whatever.',
+  severity: 'major',
+  when: null,
+  until: null,
+  body: null,
+  type: 'migration_pending'
+};
+
+export const abuseTicketNotification: Linode.Notification = {
+  type: 'ticket_abuse',
+  body: null,
+  severity: 'major',
+  until: null,
+  entity: {
+    url: '/support/tickets/123456 ',
+    type: 'ticket',
+    id: 123456,
+    label: 'Abuse Ticket'
+  },
+  label: 'You have an open abuse ticket!',
+  when: null,
+  message: 'You have an open abuse ticket!'
+};

--- a/src/components/AbuseTicketBanner.tsx
+++ b/src/components/AbuseTicketBanner.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
+import getAbuseTicket from 'src/store/selectors/getAbuseTicket';
+import { MapState } from 'src/store/types';
+
+interface Props {
+  abuseTickets: Linode.Notification[];
+}
+
+export const AbuseTicketBanner: React.FunctionComponent<Props> = props => {
+  const { abuseTickets } = props;
+  return (
+    <>
+      {abuseTickets.map((thisTicket, idx) => (
+        <Grid item xs={12} key={`ticket-banner-${idx}`}>
+          <Notice important error>
+            You have an open abuse ticket. Please{' '}
+            <Link to={thisTicket.entity!.url}>click here</Link> to view this
+            ticket.
+          </Notice>
+        </Grid>
+      ))}
+    </>
+  );
+};
+
+const mapStateToProps: MapState<Props, {}> = (state, ownProps) => ({
+  abuseTickets: getAbuseTicket(state.__resources)
+});
+
+const connected = connect(
+  mapStateToProps,
+  undefined
+);
+
+export default connected(AbuseTicketBanner);

--- a/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
+++ b/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { cleanup, render } from 'react-testing-library';
+
+import {
+  abuseTicketNotification,
+  mockNotification
+} from 'src/__data__/notifications';
+import { wrapWithTheme } from 'src/utilities/testHelpers';
+import Component, { AbuseTicketBanner } from './AbuseTicketBanner';
+
+const mockState = {
+  __resources: {
+    notifications: {
+      data: [abuseTicketNotification, mockNotification]
+    }
+  }
+};
+
+jest.mock('src/store', () => ({
+  default: {
+    getState: () => mockState,
+    subscribe: () => jest.fn(),
+    dispatch: () => jest.fn()
+  }
+}));
+
+afterEach(cleanup);
+
+describe('Abuse ticket banner', () => {
+  it('should render a banner for each abuse ticket', () => {
+    const { rerender, queryAllByText } = render(
+      wrapWithTheme(
+        <AbuseTicketBanner abuseTickets={[abuseTicketNotification]} />
+      )
+    );
+    expect(queryAllByText(/abuse/)).toHaveLength(1);
+    rerender(
+      wrapWithTheme(
+        <AbuseTicketBanner
+          abuseTickets={[abuseTicketNotification, abuseTicketNotification]}
+        />
+      )
+    );
+    expect(queryAllByText(/abuse/)).toHaveLength(2);
+  });
+
+  it('should link to the ticket', () => {
+    const { getByTestId } = render(
+      wrapWithTheme(
+        <AbuseTicketBanner abuseTickets={[abuseTicketNotification]} />
+      )
+    );
+    const link = getByTestId('abuse-ticket-link');
+    expect(link).toHaveAttribute('href', abuseTicketNotification.entity!.url);
+  });
+
+  it('should return null if there are no abuse tickets', () => {
+    expect(AbuseTicketBanner({ abuseTickets: [] })).toBeNull();
+  });
+
+  describe('integration tests', () => {
+    it('should filter out abuse ticket notifications from the store', () => {
+      const { queryAllByText } = render(wrapWithTheme(<Component />));
+      expect(queryAllByText(/abuse/)).toHaveLength(1);
+    });
+  });
+});

--- a/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
+++ b/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
@@ -13,18 +13,23 @@ interface Props {
 
 export const AbuseTicketBanner: React.FunctionComponent<Props> = props => {
   const { abuseTickets } = props;
+
+  if (!abuseTickets || abuseTickets.length === 0) {
+    return null;
+  }
+
   return (
-    <>
+    <Grid item xs={12}>
       {abuseTickets.map((thisTicket, idx) => (
-        <Grid item xs={12} key={`ticket-banner-${idx}`}>
-          <Notice important error>
-            You have an open abuse ticket. Please{' '}
-            <Link to={thisTicket.entity!.url}>click here</Link> to view this
-            ticket.
-          </Notice>
-        </Grid>
+        <Notice important error key={`ticket-banner-${idx}`}>
+          You have an open abuse ticket. Please{' '}
+          <Link data-testid="abuse-ticket-link" to={thisTicket.entity!.url}>
+            click here
+          </Link>{' '}
+          to view this ticket.
+        </Notice>
       ))}
-    </>
+    </Grid>
   );
 };
 

--- a/src/components/AbuseTicketBanner/index.tsx
+++ b/src/components/AbuseTicketBanner/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './AbuseTicketBanner';

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -2,6 +2,7 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose } from 'recompose';
+import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
 import {
   StyleRulesCallback,
   withStyles,
@@ -69,6 +70,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
   return (
     <React.Fragment>
       <Grid container spacing={24}>
+        <AbuseTicketBanner />
         <DocumentTitleSegment segment="Dashboard" />
         <Grid item xs={12}>
           <Typography variant="h1" data-qa-dashboard-header>

--- a/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -1,6 +1,7 @@
 import { compose, pathOr } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
+import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
 import AddNewLink from 'src/components/AddNewLink';
 import Breadcrumb from 'src/components/Breadcrumb';
 import AppBar from 'src/components/core/AppBar';
@@ -143,6 +144,7 @@ export class SupportTicketsLanding extends React.PureComponent<
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Support Tickets" />
+        <AbuseTicketBanner />
         <Grid container justify="space-between" updateFor={[classes]}>
           <Grid item className={classes.titleWrapper}>
             <Breadcrumb

--- a/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { mockNotification } from 'src/__data__/notifications';
 import { light } from 'src/themes';
 import {
   CombinedProps,
@@ -63,21 +64,6 @@ describe('LinodeRow', () => {
     linodeNotifications: [],
     displayType: 'Some Fancy Name',
     imageLabel: 'string'
-  };
-
-  const mockNotification: Linode.Notification = {
-    entity: {
-      url: 'doesnt/matter/',
-      type: 'linode',
-      label: 'my-linode',
-      id: 8675309
-    },
-    label: "Here's a notification!",
-    message: 'Something something... whatever.',
-    severity: 'major',
-    when: null,
-    until: null,
-    type: 'migration_pending'
   };
 
   it('should render', () => {

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { mockNotification } from 'src/__data__/notifications';
 import { light } from 'src/themes';
 import { CombinedProps, LinodeRow, RenderFlag } from './LinodeRow';
 
@@ -42,21 +43,6 @@ describe('LinodeRow', () => {
     vcpus: 0,
     disk: 0,
     mostRecentBackup: null
-  };
-
-  const mockNotification: Linode.Notification = {
-    entity: {
-      url: 'doesnt/matter/',
-      type: 'linode',
-      label: 'my-linode',
-      id: 8675309
-    },
-    label: "Here's a notification!",
-    message: 'Something something... whatever.',
-    severity: 'major',
-    when: null,
-    until: null,
-    type: 'migration_pending'
   };
 
   it('should render', () => {

--- a/src/store/selectors/getAbuseTicket.ts
+++ b/src/store/selectors/getAbuseTicket.ts
@@ -1,0 +1,10 @@
+import { pathOr } from 'ramda';
+import { ResourcesState } from 'src/store';
+
+export default (state: ResourcesState) => {
+  const notifications = pathOr([], ['notifications', 'data'], state);
+  return notifications.filter(
+    (thisNotification: Linode.Notification) =>
+      thisNotification.type === 'ticket_abuse'
+  );
+};

--- a/src/store/selectors/index.ts
+++ b/src/store/selectors/index.ts
@@ -1,6 +1,8 @@
 import { registerSelectors } from 'reselect-tools';
 
+import entityErrors from './entitiesErrors';
 import entitiesLoading from './entitiesLoading';
+import getAbuseTicket from './getAbuseTicket';
 import getEntitiesWithGroupsToImport from './getEntitiesWithGroupsToImport';
 import getSearchEntities from './getSearchEntities';
 import inProgressEventForLinode from './inProgressEventForLinode';
@@ -13,7 +15,9 @@ import recentEventForLinode from './recentEventForLinode';
 
 export const initReselectDevtools = () => {
   registerSelectors({
+    entityErrors,
     entitiesLoading,
+    getAbuseTicket,
     getEntitiesWithGroupsToImport,
     getSearchEntities,
     inProgressEventForLinode,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -67,6 +67,7 @@ namespace Linode {
     severity: NotificationSeverity;
     when: null | string;
     until: null | string;
+    body: null | string;
   }
 
   export interface Entity {

--- a/src/utilities/testHelpers.tsx
+++ b/src/utilities/testHelpers.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { render } from 'react-testing-library';
 
 import { PromiseLoaderResponse } from 'src/components/PromiseLoader';
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
+import store from 'src/store';
 
 export let createPromiseLoaderResponse: <T>(r: T) => PromiseLoaderResponse<T>;
 createPromiseLoaderResponse = response => ({ response });
@@ -20,7 +22,9 @@ createResourcePage = data => ({
 export const wrapWithTheme = (ui: any) => {
   return (
     <LinodeThemeWrapper>
-      <MemoryRouter>{ui}</MemoryRouter>
+      <Provider store={store}>
+        <MemoryRouter>{ui}</MemoryRouter>
+      </Provider>
     </LinodeThemeWrapper>
   );
 };


### PR DESCRIPTION
## Description

Display a banner on the Dashboard and tickets landing pages if the customer has an open abuse ticket. 

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Prod-test-001 has an open abuse ticket. Please check both the dashboard and support/tickets.