### PR TITLE
Update SelectPlanPanel to allow different tab sets

### DIFF
--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -89,13 +89,15 @@ export class SelectPlanPanel extends React.Component<
     );
   };
 
-  createTabs = () => {
+  createTabs = (): [Tab[], Linode.LinodeTypeClass[]] => {
     const { classes, types } = this.props;
     const tabs: Tab[] = [];
     const nanodes = getNanodes(types);
     const standards = getStandard(types);
     const highmem = getHighMem(types);
     const dedicated = getDedicated(types);
+
+    const tabOrder: Linode.LinodeTypeClass[] = [];
 
     if (!isEmpty(nanodes)) {
       tabs.push({
@@ -114,6 +116,7 @@ export class SelectPlanPanel extends React.Component<
         },
         title: 'Nanode'
       });
+      tabOrder.push('nanode');
     }
 
     if (!isEmpty(standards)) {
@@ -133,6 +136,7 @@ export class SelectPlanPanel extends React.Component<
         },
         title: 'Standard'
       });
+      tabOrder.push('standard');
     }
 
     if (!isEmpty(dedicated)) {
@@ -152,6 +156,7 @@ export class SelectPlanPanel extends React.Component<
         },
         title: 'Dedicated CPU'
       });
+      tabOrder.push('dedicated');
     }
 
     if (!isEmpty(highmem)) {
@@ -172,14 +177,16 @@ export class SelectPlanPanel extends React.Component<
         },
         title: 'High Memory'
       });
+      tabOrder.push('highmem');
     }
 
-    return tabs;
+    return [tabs, tabOrder];
   };
 
   render() {
     const { classes, copy, error, header, types, selectedID } = this.props;
 
+    const [tabs, tabOrder] = this.createTabs();
     // Determine initial plan category tab based on selectedTypeID
     // (if there is one).
     const selectedTypeClass: Linode.LinodeTypeClass = pathOr(
@@ -195,7 +202,7 @@ export class SelectPlanPanel extends React.Component<
         error={error}
         header={header || 'Linode Plan'}
         copy={copy}
-        tabs={this.createTabs()}
+        tabs={tabs}
         initTab={initialTab}
       />
     );
@@ -211,10 +218,3 @@ export default compose<
   RenderGuard,
   styled
 )(SelectPlanPanel);
-
-const tabOrder: Linode.LinodeTypeClass[] = [
-  'nanode',
-  'standard',
-  'dedicated',
-  'highmem'
-];


### PR DESCRIPTION
## Description

The SelectPlanPanel only displayed a tab if there were any instances
of that plan type (so if no Nanodes are passed to the component,
the Nanodes tab is hidden). However, the "what tab should I default to"
logic didn't consider this case, so the selected tab would default to
an incorrect value. Dynamically calculated the tabOrder list to account
for this.
## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

This was causing weirdness on the Kube cluster create flow, but please also test other instances of this component (cloning a Linode, creating, etc.)