### PR TITLE
M3-2247 LinodeSelect group by region

### DIFF
--- a/src/__data__/linodes.ts
+++ b/src/__data__/linodes.ts
@@ -112,4 +112,42 @@ export const linode3: Linode.Linode = {
   tags: []
 };
 
+export const linode4: Linode.Linode = {
+  specs: {
+    transfer: 2000,
+    memory: 2048,
+    vcpus: 1,
+    disk: 30720
+  },
+  updated: '2018-02-22T16:11:07',
+  ipv4: ['97.107.143.49'],
+  id: 12345,
+  alerts: {
+    transfer_quota: 80,
+    network_in: 10,
+    io: 10000,
+    network_out: 10,
+    cpu: 90
+  },
+  created: '2018-02-22T16:11:07',
+  hypervisor: 'kvm',
+  label: 'another-test-eu',
+  image: 'linode/Ubuntu16.04LTS',
+  group: 'inactive',
+  region: 'eu-west',
+  type: 'g5-standard-2',
+  backups: {
+    schedule: {
+      window: 'Scheduling',
+      day: 'Scheduling'
+    },
+    enabled: false
+  },
+  mostRecentBackup: null,
+  status: 'running',
+  ipv6: '2600:3c03::f03c:91ff:fe0a:0d7a/64',
+  watchdog_enabled: false,
+  tags: []
+};
+
 export const linodes = [linode1, linode2, linode3];

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -288,7 +288,7 @@ export interface Item<T = string | number> {
   data?: any;
 }
 
-export interface GroupType<T> {
+export interface GroupType<T = string | number> {
   label: string;
   options: Item<T>[];
 }
@@ -313,7 +313,7 @@ export interface NoOptionsMessageProps {
 }
 
 export interface EnhancedSelectProps {
-  options?: Item[];
+  options?: Item[] | GroupType[];
   className?: string;
   components?: any;
   disabled?: boolean;
@@ -362,8 +362,8 @@ type CombinedProps = EnhancedSelectProps &
 
 interface BaseSelectProps extends SelectProps<any> {
   classes: any;
-  /* 
-   textFieldProps isn't native to react-select 
+  /*
+   textFieldProps isn't native to react-select
    but we're using the MUI select element so any props that
    can be passed to the MUI TextField element can be passed here
   */
@@ -445,8 +445,8 @@ class Select extends React.PureComponent<CombinedProps, {}> {
         })}
         classNamePrefix="react-select"
         styles={styleOverrides}
-        /* 
-          textFieldProps isn't native to react-select 
+        /*
+          textFieldProps isn't native to react-select
           but we're using the MUI select element so any props that
           can be passed to the MUI TextField element can be passed here
          */

--- a/src/features/linodes/CloneLanding/Details.tsx
+++ b/src/features/linodes/CloneLanding/Details.tsx
@@ -207,6 +207,7 @@ export const Configs: React.FC<CombinedProps> = props => {
         excludedLinodes={
           shouldExcludeCurrentLinode ? [currentLinodeId] : undefined
         }
+        groupByRegion
         updateFor={[
           selectedLinode,
           shouldExcludeCurrentLinode,

--- a/src/features/linodes/LinodeSelect/LinodeSelect.test.ts
+++ b/src/features/linodes/LinodeSelect/LinodeSelect.test.ts
@@ -1,0 +1,79 @@
+import { linode4, linodes } from 'src/__data__/linodes';
+import {
+  linodeFromGroupedItems,
+  linodeFromItems,
+  linodesToGroupedItems,
+  linodesToItems
+} from './LinodeSelect';
+
+describe('utilities', () => {
+  describe('linodesToItems', () => {
+    const items = linodesToItems(linodes);
+    it('includes a value with the Linode ID', () => {
+      items.forEach(item => {
+        expect(item.value).toBe(item.data.id);
+      });
+    });
+
+    it('includes a label with the Linode label', () => {
+      items.forEach(item => {
+        expect(item.label).toBe(item.data.label);
+      });
+    });
+  });
+
+  describe('linodeFromItems', () => {
+    const items = linodesToItems(linodes);
+    it('returns the Linode with the given ID', () => {
+      expect(linodeFromItems(items, 2020755)).toHaveProperty('value', 2020755);
+    });
+    it('returns `null` when there is no Linode found', () => {
+      expect(linodeFromItems(items, 0)).toBe(null);
+    });
+  });
+
+  describe('linodeToGroupedItems', () => {
+    // Adding `linode4` to see one in another region
+    const groupedItems = linodesToGroupedItems([...linodes, linode4]);
+    it('returns one groupedItem for each region, with the formatted region name as label.', () => {
+      expect(groupedItems).toHaveLength(2);
+      expect(groupedItems[0].label).toBe('Newark, NJ');
+      expect(groupedItems[1].label).toBe('London, UK');
+    });
+
+    it('includes all options in a specific regions in each group', () => {
+      groupedItems[0].options.forEach(option => {
+        expect(option.data.region).toBe('us-east-1a');
+      });
+      groupedItems[1].options.forEach(option => {
+        expect(option.data.region).toBe('eu-west');
+      });
+    });
+
+    it("works even if there's only one region", () => {
+      // These are all in the same region.
+      const oneGroupOfItems = linodesToGroupedItems(linodes);
+      expect(oneGroupOfItems).toHaveLength(1);
+    });
+  });
+
+  describe('linodeFromGroupedItems', () => {
+    // Adding `linode4` to see one in another region
+    const groupedItems = linodesToGroupedItems([...linodes, linode4]);
+    it('finds a specific Linode in a set of grouped items', () => {
+      const foundLinode = linodeFromGroupedItems(groupedItems, 12345);
+      expect(foundLinode).toHaveProperty('value', 12345);
+    });
+
+    it('returns `null` when there is no Linode found', () => {
+      expect(linodeFromGroupedItems(groupedItems, 0)).toBe(null);
+    });
+
+    it("works even if there's only one region", () => {
+      // These are all in the same region.
+      const oneGroupOfItems = linodesToGroupedItems(linodes);
+      const foundLinode = linodeFromGroupedItems(oneGroupOfItems, 2020755);
+      expect(foundLinode).toHaveProperty('value', 2020755);
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR adds a new optional prop to `<LinodeSelect />` called `groupByRegion`.

<img width="314" alt="Screen Shot 2019-06-14 at 4 45 03 PM" src="https://user-images.githubusercontent.com/16911484/59537163-cff1ad80-8ec3-11e9-955e-e4d3b12ce60d.png">


## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

The only place this is implemented is in the new clone disk/config feature.
