### PR TITLE
M3-2826 POC Improve accessibility for entity icons

### DIFF
--- a/src/components/EntityIcon/EntityIcon.tsx
+++ b/src/components/EntityIcon/EntityIcon.tsx
@@ -16,6 +16,7 @@ import {
   withTheme,
   WithTheme
 } from 'src/components/core/styles';
+import Tooltip from 'src/components/core/Tooltip';
 import { COMPACT_SPACING_UNIT } from 'src/themeFactory';
 
 type ClassNames =
@@ -81,6 +82,7 @@ interface Props {
   className?: any;
   marginTop?: number;
   stopAnimation?: boolean;
+  noTooltip?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames> & WithTheme;
@@ -108,6 +110,7 @@ const EntityIcon: React.StatelessComponent<CombinedProps> = props => {
     className,
     marginTop,
     stopAnimation,
+    noTooltip,
     ...rest
   } = props;
 
@@ -136,6 +139,17 @@ const EntityIcon: React.StatelessComponent<CombinedProps> = props => {
   const finalStatus =
     variant === 'domain' ? status && getStatusForDomain(status) : status;
 
+  const icon = (
+    <Icon
+      className={classNames({
+        [classes.icon]: true,
+        ['loading']: loading
+      })}
+      width={iconSize}
+      height={iconSize}
+    />
+  );
+
   return (
     <div
       className={classNames(
@@ -153,14 +167,11 @@ const EntityIcon: React.StatelessComponent<CombinedProps> = props => {
       aria-label={`${variant} is ${finalStatus}`}
       {...rest}
     >
-      <Icon
-        className={classNames({
-          [classes.icon]: true,
-          ['loading']: loading
-        })}
-        width={iconSize}
-        height={iconSize}
-      />
+      {finalStatus && !noTooltip ? (
+        <Tooltip title={finalStatus}>{icon}</Tooltip>
+      ) : (
+        icon
+      )}
       {loading && (
         <div className={classes.loading}>
           <LoadingIcon

--- a/src/components/EntityIcon/EntityIcon.tsx
+++ b/src/components/EntityIcon/EntityIcon.tsx
@@ -27,7 +27,9 @@ type ClassNames =
   | 'offline'
   | 'loading'
   | 'loadingIcon'
-  | 'animated';
+  | 'animated'
+  | 'tooltip'
+  | 'accessibleStatus';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   '@keyframes rotate': {
@@ -63,6 +65,12 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   animated: {
     animation: 'rotate 2s linear infinite'
+  },
+  accessibleStatus: {
+    ...theme.visually.hidden
+  },
+  tooltip: {
+    marginTop: -8
   }
 });
 
@@ -168,7 +176,15 @@ const EntityIcon: React.StatelessComponent<CombinedProps> = props => {
       {...rest}
     >
       {finalStatus && !noTooltip ? (
-        <Tooltip title={finalStatus}>{icon}</Tooltip>
+        <Tooltip
+          title={finalStatus}
+          PopperProps={{ className: classes.tooltip }}
+        >
+          <span>
+            <span className={classes.accessibleStatus}>{finalStatus}</span>
+            {icon}
+          </span>
+        </Tooltip>
       ) : (
         icon
       )}

--- a/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -217,6 +217,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
               loading={isBusy}
               size={34}
               marginTop={1}
+              noTooltip
             />
             <span className={classes.buttonText}>{buttonText()}</span>
           </div>


### PR DESCRIPTION
## POC Improve accessibility for entity icons

Pretty simple POC that adds a tooltip to the display the entity status for people with visual disability (blindness, color blindness) since the status at this point only relies on a color indication.

It also will display the status as visually hidden text within the container, which will display for screen readers but not reg users.

Note: there is a noTooltip prop avail for places where the status would be displayed twice (ex: `
LinodePowerControl`

## Type of Change
- Non breaking change ('update')