### PR TITLE
Change: Source Dashboard cards from Redux

### DIFF
--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -108,7 +108,7 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
 
   renderContent = () => {
     const { loading, domains, error } = this.props;
-    if (loading) {
+    if (loading && domains.length === 0) {
       return this.renderLoading();
     }
 

--- a/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -1,6 +1,6 @@
-import { compose, take } from 'ramda';
+import { take } from 'ramda';
 import * as React from 'react';
-import { Subscription } from 'rxjs/Subscription';
+import { compose } from 'recompose';
 import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
 import {
@@ -19,9 +19,8 @@ import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 import ViewAllLink from 'src/components/ViewAllLink';
-import { events$ } from 'src/events';
+import NodeBalancerContainer from 'src/containers/withNodeBalancers.container';
 import RegionIndicator from 'src/features/linodes/LinodesLanding/RegionIndicator';
-import { getNodeBalancers } from 'src/services/nodebalancers';
 import DashboardCard from '../DashboardCard';
 
 type ClassNames =
@@ -69,127 +68,62 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   }
 });
 
-interface State {
-  loading: boolean;
-  errors?: Linode.ApiFieldError[];
-  data?: Linode.NodeBalancer[];
-  results?: number;
+interface NodeBalancerProps {
+  nodeBalancersData: Linode.NodeBalancer[];
+  nodeBalancersLoading: boolean;
+  nodeBalancersError?: Linode.ApiFieldError[];
 }
 
-type CombinedProps = WithStyles<ClassNames>;
+type CombinedProps = NodeBalancerProps & WithStyles<ClassNames>;
 
-class NodeBalancersDashboardCard extends React.Component<CombinedProps, State> {
-  state: State = {
-    loading: true
-  };
+const NodeBalancersDashboardCard: React.FunctionComponent<
+  CombinedProps
+> = props => {
+  const {
+    classes,
+    nodeBalancersError,
+    nodeBalancersLoading,
+    nodeBalancersData
+  } = props;
 
-  mounted: boolean = false;
+  const data = take(5, nodeBalancersData);
 
-  subscription: Subscription;
-
-  requestData = (initial: boolean = false) => {
-    if (!this.mounted) {
-      return;
-    }
-
-    if (initial) {
-      this.setState({ loading: true });
-    }
-
-    getNodeBalancers(
-      { page_size: 25 },
-      { '+order_by': 'label', '+order': 'asc' }
-    )
-      .then(({ data, results }) => {
-        if (!this.mounted) {
-          return;
-        }
-        this.setState({
-          loading: false,
-          data: take(5, data),
-          results
-        });
-      })
-      .catch(error => {
-        this.setState({
-          loading: false,
-          errors: [{ reason: 'Unable to load NodeBalancers.' }]
-        });
-      });
-  };
-
-  componentDidMount() {
-    this.mounted = true;
-
-    this.requestData(true);
-
-    this.subscription = events$
-      .filter(e => !e._initial)
-      .filter(e => Boolean(e.entity && e.entity.type === 'nodebalancer'))
-      .filter(
-        e =>
-          Boolean(this.state.data && this.state.data.length < 5) ||
-          isFoundInData(e.entity!.id, this.state.data)
-      )
-      .subscribe(() => this.requestData(false));
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-    this.subscription.unsubscribe();
-  }
-
-  render() {
-    return (
-      <DashboardCard title="NodeBalancers" headerAction={this.renderAction}>
-        <Paper>
-          <Table>
-            <TableBody>{this.renderContent()}</TableBody>
-          </Table>
-        </Paper>
-      </DashboardCard>
-    );
-  }
-
-  renderAction = () =>
-    this.state.results && this.state.results > 5 ? (
+  const renderAction = () =>
+    nodeBalancersData.length > 5 ? (
       <ViewAllLink
         text="View All"
         link={'/nodebalancers'}
-        count={this.state.results}
+        count={nodeBalancersData.length}
       />
     ) : null;
 
-  renderContent = () => {
-    const { loading, data, errors } = this.state;
-    if (loading) {
-      return this.renderLoading();
+  const renderContent = () => {
+    if (nodeBalancersLoading && nodeBalancersData.length === 0) {
+      return renderLoading();
     }
 
-    if (errors) {
-      return this.renderErrors(errors);
+    if (nodeBalancersError) {
+      return renderErrors(nodeBalancersError);
     }
 
     if (data && data.length > 0) {
-      return this.renderData(data);
+      return renderData();
     }
 
-    return this.renderEmpty();
+    return renderEmpty();
   };
 
-  renderLoading = () => {
+  const renderLoading = () => {
     return <TableRowLoading colSpan={2} />;
   };
 
-  renderErrors = (errors: Linode.ApiFieldError[]) => (
+  const renderErrors = (errors: Linode.ApiFieldError[]) => (
     <TableRowError colSpan={2} message={`Unable to load NodeBalancers.`} />
   );
 
-  renderEmpty = () => <TableRowEmptyState colSpan={2} />;
+  const renderEmpty = () => <TableRowEmptyState colSpan={2} />;
 
-  renderData = (data: Linode.NodeBalancer[]) => {
-    const { classes } = this.props;
-
+  const renderData = () => {
     return data.map(({ id, label, region, hostname }) => (
       <TableRow key={label} rowLink={`/nodebalancers/${id}`}>
         <TableCell className={classes.labelCol}>
@@ -219,16 +153,31 @@ class NodeBalancersDashboardCard extends React.Component<CombinedProps, State> {
       </TableRow>
     ));
   };
-}
+
+  return (
+    <DashboardCard title="NodeBalancers" headerAction={renderAction}>
+      <Paper>
+        <Table>
+          <TableBody>{renderContent()}</TableBody>
+        </Table>
+      </Paper>
+    </DashboardCard>
+  );
+};
 
 const styled = withStyles(styles);
 
-const enhanced = compose(styled);
+const withNodeBalancers = NodeBalancerContainer(
+  (ownProps, nodeBalancersData, nodeBalancersLoading, nodeBalancersError) => ({
+    ...ownProps,
+    nodeBalancersData,
+    nodeBalancersLoading,
+    nodeBalancersError
+  })
+);
+const enhanced = compose<CombinedProps, {}>(
+  styled,
+  withNodeBalancers
+);
 
-const isFoundInData = (id: number, data: Linode.NodeBalancer[] = []): boolean =>
-  data.reduce(
-    (result, nodebalancer) => result || nodebalancer.id === id,
-    false
-  );
-
-export default enhanced(NodeBalancersDashboardCard) as React.ComponentType<{}>;
+export default enhanced(NodeBalancersDashboardCard);

--- a/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
+++ b/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
@@ -1,12 +1,7 @@
-import { compose, take } from 'ramda';
+import { take } from 'ramda';
 import * as React from 'react';
-import { Subscription } from 'rxjs/Subscription';
+import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
-import {
-  StyleRulesCallback,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
 import Table from 'src/components/core/Table';
 import TableBody from 'src/components/core/TableBody';
 
@@ -14,123 +9,45 @@ import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 import ViewAllLink from 'src/components/ViewAllLink';
-import { events$ } from 'src/events';
-import { getVolumes } from 'src/services/volumes';
+import VolumesContainer from 'src/containers/volumes.container';
 import DashboardCard from '../DashboardCard';
 import VolumeDashboardRow from './VolumeDashboardRow';
 
-type ClassNames = 'root';
-
-const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {}
-});
-interface State {
-  loading: boolean;
-  errors?: Linode.ApiFieldError[];
-  data?: Linode.Volume[];
-  results?: number;
+interface VolumeProps {
+  volumesLoading: boolean;
+  volumesError?: Linode.ApiFieldError[];
+  volumesData: Linode.Volume[];
 }
 
-type CombinedProps = WithStyles<ClassNames>;
+type CombinedProps = VolumeProps;
 
-export class VolumesDashboardCard extends React.Component<
-  CombinedProps,
-  State
-> {
-  state: State = {
-    loading: true
-  };
+export const VolumesDashboardCard: React.FunctionComponent<
+  CombinedProps
+> = props => {
+  const { volumesData, volumesLoading, volumesError } = props;
 
-  mounted: boolean = false;
+  const volumes = take(5, volumesData);
 
-  subscription: Subscription;
-
-  requestData = (initial: boolean = false) => {
-    if (!this.mounted) {
-      return;
-    }
-
-    if (initial) {
-      this.setState({ loading: true });
-    }
-
-    getVolumes({ page_size: 25 }, { '+order_by': 'label', '+order': 'asc' })
-      .then(({ data, results }) => {
-        if (!this.mounted) {
-          return;
-        }
-        this.setState({
-          loading: false,
-          data: take(5, data),
-          results
-        });
-      })
-      .catch(error => {
-        this.setState({
-          loading: false,
-          errors: [{ reason: 'Unable to load Volumes.' }]
-        });
-      });
-  };
-
-  componentDidMount() {
-    this.mounted = true;
-
-    this.requestData(true);
-
-    this.subscription = events$
-      .filter(e => !e._initial)
-      .filter(e => Boolean(e.entity && e.entity.type === 'volume'))
-      .filter(
-        e =>
-          Boolean(this.state.data && this.state.data.length < 5) ||
-          isFoundInData(e.entity!.id, this.state.data)
-      )
-      .subscribe(() => this.requestData(false));
-  }
-
-  componentWillUnmount() {
-    this.mounted = false;
-    this.subscription.unsubscribe();
-  }
-
-  render() {
-    return (
-      <DashboardCard
-        title="Volumes"
-        headerAction={this.renderAction}
-        data-qa-dash-volume
-      >
-        <Paper>
-          <Table>
-            <TableBody>{this.renderContent()}</TableBody>
-          </Table>
-        </Paper>
-      </DashboardCard>
-    );
-  }
-
-  renderAction = () =>
-    this.state.results && this.state.results > 5 ? (
+  const renderAction = () =>
+    volumesData && volumesData.length > 5 ? (
       <ViewAllLink
         text="View All"
         link={'/volumes'}
-        count={this.state.results}
+        count={volumesData.length}
       />
     ) : null;
 
-  renderContent = () => {
-    const { loading, data, errors } = this.state;
-    if (loading) {
-      return this.renderLoading();
+  const renderContent = () => {
+    if (volumesLoading && volumesData.length === 0) {
+      return renderLoading();
     }
 
-    if (errors) {
-      return this.renderErrors(errors);
+    if (volumesError) {
+      return renderErrors(volumesError);
     }
 
-    if (data && data.length > 0) {
-      return data.map((volume, idx) => (
+    if (volumesData && volumesData.length > 0) {
+      return volumes.map((volume, idx) => (
         <VolumeDashboardRow
           key={`volume-dashboard-row-${idx}`}
           volume={volume}
@@ -138,25 +55,48 @@ export class VolumesDashboardCard extends React.Component<
       ));
     }
 
-    return this.renderEmpty();
+    return renderEmpty();
   };
 
-  renderLoading = () => {
+  const renderLoading = () => {
     return <TableRowLoading colSpan={3} />;
   };
 
-  renderErrors = (errors: Linode.ApiFieldError[]) => (
+  const renderErrors = (errors: Linode.ApiFieldError[]) => (
     <TableRowError colSpan={3} message={`Unable to load Volumes.`} />
   );
 
-  renderEmpty = () => <TableRowEmptyState colSpan={2} />;
-}
+  const renderEmpty = () => <TableRowEmptyState colSpan={2} />;
 
-const styled = withStyles(styles);
+  return (
+    <DashboardCard
+      title="Volumes"
+      headerAction={renderAction}
+      data-qa-dash-volume
+    >
+      <Paper>
+        <Table>
+          <TableBody>{renderContent()}</TableBody>
+        </Table>
+      </Paper>
+    </DashboardCard>
+  );
+};
 
-const enhanced = compose(styled);
+const withVolumes = VolumesContainer(
+  (ownProps, volumesData, volumesLoading, volumesError) => {
+    const mappedData = volumesData.items.map(id => ({
+      ...volumesData.itemsById[id]
+    }));
+    return {
+      ...ownProps,
+      volumesData: mappedData,
+      volumesLoading,
+      volumesError
+    };
+  }
+);
 
-const isFoundInData = (id: number, data: Linode.Volume[] = []): boolean =>
-  data.reduce((result, volume) => result || volume.id === id, false);
+const enhanced = compose<CombinedProps, {}>(withVolumes);
 
-export default enhanced(VolumesDashboardCard) as React.ComponentType<{}>;
+export default enhanced(VolumesDashboardCard);


### PR DESCRIPTION
## Description

Volumes and NodeBalancer cards were requesting manually on load, with special events-based logic to keep the list up to date. We have Redux to do all this now, so this is redundant and inefficient.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=COMMA_SEPARATED_LIST_OF_SPECS_HERE --browser=headlessChrome`

## Note to Reviewers

- Linodes are handled in a separate PR, domains are already Reduxed.
- Note that NBs are actually slower this way, since all the configs/nodes/etc. are fetched on app load. Follow-up POC, if accepted, can be adapted to quicken this up.