### PR TITLE
M3-2247 Clone Configs/Disks: Part 1 (Routing)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import SideMenu from 'src/components/SideMenu';
 import VATBanner from 'src/components/VATBanner';
 import { events$ } from 'src/events';
 import BackupDrawer from 'src/features/Backups';
+import CloneLanding from 'src/features/linodes/CloneLanding';
 import DomainDrawer from 'src/features/Domains/DomainDrawer';
 import Footer from 'src/features/Footer';
 import TheApplicationIsOnFire from 'src/features/TheApplicationIsOnFire';
@@ -388,6 +389,11 @@ export class App extends React.Component<CombinedProps, State> {
                     <Grid container spacing={0} className={classes.grid}>
                       <Grid item className={classes.switchWrapper}>
                         <Switch>
+                          {/* Note: The `clone` route needs to be placed BEFORE the `linodes` route. */}
+                          <Route
+                            path={`/linodes/:linodeId/clone`}
+                            component={CloneLanding}
+                          />
                           <Route path="/linodes" component={LinodesRoutes} />
                           <Route path="/volumes" component={Volumes} />
                           <Route

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,6 @@ import SideMenu from 'src/components/SideMenu';
 import VATBanner from 'src/components/VATBanner';
 import { events$ } from 'src/events';
 import BackupDrawer from 'src/features/Backups';
-import CloneLanding from 'src/features/linodes/CloneLanding';
 import DomainDrawer from 'src/features/Domains/DomainDrawer';
 import Footer from 'src/features/Footer';
 import TheApplicationIsOnFire from 'src/features/TheApplicationIsOnFire';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -389,11 +389,6 @@ export class App extends React.Component<CombinedProps, State> {
                     <Grid container spacing={0} className={classes.grid}>
                       <Grid item className={classes.switchWrapper}>
                         <Switch>
-                          {/* Note: The `clone` route needs to be placed BEFORE the `linodes` route. */}
-                          <Route
-                            path={`/linodes/:linodeId/clone`}
-                            component={CloneLanding}
-                          />
                           <Route path="/linodes" component={LinodesRoutes} />
                           <Route path="/volumes" component={Volumes} />
                           <Route

--- a/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -7,6 +7,7 @@ import {
   withRouter
 } from 'react-router-dom';
 import AppBar from 'src/components/core/AppBar';
+import Paper from 'src/components/core/Paper';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import Typography from 'src/components/core/Typography';
@@ -49,29 +50,32 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
       <Typography variant="h1" data-qa-clone-header>
         Clone
       </Typography>
-      <AppBar position="static" color="default">
-        <Tabs
-          value={tabs.findIndex(tab => matches(tab.routeName))}
-          onChange={handleTabChange}
-          indicatorColor="primary"
-          textColor="primary"
-          variant="scrollable"
-          scrollButtons="on"
-        >
-          {tabs.map(tab => (
-            <Tab
-              key={tab.title}
-              data-qa-tab={tab.title}
-              component={() => <TabLink to={tab.routeName} title={tab.title} />}
-            />
-          ))}
-        </Tabs>
-      </AppBar>
-      <Switch>
+      <Paper>
+        <AppBar position="static" color="default">
+          <Tabs
+            value={tabs.findIndex(tab => matches(tab.routeName))}
+            onChange={handleTabChange}
+            indicatorColor="primary"
+            textColor="primary"
+            variant="scrollable"
+            scrollButtons="on"
+          >
+            {tabs.map(tab => (
+              <Tab
+                key={tab.title}
+                data-qa-tab={tab.title}
+                component={() => (
+                  <TabLink to={tab.routeName} title={tab.title} />
+                )}
+              />
+            ))}
+          </Tabs>
+        </AppBar>
         <Route exact path={`${url}/configs`} component={Configs} />
         <Route exact path={`${url}/disks`} component={Disks} />
         <Route exact path={`${url}`} component={Configs} />
-      </Switch>
+      </Paper>
+      <Switch />
     </React.Fragment>
   );
 };

--- a/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import {
+  matchPath,
+  Route,
+  RouteComponentProps,
+  Switch,
+  withRouter
+} from 'react-router-dom';
+import AppBar from 'src/components/core/AppBar';
+import Tab from 'src/components/core/Tab';
+import Tabs from 'src/components/core/Tabs';
+import Typography from 'src/components/core/Typography';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import TabLink from 'src/components/TabLink';
+import Configs from './Configs';
+import Disks from './Disks';
+
+type CombinedProps = RouteComponentProps<{}>;
+
+export const CloneLanding: React.FC<CombinedProps> = props => {
+  const tabs = [
+    /* NB: These must correspond to the routes inside the Switch */
+    {
+      title: 'Configuration Profiles',
+      routeName: `${props.match.url}/configs`
+    },
+    { title: 'Disks', routeName: `${props.match.url}/disks` }
+  ];
+
+  const handleTabChange = (
+    event: React.ChangeEvent<HTMLDivElement>,
+    value: number
+  ) => {
+    const { history } = props;
+    const routeName = tabs[value].routeName;
+    history.push(`${routeName}`);
+  };
+
+  const {
+    match: { url }
+  } = props;
+  const matches = (p: string) => {
+    return Boolean(matchPath(p, { path: props.location.pathname }));
+  };
+
+  return (
+    <React.Fragment>
+      <DocumentTitleSegment segment="Clone" />
+      <Typography variant="h1" data-qa-clone-header>
+        Clone
+      </Typography>
+      <AppBar position="static" color="default">
+        <Tabs
+          value={tabs.findIndex(tab => matches(tab.routeName))}
+          onChange={handleTabChange}
+          indicatorColor="primary"
+          textColor="primary"
+          variant="scrollable"
+          scrollButtons="on"
+        >
+          {tabs.map(tab => (
+            <Tab
+              key={tab.title}
+              data-qa-tab={tab.title}
+              component={() => <TabLink to={tab.routeName} title={tab.title} />}
+            />
+          ))}
+        </Tabs>
+      </AppBar>
+      <Switch>
+        <Route exact path={`${url}/configs`} component={Configs} />
+        <Route exact path={`${url}/disks`} component={Disks} />
+        <Route exact path={`${url}`} component={Configs} />
+      </Switch>
+    </React.Fragment>
+  );
+};
+
+export default withRouter(CloneLanding);

--- a/src/features/linodes/CloneLanding/Configs.tsx
+++ b/src/features/linodes/CloneLanding/Configs.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const Configs: React.FC<{}> = () => {
+  return <div>Configs Component</div>;
+};
+
+export default Configs;

--- a/src/features/linodes/CloneLanding/Disks.tsx
+++ b/src/features/linodes/CloneLanding/Disks.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const Disks: React.FC<{}> = () => {
+  return <div>Disks Component</div>;
+};
+
+export default Disks;

--- a/src/features/linodes/CloneLanding/index.ts
+++ b/src/features/linodes/CloneLanding/index.ts
@@ -1,0 +1,2 @@
+import CloneLanding from './CloneLanding';
+export default CloneLanding;

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
   linodeStatus: string;
+  linodeId?: number;
   readOnly?: boolean;
   onRename: () => void;
   onResize: () => void;
@@ -11,11 +13,11 @@ interface Props {
   onDelete: () => void;
 }
 
-type CombinedProps = Props;
+type CombinedProps = Props & RouteComponentProps;
 
 class DiskActionMenu extends React.Component<CombinedProps> {
   createActions = () => (closeMenu: Function): Action[] => {
-    const { linodeStatus, readOnly } = this.props;
+    const { linodeStatus, linodeId, readOnly, history } = this.props;
     let tooltip;
     tooltip =
       linodeStatus === 'offline'
@@ -66,6 +68,16 @@ class DiskActionMenu extends React.Component<CombinedProps> {
           closeMenu();
         },
         ...disabledProps
+      },
+      {
+        title: 'Clone',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+          closeMenu();
+          history.push(`/linodes/${linodeId}/clone/disks`);
+        },
+        disabled: readOnly,
+        tooltip
       }
     ];
 
@@ -77,4 +89,4 @@ class DiskActionMenu extends React.Component<CombinedProps> {
   }
 }
 
-export default DiskActionMenu;
+export default withRouter(DiskActionMenu);

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -245,7 +245,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
   }
 
   renderTableContent = (data: Linode.Disk[], status?: string) => {
-    const { readOnly } = this.props;
+    const { linodeId, readOnly } = this.props;
 
     return data.map(disk => (
       <TableRow key={disk.id} data-qa-disk={disk.label}>
@@ -255,6 +255,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
         <TableCell>
           <LinodeDiskActionMenu
             linodeStatus={status || 'offline'}
+            linodeId={linodeId}
             onRename={this.openDrawerForRename(disk)}
             onResize={this.openDrawerForResize(disk)}
             onImagize={this.openImagizeDrawer(disk)}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
@@ -38,7 +38,7 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
   };
 
   createConfigActions = () => (closeMenu: Function): Action[] => {
-    const { readOnly } = this.props;
+    const { readOnly, history, linodeId } = this.props;
     const tooltip = readOnly
       ? "You don't have permission to perform this action"
       : undefined;
@@ -69,6 +69,16 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
           e.preventDefault();
           this.handleDelete();
           closeMenu();
+        },
+        disabled: readOnly,
+        tooltip
+      },
+      {
+        title: 'Clone',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          e.preventDefault();
+          closeMenu();
+          history.push(`/linodes/${linodeId}/clone/configs`);
         },
         disabled: readOnly,
         tooltip

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
 import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { compose, withProps } from 'recompose';
 import {

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { RouteComponentProps } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { compose, withProps } from 'recompose';
 import {
   StyleRulesCallback,
@@ -8,6 +9,7 @@ import {
 } from 'src/components/core/styles';
 import { WithTypes } from 'src/store/linodeType/linodeType.containers';
 import { ThunkDispatch } from 'src/store/types';
+import CloneLanding from '../CloneLanding/CloneLanding';
 import {
   LinodeDetailContext,
   linodeDetailContextFactory as createLinodeDetailContext,
@@ -43,17 +45,34 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 });
 
 const LinodeDetail: React.StatelessComponent<CombinedProps> = props => {
-  const { linode } = props;
-
-  const { dispatch } = props;
+  const {
+    dispatch,
+    linode,
+    match: { path }
+  } = props;
 
   const ctx: LinodeDetailContext = createLinodeDetailContext(linode, dispatch);
 
   return (
     <LinodeDetailContextProvider value={ctx}>
       {/* <pre>{JSON.stringify(linode, null, 2)}</pre> */}
-      <LinodesDetailHeader />
-      <LinodesDetailNavigation />
+      <Switch>
+        {/*
+        Currently, the "Clone Configs and Disks" feature exists OUTSIDE of LinodeDetail.
+        Or... at least it appears that way to the user. We would like it to live WITHIN
+        LinodeDetail, though, because we'd like to use the same context, so we don't
+        have to reload all the configs, disks, etc. once we get to the CloneLanding page.
+        */}
+        <Route path={`${path}/clone`} component={CloneLanding} />
+        <Route
+          render={() => (
+            <React.Fragment>
+              <LinodesDetailHeader />
+              <LinodesDetailNavigation />
+            </React.Fragment>
+          )}
+        />
+      </Switch>
     </LinodeDetailContextProvider>
   );
 };

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -9,7 +9,7 @@ import {
 } from 'src/components/core/styles';
 import { WithTypes } from 'src/store/linodeType/linodeType.containers';
 import { ThunkDispatch } from 'src/store/types';
-import CloneLanding from '../CloneLanding/CloneLanding';
+import CloneLanding from '../CloneLanding';
 import {
   LinodeDetailContext,
   linodeDetailContextFactory as createLinodeDetailContext,


### PR DESCRIPTION
## Description

Cloning of Linode configs and disks. See the ticket for designs.

I'm planning on getting this feature merged this in 4 parts:

**1) Routing** _(this PR)_
2) Components/internal state (bulk of the code changes)
3) Functionality (API requests, error, loading states)
4) Unit tests

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

To test, go to Linode Details -> Advanced. Click the action menu of a Config or Disk, and you'll be taken to the new Clone page.