### PR TITLE
M3-2926 Change: Add link to support ticket in SelectTabPanel

### DIFF
--- a/src/components/SupportLink/SupportLink.tsx
+++ b/src/components/SupportLink/SupportLink.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  title?: string;
+  description?: string;
+  text: string;
+}
+
+type CombinedProps = Props;
+
+const SupportLink: React.FunctionComponent<CombinedProps> = props => {
+  const { description, text, title } = props;
+  return (
+    <Link
+      to={{
+        pathname: '/support/tickets',
+        state: {
+          open: true,
+          title,
+          description
+        }
+      }}
+    >
+      {text}
+    </Link>
+  );
+};
+
+export default SupportLink;

--- a/src/components/SupportLink/index.tsx
+++ b/src/components/SupportLink/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './SupportLink';

--- a/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/src/components/TabbedPanel/TabbedPanel.tsx
@@ -45,7 +45,7 @@ export interface Tab {
 }
 interface Props {
   header: string;
-  error?: string;
+  error?: string | JSX.Element;
   copy?: string;
   rootClass?: string;
   innerClass?: string;

--- a/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -85,6 +85,8 @@ interface AttachmentWithTarget {
 
 export interface Props {
   open: boolean;
+  prefilledTitle?: string;
+  prefilledDescription?: string;
   onClose: () => void;
   onSuccess: (ticketId: number, attachmentErrors?: AttachmentError[]) => void;
 }
@@ -138,8 +140,8 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
   mounted: boolean = false;
   composeState = composeState;
   defaultTicket: Ticket = {
-    summary: '',
-    description: '',
+    summary: this.props.prefilledTitle || '',
+    description: this.props.prefilledDescription || '',
     entity_type: 'none',
     entity_id: ''
   };

--- a/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -44,6 +44,8 @@ interface State {
   drawerOpen: boolean;
   notice?: string;
   newTicket?: Linode.SupportTicket;
+  prefilledTitle?: string;
+  prefilledDescription?: string;
 }
 
 const tabs = ['open', 'closed'];
@@ -66,9 +68,15 @@ export class SupportTicketsLanding extends React.PureComponent<
   constructor(props: CombinedProps) {
     super(props);
 
+    const stateParams = this.props.location.state;
+    console.log(stateParams);
+
     this.state = {
       value: getSelectedTabFromQueryString(props.location.search),
-      drawerOpen: false
+      /** If we came here via a SupportLink that's passing data, use that to determine initial state */
+      drawerOpen: stateParams ? stateParams.open : false,
+      prefilledDescription: stateParams ? stateParams.description : undefined,
+      prefilledTitle: stateParams ? stateParams.title : undefined
     };
   }
 
@@ -127,12 +135,14 @@ export class SupportTicketsLanding extends React.PureComponent<
   };
 
   renderTicketDrawer = () => {
-    const { drawerOpen } = this.state;
+    const { drawerOpen, prefilledDescription, prefilledTitle } = this.state;
     return (
       <SupportTicketDrawer
         open={drawerOpen}
         onClose={this.closeDrawer}
         onSuccess={this.handleAddTicketSuccess}
+        prefilledDescription={prefilledDescription}
+        prefilledTitle={prefilledTitle}
       />
     );
   };

--- a/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -69,7 +69,6 @@ export class SupportTicketsLanding extends React.PureComponent<
     super(props);
 
     const stateParams = this.props.location.state;
-    console.log(stateParams);
 
     this.state = {
       value: getSelectedTabFromQueryString(props.location.search),

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -11,6 +11,7 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import SelectionCard from 'src/components/SelectionCard';
+import SupportLink from 'src/components/SupportLink';
 import TabbedPanel from 'src/components/TabbedPanel';
 import { Tab } from 'src/components/TabbedPanel/TabbedPanel';
 
@@ -185,7 +186,6 @@ export class SelectPlanPanel extends React.Component<
       tabOrder.push('highmem');
     }
 
-
     if (!isEmpty(gpu)) {
       const programInfo = (
         <Typography>
@@ -238,10 +238,30 @@ export class SelectPlanPanel extends React.Component<
     );
     const initialTab = tabOrder.indexOf(selectedTypeClass);
 
+    /**
+     * Intercept GPU-related errors to include a link to support/tickets
+     */
+
+    const finalError = true ? ( // error && selectedID && selectedID.match(/gpu/)
+      <>
+        <Typography>
+          Additional verification is required to add this service. Please {` `}
+          <SupportLink
+            title="GPU Request"
+            description=""
+            text="open a Support ticket"
+          />
+          .
+        </Typography>
+      </>
+    ) : (
+      error
+    );
+
     return (
       <TabbedPanel
         rootClass={`${classes.root} tabbedPanel`}
-        error={error}
+        error={finalError}
         header={header || 'Linode Plan'}
         copy={copy}
         tabs={tabs}

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -242,21 +242,26 @@ export class SelectPlanPanel extends React.Component<
      * Intercept GPU-related errors to include a link to support/tickets
      */
 
-    const finalError = true ? ( // error && selectedID && selectedID.match(/gpu/)
-      <>
-        <Typography>
-          Additional verification is required to add this service. Please {` `}
-          <SupportLink
-            title="GPU Request"
-            description=""
-            text="open a Support ticket"
-          />
-          .
-        </Typography>
-      </>
-    ) : (
-      error
-    );
+    const finalError =
+      error &&
+      selectedID &&
+      selectedID.match(/gpu/) &&
+      error.match(/verification is required/) ? (
+        <>
+          <Typography>
+            Additional verification is required to add this service. Please{' '}
+            {` `}
+            <SupportLink
+              title="GPU Request"
+              description=""
+              text="open a Support ticket"
+            />
+            .
+          </Typography>
+        </>
+      ) : (
+        error
+      );
 
     return (
       <TabbedPanel

--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -1,10 +1,13 @@
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
+import { StaticRouter } from 'react-router-dom';
 import { extDisk, swapDisk } from 'src/__data__/disks';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { types } from 'src/__data__/types';
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 import { LinodeResize, shouldEnableAutoResizeDiskOption } from './LinodeResize';
+
+const context = {};
 
 describe('LinodeResize', () => {
   const mockTypes = types.map(LinodeResize.extendType);
@@ -32,23 +35,25 @@ describe('LinodeResize', () => {
   it('should render the currently selected plan as a card', () => {
     const componentWithTheme = mount(
       <LinodeThemeWrapper>
-        <LinodeResize
-          linodeDisks={[]}
-          closeSnackbar={jest.fn()}
-          enqueueSnackbar={jest.fn()}
-          {...reactRouterProps}
-          classes={{
-            root: '',
-            title: '',
-            subTitle: '',
-            currentPlanContainer: ''
-          }}
-          linodeId={12}
-          linodeType={null}
-          currentTypesData={mockTypes}
-          deprecatedTypesData={mockTypes}
-          linodeLabel=""
-        />
+        <StaticRouter context={context}>
+          <LinodeResize
+            linodeDisks={[]}
+            closeSnackbar={jest.fn()}
+            enqueueSnackbar={jest.fn()}
+            {...reactRouterProps}
+            classes={{
+              root: '',
+              title: '',
+              subTitle: '',
+              currentPlanContainer: ''
+            }}
+            linodeId={12}
+            linodeType={null}
+            currentTypesData={mockTypes}
+            deprecatedTypesData={mockTypes}
+            linodeLabel=""
+          />
+        </StaticRouter>
       </LinodeThemeWrapper>
     );
 
@@ -65,24 +70,26 @@ describe('LinodeResize', () => {
       it('should have a heading of No Assigned Plan', () => {
         const componentWithTheme = mount(
           <LinodeThemeWrapper>
-            <LinodeResize
-              closeSnackbar={jest.fn()}
-              enqueueSnackbar={jest.fn()}
-              requestNotifications={jest.fn()}
-              linodeDisks={[]}
-              {...reactRouterProps}
-              classes={{
-                root: '',
-                title: '',
-                subTitle: '',
-                currentPlanContainer: ''
-              }}
-              linodeId={12}
-              linodeType={null}
-              currentTypesData={mockTypes}
-              deprecatedTypesData={mockTypes}
-              linodeLabel=""
-            />
+            <StaticRouter context={context}>
+              <LinodeResize
+                closeSnackbar={jest.fn()}
+                enqueueSnackbar={jest.fn()}
+                requestNotifications={jest.fn()}
+                linodeDisks={[]}
+                {...reactRouterProps}
+                classes={{
+                  root: '',
+                  title: '',
+                  subTitle: '',
+                  currentPlanContainer: ''
+                }}
+                linodeId={12}
+                linodeType={null}
+                currentTypesData={mockTypes}
+                deprecatedTypesData={mockTypes}
+                linodeLabel=""
+              />
+            </StaticRouter>
           </LinodeThemeWrapper>
         );
 
@@ -101,23 +108,25 @@ describe('LinodeResize', () => {
       it('should have a heading of Unknown Plan', () => {
         const componentWithTheme = mount(
           <LinodeThemeWrapper>
-            <LinodeResize
-              closeSnackbar={jest.fn()}
-              linodeDisks={[]}
-              enqueueSnackbar={jest.fn()}
-              {...reactRouterProps}
-              classes={{
-                root: '',
-                title: '',
-                subTitle: '',
-                currentPlanContainer: ''
-              }}
-              linodeId={12}
-              linodeType={'_something_unexpected_'}
-              currentTypesData={mockTypes}
-              deprecatedTypesData={mockTypes}
-              linodeLabel=""
-            />
+            <StaticRouter context={context}>
+              <LinodeResize
+                closeSnackbar={jest.fn()}
+                linodeDisks={[]}
+                enqueueSnackbar={jest.fn()}
+                {...reactRouterProps}
+                classes={{
+                  root: '',
+                  title: '',
+                  subTitle: '',
+                  currentPlanContainer: ''
+                }}
+                linodeId={12}
+                linodeType={'_something_unexpected_'}
+                currentTypesData={mockTypes}
+                deprecatedTypesData={mockTypes}
+                linodeLabel=""
+              />
+            </StaticRouter>
           </LinodeThemeWrapper>
         );
 

--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -1,13 +1,11 @@
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
-import { StaticRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { extDisk, swapDisk } from 'src/__data__/disks';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { types } from 'src/__data__/types';
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 import { LinodeResize, shouldEnableAutoResizeDiskOption } from './LinodeResize';
-
-const context = {};
 
 describe('LinodeResize', () => {
   const mockTypes = types.map(LinodeResize.extendType);
@@ -35,7 +33,7 @@ describe('LinodeResize', () => {
   it('should render the currently selected plan as a card', () => {
     const componentWithTheme = mount(
       <LinodeThemeWrapper>
-        <StaticRouter context={context}>
+        <MemoryRouter>
           <LinodeResize
             linodeDisks={[]}
             closeSnackbar={jest.fn()}
@@ -53,7 +51,7 @@ describe('LinodeResize', () => {
             deprecatedTypesData={mockTypes}
             linodeLabel=""
           />
-        </StaticRouter>
+        </MemoryRouter>
       </LinodeThemeWrapper>
     );
 
@@ -70,7 +68,7 @@ describe('LinodeResize', () => {
       it('should have a heading of No Assigned Plan', () => {
         const componentWithTheme = mount(
           <LinodeThemeWrapper>
-            <StaticRouter context={context}>
+            <MemoryRouter>
               <LinodeResize
                 closeSnackbar={jest.fn()}
                 enqueueSnackbar={jest.fn()}
@@ -89,7 +87,7 @@ describe('LinodeResize', () => {
                 deprecatedTypesData={mockTypes}
                 linodeLabel=""
               />
-            </StaticRouter>
+            </MemoryRouter>
           </LinodeThemeWrapper>
         );
 
@@ -108,7 +106,7 @@ describe('LinodeResize', () => {
       it('should have a heading of Unknown Plan', () => {
         const componentWithTheme = mount(
           <LinodeThemeWrapper>
-            <StaticRouter context={context}>
+            <MemoryRouter>
               <LinodeResize
                 closeSnackbar={jest.fn()}
                 linodeDisks={[]}
@@ -126,7 +124,7 @@ describe('LinodeResize', () => {
                 deprecatedTypesData={mockTypes}
                 linodeLabel=""
               />
-            </StaticRouter>
+            </MemoryRouter>
           </LinodeThemeWrapper>
         );
 


### PR DESCRIPTION
## Description

Review feedback, we were asked to make the "open a ticket" error message when requesting a GPU link to a support ticket with the summary filled out.

Added a `<SupportLink>` component to make this easier in the future, as it's likely to be a common request.


## Type of Change
- Non breaking change ('update', 'change')


## Note to Reviewers

To test the support link, set line 245 of SelectPlanPanel to `true`. It's hard to test the conditional logic until GPUs are closer to release, but the fallback is just displaying the original error message without a link, which is the current behavior. 