### PR TITLE
Fix - Remove List Linodes tags test

### DIFF
--- a/e2e/specs/create/smoke-linode-with-tags.spec.js
+++ b/e2e/specs/create/smoke-linode-with-tags.spec.js
@@ -63,8 +63,8 @@ describe('Create Linode from Image - With Tags Suite', () => {
     });
 
     it('should successfully remove the tag', () => {
-        /** 
-         * remove the available tag name from context 
+        /**
+         * remove the available tag name from context
          * because it's possbile this available tag might keep us
          * from deploying a Linode successfully
          */
@@ -86,8 +86,8 @@ describe('Create Linode from Image - With Tags Suite', () => {
 
     describe('List Linodes - Tags Suite', () => {
         it('should display the linode with tags on the grid view', () => {
-            /** 
-             * we should now be on the Linodes detail screen 
+            /**
+             * we should now be on the Linodes detail screen
              * so we need to navigate to the landing page
              */
             browser.url(constants.routes.linodes)
@@ -97,13 +97,6 @@ describe('Create Linode from Image - With Tags Suite', () => {
             ListLinodes.gridToggle.click();
             ListLinodes.rebootButton.waitForVisible(constants.wait.normal);
 
-            assertTagsDisplay(addedTags);
-        });
-
-        it('should display the linode with tags on list view', () => {
-            ListLinodes.listToggle.click();
-            ListLinodes.rebootButton.waitForVisible(constants.wait.normal, true);
-            ListLinodes.hoverLinodeTags(linodeName);
             assertTagsDisplay(addedTags);
         });
     });


### PR DESCRIPTION
## Description

* Tags are no longer displayed on the list view of /linodes , removes a test for this.

## Type of Change
- Test fix

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --file e2e/specs/create/smoke-linode-with-tags.spec.js --browser headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
