### PR TITLE
M3-2247 Part 2: Components and internal state

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -17,6 +17,7 @@ type ClassNames =
   | 'cancel'
   | 'remove'
   | 'compact'
+  | 'superCompact'
   | 'hidden'
   | 'reg';
 
@@ -27,6 +28,7 @@ export interface Props extends ButtonProps {
   className?: string;
   tooltipText?: string;
   compact?: boolean;
+  superCompact?: boolean;
 }
 
 const styles: StyleRulesCallback = theme => ({
@@ -104,6 +106,12 @@ const styles: StyleRulesCallback = theme => ({
     paddingLeft: theme.spacing.unit * 2 - 2,
     paddingRight: theme.spacing.unit * 2 - 2
   },
+  superCompact: {
+    paddingLeft: 0,
+    paddingRight: 0,
+    paddingTop: theme.spacing.unit,
+    paddingBottom: theme.spacing.unit
+  },
   hidden: {
     visibility: 'hidden'
   },
@@ -142,6 +150,7 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
     tooltipText,
     type,
     compact,
+    superCompact,
     className,
     ...rest
   } = props;
@@ -161,6 +170,7 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
             loading,
             [classes.destructive]: destructive,
             [classes.compact]: compact,
+            [classes.superCompact]: superCompact,
             disabled: props.disabled
           },
           className

--- a/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -31,21 +31,18 @@ import {
   createInitialCloneLandingState
 } from './utilities';
 
-type ClassNames = 'root' | 'configContainer' | 'diskOuter' | 'diskInner';
+type ClassNames = 'root' | 'outerContainer' | 'diskContainer';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
     marginTop: theme.spacing.unit
   },
-  configContainer: {
+  outerContainer: {
     paddingLeft: theme.spacing.unit * 2,
-    paddingBottom: theme.spacing.unit
+    paddingRight: theme.spacing.unit * 2,
+    paddingBottom: theme.spacing.unit * 2
   },
-  diskOuter: {
-    paddingLeft: theme.spacing.unit * 2,
-    paddingBottom: theme.spacing.unit
-  },
-  diskInner: {
+  diskContainer: {
     marginTop: theme.spacing.unit * 4
   }
 });
@@ -98,7 +95,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
     configs,
     disks,
     Number(queryParams.selectedConfig),
-    Number(queryParams.defaultSelectedDiskId)
+    Number(queryParams.selectedDisk)
   );
 
   const [state, dispatch] = React.useReducer(cloneLandingReducer, initialState);
@@ -141,7 +138,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
               exact
               path={`${url}/configs`}
               render={() => (
-                <div className={classes.configContainer}>
+                <div className={classes.outerContainer}>
                   <Configs
                     configs={configs}
                     selectedConfigs={state.configSelection}
@@ -154,12 +151,12 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
               exact
               path={`${url}/disks`}
               render={() => (
-                <div className={classes.diskOuter}>
+                <div className={classes.outerContainer}>
                   <Typography>
                     You can make a copy of a disk to the same or different
                     Linode. We recommend you power off your Linode first.
                   </Typography>
-                  <div className={classes.diskInner}>
+                  <div className={classes.diskContainer}>
                     <Disks
                       disks={disks}
                       selectedDisks={state.diskSelection}

--- a/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -6,17 +6,22 @@ import {
   Switch,
   withRouter
 } from 'react-router-dom';
+import { compose } from 'recompose';
 import AppBar from 'src/components/core/AppBar';
 import Paper from 'src/components/core/Paper';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Grid from 'src/components/Grid';
 import TabLink from 'src/components/TabLink';
+import { HasNumericID } from 'src/store/types';
+import { withLinodeDetailContext } from '../LinodesDetail/linodeDetailContext';
 import Configs from './Configs';
+import Details from './Details';
 import Disks from './Disks';
 
-type CombinedProps = RouteComponentProps<{}>;
+type CombinedProps = RouteComponentProps<{}> & StateProps;
 
 export const CloneLanding: React.FC<CombinedProps> = props => {
   const tabs = [
@@ -38,10 +43,44 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
   };
 
   const {
+    configs,
+    disks,
     match: { url }
   } = props;
+
   const matches = (p: string) => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
+  };
+
+  const [selectedConfigs, setSelectedConfigs] = React.useState<
+    Record<number, boolean>
+  >(initSelected(props.configs));
+
+  const [selectedDisks, setSelectedDisks] = React.useState<
+    Record<number, boolean>
+  >(initSelected(props.disks));
+
+  const handleSelectConfig = (configId: number) => {
+    setSelectedConfigs({
+      ...selectedConfigs,
+      [configId]: !selectedConfigs[configId]
+    });
+  };
+
+  const handleSelectDisk = (diskId: number) => {
+    setSelectedDisks({
+      ...selectedDisks,
+      [diskId]: !selectedDisks[diskId]
+    });
+  };
+
+  const clearAll = () => {
+    setSelectedConfigs({
+      ...initSelected(props.configs)
+    });
+    setSelectedDisks({
+      ...initSelected(props.disks)
+    });
   };
 
   return (
@@ -50,34 +89,108 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
       <Typography variant="h1" data-qa-clone-header>
         Clone
       </Typography>
-      <Paper>
-        <AppBar position="static" color="default">
-          <Tabs
-            value={tabs.findIndex(tab => matches(tab.routeName))}
-            onChange={handleTabChange}
-            indicatorColor="primary"
-            textColor="primary"
-            variant="scrollable"
-            scrollButtons="on"
-          >
-            {tabs.map(tab => (
-              <Tab
-                key={tab.title}
-                data-qa-tab={tab.title}
-                component={() => (
-                  <TabLink to={tab.routeName} title={tab.title} />
-                )}
-              />
-            ))}
-          </Tabs>
-        </AppBar>
-        <Route exact path={`${url}/configs`} component={Configs} />
-        <Route exact path={`${url}/disks`} component={Disks} />
-        <Route exact path={`${url}`} component={Configs} />
-      </Paper>
+      {/* @todo: Fix these styles */}
+      <Grid container style={{ marginTop: 8 }}>
+        <Grid item xs={12} md={8}>
+          <Paper>
+            <AppBar position="static" color="default">
+              <Tabs
+                value={tabs.findIndex(tab => matches(tab.routeName))}
+                onChange={handleTabChange}
+                indicatorColor="primary"
+                textColor="primary"
+                variant="scrollable"
+                scrollButtons="on"
+              >
+                {tabs.map(tab => (
+                  <Tab
+                    key={tab.title}
+                    data-qa-tab={tab.title}
+                    component={() => (
+                      <TabLink to={tab.routeName} title={tab.title} />
+                    )}
+                  />
+                ))}
+              </Tabs>
+            </AppBar>
+            <Route
+              exact
+              path={`${url}/configs`}
+              render={() => (
+                // @todo: fix this (make classes)
+                <div style={{ paddingLeft: 16, paddingBottom: 8 }}>
+                  <Configs
+                    configs={configs}
+                    selectedConfigs={selectedConfigs}
+                    handleSelect={handleSelectConfig}
+                  />
+                </div>
+              )}
+            />
+            <Route
+              exact
+              path={`${url}/disks`}
+              render={() => (
+                <div style={{ paddingLeft: 16, paddingBottom: 8 }}>
+                  <Typography>
+                    You can make a copy of a disk to the same or different
+                    Linode. We recommend you power off your Linode first.
+                  </Typography>
+                  {/* @todo fix these styles */}
+                  <div style={{ marginTop: 32 }}>
+                    <Disks
+                      disks={disks}
+                      selectedDisks={selectedDisks}
+                      handleSelect={handleSelectDisk}
+                    />
+                  </div>
+                </div>
+              )}
+            />
+            <Route exact path={`${url}`} component={Configs} />
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <Details
+            selectedConfigs={configs.filter(
+              config => selectedConfigs[config.id]
+            )}
+            selectedDisks={disks.filter(disk => selectedDisks[disk.id])}
+            handleSelectConfig={handleSelectConfig}
+            handleSelectDisk={handleSelectDisk}
+            clearAll={clearAll}
+          />
+        </Grid>
+      </Grid>
       <Switch />
     </React.Fragment>
   );
 };
 
-export default withRouter(CloneLanding);
+interface StateProps {
+  linodeId: number;
+  configs: Linode.Config[];
+  disks: Linode.Disk[];
+  readOnly: boolean;
+}
+const linodeContext = withLinodeDetailContext(({ linode }) => ({
+  linodeId: linode.id,
+  configs: linode._configs,
+  disks: linode._disks,
+  readOnly: linode._permissions === 'read_only'
+}));
+
+const enhanced = compose<CombinedProps, {}>(
+  linodeContext,
+  withRouter
+);
+
+export default enhanced(CloneLanding);
+
+const initSelected = <T extends HasNumericID[]>(itemsWithId: T) => {
+  const selected: Record<number, boolean> = {};
+  itemsWithId.forEach(eachItem => {
+    selected[eachItem.id] = false;
+  });
+  return selected;
+};

--- a/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -122,7 +122,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
   };
 
   const setSelectedLinodeId = (id: number) => {
-    return dispatch({ type: 'toggleDisk', id });
+    return dispatch({ type: 'setSelectedLinodeId', id });
   };
 
   const clearAll = () => dispatch({ type: 'clearAll' });
@@ -164,7 +164,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
             </AppBar>
             <Route
               exact
-              path={`${url}/configs`}
+              path={`${url}(/configs)?`}
               render={() => (
                 <div className={classes.outerContainer}>
                   <Configs
@@ -195,7 +195,6 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
                 </div>
               )}
             />
-            <Route exact path={`${url}`} component={Configs} />
           </Paper>
         </Grid>
         <Grid item xs={12} md={3}>
@@ -204,24 +203,24 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
               selectedConfigs,
               disks
             )}
-            selectedDisks={disks
-              // Filter out disks that aren't selected are that are associated with
-              // a config that IS selected
-              .filter(disk => {
-                return (
-                  // This disk has been individually selected ...
-                  state.diskSelection[disk.id].isSelected &&
-                  // ... AND it's associated configs are NOT selected
-                  intersection(
-                    pathOr(
-                      [],
-                      [disk.id, 'associatedConfigIds'],
-                      state.diskSelection
-                    ),
-                    selectedConfigIds
-                  ).length === 0
-                );
-              })}
+            // If a selected disk is associated with a selected config, we
+            // don't want it to appear in the Details component, since
+            // cloning the config takes precedence.
+            selectedDisks={disks.filter(disk => {
+              return (
+                // This disk has been individually selected ...
+                state.diskSelection[disk.id].isSelected &&
+                // ... AND it's associated configs are NOT selected
+                intersection(
+                  pathOr(
+                    [],
+                    [disk.id, 'associatedConfigIds'],
+                    state.diskSelection
+                  ),
+                  selectedConfigIds
+                ).length === 0
+              );
+            })}
             selectedLinode={state.selectedLinodeId}
             region={region}
             handleSelectLinode={setSelectedLinodeId}
@@ -252,7 +251,6 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
 const styled = withStyles(styles);
 
 const enhanced = compose<CombinedProps, {}>(
-  React.memo,
   linodeContext,
   styled,
   withLinodes((ownProps, linodesData, linodesLoading, linodesError) => ({

--- a/src/features/linodes/CloneLanding/Configs.tsx
+++ b/src/features/linodes/CloneLanding/Configs.tsx
@@ -12,6 +12,7 @@ import TableRow from 'src/components/core/TableRow';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
+import { ConfigSelection } from './utilities';
 
 type ClassNames = 'root' | 'tableCell';
 
@@ -22,10 +23,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     padding: 0
   }
 });
-
 interface Props {
   configs: Linode.Config[];
-  selectedConfigs: Record<number, boolean>;
+  selectedConfigs: ConfigSelection;
   handleSelect: (id: number) => void;
 }
 
@@ -34,6 +34,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export const Configs: React.FC<CombinedProps> = props => {
   const { classes, configs, handleSelect, selectedConfigs } = props;
 
+  // @todo: Empty State?
   return (
     <Paginate data={configs}>
       {({
@@ -52,11 +53,11 @@ export const Configs: React.FC<CombinedProps> = props => {
               border={false}
             >
               <TableBody>
-                {paginatedData.map(config => (
+                {paginatedData.map((config: Linode.Config) => (
                   <TableRow key={config.id} data-qa-config={config.label}>
                     <TableCell className={classes.tableCell}>
                       <CheckBox
-                        checked={selectedConfigs[config.id]}
+                        checked={selectedConfigs[config.id].isSelected}
                         onChange={() => handleSelect(config.id)}
                         text={config.label}
                       />

--- a/src/features/linodes/CloneLanding/Configs.tsx
+++ b/src/features/linodes/CloneLanding/Configs.tsx
@@ -1,7 +1,86 @@
 import * as React from 'react';
+import { compose } from 'recompose';
+import CheckBox from 'src/components/CheckBox';
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import TableBody from 'src/components/core/TableBody';
+import TableCell from 'src/components/core/TableCell';
+import TableRow from 'src/components/core/TableRow';
+import Paginate from 'src/components/Paginate';
+import PaginationFooter from 'src/components/PaginationFooter';
+import Table from 'src/components/Table';
 
-export const Configs: React.FC<{}> = () => {
-  return <div>Configs Component</div>;
+type ClassNames = 'root' | 'tableCell';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  tableCell: {
+    borderBottom: 'none',
+    padding: 0
+  }
+});
+
+interface Props {
+  configs: Linode.Config[];
+  selectedConfigs: Record<number, boolean>;
+  handleSelect: (id: number) => void;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export const Configs: React.FC<CombinedProps> = props => {
+  const { classes, configs, handleSelect, selectedConfigs } = props;
+
+  return (
+    <Paginate data={configs}>
+      {({
+        data: paginatedData,
+        handlePageChange,
+        handlePageSizeChange,
+        page,
+        pageSize,
+        count
+      }) => {
+        return (
+          <React.Fragment>
+            <Table
+              isResponsive={false}
+              aria-label="List of Configurations"
+              border={false}
+            >
+              <TableBody>
+                {paginatedData.map(config => (
+                  <TableRow key={config.id} data-qa-config={config.label}>
+                    <TableCell className={classes.tableCell}>
+                      <CheckBox
+                        checked={selectedConfigs[config.id]}
+                        onChange={() => handleSelect(config.id)}
+                        text={config.label}
+                      />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <PaginationFooter
+              count={count}
+              page={page}
+              pageSize={pageSize}
+              handlePageChange={handlePageChange}
+              handleSizeChange={handlePageSizeChange}
+              eventCategory="linode configs"
+            />
+          </React.Fragment>
+        );
+      }}
+    </Paginate>
+  );
 };
 
-export default Configs;
+const styled = withStyles(styles);
+const enhanced = compose<CombinedProps, Props>(styled);
+
+export default enhanced(Configs);

--- a/src/features/linodes/CloneLanding/Configs.tsx
+++ b/src/features/linodes/CloneLanding/Configs.tsx
@@ -28,14 +28,14 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 });
 interface Props {
   configs: Linode.Config[];
-  selectedConfigs: ConfigSelection;
+  configSelection: ConfigSelection;
   handleSelect: (id: number) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const Configs: React.FC<CombinedProps> = props => {
-  const { classes, configs, handleSelect, selectedConfigs } = props;
+  const { classes, configs, handleSelect, configSelection } = props;
 
   return (
     <Paginate data={configs}>
@@ -63,7 +63,7 @@ export const Configs: React.FC<CombinedProps> = props => {
                     <TableRow key={config.id} data-qa-config={config.label}>
                       <TableCell>
                         <CheckBox
-                          checked={selectedConfigs[config.id].isSelected}
+                          checked={configSelection[config.id].isSelected}
                           onChange={() => handleSelect(config.id)}
                           text={config.label}
                         />

--- a/src/features/linodes/CloneLanding/Configs.tsx
+++ b/src/features/linodes/CloneLanding/Configs.tsx
@@ -20,7 +20,8 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   tableCell: {
     borderBottom: 'none',
-    padding: 0
+    paddingTop: 0,
+    paddingBottom: 0
   }
 });
 interface Props {

--- a/src/features/linodes/CloneLanding/Configs.tsx
+++ b/src/features/linodes/CloneLanding/Configs.tsx
@@ -12,16 +12,18 @@ import TableRow from 'src/components/core/TableRow';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import { ConfigSelection } from './utilities';
 
-type ClassNames = 'root' | 'tableCell';
+type ClassNames = 'root';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
-  root: {},
-  tableCell: {
-    borderBottom: 'none',
-    paddingTop: 0,
-    paddingBottom: 0
+  root: {
+    '& td': {
+      borderBottom: 'none',
+      paddingTop: 0,
+      paddingBottom: 0
+    }
   }
 });
 interface Props {
@@ -35,7 +37,6 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export const Configs: React.FC<CombinedProps> = props => {
   const { classes, configs, handleSelect, selectedConfigs } = props;
 
-  // @todo: Empty State?
   return (
     <Paginate data={configs}>
       {({
@@ -52,19 +53,24 @@ export const Configs: React.FC<CombinedProps> = props => {
               isResponsive={false}
               aria-label="List of Configurations"
               border={false}
+              className={classes.root}
             >
               <TableBody>
-                {paginatedData.map((config: Linode.Config) => (
-                  <TableRow key={config.id} data-qa-config={config.label}>
-                    <TableCell className={classes.tableCell}>
-                      <CheckBox
-                        checked={selectedConfigs[config.id].isSelected}
-                        onChange={() => handleSelect(config.id)}
-                        text={config.label}
-                      />
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {paginatedData.length === 0 ? (
+                  <TableRowEmptyState colSpan={1} />
+                ) : (
+                  paginatedData.map((config: Linode.Config) => (
+                    <TableRow key={config.id} data-qa-config={config.label}>
+                      <TableCell>
+                        <CheckBox
+                          checked={selectedConfigs[config.id].isSelected}
+                          onChange={() => handleSelect(config.id)}
+                          text={config.label}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
               </TableBody>
             </Table>
             <PaginationFooter

--- a/src/features/linodes/CloneLanding/Details.tsx
+++ b/src/features/linodes/CloneLanding/Details.tsx
@@ -1,0 +1,119 @@
+import Close from '@material-ui/icons/Close';
+import * as React from 'react';
+import { compose } from 'recompose';
+import Button from 'src/components/Button';
+import Paper from 'src/components/core/Paper';
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+
+type ClassNames = 'root' | 'closeIcon' | 'selectedElement';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {
+    padding: theme.spacing.unit * 2
+  },
+  closeIcon: {
+    cursor: 'pointer'
+  },
+  selectedElement: {
+    marginTop: 0,
+    width: 415,
+    [theme.breakpoints.down('xs')]: {
+      width: 165
+    },
+    '& > div ': {
+      // backgroundColor: theme.bg.main,
+      border: 0
+    }
+  }
+});
+
+interface Props {
+  selectedConfigs: Linode.Config[];
+  selectedDisks: Linode.Disk[];
+  handleSelectConfig: (id: number) => void;
+  handleSelectDisk: (id: number) => void;
+  clearAll: () => void;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export const Configs: React.FC<CombinedProps> = props => {
+  const {
+    classes,
+    selectedConfigs,
+    selectedDisks,
+    handleSelectConfig,
+    handleSelectDisk,
+    clearAll
+  } = props;
+
+  return (
+    <Paper className={classes.root}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          marginBottom: 32
+        }}
+      >
+        <Typography variant="h2">Selected</Typography>
+        <Button type="secondary" superCompact onClick={clearAll}>
+          Clear
+        </Button>
+      </div>
+      {selectedConfigs.map(eachConfig => {
+        return (
+          <div
+            key={eachConfig.id}
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'space-between'
+            }}
+          >
+            <Typography variant="h3">{eachConfig.label}</Typography>
+            <a
+              onClick={() => handleSelectConfig(eachConfig.id)}
+              className={classes.closeIcon}
+              data-qa-inline-delete
+            >
+              <Close />
+            </a>
+          </div>
+        );
+      })}
+      {selectedDisks.map(eachDisk => {
+        return (
+          <div
+            key={eachDisk.id}
+            style={{
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'space-between'
+            }}
+          >
+            <Typography variant="h3">{eachDisk.label}</Typography>
+            <a
+              onClick={() => handleSelectDisk(eachDisk.id)}
+              className={classes.closeIcon}
+              data-qa-inline-delete
+            >
+              <Close />
+            </a>
+          </div>
+        );
+      })}
+    </Paper>
+  );
+};
+
+const styled = withStyles(styles);
+const enhanced = compose<CombinedProps, Props>(styled);
+
+export default enhanced(Configs);

--- a/src/features/linodes/CloneLanding/Details.tsx
+++ b/src/features/linodes/CloneLanding/Details.tsx
@@ -24,7 +24,8 @@ type ClassNames =
   | 'nestedList'
   | 'closeIcon'
   | 'divider'
-  | 'submitButton';
+  | 'submitButton'
+  | 'labelOuter';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
@@ -48,7 +49,9 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     flexBasis: '100%'
   },
   closeIcon: {
-    cursor: 'pointer'
+    cursor: 'pointer',
+    position: 'relative',
+    top: -4
   },
   divider: {
     marginTop: theme.spacing.unit * 2,
@@ -57,6 +60,11 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
   },
   submitButton: {
     marginTop: theme.spacing.unit * 3
+  },
+  labelOuter: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    width: '100%'
   }
 });
 
@@ -108,14 +116,16 @@ export const Configs: React.FC<CombinedProps> = props => {
               disableGutters
               dense
             >
-              <Typography variant="h3">{eachConfig.label}</Typography>
-              <a
-                onClick={() => handleToggleConfig(eachConfig.id)}
-                className={classes.closeIcon}
-                data-qa-inline-delete
-              >
-                <Close />
-              </a>
+              <div className={classes.labelOuter}>
+                <Typography variant="h3">{eachConfig.label}</Typography>
+                <a
+                  onClick={() => handleToggleConfig(eachConfig.id)}
+                  className={classes.closeIcon}
+                  data-qa-inline-delete
+                >
+                  <Close />
+                </a>
+              </div>
               <List className={classes.nestedList}>
                 {eachConfig.associatedDisks.map(eachDisk => {
                   return (

--- a/src/features/linodes/CloneLanding/Details.tsx
+++ b/src/features/linodes/CloneLanding/Details.tsx
@@ -19,6 +19,7 @@ import { ExtendedConfig } from './utilities';
 type ClassNames =
   | 'root'
   | 'header'
+  | 'clearButton'
   | 'list'
   | 'nestedList'
   | 'closeIcon'
@@ -33,7 +34,10 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',
-    marginBottom: theme.spacing.unit * 4
+    marginBottom: theme.spacing.unit * 2
+  },
+  clearButton: {
+    top: -(theme.spacing.unit / 2)
   },
   list: {
     flexWrap: 'wrap',
@@ -86,7 +90,12 @@ export const Configs: React.FC<CombinedProps> = props => {
     <Paper className={classes.root}>
       <header className={classes.header}>
         <Typography variant="h2">Selected</Typography>
-        <Button type="secondary" superCompact onClick={clearAll}>
+        <Button
+          className={classes.clearButton}
+          type="secondary"
+          onClick={clearAll}
+          superCompact
+        >
           Clear
         </Button>
       </header>
@@ -148,6 +157,7 @@ export const Configs: React.FC<CombinedProps> = props => {
 
       <Typography>Current Datacenter: {formatRegion(region)}</Typography>
 
+      {/* @todo: This LinodeSelect needs to be subdivided by region */}
       <LinodeSelect
         label="Destination"
         selectedLinode={selectedLinode}

--- a/src/features/linodes/CloneLanding/Details.tsx
+++ b/src/features/linodes/CloneLanding/Details.tsx
@@ -157,7 +157,7 @@ export const Configs: React.FC<CombinedProps> = props => {
 
       <Typography>Current Datacenter: {formatRegion(region)}</Typography>
 
-      {/* @todo: This LinodeSelect needs to be subdivided by region */}
+      {/* @todo: This LinodeSelect needs to be grouped by region */}
       <LinodeSelect
         label="Destination"
         selectedLinode={selectedLinode}

--- a/src/features/linodes/CloneLanding/Details.tsx
+++ b/src/features/linodes/CloneLanding/Details.tsx
@@ -65,8 +65,8 @@ interface Props {
   selectedDisks: Linode.Disk[];
   selectedLinode: number | null;
   region: string;
-  handleSelectConfig: (id: number) => void;
-  handleSelectDisk: (id: number) => void;
+  handleToggleConfig: (id: number) => void;
+  handleToggleDisk: (id: number) => void;
   handleSelectLinode: (linodeId: number) => void;
   clearAll: () => void;
 }
@@ -80,8 +80,8 @@ export const Configs: React.FC<CombinedProps> = props => {
     selectedDisks,
     selectedLinode,
     region,
-    handleSelectConfig,
-    handleSelectDisk,
+    handleToggleConfig,
+    handleToggleDisk,
     handleSelectLinode,
     clearAll
   } = props;
@@ -110,7 +110,7 @@ export const Configs: React.FC<CombinedProps> = props => {
             >
               <Typography variant="h3">{eachConfig.label}</Typography>
               <a
-                onClick={() => handleSelectConfig(eachConfig.id)}
+                onClick={() => handleToggleConfig(eachConfig.id)}
                 className={classes.closeIcon}
                 data-qa-inline-delete
               >
@@ -140,7 +140,7 @@ export const Configs: React.FC<CombinedProps> = props => {
             >
               <Typography variant="h3">{eachDisk.label}</Typography>
               <a
-                onClick={() => handleSelectDisk(eachDisk.id)}
+                onClick={() => handleToggleDisk(eachDisk.id)}
                 className={classes.closeIcon}
                 data-qa-inline-delete
               >

--- a/src/features/linodes/CloneLanding/Details.tsx
+++ b/src/features/linodes/CloneLanding/Details.tsx
@@ -2,6 +2,7 @@ import Close from '@material-ui/icons/Close';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Button from 'src/components/Button';
+import Divider from 'src/components/core/Divider';
 import Paper from 'src/components/core/Paper';
 import {
   StyleRulesCallback,
@@ -9,12 +10,29 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import LinodeSelect from '../LinodeSelect';
 
-type ClassNames = 'root' | 'closeIcon' | 'selectedElement';
+type ClassNames =
+  | 'root'
+  | 'closeIcon'
+  | 'selectedElement'
+  | 'divider'
+  | 'submitButton';
 
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {
-    padding: theme.spacing.unit * 2
+    padding: theme.spacing.unit * 2,
+    '& ul': {
+      listStyleType: 'none',
+      paddingLeft: 0
+    },
+    '& li': {
+      paddingTop: theme.spacing.unit / 2,
+      paddingBottom: theme.spacing.unit / 2
+    },
+    '& ul .diskSublist': {
+      paddingLeft: theme.spacing.unit * 2
+    }
   },
   closeIcon: {
     cursor: 'pointer'
@@ -29,15 +47,27 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
       // backgroundColor: theme.bg.main,
       border: 0
     }
+  },
+  divider: {
+    marginTop: theme.spacing.unit * 2,
+    marginBottom: theme.spacing.unit * 2,
+    backgroundColor: theme.color.grey3
+  },
+  submitButton: {
+    marginTop: theme.spacing.unit * 3
   }
 });
 
 interface Props {
   selectedConfigs: Linode.Config[];
   selectedDisks: Linode.Disk[];
+  selectedLinode: number | null;
+  allDisks: Linode.Disk[];
   handleSelectConfig: (id: number) => void;
   handleSelectDisk: (id: number) => void;
   clearAll: () => void;
+  handleSelectLinode: (linodeId: number) => void;
+  formattedRegion: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -47,9 +77,13 @@ export const Configs: React.FC<CombinedProps> = props => {
     classes,
     selectedConfigs,
     selectedDisks,
+    allDisks,
     handleSelectConfig,
     handleSelectDisk,
-    clearAll
+    clearAll,
+    selectedLinode,
+    handleSelectLinode,
+    formattedRegion
   } = props;
 
   return (
@@ -67,48 +101,81 @@ export const Configs: React.FC<CombinedProps> = props => {
           Clear
         </Button>
       </div>
-      {selectedConfigs.map(eachConfig => {
-        return (
-          <div
-            key={eachConfig.id}
-            style={{
-              display: 'flex',
-              flexDirection: 'row',
-              justifyContent: 'space-between'
-            }}
-          >
-            <Typography variant="h3">{eachConfig.label}</Typography>
-            <a
-              onClick={() => handleSelectConfig(eachConfig.id)}
-              className={classes.closeIcon}
-              data-qa-inline-delete
+      <ul>
+        {selectedConfigs.map(eachConfig => {
+          return (
+            <li key={eachConfig.id}>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  justifyContent: 'space-between'
+                }}
+              >
+                <Typography variant="h3">{eachConfig.label}</Typography>
+                <a
+                  onClick={() => handleSelectConfig(eachConfig.id)}
+                  className={classes.closeIcon}
+                  data-qa-inline-delete
+                >
+                  <Close />
+                </a>
+              </div>
+              <ul className="diskSublist">
+                {getDisksForDisplay(eachConfig, allDisks).map(eachDisk => {
+                  return (
+                    <li key={eachDisk.label}>
+                      <Typography>{eachDisk.label}</Typography>
+                    </li>
+                  );
+                })}
+              </ul>
+            </li>
+          );
+        })}
+      </ul>
+      <ul>
+        {selectedDisks.map(eachDisk => {
+          return (
+            <li
+              key={eachDisk.id}
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'space-between'
+              }}
             >
-              <Close />
-            </a>
-          </div>
-        );
-      })}
-      {selectedDisks.map(eachDisk => {
-        return (
-          <div
-            key={eachDisk.id}
-            style={{
-              display: 'flex',
-              flexDirection: 'row',
-              justifyContent: 'space-between'
-            }}
-          >
-            <Typography variant="h3">{eachDisk.label}</Typography>
-            <a
-              onClick={() => handleSelectDisk(eachDisk.id)}
-              className={classes.closeIcon}
-              data-qa-inline-delete
-            >
-              <Close />
-            </a>
-          </div>
-        );
-      })}
+              <Typography variant="h3">{eachDisk.label}</Typography>
+              <a
+                onClick={() => handleSelectDisk(eachDisk.id)}
+                className={classes.closeIcon}
+                data-qa-inline-delete
+              >
+                <Close />
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+
+      {(selectedConfigs.length > 0 || selectedDisks.length > 0) && (
+        <Divider className={classes.divider} />
+      )}
+
+      <Typography>Current Datacenter: {formattedRegion}</Typography>
+      <LinodeSelect
+        label="Destination"
+        selectedLinode={selectedLinode}
+        handleChange={linode => handleSelectLinode(linode.id)}
+        updateFor={[selectedLinode, classes]}
+      />
+      <Button
+        className={classes.submitButton}
+        type="primary"
+        onClick={() => alert(`Clone`)}
+      >
+        Clone
+      </Button>
     </Paper>
   );
 };
@@ -117,3 +184,16 @@ const styled = withStyles(styles);
 const enhanced = compose<CombinedProps, Props>(styled);
 
 export default enhanced(Configs);
+
+const getDisksForDisplay = (
+  config: Linode.Config,
+  disks: Linode.Disk[]
+): Linode.Disk[] => {
+  const disksOnConfig: number[] = [];
+  Object.keys(config.devices).forEach(key => {
+    if (config.devices[key] && config.devices[key].disk_id) {
+      disksOnConfig.push(config.devices[key].disk_id);
+    }
+  });
+  return disks.filter(eachDisk => disksOnConfig.includes(eachDisk.id));
+};

--- a/src/features/linodes/CloneLanding/Disks.tsx
+++ b/src/features/linodes/CloneLanding/Disks.tsx
@@ -1,7 +1,105 @@
 import * as React from 'react';
+import { compose } from 'recompose';
+import CheckBox from 'src/components/CheckBox';
+import {
+  StyleRulesCallback,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import TableBody from 'src/components/core/TableBody';
+import TableCell from 'src/components/core/TableCell';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/core/TableRow';
+import Grid from 'src/components/Grid';
+import Paginate from 'src/components/Paginate';
+import PaginationFooter from 'src/components/PaginationFooter';
+import Table from 'src/components/Table';
 
-export const Disks: React.FC<{}> = () => {
-  return <div>Disks Component</div>;
+type ClassNames = 'root' | 'tableCell' | 'labelCol' | 'sizeCol';
+
+const styles: StyleRulesCallback<ClassNames> = theme => ({
+  root: {},
+  tableCell: {
+    borderBottom: 'none',
+    padding: 0
+  },
+  labelCol: {
+    width: '65%'
+  },
+  sizeCol: {
+    width: '35%'
+  }
+});
+
+interface Props {
+  disks: Linode.Disk[];
+  selectedDisks: Record<number, boolean>;
+  handleSelect: (id: number) => void;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export const Configs: React.FC<CombinedProps> = props => {
+  const { classes, disks, handleSelect, selectedDisks } = props;
+
+  return (
+    <Paginate data={disks}>
+      {({
+        data: paginatedData,
+        handlePageChange,
+        handlePageSizeChange,
+        page,
+        pageSize,
+        count
+      }) => {
+        return (
+          <React.Fragment>
+            <Grid container>
+              <Grid item xs={12} md={9}>
+                <Table
+                  isResponsive={false}
+                  aria-label="List of Configurations"
+                  border
+                >
+                  <TableHead>
+                    <TableRow>
+                      <TableCell className={classes.labelCol}>Label</TableCell>
+                      <TableCell className={classes.sizeCol}>Size</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {paginatedData.map(disk => (
+                      <TableRow key={disk.id} data-qa-disk={disk.label}>
+                        <TableCell>
+                          <CheckBox
+                            checked={selectedDisks[disk.id]}
+                            onChange={() => handleSelect(disk.id)}
+                            text={disk.label}
+                          />
+                        </TableCell>
+                        <TableCell>{disk.size} MB</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </Grid>
+            </Grid>
+            <PaginationFooter
+              count={count}
+              page={page}
+              pageSize={pageSize}
+              handlePageChange={handlePageChange}
+              handleSizeChange={handlePageSizeChange}
+              eventCategory="linode disks"
+            />
+          </React.Fragment>
+        );
+      }}
+    </Paginate>
+  );
 };
 
-export default Disks;
+const styled = withStyles(styles);
+const enhanced = compose<CombinedProps, Props>(styled);
+
+export default enhanced(Configs);

--- a/src/features/linodes/CloneLanding/Disks.tsx
+++ b/src/features/linodes/CloneLanding/Disks.tsx
@@ -14,6 +14,7 @@ import Grid from 'src/components/Grid';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
+import { ConfigSelection, DiskSelection, ExtendedDisk } from './utilities';
 
 type ClassNames = 'root' | 'tableCell' | 'labelCol' | 'sizeCol';
 
@@ -33,14 +34,21 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 
 interface Props {
   disks: Linode.Disk[];
-  selectedDisks: Record<number, boolean>;
+  selectedDisks: DiskSelection;
+  selectedConfigs: ConfigSelection;
   handleSelect: (id: number) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const Configs: React.FC<CombinedProps> = props => {
-  const { classes, disks, handleSelect, selectedDisks } = props;
+  const {
+    classes,
+    disks,
+    selectedDisks,
+    selectedConfigs,
+    handleSelect
+  } = props;
 
   return (
     <Paginate data={disks}>
@@ -56,11 +64,7 @@ export const Configs: React.FC<CombinedProps> = props => {
           <React.Fragment>
             <Grid container>
               <Grid item xs={12} md={9}>
-                <Table
-                  isResponsive={false}
-                  aria-label="List of Configurations"
-                  border
-                >
+                <Table isResponsive={false} aria-label="List of Disks" border>
                   <TableHead>
                     <TableRow>
                       <TableCell className={classes.labelCol}>Label</TableCell>
@@ -68,18 +72,28 @@ export const Configs: React.FC<CombinedProps> = props => {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {paginatedData.map(disk => (
-                      <TableRow key={disk.id} data-qa-disk={disk.label}>
-                        <TableCell>
-                          <CheckBox
-                            checked={selectedDisks[disk.id]}
-                            onChange={() => handleSelect(disk.id)}
-                            text={disk.label}
-                          />
-                        </TableCell>
-                        <TableCell>{disk.size} MB</TableCell>
-                      </TableRow>
-                    ))}
+                    {paginatedData.map((disk: ExtendedDisk) => {
+                      const configId = selectedDisks[disk.id].configId;
+
+                      const isDiskSelected = selectedDisks[disk.id].isSelected;
+                      const isConfigSelected = !!(
+                        configId && selectedConfigs[configId].isSelected
+                      );
+
+                      return (
+                        <TableRow key={disk.id} data-qa-disk={disk.label}>
+                          <TableCell>
+                            <CheckBox
+                              text={disk.label}
+                              checked={isDiskSelected || isConfigSelected}
+                              disabled={isConfigSelected}
+                              onChange={() => handleSelect(disk.id)}
+                            />
+                          </TableCell>
+                          <TableCell>{disk.size} MB</TableCell>
+                        </TableRow>
+                      );
+                    })}
                   </TableBody>
                 </Table>
               </Grid>

--- a/src/features/linodes/CloneLanding/Disks.tsx
+++ b/src/features/linodes/CloneLanding/Disks.tsx
@@ -21,8 +21,8 @@ type ClassNames = 'root' | 'tableCell' | 'labelCol' | 'sizeCol';
 const styles: StyleRulesCallback<ClassNames> = theme => ({
   root: {},
   tableCell: {
-    borderBottom: 'none',
-    padding: 0
+    paddingTop: 0,
+    paddingBottom: 0
   },
   labelCol: {
     width: '65%'
@@ -82,7 +82,7 @@ export const Configs: React.FC<CombinedProps> = props => {
 
                       return (
                         <TableRow key={disk.id} data-qa-disk={disk.label}>
-                          <TableCell>
+                          <TableCell className={classes.tableCell}>
                             <CheckBox
                               text={disk.label}
                               checked={isDiskSelected || isConfigSelected}

--- a/src/features/linodes/CloneLanding/Disks.tsx
+++ b/src/features/linodes/CloneLanding/Disks.tsx
@@ -14,6 +14,7 @@ import Grid from 'src/components/Grid';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import { ConfigSelection, DiskSelection, ExtendedDisk } from './utilities';
 
 type ClassNames = 'root' | 'tableCell' | 'labelCol' | 'sizeCol';
@@ -72,28 +73,33 @@ export const Configs: React.FC<CombinedProps> = props => {
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {paginatedData.map((disk: ExtendedDisk) => {
-                      const configId = selectedDisks[disk.id].configId;
+                    {paginatedData.length === 0 ? (
+                      <TableRowEmptyState colSpan={2} />
+                    ) : (
+                      paginatedData.map((disk: ExtendedDisk) => {
+                        const configId = selectedDisks[disk.id].configId;
 
-                      const isDiskSelected = selectedDisks[disk.id].isSelected;
-                      const isConfigSelected = !!(
-                        configId && selectedConfigs[configId].isSelected
-                      );
+                        const isDiskSelected =
+                          selectedDisks[disk.id].isSelected;
+                        const isConfigSelected = !!(
+                          configId && selectedConfigs[configId].isSelected
+                        );
 
-                      return (
-                        <TableRow key={disk.id} data-qa-disk={disk.label}>
-                          <TableCell className={classes.tableCell}>
-                            <CheckBox
-                              text={disk.label}
-                              checked={isDiskSelected || isConfigSelected}
-                              disabled={isConfigSelected}
-                              onChange={() => handleSelect(disk.id)}
-                            />
-                          </TableCell>
-                          <TableCell>{disk.size} MB</TableCell>
-                        </TableRow>
-                      );
-                    })}
+                        return (
+                          <TableRow key={disk.id} data-qa-disk={disk.label}>
+                            <TableCell className={classes.tableCell}>
+                              <CheckBox
+                                text={disk.label}
+                                checked={isDiskSelected || isConfigSelected}
+                                disabled={isConfigSelected}
+                                onChange={() => handleSelect(disk.id)}
+                              />
+                            </TableCell>
+                            <TableCell>{disk.size} MB</TableCell>
+                          </TableRow>
+                        );
+                      })
+                    )}
                   </TableBody>
                 </Table>
               </Grid>

--- a/src/features/linodes/CloneLanding/utilities.ts
+++ b/src/features/linodes/CloneLanding/utilities.ts
@@ -1,0 +1,146 @@
+import { map } from 'ramda';
+
+/**
+ * Returns an array of Disks that are associated with a given config.
+ * `config.devices` looks something like this:
+ * { "sda": { "disk_id": 1234, "volume_id": 5678 }, ...etc }
+ * This function returns an array of disks that match a `disk_id` in the config.
+ */
+export const getAssociatedDisks = (
+  config: Linode.Config,
+  disks: Linode.Disk[]
+): Linode.Disk[] => {
+  const disksOnConfig: number[] = [];
+  Object.keys(config.devices).forEach(key => {
+    if (config.devices[key] && config.devices[key].disk_id) {
+      disksOnConfig.push(config.devices[key].disk_id);
+    }
+  });
+  return disks.filter(eachDisk => disksOnConfig.includes(eachDisk.id));
+};
+
+export type ConfigSelection = Record<
+  number,
+  { isSelected: boolean; associatedDisks: Linode.Disk[] }
+>;
+
+export type DiskSelection = Record<
+  number,
+  { isSelected: boolean; configId?: number }
+>;
+
+export type ExtendedConfig = Linode.Config & { associatedDisks: Linode.Disk[] };
+export type ExtendedDisk = Linode.Disk & { configId?: number };
+
+interface State {
+  configSelection: ConfigSelection;
+  diskSelection: DiskSelection;
+  selectedLinodeId: number | null;
+}
+
+export type Action =
+  | { type: 'toggleConfig'; id: number }
+  | { type: 'toggleDisk'; id: number }
+  | { type: 'setSelectedLinodeId'; id: number }
+  | { type: 'clearAll' };
+
+export const cloneLandingReducer = (state: State, action: Action): State => {
+  let id;
+  switch (action.type) {
+    case 'toggleConfig':
+      id = action.id;
+      return {
+        ...state,
+        configSelection: {
+          ...state.configSelection,
+          [id]: {
+            ...state.configSelection[id],
+            isSelected: !state.configSelection[id].isSelected
+          }
+        }
+      };
+    case 'toggleDisk':
+      id = action.id;
+      return {
+        ...state,
+        diskSelection: {
+          ...state.diskSelection,
+          [id]: {
+            ...state.diskSelection[id],
+            isSelected: !state.diskSelection[id].isSelected
+          }
+        }
+      };
+    case 'setSelectedLinodeId':
+      id = action.id;
+      return {
+        ...state,
+        selectedLinodeId: id
+      };
+    case 'clearAll':
+      return {
+        configSelection: map(
+          config => ({ ...config, isSelected: false }),
+          state.configSelection
+        ),
+        diskSelection: map(
+          disk => ({ ...disk, isSelected: false }),
+          state.diskSelection
+        ),
+        selectedLinodeId: null
+      };
+    default:
+      return state;
+  }
+};
+
+export const createInitialCloneLandingState = (
+  configs: Linode.Config[],
+  disks: Linode.Disk[],
+  preSelectedConfigId?: number,
+  preSelectedDiskId?: number
+): State => {
+  const state: State = {
+    configSelection: {},
+    diskSelection: {},
+    selectedLinodeId: null
+  };
+
+  const diskConfigMap = {};
+
+  configs.forEach(eachConfig => {
+    const isSelected = eachConfig.id === preSelectedConfigId;
+    const associatedDisks = getAssociatedDisks(eachConfig, disks);
+
+    associatedDisks.forEach(eachDisk => {
+      diskConfigMap[eachDisk.id] = eachConfig.id;
+    });
+
+    return (state.configSelection[eachConfig.id] = {
+      isSelected,
+      associatedDisks
+    });
+  });
+
+  disks.forEach(eachDisk => {
+    const isSelected = eachDisk.id === preSelectedDiskId;
+
+    const configId = diskConfigMap[eachDisk.id];
+
+    return (state.diskSelection[eachDisk.id] = {
+      isSelected,
+      configId
+    });
+  });
+
+  return state;
+};
+
+export const addConfigIdToDisks = (
+  disks: Linode.Disk[],
+  diskSelection: DiskSelection
+): ExtendedDisk[] =>
+  disks.map(eachDisk => ({
+    ...eachDisk,
+    configId: diskSelection[eachDisk.id].configId
+  }));

--- a/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -31,6 +31,7 @@ interface Props {
   region?: string;
   handleChange: (linode: Linode.Linode) => void;
   textFieldProps?: TextFieldProps;
+  label?: string;
 }
 
 type CombinedProps = Props & WithLinodesProps & WithStyles<ClassNames>;
@@ -59,7 +60,8 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
     linodesLoading,
     linodesData,
     region,
-    selectedLinode
+    selectedLinode,
+    label
   } = props;
 
   const linodes = region
@@ -74,7 +76,7 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
 
   return (
     <EnhancedSelect
-      label="Linode"
+      label={label ? label : "Linode"}
       placeholder="Select a Linode"
       value={linodeFromItems(options, selectedLinode)}
       options={options}

--- a/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -43,11 +43,14 @@ const linodesToItems = (linodes: Linode.Linode[]): Item<number>[] =>
     data: thisLinode
   }));
 
-const linodeFromItems = (linodes: Item<number>[], linodeId: number | null) => {
+const linodeFromItems = (
+  linodes: Item<number>[],
+  linodeId: number | null
+): Item<number> | null => {
   if (!linodeId) {
-    return;
+    return null;
   }
-  return linodes.find(thisLinode => thisLinode.value === linodeId);
+  return linodes.find(thisLinode => thisLinode.value === linodeId) || null;
 };
 
 const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
@@ -76,7 +79,7 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
 
   return (
     <EnhancedSelect
-      label={label ? label : "Linode"}
+      label={label ? label : 'Linode'}
       placeholder="Select a Linode"
       value={linodeFromItems(options, selectedLinode)}
       options={options}

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
@@ -6,6 +6,7 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 interface Props {
   linodeStatus: string;
   linodeId?: number;
+  diskId?: number;
   readOnly?: boolean;
   onRename: () => void;
   onResize: () => void;
@@ -17,7 +18,7 @@ type CombinedProps = Props & RouteComponentProps;
 
 class DiskActionMenu extends React.Component<CombinedProps> {
   createActions = () => (closeMenu: Function): Action[] => {
-    const { linodeStatus, linodeId, readOnly, history } = this.props;
+    const { linodeStatus, linodeId, readOnly, history, diskId } = this.props;
     let tooltip;
     tooltip =
       linodeStatus === 'offline'
@@ -74,7 +75,7 @@ class DiskActionMenu extends React.Component<CombinedProps> {
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
           closeMenu();
-          history.push(`/linodes/${linodeId}/clone/disks`);
+          history.push(`/linodes/${linodeId}/clone/disks?selectedDisk=${diskId}`);
         },
         disabled: readOnly,
         tooltip

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
@@ -75,7 +75,9 @@ class DiskActionMenu extends React.Component<CombinedProps> {
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
           closeMenu();
-          history.push(`/linodes/${linodeId}/clone/disks?selectedDisk=${diskId}`);
+          history.push(
+            `/linodes/${linodeId}/clone/disks?selectedDisk=${diskId}`
+          );
         },
         disabled: readOnly,
         tooltip

--- a/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -256,6 +256,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
           <LinodeDiskActionMenu
             linodeStatus={status || 'offline'}
             linodeId={linodeId}
+            diskId={disk.id}
             onRename={this.openDrawerForRename(disk)}
             onResize={this.openDrawerForResize(disk)}
             onImagize={this.openImagizeDrawer(disk)}

--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
@@ -38,7 +38,7 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
   };
 
   createConfigActions = () => (closeMenu: Function): Action[] => {
-    const { readOnly, history, linodeId } = this.props;
+    const { readOnly, history, linodeId, config } = this.props;
     const tooltip = readOnly
       ? "You don't have permission to perform this action"
       : undefined;
@@ -78,7 +78,7 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           e.preventDefault();
           closeMenu();
-          history.push(`/linodes/${linodeId}/clone/configs`);
+          history.push(`/linodes/${linodeId}/clone/configs?selectedConfig=${config.id}`);
         },
         disabled: readOnly,
         tooltip

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -54,6 +54,7 @@ const LinodeDetail: React.StatelessComponent<CombinedProps> = props => {
 
   return (
     <LinodeDetailContextProvider value={ctx}>
+      {/* <pre>{JSON.stringify(linode, null, 2)}</pre> */}
       <Switch>
         {/*
         Currently, the "Clone Configs and Disks" feature exists OUTSIDE of LinodeDetail.

--- a/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -54,7 +54,6 @@ const LinodeDetail: React.StatelessComponent<CombinedProps> = props => {
 
   return (
     <LinodeDetailContextProvider value={ctx}>
-      {/* <pre>{JSON.stringify(linode, null, 2)}</pre> */}
       <Switch>
         {/*
         Currently, the "Clone Configs and Disks" feature exists OUTSIDE of LinodeDetail.


### PR DESCRIPTION
## Description

I apologize for the size of this PR. It got larger and more complex than I anticipated.

This PR adds the components and internal state for cloning Configs/Disks:

<img width="1283" alt="Screen Shot 2019-06-12 at 9 37 34 AM" src="https://user-images.githubusercontent.com/16911484/59355860-cadf0380-8cf5-11e9-9efe-253dee9b0c9f.png">

The mapping of configs/disks made this complex, because of a few properties:

1. A single config can have multiple disks associated with it.
2. A single disk can be associated with multiple configs.
3. When you clone a config, _all it's associated disks are cloned too._

From the UI perspective, when a config is selected, the associated disks shown as selected and disabled:

<img width="1383" alt="Screen Shot 2019-06-12 at 9 45 57 AM" src="https://user-images.githubusercontent.com/16911484/59356492-f1516e80-8cf6-11e9-9da0-03dfd10e8154.png">

### Notes:
A few changes to components:
- `<Button />` added a new prop/class: `superCompact` with tighter spacing
- `<LinodeSelect />` can now take a custom `label` prop.

To test, go to Linode Details -> Advanced. Click the action menu of a Config or Disk, and you'll be taken to the new Clone page.

### Feature roadmap:
1. Routing
2. **Components/internal state** _(this PR)_
3. Functionality (API requests, error, loading states)
4. Unit tests
