### PR TITLE
Fix: flaky oauth clients test

### DIFF
--- a/e2e/specs/profile/clients.spec.js
+++ b/e2e/specs/profile/clients.spec.js
@@ -140,8 +140,8 @@ describe('Profile - OAuth Clients Suite', () => {
             profile.waitForNotice(/\w\d/, constants.wait.normal);
 
             browser.waitUntil(function() {
-                const successMsg = 'Here is your client secret! Store it securely, as it won\'t be shown again.';
-                return $(dialogContent).getText().includes(successMsg);
+                const successMsg = /here is your client secret/ig;
+                return !!$(dialogContent).getText().match(successMsg);
             }, constants.wait.short);
         });
     });

--- a/e2e/specs/profile/clients.spec.js
+++ b/e2e/specs/profile/clients.spec.js
@@ -139,8 +139,10 @@ describe('Profile - OAuth Clients Suite', () => {
 
             profile.waitForNotice(/\w\d/, constants.wait.normal);
 
-            const content = $(dialogContent).getText();
-            expect(content).toContain('Here is your client secret! Store it securely, as it won\'t be shown again.');
+            browser.waitUntil(function() {
+                const successMsg = 'Here is your client secret! Store it securely, as it won\'t be shown again.';
+                return $(dialogContent).getText().includes(successMsg);
+            }, constants.wait.short);
         });
     });
 
@@ -155,11 +157,11 @@ describe('Profile - OAuth Clients Suite', () => {
         it('should display delete dialog', () => {
             profile.selectActionMenu(editedClient.label, "Delete");
             browser.waitForVisible(dialogTitle);
-            
+
             const dialogMsg = $(dialogContent).getText();
             deleteButton = $(dialogConfirm);
             cancelButton = $(dialogCancel);
-            
+
             expect(dialogMsg).toMatch(/delete/i);
             expect(deleteButton.isVisible()).toBe(true);
             expect(cancelButton.isVisible()).toBe(true);


### PR DESCRIPTION
## Description

Fixes a flaky oauth clients test. There was an issue where it would get the text of the modal too quickly and it wouldn't contain the secret confirmation msg.

## Type of Change
- Test Fix

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --file=e2e/specs/profile/clients.spec.js --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
