### PR TITLE
Fix: OAuth Secret Modal

### DIFF
--- a/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -208,7 +208,11 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
         if (!this.mounted) {
           return;
         }
-        return this.setState({ ...this.defaultState });
+        return this.setState({
+          ...this.defaultState,
+          secretModalSuccessOpen: true,
+          secret: data.secret
+        });
       })
       .then(data => {
         if (!this.mounted) {

--- a/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -185,6 +185,7 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
         }
 
         return this.setState({
+          ...this.defaultState,
           secret,
           secretModalSuccessOpen: true,
           isResetting: false
@@ -202,7 +203,8 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
 
     createOAuthClient({
       label: this.state.clientLabel,
-      redirect_uri: this.state.redirectUri
+      redirect_uri: this.state.redirectUri,
+      public: this.state.isPublic
     })
       .then(data => {
         if (!this.mounted) {

--- a/src/services/account/oauth.ts
+++ b/src/services/account/oauth.ts
@@ -18,6 +18,7 @@ type Page<T> = Linode.ResourcePage<T>;
 export interface OAuthClientRequest {
   label: string;
   redirect_uri: string;
+  public?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes issue where OAuth Client Secret Modal was not appearing after creating a new Client

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/profile/clients.spec.js --browser=headlessChrome`

## Note to Reviewers

Try creating an OAuth Client and then see the modal pop up after the drawer closes.
