### PR TITLE
Add redux boilerplate for K8s clusters

### DIFF
--- a/src/containers/kubernetes.container.ts
+++ b/src/containers/kubernetes.container.ts
@@ -1,0 +1,50 @@
+import { connect, MapDispatchToProps } from 'react-redux';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { ApplicationState } from 'src/store';
+import { requestKubernetesClusters as _requestKubernetesClusters } from 'src/store/kubernetes/kubernetes.requests';
+import { EntityError } from 'src/store/types';
+
+export interface KubernetesProps {
+  clusters?: Linode.KubernetesCluster[];
+  clustersLoading: boolean;
+  clustersError: EntityError;
+  lastUpdated?: number;
+}
+
+export interface DispatchProps {
+  requestKubernetesClusters: () => void;
+}
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
+  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
+) => ({
+  requestKubernetesClusters: () => dispatch(_requestKubernetesClusters())
+});
+
+export default <TInner extends {}, TOuter extends {}>(
+  mapKubernetesToProps: (
+    ownProps: TOuter,
+    clustersLoading: boolean,
+    lastUpdated: number,
+    clustersError: EntityError,
+    clusters?: Linode.KubernetesCluster[]
+  ) => TInner
+) =>
+  connect(
+    (state: ApplicationState, ownProps: TOuter) => {
+      const clusters = state.__resources.kubernetes.entities;
+      const clustersLoading = state.__resources.kubernetes.loading;
+      const clustersError = state.__resources.kubernetes.error || {};
+      const lastUpdated = state.__resources.kubernetes.lastUpdated;
+
+      return mapKubernetesToProps(
+        ownProps,
+        clustersLoading,
+        lastUpdated,
+        clustersError,
+        clusters
+      );
+    },
+    mapDispatchToProps
+  );

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -49,6 +49,10 @@ import images, {
   defaultState as defaultImagesState,
   State as ImagesState
 } from 'src/store/image/image.reducer';
+import kubernetes, {
+  defaultState as defaultKubernetesState,
+  State as KubernetesState
+} from 'src/store/kubernetes/kubernetes.reducer';
 import linodeCreateReducer, {
   defaultState as linodeCreateDefaultState,
   State as LinodeCreateState
@@ -125,6 +129,7 @@ const __resourcesDefaultState = {
   accountSettings: defaultAccountSettingsState,
   domains: defaultDomainsState,
   images: defaultImagesState,
+  kubernetes: defaultKubernetesState,
   linodes: defaultLinodesState,
   linodeConfigs: defaultLinodeConfigsState,
   linodeDisks: defaultLinodeDisksState,
@@ -144,6 +149,7 @@ export interface ResourcesState {
   accountSettings: AccountSettingsState;
   domains: DomainsState;
   images: ImagesState;
+  kubernetes: KubernetesState;
   linodes: LinodesState;
   linodeConfigs: LinodeConfigsState;
   linodeDisks: LinodeDisksState;
@@ -194,6 +200,7 @@ const __resources = combineReducers({
   accountSettings,
   domains,
   images,
+  kubernetes,
   linodes,
   linodeConfigs,
   linodeDisks,

--- a/src/store/kubernetes/kubernetes.actions.ts
+++ b/src/store/kubernetes/kubernetes.actions.ts
@@ -1,0 +1,13 @@
+import actionCreatorFactory from 'typescript-fsa';
+
+export const actionCreator = actionCreatorFactory(`@@manager/kubernetes`);
+
+export const requestClustersActions = actionCreator.async<
+  void,
+  Linode.KubernetesCluster[],
+  Linode.ApiFieldError[]
+>('request');
+
+export const addOrUpdateCluster = actionCreator<Linode.KubernetesCluster>(
+  'add_or_update'
+);

--- a/src/store/kubernetes/kubernetes.reducer.ts
+++ b/src/store/kubernetes/kubernetes.reducer.ts
@@ -1,0 +1,54 @@
+import { Reducer } from 'redux';
+import { EntityError, EntityState } from 'src/store/types';
+// import updateOrAdd from 'src/utilities/updateOrAdd';
+import { isType } from 'typescript-fsa';
+import { requestClustersActions } from './kubernetes.actions';
+
+/**
+ * State
+ */
+
+export type State = EntityState<Linode.KubernetesCluster, EntityError>;
+
+export const defaultState: State = {
+  results: [],
+  entities: [],
+  loading: true,
+  lastUpdated: 0,
+  error: {}
+};
+
+/**
+ * Reducer
+ */
+const reducer: Reducer<State> = (state = defaultState, action) => {
+  if (isType(action, requestClustersActions.started)) {
+    return {
+      ...state,
+      loading: true
+    };
+  }
+
+  if (isType(action, requestClustersActions.done)) {
+    const { result } = action.payload;
+    return {
+      ...state,
+      entities: result,
+      results: result.map(cluster => cluster.id),
+      lastUpdated: Date.now(),
+      loading: false
+    };
+  }
+
+  if (isType(action, requestClustersActions.failed)) {
+    const { error } = action.payload;
+    return {
+      ...state,
+      error: { ...state.error, read: error },
+      loading: false
+    };
+  }
+  return state;
+};
+
+export default reducer;

--- a/src/store/kubernetes/kubernetes.requests.ts
+++ b/src/store/kubernetes/kubernetes.requests.ts
@@ -1,0 +1,26 @@
+import { getKubernetesClusters } from 'src/services/kubernetes';
+import { getAll } from 'src/utilities/getAll';
+import { ThunkActionCreator } from '../types';
+import { requestClustersActions } from './kubernetes.actions';
+
+const getAllClusters = getAll<Linode.KubernetesCluster>(getKubernetesClusters);
+
+export const requestKubernetesClusters: ThunkActionCreator<
+  Promise<Linode.Cluster[]>
+> = () => dispatch => {
+  dispatch(requestClustersActions.started());
+
+  return getAllClusters()
+    .then(({ data }) => {
+      dispatch(
+        requestClustersActions.done({
+          result: data
+        })
+      );
+      return data;
+    })
+    .catch(error => {
+      dispatch(requestClustersActions.failed({ error }));
+      return error;
+    });
+};


### PR DESCRIPTION
## Description

Decided to go with Redux/getAll pattern, so that K8s clusters are eventually searchable app-wide.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Still have to run locally (I hear alpha support is coming soon!), functionality should be the same.