### PR TITLE
M3-2932 fix subtitle typography color regression

### DIFF
--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -294,7 +294,8 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
       },
       subtitle1: {
         fontSize: '1.075rem',
-        lineHeight: '1.5rem'
+        lineHeight: '1.5rem',
+        color: primaryColors.text
       }
     },
     visually: {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -126,6 +126,9 @@ export const dark = () =>
       },
       body1: {
         color: primaryColors.text
+      },
+      subtitle1: {
+        color: primaryColors.text
       }
     },
     overrides: {


### PR DESCRIPTION
## M3-2932 fix subtitle typography color regression

<img width="890" alt="Screen Shot 2019-06-17 at 12 18 47 PM" src="https://user-images.githubusercontent.com/205353/59630698-fa39aa00-9113-11e9-854c-179e03d65165.png">
