### PR TITLE
Fix: Lish E2E tests

### DIFF
--- a/e2e/pageobjects/profile/lish.page.js
+++ b/e2e/pageobjects/profile/lish.page.js
@@ -3,18 +3,17 @@ const { constants } = require('../../constants');
 import Page from '../page';
 
 export class Lish extends Page {
-    get authModeSelect() { return $(this.basicSelect); }
+    get authModeSelect() { return $('[data-qa-mode-select]'); }
     get sshKey() { return $('[data-qa-public-key] textarea' ); }
     get addSshKey() { return this.addIcon('Add SSH Public Key'); }
     get removeButton() { return $('[data-qa-remove]'); }
     get saveButton() { return $('[data-qa-save]'); }
-    get passwordKeysOption() { return $('[data-value="password_keys"]'); }
-    get keysOnlyOption() { return $('[data-value="keys_only"]'); }
-    get disableLishOption() { return $('[data-value="disabled"]'); }
+    get passwordKeysOption() { return $('[data-qa-option="password_keys"]'); }
+    get keysOnlyOption() { return $('[data-qa-option="keys_only"]'); }
+    get disableLishOption() { return $('[data-qa-option="disabled"]'); }
 
     baseElemsDisplay() {
         this.authModeSelect.waitForVisible(constants.wait.normal);
-
         expect(this.sshKey.isVisible()).toBe(true);
         expect(this.removeButton.isVisible()).toBe(true);
         expect(this.saveButton.isVisible()).toBe(true);
@@ -23,7 +22,7 @@ export class Lish extends Page {
 
 
     disable(statusMsg) {
-        this.authModeSelect.click();
+        this.authModeSelect.$('input').setValue('\uE015');
         this.disableLishOption.waitForVisible(constants.wait.normal);
         this.disableLishOption.click();
         this.disableLishOption.waitForExist(constants.wait.normal, true);
@@ -32,7 +31,7 @@ export class Lish extends Page {
     }
 
     allowKeyAuthOnly(publicKey,statusMsg) {
-        this.authModeSelect.click();
+        this.authModeSelect.$('input').setValue('\uE015');
         this.keysOnlyOption.waitForVisible(constants.wait.normal);
         this.keysOnlyOption.click();
         this.keysOnlyOption.waitForExist(constants.wait.normal, true);
@@ -42,7 +41,7 @@ export class Lish extends Page {
     }
 
     allowPassAndKey(publicKey,statusMsg) {
-        this.authModeSelect.click();
+        this.authModeSelect.$('input').setValue('\uE015');
         this.passwordKeysOption.waitForVisible(constants.wait.normal);
         this.passwordKeysOption.click();
         this.passwordKeysOption.waitForExist(constants.wait.normal, true);

--- a/e2e/specs/profile/lish.spec.js
+++ b/e2e/specs/profile/lish.spec.js
@@ -15,7 +15,6 @@ describe('Profile - Lish SSH Key Suite', () => {
     });
 
     it('should disable lish', () => {
-        browser.debug();
         Lish.disable(successMsg);
     });
 

--- a/e2e/specs/profile/lish.spec.js
+++ b/e2e/specs/profile/lish.spec.js
@@ -15,6 +15,7 @@ describe('Profile - Lish SSH Key Suite', () => {
     });
 
     it('should disable lish', () => {
+        browser.debug();
         Lish.disable(successMsg);
     });
 
@@ -35,7 +36,7 @@ describe('Profile - Lish SSH Key Suite', () => {
 
     it('should remove the additional ssh key field', () => {
         $$(Lish.removeButton.selector)[1].click();
-        
+
         browser.waitUntil(function() {
             return $$(Lish.sshKey.selector).length === 1;
         }, constants.wait.normal);

--- a/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/src/features/Profile/LishSettings/LishSettings.tsx
@@ -156,6 +156,9 @@ class LishSettings extends React.Component<CombinedProps, State> {
             <React.Fragment>
               <FormControl className={classes.modeControl}>
                 <Select
+                  textFieldProps={{
+                    'data-qa-mode-select': true
+                  }}
                   options={modeOptions}
                   name="mode-select"
                   id="mode-select"


### PR DESCRIPTION
## Description

* Updated select to include `data-qa` attributes.

## Type of Change
- Test Fix

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --file e2e/specs/profile/lish.spec.js --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
