### PR TITLE
M3-2699 fix: Per-linode network transfer pool

### DIFF
--- a/src/services/linodes/getLinodeInfo.ts
+++ b/src/services/linodes/getLinodeInfo.ts
@@ -40,6 +40,19 @@ export const getLinodeStatsByDate = (
   ).then(response => response.data);
 
 /**
+ * getLinodeTransfer
+ *
+ * Returns current network transfer information for your Linode.
+ *
+ * @param linodeId { number } The id of the Linode to retrieve network transfer information for.
+ */
+export const getLinodeTransfer = (linodeId: number) =>
+  Request<Linode.NetworkUtilization>(
+    setURL(`${API_ROOT}/linode/instances/${linodeId}/transferpool`),
+    setMethod('GET')
+  ).then(response => response.data);
+
+/**
  * getLinodeKernels
  *
  * Returns a paginated list of available kernels.

--- a/src/services/linodes/getLinodeInfo.ts
+++ b/src/services/linodes/getLinodeInfo.ts
@@ -48,7 +48,7 @@ export const getLinodeStatsByDate = (
  */
 export const getLinodeTransfer = (linodeId: number) =>
   Request<Linode.NetworkUtilization>(
-    setURL(`${API_ROOT}/linode/instances/${linodeId}/transferpool`),
+    setURL(`${API_ROOT}/linode/instances/${linodeId}/transfer`),
     setMethod('GET')
   ).then(response => response.data);
 

--- a/src/utilities/unitConversions.test.ts
+++ b/src/utilities/unitConversions.test.ts
@@ -1,12 +1,23 @@
 import { readableBytes } from './unitConversions';
 
 describe('readableBytes', () => {
-  it('should return "0 B" if bytes === 0', () => {
+  it('should return "0 bytes" if bytes === 0', () => {
     expect(readableBytes(0).formatted).toBe('0 bytes');
   });
 
+  it("should handle negative values, unless it' disabled by the handleNegatives option", () => {
+    expect(readableBytes(-123).formatted).toBe('-123 bytes');
+    expect(readableBytes(-123).value).toBe(-123);
+    expect(readableBytes(-1048576).formatted).toBe('-1 MB');
+    expect(readableBytes(-1048576).value).toBe(-1);
+
+    expect(readableBytes(-1048576, { handleNegatives: false }).formatted).toBe(
+      '0 bytes'
+    );
+  });
+
   it('should return B if < 1024', () => {
-    expect(readableBytes(1023).formatted).toBe('1023 B');
+    expect(readableBytes(1023).formatted).toBe('1023 bytes');
   });
 
   it('handles KB, MB, GB', () => {
@@ -29,5 +40,59 @@ describe('readableBytes', () => {
     expect(readableBytes(1024 * 100).formatted).toBe('100 KB');
     expect(readableBytes(1024 * 100.25).formatted).toBe('100 KB');
     expect(readableBytes(1024 * 100.5).formatted).toBe('101 KB');
+  });
+
+  it('respects rounding when specified with number', () => {
+    const round0 = { round: 0 };
+    const round1 = { round: 1 };
+    const round2 = { round: 2 };
+
+    expect(readableBytes(1024 * 9.72, round0).formatted).toBe('10 KB');
+    expect(readableBytes(1024 * 9.72, round1).formatted).toBe('9.7 KB');
+    expect(readableBytes(1024 * 9.72, round2).formatted).toBe('9.72 KB');
+
+    expect(readableBytes(1024 * 89.99, round0).formatted).toBe('90 KB');
+    expect(readableBytes(1024 * 89.99, round1).formatted).toBe('90 KB');
+    expect(readableBytes(1024 * 89.99, round2).formatted).toBe('89.99 KB');
+
+    expect(readableBytes(1024 * 100.25, round0).formatted).toBe('100 KB');
+    expect(readableBytes(1024 * 100.25, round1).formatted).toBe('100.3 KB');
+    expect(readableBytes(1024 * 100.25, round2).formatted).toBe('100.25 KB');
+  });
+
+  it('respects rounding when given specific units', () => {
+    expect(readableBytes(1024 * 9.723, { round: { KB: 3 } }).formatted).toBe(
+      '9.723 KB'
+    );
+    expect(readableBytes(1024 * 9.723, { round: { MB: 3 } }).formatted).toBe(
+      '9.72 KB'
+    );
+    expect(
+      readableBytes(1024 * 1024 * 143.22, { round: { MB: 2 } }).formatted
+    ).toBe('143.22 MB');
+  });
+
+  it("doesn't return units higher than the specific max unit", () => {
+    expect(
+      readableBytes(1024 * 1024 * 1024 * 50, { maxUnit: 'MB' }).formatted
+    ).toBe('51200 MB');
+    expect(
+      readableBytes(1024 * 1024 * 1024 * 50, { maxUnit: 'KB' }).formatted
+    ).toBe('52428800 KB');
+    expect(
+      readableBytes(1024 * 1024 * 1024 * 50, { maxUnit: 'bytes' }).formatted
+    ).toBe('53687091200 bytes');
+  });
+
+  it('returns the given unit if specified', () => {
+    expect(
+      readableBytes(1024 * 1024 * 1024 * 50, { unit: 'MB' }).formatted
+    ).toBe('51200 MB');
+    expect(
+      readableBytes(1024 * 1024 * 1024 * 50, { unit: 'GB' }).formatted
+    ).toBe('50 GB');
+    expect(
+      readableBytes(1024 * 1024 * 1024 * 50, { unit: 'TB' }).formatted
+    ).toBe('0.05 TB');
   });
 });

--- a/src/utilities/unitConversions.ts
+++ b/src/utilities/unitConversions.ts
@@ -47,6 +47,8 @@ interface ReadableBytesOptions {
 }
 
 type StorageSymbol = 'bytes' | 'KB' | 'MB' | 'GB' | 'TB';
+
+// This code inspired by: https://ourcodeworld.com/articles/read/713/converting-bytes-to-human-readable-values-kb-mb-gb-tb-pb-eb-zb-yb-with-javascript
 export const readableBytes = (
   num: number,
   options: ReadableBytesOptions = {}

--- a/src/utilities/unitConversions.ts
+++ b/src/utilities/unitConversions.ts
@@ -24,39 +24,110 @@ export const convertMegabytesTo = (data: number) => {
   return `${totalToBytes} bytes`;
 };
 
-// Returns a human-readable version of the byte value passed in.
-// Example: readableBytes(2097152) --> { value: 2, unit: 'MB', formatted: '2 MB }
-// Value and unit are returned separately for flexibility of use.
-export const readableBytes = (num: number) => {
-  if (num === 0) {
+/**
+ * readableBytes()
+ *
+ * Returns a human-readable version of the byte value passed in.
+ *
+ * Example: readableBytes(2097152) --> { value: 2, unit: 'MB', formatted: '2 MB }
+ *
+ * Value and unit are returned separately for flexibility of use.
+ *
+ * Example options:
+ * { round: 2 } // always round to 2 places
+ * { round: { MB: 1, GB: 2 } } // if the return value is in MB, round to 1 place, otherwise round to 2 places.
+ * { unit: 'MB' } // give the return value in GB
+ * { maxUnit: 'GB' } // return values up to GB, i.e. never return TB or higher
+ */
+interface ReadableBytesOptions {
+  round?: number | Partial<Record<StorageSymbol, number>>;
+  unit?: StorageSymbol;
+  maxUnit?: StorageSymbol;
+  handleNegatives?: boolean;
+}
+
+type StorageSymbol = 'bytes' | 'KB' | 'MB' | 'GB' | 'TB';
+export const readableBytes = (
+  num: number,
+  options: ReadableBytesOptions = {}
+) => {
+  // If the value is 0, go ahead and return, because the
+  // subsequent math won't work out
+  if (num === 0 || (options.handleNegatives === false && num < 0)) {
     return { value: 0, unit: 'bytes', formatted: '0 bytes' };
   }
 
-  const kilobyte = 1024;
-
-  const power = Math.floor(Math.log(num) / Math.log(kilobyte));
-  const result = num / Math.pow(kilobyte, power);
-
-  // Rounding rules that Classic Manager uses.
-  let decimalPlaces;
-  if (result === 0) {
-    decimalPlaces = 0;
-  } else if (result < 10) {
-    decimalPlaces = 2;
-  } else if (result < 100) {
-    decimalPlaces = 1;
-  } else {
-    decimalPlaces = 0;
+  // If the value is a negative number, we're going to need flip
+  // the sign, do the math, then add the sign back at the end.
+  const isNegative = num < 0;
+  if (isNegative) {
+    num = -num;
   }
+
+  // These are the units Classic uses. This can easily be extended –
+  // just keep adding to this array and the corresponding interface.
+  const storageUnits: StorageSymbol[] = ['bytes', 'KB', 'MB', 'GB', 'TB'];
+
+  const power = determinePower(num, storageUnits, options);
+
+  // Some other magic to get the human-readable version
+  const result = num / Math.pow(1024, power);
+  const unit = storageUnits[power];
+
+  const decimalPlaces = determineDecimalPlaces(result, unit, options);
 
   const value = parseFloat(result.toFixed(decimalPlaces));
 
-  const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
-  const unit = sizes[power];
-
   return {
-    value,
+    value: isNegative ? -value : value,
     unit,
-    formatted: value + ' ' + unit
+    formatted: (isNegative ? '-' : '') + value + ' ' + unit
   };
+};
+
+// `power` corresponds to storageUnits.indexOf(<UNIT WE WANT TO USE>)
+const determinePower = (
+  num: number,
+  storageUnits: StorageSymbol[],
+  options: ReadableBytesOptions
+) => {
+  // If maxUnit has been supplied, use that
+  if (options.unit) {
+    return storageUnits.indexOf(options.unit);
+  } else {
+    // Otherwise, we need to do some magic, which I don't 100% understand
+    const magicallyCalculatedPower = Math.floor(Math.log(num) / Math.log(1024));
+
+    // If the magically calculated power/unit is higher than the
+    // provided maxUnit, use maxUnit instead.
+    return options.maxUnit &&
+      storageUnits.indexOf(options.maxUnit) < magicallyCalculatedPower
+      ? storageUnits.indexOf(options.maxUnit)
+      : magicallyCalculatedPower;
+  }
+};
+
+// Determine the number of decimal places to use.
+// This could be specified with an option, or we fallback
+// to the rounding rules that Classic Manager uses.
+const determineDecimalPlaces = (
+  num: number,
+  unit: StorageSymbol,
+  options: ReadableBytesOptions = {}
+) => {
+  if (typeof options.round === 'number') {
+    return options.round;
+  } else if (
+    typeof options.round === 'object' &&
+    // If rounding rules for the unit we're using have been specified
+    typeof options.round[unit] === 'number'
+  ) {
+    return options.round[unit];
+  } else if (num > 0 && num < 10) {
+    return 2;
+  } else if (num >= 10 && num < 100) {
+    return 1;
+  } else {
+    return 0;
+  }
 };


### PR DESCRIPTION
## Description

With this PR, we fix the per-linode Network Transfer information on LinodeDetails. To do this, we consume a new API endpoint:

`/linode/instances/:id/transferpool`

This is in contrast to the hacky way we were doing it before, where we (incorrectly) used the `/stats` data.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests
None.

## Note to Reviewers

**IMPORTANT: This new endpoint is not in production yet. You must use dev services.**

To test, use dev services and look a several Linodes, noting the network transfer. Modify the request within the code or Charles to see different values for `used`.

Much of this PR is actually adding several options to the `readableBytes()` utility function, which were needed to display the network transfer info in a friendly and intuitive way. I did a bit of annotating and refactoring to make this more readable.