### PR TITLE
Fix: StackScripts Sorting Logic

### DIFF
--- a/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -269,6 +269,7 @@ const withStackScriptBase = (isSelecting: boolean) => (
 
       this.getDataAtPage(1, filterWithSearch, true);
       this.setState({
+        currentPage: 1,
         sortOrder: nextSortOrder,
         currentFilterType: filterInfo.currentFilter,
         currentFilter: {
@@ -453,9 +454,12 @@ const withStackScriptBase = (isSelecting: boolean) => (
                   onSearch={this.handleSearch}
                   className={classes.searchBar}
                   isSearching={isSearching}
-                  /** uncomment when we upgrade to MUI v3 */
-                  // toolTipText={`Hint: try searching for a specific item by prepending your
-                  // search term with "username:", "label:", or "description:"`}
+                  toolTipText={
+                    this.props.category === 'community'
+                      ? `Hint: try searching for a specific item by prepending your
+                  search term with "username:", "label:", or "description:"`
+                      : ''
+                  }
                 />
               </div>
               <Table


### PR DESCRIPTION
## Description

Previously there was an issue where if you

1. Navigated to stackscripts landing
2. Scrolled down to request a few pages of stackscripts
3. Sorted the table

The sort would start requesting StackScripts at the page you left off at, rather than resetting back to page 1.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A