### PR TITLE
Add: Ability to Optionally Resize Disks after Linode Resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # production
 dist
 build
+packages
 
 # editor configuration
 .vscode

--- a/src/__data__/disks.ts
+++ b/src/__data__/disks.ts
@@ -1,20 +1,21 @@
-export const disks: Linode.Disk[] = [
-  {
-    updated: '2018-07-05T18:16:08',
-    label: 'Arch Linux Disk',
-    created: '2018-07-05T18:15:43',
-    filesystem: 'ext4',
-    status: 'ready',
-    size: 25088,
-    id: 19040623
-  },
-  {
-    updated: '2018-07-05T18:16:09',
-    label: '512 MB Swap Image',
-    created: '2018-07-05T18:15:43',
-    filesystem: 'swap',
-    status: 'ready',
-    size: 512,
-    id: 19040624
-  }
-];
+export const extDisk: Linode.Disk = {
+  updated: '2018-07-05T18:16:08',
+  label: 'Arch Linux Disk',
+  created: '2018-07-05T18:15:43',
+  filesystem: 'ext4',
+  status: 'ready',
+  size: 25088,
+  id: 19040623
+};
+
+export const swapDisk: Linode.Disk = {
+  updated: '2018-07-05T18:16:09',
+  label: '512 MB Swap Image',
+  created: '2018-07-05T18:15:43',
+  filesystem: 'swap',
+  status: 'ready',
+  size: 512,
+  id: 19040624
+};
+
+export const disks = [extDisk, swapDisk];

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -9,6 +9,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import HelpIcon from 'src/components/HelpIcon';
 
 type CSSClasses = 'root' | 'checked' | 'disabled' | 'warning' | 'error';
 
@@ -67,13 +68,14 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
 
 interface Props extends CheckboxProps {
   variant?: 'warning' | 'error';
-  text?: string;
+  text?: string | JSX.Element;
+  toolTipText?: string;
 }
 
 type FinalProps = Props & WithStyles<CSSClasses>;
 
 const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
-  const { classes, ...rest } = props;
+  const { toolTipText, text, classes, ...rest } = props;
 
   const classnames = classNames({
     [classes.root]: true,
@@ -85,19 +87,22 @@ const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
 
   if (props.text) {
     return (
-      <FormControlLabel
-        control={
-          <Checkbox
-            color="primary"
-            className={classnames}
-            icon={<CheckboxIcon />}
-            checkedIcon={<CheckboxCheckedIcon />}
-            data-qa-checked={props.checked}
-            {...rest}
-          />
-        }
-        label={props.text}
-      />
+      <React.Fragment>
+        <FormControlLabel
+          control={
+            <Checkbox
+              color="primary"
+              className={classnames}
+              icon={<CheckboxIcon />}
+              checkedIcon={<CheckboxCheckedIcon />}
+              data-qa-checked={props.checked}
+              {...rest}
+            />
+          }
+          label={props.text}
+        />
+        {toolTipText && <HelpIcon text={toolTipText} />}
+      </React.Fragment>
     );
   }
 

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import CheckboxIcon from 'src/assets/icons/checkbox.svg';
 import CheckboxCheckedIcon from 'src/assets/icons/checkboxChecked.svg';
 import Checkbox, { CheckboxProps } from 'src/components/core/Checkbox';
+import FormControlLabel from 'src/components/core/FormControlLabel';
 import {
   StyleRulesCallback,
   withStyles,
@@ -66,6 +67,7 @@ const styles: StyleRulesCallback<CSSClasses> = theme => ({
 
 interface Props extends CheckboxProps {
   variant?: 'warning' | 'error';
+  text?: string;
 }
 
 type FinalProps = Props & WithStyles<CSSClasses>;
@@ -80,6 +82,24 @@ const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
     [classes.warning]: props.variant === 'warning',
     [classes.error]: props.variant === 'error'
   });
+
+  if (props.text) {
+    return (
+      <FormControlLabel
+        control={
+          <Checkbox
+            color="primary"
+            className={classnames}
+            icon={<CheckboxIcon />}
+            checkedIcon={<CheckboxCheckedIcon />}
+            data-qa-checked={props.checked}
+            {...rest}
+          />
+        }
+        label={props.text}
+      />
+    );
+  }
 
   return (
     <Checkbox

--- a/src/components/Notice/Notice.stories.tsx
+++ b/src/components/Notice/Notice.stories.tsx
@@ -15,7 +15,7 @@ storiesOf('Notice', module).add('All Notices', () => (
         warning
         text="This is a dismissible Notice"
         dismissible
-        onClose={() => console.log('Dismissed!')}
+        onClose={() => null}
       />
     </div>
   </React.Fragment>

--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -1,9 +1,10 @@
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
+import { extDisk, swapDisk } from 'src/__data__/disks';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { types } from 'src/__data__/types';
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
-import { LinodeResize } from './LinodeResize';
+import { LinodeResize, shouldEnableAutoResizeDiskOption } from './LinodeResize';
 
 describe('LinodeResize', () => {
   const mockTypes = types.map(LinodeResize.extendType);
@@ -143,5 +144,41 @@ describe('LinodeResize', () => {
     component.setState({ selectedId: '' });
     const submitBtn = component.find('[data-qa-submit]');
     expect(submitBtn.prop('disabled')).toBeTruthy();
+  });
+
+  describe('utility functions', () => {
+    it('should allow for resizing disk with one ext disk with label "Arch Linux Disk"', () => {
+      const [diskLabel, shouldEnable] = shouldEnableAutoResizeDiskOption([
+        extDisk
+      ]);
+      expect(diskLabel).toBe('Arch Linux Disk');
+      expect(shouldEnable).toBeTruthy();
+    });
+
+    it('should not allow resizing disk with only one swap disk', () => {
+      const [diskLabel, shouldEnable] = shouldEnableAutoResizeDiskOption([
+        swapDisk
+      ]);
+      expect(diskLabel).toBe(undefined);
+      expect(shouldEnable).toBeFalsy();
+    });
+
+    it('should allow for resizing with one swap and one ext disk', () => {
+      const [diskLabel, shouldEnable] = shouldEnableAutoResizeDiskOption([
+        extDisk,
+        swapDisk
+      ]);
+      expect(diskLabel).toBe('Arch Linux Disk');
+      expect(shouldEnable).toBeTruthy();
+    });
+
+    it('should not allow resizing disk with more than one ext disk', () => {
+      const [diskLabel, shouldEnable] = shouldEnableAutoResizeDiskOption([
+        extDisk,
+        extDisk
+      ]);
+      expect(diskLabel).toBe('Arch Linux Disk');
+      expect(shouldEnable).toBeFalsy();
+    });
   });
 });

--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -11,6 +11,7 @@ describe('LinodeResize', () => {
   const component = shallow(
     <LinodeResize
       closeSnackbar={jest.fn()}
+      linodeDisks={[]}
       enqueueSnackbar={jest.fn()}
       requestNotifications={jest.fn()}
       {...reactRouterProps}
@@ -32,6 +33,7 @@ describe('LinodeResize', () => {
     const componentWithTheme = mount(
       <LinodeThemeWrapper>
         <LinodeResize
+          linodeDisks={[]}
           closeSnackbar={jest.fn()}
           enqueueSnackbar={jest.fn()}
           requestNotifications={jest.fn()}
@@ -68,6 +70,7 @@ describe('LinodeResize', () => {
               closeSnackbar={jest.fn()}
               enqueueSnackbar={jest.fn()}
               requestNotifications={jest.fn()}
+              linodeDisks={[]}
               {...reactRouterProps}
               classes={{
                 root: '',
@@ -101,6 +104,7 @@ describe('LinodeResize', () => {
           <LinodeThemeWrapper>
             <LinodeResize
               closeSnackbar={jest.fn()}
+              linodeDisks={[]}
               enqueueSnackbar={jest.fn()}
               requestNotifications={jest.fn()}
               {...reactRouterProps}

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -27,12 +27,22 @@ import { withNotifications } from 'src/store/notification/notification.container
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import LinodePermissionsError from '../LinodePermissionsError';
 
-type ClassNames = 'root' | 'title' | 'subTitle' | 'currentPlanContainer';
+import Checkbox from 'src/components/CheckBox';
+
+type ClassNames =
+  | 'root'
+  | 'title'
+  | 'subTitle'
+  | 'currentPlanContainer'
+  | 'checkbox';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
     padding: theme.spacing.unit * 3,
     paddingBottom: theme.spacing.unit * 2
+  },
+  checkbox: {
+    marginTop: theme.spacing.unit * 3
   },
   title: {
     marginBottom: theme.spacing.unit * 2
@@ -65,6 +75,7 @@ interface State {
   selectedId: string;
   isLoading: boolean;
   errors?: Linode.ApiFieldError[];
+  autoDiskResize: boolean;
 }
 
 interface NotificationProps {
@@ -81,7 +92,8 @@ type CombinedProps = WithTypesProps &
 export class LinodeResize extends React.Component<CombinedProps, State> {
   state: State = {
     selectedId: '',
-    isLoading: false
+    isLoading: false,
+    autoDiskResize: true
   };
 
   static extendType = (type: Linode.LinodeType): ExtendedType => {
@@ -118,7 +130,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
 
     this.setState({ isLoading: true });
 
-    resizeLinode(linodeId, selectedId)
+    resizeLinode(linodeId, selectedId, this.state.autoDiskResize)
       .then(_ => {
         this.setState({ selectedId: '', isLoading: false });
         resetEventsPolling();
@@ -143,6 +155,10 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
 
   handleSelectPlan = (id: string) => {
     this.setState({ selectedId: id });
+  };
+
+  handleToggleAutoDisksResize = () => {
+    this.setState({ autoDiskResize: !this.state.autoDiskResize });
   };
 
   render() {
@@ -222,6 +238,17 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
           selectedID={this.state.selectedId}
           disabled={disabled}
         />
+        <Paper className={`${classes.checkbox} ${classes.root}`}>
+          <Typography variant="h2" className={classes.title}>
+            Auto Resize Disks
+          </Typography>
+          <Checkbox
+            checked={this.state.autoDiskResize}
+            onChange={this.handleToggleAutoDisksResize}
+            text={`Would you like the disks on this Linode automatically resized to
+            scale with the Linode's new size? We recommend you keep this enabled.`}
+          />
+        </Paper>
         <ActionsPanel>
           <Button
             disabled={

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -274,7 +274,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
         />
         <Paper className={`${classes.checkbox} ${classes.root}`}>
           <Typography variant="h2" className={classes.title}>
-            Auto Resize Disks
+            Auto Resize Disk
             {!shouldEnableAutoResizeDiskOption && (
               <HelpIcon
                 className={classes.toolTip}

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -294,13 +294,13 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
             text={
               !shouldEnableAutoResizeDiskOption ? (
                 `Would you like your disk on this Linode automatically resized to
-            scale with this Linode's new size? We recommend you keep this enabled.`
+            scale with this Linode's new size? We recommend you keep this option enabled.`
               ) : (
                 <Typography>
                   Would you like the disk{' '}
                   <strong>{linodeExtDiskLabels[0]}</strong> to be automatically
                   scaled with this Linode's new size? We recommend you keep this
-                  enabled
+                  option enabled.
                 </Typography>
               )
             }

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -278,7 +278,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
             {!shouldEnableAutoResizeDiskOption && (
               <HelpIcon
                 className={classes.toolTip}
-                text={`Your disks can only be automatically resized if you have one ext
+                text={`Your disk can only be automatically resized if you have one ext
                 disk or one ext disk and one swap disk.`}
               />
             )}

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -278,8 +278,8 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
             {!shouldEnableAutoResizeDiskOption && (
               <HelpIcon
                 className={classes.toolTip}
-                text={`Your disk can only be automatically resized if you have one ext
-                disk or one ext disk and one swap disk.`}
+                text={`Your ext disk can only be automatically resized if you have one ext
+                disk or one ext disk and one swap disk on this Linode.`}
               />
             )}
           </Typography>

--- a/src/services/linodes/linodeActions.ts
+++ b/src/services/linodes/linodeActions.ts
@@ -98,7 +98,8 @@ export const linodeShutdown = (linodeId: number | string) =>
  * @param linodeId { number } The id of the Linode to resize.
  * @param type { string } the new size of the Linode
  * @param auto_resize_linode { boolean } do you want to resize your disks after
- * the Linode is resized?
+ * the Linode is resized? NOTE: Unless the user has 1 ext disk or 1 ext disk and
+ * 1 swap disk, this flag does nothing, regardless of whether it's true or false
  */
 export const resizeLinode = (
   linodeId: number,

--- a/src/services/linodes/linodeActions.ts
+++ b/src/services/linodes/linodeActions.ts
@@ -104,14 +104,14 @@ export const linodeShutdown = (linodeId: number | string) =>
 export const resizeLinode = (
   linodeId: number,
   type: string,
-  allow_auto_disk_linode: boolean = true
+  allow_auto_disk_resize: boolean = true
 ) =>
   Request<{}>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/resize`),
     setMethod('POST'),
     setData({
       type,
-      allow_auto_disk_linode
+      allow_auto_disk_resize
     })
   );
 

--- a/src/services/linodes/linodeActions.ts
+++ b/src/services/linodes/linodeActions.ts
@@ -97,12 +97,21 @@ export const linodeShutdown = (linodeId: number | string) =>
  *
  * @param linodeId { number } The id of the Linode to resize.
  * @param type { string } the new size of the Linode
+ * @param auto_resize_linode { boolean } do you want to resize your disks after
+ * the Linode is resized?
  */
-export const resizeLinode = (linodeId: number, type: string) =>
+export const resizeLinode = (
+  linodeId: number,
+  type: string,
+  allow_auto_disk_linode: boolean = true
+) =>
   Request<{}>(
     setURL(`${API_ROOT}/linode/instances/${linodeId}/resize`),
     setMethod('POST'),
-    setData({ type })
+    setData({
+      type,
+      allow_auto_disk_linode
+    })
   );
 
 /**


### PR DESCRIPTION
## Description

Adds the ability to toggle choice to automatically resize disks after the Linode resize is finished.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## Note to Reviewers

As per @rmcintosh, the conditions for showing this toggle should be

1. If the user has 1 ext disk (and nothing else)
2. If the user has 1 ext disk and 1 swap disk (and nothing else)