### PR TITLE
Test: Fix IP Sharing and Transfer Tests

### DIFF
--- a/e2e/pageobjects/linode-detail/linode-detail-networking.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-networking.page.js
@@ -53,8 +53,8 @@ class Networking extends Page {
 
     get domainName() { return $('[data-qa-domain-name]'); }
     get lookupError() { return $('[data-qa-error]'); }
-    get shareIpSelect() { return $('[data-qa-share-ip]>div>div'); }
-    get ipShareOption() { return $('[data-ip-idx]'); }
+    get shareIpSelect() { return $('[data-qa-share-ip] > div'); }
+    get ipShareOption() { return $('[data-qa-option]'); }
     get removeSharedIp() { return $('[data-qa-remove-shared-ip]'); }
 
     landingElemsDisplay() {
@@ -182,13 +182,12 @@ class Networking extends Page {
         this.shareIpSelect.click();
         this.ipShareSelection(ipValue).waitForVisible(constants.wait.normal);
         this.ipShareSelection(ipValue).click();
-        browser.pause(500);
         this.submitButton.click();
         this.waitForNotice('IP Sharing updated successfully');
     }
 
     ipShareSelection(ipValue){
-        return $(`[data-ip-idx][data-value="${ipValue}"]`);
+        return $(`[data-qa-option="${ipValue}"]`);
     }
 
     ipTableRow(ipValue){

--- a/e2e/pageobjects/linode-detail/linode-detail-networking.page.js
+++ b/e2e/pageobjects/linode-detail/linode-detail-networking.page.js
@@ -12,10 +12,9 @@ class Networking extends Page {
     get ipTransferSubheading() { return $('[data-qa-transfer-ip-label]'); }
     get ipTransferActionMenu() { return $('[data-qa-ip-transfer-action-menu]'); }
     get ipTransferActionMenus() { return $$('[data-qa-ip-transfer-action-menu]'); }
-    get moveIpButton() { return $('[data-qa-transfer-action="move"]'); }
-    get swapIpButton() { return $('[data-qa-transfer-action="swap"]') }
+    get moveIpButton() { return $('[data-qa-option="move"]'); }
+    get swapIpButton() { return $('[data-qa-option="swap"]') }
     get swapIpActionMenu() { return $('[data-qa-swap-ip-action-menu]'); }
-    get swapWithIps() { return $$('[data-qa-swap-with]'); }
     get ipTransferSave() { return $('[data-qa-ip-transfer-save]'); }
     get ipTransferCancel() { return $('[data-qa-ip-transfer-cancel]'); }
     get addPrivateIp() { return this.addIcon('Add Private IPv4'); }

--- a/e2e/specs/linodes/detail/ip-transfer.spec.js
+++ b/e2e/specs/linodes/detail/ip-transfer.spec.js
@@ -46,41 +46,52 @@ describe('Linode Detail - Ip Transfer Suite', () => {
 		Networking.waitForNotice(singlePublicIpError, constants.wait.normal, true);
 	});
 
-	it('should display swap ip action elements', () => {
-		Networking.ipTransferActionMenu.waitForVisible(constants.wait.normal);
-		Networking.ipTransferActionMenus[0].click();
-		Networking.swapIpButton.waitForVisible();
-		Networking.swapIpButton.click();
-		Networking.swapIpButton.waitForVisible(constants.wait.normal, true);
-		Networking.swapIpActionMenu.waitForVisible();
-		Networking.swapIpActionMenu.click();
-		browser.waitForVisible('[data-qa-swap-with]');
-
-		expect(Networking.swapWithIps.length).toBeGreaterThan(1);
-	});
-
 	it('should fail to swap public to private ips', () => {
 		const errorMsg = `${linodeA.id} must have no more than one private IP after assignment.`;
-		const privateIps =
-			Networking.swapWithIps
-				.filter(ip => !!ip.getText().match(/^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/))
-		privateIps[0].click();
 
-		browser.waitForVisible('[data-qa-swap-with]', constants.wait.normal, true);
+		chooseSwapAction();
 
+		/** select the first private IP in the list */
+		selectIP(true);
+
+		/** save the configuration */
 		Networking.ipTransferSave.click();
 		Networking.waitForNotice(errorMsg);
 	});
 
 	it('should successfully swap ips on a valid ip selection', () => {
-		Networking.swapIpActionMenu.click();
-		browser.waitForVisible('[data-qa-swap-with]');
 
-		const publicIps =
-			Networking.swapWithIps
-				.filter(ip => !!!ip.getText().match(/^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/));
-		publicIps[0].click();
-		browser.waitForVisible('[data-qa-swap-with]', constants.wait.normal, true);
+		/** chose swap fromthe dropdown */
+		chooseSwapAction();
+
+		/** click the first public IP in the list */
+		selectIP();
+
+		/** save the configuration */
 		Networking.ipTransferSave.click();
 	});
 });
+
+const chooseSwapAction = () => {
+	/** click the first actions dropdown */
+	Networking.ipTransferActionMenu.waitForVisible(constants.wait.normal);
+	Networking.ipTransferActionMenu.click();
+
+	Networking.swapIpButton.click();
+}
+
+const selectIP = (selectPrivIP = false) => {
+	/** open the IP selection dropdown */
+	const firstIPSelect = $('[data-qa-swap-ip-action-menu]');
+	firstIPSelect.click();
+
+	const filterFn = selectPrivIP === true
+		? ip => !!ip.getText().match(/^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/)
+		: ip => !ip.getText().match(/^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/)
+
+	/** click the first public IP in the list */
+	browser.waitForVisible('[data-qa-option]', constants.wait.normal);
+	const ips = $$(`[data-qa-option]`)
+		.filter(filterFn);
+	ips[0].click();
+}

--- a/e2e/specs/linodes/detail/networking-ip-sharing.spec.js
+++ b/e2e/specs/linodes/detail/networking-ip-sharing.spec.js
@@ -48,12 +48,10 @@ describe('Linode Detail - Netwrking - IP Sharing', () => {
         Networking.shareIpSelect.click();
         Networking.ipShareOption.waitForVisible(constants.wait.normal);
         expect(Networking.ipShareSelection(linodeOtherDcIp).isVisible()).toBe(false);
-        $('body').click();
-        Networking.ipShareOption.waitForVisible(constants.wait.normal, true);
-        browser.pause(500);
     });
 
     it('Can share an Ip with a linode in the same datacenter', () => {
+        $('body').click()
         Networking.selectIpForSharing(linode2Ip);
         Networking.ipTableRow(linode2Ip).waitForVisible(constants.wait.normal);
     });

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -241,7 +241,9 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
             options={ipList}
             onChange={this.onIPSelect(idx)}
             className={classes.ipField}
-            data-qa-share-ip
+            textFieldProps={{
+              'data-qa-share-ip': true
+            }}
             disabled={readOnly}
             isClearable={false}
             placeholder="Select an IP"

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -281,8 +281,10 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
           <Select
             defaultValue={state.mode}
             options={actionsList}
+            textFieldProps={{
+              'data-qa-ip-transfer-action-menu': state.mode
+            }}
             onChange={this.onModeChange(state.sourceIP)}
-            data-qa-ip-transfer-action-menu
             disabled={readOnly}
             placeholder="Select Action"
             isClearable={false}
@@ -310,6 +312,9 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
       <Grid item xs={12} className={classes.autoGridsm}>
         <Select
           options={linodeList}
+          textFieldProps={{
+            'data-qa-linode-select': true
+          }}
           disabled={readOnly || this.state.linodes.length === 1}
           defaultValue={defaultLinode}
           onChange={this.onSelectedLinodeChange(sourceIP)}
@@ -338,7 +343,9 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
           defaultValue={defaultIP}
           options={IPList}
           onChange={this.onSelectedIPChange(sourceIP)}
-          data-qa-swap-ip-action-menu
+          textFieldProps={{
+            'data-qa-swap-ip-action-menu': true
+          }}
           isClearable={false}
           noMarginTop
         />


### PR DESCRIPTION
## Description

Fixes IP sharing and transfer tests

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=e2e/specs/linodes/detail/networking-ip-sharing.spec.js,e2e/specs/linodes/detail/ip-transfer.spec.js --browser=headlessChrome`
