### PR TITLE
M3-2831 Change data transfer pool circle to be a progress bar

### DIFF
--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -142,15 +142,10 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
                 max={100}
                 value={Math.ceil(poolUsagePct)}
                 className={classes.poolUsageProgress}
-              >
-                <span className={classes.circleChildren}>
-                  <Typography className={classes.used} data-qa-transfer-used>
-                    {renderPercentageString(poolUsagePct)}
-                  </Typography>
-                </span>
-              </BarPercent>
+              />
               <Typography>
-                You have used {renderPercentageString(poolUsagePct)} of your
+                You have used{' '}
+                <strong>{renderPercentageString(poolUsagePct)}</strong> of your
                 available network transfer during the current billing cycle.
               </Typography>
               <Divider className={classes.divider} />

--- a/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import BarPercent from 'src/components/BarPercent';
 import CircleProgress from 'src/components/CircleProgress';
 import Divider from 'src/components/core/Divider';
 import Paper from 'src/components/core/Paper';
@@ -38,33 +39,12 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     }
   },
   grid: {
-    flexWrap: 'wrap',
-    flexDirection: 'column',
-    textAlign: 'center',
-    alignItems: 'center',
-    [theme.breakpoints.up('sm')]: {
-      flexWrap: 'nowrap',
-      flexDirection: 'row',
-      textAlign: 'left'
-    },
-    [theme.breakpoints.up('md')]: {
-      flexWrap: 'wrap',
-      flexDirection: 'column',
-      textAlign: 'center'
-    },
-    [theme.breakpoints.up('lg')]: {
-      flexDirection: 'row',
-      flexWrap: 'nowrap',
-      textAlign: 'left'
-    }
+    paddingLeft: 8,
+    paddingRight: 8
   },
   poolUsageProgress: {
-    margin: 0,
-    height: 'auto',
-    [theme.breakpoints.up('lg')]: {
-      margin: '8px auto',
-      paddingRight: theme.spacing.unit * 2
-    }
+    marginBottom: theme.spacing.unit * 2,
+    [theme.breakpoints.up('lg')]: {}
   },
   circleChildren: {
     textAlign: 'center',
@@ -151,17 +131,15 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
         <Paper className={classes.root}>
           <Grid
             container
-            direction="column"
-            justify="center"
-            wrap="nowrap"
             className={classes.grid}
             data-qa-card="Monthly Transfer"
           >
-            <Grid item>
-              <CircleProgress
-                variant="static"
-                noTopMargin
-                green
+            <Grid item container direction="column">
+              <Typography variant="h2" className={classes.title}>
+                This Month's Network Transfer Pool
+              </Typography>
+              <BarPercent
+                max={100}
                 value={Math.ceil(poolUsagePct)}
                 className={classes.poolUsageProgress}
               >
@@ -170,12 +148,7 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
                     {renderPercentageString(poolUsagePct)}
                   </Typography>
                 </span>
-              </CircleProgress>
-            </Grid>
-            <Grid item container direction="column">
-              <Typography variant="h2" className={classes.title}>
-                This Month's Network Transfer Pool
-              </Typography>
+              </BarPercent>
               <Typography>
                 You have used {renderPercentageString(poolUsagePct)} of your
                 available network transfer during the current billing cycle.

--- a/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
@@ -2,6 +2,7 @@ import * as moment from 'moment';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'recompose';
+import BarPercent from 'src/components/BarPercent';
 import CircleProgress from 'src/components/CircleProgress';
 import Divider from 'src/components/core/Divider';
 import { WithStyles } from 'src/components/core/styles';
@@ -119,26 +120,14 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
     return (
       <Grid container>
         <Grid item xs={12}>
-          <Typography align="center" variant="h2">
-            Monthly Network Transfer
-          </Typography>
+          <Typography variant="h3">Monthly Network Transfer</Typography>
         </Grid>
-        <Grid item xs={6} sm={3} md={12}>
-          <CircleProgress
-            variant="static"
-            noTopMargin
-            green
+        <Grid item xs={12}>
+          <BarPercent
+            max={100}
             value={Math.ceil(usagePercent)}
             className={classes.poolUsageProgress}
-          >
-            <span className={classes.circleChildren}>
-              <Typography className={classes.used} data-qa-transfer-used>
-                {renderPercentageString(usagePercent)}
-              </Typography>
-            </span>
-          </CircleProgress>
-        </Grid>
-        <Grid item xs={6} sm={9} md={12}>
+          />
           <Typography>
             You have used{' '}
             <strong>{renderPercentageString(usagePercent)}</strong> of your


### PR DESCRIPTION
## Change data transfer pool circle to be a progress bar

## Type of Change
- Non breaking change ('update')

<img width="1062" alt="Screen Shot 2019-05-22 at 4 05 47 PM" src="https://user-images.githubusercontent.com/205353/58205998-d23e5e80-7cad-11e9-9fb0-44aa48218130.png">
<img width="1049" alt="Screen Shot 2019-05-22 at 4 05 30 PM" src="https://user-images.githubusercontent.com/205353/58206000-d2d6f500-7cad-11e9-9bfc-242703f5e7d5.png">
