### PR TITLE
Fix: Show all Line Items on Invoice PDF and Detail Screen

### DIFF
--- a/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesPanel.tsx
+++ b/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesPanel.tsx
@@ -1,17 +1,9 @@
-import { compose } from 'ramda';
+import { compose, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import {
-  StyleRulesCallback,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
-import Currency from 'src/components/Currency';
-import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import ExpansionPanel from 'src/components/ExpansionPanel';
-import Notice from 'src/components/Notice';
 import paginate, { PaginationProps } from 'src/components/Pagey';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
@@ -20,54 +12,28 @@ import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
-import { printInvoice } from 'src/features/Billing/PdfGenerator/PdfGenerator';
-import createMailto from 'src/features/Footer/createMailto';
-import { getInvoiceItems, getInvoices } from 'src/services/account';
+import { getInvoices } from 'src/services/account';
 import { ApplicationState } from 'src/store';
 import { requestAccount } from 'src/store/account/account.requests';
 import { ThunkDispatch } from 'src/store/types';
 
-type ClassNames = 'root';
+import RecentInvoiceRow from './RecentInvoicesRow';
 
-const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {}
-});
-
-interface Props extends PaginationProps<Linode.Invoice> {}
-
-type CombinedProps = Props & WithStyles<ClassNames> & StateProps;
-
-interface PdfGenerationError {
-  itemId: number | undefined;
-  error?: any;
-}
+type CombinedProps = PaginationProps<Linode.Invoice> & StateProps;
 
 interface State {
-  pdfGenerationError: PdfGenerationError;
   loading: boolean;
 }
 
 class RecentInvoicesPanel extends React.Component<CombinedProps, State> {
   state: State = {
-    pdfGenerationError: {
-      itemId: undefined
-    },
     loading: false
   };
 
   componentDidMount() {
-    if (!this.props.account.data) {
+    if (!this.props.account) {
       this.props.requestAccount();
     }
-  }
-
-  setPdfError(itemId: number | undefined, error?: any) {
-    this.setState({
-      pdfGenerationError: {
-        itemId,
-        error
-      }
-    });
   }
 
   render() {
@@ -100,33 +66,21 @@ class RecentInvoicesPanel extends React.Component<CombinedProps, State> {
     );
   }
 
-  printInvoice(event: any, account: Linode.Account, item: Linode.Invoice) {
-    event.preventDefault();
-    event.stopPropagation();
-    this.setPdfError(undefined);
-
-    getInvoiceItems(item.id)
-      .then(response => {
-        const invoiceItems = response.data;
-        const result = printInvoice(account, item, invoiceItems);
-
-        if (result.status === 'error') {
-          this.setPdfError(item.id, result.error);
-        }
-      })
-      .catch(e => {
-        this.setPdfError(item.id, e);
-      });
-  }
-
   renderContent = () => {
-    const { data, error, loading } = this.props;
+    const {
+      data,
+      error,
+      loading,
+      account,
+      accountLoading,
+      accountError
+    } = this.props;
 
-    if (loading) {
+    if (loading || accountLoading) {
       return <TableRowLoading colSpan={4} />;
     }
 
-    if (error) {
+    if (error || accountError) {
       return (
         <TableRowError
           colSpan={4}
@@ -135,8 +89,10 @@ class RecentInvoicesPanel extends React.Component<CombinedProps, State> {
       );
     }
 
-    return data && data.length > 0 ? (
-      this.renderItems(data)
+    return data && data.length > 0 && account ? (
+      data.map((eachInvoice, index) => (
+        <RecentInvoiceRow key={index} invoice={eachInvoice} account={account} />
+      ))
     ) : (
       <TableRowEmptyState colSpan={4} />
     );
@@ -148,66 +104,24 @@ class RecentInvoicesPanel extends React.Component<CombinedProps, State> {
       this.props.handleOrderChange('date', 'desc');
     }
   };
-
-  renderItems = (items: Linode.Invoice[]) => items.map(this.renderRow);
-
-  renderRow = (item: Linode.Invoice) => {
-    const { pdfGenerationError } = this.state;
-    const { account } = this.props;
-
-    return (
-      <TableRow
-        key={`invoice-${item.id}`}
-        rowLink={`/account/billing/invoices/${item.id}`}
-        data-qa-invoice
-      >
-        <TableCell parentColumn="Date Created" data-qa-invoice-date>
-          <DateTimeDisplay value={item.date} />
-        </TableCell>
-        <TableCell parentColumn="Description" data-qa-invoice-desc={item.id}>
-          Invoice #{item.id}
-        </TableCell>
-        <TableCell parentColumn="Amount" data-qa-invoice-amount>
-          <Currency quantity={Number(item.total)} />
-        </TableCell>
-        <TableCell>
-          {account.data && (
-            <a
-              href="#"
-              onClick={e =>
-                this.printInvoice(e, account.data as Linode.Account, item)
-              }
-            >
-              Download PDF
-            </a>
-          )}
-          {pdfGenerationError.itemId === item.id && (
-            <Notice
-              error={true}
-              html={`Failed generating PDF. <a href="${createMailto(
-                pdfGenerationError.error && pdfGenerationError.error.stack
-              )}"
-            > Send report</a>`}
-            />
-          )}
-        </TableCell>
-      </TableRow>
-    );
-  };
 }
 
-const styled = withStyles(styles);
-
-interface S {
-  account: ApplicationState['__resources']['account'];
+interface ReduxState {
+  account?: Linode.Account;
+  accountLoading: boolean;
+  accountError?: Linode.ApiFieldError[] | Error;
 }
 
-interface StateProps extends S {
+interface StateProps extends ReduxState {
   requestAccount: () => void;
 }
 
 const connected = connect(
-  (state: ApplicationState): S => ({ account: state.__resources.account }),
+  (state: ApplicationState): ReduxState => ({
+    account: state.__resources.account.data,
+    accountLoading: pathOr(false, ['__resources', 'account', 'loading'], state),
+    accountError: state.__resources.account.error
+  }),
   (dispatch: ThunkDispatch): { requestAccount: () => void } => ({
     requestAccount: () => dispatch(requestAccount())
   })
@@ -220,8 +134,7 @@ const paginated = paginate(updatedRequest);
 
 const enhanced = compose(
   connected,
-  paginated,
-  styled
+  paginated
 );
 
 export default enhanced(RecentInvoicesPanel);

--- a/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesRow.tsx
+++ b/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesRow.tsx
@@ -51,7 +51,9 @@ const RecentInvoicesRow: React.FC<CombinedProps> = props => {
     setPDFError(undefined);
     setGeneratingPDF(true);
 
-    getAll<Linode.InvoiceItem>(() => getInvoiceItems(invoice.id))()
+    getAll<Linode.InvoiceItem>((params, filter) =>
+      getInvoiceItems(invoice.id, params, filter)
+    )()
       .then(response => {
         const invoiceItems = response.data;
         const result = printInvoice(thisAccount, thisItem, invoiceItems);

--- a/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesRow.tsx
+++ b/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesRow.tsx
@@ -1,0 +1,114 @@
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from '@material-ui/core/styles';
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import Button from 'src/components/Button';
+import Currency from 'src/components/Currency';
+import DateTimeDisplay from 'src/components/DateTimeDisplay';
+import Notice from 'src/components/Notice';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
+import createMailto from 'src/features/Footer/createMailto';
+
+import { printInvoice } from 'src/features/Billing/PdfGenerator/PdfGenerator';
+import { getInvoiceItems } from 'src/services/account';
+import { getAll } from 'src/utilities/getAll';
+
+type ClassNames = 'root' | 'button';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  button: {
+    padding: 0
+  }
+});
+
+interface Props {
+  invoice: Linode.Invoice;
+  account: Linode.Account;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+const RecentInvoicesRow: React.FC<CombinedProps> = props => {
+  const { account, classes, invoice } = props;
+
+  const [pdfError, setPDFError] = React.useState<Error | undefined>(undefined);
+  const [isGeneratingPDF, setGeneratingPDF] = React.useState<boolean>(false);
+
+  const _printInvoice = (
+    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    thisAccount: Linode.Account,
+    thisItem: Linode.Invoice
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    setPDFError(undefined);
+    setGeneratingPDF(true);
+
+    getAll<Linode.InvoiceItem>(() => getInvoiceItems(invoice.id))()
+      .then(response => {
+        const invoiceItems = response.data;
+        const result = printInvoice(thisAccount, thisItem, invoiceItems);
+        setGeneratingPDF(false);
+
+        if (result.status === 'error') {
+          setPDFError(result.error);
+        }
+      })
+      .catch(e => {
+        setPDFError(e);
+        setGeneratingPDF(false);
+      });
+  };
+
+  return (
+    <TableRow
+      key={`invoice-${invoice.id}`}
+      rowLink={`/account/billing/invoices/${invoice.id}`}
+      data-qa-invoice
+    >
+      <TableCell parentColumn="Date Created" data-qa-invoice-date>
+        <DateTimeDisplay value={invoice.date} />
+      </TableCell>
+      <TableCell parentColumn="Description" data-qa-invoice-desc={invoice.id}>
+        Invoice #{invoice.id}
+      </TableCell>
+      <TableCell parentColumn="Amount" data-qa-invoice-amount>
+        <Currency quantity={Number(invoice.total)} />
+      </TableCell>
+      <TableCell>
+        {account && (
+          <Button
+            className={classes.button}
+            onClick={e => _printInvoice(e, account as Linode.Account, invoice)}
+            loading={isGeneratingPDF}
+          >
+            Download PDF
+          </Button>
+        )}
+        {pdfError && (
+          <Notice
+            error={true}
+            html={`Failed generating PDF. <a href="${createMailto(
+              pdfError && pdfError.stack
+            )}"
+          > Send report</a>`}
+          />
+        )}
+      </TableCell>
+    </TableRow>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default compose<CombinedProps, Props>(
+  styled,
+  React.memo
+)(RecentInvoicesRow);

--- a/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -84,8 +84,8 @@ class InvoiceDetail extends React.Component<CombinedProps, State> {
       this.props.requestAccount();
     }
 
-    const getAllInvoiceItems = getAll<Linode.InvoiceItem>(() =>
-      getInvoiceItems(+invoiceId)
+    const getAllInvoiceItems = getAll<Linode.InvoiceItem>((params, filter) =>
+      getInvoiceItems(+invoiceId, params, filter)
     );
 
     Promise.all([getInvoice(+invoiceId), getAllInvoiceItems()])

--- a/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -21,6 +21,7 @@ import { ApplicationState } from 'src/store';
 import { requestAccount } from 'src/store/account/account.requests';
 import { ThunkDispatch } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { getAll } from 'src/utilities/getAll';
 import InvoiceTable from './InvoiceTable';
 
 type ClassNames = 'root' | 'backButton' | 'titleWrapper' | 'totals';
@@ -83,7 +84,11 @@ class InvoiceDetail extends React.Component<CombinedProps, State> {
       this.props.requestAccount();
     }
 
-    Promise.all([getInvoice(+invoiceId), getInvoiceItems(+invoiceId)])
+    const getAllInvoiceItems = getAll<Linode.InvoiceItem>(() =>
+      getInvoiceItems(+invoiceId)
+    );
+
+    Promise.all([getInvoice(+invoiceId), getAllInvoiceItems()])
       .then(([invoice, { data: items }]) => {
         this.setState({
           loading: false,

--- a/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -9,6 +9,9 @@ import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 
+import Paginate from 'src/components/Paginate';
+import PaginationFooter from 'src/components/PaginationFooter';
+
 interface Props {
   loading: boolean;
   errors?: Linode.ApiFieldError[];
@@ -58,38 +61,57 @@ const RenderData: React.StatelessComponent<{
 }> = props => {
   const { items } = props;
   return (
-    <>
-      {items.map(
-        ({ label, from, to, quantity, unit_price, amount, tax, total }) => (
-          <TableRow key={`${label}-${from}-${to}`}>
-            <TableCell parentColumn="Description" data-qa-descrition>
-              {label}
-            </TableCell>
-            <TableCell parentColumn="From" data-qa-from>
-              {renderDate(from)}
-            </TableCell>
-            <TableCell parentColumn="To" data-qa-to>
-              {renderDate(to)}
-            </TableCell>
-            <TableCell parentColumn="Quantity" data-qa-quantity>
-              {renderQuantity(quantity)}
-            </TableCell>
-            <TableCell parentColumn="Unit Price" data-qa-unit-price>
-              {renderUnitPrice(unit_price)}
-            </TableCell>
-            <TableCell parentColumn="Amount (USD)" data-qa-amount>
-              ${amount}
-            </TableCell>
-            <TableCell parentColumn="Tax (USD)" data-qa-tax>
-              ${tax}
-            </TableCell>
-            <TableCell parentColumn="Total (USD)" data-qa-total>
-              ${total}
-            </TableCell>
-          </TableRow>
-        )
+    <Paginate data={items} pageSize={25}>
+      {({
+        data: paginatedData,
+        count,
+        handlePageChange,
+        handlePageSizeChange,
+        page,
+        pageSize
+      }) => (
+        <React.Fragment>
+          {paginatedData.map(
+            ({ label, from, to, quantity, unit_price, amount, tax, total }) => (
+              <TableRow key={`${label}-${from}-${to}`}>
+                <TableCell parentColumn="Description" data-qa-descrition>
+                  {label}
+                </TableCell>
+                <TableCell parentColumn="From" data-qa-from>
+                  {renderDate(from)}
+                </TableCell>
+                <TableCell parentColumn="To" data-qa-to>
+                  {renderDate(to)}
+                </TableCell>
+                <TableCell parentColumn="Quantity" data-qa-quantity>
+                  {renderQuantity(quantity)}
+                </TableCell>
+                <TableCell parentColumn="Unit Price" data-qa-unit-price>
+                  {renderUnitPrice(unit_price)}
+                </TableCell>
+                <TableCell parentColumn="Amount (USD)" data-qa-amount>
+                  ${amount}
+                </TableCell>
+                <TableCell parentColumn="Tax (USD)" data-qa-tax>
+                  ${tax}
+                </TableCell>
+                <TableCell parentColumn="Total (USD)" data-qa-total>
+                  ${total}
+                </TableCell>
+              </TableRow>
+            )
+          )}
+          <PaginationFooter
+            eventCategory="invoice_items"
+            count={count}
+            page={page}
+            pageSize={pageSize}
+            handlePageChange={handlePageChange}
+            handleSizeChange={handlePageSizeChange}
+          />
+        </React.Fragment>
       )}
-    </>
+    </Paginate>
   );
 };
 

--- a/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -120,7 +120,7 @@ const addLeftHeader = (
   addLine('Remit to:');
   doc.setFontStyle('normal');
 
-  addLine(`Linode, LLC`);
+  addLine(`Linode`);
   addLine('249 Arch St.');
   addLine('Philadelphia, PA 19106');
   addLine('USA');


### PR DESCRIPTION
## Description

1. Requests all line items when the Invoice Detail Screen mounts
2. Uses `<Paginate />` to show all Invoice Line Items on the Invoice Detail Screen
3. Requests all line items when clicking "Download PDF" on the expansion panel
4. Adds loading state to downloading PDF button

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A