### PR TITLE
[for release] Fix Linode Clone kebab 

### DIFF
--- a/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -69,6 +69,12 @@ export class LinodeCreate extends React.PureComponent<
       return eachTab.title === queryParams.type;
     });
 
+    // If there is no specified "type" in the query params, update the Redux state
+    // so that the correct request is made when the form is submitted.
+    if (!queryParams.type) {
+      this.props.setTab(this.tabs[0].type);
+    }
+
     this.state = {
       selectedTab: preSelectedTab !== -1 ? preSelectedTab : 0
     };

--- a/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -11,6 +11,11 @@ import {
   getCommunityStackscripts,
   getMineAndAccountStackScripts
 } from 'src/features/StackScripts/stackScriptUtils';
+import {
+  CreateTypes,
+  handleChangeCreateType
+} from 'src/store/linodeCreate/linodeCreate.actions';
+import { getInitialType } from 'src/store/linodeCreate/linodeCreate.reducer';
 import { getParamsFromUrl } from 'src/utilities/queryParams';
 import { safeGetTabRender } from 'src/utilities/safeGetTabRender';
 import SubTabs, { Tab } from './LinodeCreateSubTabs';
@@ -19,12 +24,6 @@ import FromBackupsContent from './TabbedContent/FromBackupsContent';
 import FromImageContent from './TabbedContent/FromImageContent';
 import FromLinodeContent from './TabbedContent/FromLinodeContent';
 import FromStackScriptContent from './TabbedContent/FromStackScriptContent';
-
-import {
-  CreateTypes,
-  handleChangeCreateType
-} from 'src/store/linodeCreate/linodeCreate.actions';
-
 import {
   AllFormStateAndHandlers,
   AppsData,
@@ -84,6 +83,7 @@ export class LinodeCreate extends React.PureComponent<
 
   componentDidMount() {
     this.mounted = true;
+    this.props.setTab(getInitialType());
   }
 
   handleTabChange = (

--- a/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -7,7 +7,7 @@ export interface State {
   type: CreateTypes;
 }
 
-const getInitialType = (): CreateTypes => {
+export const getInitialType = (): CreateTypes => {
   const queryParams = parse(location.search.replace('?', '').toLowerCase());
 
   if (queryParams.type) {

--- a/src/store/linodeCreate/linodeCreate.reducer.ts
+++ b/src/store/linodeCreate/linodeCreate.reducer.ts
@@ -12,28 +12,39 @@ const getInitialType = (): CreateTypes => {
 
   if (queryParams.type) {
     if (queryParams.subtype) {
+      // Lowercase the subtype to make comparisons
+      const normalizedSubtype =
+        typeof queryParams.subtype === 'string'
+          ? queryParams.subtype.toLowerCase()
+          : queryParams.subtype.map(s => s.toLowerCase());
+
       /**
        * we have a subtype in the query string so now we need to deduce what
        * endpoint we should be POSTing to based on what is in the query params
        */
-      if (queryParams.subtype.includes('stackscript')) {
+      if (normalizedSubtype.includes('stackscript')) {
         return 'fromStackScript';
-      } else if (queryParams.subtype.includes('clone')) {
+      } else if (normalizedSubtype.includes('clone')) {
         return 'fromLinode';
-      } else if (queryParams.subtype.includes('backup')) {
+      } else if (normalizedSubtype.includes('backup')) {
         return 'fromBackup';
       } else {
         return 'fromApp';
       }
     } else {
+      // Lowercase the type to make comparisons
+      const normalizedType =
+        typeof queryParams.type === 'string'
+          ? queryParams.type.toLowerCase()
+          : queryParams.type.map(s => s.toLowerCase());
       /**
        * here we know we don't have a subtype in the query string
        * but we do have a type (AKA a parent tab is selected). In this case,
        * we can assume the first child tab is selected within the parent tabs
        */
-      if (queryParams.type.includes('one-click')) {
+      if (normalizedType.includes('one-click')) {
         return 'fromApp';
-      } else if (queryParams.type.includes('images')) {
+      } else if (normalizedType.includes('images')) {
         return 'fromImage';
       } else {
         return 'fromImage';


### PR DESCRIPTION
## Description

The Redux state wasn't being set when navigating to Create Linode URL with `types` and `subTypes` as query params, which meant the appropriate API requests were not being made.

The problem was that the Redux state was being initialized by looking for lowercased strings in the query params to set the initial state. 

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Please test the Create Linode flow thoroughly. Make sure the appropriate API requests are being made on specific creation types.
