### PR TITLE
Fix: Error and Loading States for OAuth View

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # production
-/dist
-/build
+dist
+build
 
 # editor configuration
 .vscode

--- a/src/features/Profile/OAuthClients/Modals.tsx
+++ b/src/features/Profile/OAuthClients/Modals.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
+
+interface Props {
+  secretID?: string;
+  secret: string;
+  label: string;
+  modalErrors?: Linode.ApiFieldError[];
+  secretModalOpen: boolean;
+  deleteModalOpen: boolean;
+  secretSuccessOpen: boolean;
+  closeDialogs: () => void;
+  resetClient: (id?: string) => void;
+  deleteClient: (id?: string) => void;
+  isResetting: boolean;
+  isDeleting: boolean;
+}
+
+type CombinedProps = Props;
+
+const Modals: React.FC<CombinedProps> = props => {
+  const { modalErrors, label, resetClient, isResetting, closeDialogs } = props;
+
+  return (
+    <React.Fragment>
+      <ConfirmationDialog
+        title="Client Secret"
+        actions={clientSecretActions({
+          closeDialogs
+        })}
+        open={props.secretSuccessOpen}
+        onClose={props.closeDialogs}
+      >
+        <Typography variant="body1">
+          {`Here is your client secret! Store it securely, as it won't be shown again.`}
+        </Typography>
+        <Notice typeProps={{ variant: 'body1' }} warning text={props.secret} />
+      </ConfirmationDialog>
+
+      <ConfirmationDialog
+        error={modalErrors ? modalErrors[0].reason : undefined}
+        title={`Delete ${label}?`}
+        open={props.deleteModalOpen}
+        actions={deleteDialogActions({
+          loading: props.isDeleting,
+          deleteSecret: () => props.deleteClient(props.secretID),
+          closeDialogs
+        })}
+        onClose={props.closeDialogs}
+      >
+        <Typography>
+          Are you sure you want to permanently delete this app?
+        </Typography>
+      </ConfirmationDialog>
+
+      <ConfirmationDialog
+        error={modalErrors ? modalErrors[0].reason : undefined}
+        title={`Reset secret for ${label}?`}
+        open={props.secretModalOpen}
+        actions={resetDialogActions({
+          closeDialogs,
+          resetSecret: () => resetClient(props.secretID),
+          loading: isResetting
+        })}
+        onClose={props.closeDialogs}
+      >
+        <Typography>
+          Are you sure you want to permanently reset the secret for this app?
+        </Typography>
+      </ConfirmationDialog>
+    </React.Fragment>
+  );
+};
+
+export default compose<CombinedProps, Props>(React.memo)(Modals);
+
+interface ActionsProps {
+  resetSecret: () => void;
+  closeDialogs: () => void;
+  loading: boolean;
+}
+
+const resetDialogActions = ({
+  closeDialogs,
+  resetSecret,
+  loading
+}: ActionsProps) => {
+  return (
+    <React.Fragment>
+      <ActionsPanel>
+        <Button onClick={closeDialogs} type="cancel" data-qa-button-cancel>
+          Cancel
+        </Button>
+        <Button
+          destructive
+          type="secondary"
+          onClick={resetSecret}
+          data-qa-button-confirm
+          loading={loading}
+        >
+          Reset Secret
+        </Button>
+      </ActionsPanel>
+    </React.Fragment>
+  );
+};
+
+interface DeleteActionsProps {
+  deleteSecret: () => void;
+  closeDialogs: () => void;
+  loading: boolean;
+}
+
+const deleteDialogActions = ({
+  loading,
+  deleteSecret,
+  closeDialogs
+}: DeleteActionsProps) => {
+  return (
+    <React.Fragment>
+      <ActionsPanel>
+        <Button onClick={closeDialogs} type="cancel" data-qa-button-cancel>
+          Cancel
+        </Button>
+        <Button
+          destructive
+          type="secondary"
+          onClick={deleteSecret}
+          data-qa-button-confirm
+          loading={loading}
+        >
+          Delete
+        </Button>
+      </ActionsPanel>
+    </React.Fragment>
+  );
+};
+
+const clientSecretActions = (props: { closeDialogs: () => void }) => (
+  <Button type="primary" onClick={props.closeDialogs} data-qa-close-dialog>
+    Got it!
+  </Button>
+);

--- a/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
-  openSecretModal: (id: string) => void;
-  openDeleteModal: (id: string) => void;
+  openSecretModal: (id: string, label: string) => void;
+  openDeleteModal: (id: string, label: string) => void;
   openEditDrawer: (
     isPublic: boolean,
     redirectUri: string,
@@ -19,7 +19,7 @@ interface Props {
 type CombinedProps = Props;
 
 class OAuthClientActionMenu extends React.Component<CombinedProps> {
-  createLinodeActions = () => {
+  createActions = () => {
     const { label, redirectUri, isPublic, clientID } = this.props;
     return (closeMenu: Function): Action[] => {
       const actions = [
@@ -34,14 +34,14 @@ class OAuthClientActionMenu extends React.Component<CombinedProps> {
           title: 'Reset Secret',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             closeMenu();
-            this.props.openSecretModal(clientID);
+            this.props.openSecretModal(clientID, label);
           }
         },
         {
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             closeMenu();
-            this.props.openDeleteModal(clientID);
+            this.props.openDeleteModal(clientID, label);
           }
         }
       ];
@@ -51,7 +51,7 @@ class OAuthClientActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createLinodeActions()} />;
+    return <ActionMenu createActions={this.createActions()} />;
   }
 }
 

--- a/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
@@ -1,129 +1,32 @@
 import * as React from 'react';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
-import ActionsPanel from 'src/components/ActionsPanel';
-import Button from 'src/components/Button';
-import ConfirmationDialog from 'src/components/ConfirmationDialog';
-import Typography from 'src/components/core/Typography';
 
-interface EditPayload {
-  label: string;
-  redirect_uri: string;
-  isPublic: boolean;
-}
 interface Props {
-  id: string;
-  editPayload: EditPayload;
-  onDelete: (id: string) => void;
-  onReset: (id: string) => void;
-  onEdit: (
-    id: string,
+  openSecretModal: (id: string) => void;
+  openDeleteModal: (id: string) => void;
+  openEditDrawer: (
+    isPublic: boolean,
+    redirectUri: string,
     label: string,
-    redirect_uri: string,
-    isPublic: boolean
+    clientID?: string
   ) => void;
+  label: string;
+  redirectUri: string;
+  isPublic: boolean;
+  clientID: string;
 }
 
 type CombinedProps = Props;
 
 class OAuthClientActionMenu extends React.Component<CombinedProps> {
-  state = {
-    confirmDeleteOpen: false,
-    confirmResetOpen: false,
-    createDrawerOpen: false
-  };
-
-  handleDelete = () => {
-    const { id, onDelete } = this.props;
-    onDelete(id);
-  };
-
-  handleResetSecret = () => {
-    const { id, onReset } = this.props;
-    onReset(id);
-  };
-
-  handleEdit = () => {
-    const {
-      editPayload: { label, redirect_uri, isPublic },
-      id,
-      onEdit
-    } = this.props;
-    onEdit(id, label, redirect_uri, isPublic);
-  };
-
-  toggleConfirmDelete = (v: Boolean) => this.setState({ confirmDeleteOpen: v });
-  openConfirmDelete = () => this.toggleConfirmDelete(true);
-  closeConfirmDelete = () => this.toggleConfirmDelete(false);
-
-  onDeleteConfirm = () => {
-    this.toggleConfirmDelete(false);
-    this.handleDelete();
-  };
-
-  deleteDialogActions = () => {
-    return (
-      <React.Fragment>
-        <ActionsPanel>
-          <Button
-            onClick={this.closeConfirmDelete}
-            type="cancel"
-            data-qa-button-cancel
-          >
-            Cancel
-          </Button>
-          <Button
-            destructive
-            type="secondary"
-            onClick={this.onDeleteConfirm}
-            data-qa-button-confirm
-          >
-            Delete
-          </Button>
-        </ActionsPanel>
-      </React.Fragment>
-    );
-  };
-
-  toggleConfirmReset = (v: Boolean) => this.setState({ confirmResetOpen: v });
-  openConfirmReset = () => this.toggleConfirmReset(true);
-  closeConfirmReset = () => this.toggleConfirmReset(false);
-
-  onResetConfirm = () => {
-    this.toggleConfirmReset(false);
-    this.handleResetSecret();
-  };
-
-  resetDialogActions = () => {
-    return (
-      <React.Fragment>
-        <ActionsPanel>
-          <Button
-            onClick={this.closeConfirmReset}
-            type="cancel"
-            data-qa-button-cancel
-          >
-            Cancel
-          </Button>
-          <Button
-            destructive
-            type="secondary"
-            onClick={this.onResetConfirm}
-            data-qa-button-confirm
-          >
-            Reset Secret
-          </Button>
-        </ActionsPanel>
-      </React.Fragment>
-    );
-  };
-
   createLinodeActions = () => {
+    const { label, redirectUri, isPublic, clientID } = this.props;
     return (closeMenu: Function): Action[] => {
       const actions = [
         {
           title: 'Edit',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            this.handleEdit();
+            this.props.openEditDrawer(isPublic, redirectUri, label, clientID);
             closeMenu();
           }
         },
@@ -131,14 +34,14 @@ class OAuthClientActionMenu extends React.Component<CombinedProps> {
           title: 'Reset Secret',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             closeMenu();
-            this.toggleConfirmReset(true);
+            this.props.openSecretModal(clientID);
           }
         },
         {
           title: 'Delete',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             closeMenu();
-            this.toggleConfirmDelete(true);
+            this.props.openDeleteModal(clientID);
           }
         }
       ];
@@ -148,33 +51,7 @@ class OAuthClientActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    const { editPayload } = this.props;
-
-    return (
-      <React.Fragment>
-        <ActionMenu createActions={this.createLinodeActions()} />
-        <ConfirmationDialog
-          title={`Delete ${editPayload.label}?`}
-          open={this.state.confirmDeleteOpen}
-          actions={this.deleteDialogActions}
-          onClose={this.closeConfirmDelete}
-        >
-          <Typography>
-            Are you sure you want to permanently delete this app?
-          </Typography>
-        </ConfirmationDialog>
-        <ConfirmationDialog
-          title={`Reset secret for ${editPayload.label}?`}
-          open={this.state.confirmResetOpen}
-          actions={this.resetDialogActions}
-          onClose={this.closeConfirmReset}
-        >
-          <Typography>
-            Are you sure you want to permanently reset the secret for this app?
-          </Typography>
-        </ConfirmationDialog>
-      </React.Fragment>
-    );
+    return <ActionMenu createActions={this.createLinodeActions()} />;
   }
 }
 

--- a/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -1,8 +1,6 @@
-import { compose } from 'ramda';
 import * as React from 'react';
+import { compose } from 'recompose';
 import AddNewLink from 'src/components/AddNewLink';
-import Button from 'src/components/Button';
-import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
@@ -15,7 +13,6 @@ import Typography from 'src/components/core/Typography';
 import setDocs, { SetDocsProps } from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
-import Notice from 'src/components/Notice';
 import paginate, { PaginationProps } from 'src/components/Pagey';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
@@ -37,6 +34,8 @@ import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import ActionMenu from './OAuthClientActionMenu';
 import OAuthFormDrawer from './OAuthFormDrawer';
 
+import Modals from './Modals';
+
 type ClassNames = 'root' | 'title';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
@@ -48,55 +47,48 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 interface Props extends PaginationProps<Linode.OAuthClient> {}
 
-interface FormValues {
-  label: string;
-  redirect_uri: string;
-  public: boolean;
-}
-
-interface FormState {
-  edit: boolean;
-  open: boolean;
-  errors?: Linode.ApiFieldError[];
-  id?: string;
-  values: FormValues;
-}
-
-interface SecretState {
-  open: boolean;
-  value?: string;
-}
-
 interface State {
-  secret?: SecretState;
-  form: FormState;
+  secretModalOpen: boolean;
+  secretModalSuccessOpen: boolean;
+  secret: string;
+  clientLabel: string;
+  clientID?: string;
+  isPublic: boolean;
+  redirectUri: string;
+  deleteModalOpen: boolean;
+  modalErrors?: Linode.ApiFieldError[];
+  drawerOpen: boolean;
+  drawerIsInEditMode: boolean;
+  drawerErrors?: Linode.ApiFieldError[];
+  isResetting: boolean;
+  isDeleting: boolean;
+  drawerLoading: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames> & SetDocsProps;
 
 export class OAuthClients extends React.Component<CombinedProps, State> {
-  static defaultState = {
-    secret: {
-      open: false,
-      value: undefined
-    },
-    form: {
-      id: undefined,
-      open: false,
-      edit: false,
-      errors: undefined,
-      values: {
-        label: '',
-        redirect_uri: '',
-        public: false
-      }
-    }
+  defaultState: State = {
+    modalErrors: undefined,
+    deleteModalOpen: false,
+    secret: '',
+    clientLabel: '',
+    secretModalOpen: false,
+    secretModalSuccessOpen: false,
+    redirectUri: '',
+    isPublic: false,
+    drawerErrors: undefined,
+    drawerOpen: false,
+    drawerIsInEditMode: false,
+    isResetting: false,
+    isDeleting: false,
+    drawerLoading: false
   };
 
   mounted: boolean = false;
 
-  state = {
-    ...OAuthClients.defaultState
+  state: State = {
+    ...this.defaultState
   };
 
   static defaultProps = {
@@ -105,71 +97,116 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
 
   static docs = [LinodeAPI];
 
-  reset = () => {
-    this.setState({ ...OAuthClients.defaultState });
-  };
-
-  setForm = (fn: (v: FormState) => FormState): void => {
-    this.setState(
-      prevState => ({ ...prevState, form: fn(prevState.form) }),
-      () => {
-        scrollErrorIntoView();
-      }
-    );
-  };
-
-  deleteClient = (id: string) => {
-    deleteOAuthClient(id).then(() => this.props.onDelete());
-  };
-
-  resetSecret = (id: string) => {
-    resetOAuthClientSecret(id).then(({ secret }) => {
-      if (!this.mounted) {
-        return;
-      }
-
-      return this.setState({ secret: { open: true, value: secret } });
+  openSecretModal = (id: string) =>
+    this.setState({
+      secretModalOpen: true,
+      modalErrors: undefined,
+      clientID: id
     });
-  };
 
-  startEdit = (
-    id: string,
-    label: string,
-    redirectUri: string,
-    isPublic: boolean
+  openDeleteModal = (id: string) =>
+    this.setState({
+      deleteModalOpen: true,
+      modalErrors: undefined,
+      clientID: id
+    });
+
+  closeModals = () =>
+    this.setState({
+      deleteModalOpen: false,
+      secretModalOpen: false,
+      secretModalSuccessOpen: false
+    });
+
+  openDrawer = (isEditMode: boolean = false) => (
+    isPublic: boolean = false,
+    redirectUri: string = '',
+    label: string = '',
+    clientID?: string
   ) => {
     this.setState({
-      form: {
-        edit: true,
-        open: true,
-        id,
-        values: { label, redirect_uri: redirectUri, public: isPublic }
-      }
+      drawerOpen: true,
+      drawerErrors: undefined,
+      drawerIsInEditMode: isEditMode,
+      redirectUri,
+      clientLabel: label,
+      clientID,
+      isPublic
     });
   };
 
-  createClient = () => {
-    const {
-      form: { values }
-    } = this.state;
-    createOAuthClient(values)
-      .then(data => {
+  closeDrawer = () => this.setState({ drawerOpen: false });
+
+  deleteClient = (id?: string) => {
+    if (!id) {
+      return this.setState({
+        modalErrors: [
+          {
+            reason: 'Something went wrong.'
+          }
+        ]
+      });
+    }
+    this.setState({
+      modalErrors: undefined,
+      isDeleting: true
+    });
+    deleteOAuthClient(id)
+      .then(() => {
+        this.props.onDelete();
+        this.setState({ deleteModalOpen: false, isDeleting: false });
+      })
+      .catch((e: Linode.ApiFieldError[]) =>
+        this.setState({ modalErrors: e, isDeleting: false })
+      );
+  };
+
+  resetSecret = (id?: string) => {
+    if (!id) {
+      return this.setState({
+        modalErrors: [
+          {
+            reason: 'Something went wrong.'
+          }
+        ]
+      });
+    }
+
+    this.setState({
+      modalErrors: undefined,
+      isResetting: true
+    });
+    resetOAuthClientSecret(id)
+      .then(({ secret }) => {
         if (!this.mounted) {
           return;
         }
 
         return this.setState({
-          secret: { value: data.secret, open: true },
-          form: {
-            open: false,
-            edit: false,
-            values: {
-              label: '',
-              redirect_uri: '',
-              public: false
-            }
-          }
+          secret,
+          secretModalSuccessOpen: true,
+          isResetting: false
         });
+      })
+      .catch((e: Linode.ApiFieldError[]) => {
+        this.setState({ modalErrors: e, isResetting: false });
+      });
+  };
+
+  createClient = () => {
+    this.setState({
+      drawerLoading: true
+    });
+
+    createOAuthClient({
+      label: this.state.clientLabel,
+      redirect_uri: this.state.redirectUri
+    })
+      .then(data => {
+        if (!this.mounted) {
+          return;
+        }
+        return this.setState({ ...this.defaultState });
       })
       .then(data => {
         if (!this.mounted) {
@@ -182,39 +219,57 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
         if (!this.mounted) {
           return;
         }
-
-        this.setForm(form => ({
-          ...form,
-          errors: getAPIErrorOrDefault(errResponse)
-        }));
+        this.setState(
+          {
+            drawerErrors: getAPIErrorOrDefault(
+              errResponse,
+              'There was an error creating this OAuth Client.'
+            ),
+            drawerLoading: false
+          },
+          () => scrollErrorIntoView()
+        );
       });
   };
 
   editClient = () => {
-    const {
-      form: { id, values }
-    } = this.state;
-    if (!id) {
-      return;
+    const { clientID, redirectUri, clientLabel } = this.state;
+
+    if (!clientID || !redirectUri || !clientLabel) {
+      return this.setState({
+        drawerErrors: [
+          {
+            reason: 'Something went wrong.'
+          }
+        ]
+      });
     }
 
-    updateOAuthClient(id, values)
+    this.setState({ drawerLoading: true });
+
+    updateOAuthClient(clientID, {
+      label: clientLabel,
+      redirect_uri: redirectUri
+    })
       .then(_ => {
-        this.reset();
+        this.setState({ ...this.defaultState });
       })
       .then(_ => {
         this.props.request();
       })
       .catch(errResponse => {
-        this.setForm(form => ({
-          ...form,
-          errors: getAPIErrorOrDefault(errResponse)
-        }));
+        this.setState(
+          {
+            drawerErrors: getAPIErrorOrDefault(
+              errResponse,
+              'Your OAuth App could not be updated.'
+            ),
+            drawerLoading: false
+          },
+          () => scrollErrorIntoView()
+        );
       });
   };
-
-  toggleCreateDrawer = (v: boolean) =>
-    this.setForm(form => ({ ...form, open: v }));
 
   renderContent = () => {
     const { data, error, loading } = this.props;
@@ -256,15 +311,16 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
         </TableCell>
         <TableCell>
           <ActionMenu
-            id={id}
-            editPayload={{
-              label,
-              redirect_uri,
-              isPublic
-            }}
-            onDelete={this.deleteClient}
-            onReset={this.resetSecret}
-            onEdit={this.startEdit}
+            openSecretModal={this.openSecretModal}
+            openDeleteModal={this.openDeleteModal}
+            openEditDrawer={this.openDrawer(true)}
+            label={label}
+            isPublic={isPublic}
+            redirectUri={redirect_uri}
+            /*
+             we can assume this is defined because we're doing null checking in renderContent() 
+            */
+            clientID={id}
           />
         </TableCell>
       </TableRow>
@@ -279,8 +335,6 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
   componentWillUnmount() {
     this.mounted = false;
   }
-
-  openCreateDrawer = () => this.toggleCreateDrawer(true);
 
   render() {
     const { classes } = this.props;
@@ -302,7 +356,7 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
           </Grid>
           <Grid item>
             <AddNewLink
-              onClick={this.openCreateDrawer}
+              onClick={() => this.openDrawer()(false)}
               label="Create OAuth App"
               data-qa-oauth-create
             />
@@ -323,34 +377,36 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
           </Table>
         </Paper>
 
-        <ConfirmationDialog
-          title="Client Secret"
-          actions={this.renderClientSecretActions}
-          open={this.state.secret.open}
-          onClose={this.reset}
-        >
-          <Typography variant="body1">
-            {`Here is your client secret! Store it securely, as it won't be shown again.`}
-          </Typography>
-          <Notice
-            typeProps={{ variant: 'body1' }}
-            warning
-            text={this.state.secret.value!}
-          />
-        </ConfirmationDialog>
+        <Modals
+          deleteModalOpen={this.state.deleteModalOpen}
+          secretModalOpen={this.state.secretModalOpen}
+          secretSuccessOpen={this.state.secretModalSuccessOpen}
+          resetClient={this.resetSecret}
+          closeDialogs={this.closeModals}
+          secret={this.state.secret}
+          secretID={this.state.clientID}
+          label={this.state.clientLabel}
+          isDeleting={this.state.isDeleting}
+          isResetting={this.state.isResetting}
+          deleteClient={this.deleteClient}
+          modalErrors={this.state.modalErrors}
+        />
 
         <OAuthFormDrawer
-          edit={this.state.form.edit}
-          open={this.state.form.open}
-          errors={this.state.form.errors}
-          public={this.state.form.values.public}
-          label={this.state.form.values.label}
-          redirect_uri={this.state.form.values.redirect_uri}
-          onClose={this.reset}
+          edit={this.state.drawerIsInEditMode}
+          open={this.state.drawerOpen}
+          errors={this.state.drawerErrors}
+          public={this.state.isPublic}
+          label={this.state.clientLabel}
+          redirect_uri={this.state.redirectUri}
+          onClose={this.closeDrawer}
+          loading={this.state.drawerLoading}
           onChangeLabel={this.handleChangeLabel}
           onChangeRedirectURI={this.handleChangeRedirectURI}
           onChangePublic={this.handleChangePublic}
-          onSubmit={this.state.form.edit ? this.editClient : this.createClient}
+          onSubmit={
+            this.state.drawerIsInEditMode ? this.editClient : this.createClient
+          }
         />
 
         <PaginationFooter
@@ -365,46 +421,17 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
     );
   }
 
-  onChange = (key: string, value: any) =>
-    this.setForm(form => ({
-      ...form,
-      values: { ...form.values, [key]: value }
-    }));
-
   handleChangeLabel = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState(this.createNewFormState('label', e.target.value));
+    this.setState({ clientLabel: e.target.value });
   };
 
   handleChangeRedirectURI = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState(this.createNewFormState('redirect_uri', e.target.value));
+    this.setState({ redirectUri: e.target.value });
   };
 
   handleChangePublic = () => {
-    this.setState(
-      this.createNewFormState('public', !this.state.form.values.public)
-    );
+    this.setState({ isPublic: !this.state.isPublic });
   };
-
-  createNewFormState = (
-    newState: keyof FormValues,
-    newValue: string | boolean
-  ) => {
-    return {
-      form: {
-        ...this.state.form,
-        values: {
-          ...this.state.form.values,
-          [newState]: newValue
-        }
-      }
-    };
-  };
-
-  renderClientSecretActions = () => (
-    <Button type="primary" onClick={this.reset} data-qa-close-dialog>
-      Got it!
-    </Button>
-  );
 }
 
 const styled = withStyles(styles);
@@ -414,7 +441,7 @@ const updatedRequest = (ownProps: any, params: any, filters: any) =>
 
 const paginated = paginate(updatedRequest);
 
-const enhanced = compose<any, any, any, any>(
+const enhanced = compose<CombinedProps, Props>(
   styled,
   paginated,
   setDocs(OAuthClients.docs)

--- a/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -97,18 +97,20 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
 
   static docs = [LinodeAPI];
 
-  openSecretModal = (id: string) =>
+  openSecretModal = (id: string, label: string) =>
     this.setState({
       secretModalOpen: true,
       modalErrors: undefined,
+      clientLabel: label,
       clientID: id
     });
 
-  openDeleteModal = (id: string) =>
+  openDeleteModal = (id: string, label: string) =>
     this.setState({
       deleteModalOpen: true,
       modalErrors: undefined,
-      clientID: id
+      clientID: id,
+      clientLabel: label
     });
 
   closeModals = () =>

--- a/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
+++ b/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
@@ -10,6 +10,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
+import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 
@@ -21,10 +22,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 interface Props {
   open: boolean;
+  loading: boolean;
   label?: string;
   redirect_uri?: string;
   public: boolean;
-  errors?: { field: string; reason: string }[];
+  errors?: Linode.ApiFieldError[];
   edit?: boolean;
   onClose: () => void;
   onSubmit: () => void;
@@ -43,6 +45,7 @@ const OAuthCreationDrawer: React.StatelessComponent<CombinedProps> = props => {
     public: isPublic,
     edit,
     errors,
+    loading,
     onClose,
     onSubmit
   } = props;
@@ -60,6 +63,7 @@ const OAuthCreationDrawer: React.StatelessComponent<CombinedProps> = props => {
       open={open}
       onClose={onClose}
     >
+      {hasErrorFor('none') && <Notice text={hasErrorFor('none')} error />}
       <TextField
         value={label || ''}
         errorText={hasErrorFor('label')}
@@ -88,7 +92,12 @@ const OAuthCreationDrawer: React.StatelessComponent<CombinedProps> = props => {
         />
       </FormControl>
       <ActionsPanel>
-        <Button type="primary" onClick={onSubmit} data-qa-submit>
+        <Button
+          type="primary"
+          onClick={onSubmit}
+          loading={loading}
+          data-qa-submit
+        >
           Submit
         </Button>
         <Button

--- a/src/services/account/oauth.ts
+++ b/src/services/account/oauth.ts
@@ -89,7 +89,7 @@ export const resetOAuthClientSecret = (clientId: number | string) =>
  * @param clientId { number } the ID of the client to be updated
  */
 export const updateOAuthClient = (
-  clientId: number,
+  clientId: string,
   data: Partial<OAuthClientRequest>
 ) =>
   Request<OAuthClient>(


### PR DESCRIPTION
## Description

Adds loading and error state for both the OAuth Dialogs and Drawer

Sorry I went a bit overboard with the refactoring. This code was ugly. 2 Dialogs were being rendered for every table row 😢 

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A