### PR TITLE
M3-2890 fix: Request all entities in the Support Ticket Drawer

### DIFF
--- a/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -27,6 +27,7 @@ import {
   getErrorMap,
   getErrorStringOrDefault
 } from 'src/utilities/errorUtils';
+import { getAll } from 'src/utilities/getAll';
 import { getVersionString } from 'src/utilities/getVersionString';
 import AttachFileForm from '../AttachFileForm';
 import { FileAttachment } from '../index';
@@ -195,25 +196,25 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
     // that have different signatures.
     switch (entity) {
       case 'linode_id': {
-        getLinodes()
+        getAll(getLinodes)()
           .then(this.handleThen)
           .catch(this.handleCatch);
         return;
       }
       case 'volume_id': {
-        getVolumes()
+        getAll(getVolumes)()
           .then(this.handleThen)
           .catch(this.handleCatch);
         return;
       }
       case 'domain_id': {
-        getDomains()
+        getAll(getDomains)()
           .then(this.handleThen)
           .catch(this.handleCatch);
         return;
       }
       case 'nodebalancer_id': {
-        getNodeBalancers()
+        getAll(getNodeBalancers)()
           .then(this.handleThen)
           .catch(this.handleCatch);
         return;
@@ -490,6 +491,7 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
               onChange={this.handleEntityIDChange}
               onInputChange={this.onInputValueChange}
               data-qa-ticket-entity-id
+              isLoading={this.state.loading}
               isClearable={false}
             />
             {hasNoEntitiesMessage && (


### PR DESCRIPTION
## Description

Previously we were requesting only the first page of the selected entity type in the Support Ticket drawer. This means if you had more than 100 Linodes, for example, you'd only be able to select one of the first 100.

I also added a loading spinner to the entity Select component.

**Note:** This component should probably be refactored in order to get data, errors, loading, etc. from Redux. I started down that path, but turned out to be a healthy-sized refactor, especially since this is an old component that uses a lot of old patterns. This at least fixes the bug, and I've opened a ticket to do the refactoring (M3-2902).

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests
None.

## Note to Reviewers

Use an account with a lot of stuff, and open the Support Ticket Drawer. All of your entities should be there.
