### PR TITLE
M3-2883: Re-add "Kubernetes" button to Create menu

### DIFF
--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -5,6 +5,7 @@ import { connect, Dispatch } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { bindActionCreators, compose } from 'redux';
 import DomainIcon from 'src/assets/addnewmenu/domain.svg';
+import KubernetesIcon from 'src/assets/addnewmenu/kubernetes.svg';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import NodebalancerIcon from 'src/assets/addnewmenu/nodebalancer.svg';
 import VolumeIcon from 'src/assets/addnewmenu/volume.svg';
@@ -16,6 +17,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import { isKubernetesEnabled } from 'src/constants';
 import { openForCreating as openDomainDrawerForCreating } from 'src/store/domainDrawer';
 import { openForCreating as openVolumeDrawerForCreating } from 'src/store/volumeDrawer';
 import AddNewMenuItem, { MenuItems } from './AddNewMenuItem';
@@ -93,48 +95,65 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
     anchorEl: undefined
   };
 
-  items: MenuItems[] = [
-    {
-      title: 'Linode',
-      onClick: e => {
-        this.props.history.push('/linodes/create');
-        this.handleClose();
-        e.preventDefault();
+  getItems = () => {
+    const items: MenuItems[] = [
+      {
+        title: 'Linode',
+        onClick: e => {
+          this.props.history.push('/linodes/create');
+          this.handleClose();
+          e.preventDefault();
+        },
+        body: `High performance SSD Linux servers for all of your infrastructure needs`,
+        ItemIcon: LinodeIcon
       },
-      body: `High performance SSD Linux servers for all of your infrastructure needs`,
-      ItemIcon: LinodeIcon
-    },
-    {
-      title: 'Volume',
-      onClick: e => {
-        this.props.openVolumeDrawerForCreating();
-        this.handleClose();
-        e.preventDefault();
+      {
+        title: 'Volume',
+        onClick: e => {
+          this.props.openVolumeDrawerForCreating();
+          this.handleClose();
+          e.preventDefault();
+        },
+        body: `Block Storage service allows you to attach additional storage to your Linode`,
+        ItemIcon: VolumeIcon
       },
-      body: `Block Storage service allows you to attach additional storage to your Linode`,
-      ItemIcon: VolumeIcon
-    },
-    {
-      title: 'NodeBalancer',
-      onClick: e => {
-        this.props.history.push('/nodebalancers/create');
-        this.handleClose();
-        e.preventDefault();
+      {
+        title: 'NodeBalancer',
+        onClick: e => {
+          this.props.history.push('/nodebalancers/create');
+          this.handleClose();
+          e.preventDefault();
+        },
+        body: `Ensure your valuable applications and services are highly-available`,
+        ItemIcon: NodebalancerIcon
       },
-      body: `Ensure your valuable applications and services are highly-available`,
-      ItemIcon: NodebalancerIcon
-    },
-    {
-      title: 'Domain',
-      onClick: e => {
-        this.props.openDomainDrawerForCreating();
-        this.handleClose();
-        e.preventDefault();
-      },
-      body: `Manage your DNS records using Linode’s high-availability name servers`,
-      ItemIcon: DomainIcon
+      {
+        title: 'Domain',
+        onClick: e => {
+          this.props.openDomainDrawerForCreating();
+          this.handleClose();
+          e.preventDefault();
+        },
+        body: `Manage your DNS records using Linode’s high-availability name servers`,
+        ItemIcon: DomainIcon
+      }
+    ];
+
+    if (isKubernetesEnabled) {
+      items.push({
+        title: 'Kubernetes',
+        onClick: e => {
+          this.props.history.push('/kubernetes/create');
+          this.handleClose();
+          e.preventDefault();
+        },
+        body: `Create and manage Kubernetes Clusters for highly available container workloads`,
+        ItemIcon: KubernetesIcon
+      });
     }
-  ];
+
+    return items;
+  };
 
   handleClick = (event: React.MouseEvent<HTMLElement>) => {
     this.setState({ anchorEl: event.currentTarget });
@@ -147,7 +166,9 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
   render() {
     const { anchorEl } = this.state;
     const { classes } = this.props;
-    const itemsLen = this.items.length;
+
+    const items = this.getItems();
+    const itemsLen = items.length;
 
     return (
       <div className={classes.wrapper}>
@@ -177,7 +198,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
           className={classes.menu}
         >
           <MenuItem key="placeholder" aria-hidden className={classes.hidden} />
-          {this.items.map((i, idx) => (
+          {items.map((i, idx) => (
             <AddNewMenuItem key={idx} index={idx} count={itemsLen} {...i} />
           ))}
         </Menu>


### PR DESCRIPTION
## Description

It was taken out during a hotfix, #4996. This adds it back in, and renders it only if Kubernetes is enabled.

## Note to Reviewers

Try running the app with Kubernetes enabled and with it disabled.