### PR TITLE
Linode Maintenance Part 1

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -15,6 +15,8 @@ it('renders without crashing', () => {
       <Provider store={store}>
         <StaticRouter location="/" context={{}}>
           <App
+            linodes={[]}
+            notifications={[]}
             {...mockNodeBalancerActions}
             username=""
             isLoggedInAsCustomer={false}
@@ -35,20 +37,19 @@ it('renders without crashing', () => {
             }}
             userId={123456}
             profileLoading={false}
-            actions={{
-              requestAccount: jest.fn(),
-              requestDomains: jest.fn(),
-              requestImages: jest.fn(),
-              requestLinodes: jest.fn(),
-              requestNotifications: jest.fn(),
-              requestProfile: jest.fn(),
-              requestSettings: jest.fn(),
-              requestTypes: jest.fn(),
-              requestRegions: jest.fn(),
-              requestVolumes: jest.fn(),
-              requestBuckets: jest.fn(),
-              requestClusters: jest.fn()
-            }}
+            requestAccount={jest.fn()}
+            addNotificationsToLinodes={jest.fn()}
+            requestDomains={jest.fn()}
+            requestImages={jest.fn()}
+            requestLinodes={jest.fn()}
+            requestNotifications={jest.fn()}
+            requestProfile={jest.fn()}
+            requestSettings={jest.fn()}
+            requestTypes={jest.fn()}
+            requestRegions={jest.fn()}
+            requestVolumes={jest.fn()}
+            requestBuckets={jest.fn()}
+            requestClusters={jest.fn()}
             documentation={[]}
             toggleTheme={jest.fn()}
             toggleSpacing={jest.fn()}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -214,12 +214,9 @@ export class App extends React.Component<CombinedProps, State> {
   componentDidUpdate(prevProps: CombinedProps) {
     /** run once when both notifications and linodes are loaded in Redux state */
     if (
-      (!!this.props.linodes.length &&
-        !prevProps.notifications &&
-        !!this.props.notifications) ||
-      (!!this.props.notifications &&
-        !prevProps.linodes.length &&
-        !!this.props.linodes.length)
+      !!this.props.linodes.length &&
+      !!this.props.notifications &&
+      (!prevProps.notifications || !prevProps.linodes.length)
     ) {
       this.props.addNotificationsToLinodes(
         this.props.notifications,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ import { MapState } from './store/types';
 import { isObjectStorageEnabled } from './utilities/accountCapabilities';
 
 import ErrorState from 'src/components/ErrorState';
+import { addNotificationsToLinodes } from 'src/store/linodes/linodes.actions';
 
 shim(); // allows for .finally() usage
 
@@ -210,27 +211,43 @@ export class App extends React.Component<CombinedProps, State> {
     hasError: false
   };
 
+  componentDidUpdate(prevProps: CombinedProps) {
+    /** run once when both notifications and linodes are loaded in Redux state */
+    if (
+      (!!this.props.linodes.length &&
+        !prevProps.notifications &&
+        !!this.props.notifications) ||
+      (!!this.props.notifications &&
+        !prevProps.linodes.length &&
+        !!this.props.linodes.length)
+    ) {
+      this.props.addNotificationsToLinodes(
+        this.props.notifications,
+        this.props.linodes
+      );
+    }
+  }
+
   componentDidCatch() {
     this.setState({ hasError: true });
   }
 
   async componentDidMount() {
     const {
-      actions,
       nodeBalancerActions: { getAllNodeBalancersWithConfigs }
     } = this.props;
 
     const dataFetchingPromises: Promise<any>[] = [
-      actions.requestAccount(),
-      actions.requestProfile(),
-      actions.requestDomains(),
-      actions.requestImages(),
-      actions.requestLinodes(),
-      actions.requestNotifications(),
-      actions.requestSettings(),
-      actions.requestTypes(),
-      actions.requestRegions(),
-      actions.requestVolumes(),
+      this.props.requestAccount(),
+      this.props.requestProfile(),
+      this.props.requestDomains(),
+      this.props.requestImages(),
+      this.props.requestLinodes(),
+      this.props.requestNotifications(),
+      this.props.requestSettings(),
+      this.props.requestTypes(),
+      this.props.requestRegions(),
+      this.props.requestVolumes(),
       getAllNodeBalancersWithConfigs()
     ];
 
@@ -471,40 +488,44 @@ const getObjectStorageRoute = (
 };
 
 interface DispatchProps {
-  actions: {
-    requestAccount: () => Promise<Linode.Account>;
-    requestDomains: () => Promise<Linode.Domain[]>;
-    requestImages: () => Promise<Linode.Image[]>;
-    requestLinodes: () => Promise<Linode.Linode[]>;
-    requestNotifications: () => Promise<Linode.Notification[]>;
-    requestProfile: () => Promise<Linode.Profile>;
-    requestSettings: () => Promise<Linode.AccountSettings>;
-    requestTypes: () => Promise<Linode.LinodeType[]>;
-    requestRegions: () => Promise<Linode.Region[]>;
-    requestVolumes: () => Promise<Linode.Volume[]>;
-    requestBuckets: () => Promise<Linode.Bucket[]>;
-    requestClusters: () => Promise<Linode.Cluster[]>;
-  };
+  requestAccount: () => Promise<Linode.Account>;
+  requestDomains: () => Promise<Linode.Domain[]>;
+  requestImages: () => Promise<Linode.Image[]>;
+  requestLinodes: () => Promise<Linode.Linode[]>;
+  requestNotifications: () => Promise<Linode.Notification[]>;
+  requestProfile: () => Promise<Linode.Profile>;
+  requestSettings: () => Promise<Linode.AccountSettings>;
+  requestTypes: () => Promise<Linode.LinodeType[]>;
+  requestRegions: () => Promise<Linode.Region[]>;
+  requestVolumes: () => Promise<Linode.Volume[]>;
+  requestBuckets: () => Promise<Linode.Bucket[]>;
+  requestClusters: () => Promise<Linode.Cluster[]>;
+  addNotificationsToLinodes: (
+    notifications: Linode.Notification[],
+    linodes: Linode.Linode[]
+  ) => void;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
   dispatch: ThunkDispatch<ApplicationState, undefined, Action<any>>
 ) => {
   return {
-    actions: {
-      requestAccount: () => dispatch(requestAccount()),
-      requestDomains: () => dispatch(requestDomains()),
-      requestImages: () => dispatch(requestImages()),
-      requestLinodes: () => dispatch(requestLinodes()),
-      requestNotifications: () => dispatch(requestNotifications()),
-      requestProfile: () => dispatch(requestProfile()),
-      requestSettings: () => dispatch(requestAccountSettings()),
-      requestTypes: () => dispatch(requestTypes()),
-      requestRegions: () => dispatch(requestRegions()),
-      requestVolumes: () => dispatch(getAllVolumes()),
-      requestBuckets: () => dispatch(getAllBuckets()),
-      requestClusters: () => dispatch(requestClusters())
-    }
+    requestAccount: () => dispatch(requestAccount()),
+    requestDomains: () => dispatch(requestDomains()),
+    requestImages: () => dispatch(requestImages()),
+    requestLinodes: () => dispatch(requestLinodes()),
+    requestNotifications: () => dispatch(requestNotifications()),
+    requestProfile: () => dispatch(requestProfile()),
+    requestSettings: () => dispatch(requestAccountSettings()),
+    requestTypes: () => dispatch(requestTypes()),
+    requestRegions: () => dispatch(requestRegions()),
+    requestVolumes: () => dispatch(getAllVolumes()),
+    requestBuckets: () => dispatch(getAllBuckets()),
+    requestClusters: () => dispatch(requestClusters()),
+    addNotificationsToLinodes: (
+      _notifications: Linode.Notification[],
+      linodes: Linode.Linode[]
+    ) => dispatch(addNotificationsToLinodes(_notifications, linodes))
   };
 };
 
@@ -512,9 +533,11 @@ interface StateProps {
   /** Profile */
   profileLoading: boolean;
   profileError?: Error | Linode.ApiFieldError[];
+  linodes: Linode.Linode[];
   linodesError?: Linode.ApiFieldError[];
   domainsError?: Linode.ApiFieldError[];
   imagesError?: Linode.ApiFieldError[];
+  notifications?: Linode.Notification[];
   notificationsError?: Linode.ApiFieldError[] | Error;
   settingsError?: Linode.ApiFieldError[] | Error;
   typesError?: Linode.ApiFieldError[];
@@ -534,9 +557,11 @@ const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => ({
   /** Profile */
   profileLoading: state.__resources.profile.loading,
   profileError: state.__resources.profile.error,
+  linodes: state.__resources.linodes.entities,
   linodesError: path(['read'], state.__resources.linodes.error),
   domainsError: state.__resources.domains.error,
   imagesError: state.__resources.images.error,
+  notifications: state.__resources.notifications.data,
   notificationsError: state.__resources.notifications.error,
   settingsError: state.__resources.accountSettings.error,
   typesError: state.__resources.types.error,

--- a/src/features/TopMenu/UserNotificationsMenu/UserNotificationsMenu.tsx
+++ b/src/features/TopMenu/UserNotificationsMenu/UserNotificationsMenu.tsx
@@ -88,6 +88,7 @@ class UserNotificationsMenu extends React.Component<CombinedProps, State> {
     'payment_due',
     'ticket_important',
     'ticket_abuse',
+    'maintenance',
     'notice',
     'migration_pending',
     'migration_scheduled'

--- a/src/store/linodes/linodes.actions.ts
+++ b/src/store/linodes/linodes.actions.ts
@@ -11,6 +11,9 @@ that comes down the stream
 export const updateMultipleLinodes = actionCreator<Linode.Linode[]>(
   'update_multiple'
 );
+export const addNotificationsToLinodes = actionCreator<Linode.Notification[]>(
+  'add_notifications_to_all_linodes'
+);
 export const upsertLinode = actionCreator<Linode.Linode>(`upsert`);
 export const deleteLinode = actionCreator<number>('delete');
 export const updateLinode = actionCreator<{

--- a/src/store/linodes/linodes.helpers.test.ts
+++ b/src/store/linodes/linodes.helpers.test.ts
@@ -1,0 +1,47 @@
+import { linode1 } from 'src/__data__/linodes';
+import { addNotificationsToLinodes } from './linodes.helpers';
+
+const maintenanceNotification: (
+  linodeID: number
+) => Linode.Notification[] = linodeID => [
+  {
+    label: 'This Linode is in Danger! Ahhhhh',
+    message: 'This Linode is in Danger! Ahhhhh',
+    type: 'maintenance',
+    severity: 'critical',
+    entity: {
+      id: linodeID,
+      label: 'linode1234',
+      type: 'linode',
+      url: 'https://hello.world'
+    },
+    when: 'rightnow',
+    until: 'later',
+    body: null
+  }
+];
+
+describe('Linode Redux Helpers', () => {
+  it('should add relevant notifications to Linodes', () => {
+    expect(
+      addNotificationsToLinodes(maintenanceNotification(linode1.id), [linode1])
+    ).toEqual([
+      {
+        ...linode1,
+        maintenance: {
+          when: 'rightnow',
+          until: 'later',
+          type: 'maintenance'
+        }
+      }
+    ]);
+  });
+
+  expect(
+    addNotificationsToLinodes(maintenanceNotification(4325345345), [linode1])
+  ).toEqual([
+    {
+      ...linode1
+    }
+  ]);
+});

--- a/src/store/linodes/linodes.helpers.ts
+++ b/src/store/linodes/linodes.helpers.ts
@@ -1,7 +1,7 @@
 /**
- * when is not guarenteed
+ * _when_ is not guaranteed
  *
- * when could be in the past
+ * _when_ could be in the past
  */
 
 /**
@@ -10,7 +10,7 @@
  */
 type Type = 'zombieload-reboot-scheduled' | 'zombieload-migration-scheduled';
 
-export interface LinodesWithMaintenance extends Linode.Linode {
+export interface LinodeWithMaintenance extends Linode.Linode {
   maintenance?: {
     type: Type;
     when: string | null;
@@ -21,7 +21,7 @@ export interface LinodesWithMaintenance extends Linode.Linode {
 export const addNotificationsToLinodes = (
   notifications: Linode.Notification[],
   linodes: Linode.Linode[]
-): LinodesWithMaintenance[] => {
+): LinodeWithMaintenance[] => {
   const maintenanceNotifications = notifications.filter(eachNotification => {
     return eachNotification.type === 'maintenance';
   });

--- a/src/store/linodes/linodes.helpers.ts
+++ b/src/store/linodes/linodes.helpers.ts
@@ -1,0 +1,52 @@
+/**
+ * when is not guarenteed
+ *
+ * when could be in the past
+ */
+
+/**
+ * this is what's coming back from the API, but we should absolutely not
+ * be doing exact string matching on these
+ */
+type Type = 'zombieload-reboot-scheduled' | 'zombieload-migration-scheduled';
+
+export interface LinodesWithMaintenance extends Linode.Linode {
+  maintenance?: {
+    type: Type;
+    when: string | null;
+    until: string | null;
+  };
+}
+
+export const addNotificationsToLinodes = (
+  notifications: Linode.Notification[],
+  linodes: Linode.Linode[]
+): LinodesWithMaintenance[] => {
+  const maintenanceNotifications = notifications.filter(eachNotification => {
+    return eachNotification.type === 'maintenance';
+  });
+
+  /** add the "maintenance" key to the Linode if we have one */
+  return linodes.map(eachLinode => {
+    const foundNotification = maintenanceNotifications.find(
+      eachNotification => {
+        return eachNotification.entity!.id === eachLinode.id;
+      }
+    );
+
+    return foundNotification
+      ? {
+          ...eachLinode,
+          maintenance: {
+            /**
+             * "when" and "until" are not guaranteed to exist
+             * if we have a maintenance notification
+             */
+            when: foundNotification.when,
+            until: foundNotification.until,
+            type: foundNotification.type as Type
+          }
+        }
+      : eachLinode;
+  });
+};

--- a/src/store/linodes/linodes.reducer.ts
+++ b/src/store/linodes/linodes.reducer.ts
@@ -15,14 +15,17 @@ import {
   upsertLinode
 } from './linodes.actions';
 
-import { addNotificationsToLinodes as _addNotificationsToLinodes } from './linodes.helpers';
+import {
+  addNotificationsToLinodes as _addNotificationsToLinodes,
+  LinodeWithMaintenance
+} from './linodes.helpers';
 
 const getId = <E extends HasNumericID>({ id }: E) => id;
 
 /**
  * State
  */
-export type State = EntityState<Linode.Linode, EntityError>;
+export type State = EntityState<LinodeWithMaintenance, EntityError>;
 
 export const defaultState: State = {
   results: [],

--- a/src/store/linodes/linodes.reducer.ts
+++ b/src/store/linodes/linodes.reducer.ts
@@ -4,6 +4,7 @@ import updateById from 'src/utilities/updateById';
 import updateOrAdd from 'src/utilities/updateOrAdd';
 import { isType } from 'typescript-fsa';
 import {
+  addNotificationsToLinodes,
   createLinodeActions,
   deleteLinode,
   deleteLinodeActions,
@@ -13,6 +14,8 @@ import {
   updateMultipleLinodes,
   upsertLinode
 } from './linodes.actions';
+
+import { addNotificationsToLinodes as _addNotificationsToLinodes } from './linodes.helpers';
 
 const getId = <E extends HasNumericID>({ id }: E) => id;
 
@@ -144,6 +147,18 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       params: { linodeId }
     } = action.payload;
     const entities = state.entities.filter(({ id }) => id !== linodeId);
+
+    return {
+      ...state,
+      entities,
+      results: entities.map(getId)
+    };
+  }
+
+  if (isType(action, addNotificationsToLinodes)) {
+    const { payload: notifications } = action;
+
+    const entities = _addNotificationsToLinodes(notifications, state.entities);
 
     return {
       ...state,

--- a/src/store/notification/notification.reducer.ts
+++ b/src/store/notification/notification.reducer.ts
@@ -7,7 +7,7 @@ export type State = RequestableData<Linode.Notification[]>;
 export const defaultState: State = {
   lastUpdated: 0,
   loading: false,
-  data: [],
+  data: undefined,
   error: undefined
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,7 @@ namespace Linode {
     | 'migration_pending'
     | 'reboot_scheduled'
     | 'outage'
+    | 'maintenance'
     | 'payment_due'
     | 'ticket_important'
     | 'ticket_abuse'


### PR DESCRIPTION
## Description

Adds all the Redux nonsense to get maintenance notifications attached to the relevant Linodes

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## Note to Reviewers

Flow goes like this:

1. App loads
2. Request Linodes and Notifications
3. Call Redux action to append each `maintenance` notification to the Linode 
4. Redux store is updated and some linodes will have a `maintenance` key on it's schema

Here's some mock data to play around with from GET `/notifications`. Be sure to replace the Linode IDs appropriately

```js
{
  "results": 5,
  "page": 1,
  "data": [
    {
      "until": null,
      "entity": {
        "url": "/linode/instances/500",
        "id": 500,
        "type": "linode",
        "label": "loadbal1-vagrant"
      },
      "when": null,
      "body": null,
      "severity": "major",
      "type": "migration_scheduled",
      "label": "You have a scheduled migration pending!",
      "message": "You have a scheduled migration pending!  Your Linode will be automatically shut down, migrated, and returned to its last state."
    },
    {
      "until": null,
      "entity": {
        "url": "/linode/instances/504",
        "id": 504,
        "type": "linode",
        "label": "loadbal5-xengrant"
      },
      "when": null,
      "body": null,
      "severity": "major",
      "type": "migration_pending",
      "label": "You have a migration pending!",
      "message": "You have a migration pending! Your Linode must be offline before starting the migration."
    },
    {
      "until": null,
      "entity": {
        "url": "/linode/instances/500",
        "id": 500,
        "type": "linode",
        "label": "loadbal1-vagrant"
      },
      "when": "2020-10-29T15:32:26",
      "body": "This Linode resides on a host that is pending critical maintenance. You should have recieved a support ticket that details how you will be affected. Please see the aformentioned ticket and [status.linode.com](https://status.linode.com/) for more details.",
      "severity": "critical",
      "type": "maintenance",
      "label": "zombieload-migration-scheduled",
      "message": "This Linode will be affected by critical maintenance!"
    },
    {
      "until": null,
      "entity": {
        "url": "/linode/instances/504",
        "id": 504,
        "type": "linode",
        "label": "loadbal5-xengrant"
      },
      "when": null,
      "body": "This Linode resides on a host that is pending critical maintenance. You should have recieved a support ticket that details how you will be affected. Please see the aformentioned ticket and [status.linode.com](https://status.linode.com/) for more details.",
      "severity": "critical",
      "type": "maintenance",
      "label": "zombieload-migration-scheduled",
      "message": "This Linode will be affected by critical maintenance!"
    },
    {
      "until": null,
      "entity": {
        "url": "/linode/instances/507",
        "id": 507,
        "type": "linode",
        "label": "loadbal8-xengrant"
      },
      "when": "2020-03-22T18:58:41",
      "body": "This Linode resides on a host that is pending critical maintenance. You should have recieved a support ticket that details how you will be affected. Please see the aformentioned ticket and [status.linode.com](https://status.linode.com/) for more details.",
      "severity": "critical",
      "type": "maintenance",
      "label": "zombieload-reboot-scheduled",
      "message": "This Linode will be affected by critical maintenance!"
    }
  ],
  "pages": 1
}
```