### PR TITLE
M3-2847 change: Remove TagsInput when cloning a Domain

### DIFF
--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -278,14 +278,14 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             label="Master"
             control={<Radio />}
             data-qa-domain-radio="Master"
-            disabled={mode === EDITING || disabled}
+            disabled={mode === EDITING || mode === CLONING || disabled}
           />
           <FormControlLabel
             value="slave"
             label="Slave"
             control={<Radio />}
             data-qa-domain-radio="Slave"
-            disabled={mode === EDITING || disabled}
+            disabled={mode === EDITING || mode === CLONING || disabled}
           />
         </RadioGroup>
         <TextField

--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -347,12 +347,14 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             />
           </React.Fragment>
         )}
-        <TagsInput
-          value={tags}
-          onChange={this.updateTags}
-          tagError={errorMap.tags}
-          disabled={disabled}
-        />
+        {this.props.mode !== CLONING && (
+          <TagsInput
+            value={tags}
+            onChange={this.updateTags}
+            tagError={errorMap.tags}
+            disabled={disabled}
+          />
+        )}
         {isCreatingMasterDomain && (
           <React.Fragment>
             <Select


### PR DESCRIPTION
## Description

Adding tags while cloning a Domain is not supported by the API, but we were displaying the TagsInput component in the Domain Drawer while in Clone mode. This PR removes it.

It also disables the Master/Slave radio buttons while in Cloning mode, since these buttons don't do anything (i.e. when cloning a Master domain, the new domain is also a Master).

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests
N/A

## Note to Reviewers

Create a few Domains (both master and slaves) and try cloning them. Verify functionality of the Domain Drawer in general.
