### PR TITLE
M3-2643 block device assignment

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.test.tsx
@@ -1,0 +1,47 @@
+import { getSelectedOption } from './DeviceSelection';
+
+const option1 = {
+  label: 'Option 1',
+  value: 'Option 1'
+};
+
+const option2 = {
+  label: 'Option 2',
+  value: 'Option 2'
+};
+
+const option3 = {
+  label: 'Volumes Option 1',
+  value: 'Volumes Option 1'
+};
+
+const option4 = {
+  label: 'Volumes Option 2',
+  value: 'Volumes Option 2'
+};
+
+const fakeDeviceList = [
+  {
+    label: 'Disks',
+    value: 'disks',
+    options: [option1, option2]
+  },
+  {
+    label: 'Volumes',
+    value: 'volumes',
+    options: [option3, option4]
+  }
+];
+
+describe('DeviceSelection', () => {
+  describe('getSelectedOption helper method', () => {
+    it('should retrieve an Item from a set of grouped options', () => {
+      expect(getSelectedOption(option3.value, fakeDeviceList)).toBe(option3);
+      expect(getSelectedOption(option2.value, fakeDeviceList)).toBe(option2);
+    });
+
+    it("should return null if the option isn't found", () => {
+      expect(getSelectedOption('not a real value', fakeDeviceList)).toBeNull();
+    });
+  });
+});

--- a/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
@@ -82,7 +82,7 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
         deviceList.unshift({
           value: '',
           label: '',
-          options: [{ value: 'None', label: 'None' }]
+          options: [{ value: null, label: 'None' }]
         });
 
         const selectedDevice = getSelectedOption(getSelected(slot), deviceList);

--- a/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
@@ -1,4 +1,4 @@
-import { defaultTo } from 'ramda';
+import { defaultTo, flatten } from 'ramda';
 import * as React from 'react';
 import FormControl from 'src/components/core/FormControl';
 import {
@@ -6,7 +6,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import Select, { GroupType, Item } from 'src/components/EnhancedSelect/Select';
 import { titlecase } from 'src/features/linodes/presentation';
 
 type ClassNames = 'root';
@@ -38,6 +38,20 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
+export const getSelectedOption = (
+  selectedValue: string,
+  options: GroupType<string>[]
+) => {
+  if (!selectedValue) {
+    return null;
+  }
+  // Ramda's flatten doesn't seem able to handle the typing issues here, but this returns an array of Item<string>.
+  const optionsList = (flatten(
+    options.map(option => option.options)
+  ) as unknown) as Item<string>[];
+  return optionsList.find(option => option.value === selectedValue);
+};
+
 const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
   const {
     devices,
@@ -65,15 +79,17 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
           };
         });
 
+        const selectedDevice = getSelectedOption(getSelected(slot), deviceList);
+
         return counter < idx ? null : (
           <FormControl
-            updateFor={[getSelected(slot), classes]}
+            updateFor={[selectedDevice, deviceList, classes]}
             key={slot}
             fullWidth
           >
             <Select
               options={deviceList}
-              defaultValue={getSelected(slot) || 'none'}
+              value={selectedDevice}
               onChange={(e: Item<string>) => onChange(slot, e.value)}
               disabled={disabled}
               placeholder={'None'}

--- a/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
@@ -47,9 +47,9 @@ export const getSelectedOption = (
   }
   // Ramda's flatten doesn't seem able to handle the typing issues here, but this returns an array of Item<string>.
   const optionsList = (flatten(
-    options.map(option => option.options)
+    options.map(group => group.options)
   ) as unknown) as Item<string>[];
-  return optionsList.find(option => option.value === selectedValue);
+  return optionsList.find(option => option.value === selectedValue) || null;
 };
 
 const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {

--- a/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/DeviceSelection.tsx
@@ -79,6 +79,12 @@ const DeviceSelection: React.StatelessComponent<CombinedProps> = props => {
           };
         });
 
+        deviceList.unshift({
+          value: '',
+          label: '',
+          options: [{ value: 'None', label: 'None' }]
+        });
+
         const selectedDevice = getSelectedOption(getSelected(slot), deviceList);
 
         return counter < idx ? null : (

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -284,7 +284,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
 
     const pathsOptions = [
       { label: '/dev/sda', value: '/dev/sda' },
-      { label: '/dev/sdb', value: '/dev/sdc' },
+      { label: '/dev/sdb', value: '/dev/sdb' },
       { label: '/dev/sdc', value: '/dev/sdc' },
       { label: '/dev/sdd', value: '/dev/sdd' },
       { label: '/dev/sde', value: '/dev/sde' },

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -393,7 +393,9 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             <Select
               options={kernelList}
               label="Select a Kernel"
-              defaultValue={kernel}
+              defaultValue={kernelList.find(
+                thisKernel => thisKernel.value === kernel
+              )}
               onChange={this.handleChangeKernel}
               errorText={errorFor('kernel')}
               errorGroup="linode-config-drawer"
@@ -477,11 +479,14 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
               <Select
                 options={pathsOptions}
                 label="Root Device"
-                defaultValue={root_device}
+                defaultValue={pathsOptions.find(
+                  device => device.value === root_device
+                )}
                 onChange={this.handleRootDeviceChange}
                 name="root_device"
                 id="root_device"
                 errorText={errorFor('root_device')}
+                placeholder="None"
                 disabled={readOnly}
                 isClearable={false}
               />


### PR DESCRIPTION
## Description

This was a bug ticket from Support, but I wasn't able to reproduce the error in production. However, development was broken due to the use of GroupType with EnhancedSelect, so I fixed that.


## Type of Change
- Bug fix ('fix', 'repair', 'bug')


## Applicable E2E Tests

None

## Note to Reviewers

To test, visit the Advanced tab of Linode Detail and open a config for editing. The Device Assignment dropdowns should populate and update as expected.