### PR TITLE
Change: Use Name of Datacenter in Outage Notifications

### DIFF
--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationsList.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationsList.tsx
@@ -7,6 +7,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import { dcDisplayNames } from 'src/constants';
 import UserNotificationListItem from './UserNotificationListItem';
 
 type ClassNames = 'emptyText';
@@ -43,8 +44,9 @@ class UserNotificationsList extends React.Component<CombinedProps, {}> {
     }
 
     return (notifications || []).map((notification, idx) => {
+      const interceptedNotification = interceptNotification(notification);
       const onClick = createClickHandlerForNotification(
-        notification,
+        interceptedNotification,
         (targetPath: string) => {
           closeMenu();
           push(targetPath);
@@ -52,25 +54,43 @@ class UserNotificationsList extends React.Component<CombinedProps, {}> {
       );
       return React.createElement(UserNotificationListItem, {
         key: idx,
-        label: notification.label,
-        message: notification.message,
-        severity: notification.severity,
+        label: interceptedNotification.label,
+        message: interceptedNotification.message,
+        severity: interceptedNotification.severity,
         onClick
       });
     });
   }
 }
 
-const createClickHandlerForNotification = (
-  notification: null | Linode.Notification,
-  onClick: (path: string) => void
-) => {
-  if (!notification) {
-    return;
+const interceptNotification = (
+  notification: Linode.Notification
+): Linode.Notification => {
+  /** this is an outage to one of the datacenters */
+  if (
+    notification.type === 'outage' &&
+    notification.entity &&
+    notification.entity.type === 'region'
+  ) {
+    const convertedRegion = dcDisplayNames[notification.entity.id];
+
+    /** replace "this facility" with the name of the datacenter */
+    return {
+      ...notification,
+      label: notification.label.replace('this facility', convertedRegion),
+      message: notification.message.replace('this facility', convertedRegion)
+    };
   }
 
+  return notification;
+};
+
+const createClickHandlerForNotification = (
+  notification: Linode.Notification,
+  onClick: (path: string) => void
+) => {
   /**
-   * Privacy poliicy changes can only be made in CF manager for now, so we have to
+   * Privacy policy changes can only be made in CF manager for now, so we have to
    * link externally.
    */
   if (

--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationsList.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationsList.tsx
@@ -8,6 +8,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { dcDisplayNames } from 'src/constants';
+import { reportException } from 'src/exceptionReporting';
 import UserNotificationListItem from './UserNotificationListItem';
 
 type ClassNames = 'emptyText';
@@ -73,6 +74,16 @@ const interceptNotification = (
     notification.entity.type === 'region'
   ) {
     const convertedRegion = dcDisplayNames[notification.entity.id];
+
+    if (!convertedRegion) {
+      reportException(
+        'Could not find the DC name for the outage notification',
+        {
+          rawRegion: notification.entity.id,
+          convertedRegion
+        }
+      );
+    }
 
     /** replace "this facility" with the name of the datacenter */
     return {

--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationsList.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationsList.tsx
@@ -88,8 +88,14 @@ const interceptNotification = (
     /** replace "this facility" with the name of the datacenter */
     return {
       ...notification,
-      label: notification.label.replace('this facility', convertedRegion),
-      message: notification.message.replace('this facility', convertedRegion)
+      label: notification.label.replace(
+        'this facility',
+        convertedRegion || 'one of our facilities'
+      ),
+      message: notification.message.replace(
+        'this facility',
+        convertedRegion || 'one of our facilities'
+      )
     };
   }
 


### PR DESCRIPTION
## Description

Changes this:

![Screenshot from 2019-05-31 16-26-41](https://user-images.githubusercontent.com/7387001/58734849-9484b880-83c6-11e9-979d-3dd0189b1782.png)

into this

![Screen Shot 2019-05-31 at 5 06 07 PM](https://user-images.githubusercontent.com/7387001/58734851-99496c80-83c6-11e9-8466-c0b256c4ad8d.png)

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A