### PR TITLE
Fix: invoice split

### DIFF
--- a/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -10,8 +10,8 @@ const baseFont = 'helvetica';
 
 /**
  * Where the table headers should start on the Y-Axis. The reason for passing the Tax ID length
- * is becasue if the Tax ID is a long string, we need to push the table down. JSPDF isn't smart
- * enough to determine that by iteself
+ * is because if the Tax ID is a long string, we need to push the table down. JSPDF isn't smart
+ * enough to determine that by itself
  *
  * @param taxIdLength how many digits the Tax ID is
  */
@@ -19,8 +19,8 @@ const tableTopStart = (taxIdLength: number) => 150 + (taxIdLength / 13) * 5;
 
 /**
  * Where the table body should start on the Y-Axis. The reason for passing the Tax ID length
- * is becasue if the Tax ID is a long string, we need to push the table down. JSPDF isn't smart
- * enough to determine that by iteself
+ * is because if the Tax ID is a long string, we need to push the table down. JSPDF isn't smart
+ * enough to determine that by itself
  *
  * @param taxIdLength how many digits the Tax ID is
  */
@@ -59,7 +59,7 @@ const formatDescription = (desc?: string) => {
   const isVolume = /^Storage/.test(desc);
 
   /** create an array like ["Backup service", "Linode 2GB", "MyLinode (1234)"] */
-  const descChunks = desc.split(' - ');
+  const descChunks = desc ? desc.split(' - ') : [];
 
   if (descChunks.length < 2) {
     /** in this case, it's probably a manual payment from admin */
@@ -80,8 +80,8 @@ const formatDescription = (desc?: string) => {
     )}\r\n${backupID}`;
   }
 
-  const [entitiyLabel, entitiyID] = descChunks[1].split(' ');
-  return `${descChunks[0]}\r\n${truncateLabel(entitiyLabel)}\r\n${entitiyID}`;
+  const [entityLabel, entityID] = descChunks[1].split(' ');
+  return `${descChunks[0]}\r\n${truncateLabel(entityLabel)}\r\n${entityID}`;
 };
 
 const addLeftHeader = (


### PR DESCRIPTION
## Description

Make sure we don't call `split()` on an undefined item.

<img width="962" alt="Screen Shot 2019-05-08 at 11 40 55 AM" src="https://user-images.githubusercontent.com/1624067/57388662-a89e1700-7186-11e9-8232-e6d10feeca63.png">


## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

- Use Charles to break on /invoices/id/items, then use:
```
{
"pages": 1, 
"data": [
{
   "quantity": null,
   "amount": "40.00",
   "tax": 0,
   "from": "2019-03-01T05:00:00",
   "type": "prepay",
   "total": "40.00",
   "to": "2019-04-01T03:59:59",
   "unit_price": null,
   "label": "Linode 8GB"
},
{
   "quantity": null,
   "amount": "10.00",
   "tax": 0, 
   "from": "2019-03-01T05:00:00",
   "type": "prepay",
   "total": "10.00",
   "to": "2019-04-01T03:59:59",
   "unit_price": null,
   "label": "Backup Service - Linode 8GB"
}
],
  "page": 1,
  "results": 2
}
```

for the body.