### PR TITLE
M3-2560 Add: Ability to update email from account -> user profile

### DIFF
--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -140,7 +140,7 @@ class UserDetail extends React.Component<CombinedProps> {
 
     if (locationState) {
       this.setState({
-        profileSuccess: clone(locationState.success),
+        accountSuccess: clone(locationState.success),
         createdUsername: clone(locationState.newUsername)
       });
       /* don't show the success message again on refresh */
@@ -218,14 +218,7 @@ class UserDetail extends React.Component<CombinedProps> {
           originalUsername: user.username,
           username: user.username,
           accountSaving: false,
-          accountErrors: undefined,
-          profileErrors: undefined,
-          // We update `email` state here in case the user has
-          // entered text in the `email` text input, but hasn't
-          // clicked "Save". If we didn't do this, they'd see a success
-          // message along with the un-submitted email, which could
-          // give the false impression they've updated their email.
-          email: user.email
+          accountErrors: undefined
         });
 
         /**
@@ -246,13 +239,10 @@ class UserDetail extends React.Component<CombinedProps> {
         this.setState({
           accountErrors: getAPIErrorOrDefault(
             errResponse,
-            'Error updating user profile'
+            'Error updating username'
           ),
           accountSaving: false,
-          accountSuccess: false,
-          // We need to clear profileSuccess here too, otherwise we could
-          // end up with a Success Notice and Error Notice at the same time.
-          profileSuccess: false
+          accountSuccess: false
         });
       });
   };
@@ -274,14 +264,7 @@ class UserDetail extends React.Component<CombinedProps> {
         this.setState({
           profileSaving: false,
           profileSuccess: true,
-          accountErrors: undefined,
-          profileErrors: undefined,
-          // We update `username` state here, in case the user has
-          // entered text in the `username` text input, but hasn't
-          // clicked "Save". If we didn't do this, they'd see a success
-          // message along with the un-submitted username, which could
-          // give the false impression they've updated their username.
-          username: profile.username
+          profileErrors: undefined
         });
         /**
          * If the user we updated is the current user, we need to reflect that change at the global level.
@@ -294,13 +277,10 @@ class UserDetail extends React.Component<CombinedProps> {
         this.setState({
           profileErrors: getAPIErrorOrDefault(
             errResponse,
-            'Error updating user profile'
+            'Error updating email'
           ),
           profileSaving: false,
-          profileSuccess: false,
-          // We need to clear accountSuccess here too, otherwise we could
-          // end up with Success Notice and Error Notice at the same time.
-          accountSuccess: false
+          profileSuccess: false
         });
       });
   };

--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -206,7 +206,9 @@ class UserDetail extends React.Component<CombinedProps> {
     this.setState({
       accountSuccess: false,
       accountSaving: true,
-      accountErrors: []
+      accountErrors: [],
+      profileSuccess: false,
+      profileErrors: []
     });
 
     updateUser(originalUsername, { username, restricted })
@@ -256,7 +258,9 @@ class UserDetail extends React.Component<CombinedProps> {
     this.setState({
       profileSuccess: false,
       profileSaving: true,
-      profileErrors: []
+      profileErrors: [],
+      accountSuccess: false,
+      accountErrors: []
     });
 
     updateProfile({ email })

--- a/src/features/Users/UserProfile.tsx
+++ b/src/features/Users/UserProfile.tsx
@@ -38,6 +38,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     flexGrow: 1,
     width: '100%',
     marginTop: theme.spacing.unit,
+    marginBottom: theme.spacing.unit * 3,
     backgroundColor: theme.color.white
   },
   deleteRoot: {
@@ -136,61 +137,80 @@ class UserProfile extends React.Component<CombinedProps> {
       profileErrors
     );
 
-    const generalError =
-      hasAccountErrorFor('none') || hasProfileErrorFor('none');
+    const generalAccountError = hasAccountErrorFor('none');
+
+    const generalProfileError = hasProfileErrorFor('none');
 
     return (
-      <Paper className={classes.root}>
-        <div className={classes.inner}>
-          {(accountSuccess || profileSuccess) && (
-            <Notice success>User Profile updated successfully</Notice>
-          )}
-          {generalError && <Notice error text={generalError} />}
-          <Typography variant="h2" data-qa-profile-header>
-            User Profile
-          </Typography>
-          <TextField
-            className={classes.field}
-            label="Username"
-            value={username}
-            onChange={changeUsername}
-            errorText={hasAccountErrorFor('username')}
-            data-qa-username
-          />
-          <ActionsPanel>
-            <Button
-              type="primary"
-              loading={accountSaving}
-              onClick={saveAccount}
-              data-qa-submit
-            >
-              Save
-            </Button>
-          </ActionsPanel>
-          <TextField
-            // This should be disabled if this is NOT the current user.
-            disabled={profileUsername !== originalUsername}
-            className={classes.field}
-            label="Email"
-            value={email}
-            onChange={changeEmail}
-            errorText={hasProfileErrorFor('email')}
-            data-qa-username
-          />
-          <ActionsPanel>
-            <Button
+      <React.Fragment>
+        <Typography variant="h2" data-qa-profile-header>
+          User Profile
+        </Typography>
+        <Paper className={classes.root}>
+          <div className={classes.inner}>
+            {accountSuccess && (
+              <Notice success spacingBottom={0}>
+                Username updated successfully
+              </Notice>
+            )}
+            {generalAccountError && (
+              <Notice error text={generalAccountError} spacingBottom={0} />
+            )}
+            <TextField
+              className={classes.field}
+              label="Username"
+              value={username}
+              onChange={changeUsername}
+              errorText={hasAccountErrorFor('username')}
+              data-qa-username
+            />
+            <ActionsPanel>
+              <Button
+                type="primary"
+                loading={accountSaving}
+                onClick={saveAccount}
+                data-qa-submit
+              >
+                Save
+              </Button>
+            </ActionsPanel>
+          </div>
+        </Paper>
+        <Paper className={classes.root}>
+          <div className={classes.inner}>
+            {profileSuccess && (
+              <Notice success spacingBottom={0}>
+                Email updated successfully
+              </Notice>
+            )}
+            {generalProfileError && (
+              <Notice error text={generalProfileError} spacingBottom={0} />
+            )}
+            <TextField
               // This should be disabled if this is NOT the current user.
               disabled={profileUsername !== originalUsername}
-              type="primary"
-              loading={profileSaving}
-              onClick={saveProfile}
-              data-qa-submit
-            >
-              Save
-            </Button>
-          </ActionsPanel>
-        </div>
-      </Paper>
+              className={classes.field}
+              label="Email"
+              value={email}
+              onChange={changeEmail}
+              errorText={hasProfileErrorFor('email')}
+              data-qa-username
+            />
+            <ActionsPanel>
+              <Button
+                // This should be disabled if this is NOT the current user.
+                disabled={profileUsername !== originalUsername}
+                type="primary"
+                loading={profileSaving}
+                onClick={saveProfile}
+                data-qa-submit
+              >
+                Save
+              </Button>
+            </ActionsPanel>
+          </div>
+        </Paper>
+      </React.Fragment>
     );
   };
 

--- a/src/features/Users/UserProfile.tsx
+++ b/src/features/Users/UserProfile.tsx
@@ -7,7 +7,6 @@ import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
-import InputLabel from 'src/components/core/InputLabel';
 import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
@@ -69,11 +68,16 @@ interface Props {
   username: string;
   email?: string;
   changeUsername: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  save: () => void;
-  reset: () => void;
-  saving: boolean;
-  success: boolean;
-  errors?: Linode.ApiFieldError[];
+  changeEmail: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  saveAccount: () => void;
+  accountSaving: boolean;
+  accountSuccess: boolean;
+  accountErrors?: Linode.ApiFieldError[];
+  saveProfile: () => void;
+  profileSaving: boolean;
+  profileSuccess: boolean;
+  profileErrors?: Linode.ApiFieldError[];
+  originalUsername?: string;
 }
 
 interface State {
@@ -109,18 +113,36 @@ class UserProfile extends React.Component<CombinedProps> {
       username,
       email,
       changeUsername,
-      save,
-      reset,
-      saving,
-      success,
-      errors
+      changeEmail,
+      saveAccount,
+      accountSaving,
+      accountSuccess,
+      accountErrors,
+      saveProfile,
+      profileSaving,
+      profileSuccess,
+      profileErrors,
+      profileUsername,
+      originalUsername
     } = this.props;
-    const hasErrorFor = getAPIErrorsFor({ username: 'Username' }, errors);
-    const generalError = hasErrorFor('none');
+
+    const hasAccountErrorFor = getAPIErrorsFor(
+      { username: 'Username' },
+      accountErrors
+    );
+
+    const hasProfileErrorFor = getAPIErrorsFor(
+      { email: 'Email' },
+      profileErrors
+    );
+
+    const generalError =
+      hasAccountErrorFor('none') || hasProfileErrorFor('none');
+
     return (
       <Paper className={classes.root}>
         <div className={classes.inner}>
-          {success && (
+          {(accountSuccess || profileSuccess) && (
             <Notice success>User Profile updated successfully</Notice>
           )}
           {generalError && <Notice error text={generalError} />}
@@ -132,27 +154,39 @@ class UserProfile extends React.Component<CombinedProps> {
             label="Username"
             value={username}
             onChange={changeUsername}
-            errorText={hasErrorFor('username')}
+            errorText={hasAccountErrorFor('username')}
             data-qa-username
           />
-          {/* API doesn't allow changing user email address */}
-          <div className={classes.emailField}>
-            <InputLabel>Email Address</InputLabel>
-            <Typography data-qa-email className={classes.emailAddress}>
-              {email}
-            </Typography>
-          </div>
-          <ActionsPanel style={{ marginTop: 16 }}>
+          <ActionsPanel>
             <Button
               type="primary"
-              loading={saving}
-              onClick={save}
+              loading={accountSaving}
+              onClick={saveAccount}
               data-qa-submit
             >
               Save
             </Button>
-            <Button type="cancel" onClick={reset} data-qa-cancel>
-              Cancel
+          </ActionsPanel>
+          <TextField
+            // This should be disabled if this is NOT the current user.
+            disabled={profileUsername !== originalUsername}
+            className={classes.field}
+            label="Email"
+            value={email}
+            onChange={changeEmail}
+            errorText={hasProfileErrorFor('email')}
+            data-qa-username
+          />
+          <ActionsPanel>
+            <Button
+              // This should be disabled if this is NOT the current user.
+              disabled={profileUsername !== originalUsername}
+              type="primary"
+              loading={profileSaving}
+              onClick={saveProfile}
+              data-qa-submit
+            >
+              Save
             </Button>
           </ActionsPanel>
         </div>

--- a/src/features/Users/UserProfile.tsx
+++ b/src/features/Users/UserProfile.tsx
@@ -193,6 +193,11 @@ class UserProfile extends React.Component<CombinedProps> {
               label="Email"
               value={email}
               onChange={changeEmail}
+              tooltipText={
+                profileUsername !== originalUsername
+                  ? "You can't change another user's email address"
+                  : ''
+              }
               errorText={hasProfileErrorFor('email')}
               data-qa-username
             />


### PR DESCRIPTION
## Description

The difficult with this is:

a) Username is only editable at `/account`
b) Email is only editable at `/profile`

Therefore the “User Profile” form had to be separated into two parts. “Email” is disabled if an account owner is looking at another user’s profile (account owners don’t have the ability to change other user’s email addresses.)

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please test a range of success/failure states, as there are two forms to deal with.
