### PR TITLE
Fix: create from stackscript tests

### DIFF
--- a/e2e/pageobjects/configure-linode.js
+++ b/e2e/pageobjects/configure-linode.js
@@ -52,6 +52,10 @@ class ConfigureLinode extends Page {
     return $('[data-qa-show-more-expanded]');
   }
 
+  get stackScriptSearch() {
+    return $('[data-qa-debounced-search] input');
+  }
+
   get selectStackScriptPanel() {
     return $('[data-qa-panel="Select a StackScript"]');
   }
@@ -229,11 +233,13 @@ class ConfigureLinode extends Page {
 
   stackScriptTableDisplay() {
     this.stackScriptTableHeader.waitForVisible(constants.wait.normal);
-    this.stackScriptDeploysHeader.waitForVisible(constants.wait.normal);
-    this.stackScriptRevisionsHeader.waitForVisible(constants.wait.normal);
-    this.stackScriptCompatibleImagesHeader.waitForVisible(
-      constants.wait.normal
-    );
+    if (browser.getUrl().includes('/stackscripts')) {
+      this.stackScriptDeploysHeader.waitForVisible(constants.wait.normal);
+      this.stackScriptRevisionsHeader.waitForVisible(constants.wait.normal);
+      this.stackScriptCompatibleImagesHeader.waitForVisible(
+        constants.wait.normal
+      );
+    }
   }
 
   stackScriptMetadataDisplay() {

--- a/e2e/pageobjects/list-stackscripts.page.js
+++ b/e2e/pageobjects/list-stackscripts.page.js
@@ -58,7 +58,7 @@ class ListStackScripts extends Page {
     return $('[data-qa-stackscript-title]');
   }
   get stackScriptDescription() {
-    return $('[data-qa-stackscript-title] > p');
+    return $('[data-qa-stackscript-title]');
   }
   get stackScriptDeploys() {
     return $('[data-qa-stackscript-deploys]');

--- a/e2e/specs/create/create-linode-from-stackscript.spec.js
+++ b/e2e/specs/create/create-linode-from-stackscript.spec.js
@@ -2,12 +2,9 @@ const { constants } = require('../../constants');
 
 import ConfigureStackScripts from '../../pageobjects/configure-stackscript.page';
 import ConfigureLinode from '../../pageobjects/configure-linode';
-import ListLinodes from '../../pageobjects/list-linodes';
 import {
   timestamp,
-  waitForLinodeStatus,
   apiDeleteAllLinodes,
-  apiDeleteMyStackScripts
 } from '../../utils/common';
 
 describe('Create Linode - Create from StackScript Suite', () => {
@@ -20,23 +17,13 @@ describe('Create Linode - Create from StackScript Suite', () => {
     apiDeleteAllLinodes();
   });
 
-  afterEach(() => {
-    apiDeleteMyStackScripts();
-  });
-
   it('should change tab to create from stackscript', () => {
-    ConfigureLinode.createFrom('My Images');
-    ConfigureLinode.createFrom('Account StackScripts');
+    ConfigureLinode.createFrom('One-Click');
+    ConfigureLinode.createFrom('Community StackScripts');
   });
 
   it('should display stackscript table', () => {
-    ConfigureLinode.createFrom('One-Click');
-    ConfigureLinode.createFrom('Community StackScripts');
     ConfigureLinode.stackScriptTableDisplay();
-  });
-
-  it('should display community stackscripts', () => {
-    ConfigureLinode.stackScriptMetadataDisplay();
   });
 
   it('should fail to create without selecting a stackscript', () => {
@@ -46,14 +33,16 @@ describe('Create Linode - Create from StackScript Suite', () => {
     ConfigureLinode.waitForNotice(noticeMsg);
   });
 
-  it('should select a stackscript if the associated table row is clicked', () => {
-    ConfigureLinode.createFrom('One-Click');
-    ConfigureLinode.createFrom('Community StackScripts');
-    ConfigureLinode.stackScriptTableDisplay();
-    ConfigureLinode.selectFirstStackScript().waitForVisible(
-      constants.wait.normal
-    );
-    ConfigureLinode.selectFirstStackScript().click();
+  it('should search for a community stackscript', () => {
+    const docker = 'docker-ubuntu';
+    ConfigureLinode.stackScriptSearch.setValue(docker);
+    browser.waitForVisible('[data-qa-table-row="docker-ubuntu"]', constants.wait.normal);
+  });
+
+  it('should select a stackscript if its table row is clicked', () => {
+    /** Select a stackscript we know of */
+    const dockerStackScript = $('[data-qa-table-row="docker-ubuntu"]');
+    dockerStackScript.click();
 
     const checkedRows = ConfigureLinode.stackScriptRows.filter(
       row => row.$('[data-qa-radio]').getAttribute('data-qa-radio') === 'true'
@@ -65,23 +54,6 @@ describe('Create Linode - Create from StackScript Suite', () => {
   it('should display an error when creating without selecting a region', () => {
     const regionErr = 'Region is required.';
 
-    /** create the stackscript */
-    ConfigureStackScripts.createStackScriptNoUDFs();
-
-    /** navigate to the Account StackScripts tab */
-    $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(
-      constants.wait.normal
-    );
-    browser.url(constants.routes.create.linode);
-    ConfigureLinode.createFrom('My Images');
-    ConfigureLinode.createFrom('Account StackScripts');
-
-    /** Select the first one in the list */
-    ConfigureLinode.selectFirstStackScript().waitForVisible(
-      constants.wait.normal
-    );
-    ConfigureLinode.selectFirstStackScript().click();
-
     ConfigureLinode.deploy.click();
     ConfigureLinode.waitForNotice(regionErr, constants.wait.normal);
   });
@@ -89,69 +61,13 @@ describe('Create Linode - Create from StackScript Suite', () => {
   it('should display an error when creating without selecting a plan', () => {
     const planError = 'Plan is required.';
 
-    /** create the stackscript */
-    ConfigureStackScripts.createStackScriptNoUDFs();
-
-    /** navigate to the Account StackScripts tab */
-    $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(
-      constants.wait.normal
-    );
-    browser.url(constants.routes.create.linode);
-    ConfigureLinode.createFrom('My Images');
-    ConfigureLinode.createFrom('Account StackScripts');
-
-    /** Select the first one in the list */
-    ConfigureLinode.selectFirstStackScript().waitForVisible(
-      constants.wait.normal
-    );
-    ConfigureLinode.selectFirstStackScript().click();
     ConfigureLinode.regions[0].click();
     ConfigureLinode.deploy.click();
     ConfigureLinode.waitForNotice(planError, constants.wait.normal);
   });
 
-  it('should display user-defined fields on selection of a stackscript containing UD fields', () => {
-    /** create the stackscript */
-    ConfigureStackScripts.createStackScriptWithRequiredUDFs();
-
-    /** navigate to the Account StackScripts tab */
-    $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(
-      constants.wait.normal
-    );
-    browser.url(constants.routes.create.linode);
-    ConfigureLinode.createFrom('My Images');
-    ConfigureLinode.createFrom('Account StackScripts');
-
-    ConfigureLinode.selectFirstStackScript().waitForVisible(
-      constants.wait.normal
-    );
-    ConfigureLinode.selectFirstStackScript().click();
-    ConfigureLinode.userDefinedFieldsHeader.waitForVisible(
-      constants.wait.normal
-    );
-  });
-
   it('should create from stackscript', () => {
-    /** create the stackscript */
-    ConfigureStackScripts.createStackScriptNoUDFs();
-
-    /** navigate to the Account StackScripts tab */
-    $('[data-qa-icon-text-link="Create New StackScript"]').waitForVisible(
-      constants.wait.normal
-    );
-    browser.url(constants.routes.create.linode);
-    ConfigureLinode.createFrom('My Images');
-    ConfigureLinode.createFrom('Account StackScripts');
-
-    ConfigureLinode.selectFirstStackScript().waitForVisible(
-      constants.wait.normal
-    );
-    ConfigureLinode.selectFirstStackScript().click();
-
-    ConfigureLinode.regions[0].click();
     ConfigureLinode.plans[0].click();
-    /** image is already pre-selected */
-    // ConfigureLinode.images[0].click();
 
     const imageName = ConfigureLinode.images[0]
       .$('[data-qa-select-card-subheading]')
@@ -168,7 +84,7 @@ describe('Create Linode - Create from StackScript Suite', () => {
      * at this point, we've been redirected to the Linodes detail page
      * and we should see the editable text on the screen
      */
-    $('[data-qa-editable-text]').waitForVisible(constants.wait.normal);
+    $('[data-qa-editable-text]').waitForVisible(constants.wait.minute);
     expect($('[data-qa-editable-text]').getText()).toBe(linodeLabel);
   });
 });


### PR DESCRIPTION
## Description

I narrowed the scope of the create linode from stackscript tests quite a bit. They were running through a lot more tests and setup steps than described (they created custom stackscripts before each test and removed them after each test, as opposed to using a known community stackscript and attempting to deploy with that).

Ultimately, the tests are a bit more specific, but don't rely on creating a stackscript several times over the course of the test in order to run.

## Type of Change
- Test fix

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --file e2e/specs/create/create-linode-from-stackscript.spec.js --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
