### PR TITLE
Test Fixes: Override onPrepare in Storybook config, remove extraneous logging

### DIFF
--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -43,7 +43,6 @@ const getRunnerCount = () => {
 }
 
 const parallelRunners = getRunnerCount();
-console.log("parallel runners: " + parallelRunners);
 
 // NOTE: credStore provides a promise-based API.  In order to work correctly with WDIO, any calls in
 // lifecycle methods *other than* onPrepare and onComplete should be wrapped using WDIO's browser.call
@@ -58,7 +57,6 @@ const credStores = {
 };
 
 let CRED_STORE_MODE = process.env.CRED_STORE_MODE ? process.env.CRED_STORE_MODE : 'fs';
-console.log("process.env.CRED_STORE_MODE set to: " + CRED_STORE_MODE);
 
 if (!(CRED_STORE_MODE in credStores)) {
     let msg = "CRED_STORE_MODE must be one of: ";
@@ -237,8 +235,6 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      */
     onPrepare: function (config, capabilities, user) {
-        console.log("onPrepare");
-
         if ((parallelRunners > 1) && (CRED_STORE_MODE === 'fs')) {
             throw new Error("***** Can't use filesystem cred store when parallelRunners > 1.\n***** Set CRED_STORE_MODE=mongolocal in .env and launch mongodb by running: docker run -d -p 27017:27017 mongo");
         }
@@ -309,8 +305,6 @@ exports.config = {
                 creds = testCreds;
             }).catch((err) => console.log(err));
         });
-        console.log("creds are");
-        console.log(creds);
         credStore.login(creds.username, creds.password, false);
     },
     /**
@@ -390,7 +384,7 @@ exports.config = {
 
         // Set "inUse:false" on the account under test in the credentials file
         browser.call(
-            () => credStore.checkinCreds(specs[0]).then((creds) => console.log(creds))
+            () => credStore.checkinCreds(specs[0]).then((creds) => creds)
         );
     },
     /**
@@ -408,9 +402,8 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      */
     onComplete: function(exitCode, config, capabilities) {
-        console.log("onComplete");
-        // delete all data created during the test and remove test credentials from
-        // the underlying store
+        /* delete all data created during the test and remove test credentials
+           from the underlying store */
         return credStore.cleanupAccounts();
     }
 }

--- a/e2e/config/wdio.storybook.conf.js
+++ b/e2e/config/wdio.storybook.conf.js
@@ -31,14 +31,14 @@ exports.config = merge(wdioMaster.config, {
     services: servicesToStart,
     seleniumInstallArgs: seleniumSettings,
     seleniumArgs: seleniumSettings,
+    onPrepare: function(config, capabilities, user) {
+    },
     before: function (capabilities, specs) {
         browserCommands();
     },
     beforeSuite: function(suite) {
-        // Do nothing before suites
     },
     after: function (result, capabilities, specs) {
-
     },
     onComplete: function(exitCode, config, capabilities) {
     }

--- a/e2e/utils/config-utils.js
+++ b/e2e/utils/config-utils.js
@@ -4,7 +4,6 @@ module.exports.readToken = () => {
     browser.call(() => {
         return browser.credStore.readToken(browser.options.testUser).then((t) => token = t);
     });
-    console.log(`token is ${token}`);
     return token;
 }
 
@@ -13,7 +12,6 @@ module.exports.getToken = (username) => {
     browser.call(() => {
         return browser.credStore.readToken(username).then((t) => token = t);
     });
-    console.log(`token is ${token}`);
     return token;
 }
 

--- a/e2e/utils/fs-cred-store.js
+++ b/e2e/utils/fs-cred-store.js
@@ -8,7 +8,7 @@ const CredStore = require('./cred-store');
  * on the local filesystem.
  */
 class FSCredStore extends CredStore {
-    
+
     constructor(credsFile, shouldCleanupUsingAPI, browser) {
         super(shouldCleanupUsingAPI, browser);
         this.credsFile = credsFile;
@@ -55,7 +55,7 @@ class FSCredStore extends CredStore {
             if (!currentUser.isPresetToken) {
                 currentUser.token = this.getTokenFromLocalStorage();
             }
-    
+
             return this._writeCredsFile(credCollection);
         })
     }
@@ -75,7 +75,7 @@ class FSCredStore extends CredStore {
                 if (!cred.inUse) {
                     credCollection[i].inUse = true;
                     credCollection[i].spec = specFile;
-                    
+
                     this.browser.options.testUser = credCollection[i].username;
                     return true;
                 }
@@ -86,7 +86,7 @@ class FSCredStore extends CredStore {
 
     checkinCreds(specFile) {
         console.log("checkinCreds: " + specFile);
-        
+
         return this._readCredsFile().then((credCollection) => {
             const creds = credCollection.find((cred, i) => {
                 if (cred.spec === specFile) {
@@ -117,7 +117,7 @@ class FSCredStore extends CredStore {
                 setCredCollection('MANAGER_USER', `_${i}`);
             }
         }
-        
+
         console.log("adding users:");
         console.log(credCollection);
         return this._writeCredsFile(credCollection);
@@ -139,7 +139,7 @@ class FSCredStore extends CredStore {
                         resolve(this.credsFile);
                     }
                 })
-            });            
+            });
         })
     }
 }
@@ -147,9 +147,9 @@ class FSCredStore extends CredStore {
 if (process.argv[2] == "test-fs") {
 
     console.log("running fs credential tests");
-    
+
     let mockTestConfig = {"host":"selenium","port":4444,"sync":true,"specs":["./e2e/specs/search/smoke-search.spec.js"],"suites":{},"exclude":["./e2e/specs/accessibility/*.spec.js"],"logLevel":"silent","coloredLogs":true,"deprecationWarnings":false,"baseUrl":"http://localhost:3000","bail":0,"waitforInterval":500,"waitforTimeout":30000,"framework":"jasmine","reporters":["spec","junit"],"reporterOptions":{"junit":{"outputDir":"./e2e/test-results"}},"maxInstances":1,"maxInstancesPerCapability":100,"connectionRetryTimeout":90000,"connectionRetryCount":3,"debug":false,"execArgv":null,"mochaOpts":{"timeout":10000},"jasmineNodeOpts":{"defaultTimeoutInterval":600000},"before":[null],"beforeSession":[],"beforeSuite":[],"beforeHook":[],"beforeTest":[],"beforeCommand":[],"afterCommand":[],"afterTest":[],"afterHook":[],"afterSuite":[],"afterSession":[],"after":[null],"onError":[],"onReload":[],"beforeFeature":[],"beforeScenario":[],"beforeStep":[],"afterFeature":[],"afterScenario":[],"afterStep":[],"mountebankConfig":{"proxyConfig":{"imposterPort":"8088","imposterProtocol":"https","imposterName":"Linode-API","proxyHost":"https://api.linode.com/v4","mutualAuth":true}},"testUser":"","watch":false};
-    
+
     let credStore = new FSCredStore("/tmp/e2e-users.js", false);
 
     // assumes env var config for 2 test users, see .env or .env.example
@@ -169,7 +169,6 @@ if (process.argv[2] == "test-fs") {
         return credStore.readToken(creds.username);
     })
     .then((token) => {
-        console.log("token is: " + token);
         return credStore.getAllCreds();
     }).then((allCreds) => {
         console.log("got all creds:");


### PR DESCRIPTION
## Description

All this logging when running the e2e tests was unnecessary noise. I removed it and also made a change to override the `onPrepare` method in the `storybook.conf.js`. No creds need to be checked out to run the storybook tests, so this overrides the base onPrepare method delcared in `wdio.conf.js`.

## Type of Change
- Tests fix

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn storybook`
2. `yarn selenium`
3. `yarn storybook:e2e`
