### PR TITLE
Change: Includes the Linode Label in Delete Dialog Modal

### DIFF
--- a/e2e/pageobjects/list-linodes.js
+++ b/e2e/pageobjects/list-linodes.js
@@ -125,13 +125,13 @@ export class ListLinodes extends Page {
             // Select from action menu
             linode.$(this.linodeActionMenu.selector).click();
             browser.click('[data-qa-action-menu-item="Reboot"]');
-            this.acceptDialog('Confirm Reboot');
+            this.acceptDialog('Reboot');
             browser.waitForVisible('[data-qa-loading]');
         }
 
         if (activeView === 'grid') {
             linode.$(this.rebootButton).click();
-            this.acceptDialog('Confirm Reboot');
+            this.acceptDialog('Reboot');
             browser.waitForVisible('[data-qa-circular-progress]');
         }
 
@@ -146,7 +146,7 @@ export class ListLinodes extends Page {
 
     powerOff(linode) {
         this.selectActionMenuItemV2(this.getLinodeSelector(linode),'Power Off');
-        this.acceptDialog('Powering Off');
+        this.acceptDialog('Power Off');
 
         browser.waitUntil(function() {
             return browser.isVisible(`${this.getLinodeSelector(linode)} [data-qa-entity-status="offline"]`);
@@ -178,7 +178,7 @@ export class ListLinodes extends Page {
         this.confirmDialogTitle.waitForVisible();
         this.confirmDialogCancel.waitForVisible();
         this.confirmDialogSubmit.waitForVisible();
-        expect(this.confirmDialogTitle.getText()).toBe(dialogTitle);
+        expect(this.confirmDialogTitle.getText()).toMatch(dialogTitle);
         this.confirmDialogSubmit.click();
         this.confirmDialogTitle.waitForVisible(constants.wait.normal, true);
     }

--- a/e2e/specs/linodes/smoke-linodes.spec.js
+++ b/e2e/specs/linodes/smoke-linodes.spec.js
@@ -10,7 +10,7 @@ import ListLinodes from '../../pageobjects/list-linodes';
 import LinodeDetail from '../../pageobjects/linode-detail/linode-detail.page';
 import SearchResults from '../../pageobjects/search-results.page';
 
-xdescribe('List Linodes Suite', () => {
+describe('List Linodes Suite', () => {
     const linode = {
         linodeLabel: `AutoLinode${timestamp()}`,
         privateIp: false,
@@ -18,7 +18,16 @@ xdescribe('List Linodes Suite', () => {
     }
 
     const assertActionMenuItems = (linode) => {
-        const expectedOptions = ['Reboot', 'Power Off', 'Launch Console', 'View Graphs', 'Resize', 'Enable Backups', 'Settings'];
+        const expectedOptions = [
+            'Reboot', 
+            'Power Off',
+            'Launch Console',
+            'View Graphs', 
+            'Resize',
+            'View Backups',
+            'Enable Backups',
+            'Delete'
+            ];
         ListLinodes.actionMenuOptionExists($(ListLinodes.getLinodeSelector(linode)), expectedOptions);
         browser.click('body');
         ListLinodes.actionMenuItem.waitForExist(constants.wait.normal, true);
@@ -47,7 +56,7 @@ xdescribe('List Linodes Suite', () => {
         }
     });
 
-    it('should display with documentation', () => {
+    xit('should display with documentation', () => {
             ListLinodes.assertDocsDisplay();
     });
 
@@ -96,7 +105,7 @@ xdescribe('List Linodes Suite', () => {
         it('should display copy to clipboard elements', () => {
             copyButtons = flatten(ListLinodes.linode.map(l => l.$$(ListLinodes.copyIp.selector)));
             const linodesLength = ListLinodes.linode.length;
-            const expectedCopyButtons = linodesLength * 2;
+            const expectedCopyButtons = linodesLength;
 
             expect(copyButtons.length).toEqual(expectedCopyButtons);
         });
@@ -114,13 +123,6 @@ xdescribe('List Linodes Suite', () => {
 
         it('should display action menu and linode action menu items', () => {
             assertActionMenuItems(linode.linodeLabel);
-        });
-
-        it('tags should be clickable in list view and navigate to search result page for the tag', () => {
-            expect(ListLinodes.tag.isVisible()).toBe(true);
-            ListLinodes.tag.click();
-            SearchResults.waitForSearchResult('linodes',linode.linodeLabel);
-            expect(browser.getUrl()).toContain(`?query=${linode.tags[0]}`);
         });
     });
 });

--- a/e2e/specs/linodes/smoke-reboot-linodes.spec.js
+++ b/e2e/specs/linodes/smoke-reboot-linodes.spec.js
@@ -34,7 +34,7 @@ describe('List Linodes - Actions - Reboot Suite', () => {
         it('should reboot linode on click', () => {
             linodes = ListLinodes.linode;
             linodes[0].$(ListLinodes.rebootButton.selector).click();
-            ListLinodes.acceptDialog('Confirm Reboot');
+            ListLinodes.acceptDialog('Reboot');
         });
 
         it('should update status on reboot to rebooting', () => {
@@ -61,7 +61,7 @@ describe('List Linodes - Actions - Reboot Suite', () => {
 
         it('should reboot linode on click', () => {
             ListLinodes.selectActionMenuItemV2(ListLinodes.getLinodeSelector(linode), 'Reboot');
-            ListLinodes.acceptDialog('Confirm Reboot');
+            ListLinodes.acceptDialog('Reboot');
         });
 
         it('should update status on reboot to rebooting', () => {

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -96,13 +96,14 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
           </Typography>
         </ExpansionPanel>
         <ConfirmationDialog
-          title={`Confirm Deletion of ${this.props.linodeLabel}`}
+          title={`Delete ${this.props.linodeLabel}?`}
           actions={this.renderConfirmationActions}
           open={this.state.open}
           onClose={this.closeDeleteDialog}
         >
           <Typography>
-            Deleting a Linode will result in permanent data loss. Are you sure?
+            Are you sure you want to delete your Linode? This will result in
+            permanent data loss.
           </Typography>
         </ConfirmationDialog>
       </React.Fragment>

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -419,10 +419,10 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
             <ConfirmationDialog
               title={
                 actionOption === 'reboot'
-                  ? 'Confirm Reboot'
+                  ? `Reboot ${this.state.selectedLinodeLabel}?`
                   : actionOption === 'power_down'
-                  ? 'Powering Off'
-                  : 'Confirm Delete'
+                  ? `Power Off ${this.state.selectedLinodeLabel}?`
+                  : `Delete ${this.state.selectedLinodeLabel}?`
               }
               actions={this.renderConfirmationActions}
               open={confirmationOpen}
@@ -454,7 +454,7 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
           Cancel
         </Button>
         <Button
-          type="primary"
+          type="secondary"
           onClick={this.executeAction}
           data-qa-confirm-cancel
           loading={confirmationLoading}


### PR DESCRIPTION
## Description

Includes the Linode Label in the delete dialog on the Linode Landing page

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/linodes/smoke-linodes.spec.js,e2e/specs/linodes/smoke-reboot-linodes.spec.js --browser=headlessChrome`