### PR TITLE
fix: add patches and remove extraneous yarn install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,10 @@ FROM node:8.11.2-stretch
 
 WORKDIR /src
 
-RUN apt-get update
-RUN apt-get install -y apt-transport-https ca-certificates
-RUN curl -o- -L https://yarnpkg.com/install.sh | bash
-RUN $HOME/.yarn/bin/yarn install
-
 # Install Deps
 COPY package.json .
 COPY yarn.lock .
+COPY patches patches
 
 RUN yarn
 


### PR DESCRIPTION
## Description

The patches were not being installed in the Docker container. This resolves that issue.

This also removes an extraneous call to install Yarn, since Yarn is already installed by default in `node` docker images.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
- Non breaking change ('update', 'change')