### PR TITLE
M3-2797 Refactor/Improve StackScripts Table styles and mobile handling

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -17,7 +17,6 @@ type ClassNames =
   | 'cancel'
   | 'remove'
   | 'compact'
-  | 'noBold'
   | 'hidden'
   | 'reg';
 
@@ -28,7 +27,6 @@ export interface Props extends ButtonProps {
   className?: string;
   tooltipText?: string;
   compact?: boolean;
-  noBold?: boolean;
 }
 
 const styles: StyleRulesCallback = theme => ({
@@ -112,10 +110,6 @@ const styles: StyleRulesCallback = theme => ({
   reg: {
     display: 'flex',
     alignItems: 'center'
-  },
-  noBold: {
-    fontSize: '0.875rem',
-    fontFamily: theme.font.normal
   }
 });
 
@@ -148,7 +142,6 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
     tooltipText,
     type,
     compact,
-    noBold,
     className,
     ...rest
   } = props;
@@ -177,8 +170,7 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
         <span
           className={classNames({
             [classes.hidden]: loading,
-            [classes.reg]: !loading,
-            [classes.noBold]: noBold
+            [classes.reg]: !loading
           })}
         >
           {props.children}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -17,6 +17,7 @@ type ClassNames =
   | 'cancel'
   | 'remove'
   | 'compact'
+  | 'noBold'
   | 'hidden'
   | 'reg';
 
@@ -27,6 +28,7 @@ export interface Props extends ButtonProps {
   className?: string;
   tooltipText?: string;
   compact?: boolean;
+  noBold?: boolean;
 }
 
 const styles: StyleRulesCallback = theme => ({
@@ -110,6 +112,10 @@ const styles: StyleRulesCallback = theme => ({
   reg: {
     display: 'flex',
     alignItems: 'center'
+  },
+  noBold: {
+    fontSize: '0.875rem',
+    fontFamily: theme.font.normal
   }
 });
 
@@ -142,6 +148,7 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
     tooltipText,
     type,
     compact,
+    noBold,
     className,
     ...rest
   } = props;
@@ -167,7 +174,13 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
         )}
       >
         {loading && <Reload />}
-        <span className={loading ? classes.hidden : classes.reg}>
+        <span
+          className={classNames({
+            [classes.hidden]: loading,
+            [classes.reg]: !loading,
+            [classes.noBold]: noBold
+          })}
+        >
           {props.children}
         </span>
         {type === 'remove' && 'Remove'}

--- a/src/components/DateTimeDisplay/DateTimeDisplay.tsx
+++ b/src/components/DateTimeDisplay/DateTimeDisplay.tsx
@@ -6,6 +6,7 @@ export interface Props {
   value: string;
   format?: string;
   humanizeCutoff?: TimeInterval;
+  className?: string;
 }
 
 type CombinedProps = Props;
@@ -13,10 +14,10 @@ type CombinedProps = Props;
 export const DateTimeDisplay: React.StatelessComponent<
   CombinedProps
 > = props => {
-  const { format, humanizeCutoff, value } = props;
+  const { format, humanizeCutoff, value, className } = props;
   return (
     <React.Fragment>
-      <Typography component="span">
+      <Typography component="span" className={className}>
         {formatDate(value, { format, humanizeCutoff })}
       </Typography>
     </React.Fragment>

--- a/src/components/StackScript/StackScript.test.tsx
+++ b/src/components/StackScript/StackScript.test.tsx
@@ -33,7 +33,11 @@ describe('StackScript', () => {
           author: '',
           description: '',
           scriptHeading: '',
-          descriptionText: ''
+          descriptionText: '',
+          deploymentSection: '',
+          dateTimeDisplay: '',
+          compatibleImages: '',
+          divider: ''
         }}
       />
     );

--- a/src/components/StackScript/StackScript.tsx
+++ b/src/components/StackScript/StackScript.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { compose } from 'recompose';
+import Chip from 'src/components/core/Chip';
+import Divider from 'src/components/core/Divider';
 import {
   StyleRulesCallback,
   withStyles,
@@ -17,7 +19,11 @@ type CSSClasses =
   | 'author'
   | 'description'
   | 'scriptHeading'
-  | 'descriptionText';
+  | 'descriptionText'
+  | 'deploymentSection'
+  | 'dateTimeDisplay'
+  | 'compatibleImages'
+  | 'divider';
 
 const styles: StyleRulesCallback<CSSClasses> = theme => {
   return {
@@ -27,24 +33,37 @@ const styles: StyleRulesCallback<CSSClasses> = theme => {
         padding: theme.spacing.unit * 4
       }
     },
-    deployments: {},
+    deployments: {
+      marginTop: theme.spacing.unit
+    },
     author: {
       marginTop: theme.spacing.unit * 2,
       marginBottom: theme.spacing.unit * 2
     },
     description: {
-      marginTop: theme.spacing.unit * 4,
-      marginBottom: theme.spacing.unit * 4,
-      paddingTop: theme.spacing.unit * 4,
-      paddingBottom: theme.spacing.unit * 4,
-      whiteSpace: 'pre-wrap',
-      borderTop: `1px solid ${theme.color.grey2}`,
-      borderBottom: `1px solid ${theme.color.grey2}`
+      whiteSpace: 'pre-wrap'
     },
     scriptHeading: {
-      marginBottom: theme.spacing.unit
+      marginBottom: theme.spacing.unit,
+      fontSize: '1rem'
     },
     descriptionText: {
+      marginBottom: theme.spacing.unit * 2
+    },
+    deploymentSection: {
+      marginTop: theme.spacing.unit,
+      fontSize: '1rem'
+    },
+    dateTimeDisplay: {
+      display: 'inline-block',
+      fontSize: '1rem'
+    },
+    compatibleImages: {
+      display: 'block',
+      marginTop: theme.spacing.unit
+    },
+    divider: {
+      marginTop: theme.spacing.unit * 2,
       marginBottom: theme.spacing.unit * 2
     }
   };
@@ -78,17 +97,22 @@ export class StackScript extends React.Component<CombinedProps> {
     } = this.props;
 
     const compatibleImages =
-      images
-        .reduce((acc: string[], image: string) => {
-          const imageObj = imagesData.find(i => i.id === image);
+      images.reduce((acc: any[], image: string) => {
+        const imageObj = imagesData.find(i => i.id === image);
 
-          if (imageObj) {
-            acc.push(imageObj.label);
-          }
+        if (imageObj) {
+          acc.push(
+            <Chip
+              key={imageObj.id}
+              label={imageObj.label}
+              component="span"
+              clickable={false}
+            />
+          );
+        }
 
-          return acc;
-        }, [])
-        .join(', ') || 'No compatible images found';
+        return acc;
+      }, []) || 'No compatible images found';
 
     return (
       <div className={classes.root}>
@@ -107,32 +131,47 @@ export class StackScript extends React.Component<CombinedProps> {
             data-qa-community-stack-link
           />
         </Typography>
-        <Typography
-          variant="body2"
-          className={classes.deployments}
-          data-qa-stack-deployments
-        >
-          {deployments_total} deployments &bull; {deployments_active} still
-          active &bull; last rev.{' '}
-          <DateTimeDisplay value={updated} humanizeCutoff={'never'} />
-        </Typography>
-        <div className={classes.description}>
-          {description && (
+        <div data-qa-stack-deployments className={classes.deployments}>
+          <Typography className={classes.deploymentSection}>
+            <strong>{deployments_total}</strong> deployments
+          </Typography>
+          <Typography className={classes.deploymentSection}>
+            <strong>{deployments_active}</strong> still active
+          </Typography>
+          <Typography className={classes.deploymentSection}>
+            <strong>Last revision: </strong>
+            <DateTimeDisplay
+              value={updated}
+              humanizeCutoff={'never'}
+              className={classes.dateTimeDisplay}
+            />
+          </Typography>
+          <Divider className={classes.divider} />
+        </div>
+        {description && (
+          <div className={classes.description}>
             <Typography
-              variant="body2"
               className={classes.descriptionText}
               data-qa-stack-description
             >
               {description}
             </Typography>
-          )}
-          <Typography variant="body2" data-qa-compatible-distro>
-            <strong>Compatible with: </strong>
-            {compatibleImages}
+            <Divider className={classes.divider} />
+          </div>
+        )}
+        <div>
+          <Typography
+            data-qa-compatible-distro
+            className={classes.deploymentSection}
+            style={{ marginTop: 0 }}
+          >
+            <strong>Compatible with:</strong>
+            <span className={classes.compatibleImages}>{compatibleImages}</span>
           </Typography>
+          <Divider className={classes.divider} />
         </div>
-        <Typography variant="h3" className={classes.scriptHeading}>
-          Script:
+        <Typography className={classes.scriptHeading}>
+          <strong>Script:s</strong>
         </Typography>
         <ScriptCode script={script} />
       </div>

--- a/src/components/StackScript/StackScript.tsx
+++ b/src/components/StackScript/StackScript.tsx
@@ -142,7 +142,7 @@ export class StackScript extends React.Component<CombinedProps> {
             <strong>Last revision: </strong>
             <DateTimeDisplay
               value={updated}
-              humanizeCutoff={'never'}
+              humanizeCutoff={'month'}
               className={classes.dateTimeDisplay}
             />
           </Typography>
@@ -171,7 +171,7 @@ export class StackScript extends React.Component<CombinedProps> {
           <Divider className={classes.divider} />
         </div>
         <Typography className={classes.scriptHeading}>
-          <strong>Script:s</strong>
+          <strong>Script:</strong>
         </Typography>
         <ScriptCode script={script} />
       </div>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -31,7 +31,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       '& tbody > tr': {
         marginBottom: 0,
         '& > td:first-child': {
-          backgroundColor: theme.bg.tableHeader
+          backgroundColor: theme.bg.tableHeader,
+          '& .data': {
+            textAlign: 'left'
+          }
         }
       },
       '& tr': {
@@ -55,8 +58,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
         }
       },
       '& .data': {
-        marginLeft: 0,
-        textAlign: 'left'
+        marginLeft: 0
       }
     }
   },

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -7,7 +7,12 @@ import {
 } from 'src/components/core/styles';
 import Table, { TableProps } from 'src/components/core/Table';
 
-type ClassNames = 'root' | 'border' | 'responsive' | 'noMobileLabel';
+type ClassNames =
+  | 'root'
+  | 'border'
+  | 'responsive'
+  | 'noMobileLabel'
+  | 'stickyHeader';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
@@ -65,6 +70,30 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   border: {
     border: `1px solid ${theme.palette.divider}`,
     borderBottom: 0
+  },
+  stickyHeader: {
+    borderTop: 0,
+    '& th': {
+      position: 'sticky',
+      top: theme.spacing.unit * 12,
+      backgroundColor: theme.bg.tableHeader,
+      paddingTop: 0,
+      paddingBottom: 0,
+      height: 48,
+      zIndex: 5,
+      borderTop: `1px solid ${theme.palette.divider}`,
+      '&:first-child::before': {
+        content: '""',
+        borderTop: `1px solid ${theme.palette.divider}`,
+        backgroundColor: theme.bg.tableHeader,
+        position: 'absolute',
+        width: 5,
+        top: -1,
+        borderBottom: `2px solid ${theme.palette.divider}`,
+        height: 48,
+        left: -5
+      }
+    }
   }
 });
 
@@ -76,6 +105,7 @@ interface Props {
   isResponsive?: boolean; // back-door for tables that don't need to be responsive
   spacingTop?: 0 | 8 | 16 | 24;
   spacingBottom?: 0 | 8 | 16 | 24;
+  stickyHeader?: boolean;
   removeLabelonMobile?: boolean; // only for table instances where we want to hide the cell label for small screens
 }
 
@@ -93,6 +123,7 @@ class WrappedTable extends React.Component<CombinedProps> {
       spacingTop,
       spacingBottom,
       removeLabelonMobile,
+      stickyHeader,
       ...rest
     } = this.props;
 
@@ -104,7 +135,8 @@ class WrappedTable extends React.Component<CombinedProps> {
             [classes.root]: !noOverflow,
             [classes.responsive]: !(isResponsive === false), // must be explicity set to false
             [classes.border]: border,
-            [classes.noMobileLabel]: removeLabelonMobile
+            [classes.noMobileLabel]: removeLabelonMobile,
+            [classes.stickyHeader]: stickyHeader
           },
           className
         )}

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -75,7 +75,6 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     borderTop: 0,
     '& th': {
       position: 'sticky',
-      top: theme.spacing.unit * 12,
       backgroundColor: theme.bg.tableHeader,
       paddingTop: 0,
       paddingBottom: 0,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -55,7 +55,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
         }
       },
       '& .data': {
-        marginLeft: 0
+        marginLeft: 0,
+        textAlign: 'left'
       }
     }
   },

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -8,7 +8,13 @@ import {
 } from 'src/components/core/styles';
 import TableCell, { TableCellProps } from 'src/components/core/TableCell';
 
-type ClassNames = 'root' | 'noWrap' | 'sortable' | 'data' | 'compact';
+type ClassNames =
+  | 'root'
+  | 'noWrap'
+  | 'sortable'
+  | 'data'
+  | 'compact'
+  | 'parentColSpan';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
@@ -37,6 +43,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       width: '100%',
       marginLeft: theme.spacing.unit * 3
     }
+  },
+  parentColSpan: {
+    width: '100%'
   },
   compact: {
     padding: 6
@@ -84,7 +93,7 @@ class WrappedTableCell extends React.Component<CombinedProps> {
         {!!parentColumn ? (
           <React.Fragment>
             <Hidden mdUp>
-              <span>{parentColumn}</span>
+              <span className={classes.parentColSpan}>{parentColumn}</span>
             </Hidden>
             <div className={`${classes.data} data`}>{this.props.children}</div>
           </React.Fragment>

--- a/src/features/Footer/Footer.tsx
+++ b/src/features/Footer/Footer.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import {
   StyleRulesCallback,
@@ -9,13 +10,23 @@ import createMailto from './createMailto';
 
 import AdaLink from './AdaLink';
 
-type CSSClasses = 'container' | 'link' | 'version' | 'adaLink';
+type CSSClasses =
+  | 'container'
+  | 'linkContainer'
+  | 'link'
+  | 'version'
+  | 'feedbackLink'
+  | 'adaLink';
 
 const styles: StyleRulesCallback<CSSClasses> = theme => ({
   container: {
     width: '100%',
     backgroundColor: theme.bg.main,
     margin: 0,
+    [theme.breakpoints.down('xs')]: {
+      flexDirection: 'column',
+      alignItems: 'flex-start'
+    },
     [theme.breakpoints.up('md')]: {
       paddingLeft: theme.spacing.unit * 17 + 79 // 215
     },
@@ -25,6 +36,12 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
   },
   version: {
     flex: 1
+  },
+  linkContainer: {
+    [theme.breakpoints.down('xs')]: {
+      paddingTop: '0 !important',
+      paddingBottom: '0 !important'
+    }
   },
   link: {
     color: theme.palette.text.primary,
@@ -37,6 +54,15 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     [theme.breakpoints.up('sm')]: {
       marginLeft: theme.spacing.unit,
       marginRight: theme.spacing.unit
+    }
+  },
+  feedbackLink: {
+    [theme.breakpoints.down('xs')]: {
+      marginBottom: theme.spacing.unit
+    },
+    [theme.breakpoints.up('xs')]: {
+      paddingLeft: 0,
+      marginRight: 60
     }
   },
   adaLink: {
@@ -70,7 +96,12 @@ export class Footer extends React.PureComponent<CombinedProps> {
         <Grid item className={classes.version}>
           {this.renderVersion(classes.link)}
         </Grid>
-        <Grid item>
+        <Grid
+          item
+          className={classNames({
+            [classes.linkContainer]: true
+          })}
+        >
           <a
             className={classes.link}
             href="https://developers.linode.com"
@@ -79,7 +110,13 @@ export class Footer extends React.PureComponent<CombinedProps> {
             API Reference
           </a>
         </Grid>
-        <Grid item style={{ paddingLeft: 0, marginRight: 60 }}>
+        <Grid
+          item
+          className={classNames({
+            [classes.linkContainer]: true,
+            [classes.feedbackLink]: true
+          })}
+        >
           <a
             className={classes.link}
             href={createMailto(window.navigator.userAgent || '')}

--- a/src/features/Footer/Footer.tsx
+++ b/src/features/Footer/Footer.tsx
@@ -43,6 +43,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
     padding: '0 !important',
     marginRight: theme.spacing.unit * 2,
     position: 'fixed',
+    zIndex: 2,
     right: 0,
     bottom: 8,
     [theme.breakpoints.up('sm')]: {

--- a/src/features/StackScripts/Partials/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/Partials/StackScriptTableHead.tsx
@@ -27,11 +27,13 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   stackscriptTitles: {
     width: '60%',
-    minWidth: 200
+    minWidth: 150
   },
   deploys: {
     width: '13%',
-    minWidth: 140
+    [theme.breakpoints.up('lg')]: {
+      minWidth: 140
+    }
   },
   revisions: {
     width: '13%',

--- a/src/features/StackScripts/Partials/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/Partials/StackScriptTableHead.tsx
@@ -14,33 +14,52 @@ type ClassNames =
   | 'root'
   | 'stackscriptLabel'
   | 'stackscriptTitles'
+  | 'selectingStackscriptTitles'
   | 'deploys'
   | 'revisions'
   | 'tags'
+  | 'actionMenu'
   | 'tr'
   | 'tableHead';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
-  stackscriptLabel: {
-    width: 84
-  },
+  stackscriptLabel: {},
   stackscriptTitles: {
     width: '60%',
-    minWidth: 150
+    [theme.breakpoints.up('lg')]: {
+      minWidth: 150
+    }
+  },
+  selectingStackscriptTitles: {
+    width: 'calc(100% - 65px)'
   },
   deploys: {
-    width: '13%',
+    width: '10%',
     [theme.breakpoints.up('lg')]: {
+      width: '12%',
       minWidth: 140
     }
   },
   revisions: {
-    width: '13%',
-    minWidth: 150
+    width: '10%',
+    [theme.breakpoints.up('lg')]: {
+      width: '12%',
+      minWidth: 150
+    }
   },
   tags: {
-    width: '13%'
+    width: '10%',
+    [theme.breakpoints.up('lg')]: {
+      width: '12%',
+      minWidth: 100
+    }
+  },
+  actionMenu: {
+    width: '10%',
+    [theme.breakpoints.up('lg')]: {
+      width: 65
+    }
   },
   tr: {
     height: 48
@@ -100,7 +119,8 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           <Cell
             className={classNames({
               [classes.tableHead]: true,
-              [classes.stackscriptTitles]: true
+              [classes.stackscriptTitles]: true,
+              [classes.selectingStackscriptTitles]: isSelecting
             })}
             data-qa-stackscript-table-header
             {...maybeAddSortingProps('label')}

--- a/src/features/StackScripts/Partials/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/Partials/StackScriptTableHead.tsx
@@ -52,7 +52,17 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     paddingTop: 0,
     paddingBottom: 0,
     height: 48,
-    zIndex: 5
+    zIndex: 5,
+    '&:first-child::before': {
+      content: '""',
+      backgroundColor: theme.bg.tableHeader,
+      position: 'absolute',
+      width: 5,
+      top: 0,
+      borderBottom: `2px solid ${theme.palette.divider}`,
+      height: 48,
+      left: -5
+    }
   }
 });
 
@@ -98,14 +108,12 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           {!!isSelecting && (
             <TableCell
               className={classNames({
-                [classes.tableHead]: true,
                 [classes.stackscriptLabel]: true
               })}
             />
           )}
           <Cell
             className={classNames({
-              [classes.tableHead]: true,
               [classes.stackscriptTitles]: true
             })}
             data-qa-stackscript-table-header
@@ -116,7 +124,6 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           {!isSelecting && (
             <Cell
               className={classNames({
-                [classes.tableHead]: true,
                 [classes.deploys]: true
               })}
               data-qa-stackscript-active-deploy-header
@@ -128,7 +135,6 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           {!isSelecting && (
             <Cell
               className={classNames({
-                [classes.tableHead]: true,
                 [classes.revisions]: true
               })}
               data-qa-stackscript-revision-header
@@ -140,7 +146,6 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           {!isSelecting && (
             <TableCell
               className={classNames({
-                [classes.tableHead]: true,
                 [classes.tags]: true
               })}
               data-qa-stackscript-compatible-images
@@ -151,7 +156,6 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           {!isSelecting && (
             <TableCell
               className={classNames({
-                [classes.tableHead]: true,
                 [classes.stackscriptLabel]: true
               })}
             />

--- a/src/features/StackScripts/Partials/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/Partials/StackScriptTableHead.tsx
@@ -113,35 +113,41 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           >
             StackScript
           </Cell>
-          <Cell
-            className={classNames({
-              [classes.tableHead]: true,
-              [classes.deploys]: true
-            })}
-            data-qa-stackscript-active-deploy-header
-            {...maybeAddSortingProps('deploys')}
-          >
-            Active Deploys
-          </Cell>
-          <Cell
-            className={classNames({
-              [classes.tableHead]: true,
-              [classes.revisions]: true
-            })}
-            data-qa-stackscript-revision-header
-            {...maybeAddSortingProps('revision')}
-          >
-            Last Revision
-          </Cell>
-          <TableCell
-            className={classNames({
-              [classes.tableHead]: true,
-              [classes.tags]: true
-            })}
-            data-qa-stackscript-compatible-images
-          >
-            Compatible Images
-          </TableCell>
+          {!isSelecting && (
+            <Cell
+              className={classNames({
+                [classes.tableHead]: true,
+                [classes.deploys]: true
+              })}
+              data-qa-stackscript-active-deploy-header
+              {...maybeAddSortingProps('deploys')}
+            >
+              Active Deploys
+            </Cell>
+          )}
+          {!isSelecting && (
+            <Cell
+              className={classNames({
+                [classes.tableHead]: true,
+                [classes.revisions]: true
+              })}
+              data-qa-stackscript-revision-header
+              {...maybeAddSortingProps('revision')}
+            >
+              Last Revision
+            </Cell>
+          )}
+          {!isSelecting && (
+            <TableCell
+              className={classNames({
+                [classes.tableHead]: true,
+                [classes.tags]: true
+              })}
+              data-qa-stackscript-compatible-images
+            >
+              Compatible Images
+            </TableCell>
+          )}
           {!isSelecting && (
             <TableCell
               className={classNames({

--- a/src/features/StackScripts/Partials/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/Partials/StackScriptTableHead.tsx
@@ -41,7 +41,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   tableHead: {
     position: 'sticky',
-    top: theme.spacing.unit * 9,
+    top: theme.spacing.unit * 12,
     backgroundColor: theme.bg.tableHeader,
     paddingTop: 0,
     paddingBottom: 0,

--- a/src/features/StackScripts/Partials/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/Partials/StackScriptTableHead.tsx
@@ -46,23 +46,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     height: 48
   },
   tableHead: {
-    position: 'sticky',
-    top: theme.spacing.unit * 12,
-    backgroundColor: theme.bg.tableHeader,
-    paddingTop: 0,
-    paddingBottom: 0,
-    height: 48,
-    zIndex: 5,
-    '&:first-child::before': {
-      content: '""',
-      backgroundColor: theme.bg.tableHeader,
-      position: 'absolute',
-      width: 5,
-      top: 0,
-      borderBottom: `2px solid ${theme.palette.divider}`,
-      height: 48,
-      left: -5
-    }
+    top: theme.spacing.unit * 11
   }
 });
 
@@ -108,12 +92,14 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           {!!isSelecting && (
             <TableCell
               className={classNames({
+                [classes.tableHead]: true,
                 [classes.stackscriptLabel]: true
               })}
             />
           )}
           <Cell
             className={classNames({
+              [classes.tableHead]: true,
               [classes.stackscriptTitles]: true
             })}
             data-qa-stackscript-table-header
@@ -124,6 +110,7 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           {!isSelecting && (
             <Cell
               className={classNames({
+                [classes.tableHead]: true,
                 [classes.deploys]: true
               })}
               data-qa-stackscript-active-deploy-header
@@ -135,6 +122,7 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           {!isSelecting && (
             <Cell
               className={classNames({
+                [classes.tableHead]: true,
                 [classes.revisions]: true
               })}
               data-qa-stackscript-revision-header
@@ -146,6 +134,7 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           {!isSelecting && (
             <TableCell
               className={classNames({
+                [classes.tableHead]: true,
                 [classes.tags]: true
               })}
               data-qa-stackscript-compatible-images
@@ -156,6 +145,7 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
           {!isSelecting && (
             <TableCell
               className={classNames({
+                [classes.tableHead]: true,
                 [classes.stackscriptLabel]: true
               })}
             />

--- a/src/features/StackScripts/Partials/StackScriptTableHead.tsx
+++ b/src/features/StackScripts/Partials/StackScriptTableHead.tsx
@@ -16,6 +16,7 @@ type ClassNames =
   | 'stackscriptTitles'
   | 'deploys'
   | 'revisions'
+  | 'tags'
   | 'tr'
   | 'tableHead';
 
@@ -25,16 +26,19 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     width: 84
   },
   stackscriptTitles: {
-    width: '45%',
+    width: '60%',
     minWidth: 200
   },
   deploys: {
-    width: '15%',
+    width: '13%',
     minWidth: 140
   },
   revisions: {
-    width: '15%',
+    width: '13%',
     minWidth: 150
+  },
+  tags: {
+    width: '13%'
   },
   tr: {
     height: 48
@@ -128,7 +132,10 @@ class StackScriptTableHead extends React.Component<CombinedProps, {}> {
             Last Revision
           </Cell>
           <TableCell
-            className={classes.tableHead}
+            className={classNames({
+              [classes.tableHead]: true,
+              [classes.tags]: true
+            })}
             data-qa-stackscript-compatible-images
           >
             Compatible Images

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -171,7 +171,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
         return (
           <React.Fragment>
             <Table
-              isResponsive={false}
+              // isResponsive={false}
               aria-label="List of StackScripts"
               noOverflow={true}
               tableClass={classes.table}

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -171,6 +171,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
         return (
           <React.Fragment>
             <Table
+              // removeLabelonMobile
               // isResponsive={false}
               aria-label="List of StackScripts"
               noOverflow={true}

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -50,13 +50,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   selecting: {
     minHeight: '400px',
     maxHeight: '1000px',
-    // overflowX: 'auto',
     overflowY: 'scroll',
     paddingTop: 0
-    // '.tableWrapper': {
-    //   maxHeight: '1000px',
-    //   overflowY: 'auto',
-    // }
   },
   link: {
     display: 'block',
@@ -176,6 +171,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
               aria-label="List of StackScripts"
               noOverflow={true}
               tableClass={classes.table}
+              stickyHeader
             >
               <StackScriptTableHead
                 currentFilterType={null}

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -67,8 +67,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   inner: {
     padding: theme.spacing.unit * 2,
+    paddingTop: 0,
     [theme.breakpoints.up('sm')]: {
-      padding: theme.spacing.unit * 3
+      padding: theme.spacing.unit * 3,
+      paddingTop: 0
     }
   },
   header: {}
@@ -149,14 +151,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const {
-      category,
-      classes,
-      header,
-      request,
-      selectedId,
-      error
-    } = this.props;
+    const { category, classes, request, selectedId, error } = this.props;
     const { stackScript, stackScriptLoading, stackScriptError } = this.state;
 
     if (selectedId) {
@@ -207,9 +202,6 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
       <Paper className={classes.panel}>
         <div className={classes.inner}>
           {error && <Notice text={error} error />}
-          <Typography className={classes.header} variant="h2" data-qa-tp-title>
-            {header}
-          </Typography>
           {stackScriptError && (
             <Typography variant="body2">
               An error occurred while loading the selected StackScript.

--- a/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -50,10 +50,13 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   selecting: {
     minHeight: '400px',
     maxHeight: '1000px',
-    overflowX: 'auto',
+    // overflowX: 'auto',
     overflowY: 'scroll',
-    paddingTop: 0,
-    marginTop: theme.spacing.unit * 2
+    paddingTop: 0
+    // '.tableWrapper': {
+    //   maxHeight: '1000px',
+    //   overflowY: 'auto',
+    // }
   },
   link: {
     display: 'block',
@@ -73,9 +76,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       padding: theme.spacing.unit * 3
     }
   },
-  header: {
-    paddingBottom: theme.spacing.unit * 2
-  }
+  header: {}
 });
 
 interface Props extends RenderGuardProps {
@@ -171,8 +172,7 @@ class SelectStackScriptPanel extends React.Component<CombinedProps, State> {
         return (
           <React.Fragment>
             <Table
-              // removeLabelonMobile
-              // isResponsive={false}
+              isResponsive={false}
               aria-label="List of StackScripts"
               noOverflow={true}
               tableClass={classes.table}

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
@@ -123,10 +123,7 @@ export class StackScriptSelectionRow extends React.Component<
               {updated}
             </Typography>
           </TableCell>
-          <TableCell
-            className={classes.stackScriptCell}
-            data-qa-stackscript-images
-          >
+          <TableCell data-qa-stackscript-images>
             {displayTagsAndShowMore(images)}
           </TableCell>
         </TableRow>

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
@@ -6,13 +6,14 @@ import Button from 'src/components/Button';
 import { withStyles, WithStyles } from 'src/components/core/styles';
 import TableCell from 'src/components/core/TableCell';
 import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
 import Radio from 'src/components/Radio';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import TableRow from 'src/components/TableRow';
 import { openStackScriptDrawer as openStackScriptDrawerAction } from 'src/store/stackScriptDrawer';
 import {
   ClassNames,
-  displayTagsAndShowMore,
+  // displayTagsAndShowMore,
   styles
 } from '../StackScriptRowHelpers';
 
@@ -51,9 +52,9 @@ export class StackScriptSelectionRow extends React.Component<
       checked,
       label,
       description,
-      images,
-      deploymentsActive,
-      updated,
+      // images,
+      // deploymentsActive,
+      // updated,
       stackScriptID,
       stackScriptUsername,
       openStackScriptDrawer,
@@ -66,30 +67,42 @@ export class StackScriptSelectionRow extends React.Component<
         openStackScriptDrawer(stackScriptID);
       };
       return (
-        <React.Fragment>
-          <Typography variant="h3">
-            {stackScriptUsername && (
+        <Grid container alignItems="center" className={classes.selectionGrid}>
+          <Grid item>
+            <Typography variant="h3">
+              {stackScriptUsername && (
+                <label
+                  htmlFor={`${stackScriptID}`}
+                  className={`${classes.libRadioLabel} ${
+                    classes.stackScriptUsername
+                  }`}
+                >
+                  {stackScriptUsername} /&nbsp;
+                </label>
+              )}
               <label
                 htmlFor={`${stackScriptID}`}
-                className={`${classes.libRadioLabel} ${
-                  classes.stackScriptUsername
-                }`}
+                className={classes.libRadioLabel}
               >
-                {stackScriptUsername} /&nbsp;
+                {label}
               </label>
+            </Typography>
+            {description && (
+              <Typography variant="body1" className={classes.libDescription}>
+                {description}
+              </Typography>
             )}
-            <label
-              htmlFor={`${stackScriptID}`}
-              className={classes.libRadioLabel}
+          </Grid>
+          <Grid item>
+            <Button
+              className={classes.detailsButton}
+              onClick={openDrawer}
+              noBold
             >
-              {label}
-            </label>
-          </Typography>
-          <Typography variant="body1">{description}</Typography>
-          <Button className={classes.detailsButton} onClick={openDrawer}>
-            Show Details
-          </Button>
-        </React.Fragment>
+              Show Details
+            </Button>
+          </Grid>
+        </Grid>
       );
     };
 
@@ -113,7 +126,7 @@ export class StackScriptSelectionRow extends React.Component<
           >
             {renderLabel()}
           </TableCell>
-          <TableCell>
+          {/* <TableCell>
             <Typography variant="h3" data-qa-stackscript-deploys>
               {deploymentsActive}
             </Typography>
@@ -125,7 +138,7 @@ export class StackScriptSelectionRow extends React.Component<
           </TableCell>
           <TableCell data-qa-stackscript-images>
             {displayTagsAndShowMore(images)}
-          </TableCell>
+          </TableCell> */}
         </TableRow>
       </React.Fragment>
     );

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
@@ -95,9 +95,9 @@ export class StackScriptSelectionRow extends React.Component<
           </Grid>
           <Grid item>
             <Button
+              compact
               className={classes.detailsButton}
               onClick={openDrawer}
-              noBold
             >
               Show Details
             </Button>

--- a/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
+++ b/src/features/StackScripts/SelectStackScriptPanel/StackScriptSelectionRow.tsx
@@ -11,11 +11,7 @@ import Radio from 'src/components/Radio';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import TableRow from 'src/components/TableRow';
 import { openStackScriptDrawer as openStackScriptDrawerAction } from 'src/store/stackScriptDrawer';
-import {
-  ClassNames,
-  // displayTagsAndShowMore,
-  styles
-} from '../StackScriptRowHelpers';
+import { ClassNames, styles } from '../StackScriptRowHelpers';
 
 export interface Props {
   label: string;
@@ -52,9 +48,6 @@ export class StackScriptSelectionRow extends React.Component<
       checked,
       label,
       description,
-      // images,
-      // deploymentsActive,
-      // updated,
       stackScriptID,
       stackScriptUsername,
       openStackScriptDrawer,
@@ -126,19 +119,6 @@ export class StackScriptSelectionRow extends React.Component<
           >
             {renderLabel()}
           </TableCell>
-          {/* <TableCell>
-            <Typography variant="h3" data-qa-stackscript-deploys>
-              {deploymentsActive}
-            </Typography>
-          </TableCell>
-          <TableCell>
-            <Typography variant="h3" data-qa-stackscript-revision>
-              {updated}
-            </Typography>
-          </TableCell>
-          <TableCell data-qa-stackscript-images>
-            {displayTagsAndShowMore(images)}
-          </TableCell> */}
         </TableRow>
       </React.Fragment>
     );

--- a/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
+++ b/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
@@ -26,7 +26,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     width: '100%',
     top: 0,
     zIndex: 11,
-    paddingTop: theme.spacing.unit * 3,
+    paddingTop: theme.spacing.unit * 2,
     paddingBottom: theme.spacing.unit * 3,
     backgroundColor: theme.bg.white
   },

--- a/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
+++ b/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
@@ -32,7 +32,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   searchBar: {
     marginTop: 0,
-    backgroundColor: theme.color.white
+    backgroundColor: theme.color.white,
+    '& > div': {
+      marginRight: 0
+    }
   },
   // Styles to override base placeholder styles for StackScript null state
   stackscriptPlaceholder: {

--- a/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
+++ b/src/features/StackScripts/StackScriptBase/StackScriptBase.styles.ts
@@ -26,6 +26,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     width: '100%',
     top: 0,
     zIndex: 11,
+    paddingTop: theme.spacing.unit * 3,
     paddingBottom: theme.spacing.unit * 3,
     backgroundColor: theme.bg.white
   },

--- a/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -463,7 +463,7 @@ const withStackScriptBase = (isSelecting: boolean) => (
                 aria-label="List of StackScripts"
                 noOverflow={true}
                 tableClass={classes.table}
-                removeLabelonMobile={false}
+                removeLabelonMobile={true}
               >
                 <StackScriptTableHead
                   handleClickTableHeader={this.handleClickTableHeader}

--- a/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -459,10 +459,11 @@ const withStackScriptBase = (isSelecting: boolean) => (
                 />
               </div>
               <Table
-                isResponsive={false}
+                // isResponsive={false}
                 aria-label="List of StackScripts"
                 noOverflow={true}
                 tableClass={classes.table}
+                removeLabelonMobile={false}
               >
                 <StackScriptTableHead
                   handleClickTableHeader={this.handleClickTableHeader}

--- a/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -125,7 +125,7 @@ const withStackScriptBase = (isSelecting: boolean) => (
 
       return request(
         filteredUser,
-        { page, page_size: 50 },
+        { page, page_size: 25 },
         filter,
         stackScriptGrants
       )
@@ -459,11 +459,12 @@ const withStackScriptBase = (isSelecting: boolean) => (
                 />
               </div>
               <Table
-                // isResponsive={false}
+                isResponsive={!isSelecting && true}
                 aria-label="List of StackScripts"
                 noOverflow={true}
                 tableClass={classes.table}
-                removeLabelonMobile={true}
+                removeLabelonMobile={!isSelecting && true}
+                border
               >
                 <StackScriptTableHead
                   handleClickTableHeader={this.handleClickTableHeader}

--- a/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -459,11 +459,11 @@ const withStackScriptBase = (isSelecting: boolean) => (
                 />
               </div>
               <Table
-                isResponsive={!isSelecting && true}
+                isResponsive={!isSelecting}
                 aria-label="List of StackScripts"
                 noOverflow={true}
                 tableClass={classes.table}
-                removeLabelonMobile={!isSelecting && true}
+                removeLabelonMobile={!isSelecting}
                 border
               >
                 <StackScriptTableHead

--- a/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -465,6 +465,7 @@ const withStackScriptBase = (isSelecting: boolean) => (
                 tableClass={classes.table}
                 removeLabelonMobile={!isSelecting}
                 border
+                stickyHeader
               >
                 <StackScriptTableHead
                   handleClickTableHeader={this.handleClickTableHeader}

--- a/src/features/StackScripts/StackScriptPanel/StackScriptPanel.tsx
+++ b/src/features/StackScripts/StackScriptPanel/StackScriptPanel.tsx
@@ -32,11 +32,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     backgroundColor: theme.color.white
   },
   creating: {
-    height: 400,
-    overflowX: 'auto',
     paddingTop: 0,
     marginTop: theme.spacing.unit * 2,
-    overflowY: 'scroll',
     '-webkit-appearance': 'none'
   },
   link: {

--- a/src/features/StackScripts/StackScriptPanel/StackScriptPanel.tsx
+++ b/src/features/StackScripts/StackScriptPanel/StackScriptPanel.tsx
@@ -32,9 +32,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     backgroundColor: theme.color.white
   },
   creating: {
-    paddingTop: 0,
-    marginTop: theme.spacing.unit * 2,
-    '-webkit-appearance': 'none'
+    paddingTop: 0
   },
   link: {
     display: 'block',

--- a/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -72,9 +72,11 @@ export class StackScriptRow extends React.Component<CombinedProps, {}> {
               <span className={classes.libRadioLabel}>{label}</span>
             </Typography>
           </Link>
-          <Typography variant="body1" className={classes.libDescription}>
-            {description}
-          </Typography>
+          {description && (
+            <Typography variant="body1" className={classes.libDescription}>
+              {description}
+            </Typography>
+          )}
         </React.Fragment>
       );
     };
@@ -82,11 +84,7 @@ export class StackScriptRow extends React.Component<CombinedProps, {}> {
     return (
       <React.Fragment>
         <TableRow data-qa-table-row={label}>
-          <TableCell
-            className={classes.stackScriptCell}
-            data-qa-stackscript-title
-            parentColumn="StackScript"
-          >
+          <TableCell data-qa-stackscript-title parentColumn="StackScript">
             {renderLabel()}
           </TableCell>
           <TableCell parentColumn="Active Deploys">

--- a/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -90,14 +90,12 @@ export class StackScriptRow extends React.Component<CombinedProps, {}> {
             {renderLabel()}
           </TableCell>
           <TableCell parentColumn="Active Deploys">
-            <Typography variant="h3" data-qa-stackscript-deploys>
+            <Typography data-qa-stackscript-deploys>
               {deploymentsActive}
             </Typography>
           </TableCell>
           <TableCell parentColumn="Last Revision">
-            <Typography variant="h3" data-qa-stackscript-revision>
-              {updated}
-            </Typography>
+            <Typography data-qa-stackscript-revision>{updated}</Typography>
           </TableCell>
           <TableCell
             data-qa-stackscript-images

--- a/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -96,10 +96,7 @@ export class StackScriptRow extends React.Component<CombinedProps, {}> {
               {updated}
             </Typography>
           </TableCell>
-          <TableCell
-            className={classes.stackScriptCell}
-            data-qa-stackscript-images
-          >
+          <TableCell data-qa-stackscript-images>
             {displayTagsAndShowMore(images)}
           </TableCell>
           <TableCell>

--- a/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
+++ b/src/features/StackScripts/StackScriptPanel/StackScriptRow.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { compose as recompose } from 'recompose';
 import { withStyles, WithStyles } from 'src/components/core/styles';
-import TableCell from 'src/components/core/TableCell';
 import Typography from 'src/components/core/Typography';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
+import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import StackScriptsActionMenu from 'src/features/StackScripts/StackScriptPanel/StackScriptActionMenu';
 import { StackScriptCategory } from 'src/features/StackScripts/stackScriptUtils';
@@ -59,7 +59,7 @@ export class StackScriptRow extends React.Component<CombinedProps, {}> {
       return (
         <React.Fragment>
           <Link to={`/stackscripts/${stackScriptID}`}>
-            <Typography variant="h3">
+            <Typography variant="h3" className={classes.libTitle}>
               {stackScriptUsername && (
                 <span
                   className={`${classes.libRadioLabel} ${
@@ -72,7 +72,9 @@ export class StackScriptRow extends React.Component<CombinedProps, {}> {
               <span className={classes.libRadioLabel}>{label}</span>
             </Typography>
           </Link>
-          <Typography variant="body1">{description}</Typography>
+          <Typography variant="body1" className={classes.libDescription}>
+            {description}
+          </Typography>
         </React.Fragment>
       );
     };
@@ -83,20 +85,24 @@ export class StackScriptRow extends React.Component<CombinedProps, {}> {
           <TableCell
             className={classes.stackScriptCell}
             data-qa-stackscript-title
+            parentColumn="StackScript"
           >
             {renderLabel()}
           </TableCell>
-          <TableCell>
+          <TableCell parentColumn="Active Deploys">
             <Typography variant="h3" data-qa-stackscript-deploys>
               {deploymentsActive}
             </Typography>
           </TableCell>
-          <TableCell>
+          <TableCell parentColumn="Last Revision">
             <Typography variant="h3" data-qa-stackscript-revision>
               {updated}
             </Typography>
           </TableCell>
-          <TableCell data-qa-stackscript-images>
+          <TableCell
+            data-qa-stackscript-images
+            parentColumn="Compatible Images"
+          >
             {displayTagsAndShowMore(images)}
           </TableCell>
           <TableCell>

--- a/src/features/StackScripts/StackScriptRowHelpers.tsx
+++ b/src/features/StackScripts/StackScriptRowHelpers.tsx
@@ -96,12 +96,16 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
     border: 0
   },
   detailsButton: {
-    textAlign: 'left',
     padding: 0,
+    fontSize: '0.875rem',
     marginTop: -theme.spacing.unit,
     [theme.breakpoints.up('sm')]: {
+      padding: theme.spacing.unit,
       marginTop: 0,
       width: 100
+    },
+    '&:hover, &:focus': {
+      backgroundColor: 'transparent'
     }
   }
 });

--- a/src/features/StackScripts/StackScriptRowHelpers.tsx
+++ b/src/features/StackScripts/StackScriptRowHelpers.tsx
@@ -51,7 +51,7 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
     cursor: 'pointer'
   },
   libTitle: {
-    [theme.breakpoints.between('sm', 'md')]: {
+    [theme.breakpoints.down('sm')]: {
       wordBreak: 'break-all'
     }
   },
@@ -62,8 +62,8 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   libDescription: {
     marginTop: theme.spacing.unit / 2,
-    [theme.breakpoints.between('sm', 'md')]: {
-      wordBreak: 'break-all'
+    [theme.breakpoints.down('sm')]: {
+      fontSize: 12
     }
   },
   images: {

--- a/src/features/StackScripts/StackScriptRowHelpers.tsx
+++ b/src/features/StackScripts/StackScriptRowHelpers.tsx
@@ -15,6 +15,7 @@ export type ClassNames =
   | 'libTitleLink'
   | 'libDescription'
   | 'colImages'
+  | 'selectionGrid'
   | 'stackScriptCell'
   | 'stackScriptUsername'
   | 'deployButton'
@@ -64,6 +65,9 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
     marginTop: theme.spacing.unit / 2,
     [theme.breakpoints.down('sm')]: {
       fontSize: 12
+    },
+    [theme.breakpoints.between('sm', 'lg')]: {
+      wordBreak: 'break-word'
     }
   },
   images: {
@@ -71,7 +75,19 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
     marginRight: theme.spacing.unit,
     marginBottom: theme.spacing.unit
   },
-  stackScriptCell: {},
+  selectionGrid: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    [theme.breakpoints.up('sm')]: {
+      flexWrap: 'nowrap',
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center'
+    }
+  },
+  stackScriptCell: {
+    width: '100%'
+  },
   stackScriptUsername: {
     color: theme.color.grey1
   },
@@ -81,7 +97,12 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   detailsButton: {
     textAlign: 'left',
-    padding: 0
+    padding: 0,
+    marginTop: -theme.spacing.unit,
+    [theme.breakpoints.up('sm')]: {
+      marginTop: 0,
+      width: 100
+    }
   }
 });
 

--- a/src/features/StackScripts/StackScriptRowHelpers.tsx
+++ b/src/features/StackScripts/StackScriptRowHelpers.tsx
@@ -51,13 +51,8 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
     cursor: 'pointer'
   },
   libTitle: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    maxWidth: '100%',
-    justifyContent: 'space-between',
-    paddingBottom: '0 !important',
-    '& h3': {
-      marginRight: 10
+    [theme.breakpoints.between('sm', 'md')]: {
+      wordBreak: 'break-all'
     }
   },
   libTitleLink: {
@@ -66,9 +61,9 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
     fontSize: '.9rem'
   },
   libDescription: {
-    paddingTop: '0 !important',
-    [theme.breakpoints.up('md')]: {
-      paddingRight: '100px !important'
+    marginTop: theme.spacing.unit / 2,
+    [theme.breakpoints.between('sm', 'md')]: {
+      wordBreak: 'break-all'
     }
   },
   images: {
@@ -76,11 +71,7 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
     marginRight: theme.spacing.unit,
     marginBottom: theme.spacing.unit
   },
-  stackScriptCell: {
-    '& p': {
-      marginTop: theme.spacing.unit / 2
-    }
-  },
+  stackScriptCell: {},
   stackScriptUsername: {
     color: theme.color.grey1
   },

--- a/src/features/StackScripts/StackScriptRowHelpers.tsx
+++ b/src/features/StackScripts/StackScriptRowHelpers.tsx
@@ -77,15 +77,14 @@ export const styles: StyleRulesCallback<ClassNames> = theme => ({
     marginBottom: theme.spacing.unit
   },
   stackScriptCell: {
-    maxWidth: '200px'
+    '& p': {
+      marginTop: theme.spacing.unit / 2
+    }
   },
   stackScriptUsername: {
     color: theme.color.grey1
   },
   deployButton: {
-    // marginLeft: -26,
-    // width: '100%',
-    // justifyContent: 'flex-start',
     whiteSpace: 'nowrap',
     border: 0
   },
@@ -121,5 +120,5 @@ export const displayTagsAndShowMore: (s: string[]) => JSX.Element[][] = compose<
 >(
   over(lensIndex(1), unless(isEmpty, createShowMore)),
   over(lensIndex(0), createTags),
-  splitAt(3)
+  splitAt(1)
 );

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx
@@ -43,10 +43,10 @@ describe('RebuildFromStackScript', () => {
   });
 
   it('renders a SelectStackScript panel', () => {
-    const { queryByText } = render(
+    const { queryByPlaceholderText } = render(
       wrapWithTheme(<RebuildFromStackScript {...props} />)
     );
-    expect(queryByText('Select StackScript')).toBeInTheDocument();
+    expect(queryByPlaceholderText('Search by Label, Username, or Description'));
   });
 
   it('validates the form upon clicking the "Rebuild" button', async () => {


### PR DESCRIPTION
## Refactor/Improve StackScripts Table styles and mobile handling

The StackScripts landing page was in great need of work - the work was help up waiting for pagination. Since it is not happening anytime soon we still need to update the styles and give users a better experience.

The stackScripts table on the create workflow was also updated and since we have a button there for details I removed some of the table cells so that's it's easier to read and provides a better experience.

**To be tested on various breakpoints and browsers.**

## Type of Change
- Non breaking change ('update')