### PR TITLE
Change: Include App Name in Reset and Delete OAuth App Modal

### DIFF
--- a/e2e/specs/profile/clients.spec.js
+++ b/e2e/specs/profile/clients.spec.js
@@ -111,7 +111,7 @@ describe('Profile - OAuth Clients Suite', () => {
             const actionMenuItems = $$('[data-qa-action-menu-item]')
                 .map(item => item.getAttribute('data-qa-action-menu-item'));
 
-            expect(actionMenuItems).toContain('Reset Secret');
+            expect(actionMenuItems).toMatch(/Reset/);
         });
 
         it('should display the reset dialog', () => {
@@ -123,8 +123,8 @@ describe('Profile - OAuth Clients Suite', () => {
 
             const title = $(dialogTitle).getText();
             const msg = $(dialogContent).getText();
-            expect(title).toBe('Confirm Reset');
-            expect(msg).toBe('Are you sure you want to permanently reset the secret for this app?');
+            expect(title).toMatch(/reset/i);
+            expect(msg).toMatch(/reset/i);
         });
 
         it('should close on cancel', () => {
@@ -156,12 +156,11 @@ describe('Profile - OAuth Clients Suite', () => {
             profile.selectActionMenu(editedClient.label, "Delete");
             browser.waitForVisible(dialogTitle);
             
-            const deleteMsg = 'Are you sure you want to permanently delete this app?';
             const dialogMsg = $(dialogContent).getText();
             deleteButton = $(dialogConfirm);
             cancelButton = $(dialogCancel);
             
-            expect(dialogMsg).toContain(deleteMsg);
+            expect(dialogMsg).toMatch(/delete/i);
             expect(deleteButton.isVisible()).toBe(true);
             expect(cancelButton.isVisible()).toBe(true);
         });

--- a/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
@@ -148,11 +148,13 @@ class OAuthClientActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
+    const { editPayload } = this.props;
+
     return (
       <React.Fragment>
         <ActionMenu createActions={this.createLinodeActions()} />
         <ConfirmationDialog
-          title="Confirm Delete"
+          title={`Delete ${editPayload.label}?`}
           open={this.state.confirmDeleteOpen}
           actions={this.deleteDialogActions}
           onClose={this.closeConfirmDelete}
@@ -162,7 +164,7 @@ class OAuthClientActionMenu extends React.Component<CombinedProps> {
           </Typography>
         </ConfirmationDialog>
         <ConfirmationDialog
-          title="Confirm Reset"
+          title={`Reset secret for ${editPayload.label}?`}
           open={this.state.confirmResetOpen}
           actions={this.resetDialogActions}
           onClose={this.closeConfirmReset}


### PR DESCRIPTION
## Description

Adds app name to both the delete and reset secret modal for OAuth Apps

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/profile/clients.spec.js --browser=headlessChrome`
