### PR TITLE
M3-2829 VAT banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
 import Grid from 'src/components/Grid';
 import NotFound from 'src/components/NotFound';
 import SideMenu from 'src/components/SideMenu';
+import VATBanner from 'src/components/VATBanner';
 import { events$ } from 'src/events';
 import BackupDrawer from 'src/features/Backups';
 import DomainDrawer from 'src/features/Domains/DomainDrawer';
@@ -357,6 +358,7 @@ export class App extends React.Component<CombinedProps, State> {
                     isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
                     username={this.props.username}
                   />
+                  <VATBanner />
                   <div className={classes.wrapper} id="main-content">
                     <Grid container spacing={0} className={classes.grid}>
                       <Grid item className={classes.switchWrapper}>

--- a/src/components/Notice/Notice.spec.js
+++ b/src/components/Notice/Notice.spec.js
@@ -12,9 +12,9 @@ describe('Notice Suite', () => {
         navigateToStory(component, childStories[0]);
     });
 
-    it('should display three notices', () => {
+    it('should display all the notices', () => {
         notices = $$('[data-qa-notice]');
-        expect(notices.length).toEqual(6);
+        expect(notices.length).toEqual(7);
     });
 
     it('should display an error notice', () => {

--- a/src/components/Notice/Notice.stories.tsx
+++ b/src/components/Notice/Notice.stories.tsx
@@ -11,6 +11,12 @@ storiesOf('Notice', module).add('All Notices', () => (
       <Notice error important text="This is an important error notice" />
       <Notice warning important text="This is an important warning notice" />
       <Notice success important text="This is an important success notice" />
+      <Notice
+        warning
+        text="This is a dismissible Notice"
+        dismissible
+        onClose={() => console.log('Dismissed!')}
+      />
     </div>
   </React.Fragment>
 ));

--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -1,3 +1,4 @@
+import Close from '@material-ui/icons/Close';
 import * as classNames from 'classnames';
 import * as React from 'react';
 import Error from 'src/assets/icons/alert.svg';
@@ -25,7 +26,8 @@ type ClassNames =
   | 'successList'
   | 'flag'
   | 'breakWords'
-  | 'icon';
+  | 'icon'
+  | 'closeIcon';
 
 const styles: StyleRulesCallback = theme => {
   const {
@@ -109,12 +111,15 @@ const styles: StyleRulesCallback = theme => {
       color: 'white',
       marginLeft: -(theme.spacing.unit * 2 + 22),
       marginRight: 18
+    },
+    closeIcon: {
+      paddingLeft: theme.spacing.unit
     }
   };
 };
 
 interface Props extends GridProps {
-  text?: string;
+  text?: string | JSX.Element;
   html?: string;
   error?: boolean;
   errorGroup?: string;
@@ -129,6 +134,9 @@ interface Props extends GridProps {
   spacingBottom?: 0 | 8 | 16 | 24;
   breakWords?: boolean;
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+  // Dismissible Props
+  dismissible?: boolean;
+  onClose?: () => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -139,6 +147,7 @@ const Notice: React.StatelessComponent<CombinedProps> = props => {
     className,
     important,
     text,
+    dismissible,
     error,
     breakWords,
     errorGroup,
@@ -150,6 +159,7 @@ const Notice: React.StatelessComponent<CombinedProps> = props => {
     html,
     notificationList,
     onClick,
+    onClose,
     spacingTop,
     spacingBottom
   } = props;
@@ -214,6 +224,11 @@ const Notice: React.StatelessComponent<CombinedProps> = props => {
           (warning && <Warning className={classes.icon} />) ||
           (error && <Error className={classes.icon} />))}
       <div className={classes.inner}>{c}</div>
+      {dismissible && (
+        <Grid item className={classes.closeIcon}>
+          <Close onClick={onClose} />
+        </Grid>
+      )}
     </Grid>
   );
 };

--- a/src/components/VATBanner/VATBanner.test.tsx
+++ b/src/components/VATBanner/VATBanner.test.tsx
@@ -1,0 +1,32 @@
+import { shouldShowVatBanner } from './VATBanner';
+
+describe('VAT banner', () => {
+  describe('show/hide logic', () => {
+    it('should hide the banner if no country is available', () => {
+      expect(shouldShowVatBanner(true, 'show', undefined, undefined)).toBe(
+        false
+      );
+    });
+
+    it('should hide the banner if the local showBanner state is set to false', () => {
+      expect(shouldShowVatBanner(false, 'show', 'DE', '12345')).toBe(false);
+    });
+
+    it("should hide the banner if the user's country is not in the EU", () => {
+      expect(shouldShowVatBanner(true, 'show', 'US', undefined)).toBe(false);
+    });
+
+    it('should hide the banner if the user already has a tax_id value', () => {
+      expect(shouldShowVatBanner(true, 'show', 'FR', '12345')).toBe(false);
+    });
+
+    it('should hide the banner if it has been dismissed previously', () => {
+      expect(shouldShowVatBanner(true, 'hide', 'FR', undefined)).toBe(false);
+    });
+
+    it("should show the banner for users in the EU who don't have a tax ID", () => {
+      expect(shouldShowVatBanner(true, 'show', 'FR', undefined)).toBe(true);
+      expect(shouldShowVatBanner(true, 'show', 'FR', '')).toBe(true);
+    });
+  });
+});

--- a/src/components/VATBanner/VATBanner.test.tsx
+++ b/src/components/VATBanner/VATBanner.test.tsx
@@ -3,30 +3,24 @@ import { shouldShowVatBanner } from './VATBanner';
 describe('VAT banner', () => {
   describe('show/hide logic', () => {
     it('should hide the banner if no country is available', () => {
-      expect(shouldShowVatBanner(true, 'show', undefined, undefined)).toBe(
-        false
-      );
-    });
-
-    it('should hide the banner if the local showBanner state is set to false', () => {
-      expect(shouldShowVatBanner(false, 'show', 'DE', '12345')).toBe(false);
+      expect(shouldShowVatBanner(true, undefined, undefined)).toBe(false);
     });
 
     it("should hide the banner if the user's country is not in the EU", () => {
-      expect(shouldShowVatBanner(true, 'show', 'US', undefined)).toBe(false);
+      expect(shouldShowVatBanner(true, 'US', undefined)).toBe(false);
     });
 
     it('should hide the banner if the user already has a tax_id value', () => {
-      expect(shouldShowVatBanner(true, 'show', 'FR', '12345')).toBe(false);
+      expect(shouldShowVatBanner(true, 'FR', '12345')).toBe(false);
     });
 
     it('should hide the banner if it has been dismissed previously', () => {
-      expect(shouldShowVatBanner(true, 'hide', 'FR', undefined)).toBe(false);
+      expect(shouldShowVatBanner(false, 'FR', undefined)).toBe(false);
     });
 
     it("should show the banner for users in the EU who don't have a tax ID", () => {
-      expect(shouldShowVatBanner(true, 'show', 'FR', undefined)).toBe(true);
-      expect(shouldShowVatBanner(true, 'show', 'FR', '')).toBe(true);
+      expect(shouldShowVatBanner(true, 'FR', undefined)).toBe(true);
+      expect(shouldShowVatBanner(true, 'FR', '')).toBe(true);
     });
   });
 });

--- a/src/components/VATBanner/VATBanner.tsx
+++ b/src/components/VATBanner/VATBanner.tsx
@@ -27,6 +27,7 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 interface AccountProps {
   country?: string;
   taxId?: string;
+  lastUpdated: number;
 }
 
 type CombinedProps = AccountProps &
@@ -37,17 +38,16 @@ type CombinedProps = AccountProps &
 
 const message = (
   <div>
-    {`Starting 1 June 2019, VAT may be applied to your Linode services.
-    For more information please see `}
+    {`Starting 1 June 2019, `}
     <a
       href="https://www.linode.com/docs/platform/billing-and-support/tax-information/#value-added-tax-in-the-european-union"
       target="_blank"
     >
-      Value Added Tax in the European Union
+      value added tax
     </a>
-    {`. To ensure the correct VAT rate is applied, please verify that your `}
-    <Link to="/account/billing">contact information</Link>
-    {` is up to date.`}
+    {` may be applied to your Linode services. To ensure proper billing, please confirm the accuracy of your account information by `}
+    <Link to="/account/billing">clicking here</Link>
+    {`.`}
   </div>
 );
 
@@ -76,7 +76,10 @@ export const shouldShowVatBanner = (
 
 export const VATBanner: React.FunctionComponent<CombinedProps> = props => {
   React.useEffect(() => {
-    props.requestAccount();
+    if (props.lastUpdated === 0) {
+      // If we haven't already requested account data, do it here:
+      props.requestAccount();
+    }
   }, []);
 
   const { showVATBanner, hideVATBanner } = props;
@@ -104,10 +107,11 @@ export const VATBanner: React.FunctionComponent<CombinedProps> = props => {
 const styled = withStyles(styles);
 
 const withAccount = AccountContainer(
-  (ownProps, accountLoading, accountData) => ({
+  (ownProps, accountLoading, lastUpdated, accountData) => ({
     ...ownProps,
     country: path(['country'], accountData),
-    taxId: path(['tax_id'], accountData)
+    taxId: path(['tax_id'], accountData),
+    accountUpdated: lastUpdated
   })
 );
 

--- a/src/components/VATBanner/VATBanner.tsx
+++ b/src/components/VATBanner/VATBanner.tsx
@@ -1,0 +1,125 @@
+import { path } from 'ramda';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { compose } from 'recompose';
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Notice from 'src/components/Notice';
+import { EU_COUNTRIES } from 'src/constants';
+import AccountContainer, {
+  DispatchProps
+} from 'src/containers/account.container';
+import { notifications } from 'src/utilities/storage';
+
+type ClassNames = 'root';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {
+    paddingTop: theme.spacing.unit * 3,
+    paddingRight: theme.spacing.unit * 3,
+    paddingLeft: theme.spacing.unit * 3
+  }
+});
+
+interface AccountProps {
+  country?: string;
+  taxId?: string;
+}
+
+type CombinedProps = AccountProps & DispatchProps & WithStyles<ClassNames>;
+
+const message = (
+  <div>
+    {`Starting 1 June 2019, VAT may be applied to your Linode services.
+    For more information please see `}
+    <a
+      href="https://www.linode.com/docs/platform/billing-and-support/tax-information/#value-added-tax-in-the-european-union"
+      target="_blank"
+    >
+      Value Added Tax in the European Union
+    </a>
+    {`. To ensure the correct VAT rate is applied, please verify that your `}
+    <Link to="/account/billing">contact information</Link>
+    {` is up to date.`}
+  </div>
+);
+
+export const shouldShowVatBanner = (
+  showLocal: boolean,
+  showLocalStorage: 'hide' | 'show',
+  country?: string,
+  taxId?: string
+) => {
+  if (!country) {
+    return false;
+  }
+
+  /**
+   * If the user has previously dismissed the banner, don't show it
+   */
+  if (!showLocal || showLocalStorage === 'hide') {
+    return false;
+  }
+
+  /**
+   * We want to show the banner to users in the EU who
+   * don't already have a tax_id set on their account
+   */
+  return EU_COUNTRIES.includes(country || '') && !taxId;
+};
+
+export const VATBanner: React.FunctionComponent<CombinedProps> = props => {
+  React.useEffect(() => {
+    props.requestAccount();
+  }, []);
+
+  const [showBanner, setBanner] = React.useState<boolean>(true);
+
+  const hideBanner = () => {
+    notifications.VAT.set('hide');
+    setBanner(false);
+  };
+
+  const { classes, country, taxId } = props;
+
+  const previouslyDismissedBanner = notifications.VAT.get();
+
+  if (
+    !shouldShowVatBanner(showBanner, previouslyDismissedBanner, country, taxId)
+  ) {
+    return null;
+  }
+
+  return (
+    <div className={classes.root}>
+      <Notice
+        important
+        warning
+        dismissible
+        onClose={hideBanner}
+        text={message}
+        spacingBottom={0}
+      />
+    </div>
+  );
+};
+
+const styled = withStyles(styles);
+
+const withAccount = AccountContainer(
+  (ownProps, accountLoading, accountData) => ({
+    ...ownProps,
+    country: path(['country'], accountData),
+    taxId: path(['tax_id'], accountData)
+  })
+);
+
+const enhanced = compose<CombinedProps, {}>(
+  styled,
+  withAccount
+);
+
+export default enhanced(VATBanner);

--- a/src/components/VATBanner/VATBanner.tsx
+++ b/src/components/VATBanner/VATBanner.tsx
@@ -86,7 +86,7 @@ export const VATBanner: React.FunctionComponent<CombinedProps> = props => {
       >
         value added tax
       </a>
-      {` may be applied to your Linode services. To ensure proper billing, please confirm the accuracy of your account information by `}
+      {` may be applied to your Linode services. To ensure proper billing, please confirm the accuracy of your account information `}
       {props.location.pathname.match('/account/billing') ? (
         // Don't link to /account/billing if you're already on account/billing
         `in Update Contact Information below`

--- a/src/components/VATBanner/index.tsx
+++ b/src/components/VATBanner/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './VATBanner';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -155,3 +155,35 @@ export const allowedHTMLTags = [
 ];
 
 export const allowedHTMLAttr = ['href', 'lang', 'title', 'align', 'target'];
+
+// List of country codes in the European Union; used for VAT display
+export const EU_COUNTRIES = [
+  'AT', // Austria
+  'BE', // Belgium
+  'BG', // Bulgaria
+  'CY', // Cyprus
+  'CZ', // Czech Republic
+  'DE', // Germany
+  'DK', // Denmark
+  'EE', // Estonia
+  'ES', // Spain
+  'FI', // Finland
+  'FR', // France
+  'GR', // Greece
+  'HR', // Croatia
+  'HU', // Hungary
+  'IE', // Ireland
+  'IT', // Italy
+  'LT', // Lithuania
+  'LU', // Luxembourg
+  'LV', // Latvia
+  'MT', // Malta
+  'NL', // Netherlands
+  'PL', // Poland
+  'PT', // Portugal
+  'RO', // Romania
+  'SE', // Sweden
+  'SI', // Slovenia
+  'SK', // Slovakia
+  'GB' // United Kingdom
+];

--- a/src/containers/account.container.ts
+++ b/src/containers/account.container.ts
@@ -8,6 +8,7 @@ export interface AccountProps {
   account?: Linode.Account;
   accountLoading: boolean;
   accountError?: Linode.ApiFieldError[] | Error;
+  lastUpdated: number;
 }
 
 export interface DispatchProps {
@@ -24,6 +25,7 @@ export default <TInner extends {}, TOuter extends {}>(
   mapAccountToProps: (
     ownProps: TOuter,
     accountLoading: boolean,
+    lastUpdated: number,
     account?: Linode.Account,
     accountError?: Linode.ApiFieldError[] | Error
   ) => TInner
@@ -33,8 +35,15 @@ export default <TInner extends {}, TOuter extends {}>(
       const account = state.__resources.account.data;
       const accountLoading = state.__resources.account.loading;
       const accountError = state.__resources.account.error;
+      const lastUpdated = state.__resources.account.lastUpdated;
 
-      return mapAccountToProps(ownProps, accountLoading, account, accountError);
+      return mapAccountToProps(
+        ownProps,
+        accountLoading,
+        lastUpdated,
+        account,
+        accountError
+      );
     },
     mapDispatchToProps
   );

--- a/src/utilities/mockLocalStorage.ts
+++ b/src/utilities/mockLocalStorage.ts
@@ -1,0 +1,31 @@
+/**
+ * Used for tests where a component relies on localStorage.
+ * Usage:
+ *
+ * import LocalStorageMock from 'src/utilities/mockLocalStorage';
+ * Object.defineProperty(window, 'localStorage', {
+ *   value: new LocalStorageMock()
+ * });
+ */
+
+class LocalStorageMock {
+  store: any = {};
+
+  clear() {
+    this.store = {};
+  }
+
+  getItem(key: string) {
+    return this.store[key] || null;
+  }
+
+  setItem(key: string, value: string) {
+    this.store[key] = value.toString();
+  }
+
+  removeItem(key: string) {
+    delete this.store[key];
+  }
+}
+
+export default LocalStorageMock;

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -34,6 +34,7 @@ const THEME = 'themeChoice';
 const SPACING = 'spacingChoice';
 const PAGE_SIZE = 'PAGE_SIZE';
 const BETA_NOTIFICATION = 'BetaNotification';
+const VAT_NOTIFICATION = 'vatNotification';
 const LINODE_VIEW = 'linodesViewStyle';
 const GROUP_LINODES = 'GROUP_LINODES';
 const HIDE_DISPLAY_GROUPS_CTA = 'importDisplayGroupsCTA';
@@ -51,6 +52,7 @@ type Theme = 'dark' | 'light';
 export type Spacing = 'compact' | 'normal';
 export type PageSize = number;
 type Beta = 'open' | 'closed';
+type Notification = 'show' | 'hide';
 type LinodeView = 'grid' | 'list';
 
 interface AuthGetAndSet {
@@ -86,6 +88,10 @@ export interface Storage {
     welcome: {
       get: () => Beta;
       set: (open: Beta) => void;
+    };
+    VAT: {
+      get: () => Notification;
+      set: (show: Notification) => void;
     };
   };
   views: {
@@ -163,6 +169,10 @@ export const storage: Storage = {
       /** Leaving the LS key alone so it's not popping for those who've dismissed it. */
       get: () => getStorage(BETA_NOTIFICATION, 'open'),
       set: open => setStorage(BETA_NOTIFICATION, open)
+    },
+    VAT: {
+      get: () => getStorage(VAT_NOTIFICATION, 'show'),
+      set: show => setStorage(VAT_NOTIFICATION, show)
     }
   },
   views: {


### PR DESCRIPTION
## Description

Show banner for EU users

- Conditionally render banner
- Add list of EU country codes to src/constants
- Add logic to display banner (if country is in the EU and no tax_id)
- Adjust banner padding
- Make Notices dismissible
- Add VAT notification to localStorage
- Add tests

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Toggle your country (in or out of the EU) and tax_id (defined or undefined).

NOTE: The Billing info panel is using an old Context rather than Redux, and toggling your account settings here won't update the banner until you reload the page. I'm going to start working on that change in a follow-up PR, and we can decide whether or not to wait for that change before releasing this.