### PR TITLE
fix: Added issuer to TFA URI

### DIFF
--- a/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
@@ -59,7 +59,8 @@ export class EnableTwoFactorForm extends React.Component<CombinedProps, State> {
 
   getSecretLink = () => {
     const { secret, username } = this.props;
-    return `otpauth://totp/LinodeManager%3A${username}?secret=${secret}&issuer=LinodeManager`;
+    const issuer = 'Linode';
+    return `otpauth://totp/${issuer}%3A${username}?secret=${secret}&issuer=${issuer}`;
   };
 
   handleTokenInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
@@ -59,7 +59,7 @@ export class EnableTwoFactorForm extends React.Component<CombinedProps, State> {
 
   getSecretLink = () => {
     const { secret, username } = this.props;
-    return `otpauth://totp/LinodeManager%3A${username}?secret=${secret}`;
+    return `otpauth://totp/LinodeManager%3A${username}?secret=${secret}&issuer=LinodeManager`;
   };
 
   handleTokenInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Description

The two factor URI had an issuer prefix before the account name, but it is recommended to have the issuer in the optional parameters as well. [link](https://github.com/google/google-authenticator/wiki/Key-Uri-Format#issuer)

## Type of Change
fix: Issuer parameter was missing from TFA URI.

M3-2893 #done