### PR TITLE
M3-2771 Fix: domains validation

### DIFF
--- a/src/__data__/domains.ts
+++ b/src/__data__/domains.ts
@@ -53,3 +53,47 @@ export const domain3: Linode.Domain = {
 };
 
 export const domains = [domain1, domain2, domain3];
+
+export const domainRecord1: Linode.DomainRecord = {
+  id: 12938697,
+  name: 'www',
+  port: 0,
+  priority: 0,
+  protocol: null,
+  service: null,
+  tag: null,
+  target: 'www.example.com',
+  ttl_sec: 0,
+  type: 'CNAME',
+  weight: 0
+};
+
+export const domainRecord2: Linode.DomainRecord = {
+  id: 12938693,
+  name: 'kibana',
+  port: 0,
+  priority: 0,
+  protocol: null,
+  service: null,
+  tag: null,
+  target: 'www.example.com',
+  ttl_sec: 0,
+  type: 'CNAME',
+  weight: 0
+};
+
+export const domainRecord3: Linode.DomainRecord = {
+  id: 22938693,
+  name: 'host',
+  port: 0,
+  priority: 0,
+  protocol: null,
+  service: null,
+  tag: null,
+  target: 'www.example.com',
+  ttl_sec: 0,
+  type: 'TXT',
+  weight: 0
+};
+
+export const domainRecords = [domainRecord1, domainRecord2, domainRecord3];

--- a/src/__data__/domains.ts
+++ b/src/__data__/domains.ts
@@ -92,7 +92,7 @@ export const domainRecord3: Linode.DomainRecord = {
   tag: null,
   target: 'www.example.com',
   ttl_sec: 0,
-  type: 'TXT',
+  type: 'AAAA',
   weight: 0
 };
 

--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -477,15 +477,16 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
      *
      * Currently, the API does not check that the soaEmail
      * is not associated with the target hostname. If you're creating
-     * example.com, you shouldn't be able to use `marty@example.com` as your soaEmail.
-     * Checking for this here to prevent broken domains.
+     * example.com, using `marty@example.com` as your soaEmail is unwise
+     * (though technically won't break anything.).
      */
 
     if (type === 'master' && !isValidSOAEmail(email, domain)) {
       const err = [
         {
           field: 'soa_email',
-          reason: 'SOA Email address must not belong to the target Domain.'
+          reason:
+            'Please choose an SOA Email address that does not belong to the target Domain.'
         }
       ];
       this.setState(

--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -486,7 +486,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
         {
           field: 'soa_email',
           reason:
-            'Please choose an SOA Email address that does not belong to the target Domain.'
+            'Please choose an SOA email address that does not belong to the target Domain.'
         }
       ];
       this.setState(

--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -481,7 +481,10 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
      */
 
     if (!isValidDomainRecord(pathOr('', ['name'], data), records)) {
-      const error = { field: 'name', reason: 'Must be unique.' };
+      const error = {
+        field: 'name',
+        reason: 'Record conflict - CNAMES must be unique'
+      };
       this.handleSubmissionErrors([error]);
       return;
     }

--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -33,7 +33,7 @@ import defaultNumeric from 'src/utilities/defaultNumeric';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { isValidDomainRecord } from './domainUtils';
+import { isValidDomainRecord, isValidSOAEmail } from './domainUtils';
 
 const TextField: React.StatelessComponent<TextFieldProps> = props => (
   <_TextField {...props} />
@@ -432,18 +432,34 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
   };
 
   onDomainEdit = () => {
-    const { domainId, type, domainActions } = this.props;
+    const { domain, domainId, type, domainActions } = this.props;
     this.setState({ submitting: true, errors: undefined });
 
     const data = {
       ...this.filterDataByType(this.state.fields, type)
     } as Partial<EditableDomainFields>;
 
+    /**
+     * Prevent changing the soa_email to an
+     * email within this Domain. This isn't breaking,
+     * but is bad practice.
+     */
+
+    if (!isValidSOAEmail(data.soa_email || '', domain || '')) {
+      const error = {
+        field: 'soa_email',
+        reason:
+          'Please choose an SOA email address that does not belong to this Domain.'
+      };
+      this.handleSubmissionErrors([error]);
+      return;
+    }
+
     if (data.axfr_ips) {
       /**
        * Don't submit blank strings to the API.
        * Also trim the resulting array, since '192.0.2.0, 192.0.2.1'
-       * will submit ' 192.0.2.1', which is also an invalid value.
+       * will submit ' 192.0.2.1', which is an invalid value.
        */
       data.axfr_ips = data.axfr_ips
         .filter(ip => ip !== '')

--- a/src/features/Domains/DomainRecords.tsx
+++ b/src/features/Domains/DomainRecords.tsx
@@ -652,7 +652,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { domain, classes } = this.props;
+    const { domain, domainRecords, classes } = this.props;
     const { drawer, confirmDialog } = this.state;
 
     return (
@@ -795,6 +795,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
           domainId={this.props.domain.id}
           onClose={this.resetDrawer}
           mode={drawer.mode}
+          records={domainRecords}
           type={drawer.type}
           updateRecords={this.props.updateRecords}
           updateDomain={this.props.updateDomain}

--- a/src/features/Domains/domainUtils.test.ts
+++ b/src/features/Domains/domainUtils.test.ts
@@ -1,0 +1,37 @@
+import { domainRecords as records } from 'src/__data__/domains';
+import { isValidDomainRecord, isValidSOAEmail } from './domainUtils';
+
+describe('Domain-related utilities', () => {
+  describe('Validating email addresses', () => {
+    it('should not allow an email address that belongs to the target domain', () => {
+      // If you're creating example.com, admin@example.com will break things.
+      expect(isValidSOAEmail('admin@example.com', 'example.com')).toBe(false);
+    });
+
+    it('should allow normal combinations', () => {
+      expect(isValidSOAEmail('example@stuff.com', 'example.com')).toBe(true);
+    });
+
+    it('should not concern itself with email address format validation', () => {
+      expect(isValidSOAEmail('email.example.com', 'example.com')).toBe(true);
+    });
+
+    it('should handle subdomains', () => {
+      // @todo Is this actually the correct behavior?
+      expect(isValidSOAEmail('admin@example.com', 'www.example.com')).toBe(
+        false
+      );
+      expect(isValidSOAEmail('admin@example.com', 'www.google.com')).toBe(true);
+    });
+  });
+
+  describe('Validating domain records', () => {
+    it('should not allow duplicate hostnames for a Domain record', () => {
+      expect(isValidDomainRecord('www', records)).toBe(false);
+    });
+
+    it('should allow valid records', () => {
+      expect(isValidDomainRecord('api', records)).toBe(true);
+    });
+  });
+});

--- a/src/features/Domains/domainUtils.test.ts
+++ b/src/features/Domains/domainUtils.test.ts
@@ -17,7 +17,6 @@ describe('Domain-related utilities', () => {
     });
 
     it('should handle subdomains', () => {
-      // @todo Is this actually the correct behavior?
       expect(isValidSOAEmail('admin@example.com', 'www.example.com')).toBe(
         false
       );
@@ -26,8 +25,12 @@ describe('Domain-related utilities', () => {
   });
 
   describe('Validating domain records', () => {
-    it('should not allow duplicate hostnames for a Domain record', () => {
+    it('should not allow hostnames that conflict with an existing CNAME record.', () => {
       expect(isValidDomainRecord('www', records)).toBe(false);
+    });
+
+    it('should not care about conflicts between non-CNAME records', () => {
+      expect(isValidDomainRecord('host', records)).toBe(true);
     });
 
     it('should allow valid records', () => {

--- a/src/features/Domains/domainUtils.ts
+++ b/src/features/Domains/domainUtils.ts
@@ -19,5 +19,7 @@ export const isUniqueHostname = (
   hostname: string,
   records: Linode.DomainRecord[]
 ) => {
-  return !records.some(record => record.name === hostname);
+  return !records.some(
+    record => record.type === 'CNAME' && record.name === hostname
+  );
 };

--- a/src/features/Domains/domainUtils.ts
+++ b/src/features/Domains/domainUtils.ts
@@ -1,0 +1,23 @@
+import { takeLast } from 'ramda';
+
+export const isValidDomainRecord = (
+  hostname: string,
+  records: Linode.DomainRecord[]
+) => {
+  return isUniqueHostname(hostname, records);
+};
+
+export const isValidSOAEmail = (email: string, hostname: string) => {
+  // admin@example.com --> example.com
+  const emailDomain = email.split('@')[1];
+  // mail.example.com --> example.com
+  const strippedHostname = takeLast(2, hostname.split('.')).join('.');
+  return strippedHostname !== emailDomain;
+};
+
+export const isUniqueHostname = (
+  hostname: string,
+  records: Linode.DomainRecord[]
+) => {
+  return !records.some(record => record.name === hostname);
+};

--- a/src/features/Domains/domainUtils.ts
+++ b/src/features/Domains/domainUtils.ts
@@ -9,7 +9,7 @@ export const isValidDomainRecord = (
 
 export const isValidSOAEmail = (email: string, hostname: string) => {
   // admin@example.com --> example.com
-  const emailDomain = email.split('@')[1];
+  const emailDomain = email.substr(email.indexOf('@') + 1);
   // mail.example.com --> example.com
   const strippedHostname = takeLast(2, hostname.split('.')).join('.');
   return strippedHostname !== emailDomain;


### PR DESCRIPTION
## Description

API currently allows you to add records with a duplicate hostname
(e.g. a TXT record for "www" when there's already a "www" entry in
CNAME). Added uniqueness checking to fix this.

Also added validation to prevent email addresses in the target domain, e.g. using john@example.com when creating the domain example.com. CF doesn't check for this, and it doesn't seem to break anything, but it's a bad idea (if your domain goes down you can't be contacted by email about it) and Support asked for this fix.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

1. Create a CNAME record in one of your domains (e.g. 'mail'), the alias doesn't matter.
2. Create a TXT (or any other record) with the same hostname ('mail'). You should observe an error.
3. Any other records should be fine (an A and TXT/whatever record can have the same hostname).

<img width="448" alt="Screen Shot 2019-06-05 at 5 34 59 PM" src="https://user-images.githubusercontent.com/1624067/58992650-65e95200-87b9-11e9-969c-6c226487fd49.png">
<img width="471" alt="Screen Shot 2019-06-05 at 5 41 34 PM" src="https://user-images.githubusercontent.com/1624067/58992651-65e95200-87b9-11e9-94f0-f4ab671cffc0.png">
