### PR TITLE
Change: Adds CRUD error shape to NodeBalancers

### DIFF
--- a/src/containers/withNodeBalancers.container.ts
+++ b/src/containers/withNodeBalancers.container.ts
@@ -29,5 +29,10 @@ export default <TInner extends {}, TOuter extends {}>(
       eachKey => itemsById[eachKey]
     );
 
-    return mapToProps(ownProps, nodeBalancers, loading, error);
+    return mapToProps(
+      ownProps,
+      nodeBalancers,
+      loading,
+      error ? error.read : undefined
+    );
   });

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -401,7 +401,7 @@ export const enhanced = compose<CombinedProps, {}>(
     return {
       nodeBalancersCount: items.length,
       nodeBalancersData: nodeBalancersWithConfigs(__resources),
-      nodeBalancersError: error,
+      nodeBalancersError: path(['read'], error),
       // In this component we only want to show loading state on initial load
       nodeBalancersLoading: nodeBalancersLoading && lastUpdated === 0
     };

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -348,7 +348,7 @@ interface NodeBalancerWithConfigs extends Linode.NodeBalancer {
 interface WithNodeBalancers {
   nodeBalancersCount: number;
   nodeBalancersData: NodeBalancerWithConfigs[];
-  nodeBalancersError?: Error;
+  nodeBalancersError?: Linode.ApiFieldError[];
   nodeBalancersLoading: boolean;
 }
 

--- a/src/store/nodeBalancer/nodeBalancer.actions.ts
+++ b/src/store/nodeBalancer/nodeBalancer.actions.ts
@@ -45,5 +45,5 @@ export type GetNodeBalancerWithConfigsParams = BalancerParams;
 export const getNodeBalancerWithConfigsActions = actionCreator.async<
   GetNodeBalancerWithConfigsParams,
   Linode.NodeBalancer,
-  Linode.ApiFieldError
+  Linode.ApiFieldError[]
 >(`get`);

--- a/src/store/nodeBalancer/nodeBalancer.reducer.ts
+++ b/src/store/nodeBalancer/nodeBalancer.reducer.ts
@@ -1,5 +1,5 @@
 import { Reducer } from 'redux';
-import { MappedEntityState } from 'src/store/types';
+import { EntityError, MappedEntityState } from 'src/store/types';
 import { isType } from 'typescript-fsa';
 import {
   createDefaultState,
@@ -17,7 +17,7 @@ import {
   updateNodeBalancersActions
 } from './nodeBalancer.actions';
 
-export type State = MappedEntityState<Linode.NodeBalancer>;
+export type State = MappedEntityState<Linode.NodeBalancer, EntityError>;
 
 export const defaultState: State = createDefaultState();
 
@@ -43,7 +43,15 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
   if (isType(action, getAllNodeBalancersActions.failed)) {
     const { error } = action.payload;
-    return onError(error, state);
+    return onError<
+      MappedEntityState<Linode.NodeBalancer, EntityError>,
+      EntityError
+    >(
+      {
+        read: error
+      },
+      state
+    );
   }
 
   /** Create */

--- a/src/store/nodeBalancer/nodeBalancer.requests.ts
+++ b/src/store/nodeBalancer/nodeBalancer.requests.ts
@@ -130,6 +130,6 @@ export const getNodeBalancerWithConfigs: ThunkActionCreator<
     return nodeBalancer;
   } catch (error) {
     dispatch(failed({ params, error }));
-    throw error;
+    return error;
   }
 };


### PR DESCRIPTION
## Description

Adds the CRUD error shape to NodeBalancers in redux.

```js
error: {
  create?: Linode.ApiFieldError[];
  update?: Linode.ApiFieldError[];
  read?: Linode.ApiFieldError[];
  delete?: Linode.ApiFieldError[];
}
```
## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A