### PR TITLE
Fix LinodeConfig default memory_limit value

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -143,7 +143,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     if (this.isOpening(prevProps.open, this.props.open)) {
       /** Reset the form to the default create state. */
       this.setState({
-        fields: LinodeConfigDrawer.defaultFieldsValues(this.props.maxMemory)
+        fields: LinodeConfigDrawer.defaultFieldsValues()
       });
 
       if (this.state.errors) {
@@ -174,10 +174,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
                 devices: createStringsFromDevices(config.devices),
                 kernel: config.kernel,
                 comments: config.comments,
-                memory_limit:
-                  config.memory_limit === 0
-                    ? this.props.maxMemory
-                    : config.memory_limit,
+                memory_limit: config.memory_limit,
                 run_level: config.run_level,
                 virt_mode: config.virt_mode,
                 helpers: config.helpers,

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -114,7 +114,8 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     loading: {
       kernels: false
     },
-    kernels: []
+    kernels: [],
+    fields: LinodeConfigDrawer.defaultFieldsValues()
   };
 
   static defaultFieldsValues: () => EditableFields => ({

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -87,6 +87,7 @@ interface EditableFields {
 interface Props {
   linodeHypervisor: 'kvm' | 'xen';
   linodeRegion: string;
+  maxMemory: number;
   open: boolean;
   linodeConfigId?: number;
   onClose: () => void;
@@ -198,7 +199,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { open, onClose, linodeConfigId } = this.props;
+    const { open, onClose, maxMemory, linodeConfigId } = this.props;
     const { errors } = this.state;
     const loading = Object.values(this.state.loading).some(v => v === true);
 

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -87,7 +87,6 @@ interface EditableFields {
 interface Props {
   linodeHypervisor: 'kvm' | 'xen';
   linodeRegion: string;
-  maxMemory: number;
   open: boolean;
   linodeConfigId?: number;
   onClose: () => void;
@@ -114,13 +113,10 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     loading: {
       kernels: false
     },
-    kernels: [],
-    fields: LinodeConfigDrawer.defaultFieldsValues(this.props.maxMemory)
+    kernels: []
   };
 
-  static defaultFieldsValues: (
-    maxMemory: number
-  ) => EditableFields = maxMemory => ({
+  static defaultFieldsValues: () => EditableFields => ({
     comments: '',
     devices: {},
     helpers: {
@@ -132,7 +128,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     },
     kernel: 'linode/latest-64bit',
     label: '',
-    memory_limit: maxMemory,
+    memory_limit: 0,
     root_device: '/dev/sda',
     run_level: 'default',
     useCustomRoot: false,
@@ -241,7 +237,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
   );
 
   renderForm = (errors?: Linode.ApiFieldError[]) => {
-    const { onClose, maxMemory, classes, readOnly } = this.props;
+    const { onClose, classes, readOnly } = this.props;
 
     const {
       kernels,

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -118,7 +118,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     fields: LinodeConfigDrawer.defaultFieldsValues()
   };
 
-  static defaultFieldsValues: () => EditableFields => ({
+  static defaultFieldsValues: () => EditableFields = () => ({
     comments: '',
     devices: {},
     helpers: {

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -199,7 +199,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { open, onClose, maxMemory, linodeConfigId } = this.props;
+    const { open, onClose, linodeConfigId } = this.props;
     const { errors } = this.state;
     const loading = Object.values(this.state.loading).some(v => v === true);
 
@@ -238,7 +238,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
   );
 
   renderForm = (errors?: Linode.ApiFieldError[]) => {
-    const { onClose, classes, readOnly } = this.props;
+    const { onClose, maxMemory, classes, readOnly } = this.props;
 
     const {
       kernels,


### PR DESCRIPTION
Changes default text value to use the literal `memory_limit` from the APIv4's `/instances/:id/config/:id` response