### PR TITLE
M3-2414 fix: UI experience when entering migration queue

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -1,4 +1,4 @@
-import { WithSnackbarProps } from 'notistack';
+import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { compose } from 'recompose';
 import {
@@ -51,7 +51,16 @@ const Notifications: React.StatelessComponent<CombinedProps> = props => {
         enqueueSnackbar(successMessage, { variant: 'success' });
         requestNotifications();
       })
-      .catch(_ => undefined);
+      .catch(_ => {
+        const errorMessage =
+          type === 'migration_scheduled'
+            ? 'An error occurred entering the migration queue.'
+            : 'An error occurred scheduling your migration.';
+
+        enqueueSnackbar(errorMessage, {
+          variant: 'error'
+        });
+      });
   };
 
   return (
@@ -95,6 +104,7 @@ interface ContextProps {
 
 const enhanced = compose<CombinedProps, {}>(
   styled,
+  withSnackbar,
   withLinodeDetailContext<ContextProps>(({ linode }) => ({
     linodeNotifications: linode._notifications,
     linodeId: linode.id,


### PR DESCRIPTION
## Description

Entering the migration queue by clicking "click here" didn't result in any UI feedback, even though the request to `/migrations` might have been successful.

<img width="806" alt="Screen Shot 2019-05-15 at 4 27 58 PM" src="https://user-images.githubusercontent.com/16911484/57807061-6b112f00-772e-11e9-8588-1002165b7786.png">

The `withSnackbar` HOC wasn't being included in the export for the component, so the success toast wasn't actually appearing.

Additionally, the `.catch()` function was empty, so an error toast has been added here.

_Note:_ There's another ticket, M3-2509, which states that we should request notifications as soon as migrations start, which would clear the "Migration imminent" notification once the migration starts. Once that's done, this flow will be even better.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

**TO TEST:**

_The happy path:_
1) Configure a migration for a Linode.
2) Navigate to that Linode's Details page.
3) Click "click here" on the migration banner.
4) Observe: a success message appears in a toast. The banner/notification has changed to let you know your Linode is about to be migrated.

_A sad path:_
1) Configure a migration for a Linode.
2) Navigate to that Linode's Details page.
3) Set up request blocking for `/migrate`.
4) Click "click here" on the migration banner.
5) Observe: an error message appears in a toast.