### PR TITLE
Aggregate multiple abuse tickets

### DIFF
--- a/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
+++ b/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
@@ -27,21 +27,24 @@ jest.mock('src/store', () => ({
 afterEach(cleanup);
 
 describe('Abuse ticket banner', () => {
-  it('should render a banner for each abuse ticket', () => {
-    const { rerender, queryAllByText } = render(
+  it('should render a banner for an abuse ticket', () => {
+    const { queryAllByText } = render(
       wrapWithTheme(
         <AbuseTicketBanner abuseTickets={[abuseTicketNotification]} />
       )
     );
-    expect(queryAllByText(/abuse/)).toHaveLength(1);
-    rerender(
+    expect(queryAllByText(/an open abuse ticket/)).toHaveLength(1);
+  });
+
+  it('should aggregate multiple abuse tickets', () => {
+    const { queryAllByText } = render(
       wrapWithTheme(
         <AbuseTicketBanner
           abuseTickets={[abuseTicketNotification, abuseTicketNotification]}
         />
       )
     );
-    expect(queryAllByText(/abuse/)).toHaveLength(2);
+    expect(queryAllByText(/2 open abuse tickets/)).toHaveLength(1);
   });
 
   it('should link to the ticket', () => {

--- a/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
+++ b/src/components/AbuseTicketBanner/AbuseTicketBanner.tsx
@@ -18,17 +18,28 @@ export const AbuseTicketBanner: React.FunctionComponent<Props> = props => {
     return null;
   }
 
+  const count = abuseTickets.length;
+  const multiple = count > 1;
+
+  const message = `You have ${multiple ? count : `an`} open abuse ticket${
+    multiple ? 's' : ''
+  }.`;
+
+  /**
+   * The ticket list page doesn't indicate which tickets are abuse tickets
+   * so for now, the link can just take the user to the first ticket.
+   */
+  const href = abuseTickets[0].entity!.url;
+
   return (
     <Grid item xs={12}>
-      {abuseTickets.map((thisTicket, idx) => (
-        <Notice important error key={`ticket-banner-${idx}`}>
-          You have an open abuse ticket. Please{' '}
-          <Link data-testid="abuse-ticket-link" to={thisTicket.entity!.url}>
-            click here
-          </Link>{' '}
-          to view this ticket.
-        </Notice>
-      ))}
+      <Notice important error>
+        {message} Please{' '}
+        <Link data-testid="abuse-ticket-link" to={href}>
+          click here
+        </Link>{' '}
+        to view {`${multiple ? 'these tickets' : 'this ticket'}.`}
+      </Notice>
     </Grid>
   );
 };


### PR DESCRIPTION
Instead of mapping over an array of abuse tickets, display a single alert banner
with the total number of open tickets.