### PR TITLE
M3 2247 Part 3: Functionality

### DIFF
--- a/src/features/linodes/CloneLanding/Details.tsx
+++ b/src/features/linodes/CloneLanding/Details.tsx
@@ -12,6 +12,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
 import { formatRegion } from 'src/utilities';
 import LinodeSelect from '../LinodeSelect';
 import { ExtendedConfig } from './utilities';
@@ -73,9 +74,13 @@ interface Props {
   selectedDisks: Linode.Disk[];
   selectedLinode: number | null;
   region: string;
+  isSubmitting: boolean;
+  currentLinodeId: number;
+  errorMap?: Record<string, string | undefined>;
   handleToggleConfig: (id: number) => void;
   handleToggleDisk: (id: number) => void;
   handleSelectLinode: (linodeId: number) => void;
+  handleClone: () => void;
   clearAll: () => void;
 }
 
@@ -84,15 +89,38 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export const Configs: React.FC<CombinedProps> = props => {
   const {
     classes,
+    currentLinodeId,
     selectedConfigs,
     selectedDisks,
     selectedLinode,
     region,
+    isSubmitting,
+    errorMap,
     handleToggleConfig,
     handleToggleDisk,
     handleSelectLinode,
+    handleClone,
     clearAll
   } = props;
+
+  // These errors come back from from the API under the "disk_size" field
+  // when duplicated a disk on the same Linode.
+  const linodeError = errorMap && errorMap.disk_size;
+
+  /**
+   * Don't include the current Linode in the LinodeSelect component if:
+   * 1) There is a selected config (because you can't duplicate configs on the same Linode).
+   * 2) There's more than one disk selected (because you can't duplicate multiple configs at once on the same Linode).
+   */
+  const shouldExcludeCurrentLinode =
+    selectedConfigs.length > 0 || selectedDisks.length > 1;
+
+  // Disable the Clone if there is no selected Linode, or if
+  // there are no selected configs or disks
+  const isCloneButtonDisabled =
+    (selectedConfigs.length === 0 && selectedDisks.length === 0) ||
+    !selectedLinode ||
+    (shouldExcludeCurrentLinode && selectedLinode === currentLinodeId);
 
   return (
     <Paper className={classes.root}>
@@ -107,6 +135,9 @@ export const Configs: React.FC<CombinedProps> = props => {
           Clear
         </Button>
       </header>
+
+      {errorMap && errorMap.none && <Notice error text={errorMap.none} />}
+
       <List>
         {selectedConfigs.map(eachConfig => {
           return (
@@ -170,15 +201,26 @@ export const Configs: React.FC<CombinedProps> = props => {
       {/* @todo: This LinodeSelect needs to be grouped by region */}
       <LinodeSelect
         label="Destination"
+        generalError={linodeError}
         selectedLinode={selectedLinode}
         handleChange={linode => handleSelectLinode(linode.id)}
-        updateFor={[selectedLinode, classes]}
+        excludedLinodes={
+          shouldExcludeCurrentLinode ? [currentLinodeId] : undefined
+        }
+        updateFor={[
+          selectedLinode,
+          shouldExcludeCurrentLinode,
+          errorMap,
+          classes
+        ]}
       />
 
       <Button
         className={classes.submitButton}
+        disabled={isCloneButtonDisabled}
         type="primary"
-        onClick={() => alert(`Clone`)}
+        onClick={handleClone}
+        loading={isSubmitting}
       >
         Clone
       </Button>

--- a/src/features/linodes/CloneLanding/Details.tsx
+++ b/src/features/linodes/CloneLanding/Details.tsx
@@ -104,7 +104,7 @@ export const Configs: React.FC<CombinedProps> = props => {
   } = props;
 
   // These errors come back from from the API under the "disk_size" field
-  // when duplicated a disk on the same Linode.
+  // when duplicating a disk on the same Linode.
   const linodeError = errorMap && errorMap.disk_size;
 
   /**
@@ -115,8 +115,8 @@ export const Configs: React.FC<CombinedProps> = props => {
   const shouldExcludeCurrentLinode =
     selectedConfigs.length > 0 || selectedDisks.length > 1;
 
-  // Disable the Clone if there is no selected Linode, or if
-  // there are no selected configs or disks
+  // Disable the "Clone" button if there is no selected Linode,
+  // or if there are no selected configs or disks, or if the selected Linode should be excluded.
   const isCloneButtonDisabled =
     (selectedConfigs.length === 0 && selectedDisks.length === 0) ||
     !selectedLinode ||

--- a/src/features/linodes/CloneLanding/utilities.ts
+++ b/src/features/linodes/CloneLanding/utilities.ts
@@ -88,7 +88,9 @@ export const cloneLandingReducer = (
             // This is the actual toggle:
             isSelected: !state.configSelection[id].isSelected
           }
-        }
+        },
+        // Clear errors on input change.
+        errors: undefined
       };
     case 'toggleDisk':
       id = action.id;
@@ -101,13 +103,17 @@ export const cloneLandingReducer = (
             ...state.diskSelection[id],
             isSelected: !state.diskSelection[id].isSelected
           }
-        }
+        },
+        // Clear errors on input change.
+        errors: undefined
       };
     case 'setSelectedLinodeId':
       id = action.id;
       return {
         ...state,
-        selectedLinodeId: id
+        selectedLinodeId: id,
+        // Clear errors on input change.
+        errors: undefined
       };
     case 'setSubmitting':
       return {
@@ -131,7 +137,8 @@ export const cloneLandingReducer = (
           disk => ({ ...disk, isSelected: false }),
           state.diskSelection
         ),
-        selectedLinodeId: null
+        selectedLinodeId: null,
+        errors: undefined
       };
     default:
       return state;

--- a/src/features/linodes/CloneLanding/utilities.ts
+++ b/src/features/linodes/CloneLanding/utilities.ts
@@ -8,6 +8,8 @@ interface CloneLandingState {
   configSelection: ConfigSelection;
   diskSelection: DiskSelection;
   selectedLinodeId: number | null;
+  isSubmitting: boolean;
+  errors?: Linode.ApiFieldError[];
 }
 
 // Allows for easy toggling of a selected config
@@ -26,6 +28,8 @@ export type CloneLandingAction =
   | { type: 'toggleConfig'; id: number }
   | { type: 'toggleDisk'; id: number }
   | { type: 'setSelectedLinodeId'; id: number }
+  | { type: 'setSubmitting'; value: boolean }
+  | { type: 'setErrors'; errors?: Linode.ApiFieldError[] }
   | { type: 'clearAll' };
 
 export type ExtendedConfig = Linode.Config & { associatedDisks: Linode.Disk[] };
@@ -105,9 +109,20 @@ export const cloneLandingReducer = (
         ...state,
         selectedLinodeId: id
       };
+    case 'setSubmitting':
+      return {
+        ...state,
+        isSubmitting: action.value
+      };
+    case 'setErrors':
+      return {
+        ...state,
+        errors: action.errors
+      };
     case 'clearAll':
       // Set all `isSelected`s to `false, and set selectedLinodeId to null
       return {
+        ...state,
         configSelection: map(
           config => ({ ...config, isSelected: false }),
           state.configSelection
@@ -132,7 +147,8 @@ export const createInitialCloneLandingState = (
   const state: CloneLandingState = {
     configSelection: {},
     diskSelection: {},
-    selectedLinodeId: null
+    selectedLinodeId: null,
+    isSubmitting: false
   };
 
   // Mapping of diskIds to an array of associated configIds

--- a/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -32,6 +32,7 @@ interface Props {
   handleChange: (linode: Linode.Linode) => void;
   textFieldProps?: TextFieldProps;
   label?: string;
+  excludedLinodes?: number[];
 }
 
 type CombinedProps = Props & WithLinodesProps & WithStyles<ClassNames>;
@@ -64,12 +65,18 @@ const LinodeSelect: React.StatelessComponent<CombinedProps> = props => {
     linodesData,
     region,
     selectedLinode,
+    excludedLinodes,
     label
   } = props;
 
-  const linodes = region
+  let linodes = region
     ? linodesData.filter(thisLinode => thisLinode.region === region)
     : linodesData;
+
+  linodes = excludedLinodes
+    ? linodes.filter(thisLinode => !excludedLinodes.includes(thisLinode.id))
+    : linodes;
+
   const options = linodesToItems(linodes);
 
   const noOptionsMessage =

--- a/src/features/linodes/transitions.ts
+++ b/src/features/linodes/transitions.ts
@@ -19,6 +19,7 @@ export const transitionAction = [
   'disk_resize',
   'backups_restore',
   'disk_imagize',
+  'disk_duplicate',
   'linode_mutate'
 ];
 

--- a/src/services/linodes/linodeActions.ts
+++ b/src/services/linodes/linodeActions.ts
@@ -15,12 +15,14 @@ export type RescueRequestObject = Pick<
 >;
 
 export interface LinodeCloneData {
-  linode_id?: string;
+  linode_id?: number;
   region?: string | null;
   type?: string | null;
   label?: string | null;
   backups_enabled?: boolean | null;
   tags?: string[] | null;
+  configs?: number[];
+  disks?: number[];
 }
 
 export interface RebuildRequest {

--- a/src/services/linodes/linodeDisks.ts
+++ b/src/services/linodes/linodeDisks.ts
@@ -120,6 +120,19 @@ export const resizeLinodeDisk = (
   );
 
 /**
+ * cloneLinodeDisk
+ *
+ * Clones (duplicates) a Disk on an individual Linode.
+ * @param linodeId { number } The id of the Linode containing the disk to be resized.
+ * @param diskId { number } The id of the disk to be resized.
+ */
+export const cloneLinodeDisk = (linodeId: number, diskId: number) =>
+  Request<Linode.Disk>(
+    setURL(`${API_ROOT}/linode/instances/${linodeId}/disks/${diskId}/clone`),
+    setMethod('POST')
+  ).then(response => response.data);
+
+/**
  * deleteLinodeDisk
  *
  * Deletes a Disk you have permission to read_write.


### PR DESCRIPTION
## Description

This PR adds the API requests necessary to make this feature work. It includes error and loading states.

## Note to Reviewers

**To test**, go to Linode Details -> Advanced. Click the action menu of a Config or Disk, and you'll be taken to the new Clone page. Try cloning different combinations of disks/configs to different Linodes.

### Feature roadmap:
1. Routing
2. Components/internal state
3. **Functionality (API requests, error, loading states)** _(this PR)_
3.5. Proactive space errors / grouped Linodes in LinodeSelect
4. Unit tests