### PR TITLE
Add event messages for host and lassie reboots and lish boots

### DIFF
--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -139,16 +139,16 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     finished: e => `Linode ${e.entity!.label} has booted by the Lassie watchdog service.`
   },
   host_reboot: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot via a Host initiated restart`,
-    started: e => `Linode ${e.entity!.label} is booting via a Host initiated restart.`,
-    failed: e => `Linode ${e.entity!.label} could not be booted via a Host initiated restart.`,
-    finished: e => `Linode ${e.entity!.label} has booted via a Host initiated restart.`
+    scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot (Host initiated restart).`,
+    started: e => `Linode ${e.entity!.label} is booting (Host initiated restart).`,
+    failed: e => `Linode ${e.entity!.label} could not be booted (Host initiated restart).`,
+    finished: e => `Linode ${e.entity!.label} has booted (Host initiated restart).`
   },
   lish_boot: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot via Lish.`,
-    started: e => `Linode ${e.entity!.label} is booting via Lish.`,
-    failed: e => `Linode ${e.entity!.label} could not be booted via Lish.`,
-    finished: e => `Linode ${e.entity!.label} has booted via Lish.`
+    scheduled: e => `Linode ${e.entity!.label} is scheduled to boot (Lish boot).`,
+    started: e => `Linode ${e.entity!.label} is booting (Lish boot).`,
+    failed: e => `Linode ${e.entity!.label} could not be booted (Lish boot).`,
+    finished: e => `Linode ${e.entity!.label} has booted (Lish boot).`
   },
   linode_clone: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled to be cloned.`,

--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -132,6 +132,18 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     failed: e => `Linode ${e.entity!.label} could not be booted.`,
     finished: e => `Linode ${e.entity!.label} has booted.`
   },
+  lassie_reboot: {
+    scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot via the Lassie watchdog service.`,
+    started: e => `Linode ${e.entity!.label} is booting via the Lassie watchdog service.`,
+    failed: e => `Linode ${e.entity!.label} could not be booted via the Lassie watchdog service.`,
+    finished: e => `Linode ${e.entity!.label} has booted via the Lassie watchdog service.`
+  },
+  host_reboot: {
+    scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot via a Host initiated restart`,
+    started: e => `Linode ${e.entity!.label} is booting via a Host initiated restart.`,
+    failed: e => `Linode ${e.entity!.label} could not be booted via a Host initiated restart.`,
+    finished: e => `Linode ${e.entity!.label} has booted via a Host initiated restart.`
+  },
   linode_clone: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled to be cloned.`,
     started: e => `Linode ${e.entity!.label} is being cloned.`,

--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -145,10 +145,10 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     finished: e => `Linode ${e.entity!.label} has booted (Host initiated restart).`
   },
   lish_boot: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled to boot (Lish boot).`,
-    started: e => `Linode ${e.entity!.label} is booting (Lish boot).`,
-    failed: e => `Linode ${e.entity!.label} could not be booted (Lish boot).`,
-    finished: e => `Linode ${e.entity!.label} has booted (Lish boot).`
+    scheduled: e => `Linode ${e.entity!.label} is scheduled to boot (Lish initiated boot).`,
+    started: e => `Linode ${e.entity!.label} is booting (Lish initiated boot).`,
+    failed: e => `Linode ${e.entity!.label} could not be booted (Lish initiated boot).`,
+    finished: e => `Linode ${e.entity!.label} has booted (Lish initiated boot).`
   },
   linode_clone: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled to be cloned.`,

--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -133,10 +133,10 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     finished: e => `Linode ${e.entity!.label} has booted.`
   },
   lassie_reboot: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot by the Lassie watchdog service.`,
-    started: e => `Linode ${e.entity!.label} is booting  by the Lassie watchdog service.`,
+    scheduled: e => `Linode ${e.entity!.label} is scheduled to be rebooted by the Lassie watchdog service.`,
+    started: e => `Linode ${e.entity!.label} is being booted by the Lassie watchdog service.`,
     failed: e => `Linode ${e.entity!.label} could not be booted by the Lassie watchdog service.`,
-    finished: e => `Linode ${e.entity!.label} has booted by the Lassie watchdog service.`
+    finished: e => `Linode ${e.entity!.label} has been booted by the Lassie watchdog service.`
   },
   host_reboot: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot (Host initiated restart).`,

--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -133,16 +133,22 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     finished: e => `Linode ${e.entity!.label} has booted.`
   },
   lassie_reboot: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot via the Lassie watchdog service.`,
-    started: e => `Linode ${e.entity!.label} is booting via the Lassie watchdog service.`,
-    failed: e => `Linode ${e.entity!.label} could not be booted via the Lassie watchdog service.`,
-    finished: e => `Linode ${e.entity!.label} has booted via the Lassie watchdog service.`
+    scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot by the Lassie watchdog service.`,
+    started: e => `Linode ${e.entity!.label} is booting  by the Lassie watchdog service.`,
+    failed: e => `Linode ${e.entity!.label} could not be booted by the Lassie watchdog service.`,
+    finished: e => `Linode ${e.entity!.label} has booted by the Lassie watchdog service.`
   },
   host_reboot: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot via a Host initiated restart`,
     started: e => `Linode ${e.entity!.label} is booting via a Host initiated restart.`,
     failed: e => `Linode ${e.entity!.label} could not be booted via a Host initiated restart.`,
     finished: e => `Linode ${e.entity!.label} has booted via a Host initiated restart.`
+  },
+  lish_boot: {
+    scheduled: e => `Linode ${e.entity!.label} is scheduled to reboot via Lish.`,
+    started: e => `Linode ${e.entity!.label} is booting via Lish.`,
+    failed: e => `Linode ${e.entity!.label} could not be booted via Lish.`,
+    finished: e => `Linode ${e.entity!.label} has booted via Lish.`
   },
   linode_clone: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled to be cloned.`,


### PR DESCRIPTION
Feedback welcome... the host initiated restart messages in particular are awkward ... probably a better way to phrase all of this that doesn't use "via"