### PR TITLE
M3-2899 Fix: Catch deleted events errors

### DIFF
--- a/src/store/linodes/linode.requests.ts
+++ b/src/store/linodes/linode.requests.ts
@@ -94,6 +94,6 @@ export const requestLinodeForStore: RequestLinodeForStoreThunk = id => (
          */
       });
   } else {
-    return;
+    return Promise.resolve();
   }
 };


### PR DESCRIPTION
## Description

After a Linode was deleted, if it had long-running events on it,
our linode.events.ts logic was requesting the (nonexistent)
Linode after every event, and these errors were uncaught and therefore
being reported to Sentry.

Fixed this in two ways:

- Added a catch block to the requestLinodeForStore method, which
drops the error
- Added a check in the requestLinodeForStore thunk, so that the API
is only hit for a Linode that exists in our store. Since requestLinodeForStore
is only called for existing Linodes, this shouldn't cause any issues; however,
fix #1 above is enough to resolve this issue, so it might be safer to remove this.


