### PR TITLE
Add: Option to Automatically Create Domain Records

### DIFF
--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -11,6 +11,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import { Props as TextFieldProps } from 'src/components/TextField';
 /* TODO will be refactoring enhanced select to be an abstraction.
 Styles added in this file and the below imports will be utilized for the abstraction. */
 import DropdownIndicator from './components/DropdownIndicator';
@@ -361,7 +362,12 @@ type CombinedProps = EnhancedSelectProps &
 
 interface BaseSelectProps extends SelectProps<any> {
   classes: any;
-  textFieldProps?: any;
+  /* 
+   textFieldProps isn't native to react-select 
+   but we're using the MUI select element so any props that
+   can be passed to the MUI TextField element can be passed here
+  */
+  textFieldProps?: TextFieldProps;
 }
 
 interface CreatableProps extends CreatableSelectProps<any> {}
@@ -439,6 +445,11 @@ class Select extends React.PureComponent<CombinedProps, {}> {
         })}
         classNamePrefix="react-select"
         styles={styleOverrides}
+        /* 
+          textFieldProps isn't native to react-select 
+          but we're using the MUI select element so any props that
+          can be passed to the MUI TextField element can be passed here
+         */
         textFieldProps={{
           ...textFieldProps,
           label,

--- a/src/containers/withNodeBalancers.container.ts
+++ b/src/containers/withNodeBalancers.container.ts
@@ -1,0 +1,33 @@
+import { connect } from 'react-redux';
+import { ApplicationState } from 'src/store';
+
+type MapProps<TOuter, TInner> = (
+  ownProps: TOuter,
+  nodeBalancers: Linode.NodeBalancer[],
+  loading: boolean,
+  error?: Linode.ApiFieldError[]
+) => TInner;
+
+export default <TInner extends {}, TOuter extends {}>(
+  mapToProps: MapProps<TOuter, TInner>
+) =>
+  connect((state: ApplicationState, ownProps: TOuter) => {
+    const { loading, error, itemsById } = state.__resources.nodeBalancers;
+
+    /** itemsById looks like this
+     *
+     * {
+     *  123: Linode.NodeBalancer,
+     *  4234: Linode.NodeBalancer
+     * }
+     *
+     * we want it to look like
+     *
+     * Linode.NodeBalancer[]
+     */
+    const nodeBalancers = Object.keys(itemsById).map(
+      eachKey => itemsById[eachKey]
+    );
+
+    return mapToProps(ownProps, nodeBalancers, loading, error);
+  });

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -21,6 +21,7 @@ import Typography from 'src/components/core/Typography';
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
 import PromiseLoader, {
   PromiseLoaderResponse
 } from 'src/components/PromiseLoader/PromiseLoader';
@@ -49,13 +50,22 @@ interface PreloadedProps {
   records: PromiseLoaderResponse<Linode.DomainRecord>;
 }
 
-type ClassNames = 'main' | 'sidebar' | 'domainSidebar' | 'titleWrapper';
+type ClassNames =
+  | 'main'
+  | 'sidebar'
+  | 'domainSidebar'
+  | 'titleWrapper'
+  | 'error';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   main: {
     [theme.breakpoints.up('md')]: {
       order: 1
     }
+  },
+  error: {
+    marginTop: `${theme.spacing.unit * 3}px !important`,
+    marginBottom: `0 !important`
   },
   sidebar: {
     [theme.breakpoints.up('md')]: {
@@ -266,6 +276,13 @@ class DomainDetail extends React.Component<CombinedProps, State> {
             />
           </Grid>
         </Grid>
+        {this.props.location.state && this.props.location.state.recordError && (
+          <Notice
+            className={classes.error}
+            error
+            text={this.props.location.state.recordError}
+          />
+        )}
         <AppBar position="static" color="default">
           <Tabs
             value={this.tabs.findIndex(tab => matches(tab.routeName))}

--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -155,7 +155,9 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     errors: [],
     master_ips: [],
     masterIPsCount: 1,
-    defaultRecordsSetting: 'none'
+    defaultRecordsSetting: 'none',
+    selectedDefaultLinode: undefined,
+    selectedDefaultNodeBalancer: undefined
   };
 
   state: State = {

--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -559,7 +559,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             domainData.domain,
             domainData.id,
             path(['ipv4'], selectedDefaultNodeBalancer),
-            path(['ipv6'], selectedDefaultLinode)
+            path(['ipv6'], selectedDefaultNodeBalancer)
           )
             .then(() => {
               return this.redirectToLandingOrDetail(type, domainData.id);

--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -353,9 +353,8 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               label: 'Do not insert default records for me.'
             }}
             textFieldProps={{
-              helperText: `Once this domain is created, we\'ll go ahead and automatically
-                create some domain records (A/AAAA and MX) to get you started, based on a Linode
-                or NodeBalancer that you specify.`
+              helperText: `If specified, we can automatically create some domain records 
+              (A/AAAA and MX) to get you started, based on a Linode or NodeBalancer that you specify.`
             }}
             label="Insert Default Records"
             options={[
@@ -365,11 +364,11 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               },
               {
                 value: 'linode',
-                label: 'Insert default decords from one of my Linodes.'
+                label: 'Insert default records from one of my Linodes.'
               },
               {
                 value: 'nodebalancer',
-                label: 'Insert default decords from one of my NodeBalancers.'
+                label: 'Insert default records from one of my NodeBalancers.'
               }
             ]}
           />

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -274,18 +274,20 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
             </Grid>
           </Grid>
         </Grid>
-        {this.props.howManyLinodesOnAccount === 0 && domainsLength > 0 && (
-          <Notice warning important className={classes.dnsWarning}>
-            <Typography variant="h3">
-              Your DNS zones are not being served.
-            </Typography>
-            <Typography>
-              Your domains will not be served by Linode's nameservers unless you
-              have at least one active Linode on your account.
-              <Link to="/linodes/create"> You can create one here.</Link>
-            </Typography>
-          </Notice>
-        )}
+        {!this.props.linodesLoading &&
+          this.props.howManyLinodesOnAccount === 0 &&
+          domainsLength > 0 && (
+            <Notice warning important className={classes.dnsWarning}>
+              <Typography variant="h3">
+                Your DNS zones are not being served.
+              </Typography>
+              <Typography>
+                Your domains will not be served by Linode's nameservers unless
+                you have at least one active Linode on your account.
+                <Link to="/linodes/create"> You can create one here.</Link>
+              </Typography>
+            </Notice>
+          )}
         <Grid item xs={12}>
           {/* Duplication starts here. How can we refactor this? */}
           <OrderBy data={domainsData} order={'asc'} orderBy={'domain'}>
@@ -420,6 +422,7 @@ const withLocalStorage = localStorageContainer<
 
 interface StateProps {
   howManyLinodesOnAccount: number;
+  linodesLoading: boolean;
 }
 
 const mapStateToProps: MapStateToProps<
@@ -431,7 +434,8 @@ const mapStateToProps: MapStateToProps<
     [],
     ['__resources', 'linodes', 'results'],
     state
-  ).length
+  ).length,
+  linodesLoading: pathOr(false, ['linodes', 'loading'], state.__resources)
 });
 
 export const connected = connect(

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -288,6 +288,9 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
               </Typography>
             </Notice>
           )}
+        {this.props.location.state && this.props.location.state.recordError && (
+          <Notice error text={this.props.location.state.recordError} />
+        )}
         <Grid item xs={12}>
           {/* Duplication starts here. How can we refactor this? */}
           <OrderBy data={domainsData} order={'asc'} orderBy={'domain'}>

--- a/src/features/Images/ImagesDrawer.tsx
+++ b/src/features/Images/ImagesDrawer.tsx
@@ -308,7 +308,7 @@ class ImageDrawer extends React.Component<CombinedProps, State> {
           <LinodeSelect
             selectedLinode={selectedLinode}
             linodeError={linodeError}
-            handleChange={changeLinode}
+            handleChange={linode => changeLinode(linode.id)}
             updateFor={[selectedLinode, linodeError, classes]}
           />
         )}

--- a/src/features/NodeBalancers/NodeBalancerSelect.tsx
+++ b/src/features/NodeBalancers/NodeBalancerSelect.tsx
@@ -76,6 +76,11 @@ const NodeBalancerSelect: React.StatelessComponent<CombinedProps> = props => {
     : nodeBalancersData;
   const options = nodeBalancersToItems(nodeBalancer);
 
+  const noOptionsMessage =
+    !nodeBalancerError && !nodeBalancersLoading && options.length === 0
+      ? 'You have no NodeBalancers to choose from'
+      : 'No Options';
+
   return (
     <EnhancedSelect
       label="NodeBalancer"
@@ -92,6 +97,7 @@ const NodeBalancerSelect: React.StatelessComponent<CombinedProps> = props => {
       )}
       isClearable={false}
       textFieldProps={props.textFieldProps}
+      noOptionsMessage={() => noOptionsMessage}
     />
   );
 };

--- a/src/features/NodeBalancers/NodeBalancerSelect.tsx
+++ b/src/features/NodeBalancers/NodeBalancerSelect.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+import {
+  StyleRulesCallback,
+  WithStyles,
+  withStyles
+} from 'src/components/core/styles';
+import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
+import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
+import { Props as TextFieldProps } from 'src/components/TextField';
+import withNodeBalancers from 'src/containers/withNodeBalancers.container';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {}
+});
+
+interface WithNodeBalancersProps {
+  nodeBalancersData: Linode.NodeBalancer[];
+  nodeBalancersLoading: boolean;
+  nodeBalancersError?: Linode.ApiFieldError[];
+}
+
+interface Props {
+  generalError?: string;
+  nodeBalancerError?: string;
+  selectedNodeBalancer: number | null;
+  disabled?: boolean;
+  region?: string;
+  handleChange: (nodeBalancer: Linode.NodeBalancer) => void;
+  textFieldProps?: TextFieldProps;
+}
+
+type CombinedProps = Props & WithNodeBalancersProps & WithStyles<ClassNames>;
+
+const nodeBalancersToItems = (
+  nodeBalancers: Linode.NodeBalancer[]
+): Item<number>[] =>
+  nodeBalancers.map(thisNodeBalancer => ({
+    value: thisNodeBalancer.id,
+    label: thisNodeBalancer.label,
+    data: thisNodeBalancer
+  }));
+
+const nodeBalancerFromItems = (
+  nodeBalancers: Item<number>[],
+  nodeBalancerId: number | null
+) => {
+  if (!nodeBalancerId) {
+    return;
+  }
+  return nodeBalancers.find(
+    thisNodeBalancer => thisNodeBalancer.value === nodeBalancerId
+  );
+};
+
+const NodeBalancerSelect: React.StatelessComponent<CombinedProps> = props => {
+  const {
+    disabled,
+    generalError,
+    handleChange,
+    nodeBalancerError,
+    nodeBalancersError,
+    nodeBalancersLoading,
+    nodeBalancersData,
+    region,
+    selectedNodeBalancer
+  } = props;
+
+  const nodeBalancer = region
+    ? nodeBalancersData.filter(
+        thisNodeBalancer => thisNodeBalancer.region === region
+      )
+    : nodeBalancersData;
+  const options = nodeBalancersToItems(nodeBalancer);
+
+  return (
+    <EnhancedSelect
+      label="NodeBalancer"
+      placeholder="Select a NodeBalancer"
+      value={nodeBalancerFromItems(options, selectedNodeBalancer)}
+      options={options}
+      disabled={disabled}
+      isLoading={nodeBalancersLoading}
+      onChange={(selected: Item<number>) => {
+        return handleChange(selected.data);
+      }}
+      errorText={getErrorStringOrDefault(
+        generalError || nodeBalancerError || nodeBalancersError || ''
+      )}
+      isClearable={false}
+      textFieldProps={props.textFieldProps}
+    />
+  );
+};
+
+const styled = withStyles(styles);
+
+export default compose<CombinedProps, Props & RenderGuardProps>(
+  styled,
+  RenderGuard,
+  withNodeBalancers(
+    (
+      ownProps,
+      nodeBalancersData,
+      nodeBalancersLoading,
+      nodeBalancersError
+    ) => ({
+      ...ownProps,
+      nodeBalancersData,
+      nodeBalancersLoading,
+      nodeBalancersError
+    })
+  )
+)(NodeBalancerSelect);

--- a/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -196,7 +196,7 @@ class VolumeAttachmentDrawer extends React.Component<CombinedProps, State> {
         <LinodeSelect
           selectedLinode={selectedLinode}
           region={linodeRegion}
-          handleChange={this.changeSelectedLinode}
+          handleChange={linode => this.changeSelectedLinode(linode.id)}
           linodeError={linodeError}
           generalError={generalError}
           disabled={disabled || readOnly}

--- a/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -7,6 +7,7 @@ import {
 } from 'src/components/core/styles';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
+import { Props as TextFieldProps } from 'src/components/TextField';
 import withLinodes from 'src/containers/withLinodes.container';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
@@ -28,7 +29,8 @@ interface Props {
   selectedLinode: number | null;
   disabled?: boolean;
   region?: string;
-  handleChange: (linodeId: number | null) => void;
+  handleChange: (linode: Linode.Linode) => void;
+  textFieldProps?: TextFieldProps;
 }
 
 type CombinedProps = Props & WithLinodesProps & WithStyles<ClassNames>;
@@ -36,7 +38,8 @@ type CombinedProps = Props & WithLinodesProps & WithStyles<ClassNames>;
 const linodesToItems = (linodes: Linode.Linode[]): Item<number>[] =>
   linodes.map(thisLinode => ({
     value: thisLinode.id,
-    label: thisLinode.label
+    label: thisLinode.label,
+    data: thisLinode
   }));
 
 const linodeFromItems = (linodes: Item<number>[], linodeId: number | null) => {
@@ -72,13 +75,14 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
       options={options}
       disabled={disabled}
       isLoading={linodesLoading}
-      onChange={(selected: Item<number> | null) =>
-        handleChange(selected ? selected.value : null)
-      }
+      onChange={(selected: Item<number>) => {
+        return handleChange(selected.data);
+      }}
       errorText={getErrorStringOrDefault(
         generalError || linodeError || linodesError || ''
       )}
       isClearable={false}
+      textFieldProps={props.textFieldProps}
     />
   );
 };

--- a/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -67,6 +67,11 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
     : linodesData;
   const options = linodesToItems(linodes);
 
+  const noOptionsMessage =
+    !linodeError && !linodesLoading && options.length === 0
+      ? 'You have no Linodes to choose from'
+      : 'No Options';
+
   return (
     <EnhancedSelect
       label="Linode"
@@ -83,6 +88,7 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
       )}
       isClearable={false}
       textFieldProps={props.textFieldProps}
+      noOptionsMessage={() => noOptionsMessage}
     />
   );
 };


### PR DESCRIPTION
## Description

Adds the ability to automatically create domain records from either Linode or NodeBalancer IP addresses while creating a master domain

Fixes #4941 

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/domains/smoke-list-domains.spec.js --browser=headlessChrome`

## Note to Reviewers

Please test by both request blocking both requests to `/domains` and `domains/${id}/records`

Also please attempt to request only some network requests to `domains/${id}/records` but not all.