### PR TITLE
M3-2762 add: Clone Linode from Linode Action Menu

### DIFF
--- a/e2e/pageobjects/list-linodes.js
+++ b/e2e/pageobjects/list-linodes.js
@@ -32,7 +32,6 @@ export class ListLinodes extends Page {
     get powerOnMenu() { return $('[data-qa-action-menu-item="Power On"]'); }
     get launchConsoleMenu() { return $('[data-qa-action-menu-item="Launch Console"]'); }
     get rebootMenu() { return $('[data-qa-action-menu-item="Reboot"]'); }
-    get viewGraphsMenu() { return $('[data-qa-action-menu-item="View Graphs"]'); }
     get resizeMenu() { return $('[data-qa-action-menu-item="Resize"]'); }
     get viewBackupsMenu() { return $('[data-qa-action-menu-item="View Backups"]'); }
     get enableBackupsMenu() { return $('[data-qa-action-menu-item="Enable Backups"]'); }

--- a/e2e/specs/linodes/smoke-linodes.spec.js
+++ b/e2e/specs/linodes/smoke-linodes.spec.js
@@ -22,7 +22,7 @@ describe('List Linodes Suite', () => {
             'Reboot',
             'Power Off',
             'Launch Console',
-            'Clone Linode',
+            'Clone',
             'Resize',
             'View Backups',
             'Enable Backups',

--- a/e2e/specs/linodes/smoke-linodes.spec.js
+++ b/e2e/specs/linodes/smoke-linodes.spec.js
@@ -19,10 +19,10 @@ describe('List Linodes Suite', () => {
 
     const assertActionMenuItems = (linode) => {
         const expectedOptions = [
-            'Reboot', 
+            'Reboot',
             'Power Off',
             'Launch Console',
-            'View Graphs', 
+            'Clone Linode',
             'Resize',
             'View Backups',
             'Enable Backups',
@@ -77,7 +77,7 @@ describe('List Linodes Suite', () => {
             assertActionMenuItems(linode.linodeLabel);
         });
 
-        it('should display launch console button', () => {
+        it('should display  console button', () => {
             expect(ListLinodes.launchConsole.isVisible()).toBe(true);
         });
 

--- a/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -17,6 +17,7 @@ import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import SelectionCard from 'src/components/SelectionCard';
 import TabbedPanel from 'src/components/TabbedPanel';
 import { Tab } from 'src/components/TabbedPanel/TabbedPanel';
+import { ContinentKey, dcContinent } from 'src/constants';
 
 const flags = {
   us: () => <US width="32" height="24" viewBox="0 0 720 480" />,
@@ -136,6 +137,13 @@ class SelectRegionPanel extends React.Component<
     if (this.props.regions.length === 0) {
       return null;
     }
+
+    // Determine initial tag selection based on which
+    // continent the selected region is in.
+    const tabOrder: ContinentKey[] = ['NA', 'EU', 'AS'];
+    const selectedContinent = dcContinent[this.props.selectedID || ''];
+    const initialTab = tabOrder.indexOf(selectedContinent || 'NA');
+
     return (
       <TabbedPanel
         rootClass={this.props.classes.root}
@@ -143,6 +151,7 @@ class SelectRegionPanel extends React.Component<
         header="Region"
         copy={this.props.copy}
         tabs={this.createTabs()}
+        initTab={initialTab}
       />
     );
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -118,6 +118,28 @@ export const dcDisplayCountry = {
   'ca-east': 'CA'
 };
 
+export type ContinentKey = 'NA' | 'EU' | 'AS';
+export const dcContinent: Record<string, ContinentKey> = {
+  'us-east-1a': 'NA',
+  'us-south-1a': 'NA',
+  'us-west-1a': 'NA',
+  'us-southeast-1a': 'NA',
+  'eu-central-1a': 'EU',
+  'eu-west-1a': 'EU',
+  'ap-northeast-1a': 'AS',
+  'ap-northeast-1b': 'AS',
+  'us-central': 'NA',
+  'us-west': 'NA',
+  'us-southeast': 'NA',
+  'us-east': 'NA',
+  'eu-west': 'EU',
+  'ap-south': 'AS',
+  'eu-central': 'EU',
+  'ap-northeast': 'AS',
+  'ca-central': 'NA',
+  'ca-east': 'NA'
+};
+
 // At this time, the following regions do not support block storage.
 export const regionsWithoutBlockStorage = ['us-southeast', 'ap-northeast-1a'];
 

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -127,7 +127,14 @@ const trimOneClickFromLabel = (script: StackScript) => {
 };
 
 class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
-  state: State = defaultState;
+  params = getParamsFromUrl(this.props.location.search);
+
+  state: State = {
+    ...defaultState,
+    // These can be passed in as query params
+    selectedTypeID: this.params.typeID,
+    selectedRegionID: this.params.regionID
+  };
 
   componentDidUpdate(prevProps: CombinedProps) {
     /**

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -102,7 +102,10 @@ export class SelectPlanPanel extends React.Component<
         render: () => {
           return (
             <>
-              <Typography className={classes.copy}>Nanode instances are good for low-duty workloads, where performance isn't critical.</Typography>
+              <Typography className={classes.copy}>
+                Nanode instances are good for low-duty workloads, where
+                performance isn't critical.
+              </Typography>
               <Grid container spacing={16}>
                 {nanodes.map(this.renderCard)}
               </Grid>
@@ -118,7 +121,10 @@ export class SelectPlanPanel extends React.Component<
         render: () => {
           return (
             <>
-              <Typography className={classes.copy}>Standard instances are good for medium-duty workloads and are a good mix of performance, resources, and price.</Typography>
+              <Typography className={classes.copy}>
+                Standard instances are good for medium-duty workloads and are a
+                good mix of performance, resources, and price.
+              </Typography>
               <Grid container spacing={16}>
                 {standards.map(this.renderCard)}
               </Grid>
@@ -134,7 +140,10 @@ export class SelectPlanPanel extends React.Component<
         render: () => {
           return (
             <>
-              <Typography className={classes.copy}>Dedicated CPU instances are good for full-duty workloads where consistent performance is important.</Typography>
+              <Typography className={classes.copy}>
+                Dedicated CPU instances are good for full-duty workloads where
+                consistent performance is important.
+              </Typography>
               <Grid container spacing={16}>
                 {dedicated.map(this.renderCard)}
               </Grid>
@@ -150,7 +159,11 @@ export class SelectPlanPanel extends React.Component<
         render: () => {
           return (
             <>
-              <Typography className={classes.copy}>High Memory instances favor RAM over other resources, and can be good for memory hungry use cases like caching and in-memory databases.</Typography>
+              <Typography className={classes.copy}>
+                High Memory instances favor RAM over other resources, and can be
+                good for memory hungry use cases like caching and in-memory
+                databases.
+              </Typography>
               <Grid container spacing={16}>
                 {highmem.map(this.renderCard)}
               </Grid>

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -1,4 +1,4 @@
-import { isEmpty } from 'ramda';
+import { isEmpty, pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import {
@@ -178,7 +178,17 @@ export class SelectPlanPanel extends React.Component<
   };
 
   render() {
-    const { classes, copy, error, header } = this.props;
+    const { classes, copy, error, header, types, selectedID } = this.props;
+
+    // Determine initial plan category tab based on selectedTypeID
+    // (if there is one).
+    const selectedTypeClass: Linode.LinodeTypeClass = pathOr(
+      'standard', // Use `standard` by default
+      ['class'],
+      types.find(type => type.id === selectedID)
+    );
+    const initialTab = tabOrder.indexOf(selectedTypeClass);
+
     return (
       <TabbedPanel
         rootClass={`${classes.root} tabbedPanel`}
@@ -186,7 +196,7 @@ export class SelectPlanPanel extends React.Component<
         header={header || 'Linode Plan'}
         copy={copy}
         tabs={this.createTabs()}
-        initTab={1}
+        initTab={initialTab}
       />
     );
   }
@@ -201,3 +211,10 @@ export default compose<
   RenderGuard,
   styled
 )(SelectPlanPanel);
+
+const tabOrder: Linode.LinodeTypeClass[] = [
+  'nanode',
+  'standard',
+  'dedicated',
+  'highmem'
+];

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -1,0 +1,71 @@
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { extendedTypes } from 'src/__data__/ExtendedType';
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import { CombinedProps, LinodeActionMenu } from './LinodeActionMenu';
+
+const props: CombinedProps = {
+  linodeId: 123,
+  linodeLabel: 'testLinode',
+  linodeRegion: 'us-east',
+  linodeType: 'g6-standard-1',
+  linodeBackups: {
+    schedule: {
+      window: null,
+      day: null
+    }
+  },
+  linodeStatus: '',
+  noImage: false,
+  openConfigDrawer: jest.fn(),
+  toggleConfirmation: jest.fn(),
+  ...reactRouterProps
+};
+
+describe('LinodeActionMenu', () => {
+  const wrapper = shallow<LinodeActionMenu>(<LinodeActionMenu {...props} />);
+
+  describe('buildQueryStringForLinodeClone', () => {
+    it('returns `type`, `subtype`, and `linodeID` params', () => {
+      const result = wrapper.instance().buildQueryStringForLinodeClone();
+      expect(result).toMatch('type=');
+      expect(result).toMatch('subtype=');
+      expect(result).toMatch('linodeID=');
+    });
+
+    it('includes `regionID` param if valid region', () => {
+      wrapper.setProps({
+        linodeRegion: 'us-east',
+        regionsData: [{ id: 'us-east', country: 'us' }]
+      });
+      expect(wrapper.instance().buildQueryStringForLinodeClone()).toMatch(
+        'regionID=us-east'
+      );
+
+      wrapper.setProps({
+        linodeRegion: 'invalid-region'
+      });
+      expect(wrapper.instance().buildQueryStringForLinodeClone()).not.toMatch(
+        'regionID='
+      );
+    });
+
+    it('includes `typeID` param if valid type', () => {
+      wrapper.setProps({
+        // This is not actually (currently) a valid type, but it's in the mock data
+        linodeType: 'g5-standard-2',
+        typesData: extendedTypes
+      });
+      expect(wrapper.instance().buildQueryStringForLinodeClone()).toMatch(
+        'typeID=g5-standard-2'
+      );
+
+      wrapper.setProps({
+        linodeType: 'invalid-type'
+      });
+      expect(wrapper.instance().buildQueryStringForLinodeClone()).not.toMatch(
+        'typeID='
+      );
+    });
+  });
+});

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -1,3 +1,4 @@
+import { stringify } from 'qs';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -16,13 +17,19 @@ import {
   sendLinodeActionMenuItemEvent
 } from 'src/utilities/ga';
 
+import regionsContainer, {
+  DefaultProps as WithRegionsProps
+} from 'src/containers/regions.container';
+import withTypes, { WithTypesProps } from 'src/containers/types.container';
 import { getLinodeConfigs } from 'src/services/linodes';
 import { getPermissionsForLinode } from 'src/store/linodes/permissions/permissions.selector.ts';
 import { MapState } from 'src/store/types';
 
-interface Props {
+export interface Props {
   linodeId: number;
   linodeLabel: string;
+  linodeRegion: string;
+  linodeType: string | null;
   linodeBackups: Linode.LinodeBackups;
   linodeStatus: string;
   noImage: boolean;
@@ -37,7 +44,11 @@ interface Props {
   ) => void;
 }
 
-type CombinedProps = Props & RouteComponentProps<{}> & StateProps;
+export type CombinedProps = Props &
+  RouteComponentProps<{}> &
+  StateProps &
+  WithTypesProps &
+  WithRegionsProps;
 
 interface State {
   configs: Linode.Config[];
@@ -45,7 +56,7 @@ interface State {
   configsError?: Linode.ApiFieldError[];
 }
 
-class LinodeActionMenu extends React.Component<CombinedProps, State> {
+export class LinodeActionMenu extends React.Component<CombinedProps, State> {
   state: State = {
     configs: [],
     hasMadeConfigsRequest: false,
@@ -66,6 +77,36 @@ class LinodeActionMenu extends React.Component<CombinedProps, State> {
       });
 
     sendLinodeActionEvent();
+  };
+
+  // When we clone a Linode from the action menu, we pass in several query string
+  // params so everything is selected for us when we get to the Create flow.
+  buildQueryStringForLinodeClone = () => {
+    const {
+      linodeId,
+      linodeRegion,
+      linodeType,
+      typesData,
+      regionsData
+    } = this.props;
+
+    const params: Record<string, string> = {
+      type: 'My Images',
+      subtype: 'Clone Linode',
+      linodeID: String(linodeId)
+    };
+
+    // If the type of this Linode is a valid (current) type, use it in the QS
+    if (typesData && typesData.some(type => type.id === linodeType)) {
+      params.typeID = linodeType!;
+    }
+
+    // If the region of this Linode is a valid region, use it in the QS
+    if (regionsData && regionsData.some(region => region.id === linodeRegion)) {
+      params.regionID = linodeRegion;
+    }
+
+    return stringify(params);
   };
 
   createLinodeActions = () => {
@@ -97,6 +138,19 @@ class LinodeActionMenu extends React.Component<CombinedProps, State> {
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             sendLinodeActionMenuItemEvent('Launch Console');
             lishLaunch(linodeId);
+            e.preventDefault();
+            e.stopPropagation();
+          },
+          ...readOnlyProps
+        },
+        {
+          title: 'Clone Linode',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendLinodeActionMenuItemEvent('Clone Linode');
+            push({
+              pathname: '/linodes/create',
+              search: this.buildQueryStringForLinodeClone()
+            });
             e.preventDefault();
             e.stopPropagation();
           },
@@ -240,9 +294,12 @@ const mapStateToProps: MapState<StateProps, CombinedProps> = (
 });
 
 const connected = connect(mapStateToProps);
+const withRegions = regionsContainer();
 
 const enhanced = compose<CombinedProps, Props>(
   connected,
+  withTypes,
+  withRegions,
   withRouter
 );
 

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -103,15 +103,6 @@ class LinodeActionMenu extends React.Component<CombinedProps, State> {
           ...readOnlyProps
         },
         {
-          title: 'View Graphs',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            sendLinodeActionMenuItemEvent('View Linode Graphs');
-            push(`/linodes/${linodeId}/summary`);
-            e.preventDefault();
-            e.stopPropagation();
-          }
-        },
-        {
           title: 'Resize',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             sendLinodeActionMenuItemEvent('Navigate to Resize Page');

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -144,9 +144,9 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
           ...readOnlyProps
         },
         {
-          title: 'Clone Linode',
+          title: 'Clone',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
-            sendLinodeActionMenuItemEvent('Clone Linode');
+            sendLinodeActionMenuItemEvent('Clone');
             push({
               pathname: '/linodes/create',
               search: this.buildQueryStringForLinodeClone()

--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -92,6 +92,7 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
       disk,
       vcpus,
       region,
+      type,
       ipv4,
       ipv6,
       tags,
@@ -134,6 +135,8 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
                 <LinodeActionMenu
                   linodeId={id}
                   linodeLabel={label}
+                  linodeRegion={region}
+                  linodeType={type}
                   linodeStatus={status}
                   linodeBackups={backups}
                   openConfigDrawer={openConfigDrawer}

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -153,6 +153,8 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = props => {
             <LinodeActionMenu
               linodeId={id}
               linodeLabel={label}
+              linodeRegion={region}
+              linodeType={type}
               linodeStatus={status}
               linodeBackups={backups}
               openConfigDrawer={openConfigDrawer}

--- a/src/types/LinodeType.ts
+++ b/src/types/LinodeType.ts
@@ -15,5 +15,5 @@ namespace Linode {
     vcpus: number;
   }
 
-  type LinodeTypeClass = 'nanode' | 'standard' | 'highmem';
+  export type LinodeTypeClass = 'nanode' | 'standard' | 'dedicated' | 'highmem';
 }


### PR DESCRIPTION
## Description

Adds a "Clone" option in the kebab menu on the Linodes Landing page. This option takes you to the Create Linode flow with the appropriate options pre-selected.

This was pretty straightforward since the Create Linode flow accepts (some) query params. I just had to add support for `regionID` and `typeID` query params.

The one wrinkle in this was getting the correct Continent and Plan Type tabs pre-selected. I added some logic in `SelectRegionPanel` and `SelectPlanPanel` to set the correct `initTab` if appropriate.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e e2e/specs/linodes/smoke-linodes.spec.js --browser=headlessChrome`

## Note to Reviewers

Create several Linodes with different regions and plans. Try cloning them with the new kebab menu option. Also check the Create Linode flow in general.
