### PR TITLE
M3-2774 Fix: Domain SPA edit error

### DIFF
--- a/e2e/pageobjects/domain-detail/detail.page.js
+++ b/e2e/pageobjects/domain-detail/detail.page.js
@@ -5,8 +5,6 @@ import Page from '../page';
 class DomainDetail extends Page {
     get domainTitle() { return this.breadcrumbStaticText; }
     get domainRecords() { return ['SOA Record','NS Record','MX Record','A/AAAA Record','CNAME Record','TXT Record','SRV Record','CAA Record']; }
-    get expireRateSelect() { return $('[data-qa-expire-rate] div'); }
-    get exireRateOptions() { return $$('[data-qa-expire-options]'); }
     get protocolSelect(){ return $('[data-qa-protocol] div'); }
     get protocolOptions() { return $$('[data-qa-protocol-options]'); }
     get caaTagSelect() { return $('[data-qa-caa-tag] div'); }
@@ -26,7 +24,11 @@ class DomainDetail extends Page {
         return button;
     }
 
-    selectElelementByLabel(label){
+    selectElementByLabel(label){
+        return $(`[data-qa-domain-select="${label}"]`)
+    }
+
+    selectInputByLabel(label){
         return $(`[data-qa-domain-select="${label}"] div`)
     }
 
@@ -43,12 +45,10 @@ class DomainDetail extends Page {
     }
 
     selectDropdownOption(dropdown) {
-        const options = '[data-qa-options]';
-        this.selectElelementByLabel(dropdown).click();
-        browser.pause(1000);
-        $$(options)[0].click();
-        $(options).waitForVisible(constants.wait.normal,true);
-        return this.selectElelementByLabel(dropdown).getText();
+        this.selectElementByLabel(dropdown).click();
+        // Select the first option
+        browser.keys(["\ue015", "\uE007"]);
+        return this.selectInputByLabel(dropdown).getText();
     }
 
     domainDetailDisplays(domainName) {
@@ -57,7 +57,9 @@ class DomainDetail extends Page {
             this.recordHeaderElementByLabel(record).waitForVisible(constants.wait.normal);
         });
         this.domainRecords.forEach((record) => {
-            this.addRecordButtonElementByLabel(record).waitForVisible(constants.wait.normal);
+            if (record !== 'SOA Record') {
+                this.addRecordButtonElementByLabel(record).waitForVisible(constants.wait.normal);
+            }
         });
         expect(this.domainTitle.getText()).toEqual(domainName);
     }
@@ -67,11 +69,10 @@ class DomainDetail extends Page {
         ['Domain', 'SOA Email'].forEach((label) => {
             this.inputElementByLabel(label).waitForVisible(constants.wait.normal);
         });
-        ['Default TTL', 'Refresh Rate', 'Retry Rate'].forEach((label) => {
-            this.selectElelementByLabel(label).waitForVisible(constants.wait.normal);
+        ['Default TTL', 'Refresh Rate', 'Retry Rate', 'Expire Rate'].forEach((label) => {
+            this.selectElementByLabel(label).waitForVisible(constants.wait.normal);
         });
-        this.expireRateSelect.waitForVisible(constants.wait.normal);
-        expect(this.drawerTitle.getText()).toEqual('Edit SOA Record');
+        expect(this.drawerTitle.getText()).toMatch(/edit/i);
     }
 
     nsRecordDrawerDisplays(){
@@ -79,7 +80,7 @@ class DomainDetail extends Page {
         ['Name Server', 'Subdomain'].forEach((label) => {
             this.inputElementByLabel(label).waitForVisible(constants.wait.normal);
         });
-        this.selectElelementByLabel('TTL').waitForVisible(constants.wait.normal);
+        this.selectElementByLabel('TTL').waitForVisible(constants.wait.normal);
         expect(this.drawerTitle.getText()).toContain('NS Record');
     }
 
@@ -88,7 +89,7 @@ class DomainDetail extends Page {
         ['Mail Server', 'Preference', 'Subdomain'].forEach((label) => {
             this.inputElementByLabel(label).waitForVisible(constants.wait.normal);
         });
-        this.selectElelementByLabel('TTL').waitForVisible(constants.wait.normal);
+        this.selectElementByLabel('TTL').waitForVisible(constants.wait.normal);
         expect(this.drawerTitle.getText()).toContain('MX Record');
     }
 
@@ -97,7 +98,7 @@ class DomainDetail extends Page {
         ['Hostname', 'IP Address'].forEach((label) => {
             this.inputElementByLabel(label).waitForVisible(constants.wait.normal);
         });
-        this.selectElelementByLabel('TTL').waitForVisible(constants.wait.normal);
+        this.selectElementByLabel('TTL').waitForVisible(constants.wait.normal);
         expect(this.drawerTitle.getText()).toContain('AAAA Record');
     }
 
@@ -106,7 +107,7 @@ class DomainDetail extends Page {
         ['Hostname', 'Alias to'].forEach((label) => {
             this.inputElementByLabel(label).waitForVisible(constants.wait.normal);
         });
-        this.selectElelementByLabel('TTL').waitForVisible(constants.wait.normal);
+        this.selectElementByLabel('TTL').waitForVisible(constants.wait.normal);
         expect(this.drawerTitle.getText()).toContain('CNAME Record');
     }
 
@@ -115,7 +116,7 @@ class DomainDetail extends Page {
         ['Hostname', 'Value'].forEach((label) => {
             this.inputElementByLabel(label).waitForVisible(constants.wait.normal);
         });
-        this.selectElelementByLabel('TTL').waitForVisible(constants.wait.normal);
+        this.selectElementByLabel('TTL').waitForVisible(constants.wait.normal);
         expect(this.drawerTitle.getText()).toContain('TXT Record');
     }
 
@@ -124,7 +125,7 @@ class DomainDetail extends Page {
         ['Service', 'Priority', 'Weight', 'Port'].forEach((label) => {
             this.inputElementByLabel(label).waitForVisible(constants.wait.normal);
         });
-        this.selectElelementByLabel('TTL').waitForVisible(constants.wait.normal);
+        this.selectElementByLabel('TTL').waitForVisible(constants.wait.normal);
         this.protocolSelect.waitForVisible(constants.wait.normal);
         expect(this.drawerTitle.getText()).toContain('SRV Record');
     }
@@ -134,7 +135,7 @@ class DomainDetail extends Page {
         ['Name', 'Value'].forEach((label) => {
             this.inputElementByLabel(label).waitForVisible(constants.wait.normal);
         });
-        this.selectElelementByLabel('TTL').waitForVisible(constants.wait.normal);
+        this.selectElementByLabel('TTL').waitForVisible(constants.wait.normal);
         this.caaTagSelect.waitForVisible(constants.wait.normal);
         expect(this.drawerTitle.getText()).toContain('CAA Record');
     }

--- a/e2e/pageobjects/domain-detail/detail.page.js
+++ b/e2e/pageobjects/domain-detail/detail.page.js
@@ -5,10 +5,6 @@ import Page from '../page';
 class DomainDetail extends Page {
     get domainTitle() { return this.breadcrumbStaticText; }
     get domainRecords() { return ['SOA Record','NS Record','MX Record','A/AAAA Record','CNAME Record','TXT Record','SRV Record','CAA Record']; }
-    get protocolSelect(){ return $('[data-qa-protocol] div'); }
-    get protocolOptions() { return $$('[data-qa-protocol-options]'); }
-    get caaTagSelect() { return $('[data-qa-caa-tag] div'); }
-    get caaTagOptions() { return $$('[data-qa-caa-tags]'); }
     get confirmButton() { return $('[data-qa-record-save]'); }
     get cancelButton() { return $('[data-qa-record-cancel]'); }
 
@@ -44,10 +40,17 @@ class DomainDetail extends Page {
         return rowColumnSelector[index];
     }
 
-    selectDropdownOption(dropdown) {
+    selectDropdownOption(dropdown, value) {
         this.selectElementByLabel(dropdown).click();
-        // Select the first option
-        browser.keys(["\ue015", "\uE007"]);
+        if (value) {
+            // Try to assign the requested value
+            browser.trySetValue(`[data-qa-domain-select="${dropdown}"] input`, value);
+            browser.keys(["\uE007"]);
+        } else {
+            // Select the first option
+            browser.keys(["\ue015", "\uE007"]);
+        }
+
         return this.selectInputByLabel(dropdown).getText();
     }
 
@@ -126,7 +129,7 @@ class DomainDetail extends Page {
             this.inputElementByLabel(label).waitForVisible(constants.wait.normal);
         });
         this.selectElementByLabel('TTL').waitForVisible(constants.wait.normal);
-        this.protocolSelect.waitForVisible(constants.wait.normal);
+        this.selectElementByLabel('Protocol').waitForVisible(constants.wait.normal);
         expect(this.drawerTitle.getText()).toContain('SRV Record');
     }
 
@@ -136,7 +139,7 @@ class DomainDetail extends Page {
             this.inputElementByLabel(label).waitForVisible(constants.wait.normal);
         });
         this.selectElementByLabel('TTL').waitForVisible(constants.wait.normal);
-        this.caaTagSelect.waitForVisible(constants.wait.normal);
+        this.selectElementByLabel('caa tag').waitForVisible(constants.wait.normal);
         expect(this.drawerTitle.getText()).toContain('CAA Record');
     }
 
@@ -189,10 +192,7 @@ class DomainDetail extends Page {
     addSrvRecord(service,protocol,priority,weight,port,target){
         this.srvRecordDrawerDisplays();
         this.inputElementByLabel('Service').setValue(service);
-        this.protocolSelect.click();
-        browser.pause(1000);
-        this.protocolOptions.find( option => option.getText() === protocol).click();
-        this.protocolOptions[0].waitForVisible(constants.wait.normal, true);
+        this.selectDropdownOption('Protocol', protocol);
         this.inputElementByLabel('Priority').setValue(priority);
         this.inputElementByLabel('Weight').setValue(weight);
         this.inputElementByLabel('Port').setValue(port);
@@ -206,10 +206,7 @@ class DomainDetail extends Page {
         this.caaRecordDrawerDisplays()
         this.inputElementByLabel('Name').setValue(name);
         this.inputElementByLabel('Value').setValue(value);
-        this.caaTagSelect.click();
-        browser.pause(1000);
-        this.caaTagOptions.find( option => option.getText() === tag).click();
-        this.caaTagOptions[0].waitForVisible(constants.wait.normal, true);
+        this.selectDropdownOption('caa tag', tag);
         const ttl = this.selectDropdownOption('TTL');
         this.saveRecord();
         return ttl;

--- a/e2e/specs/domains/detail-add-records.spec.js
+++ b/e2e/specs/domains/detail-add-records.spec.js
@@ -56,7 +56,7 @@ describe('Domains - Detail - Add Records Suite', () => {
         expectedTagsDisplay();
     });
 
-    it('A tag can be added to the domain detial page', () => {
+    it('A tag can be added to the domain detail page', () => {
         const domainDetailTag = `Auto2-${timestamp()}`;
         DomainDetail.addTagToTagPanel(domainDetailTag);
         domainTags.push(domainDetailTag);
@@ -65,7 +65,7 @@ describe('Domains - Detail - Add Records Suite', () => {
 
     describe('SOA Record Update', () => {
 
-        it('SOA recored table shows master domain name and email', () => {
+        it('SOA record table shows master domain name and email', () => {
             checkSoaTableValues(domainName,domainEmail,'Default','Default','Default','Default');
         });
 
@@ -79,12 +79,7 @@ describe('Domains - Detail - Add Records Suite', () => {
             const ttl = DomainDetail.selectDropdownOption('Default TTL');
             const refresh = DomainDetail.selectDropdownOption('Refresh Rate');
             const retry = DomainDetail.selectDropdownOption('Retry Rate');
-            DomainDetail.expireRateSelect.click();
-            DomainDetail.exireRateOptions[0].waitForVisible(constants.wait.normal);
-            DomainDetail.exireRateOptions[0].click();
-            DomainDetail.exireRateOptions[0].waitForVisible(constants.wait.normal, true);
-            browser.pause(500);
-            const expire = DomainDetail.expireRateSelect.getText();
+            const expire = DomainDetail.selectDropdownOption('Expire Rate')
             DomainDetail.saveRecord();
             checkSoaTableValues(domainName,domainEmail,ttl,refresh,retry,expire);
             expect(DomainDetail.domainTitle.getText()).toEqual(domainName);

--- a/e2e/specs/domains/detail-add-records.spec.js
+++ b/e2e/specs/domains/detail-add-records.spec.js
@@ -284,7 +284,7 @@ describe('Domains - Detail - Add Records Suite', () => {
             const priority = '20';
             const weight = '10';
             const port = '8080';
-            const target =  `target${timestamp()}`;
+            const target = `target${timestamp()}`;
             DomainDetail.addRecordButtonElementByLabel('SRV Record').click();
             const ttl = DomainDetail.addSrvRecord(serviceName, protocol,priority,weight,port,target);
             const serviceNameCell = DomainDetail.domainTableCellValue('SRV Record','Name',0);
@@ -294,7 +294,7 @@ describe('Domains - Detail - Add Records Suite', () => {
             const portCell = DomainDetail.domainTableCellValue('SRV Record','Port',0);
             const targetCell = DomainDetail.domainTableCellValue('SRV Record','Target',0);
             const ttlCell = DomainDetail.domainTableCellValue('SRV Record','TTL',0);
-            expect(serviceNameCell.getText()).toEqual(`_${serviceName}.${protocol}._${protocol}`);
+            expect(serviceNameCell.getText()).toEqual(`_${serviceName}._${protocol}`);
             expect(domainCell.getText()).toEqual(domainName);
             expect(priorityCell.getText()).toEqual(priority);
             expect(weightCell.getText()).toEqual(weight);
@@ -319,7 +319,7 @@ describe('Domains - Detail - Add Records Suite', () => {
             const portCell = DomainDetail.domainTableCellValue('SRV Record','Port',0);
             const targetCell = DomainDetail.domainTableCellValue('SRV Record','Target',0);
             const ttlCell = DomainDetail.domainTableCellValue('SRV Record','TTL',0);
-            expect(serviceNameCell.getText()).toEqual(`_${serviceNameUpdate}.${protocolUpdate}._${protocolUpdate}`);
+            expect(serviceNameCell.getText()).toEqual(`_${serviceNameUpdate}._${protocolUpdate}`);
             expect(domainCell.getText()).toEqual(domainName);
             expect(priorityCell.getText()).toEqual(priorityUpdate);
             expect(weightCell.getText()).toEqual(weightUpdate);

--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -276,8 +276,10 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         label="Expire Rate"
         defaultValue={defaultRate}
         onChange={(e: Item) => this.setExpireSec(+e.value)}
-        data-qa-expire-rate
         isClearable={false}
+        textFieldProps={{
+          'data-qa-domain-select': 'Expire Rate'
+        }}
       />
     );
   };
@@ -323,8 +325,10 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         label={label}
         defaultValue={defaultOption}
         onChange={(e: Item) => fn(+e.value)}
-        data-qa-domain-select={label}
         isClearable={false}
+        textFieldProps={{
+          'data-qa-domain-select': label
+        }}
       />
     );
   };
@@ -354,8 +358,10 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         label="Protocol"
         defaultValue={defaultProtocol}
         onChange={(e: Item) => this.setProtocol(e.value)}
-        data-qa-protocol
         isClearable={false}
+        textFieldProps={{
+          'data-qa-protocol': true
+        }}
       />
     );
   };
@@ -382,8 +388,10 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         options={tagOptions}
         defaultValue={defaultTag || tagOptions[0]}
         onChange={(e: Item) => this.setTag(e.value)}
-        data-qa-caa-tag
         isClearable={false}
+        textFieldProps={{
+          'data-qa-caa-tag': true
+        }}
       />
     );
   };

--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -360,7 +360,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         onChange={(e: Item) => this.setProtocol(e.value)}
         isClearable={false}
         textFieldProps={{
-          'data-qa-protocol': true
+          'data-qa-domain-select': 'Protocol'
         }}
       />
     );
@@ -390,7 +390,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         onChange={(e: Item) => this.setTag(e.value)}
         isClearable={false}
         textFieldProps={{
-          'data-qa-caa-tag': true
+          'data-qa-domain-select': 'caa tag'
         }}
       />
     );

--- a/src/services/domains/domains.schema.ts
+++ b/src/services/domains/domains.schema.ts
@@ -17,7 +17,9 @@ const domainSchemaBase = object().shape({
     .max(255, 'Description must be between 1 and 255 characters.'),
   retry_sec: number(),
   master_ips: array().of(string()),
-  axfr_ips: array().of(string()),
+  axfr_ips: array()
+    .of(string())
+    .typeError('Must be a comma-separated list of IP addresses.'),
   expire_sec: number(),
   refresh_sec: number(),
   ttl_sec: number()


### PR DESCRIPTION
Values for axfr_ips were typed as string[], but the string input
was never being split. Added split() to the change handler, and also:

- Filtered and trimmed input on form submit to avoid API errors
for trailing commas and whitespace
- Updated schema so that a better error message would be displayed
in the future
- Added placeholder and helper text to make it clear what the "Domain
transfers" field was intended to do and what input it expects.
- Fixed a bunch of e2e tests

## Description

Please start the pull request title with the jira ticket corresponding to the work if applicable. Please include a short summary of the feature added, the change, or issue fixed.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')


## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/domains/detail-add-records.spec.js`

## Note to Reviewers

Open the Edit drawer for an SOA record and try different values for the Domain Transfers field.