### PR TITLE
Fix: fix user detail e2e tests

### DIFF
--- a/e2e/pageobjects/account/user-detail.page.js
+++ b/e2e/pageobjects/account/user-detail.page.js
@@ -8,7 +8,7 @@ class UserDetail extends Page {
     get deleteSubHeader() { return $('[data-qa-delete-user-header]'); }
     get deleteButton() { return $('[data-qa-confirm-delete]'); }
     get usernameField() { return $('[data-qa-username]'); }
-    get emailField() { return $('[data-qa-email]'); }
+    get emailWarningToolTip() { return $('[data-qa-help-tooltip]'); }
     get saveButton() { return this.submitButton; }
     get usernameWarning() { return $(`${this.usernameField.selector} p`); }
 
@@ -23,9 +23,9 @@ class UserDetail extends Page {
         expect(this.deleteSubHeader.isVisible()).toBe(true);
         expect(this.deleteButton.isExisting()).toBe(true);
         expect(this.usernameField.isVisible()).toBe(true);
-        expect(this.emailField.isVisible()).toBe(true);
+
+        expect(this.emailWarningToolTip.isVisible()).toBe(true);
         expect(this.saveButton.isVisible()).toBe(true);
-        expect(this.cancelButton.isVisible()).toBe(true);
     }
 
 

--- a/e2e/specs/account/user-detail-spec.js
+++ b/e2e/specs/account/user-detail-spec.js
@@ -22,42 +22,23 @@ describe('Account - User Detail - Username Suite', () => {
             UserDetail.baseElementsDisplay();
         });
 
-        it('should clear username changes on cancel', () => {
-            const originalUsername = browser.getText(`${UserDetail.usernameField.selector} input`);
-            browser.setValue(`${UserDetail.usernameField.selector} input`, `someTest${new Date().getTime()}`);
-            UserDetail.cancelButton.click();
-            const updatedUsername = browser.getText(`${UserDetail.usernameField.selector} input`);
-
-            expect(updatedUsername).toBe(originalUsername);
-        });
-
-        it('should fail to update username on empty string', () => {
-            UserDetail.updateUsername(' ');
-            UserDetail.usernameWarning.waitForVisible(constants.wait.normal);
-            expect(UserDetail.usernameWarning.getText()).toContain('Username must be between');
-            UserDetail.cancelButton.click();
-        });
-
         it('should fail validation on bad username value', () => {
             const badUsername = '$%#5364é-';
             UserDetail.updateUsername(badUsername);
             UserDetail.usernameWarning.waitForVisible(constants.wait.normal);
             expect(UserDetail.usernameWarning.getText()).toContain('Username must only use ASCII characters');
-            UserDetail.cancelButton.click();
         });
 
         it('should fail to update when submitting an existing username', () => {
             UserDetail.updateUsername(browser.options.testUser);
             UserDetail.usernameWarning.waitForVisible(constants.wait.normal);
             expect(UserDetail.usernameWarning.getText()).toContain('Username taken');
-            UserDetail.cancelButton.click();
-
         });
 
         it('should succeed updating with a legitimate username', () => {
             userConfig['username'] = `Test${new Date().getTime()}`;
             UserDetail.updateUsername(userConfig.username);
-            UserDetail.waitForNotice('User Profile updated successfully', constants.wait.normal);
+            UserDetail.waitForNotice('Username updated successfully', constants.wait.normal);
         });
     });
 


### PR DESCRIPTION
## Description

* Fixes user detail tests. The cancel button was removed from the page breaking a bunch of the tests that rely on it being there to reset the state.
* Removed a test that didn't really add much value.

## Type of Change
- Test fix

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --file e2e/specs/account/user-detail-spec.js --browser=headlessChrome`x

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
