### PR TITLE
M3-2837 Fix: IP sharing 

### DIFF
--- a/src/__data__/ipResponse.ts
+++ b/src/__data__/ipResponse.ts
@@ -1,0 +1,113 @@
+export const ipResponse: Linode.LinodeIPsResponse = {
+  ipv4: {
+    private: [
+      {
+        address: '192.168.0.1',
+        gateway: null,
+        linode_id: 23456,
+        prefix: 17,
+        public: false,
+        rdns: null,
+        region: 'us-central',
+        subnet_mask: '255.255.128.0',
+        type: 'ipv4'
+      },
+      {
+        address: '192.168.0.1',
+        gateway: null,
+        linode_id: 123456,
+        prefix: 17,
+        public: false,
+        rdns: null,
+        region: 'us-central',
+        subnet_mask: '255.255.128.0',
+        type: 'ipv4'
+      }
+    ],
+    public: [
+      {
+        address: '198.51.100.1',
+        gateway: '198.51.100.2',
+        linode_id: 123456,
+        prefix: 24,
+        public: true,
+        rdns: 'li1612-253.members.linode.com',
+        region: 'ap-south',
+        subnet_mask: '255.255.255.0',
+        type: 'ipv4'
+      },
+      {
+        address: '198.51.100.5',
+        gateway: null,
+        linode_id: 1233456,
+        prefix: 24,
+        public: true,
+        rdns: 'li1612-253.members.linode.com',
+        region: 'ap-south',
+        subnet_mask: '255.255.255.0',
+        type: 'ipv4'
+      }
+    ],
+    reserved: [],
+    shared: [
+      {
+        address: '192.168.0.1',
+        gateway: null,
+        linode_id: 453211,
+        prefix: 17,
+        public: false,
+        rdns: null,
+        region: 'us-central',
+        subnet_mask: '255.255.128.0',
+        type: 'ipv4'
+      },
+      {
+        address: '192.168.0.1',
+        gateway: null,
+        linode_id: 23134,
+        prefix: 17,
+        public: false,
+        rdns: null,
+        region: 'ap-south',
+        subnet_mask: '255.255.128.0',
+        type: 'ipv4'
+      },
+      {
+        address: '192.168.0.2',
+        gateway: null,
+        linode_id: 143221,
+        prefix: 17,
+        public: false,
+        rdns: null,
+        region: 'eu-central',
+        subnet_mask: '255.255.128.0',
+        type: 'ipv4'
+      }
+    ]
+  },
+  ipv6: {
+    global: [],
+    link_local: {
+      address: 'fe81::f04d:95ff:fe7e:c3ba',
+      gateway: 'fe81::1',
+      linode_id: 13423412,
+      prefix: 64,
+      public: false,
+      rdns: null,
+      region: 'ap-south',
+      subnet_mask: 'ffff:ffff:ffff:ffff::',
+      type: 'ipv6'
+    },
+    slaac: {
+      address: '2401:8931::f04c:92ff:fc7e:c6ba',
+      gateway: 'fe80::1',
+      linode_id: 3523113,
+      prefix: 64,
+      public: true,
+      rdns: null,
+      region: 'ap-south',
+      subnet_mask: 'ffff:ffff:ffff:ffff::',
+      type: 'ipv6'
+    }
+  }
+};

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
@@ -24,12 +24,12 @@ const styles: StyleRulesCallback<ClassNames> = theme => ({
 interface Props {
   open: boolean;
   onClose: () => void;
-  rdns?: string;
+  rdns?: string | null;
   address?: string;
 }
 
 interface State {
-  rdns?: string;
+  rdns?: string | null;
   address?: string;
   errors?: Linode.ApiFieldError[];
 }

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -127,9 +127,11 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
               });
               return linode.ipv4;
             })
-        ).filter((ip: string) => {
-          return !ip.startsWith('192.168.');
-        });
+        );
+        /**
+         * NB: We were previously filtering private IP addresses out at this point,
+         * but it seems that the API (or our infra) doesn't care about this.
+         */
         ipChoices.unshift(IPSharingPanel.selectIPText);
         if (!this.mounted) {
           return;

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.test.ts
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.test.ts
@@ -1,0 +1,18 @@
+import { ipResponse } from 'src/__data__/ipResponse';
+import { uniqByIP } from './LinodeNetworking';
+
+const {
+  private: _privateIPs,
+  public: _publicIPs,
+  shared: _sharedIPs,
+  reserved: _reservedIPs
+} = ipResponse.ipv4;
+
+describe('Linode Networking tab', () => {
+  it('should remove duplicate values from lists of IP addresses', () => {
+    expect(uniqByIP(_privateIPs)).toHaveLength(1);
+    expect(uniqByIP(_publicIPs)).toHaveLength(2);
+    expect(uniqByIP(_sharedIPs)).toHaveLength(2);
+    expect(uniqByIP(_reservedIPs)).toHaveLength(0);
+  });
+});

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -1,4 +1,4 @@
-import { compose, head, isEmpty, path, pathOr } from 'ramda';
+import { compose, head, isEmpty, path, pathOr, uniq } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose as recompose } from 'recompose';
@@ -413,16 +413,23 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     }
 
     const {
-      private: privateIPs,
-      public: publicIPs,
-      shared: sharedIPs,
+      private: _privateIPs,
+      public: _publicIPs,
+      shared: _sharedIPs,
       reserved: reservedIPs
     } = ipv4;
 
     // `ipv4.reserved` contains both Public and Private IPs, so we use the `public` field to differentiate.
     // Splitting them into two arrays so we can order as desired (Public, then Private).
-    const publicReservedIps = reservedIPs.filter(ip => ip.public);
-    const privateReservedIps = reservedIPs.filter(ip => !ip.public);
+    const publicReservedIps = uniq(reservedIPs.filter(ip => ip.public));
+    const privateReservedIps = uniq(reservedIPs.filter(ip => !ip.public));
+    /**
+     * Customer reported an issue where a shared IP was displaying in the table multiple times.
+     * We were unable to reproduce this, but added this as a safety check.
+     */
+    const privateIPs = uniq(_privateIPs);
+    const publicIPs = uniq(_publicIPs);
+    const sharedIPs = uniq(_sharedIPs);
 
     return (
       <React.Fragment>

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -1,4 +1,4 @@
-import { compose, head, isEmpty, path, pathOr, uniqBy } from 'ramda';
+import { compose, head, isEmpty, path, pathOr, uniq, uniqBy } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose as recompose } from 'recompose';
@@ -118,7 +118,7 @@ interface State {
 type CombinedProps = ContextProps & WithStyles<ClassNames> & DispatchProps;
 
 // Save some typing below
-const uniqByIP = uniqBy((thisIP: Linode.IPAddress) => thisIP.address);
+export const uniqByIP = uniqBy((thisIP: Linode.IPAddress) => thisIP.address);
 
 class LinodeNetworking extends React.Component<CombinedProps, State> {
   state: State = {
@@ -579,14 +579,20 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     } = this.props;
     const { linodeIPs } = this.state;
 
-    const publicIPs = pathOr([], ['ipv4', 'public'], linodeIPs).map(
-      (i: Linode.IPAddress) => i.address
+    const publicIPs = uniq<string>(
+      pathOr([], ['ipv4', 'public'], linodeIPs).map(
+        (i: Linode.IPAddress) => i.address
+      )
     );
-    const privateIPs = pathOr([], ['ipv4', 'private'], linodeIPs).map(
-      (i: Linode.IPAddress) => i.address
+    const privateIPs = uniq<string>(
+      pathOr([], ['ipv4', 'private'], linodeIPs).map(
+        (i: Linode.IPAddress) => i.address
+      )
     );
-    const sharedIPs = pathOr([], ['ipv4', 'shared'], linodeIPs).map(
-      (i: Linode.IPAddress) => i.address
+    const sharedIPs = uniq<string>(
+      pathOr([], ['ipv4', 'shared'], linodeIPs).map(
+        (i: Linode.IPAddress) => i.address
+      )
     );
 
     return (

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -1,4 +1,4 @@
-import { compose, head, isEmpty, path, pathOr, uniq } from 'ramda';
+import { compose, head, isEmpty, path, pathOr, uniqBy } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose as recompose } from 'recompose';
@@ -116,6 +116,9 @@ interface State {
 }
 
 type CombinedProps = ContextProps & WithStyles<ClassNames> & DispatchProps;
+
+// Save some typing below
+const uniqByIP = uniqBy((thisIP: Linode.IPAddress) => thisIP.address);
 
 class LinodeNetworking extends React.Component<CombinedProps, State> {
   state: State = {
@@ -421,15 +424,15 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
 
     // `ipv4.reserved` contains both Public and Private IPs, so we use the `public` field to differentiate.
     // Splitting them into two arrays so we can order as desired (Public, then Private).
-    const publicReservedIps = uniq(reservedIPs.filter(ip => ip.public));
-    const privateReservedIps = uniq(reservedIPs.filter(ip => !ip.public));
+    const publicReservedIps = uniqByIP(reservedIPs.filter(ip => ip.public));
+    const privateReservedIps = uniqByIP(reservedIPs.filter(ip => !ip.public));
     /**
      * Customer reported an issue where a shared IP was displaying in the table multiple times.
      * We were unable to reproduce this, but added this as a safety check.
      */
-    const privateIPs = uniq(_privateIPs);
-    const publicIPs = uniq(_publicIPs);
-    const sharedIPs = uniq(_sharedIPs);
+    const privateIPs = uniqByIP(_privateIPs);
+    const publicIPs = uniqByIP(_publicIPs);
+    const sharedIPs = uniqByIP(_sharedIPs);
 
     return (
       <React.Fragment>

--- a/src/types/Linode.ts
+++ b/src/types/Linode.ts
@@ -116,12 +116,12 @@ namespace Linode {
 
   export interface IPAddress {
     address: string;
-    gateway: string;
+    gateway: string | null;
     subnet_mask: string;
     prefix: number;
     type: string;
     public: boolean;
-    rdns: string;
+    rdns: string | null;
     linode_id: number;
     region: string;
   }


### PR DESCRIPTION
## Description

This PR includes 2 changes:

1. A customer reported seeing a shared IP listed multiple times in the IPv4 table in LinodesDetail/networking. Marty and I were unable to reproduce this, but I added a `uniq` to the address lists as a safety check, which shouldn't hurt anything.

2. We were manually filtering private IPs out of the list of available choices, which the API doesn't seem to care about. Removed that filter.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')



