### PR TITLE
Add: Linode and Volume Labels to Volume Dialogs

### DIFF
--- a/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-volume.page.js
@@ -156,20 +156,19 @@ export class VolumeDetail extends Page {
         browser.waitForVisible('[data-qa-volume-label] input', constants.wait.normal);
         browser.trySetValue('[data-qa-volume-label] input', volume.label);
         browser.trySetValue('[data-qa-size] input', volume.size);
-
+        
         if (volume.hasOwnProperty('region')) {
-            this.selectRegion(volume.region);
-            browser.waitForValue('[data-qa-select-region] input', constants.wait.normal);
+            $('[data-qa-select-region]').click();
+            browser.trySetValue('[data-qa-select-region] input', volume.region);
+            /** press the enter key to select first value */
+            browser.keys("\uE007");
         }
 
         if (volume.hasOwnProperty('attachedLinode')) {
-            this.selectLinodeOrVolume.click();
-            this.selectOption.waitForVisible(constants.wait.normal);
-
-            const optionToSelect =
-                this.selectOptions.filter(opt => opt.getText().includes(volume.attachedLinode));
-
-            optionToSelect[0].click();
+            $('[data-qa-select-linode]').click();
+            browser.trySetValue('[data-qa-select-linode] input', volume.attachedLinode);
+            /** press the enter key to select first value */
+            browser.keys("\uE007");
         }
 
         if(volume.hasOwnProperty('tag')) {

--- a/e2e/pageobjects/volumes.page.js
+++ b/e2e/pageobjects/volumes.page.js
@@ -44,7 +44,7 @@ class Volumes extends Page {
         const dialogCancel = $(this.cancelButton.selector);
 
         expect(dialogTitle.isVisible()).toBe(true);
-        expect(dialogTitle.getText()).toBe('Delete Volume');
+        expect(dialogTitle.getText()).toMatch('Delete');
         expect(dialogConfirm.isVisible()).toBe(true);
         expect(dialogConfirm.getTagName()).toBe('button');
         expect(dialogCancel.isVisible()).toBe(true);

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -395,6 +395,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
       medium,
       small,
       noMarginTop,
+      textFieldProps,
       inline,
       hideLabel,
       errorGroup,
@@ -439,6 +440,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
         classNamePrefix="react-select"
         styles={styleOverrides}
         textFieldProps={{
+          ...textFieldProps,
           label,
           errorText,
           disabled,

--- a/src/features/Volumes/DestructiveVolumeDialog.tsx
+++ b/src/features/Volumes/DestructiveVolumeDialog.tsx
@@ -21,6 +21,8 @@ interface Props {
   onClose: () => void;
   onDetach: () => void;
   onDelete: () => void;
+  volumeLabel: string;
+  linodeLabel: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -50,9 +52,10 @@ class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
   };
 
   render() {
+    const { volumeLabel: label, linodeLabel } = this.props;
     const title = {
-      detach: 'Detach Volume',
-      delete: 'Delete Volume'
+      detach: `Detach ${label ? label : 'Volume'}?`,
+      delete: `Delete ${label ? label : 'Volume'}?`
     }[this.props.mode];
 
     return (
@@ -63,7 +66,8 @@ class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
         actions={this.renderActions}
       >
         <Typography>
-          Are you sure you want to {this.props.mode} this volume?
+          Are you sure you want to {this.props.mode} this volume
+          {`${linodeLabel ? ` from ${linodeLabel}?` : '?'}`}
         </Typography>
       </ConfirmationDialog>
     );

--- a/src/features/Volumes/RenderVolumeData.tsx
+++ b/src/features/Volumes/RenderVolumeData.tsx
@@ -21,8 +21,12 @@ export interface RenderVolumeDataProps {
   ) => void;
   openForConfig: (volumeLabel: string, volumePath: string) => void;
   handleAttach: (volumeId: number, label: string, regionID: string) => void;
-  handleDetach: (volumeId: number) => void;
-  handleDelete: (volumeId: number) => void;
+  handleDetach: (
+    volumeId: number,
+    volumeLabel: string,
+    linodeLabel: string
+  ) => void;
+  handleDelete: (volumeId: number, volumeLabel: string) => void;
 }
 
 const RenderData: React.StatelessComponent<

--- a/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
@@ -193,7 +193,9 @@ export class LinodeSelect extends React.Component<CombinedProps, State> {
           options={[{ label: 'Select a Linode', value: -1 }, ...options]}
           onChange={this.setSelectedLinode}
           onInputChange={this.onInputChange}
-          data-qa-select-linode
+          textFieldProps={{
+            'data-qa-select-linode': true
+          }}
           {...rest}
         />
         {!error && (

--- a/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
+++ b/src/features/Volumes/VolumeDrawer/RegionSelect.tsx
@@ -58,7 +58,9 @@ export const RegionSelect: React.StatelessComponent<CombinedProps> = props => {
         placeholder="All Regions"
         onChange={(item: Item<string>) => onChange(item.value)}
         onBlur={onBlur}
-        data-qa-select-region
+        textFieldProps={{
+          'data-qa-select-region': true
+        }}
         disabled={disabled}
         label="Region"
         isClearable={false}

--- a/src/features/Volumes/VolumeTableRow.tsx
+++ b/src/features/Volumes/VolumeTableRow.tsx
@@ -99,8 +99,12 @@ interface Props {
   ) => void;
   openForConfig: (volumeLabel: string, volumePath: string) => void;
   handleAttach: (volumeId: number, label: string, regionID: string) => void;
-  handleDetach: (volumeId: number) => void;
-  handleDelete: (volumeId: number) => void;
+  handleDetach: (
+    volumeId: number,
+    volumeLabel: string,
+    linodeLabel: string
+  ) => void;
+  handleDelete: (volumeId: number, volumeLabel: string) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -229,6 +233,7 @@ export const VolumeTableRow: React.StatelessComponent<
           onEdit={openForEdit}
           onResize={openForResize}
           onClone={openForClone}
+          volumeLabel={volume.label}
           /**
            * This is a safer check than volume.linode_id (see logic in addAttachedLinodeInfoToVolume() from VolumesLanding)
            * as it actually checks to see if the Linode exists before adding linodeLabel and linodeStatus.

--- a/src/features/Volumes/VolumesActionMenu.tsx
+++ b/src/features/Volumes/VolumesActionMenu.tsx
@@ -15,14 +15,19 @@ interface Props {
   ) => void;
   attached: boolean;
   onAttach: (volumeId: number, label: string, linodeRegion: string) => void;
-  onDetach: (volumeId: number) => void;
+  onDetach: (
+    volumeId: number,
+    volumeLabel: string,
+    linodeLabel: string
+  ) => void;
   poweredOff: boolean;
-  onDelete: (volumeId: number) => void;
+  onDelete: (volumeId: number, volumeLabel: string) => void;
   filesystemPath: string;
   label: string;
   linodeLabel: string;
   regionID: string;
   volumeId: number;
+  volumeLabel: string;
   volumeTags: string[];
   size: number;
 }
@@ -56,13 +61,13 @@ export class VolumesActionMenu extends React.Component<CombinedProps> {
   };
 
   handleDetach = () => {
-    const { volumeId, onDetach } = this.props;
-    onDetach(volumeId);
+    const { volumeId, onDetach, volumeLabel, linodeLabel } = this.props;
+    onDetach(volumeId, volumeLabel, linodeLabel);
   };
 
   handleDelete = () => {
-    const { volumeId, onDelete } = this.props;
-    onDelete(volumeId);
+    const { volumeId, onDelete, volumeLabel } = this.props;
+    onDelete(volumeId, volumeLabel);
   };
 
   createActions = () => {

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -180,7 +180,9 @@ interface State {
   destructiveDialog: {
     open: boolean;
     mode: 'detach' | 'delete';
+    volumeLabel: string;
     volumeId?: number;
+    linodeLabel: string;
   };
 }
 
@@ -208,7 +210,9 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     },
     destructiveDialog: {
       open: false,
-      mode: 'detach'
+      mode: 'detach',
+      volumeLabel: '',
+      linodeLabel: ''
     }
   };
 
@@ -246,22 +250,30 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
     });
   };
 
-  handleDetach = (volumeId: number) => {
+  handleDetach = (
+    volumeId: number,
+    volumeLabel: string,
+    linodeLabel: string
+  ) => {
     this.setState({
       destructiveDialog: {
         open: true,
         mode: 'detach',
-        volumeId
+        volumeId,
+        volumeLabel,
+        linodeLabel
       }
     });
   };
 
-  handleDelete = (volumeId: number) => {
+  handleDelete = (volumeId: number, volumeLabel: string) => {
     this.setState({
       destructiveDialog: {
         open: true,
         mode: 'delete',
-        volumeId
+        volumeId,
+        volumeLabel,
+        linodeLabel: ''
       }
     });
   };
@@ -343,6 +355,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
         />
         <DestructiveVolumeDialog
           open={this.state.destructiveDialog.open}
+          volumeLabel={this.state.destructiveDialog.volumeLabel}
+          linodeLabel={this.state.destructiveDialog.linodeLabel}
           mode={this.state.destructiveDialog.mode}
           onClose={this.closeDestructiveDialog}
           onDetach={this.detachVolume}


### PR DESCRIPTION
## Description

Adds Volume and Linode label to volume dialogs (delete and detach)

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/create/smoke-create-attached-volume.spec.js --browser=headlessChrome`