### PR TITLE
Change: Adds CRUD error shape to Linode Configs

### DIFF
--- a/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -35,7 +35,7 @@ const collectErrors: MapState<InnerProps, OuterProps> = (
       path(['error', 'read'], linodes.error) ||
       types.error ||
       notifications.error ||
-      linodeConfigs.error ||
+      path(['error', 'read'], linodeConfigs) ||
       linodeDisks.error
   };
 };

--- a/src/store/linodes/config/config.actions.ts
+++ b/src/store/linodes/config/config.actions.ts
@@ -4,8 +4,6 @@ import { Entity } from './config.types';
 
 const actionCreator = actionCreatorFactory(`@@manager/linodeConfigs`);
 
-type Error = Linode.ApiFieldError[];
-
 interface LinodeIdParam {
   linodeId: number;
 }
@@ -30,7 +28,7 @@ export type GetLinodeConfigsRequest = (
 export const getLinodeConfigsActions = actionCreator.async<
   GetLinodeConfigsParams,
   Entity[],
-  Error
+  Linode.ApiFieldError[]
 >(`get-page`);
 
 /** Get Linode Configs (all) */
@@ -45,7 +43,7 @@ export type GetAllLinodeConfigsRequest = (
 export const getAllLinodeConfigsActions = actionCreator.async<
   GetAllLinodeConfigsParams,
   Entity[],
-  Error
+  Linode.ApiFieldError[]
 >(`get-all`);
 
 /** Get Linode Config */
@@ -60,7 +58,7 @@ export type GetLinodeConfigRequest = (
 export const getLinodeConfigActions = actionCreator.async<
   GetLinodeConfigParams,
   Entity,
-  Error
+  Linode.ApiFieldError[]
 >(`get`);
 
 /** Create Linode Config */
@@ -75,7 +73,7 @@ export type CreateLinodeConfigRequest = (
 export const createLinodeConfigActions = actionCreator.async<
   CreateLinodeConfigParams,
   Entity,
-  Error
+  Linode.ApiFieldError[]
 >(`create`);
 
 /** Update Linode Config */
@@ -91,7 +89,7 @@ export type UpdateLinodeConfigRequest = (
 export const updateLinodeConfigActions = actionCreator.async<
   UpdateLinodeConfigParams,
   Entity,
-  Error
+  Linode.ApiFieldError[]
 >(`update`);
 
 /** Delete Linode Config */
@@ -106,5 +104,5 @@ export type DeleteLinodeConfigRequest = (
 export const deleteLinodeConfigActions = actionCreator.async<
   DeleteLinodeConfigParams,
   {},
-  Error
+  Linode.ApiFieldError[]
 >(`delete`);

--- a/src/store/linodes/config/config.reducer.ts
+++ b/src/store/linodes/config/config.reducer.ts
@@ -9,7 +9,7 @@ import {
   onStart,
   removeMany
 } from 'src/store/store.helpers';
-import { MappedEntityState } from 'src/store/types';
+import { EntityError, MappedEntityState } from 'src/store/types';
 import { isType } from 'typescript-fsa';
 import { deleteLinode, deleteLinodeActions } from '../linodes.actions';
 import {
@@ -22,9 +22,9 @@ import {
 } from './config.actions';
 import { Entity } from './config.types';
 
-export type State = MappedEntityState<Entity>;
+export type State = MappedEntityState<Entity, EntityError>;
 
-export const defaultState: State = createDefaultState<Entity>();
+export const defaultState: State = createDefaultState<Entity, EntityError>();
 
 const reducer: Reducer<State> = (state = defaultState, action) => {
   if (isType(action, deleteLinodeActions.done)) {
@@ -96,7 +96,12 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
   if (isType(action, getAllLinodeConfigsActions.failed)) {
     const { error } = action.payload;
-    return onError(error, state);
+    return onError<MappedEntityState<Entity, EntityError>, EntityError>(
+      {
+        read: error
+      },
+      state
+    );
   }
 
   return state;


### PR DESCRIPTION
## Description

Adds the CRUD error shape to Linode Configs in redux.

```js
error: {
  create?: Linode.ApiFieldError[];
  update?: Linode.ApiFieldError[];
  read?: Linode.ApiFieldError[];
  delete?: Linode.ApiFieldError[];
}
```
## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A