### PR TITLE
OBJ-159: Split "Size" column into "Objects" and "Size"

### DIFF
--- a/src/features/ObjectStorage/Buckets/BucketTableRow.test.tsx
+++ b/src/features/ObjectStorage/Buckets/BucketTableRow.test.tsx
@@ -79,14 +79,14 @@ describe('BucketTableRow', () => {
     expect(actionMenuProps.onRemove).toBe(mockOnRemove);
   });
 
-  it('should correctly pluralize the number of items in the bucket', () => {
+  it('should correctly pluralize the number of objects in the bucket', () => {
     wrapper.setProps({ objects: 0 });
     expect(
       wrapper
         .find('[data-qa-num-objects]')
         .childAt(0)
         .text()
-    ).toBe('0 items');
+    ).toBe('0 objects');
 
     wrapper.setProps({ objects: 1 });
     expect(
@@ -94,7 +94,7 @@ describe('BucketTableRow', () => {
         .find('[data-qa-num-objects]')
         .childAt(0)
         .text()
-    ).toBe('1 item');
+    ).toBe('1 object');
 
     wrapper.setProps({ objects: 24 });
     expect(
@@ -102,6 +102,6 @@ describe('BucketTableRow', () => {
         .find('[data-qa-num-objects]')
         .childAt(0)
         .text()
-    ).toBe('24 items');
+    ).toBe('24 objects');
   });
 });

--- a/src/features/ObjectStorage/Buckets/BucketTableRow.tsx
+++ b/src/features/ObjectStorage/Buckets/BucketTableRow.tsx
@@ -98,7 +98,7 @@ export const BucketTableRow: React.StatelessComponent<
           {formatRegion(region)}
         </Typography>
       </TableCell>
-      <TableCell parentColumn="created">
+      <TableCell parentColumn="Created">
         <DateTimeDisplay
           value={created}
           humanizeCutoff="month"

--- a/src/features/ObjectStorage/Buckets/BucketTableRow.tsx
+++ b/src/features/ObjectStorage/Buckets/BucketTableRow.tsx
@@ -79,15 +79,17 @@ export const BucketTableRow: React.StatelessComponent<
         {/* @todo: uncomment this <Link/> when a bucket landing page exists*/}
         {/* </Link> */}
       </TableCell>
+      <TableCell parentColumn="Objects">
+        <Grid>
+          <Typography variant="body2" data-qa-num-objects>
+            {`${objects} ${objects === 1 ? 'object' : 'objects'}`}
+          </Typography>
+        </Grid>
+      </TableCell>
       <TableCell parentColumn="Size">
         <Grid>
           <Typography variant="body1" data-qa-size>
             {readableBytes(size).formatted}
-          </Typography>
-        </Grid>
-        <Grid>
-          <Typography variant="body2" data-qa-num-objects>
-            {`${objects} ${objects === 1 ? 'item' : 'items'}`}
           </Typography>
         </Grid>
       </TableCell>

--- a/src/features/ObjectStorage/Buckets/ListBuckets.test.tsx
+++ b/src/features/ObjectStorage/Buckets/ListBuckets.test.tsx
@@ -25,6 +25,9 @@ describe('ListBuckets', () => {
   it('renders a "Name" column', () => {
     expect(innerComponent.find('[data-qa-name]')).toHaveLength(1);
   });
+  it('renders an "Objects" column', () => {
+    expect(innerComponent.find('[data-qa-objects]')).toHaveLength(1);
+  });
   it('renders a "Size" column', () => {
     expect(innerComponent.find('[data-qa-size]')).toHaveLength(1);
   });

--- a/src/features/ObjectStorage/Buckets/ListBuckets.tsx
+++ b/src/features/ObjectStorage/Buckets/ListBuckets.tsx
@@ -141,6 +141,15 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
                     Name
                   </TableSortCell>
                   <TableSortCell
+                    active={orderBy === 'objects'}
+                    label="objects"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                    data-qa-objects
+                  >
+                    Objects
+                  </TableSortCell>
+                  <TableSortCell
                     active={orderBy === 'size'}
                     label="size"
                     direction={order}


### PR DESCRIPTION
## Description

This came out of review feedback on 5/8.

<img width="203" alt="Screen Shot 2019-05-10 at 4 56 11 PM" src="https://user-images.githubusercontent.com/16911484/57556267-894ce880-7344-11e9-8f77-65f557e66b5d.png">

Exact copy hasn't been discussed – open to feedback.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Make sure OBJ is enabled. Look at the Buckets landing page.
