### PR TITLE
localStorage POC

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -271,7 +271,7 @@ export class App extends React.Component<CombinedProps, State> {
         }
       });
 
-    if (notifications.welcome.get() === 'open') {
+    if (notifications.get('welcome', true)) {
       this.setState({ welcomeBanner: true });
     }
   }
@@ -291,7 +291,7 @@ export class App extends React.Component<CombinedProps, State> {
 
   closeWelcomeBanner = () => {
     this.setState({ welcomeBanner: false });
-    notifications.welcome.set('closed');
+    notifications.set('welcome', false);
   };
 
   render() {

--- a/src/WelcomeBanner.tsx
+++ b/src/WelcomeBanner.tsx
@@ -109,7 +109,7 @@ class WelcomeBanner extends React.Component<CombinedProps, {}> {
       storage.loginCloudManager.set('-1');
     }
 
-    storage.notifications.welcome.set('closed');
+    storage.notifications.set('welcome', false);
   };
 
   render() {

--- a/src/components/VATBanner/VATBanner.test.tsx
+++ b/src/components/VATBanner/VATBanner.test.tsx
@@ -3,7 +3,6 @@ import { shouldShowVatBanner } from './VATBanner';
 describe('VAT banner', () => {
   describe('show/hide logic', () => {
     it('should hide the banner if no country is available', () => {
-<<<<<<< HEAD
       expect(shouldShowVatBanner(true, undefined, undefined)).toBe(false);
     });
 
@@ -22,32 +21,27 @@ describe('VAT banner', () => {
     it("should show the banner for users in the EU who don't have a tax ID", () => {
       expect(shouldShowVatBanner(true, 'FR', undefined)).toBe(true);
       expect(shouldShowVatBanner(true, 'FR', '')).toBe(true);
-=======
-      expect(shouldShowVatBanner(true, 'show', undefined, undefined)).toBe(
-        false
-      );
     });
 
     it('should hide the banner if the local showBanner state is set to false', () => {
-      expect(shouldShowVatBanner(false, 'show', 'DE', '12345')).toBe(false);
+      expect(shouldShowVatBanner(true, undefined, undefined)).toBe(false);
     });
 
     it("should hide the banner if the user's country is not in the EU", () => {
-      expect(shouldShowVatBanner(true, 'show', 'US', undefined)).toBe(false);
+      expect(shouldShowVatBanner(true, 'US', undefined)).toBe(false);
     });
 
     it('should hide the banner if the user already has a tax_id value', () => {
-      expect(shouldShowVatBanner(true, 'show', 'FR', '12345')).toBe(false);
+      expect(shouldShowVatBanner(true, 'FR', '12345')).toBe(false);
     });
 
     it('should hide the banner if it has been dismissed previously', () => {
-      expect(shouldShowVatBanner(true, 'hide', 'FR', undefined)).toBe(false);
+      expect(shouldShowVatBanner(false, 'FR', undefined)).toBe(false);
     });
 
     it("should show the banner for users in the EU who don't have a tax ID", () => {
-      expect(shouldShowVatBanner(true, 'show', 'FR', undefined)).toBe(true);
-      expect(shouldShowVatBanner(true, 'show', 'FR', '')).toBe(true);
->>>>>>> Display banner for EU users who don't have tax information in their account
+      expect(shouldShowVatBanner(true, 'FR', undefined)).toBe(true);
+      expect(shouldShowVatBanner(true, 'FR', '')).toBe(true);
     });
   });
 });

--- a/src/components/VATBanner/VATBanner.test.tsx
+++ b/src/components/VATBanner/VATBanner.test.tsx
@@ -3,6 +3,7 @@ import { shouldShowVatBanner } from './VATBanner';
 describe('VAT banner', () => {
   describe('show/hide logic', () => {
     it('should hide the banner if no country is available', () => {
+<<<<<<< HEAD
       expect(shouldShowVatBanner(true, undefined, undefined)).toBe(false);
     });
 
@@ -21,6 +22,32 @@ describe('VAT banner', () => {
     it("should show the banner for users in the EU who don't have a tax ID", () => {
       expect(shouldShowVatBanner(true, 'FR', undefined)).toBe(true);
       expect(shouldShowVatBanner(true, 'FR', '')).toBe(true);
+=======
+      expect(shouldShowVatBanner(true, 'show', undefined, undefined)).toBe(
+        false
+      );
+    });
+
+    it('should hide the banner if the local showBanner state is set to false', () => {
+      expect(shouldShowVatBanner(false, 'show', 'DE', '12345')).toBe(false);
+    });
+
+    it("should hide the banner if the user's country is not in the EU", () => {
+      expect(shouldShowVatBanner(true, 'show', 'US', undefined)).toBe(false);
+    });
+
+    it('should hide the banner if the user already has a tax_id value', () => {
+      expect(shouldShowVatBanner(true, 'show', 'FR', '12345')).toBe(false);
+    });
+
+    it('should hide the banner if it has been dismissed previously', () => {
+      expect(shouldShowVatBanner(true, 'hide', 'FR', undefined)).toBe(false);
+    });
+
+    it("should show the banner for users in the EU who don't have a tax ID", () => {
+      expect(shouldShowVatBanner(true, 'show', 'FR', undefined)).toBe(true);
+      expect(shouldShowVatBanner(true, 'show', 'FR', '')).toBe(true);
+>>>>>>> Display banner for EU users who don't have tax information in their account
     });
   });
 });

--- a/src/components/VATBanner/VATBanner.tsx
+++ b/src/components/VATBanner/VATBanner.tsx
@@ -121,7 +121,7 @@ export const VATBanner: React.FunctionComponent<CombinedProps> = props => {
 const styled = withStyles(styles);
 
 const withAccount = AccountContainer(
-  (ownProps, accountLoading, lastUpdated, accountData) => ({
+  (ownProps, accountLoading, lastUpdated, accountData, accountError) => ({
     ...ownProps,
     country: path(['country'], accountData),
     taxId: path(['tax_id'], accountData),

--- a/src/components/VATBanner/VATBanner.tsx
+++ b/src/components/VATBanner/VATBanner.tsx
@@ -152,12 +152,12 @@ const withLocalStorage = localStorageContainer<
 >(
   storage => {
     return {
-      showVATBanner: storage.notifications.VAT.get() === 'show'
+      showVATBanner: storage.notifications.get('VAT', true) || true
     };
   },
   storage => ({
     hideVATBanner: state => () => {
-      storage.notifications.VAT.set('hide');
+      storage.notifications.set('VAT', false);
 
       return {
         ...state,

--- a/src/components/VATBanner/VATBanner.tsx
+++ b/src/components/VATBanner/VATBanner.tsx
@@ -137,6 +137,14 @@ interface LocalStorageUpdater {
   hideVATBanner: () => Partial<LocalStorageState>;
 }
 
+interface LocalStorageState {
+  showVATBanner: boolean;
+}
+
+interface LocalStorageUpdater {
+  hideVATBanner: () => Partial<LocalStorageState>;
+}
+
 const withLocalStorage = localStorageContainer<
   LocalStorageState,
   LocalStorageUpdater,

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -32,7 +32,7 @@ export const setStorage = (key: string, value: string) => {
 };
 
 export const setNotificationField = (key: string, value: boolean) => {
-  const _notifications = JSON.parse(getStorage(NOTIFICATIONS));
+  const _notifications = getStorage(NOTIFICATIONS);
   const updatedNotifications = {
     ..._notifications,
     [key]: value
@@ -41,7 +41,7 @@ export const setNotificationField = (key: string, value: boolean) => {
 };
 
 export const getNotificationField = (key: string, fallback?: boolean) => {
-  const _notifications = JSON.parse(getStorage(NOTIFICATIONS));
+  const _notifications = getStorage(NOTIFICATIONS);
   return pathOr(fallback, [key], _notifications);
 };
 

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -1,4 +1,5 @@
 import * as Cookies from 'js-cookie';
+import { pathOr } from 'ramda';
 
 const localStorageCache = {};
 
@@ -30,11 +31,24 @@ export const setStorage = (key: string, value: string) => {
   return window.localStorage.setItem(key, value);
 };
 
+export const setNotificationField = (key: string, value: boolean) => {
+  const _notifications = JSON.parse(getStorage(NOTIFICATIONS));
+  const updatedNotifications = {
+    ..._notifications,
+    [key]: value
+  };
+  setStorage(NOTIFICATIONS, JSON.stringify(updatedNotifications));
+};
+
+export const getNotificationField = (key: string, fallback?: boolean) => {
+  const _notifications = JSON.parse(getStorage(NOTIFICATIONS));
+  return pathOr(fallback, [key], _notifications);
+};
+
+const NOTIFICATIONS = 'notifications';
 const THEME = 'themeChoice';
 const SPACING = 'spacingChoice';
 const PAGE_SIZE = 'PAGE_SIZE';
-const BETA_NOTIFICATION = 'BetaNotification';
-const VAT_NOTIFICATION = 'vatNotification';
 const LINODE_VIEW = 'linodesViewStyle';
 const GROUP_LINODES = 'GROUP_LINODES';
 const HIDE_DISPLAY_GROUPS_CTA = 'importDisplayGroupsCTA';
@@ -51,8 +65,6 @@ const EXPIRE = 'authentication/expire';
 type Theme = 'dark' | 'light';
 export type Spacing = 'compact' | 'normal';
 export type PageSize = number;
-type Beta = 'open' | 'closed';
-type Notification = 'show' | 'hide';
 type LinodeView = 'grid' | 'list';
 
 interface AuthGetAndSet {
@@ -85,14 +97,8 @@ export interface Storage {
     set: (perPage: PageSize) => void;
   };
   notifications: {
-    welcome: {
-      get: () => Beta;
-      set: (open: Beta) => void;
-    };
-    VAT: {
-      get: () => Notification;
-      set: (show: Notification) => void;
-    };
+    get: (field: string, fallback: boolean) => boolean | undefined;
+    set: (field: string, value: boolean) => void;
   };
   views: {
     linode: {
@@ -165,15 +171,9 @@ export const storage: Storage = {
     set: v => setStorage(PAGE_SIZE, `${v}`)
   },
   notifications: {
-    welcome: {
-      /** Leaving the LS key alone so it's not popping for those who've dismissed it. */
-      get: () => getStorage(BETA_NOTIFICATION, 'open'),
-      set: open => setStorage(BETA_NOTIFICATION, open)
-    },
-    VAT: {
-      get: () => getStorage(VAT_NOTIFICATION, 'show'),
-      set: show => setStorage(VAT_NOTIFICATION, show)
-    }
+    get: (field: string, fallback: boolean) =>
+      getNotificationField(field, fallback),
+    set: (field: string, value: boolean) => setNotificationField(field, value)
   },
   views: {
     linode: {


### PR DESCRIPTION
## Description

Combine some stuff in local storage.

## Note to Reviewers

Little hard to assess the effects on memory, my usage increased from 1.2K to 1.5K with this, but that's because the old values are still there. If you're curious, you can run this script to see what's in LS (courtesy of StackOverflow):

```
var _lsTotal=0,_xLen,_x;for(_x in localStorage){ if(!localStorage.hasOwnProperty(_x)){continue;} _xLen= ((localStorage[_x].length + _x.length)* 2);_lsTotal+=_xLen; console.log(_x.substr(0,50)+" = "+ (_xLen/1024).toFixed(2)+" KB")};console.log("Total = " + (_lsTotal / 1024).toFixed(2) + " KB");
```