### PR TITLE
bug: Updated logout to split token before revoking it

### DIFF
--- a/src/layouts/Logout.tsx
+++ b/src/layouts/Logout.tsx
@@ -9,7 +9,8 @@ import { handleLogout } from 'src/store/authentication/authentication.requests';
 
 export class Logout extends Component<DispatchProps & StateProps> {
   componentDidMount() {
-    this.props.dispatchLogout(CLIENT_ID || '', this.props.token);
+    // Split the token so we can get the token portion of the "<prefix> <token>" pair
+    this.props.dispatchLogout(CLIENT_ID || '', this.props.token.split(' ')[1]);
   }
 
   render() {


### PR DESCRIPTION
## Description

Because the prefix for the `Authorization` header is included in the token in local storage, POST to login's `/oauth/revoke` endpoint with the full token payload was not actually revoking anything. This should fix that.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

If you are running this on an environment where you can fiddle with local storage, try transplanting a token used in one manager session into another manager session after logging out and see if the old token still works. Alternatively, strip out the `Bearer` prefix and try to use the token directly against the API.