### PR TITLE
Fix: Rely on Theme Spacing Unit for Theme Toggle

### DIFF
--- a/src/components/CircleProgress/CircleProgress.tsx
+++ b/src/components/CircleProgress/CircleProgress.tsx
@@ -136,6 +136,7 @@ const circleProgressComponent: React.StatelessComponent<
     mini,
     tag,
     sort,
+    noInner,
     ...rest
   } = props;
 
@@ -163,7 +164,7 @@ const circleProgressComponent: React.StatelessComponent<
       {children !== undefined && (
         <div className={classes.valueInside}>{children}</div>
       )}
-      {props.noInner !== true && (
+      {noInner !== true && (
         <div className={classes.topWrapper}>
           <div className={classes.top} />
         </div>

--- a/src/components/PrimaryNav/SpacingToggle.tsx
+++ b/src/components/PrimaryNav/SpacingToggle.tsx
@@ -8,7 +8,8 @@ import {
   WithTheme
 } from 'src/components/core/styles';
 import Toggle from 'src/components/Toggle';
-import { spacing as spacingStorage } from 'src/utilities/storage';
+
+import { COMPACT_SPACING_UNIT } from 'src/themeFactory';
 
 type ClassNames = 'switchWrapper' | 'switchText' | 'toggle';
 
@@ -47,8 +48,9 @@ interface Props {
 type CombinedProps = Props & WithStyles<ClassNames> & WithTheme;
 
 export const SpacingToggle: React.StatelessComponent<CombinedProps> = props => {
-  const { classes, toggleSpacing } = props;
-  const spacingMode = spacingStorage.get();
+  const { classes, toggleSpacing, theme } = props;
+  const spacingMode =
+    theme.spacing() === COMPACT_SPACING_UNIT ? 'compact' : 'normal';
 
   return (
     <div className={classes.switchWrapper}>


### PR DESCRIPTION
## Description

Removes reliance on local storage in favor of the theme spacing unit for the toggle

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A