### PR TITLE
re-enable plan type copy and update the text

### DIFF
--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -6,7 +6,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-// import Typography from 'src/components/core/Typography';
+import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import SelectionCard from 'src/components/SelectionCard';
@@ -88,7 +88,7 @@ export class SelectPlanPanel extends React.Component<
   };
 
   createTabs = () => {
-    const { types } = this.props;
+    const { classes, types } = this.props;
     const tabs: Tab[] = [];
     const nanodes = getNanodes(types);
     const standards = getStandard(types);
@@ -100,7 +100,7 @@ export class SelectPlanPanel extends React.Component<
         render: () => {
           return (
             <>
-              {/* <Typography className={classes.copy}>The Nanode is Linode's smallest plan, offering enough resources to host static web sites, small blogs, self-hosted utilities, and hobby projects.</Typography> */}
+              <Typography className={classes.copy}>Nanode instances are good for low-duty workloads, where performance isn't critical.</Typography>
               <Grid container spacing={16}>
                 {nanodes.map(this.renderCard)}
               </Grid>
@@ -116,7 +116,7 @@ export class SelectPlanPanel extends React.Component<
         render: () => {
           return (
             <>
-              {/* <Typography className={classes.copy}>The Standard plans represent different tiers of service suitable for hosting applications, databases, and web sites.</Typography> */}
+              <Typography className={classes.copy}>Standard instances are good for medium-duty workloads and are a good mix of performance, resources, and price.</Typography>
               <Grid container spacing={16}>
                 {standards.map(this.renderCard)}
               </Grid>
@@ -132,7 +132,7 @@ export class SelectPlanPanel extends React.Component<
         render: () => {
           return (
             <>
-              {/* <Typography className={classes.copy}>Dedicated CPU plans are tailored for consistently-high CPU workloads like, as data analytics services, CI/CD toolchains and build servers, and other CPU-bound tasks.</Typography> */}
+              <Typography className={classes.copy}>Dedicated CPU instances are good for full-duty workloads where consistent performance is important.</Typography>
               <Grid container spacing={16}>
                 {dedicated.map(this.renderCard)}
               </Grid>
@@ -148,7 +148,7 @@ export class SelectPlanPanel extends React.Component<
         render: () => {
           return (
             <>
-              {/* <Typography className={classes.copy}>The High Memory Linode plans are perfect for running memory intensive applications, like in-memory databases.</Typography> */}
+              <Typography className={classes.copy}>High Memory instances favor RAM over other resources, and can be good for memory hungry use cases like caching and in-memory databases.</Typography>
               <Grid container spacing={16}>
                 {highmem.map(this.renderCard)}
               </Grid>


### PR DESCRIPTION
Reverts https://github.com/linode/manager/pull/4388. At the time, this copy hadn't been finalized anywhere. Now that we have finalized copy for this in classic, we may as well use it here and re-enable it.