### PR TITLE
M3-2346 Add: Mumbai region in Linodes Create

### DIFF
--- a/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -1,6 +1,7 @@
 import CA from 'flag-icon-css/flags/4x3/ca.svg';
 import DE from 'flag-icon-css/flags/4x3/de.svg';
 import UK from 'flag-icon-css/flags/4x3/gb.svg';
+import IN from 'flag-icon-css/flags/4x3/in.svg';
 import JP from 'flag-icon-css/flags/4x3/jp.svg';
 import SG from 'flag-icon-css/flags/4x3/sg.svg';
 import US from 'flag-icon-css/flags/4x3/us.svg';
@@ -31,7 +32,8 @@ const flags = {
   ),
   uk: () => <UK width="32" height="24" viewBox="0 0 640 480" />,
   de: () => <DE width="32" height="24" viewBox="0 0 720 480" />,
-  ca: () => <CA width="32" height="24" viewBox="0 0 640 480" />
+  ca: () => <CA width="32" height="24" viewBox="0 0 640 480" />,
+  in: () => <IN width="32" height="24" viewBox="0 0 640 480" />
 };
 
 export interface ExtendedRegion extends Linode.Region {
@@ -62,7 +64,7 @@ const getEURegions = (regions: ExtendedRegion[]) =>
   regions.filter(r => /(de|uk)/.test(r.country));
 
 const getASRegions = (regions: ExtendedRegion[]) =>
-  regions.filter(r => /(jp|sg)/.test(r.country));
+  regions.filter(r => /(jp|sg|in)/.test(r.country));
 
 const renderCard = (
   handleSelection: Function,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,7 +70,8 @@ export const ZONES: Record<string, Linode.ZoneName> = {
   'ap-south': 'singapore',
   'ap-south-1a': 'singapore',
   'ca-central': 'toronto1',
-  'ca-east': 'toronto1' // @todo Fallback for old Toronto ID; remove once DB has been updated.
+  'ca-east': 'toronto1', // @todo Fallback for old Toronto ID; remove once DB has been updated.
+  'ap-west': 'mumbai1'
 };
 
 export const dcDisplayNames = {
@@ -91,7 +92,8 @@ export const dcDisplayNames = {
   'eu-central': 'Frankfurt, DE',
   'ap-northeast': 'Tokyo 2, JP',
   'ca-central': 'Toronto, ON',
-  'ca-east': 'Toronto, ON' // @todo Fallback for old Toronto ID; remove once DB has been updated.
+  'ca-east': 'Toronto, ON', // @todo Fallback for old Toronto ID; remove once DB has been updated.
+  'ap-west': 'Mumbai, IN'
 };
 
 export const dcDisplayCountry = {
@@ -112,7 +114,8 @@ export const dcDisplayCountry = {
   'eu-central': 'DE',
   'ap-northeast': 'JP',
   'ca-central': 'CA',
-  'ca-east': 'CA'
+  'ca-east': 'CA',
+  'ap-west': 'IN'
 };
 
 // At this time, the following regions do not support block storage.

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/resolvers.ts
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/resolvers.ts
@@ -103,6 +103,18 @@ export const ipv4DNSResolvers: Record<Linode.ZoneName, string[]> = {
     '172.105.9.5',
     '172.105.10.5',
     '172.105.11.5'
+  ],
+  mumbai1: [
+    '172.105.34.5',
+    '172.105.35.5',
+    '172.105.36.5',
+    '172.105.37.5',
+    '172.105.38.5',
+    '172.105.39.5',
+    '172.105.40.5',
+    '172.105.41.5',
+    '172.105.42.5',
+    '172.105.43.5'
   ]
 };
 
@@ -146,5 +158,6 @@ export const ipv6DNSResolverPrefixes: Record<Linode.ZoneName, string> = {
   singapore: '2400:8901::',
   frankfurt: '2a01:7e01::',
   shinagawa1: '2400:8902::',
-  toronto1: '2600:3C04::'
+  toronto1: '2600:3C04::',
+  mumbai1: '2400:8904::'
 };

--- a/src/types/Networking.ts
+++ b/src/types/Networking.ts
@@ -9,5 +9,6 @@ namespace Linode {
     | 'singapore'
     | 'frankfurt'
     | 'shinagawa1'
-    | 'toronto1';
+    | 'toronto1'
+    | 'mumbai1';
 }

--- a/src/utilities/doesRegionSupportBlockStorage.test.ts
+++ b/src/utilities/doesRegionSupportBlockStorage.test.ts
@@ -6,6 +6,7 @@ describe('does region support block storage', () => {
     expect(doesRegionSupportBlockStorage('us-east')).toBe(true);
     expect(doesRegionSupportBlockStorage('us-central')).toBe(true);
     expect(doesRegionSupportBlockStorage('ca-central')).toBe(true);
+    expect(doesRegionSupportBlockStorage('ap-west')).toBe(true);
   });
 
   it('returns false if the region does not support block storage', () => {


### PR DESCRIPTION
## Description

~Wait for #4928 to be merged, then rebase feature branch with develop and drop 2a5d1c87804a7496a87aa921944517fb4bccf2d9 from this PR.~ DONE

Adds support for Mumbai. Merging this into a feature branch until launch, so we can coordinate with API.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

1) Use Charles to add `{"country": "in", "id": "ap-west"}` to the response for `/regions`. 
2) Go through the Linode Create flow, NodeBalancer Create flow, & Volume Create flow.

Prod test account 9 has a Linode in Mumbai, called `ap-west`, which you can use to look at the DNS resolvers on the LinodeNetworking page.