### PR TITLE
Fix: Conditional Logic When Validating SOA Record for Slave Domains

### DIFF
--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -154,19 +154,6 @@ const masterIPsCountLens = lensPath(['masterIPsCount']);
 const updateMasterIPsCount = (fn: (s: any) => any) => (obj: any) =>
   over(masterIPsCountLens, fn, obj);
 
-const validateEmail = (domain: string, email: string) => {
-  /**
-   * Validation
-   *
-   * Currently, the API does not check that the soaEmail
-   * is not associated with the target hostname. If you're creating
-   * example.com, using `marty@example.com` as your soaEmail is unwise
-   * (though technically won't break anything).
-   */
-
-  return isValidSOAEmail(email, domain);
-};
-
 class DomainDrawer extends React.Component<CombinedProps, State> {
   mounted: boolean = false;
   defaultState: State = {
@@ -569,7 +556,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
         ? { domain, type, tags, soa_email: soaEmail }
         : { domain, type, tags, master_ips: finalMasterIPs };
 
-    if (type === 'master' && !validateEmail(domain, data.soa_email || '')) {
+    if (type === 'master' && !isValidSOAEmail(data.soa_email || '', domain)) {
       this.handleEmailValidationErrors();
       return;
     }
@@ -734,7 +721,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
           { domain, tags, soa_email: soaEmail, domainId: id }
         : { domain, type, tags, master_ips: finalMasterIPs, domainId: id };
 
-    if (type === 'master' && !validateEmail(domain, data.soa_email || '')) {
+    if (type === 'master' && !isValidSOAEmail(data.soa_email || '', domain)) {
       this.handleEmailValidationErrors();
       return;
     }

--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -154,7 +154,7 @@ const masterIPsCountLens = lensPath(['masterIPsCount']);
 const updateMasterIPsCount = (fn: (s: any) => any) => (obj: any) =>
   over(masterIPsCountLens, fn, obj);
 
-const validateEmail = (type: string, domain: string, email: string) => {
+const validateEmail = (domain: string, email: string) => {
   /**
    * Validation
    *
@@ -164,7 +164,7 @@ const validateEmail = (type: string, domain: string, email: string) => {
    * (though technically won't break anything).
    */
 
-  return type === 'master' && isValidSOAEmail(email, domain);
+  return isValidSOAEmail(email, domain);
 };
 
 class DomainDrawer extends React.Component<CombinedProps, State> {
@@ -569,7 +569,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
         ? { domain, type, tags, soa_email: soaEmail }
         : { domain, type, tags, master_ips: finalMasterIPs };
 
-    if (!validateEmail(type, domain, data.soa_email || '')) {
+    if (type === 'master' && !validateEmail(domain, data.soa_email || '')) {
       this.handleEmailValidationErrors();
       return;
     }
@@ -734,7 +734,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
           { domain, tags, soa_email: soaEmail, domainId: id }
         : { domain, type, tags, master_ips: finalMasterIPs, domainId: id };
 
-    if (!validateEmail(type, domain, data.soa_email || '')) {
+    if (type === 'master' && !validateEmail(domain, data.soa_email || '')) {
       this.handleEmailValidationErrors();
       return;
     }

--- a/src/features/Domains/domainUtils.ts
+++ b/src/features/Domains/domainUtils.ts
@@ -7,6 +7,14 @@ export const isValidDomainRecord = (
   return isUniqueHostname(hostname, records);
 };
 
+/**
+ * Validation
+ *
+ * Currently, the API does not check that the soaEmail
+ * is not associated with the target hostname. If you're creating
+ * example.com, using `marty@example.com` as your soaEmail is unwise
+ * (though technically won't break anything).
+ */
 export const isValidSOAEmail = (email: string, hostname: string) => {
   // admin@example.com --> example.com
   const emailDomain = email.substr(email.indexOf('@') + 1);


### PR DESCRIPTION
## Description

Previous logic was checking `!type === 'master' && !isValidSOAEmail` when in reality in should have been `type === master && !isValidSOAEmail `

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A