### PR TITLE
Change: Adds CRUD error shape to Linode Disks

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -262,7 +262,11 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
 }));
 
 const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
-  diskError: pathOr(undefined, ['__resources', 'linodeDisks', 'error'], state)
+  diskError: pathOr(
+    undefined,
+    ['__resources', 'linodeDisks', 'error', 'read'],
+    state
+  )
 });
 
 const connected = connect(mapStateToProps);

--- a/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -58,7 +58,7 @@ interface ContextProps {
 }
 
 interface StateProps {
-  diskError?: string;
+  diskError?: Linode.ApiFieldError[];
 }
 
 interface VolumesProps {

--- a/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -32,11 +32,11 @@ const collectErrors: MapState<InnerProps, OuterProps> = (
     error:
       configsError ||
       typesError ||
-      path(['error', 'read'], linodes.error) ||
+      path(['error', 'read'], linodes) ||
       types.error ||
       notifications.error ||
       path(['error', 'read'], linodeConfigs) ||
-      linodeDisks.error
+      path(['error', 'read'], linodeDisks)
   };
 };
 

--- a/src/store/linodes/disk/disk.actions.ts
+++ b/src/store/linodes/disk/disk.actions.ts
@@ -4,8 +4,6 @@ import { Entity } from './disk.types';
 
 const actionCreator = actionCreatorFactory(`@@manager/linodeDisks`);
 
-type Error = Linode.ApiFieldError[];
-
 interface LinodeIdParam {
   linodeId: number;
 }
@@ -32,7 +30,7 @@ export type GetLinodeDisksRequest = (
 export const getLinodeDisksActions = actionCreator.async<
   GetLinodeDisksParams,
   Entity[],
-  Error
+  Linode.ApiFieldError[]
 >(`get-page`);
 
 /** Get Linode Disks (all) */
@@ -47,7 +45,7 @@ export type GetAllLinodeDisksRequest = (
 export const getAllLinodeDisksActions = actionCreator.async<
   GetAllLinodeDisksParams,
   Entity[],
-  Error
+  Linode.ApiFieldError[]
 >(`get-all`);
 
 /** Get Linode Disk */
@@ -62,7 +60,7 @@ export type GetLinodeDiskRequest = (
 export const getLinodeDiskActions = actionCreator.async<
   GetLinodeDiskParams,
   Entity,
-  Error
+  Linode.ApiFieldError[]
 >(`get`);
 
 /** Create Linode Disk */
@@ -77,7 +75,7 @@ export type CreateLinodeDiskRequest = (
 export const createLinodeDiskActions = actionCreator.async<
   CreateLinodeDiskParams,
   Entity,
-  Error
+  Linode.ApiFieldError[]
 >(`create`);
 
 /** Update Linode Disk */
@@ -93,7 +91,7 @@ export type UpdateLinodeDiskRequest = (
 export const updateLinodeDiskActions = actionCreator.async<
   UpdateLinodeDiskParams,
   Entity,
-  Error
+  Linode.ApiFieldError[]
 >(`update`);
 
 /** Delete Linode Disk */
@@ -108,7 +106,7 @@ export type DeleteLinodeDiskRequest = (
 export const deleteLinodeDiskActions = actionCreator.async<
   DeleteLinodeDiskParams,
   {},
-  Error
+  Linode.ApiFieldError[]
 >(`delete`);
 
 /** Resize Linode Disk */
@@ -123,5 +121,5 @@ export type ResizeLinodeDiskRequest = (
 export const resizeLinodeDiskActions = actionCreator.async<
   ResizeLinodeDiskParams,
   Entity,
-  Error
+  Linode.ApiFieldError[]
 >(`resize`);

--- a/src/store/linodes/disk/disk.reducer.ts
+++ b/src/store/linodes/disk/disk.reducer.ts
@@ -9,7 +9,7 @@ import {
   onStart,
   removeMany
 } from 'src/store/store.helpers';
-import { MappedEntityState } from 'src/store/types';
+import { EntityError, MappedEntityState } from 'src/store/types';
 import { isType } from 'typescript-fsa';
 import { deleteLinode, deleteLinodeActions } from '../linodes.actions';
 import {
@@ -22,9 +22,9 @@ import {
 } from './disk.actions';
 import { Entity } from './disk.types';
 
-export type State = MappedEntityState<Entity>;
+export type State = MappedEntityState<Entity, EntityError>;
 
-export const defaultState: State = createDefaultState<Entity>();
+export const defaultState: State = createDefaultState<Entity, EntityError>();
 
 const reducer: Reducer<State> = (state = defaultState, action) => {
   if (isType(action, deleteLinodeActions.done)) {
@@ -95,7 +95,12 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
   if (isType(action, getAllLinodeDisksActions.failed)) {
     const { error } = action.payload;
-    return onError(error, state);
+    return onError<MappedEntityState<Entity, EntityError>, EntityError>(
+      {
+        read: error
+      },
+      state
+    );
   }
 
   return state;


### PR DESCRIPTION
## Description

Adds the CRUD error shape to Linode Disks in redux.

```js
error: {
  create?: Linode.ApiFieldError[];
  update?: Linode.ApiFieldError[];
  read?: Linode.ApiFieldError[];
  delete?: Linode.ApiFieldError[];
}
```
## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A