### PR TITLE
Add: Maintenance Window to CSV

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import { isObjectStorageEnabled } from './utilities/accountCapabilities';
 
 import ErrorState from 'src/components/ErrorState';
 import { addNotificationsToLinodes } from 'src/store/linodes/linodes.actions';
+import { formatDate } from 'src/utilities/formatDate';
 
 shim(); // allows for .finally() usage
 
@@ -220,7 +221,18 @@ export class App extends React.Component<CombinedProps, State> {
       (!prevProps.notifications || !prevProps.linodes.length)
     ) {
       this.props.addNotificationsToLinodes(
-        this.props.notifications,
+        this.props.notifications.map(eachNotification => ({
+          ...eachNotification,
+          /** alter when and until to respect the user's timezone */
+          when:
+            typeof eachNotification.when === 'string'
+              ? formatDate(eachNotification.when)
+              : eachNotification.when,
+          until:
+            typeof eachNotification.until === 'string'
+              ? formatDate(eachNotification.until)
+              : eachNotification.until
+        })),
         this.props.linodes
       );
     }

--- a/src/assets/timezones/timezones.ts
+++ b/src/assets/timezones/timezones.ts
@@ -786,6 +786,11 @@ export default [
     offset: 0
   },
   {
+    label: 'Troll Time',
+    name: 'Antarctica/Troll',
+    offset: 0
+  },
+  {
     label: 'United Kingdom Time',
     name: 'Europe/London',
     offset: 0
@@ -1078,11 +1083,6 @@ export default [
   {
     label: 'South Africa Standard Time',
     name: 'Africa/Johannesburg',
-    offset: 2
-  },
-  {
-    label: 'Troll Time',
-    name: 'Antarctica/Troll',
     offset: 2
   },
   {

--- a/src/assets/timezones/timezones.ts
+++ b/src/assets/timezones/timezones.ts
@@ -786,11 +786,6 @@ export default [
     offset: 0
   },
   {
-    label: 'Troll Time',
-    name: 'Antarctica/Troll',
-    offset: 0
-  },
-  {
     label: 'United Kingdom Time',
     name: 'Europe/London',
     offset: 0
@@ -1083,6 +1078,11 @@ export default [
   {
     label: 'South Africa Standard Time',
     name: 'Africa/Johannesburg',
+    offset: 2
+  },
+  {
+    label: 'Troll Time',
+    name: 'Antarctica/Troll',
     offset: 2
   },
   {

--- a/src/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/src/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -91,9 +91,12 @@ const MaintenanceBanner: React.FC<CombinedProps> = props => {
       <Typography>
         {generateIntroText(type, maintenanceStart, maintenanceEnd)}
       </Typography>
-      <Typography>
-        Timezone: <Link to="/profile/display">{timezoneMsg()} </Link>
-      </Typography>
+      {/** only display timezone on the Linode detail */
+      maintenanceStart && (
+        <Typography>
+          Timezone: <Link to="/profile/display">{timezoneMsg()} </Link>
+        </Typography>
+      )}
       <Typography>
         Please see
         <a

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -52,6 +52,7 @@ import { powerOffLinode, rebootLinode } from './powerActions';
 import ToggleBox from './ToggleBox';
 
 import MaintenanceBanner from 'src/components/MaintenanceBanner';
+import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
 
 interface ConfigDrawerState {
   open: boolean;
@@ -409,7 +410,18 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                   <Grid item className={classes.CSVlinkContainer}>
                     <CSVLink
                       data={linodesData}
-                      headers={headers}
+                      headers={
+                        this.props.someLinodesHaveScheduledMaintenance
+                          ? [
+                              ...headers,
+                              /** only add maintenance window to CSV if one Linode has a window */
+                              {
+                                label: 'Maintenance Status',
+                                key: 'maintenance.when'
+                              }
+                            ]
+                          : headers
+                      }
                       filename={`linodes-${formatDate(moment().format())}.csv`}
                       className={classes.CSVlink}
                     >
@@ -518,7 +530,7 @@ const getUserSelectedDisplay = (
 interface StateProps {
   managed: boolean;
   linodesCount: number;
-  linodesData: Linode.Linode[];
+  linodesData: LinodeWithMaintenance[];
   linodesRequestError?: Linode.ApiFieldError[];
   linodesRequestLoading: boolean;
   userTimezone: string;

--- a/src/features/linodes/LinodesLanding/utils.test.ts
+++ b/src/features/linodes/LinodesLanding/utils.test.ts
@@ -2,7 +2,7 @@ import { parseMaintenanceStartTime } from './utils';
 
 describe('Linode Landing Utilites', () => {
   it('should return "Maintenance Window Unknown" for invalid dates', () => {
-    expect(parseMaintenanceStartTime('iVALid DATE')).toBe(
+    expect(parseMaintenanceStartTime('inVALid DATE')).toBe(
       'Maintenance Window Unknown'
     );
     expect(parseMaintenanceStartTime('Invalid Date')).toBe(
@@ -11,16 +11,13 @@ describe('Linode Landing Utilites', () => {
     expect(parseMaintenanceStartTime('valid')).toBe(
       'Maintenance Window Unknown'
     );
-    expect(parseMaintenanceStartTime('2018-4-21T18:58:41')).toBe(
-      'Maintenance Window Unknown'
-    );
   });
 
   it('should return a parsed date stamp for a valid datetime', () => {
-    expect(parseMaintenanceStartTime('2020-03-22T18:58:41')).toBe(
+    expect(parseMaintenanceStartTime('2020-03-22 18:58:41')).toBe(
       '2020-03-22 18:58:41'
     );
-    expect(parseMaintenanceStartTime('2018-04-21T18:58:41')).toBe(
+    expect(parseMaintenanceStartTime('2018-04-21 18:58:41')).toBe(
       '2018-04-21 18:58:41'
     );
   });

--- a/src/features/linodes/LinodesLanding/utils.ts
+++ b/src/features/linodes/LinodesLanding/utils.ts
@@ -1,24 +1,20 @@
 import { reportException } from 'src/exceptionReporting';
-import { formatDate } from 'src/utilities/formatDate';
 
 export const parseMaintenanceStartTime = (startTime?: string | null) => {
   if (!startTime) {
     return 'No Maintenance Needed';
   }
-
-  const parsedDate = formatDate(startTime);
-
   /**
    * this should never happen as long as the API is returning
    * a date format we can parse, but this is a good failsafe.
    */
-  if (parsedDate.match(/invalid/i)) {
+  if (startTime.match(/valid/i)) {
     reportException('Error parsing maintenance start time', {
       rawDate: startTime,
-      convertedDate: parsedDate
+      convertedDate: startTime
     });
     return 'Maintenance Window Unknown';
   }
 
-  return parsedDate;
+  return startTime;
 };


### PR DESCRIPTION
## Description

Adds Linode Maintenance window start time to the CSV. Totally forgot to add this feature.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## Note to Reviewers

Also does the following:

1.  Removes timezone from banner (with the exception of the Linode Detail page)
2. Fixes Troll timezone.
3. Converts the start window to observe user timezone at the time the notification is attached to the Linode object.