### PR TITLE
E2E Tests - Continue on spec failure

### DIFF
--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -208,7 +208,7 @@ exports.config = {
         expectationResultHandler: function(passed, assertion) {
             // do something
         },
-        stopOnSpecFailure: true
+        stopOnSpecFailure: false,
     },
 
     mountebankConfig: {


### PR DESCRIPTION
## Description

Gives accurate reporting of overall test suite failures. The current setting will indicate how many suites have failing tests. The main problem with the way it's set currently is that the test reporter does not mark the tests following a failure as skipped. So if a test suite has a failure, that test is reported as failing and all the following skipped tests are missing from the report.


## Type of Change
- Bug fix ('fix', 'repair', 'bug')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=COMMA_SEPARATED_LIST_OF_SPECS_HERE --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
