### PR TITLE
Fix: Error Handling re: Linode Settings Panels

### DIFF
--- a/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -182,7 +182,6 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
   };
 
   handleCatch = (errors: Linode.ApiFieldError[]) => {
-    // @todo replace with LinodeAPIFieldError[] when/if we return that from services
     this.setState({
       errors,
       loading: false

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -18,6 +18,7 @@ import {
 } from 'src/store/linodes/linode.containers';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import AlertSection from './AlertSection';
 
 type ClassNames = 'root';
@@ -266,13 +267,16 @@ class LinodeSettingsAlertsPanel extends React.Component<CombinedProps, State> {
         );
       })
       .catch(error => {
-        this.setState({
-          submitting: false,
-          errors: getAPIErrorOrDefault(
-            error,
-            'Unable to update alerts thresholds.'
-          )
-        });
+        this.setState(
+          {
+            submitting: false,
+            errors: getAPIErrorOrDefault(
+              error,
+              'Unable to update alerts thresholds.'
+            )
+          },
+          () => scrollErrorIntoView()
+        );
       });
   };
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -34,6 +34,7 @@ interface Props {
 
 interface State {
   open: boolean;
+  errors?: Linode.ApiFieldError[];
 }
 
 type CombinedProps = Props &
@@ -58,13 +59,10 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
         resetEventsPolling();
         this.props.history.push('/linodes');
       })
-      .catch(error => {
-        this.setState(
-          set(lensPath(['errors']), error.response.data.errors),
-          () => {
-            scrollErrorIntoView();
-          }
-        );
+      .catch((error: Linode.ApiFieldError[]) => {
+        this.setState(set(lensPath(['errors']), error), () => {
+          scrollErrorIntoView();
+        });
       });
   };
 
@@ -78,6 +76,8 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
 
   render() {
     const { readOnly } = this.props;
+    const { errors } = this.state;
+
     return (
       <React.Fragment>
         <ExpansionPanel heading="Delete Linode">
@@ -100,6 +100,7 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
           actions={this.renderConfirmationActions}
           open={this.state.open}
           onClose={this.closeDeleteDialog}
+          error={errors ? errors[0].reason : undefined}
         >
           <Typography>
             Are you sure you want to delete your Linode? This will result in

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -85,10 +85,10 @@ class LinodeSettingsPasswordPanel extends React.Component<
           )
         );
       })
-      .catch(error => {
+      .catch((errors: Linode.ApiFieldError[]) => {
         this.setState(
           compose(
-            set(lensPath(['errors']), error.response.data.errors),
+            set(lensPath(['errors']), errors),
             set(lensPath(['submitting']), false)
           ),
           () => {

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -76,12 +76,7 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
         this.setState(
           compose(
             setSubmitting(false),
-            setErrors([
-              {
-                field: 'none',
-                reason: `Unable to ${value ? 'disable' : 'enable'} Watchdog.`
-              }
-            ])
+            setErrors(`Unable to ${value ? 'disable' : 'enable'} Watchdog.`)
           )
         );
       });
@@ -149,7 +144,7 @@ const L = {
 
 const setCurrentStatus = (v: boolean) => set(L.currentStatus, v);
 
-const setErrors = (v: Linode.ApiFieldError[]) => set(L.error, v);
+const setErrors = (v: string) => set(L.error, v);
 
 const setSubmitting = (v: boolean) => set(L.submitting, v);
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeWatchdogPanel.tsx
@@ -58,7 +58,11 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
     const {
       linodeActions: { updateLinode }
     } = this.props;
-    this.setState(setSubmitting(true));
+    this.setState({
+      submitting: true,
+      errors: undefined,
+      success: undefined
+    });
 
     updateLinode({ linodeId: this.props.linodeId, watchdog_enabled: value })
       .then(response => {
@@ -76,7 +80,7 @@ class LinodeWatchdogPanel extends React.Component<CombinedProps, State> {
         this.setState(
           compose(
             setSubmitting(false),
-            setErrors(`Unable to ${value ? 'disable' : 'enable'} Watchdog.`)
+            setErrors(`Unable to ${!value ? 'disable' : 'enable'} Watchdog.`)
           )
         );
       });


### PR DESCRIPTION
## Description

The `compose(lensPath)` logic was causing some incorrect behavior. Because they were not correctly typed, when we switched over to returning `Linode.ApiFieldError[]` for all `.catch`es, they were looking at the wrong property keys.

This also addresses recent Sentry errors

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A