### PR TITLE
M3-2772 fix: Ability to remove LISH key when it's disabled

### DIFF
--- a/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/src/features/Profile/LishSettings/LishSettings.tsx
@@ -227,7 +227,7 @@ class LishSettings extends React.Component<CombinedProps, State> {
 
     updateProfile({
       lish_auth_method: lishAuthMethod,
-      ...(lishAuthMethod !== 'disabled' && { authorized_keys: keys })
+      authorized_keys: keys
     })
       .then(profileData => {
         this.setState(


### PR DESCRIPTION
## Description

When updating profile from LISH settings, we were ignoring `authorized_keys` if `lish_auth_mode` was "disabled". This meant that a user could not remove keys while LISH was disabled. This was unnecessary, though. From the API docs: 

> `authorized_keys`: The list of SSH Keys authorized to use Lish for your User. This value is ignored if `lish_auth_method` is "disabled."

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Navigate to `/profile/lish`. Try adding and removing pub keys. This should work regardless of "Authentication Mode".
