### PR TITLE
M3-2799 Fix Linode list layout tablet size layout

### DIFF
--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -34,8 +34,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   data: {
     [theme.breakpoints.down('sm')]: {
       textAlign: 'right',
-      width: '100%',
       marginLeft: theme.spacing.unit * 3
+    },
+    [theme.breakpoints.down('xs')]: {
+      width: '100%'
     }
   },
   compact: {

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -38,9 +38,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     paddingTop: theme.spacing.unit / 4
   },
   root: {
-    width: '40%',
     '& h3': {
       transition: theme.transitions.create(['color'])
+    },
+    [theme.breakpoints.up('lg')]: {
+      width: '40%'
     },
     [theme.breakpoints.up('xl')]: {
       width: '35%'


### PR DESCRIPTION
## Description

Adjustments for the Linode list layout on tablet size. Entity title width was off and the details labels were getting scrunched up. 

## Type of Change
- Non breaking change ('update', 'change')
