### PR TITLE
M3-2787 Fix: IPv6 DNS Resolvers

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,7 +50,7 @@ export const MAX_VOLUME_SIZE = 10240;
  * Used by e.g. LISH to determine the websocket connection address.
  * Whenever updating this, also update the corresponding name in resolvers.ts
  */
-export const ZONES = {
+export const ZONES: Record<string, Linode.ZoneName> = {
   'us-east': 'newark',
   'us-east-1a': 'newark',
   'us-south': 'dallas',

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -21,6 +21,7 @@ import Grid from 'src/components/Grid';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import { ZONES } from 'src/constants';
+import { reportException } from 'src/exceptionReporting';
 import { getLinodeIPs } from 'src/services/linodes';
 import { upsertLinode as _upsertLinode } from 'src/store/linodes/linodes.actions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -324,6 +325,14 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
       return null;
     }
 
+    const zoneName = ZONES[linodeRegion];
+
+    if (!zoneName) {
+      reportException(`Unknown region: ${linodeRegion}`, {
+        linodeID
+      });
+    }
+
     return (
       <React.Fragment>
         <DocumentTitleSegment segment={`${linodeLabel} - Networking`} />
@@ -332,7 +341,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
           linkLocal={path(['ipv6', 'link_local', 'address'], linodeIPs)}
           sshIPAddress={firstPublicIPAddress}
           linodeLabel={linodeLabel}
-          linodeRegion={ZONES[linodeRegion]}
+          linodeRegion={zoneName}
         />
 
         {this.renderIPv4()}

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingSummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingSummaryPanel.tsx
@@ -15,7 +15,13 @@ import { MapState } from 'src/store/types';
 
 import { getIPv6DNSResolvers, ipv4DNSResolvers } from './resolvers';
 
-type ClassNames = 'root' | 'title' | 'section' | 'individualContainer' | 'ips';
+type ClassNames =
+  | 'root'
+  | 'title'
+  | 'section'
+  | 'individualContainer'
+  | 'ips'
+  | 'error';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
@@ -34,6 +40,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   ips: {
     padding: `0 ${theme.spacing.unit}px !important`
+  },
+  error: {
+    color: theme.palette.status.errorDark
   }
 });
 
@@ -75,6 +84,16 @@ const LinodeNetworkingSummaryPanel: React.StatelessComponent<
   CombinedProps
 > = props => {
   const { classes, sshIPAddress, username, linodeRegion, linodeLabel } = props;
+
+  const v4Resolvers = getIPv4DNSResolvers(linodeRegion);
+  const v6Resolvers = getIPv6DNSResolvers(linodeRegion);
+
+  const renderErrorMessage = () => (
+    <Typography className={classes.error} component="span">
+      There was an error loading DNS resolvers.
+    </Typography>
+  );
+
   return (
     <Grid container justify="space-between">
       <Grid item xs={12}>
@@ -104,11 +123,19 @@ const LinodeNetworkingSummaryPanel: React.StatelessComponent<
             <Grid item xs={12} md={6}>
               <StyledSummarySection
                 title="DNS Resolvers (IPv4)"
-                renderValue={renderIPv4DNSResolvers(linodeRegion)}
+                renderValue={
+                  v4Resolvers.length > 0
+                    ? renderDNSResolvers(v4Resolvers)
+                    : renderErrorMessage
+                }
               />
               <StyledSummarySection
                 title="DNS Resolvers (IPv6)"
-                renderValue={renderIPv6DNSResolvers(linodeRegion)}
+                renderValue={
+                  v6Resolvers.length > 0
+                    ? renderDNSResolvers(v6Resolvers)
+                    : renderErrorMessage
+                }
               />
             </Grid>
           </Grid>
@@ -138,15 +165,9 @@ const getIPv4DNSResolvers = (region: string) => {
   return pathOr(ipv4DNSResolvers.newark, [region], ipv4DNSResolvers);
 };
 
-const renderIPv4DNSResolvers = (region: Linode.ZoneName) => () => (
+const renderDNSResolvers = (ips: string[]) => () => (
   <div style={{ display: 'flex', alignItems: 'center' }}>
-    <IPAddress ips={getIPv4DNSResolvers(region)} copyRight showMore />
-  </div>
-);
-
-const renderIPv6DNSResolvers = (region: Linode.ZoneName) => () => (
-  <div style={{ display: 'flex', alignItems: 'center' }}>
-    <IPAddress ips={getIPv6DNSResolvers(region)} copyRight showMore />
+    <IPAddress ips={ips} copyRight showMore />
   </div>
 );
 

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingSummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingSummaryPanel.tsx
@@ -13,7 +13,7 @@ import Grid from 'src/components/Grid';
 import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
 import { MapState } from 'src/store/types';
 
-import { ipv4DNSResolvers, ipv6DNSResolvers } from './resolvers';
+import { getIPv6DNSResolvers, ipv4DNSResolvers } from './resolvers';
 
 type ClassNames = 'root' | 'title' | 'section' | 'individualContainer' | 'ips';
 
@@ -40,7 +40,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 const styled = withStyles(styles);
 
 interface Props {
-  linodeRegion: string;
+  linodeRegion: Linode.ZoneName;
   linodeLabel: string;
   linkLocal?: string;
   sshIPAddress?: string;
@@ -108,7 +108,7 @@ const LinodeNetworkingSummaryPanel: React.StatelessComponent<
               />
               <StyledSummarySection
                 title="DNS Resolvers (IPv6)"
-                renderValue={renderIPv6DNSResolvers()}
+                renderValue={renderIPv6DNSResolvers(linodeRegion)}
               />
             </Grid>
           </Grid>
@@ -138,15 +138,15 @@ const getIPv4DNSResolvers = (region: string) => {
   return pathOr(ipv4DNSResolvers.newark, [region], ipv4DNSResolvers);
 };
 
-const renderIPv4DNSResolvers = (region: string) => () => (
+const renderIPv4DNSResolvers = (region: Linode.ZoneName) => () => (
   <div style={{ display: 'flex', alignItems: 'center' }}>
     <IPAddress ips={getIPv4DNSResolvers(region)} copyRight showMore />
   </div>
 );
 
-const renderIPv6DNSResolvers = () => () => (
+const renderIPv6DNSResolvers = (region: Linode.ZoneName) => () => (
   <div style={{ display: 'flex', alignItems: 'center' }}>
-    <IPAddress ips={ipv6DNSResolvers} copyRight showMore />
+    <IPAddress ips={getIPv6DNSResolvers(region)} copyRight showMore />
   </div>
 );
 

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/resolvers.test.ts
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/resolvers.test.ts
@@ -5,6 +5,10 @@ describe('getIPv6DNSResolvers', () => {
     expect(getIPv6DNSResolvers('atlanta')).toHaveLength(7);
   });
 
+  it('should return an empty array if the region is not found', () => {
+    expect(getIPv6DNSResolvers('fake-region' as any)).toHaveLength(0);
+  });
+
   it('should begin all resolvers with the prefix for the given region', () => {
     const resolvers = getIPv6DNSResolvers('atlanta');
     resolvers.forEach(resolver => {

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/resolvers.test.ts
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/resolvers.test.ts
@@ -1,0 +1,28 @@
+import { getIPv6DNSResolvers, ipv6DNSResolverPrefixes } from './resolvers';
+
+describe('getIPv6DNSResolvers', () => {
+  it('should return all 7 IPv6 DNS Resolvers for the given region', () => {
+    expect(getIPv6DNSResolvers('atlanta')).toHaveLength(7);
+  });
+
+  it('should begin all resolvers with the prefix for the given region', () => {
+    const resolvers = getIPv6DNSResolvers('atlanta');
+    resolvers.forEach(resolver => {
+      expect(resolver.startsWith(ipv6DNSResolverPrefixes.atlanta)).toBe(true);
+    });
+  });
+
+  it('should return ::5-9, ::b, and ::c', () => {
+    const resolvers = getIPv6DNSResolvers('atlanta');
+    const hasElementThatEndsWith = (toMatch: string) =>
+      resolvers.filter(resolver => resolver.endsWith(toMatch)).length > 0;
+
+    expect(hasElementThatEndsWith('5')).toBe(true);
+    expect(hasElementThatEndsWith('6')).toBe(true);
+    expect(hasElementThatEndsWith('7')).toBe(true);
+    expect(hasElementThatEndsWith('8')).toBe(true);
+    expect(hasElementThatEndsWith('9')).toBe(true);
+    expect(hasElementThatEndsWith('b')).toBe(true);
+    expect(hasElementThatEndsWith('c')).toBe(true);
+  });
+});

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/resolvers.ts
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/resolvers.ts
@@ -1,4 +1,7 @@
-export const ipv4DNSResolvers = {
+// @todo: In principle, everything in this file should be returned by the API.
+// We have no choice but to hard-code these at the moment.
+
+export const ipv4DNSResolvers: Record<Linode.ZoneName, string[]> = {
   newark: [
     '66.228.42.5',
     '96.126.106.5',
@@ -103,15 +106,41 @@ export const ipv4DNSResolvers = {
   ]
 };
 
-export const ipv6DNSResolvers = [
-  '2600:3c00::', // Dallas, TX
-  '2600:3c01::', // Fremont, CA
-  '2600:3c02::', // Atlanta, GA
-  '2600:3c03::', // Newark, NJ
-  '2a01:7e00::', // London, UK
-  '2400:8900::', // Tokyo, JP
-  '2400:8901::', // Singapore, SG
-  '2a01:7e01::', // Frankfurt, DE
-  '2400:8902::', // Shinagawa1, JP
-  '2600:3C04::' // Toronto, CAN
-];
+// Returns all 7 IPv6 resolvers for a given region.
+//
+// Each region has a prefix and 7 IPv6 resolvers that begin with this prefix.
+// The tails of each resolver follow a convention standardized across all regions:
+// ::5
+// ::6
+// ::7
+// ::8
+// ::9
+// ::b
+// ::c
+export const getIPv6DNSResolvers = (region: Linode.ZoneName) => {
+  const prefix = ipv6DNSResolverPrefixes[region];
+
+  return [
+    `${prefix}5`,
+    `${prefix}6`,
+    `${prefix}7`,
+    `${prefix}8`,
+    `${prefix}9`,
+    `${prefix}b`,
+    `${prefix}c`
+  ];
+};
+
+// IPv6 Prefixes for each region.
+export const ipv6DNSResolverPrefixes: Record<Linode.ZoneName, string> = {
+  newark: '2600:3c03::',
+  dallas: '2600:3c00::',
+  fremont: '2600:3c01::',
+  atlanta: '2600:3c02::',
+  london: '2a01:7e00::',
+  tokyo: '2400:8900::',
+  singapore: '2400:8901::',
+  frankfurt: '2a01:7e01::',
+  shinagawa1: '2400:8902::',
+  toronto1: '2600:3C04::'
+};

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/resolvers.ts
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/resolvers.ts
@@ -120,6 +120,10 @@ export const ipv4DNSResolvers: Record<Linode.ZoneName, string[]> = {
 export const getIPv6DNSResolvers = (region: Linode.ZoneName) => {
   const prefix = ipv6DNSResolverPrefixes[region];
 
+  if (!region || !prefix) {
+    return [];
+  }
+
   return [
     `${prefix}5`,
     `${prefix}6`,

--- a/src/types/Networking.ts
+++ b/src/types/Networking.ts
@@ -1,0 +1,13 @@
+namespace Linode {
+  export type ZoneName =
+    | 'newark'
+    | 'dallas'
+    | 'fremont'
+    | 'atlanta'
+    | 'london'
+    | 'tokyo'
+    | 'singapore'
+    | 'frankfurt'
+    | 'shinagawa1'
+    | 'toronto1';
+}


### PR DESCRIPTION
## Description

There were two problems with the way we were displaying IPv6 resolvers.

1) We weren't displaying the full addresses.
2) We were displaying IPv6 resolvers for every region, when we should only be displaying resolvers for the region of the particular Linode we're looking at.

Also, I added new typing: `ZoneName` (region name?). Wasn't totally sure what to call this; feedback welcome.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please assume I made a mistake in copying the resolvers over, and thoroughly check that they're all correct. Test account 9 has a Linode in every region to help with this.
