### PR TITLE
Fix uncaught error in disks and configs requests

### DIFF
--- a/src/store/linodes/config/config.requests.ts
+++ b/src/store/linodes/config/config.requests.ts
@@ -79,6 +79,6 @@ export const getAllLinodeConfigs: ThunkActionCreator<Promise<Entity[]>> = (
     return data;
   } catch (error) {
     dispatch(failed({ params, error }));
-    throw error;
+    return error;
   }
 };

--- a/src/store/linodes/disk/disk.requests.ts
+++ b/src/store/linodes/disk/disk.requests.ts
@@ -79,7 +79,7 @@ export const getAllLinodeDisks: ThunkActionCreator<Promise<Entity[]>> = (
     return data;
   } catch (error) {
     dispatch(failed({ params, error }));
-    throw error;
+    return error;
   }
 };
 


### PR DESCRIPTION
## Description

In `getAllLinodeDisks` and `getAllLinodeConfigs`, we were throwing a new error inside the catch block, which was unhandled. This resulted in a Sentry error and a console error, though thankfully the app wasn't crashing.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Block request to `/disks`  and to `/configs` and go to Linode summary. This shouldn't result in any console errors, and no error should be reported to Sentry.