### PR TITLE
M3-2900 Fix: Disable auto-resize option when moving to a smaller plan

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -5,7 +5,11 @@ import { extDisk, swapDisk } from 'src/__data__/disks';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { types } from 'src/__data__/types';
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
-import { LinodeResize, shouldEnableAutoResizeDiskOption } from './LinodeResize';
+import {
+  isSmallerThanCurrentPlan,
+  LinodeResize,
+  shouldEnableAutoResizeDiskOption
+} from './LinodeResize';
 
 describe('LinodeResize', () => {
   const mockTypes = types.map(LinodeResize.extendType);
@@ -183,6 +187,35 @@ describe('LinodeResize', () => {
       ]);
       expect(diskLabel).toBe('Arch Linux Disk');
       expect(shouldEnable).toBeFalsy();
+    });
+
+    describe('isSmallerThanCurrentPlan', () => {
+      it('returns false when the first type provided is larger than the second', () => {
+        expect(
+          isSmallerThanCurrentPlan('g5-standard-2', 'g5-standard-1', mockTypes)
+        ).toBe(false);
+      });
+
+      it('returns true when the first type provided is smaller than the second', () => {
+        expect(
+          isSmallerThanCurrentPlan('g5-standard-1', 'g5-standard-2', mockTypes)
+        ).toBe(true);
+      });
+
+      it("defaults to false if one or both of the passed plans aren't found", () => {
+        expect(
+          isSmallerThanCurrentPlan('g5-standard-2', 'g5-fake-1', mockTypes)
+        ).toBe(false);
+        expect(
+          isSmallerThanCurrentPlan('g5-fake-2', 'g5-standard-1', mockTypes)
+        ).toBe(false);
+        expect(
+          isSmallerThanCurrentPlan('g5-fake-2', 'g5-fake-1', mockTypes)
+        ).toBe(false);
+        expect(
+          isSmallerThanCurrentPlan('g5-standard-2', 'g5-standard-1', [])
+        ).toBe(false);
+      });
     });
   });
 });

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -39,7 +39,8 @@ type ClassNames =
   | 'subTitle'
   | 'toolTip'
   | 'currentPlanContainer'
-  | 'checkbox';
+  | 'checkbox'
+  | 'resizeTitle';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -55,6 +56,11 @@ const styles = (theme: Theme) =>
     },
     title: {
       marginBottom: theme.spacing(2)
+    },
+    resizeTitle: {
+      display: 'flex',
+      alignItems: 'center',
+      minHeight: '44px'
     },
     subTitle: {
       marginTop: theme.spacing(3),
@@ -258,21 +264,20 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
           disabled={disabled}
         />
         <Paper className={`${classes.checkbox} ${classes.root}`}>
-          <Typography variant="h2" className={classes.title}>
+          <Typography variant="h2" className={classes.resizeTitle}>
             Auto Resize Disk
-            {!_shouldEnableAutoResizeDiskOption && (
-              <HelpIcon
-                className={classes.toolTip}
-                text={`Your ext disk can only be automatically resized if you have one ext
-                disk or one ext disk and one swap disk on this Linode.`}
-              />
-            )}
-            {isSmaller && (
+            {isSmaller ? (
               <HelpIcon
                 className={classes.toolTip}
                 text={`Your disks cannot be automatically resized when moving to a smaller plan.`}
               />
-            )}
+            ) : !_shouldEnableAutoResizeDiskOption ? (
+              <HelpIcon
+                className={classes.toolTip}
+                text={`Your ext disk can only be automatically resized if you have one ext
+                      disk or one ext disk and one swap disk on this Linode.`}
+              />
+            ) : null}
           </Typography>
           <Checkbox
             disabled={!_shouldEnableAutoResizeDiskOption || isSmaller}

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -128,16 +128,35 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
   };
 
   onSubmit = () => {
-    const { linodeId, enqueueSnackbar, history, updateLinode } = this.props;
+    const {
+      linodeId,
+      linodeType,
+      enqueueSnackbar,
+      history,
+      updateLinode,
+      currentTypesData
+    } = this.props;
     const { selectedId } = this.state;
 
     if (!linodeId) {
       return;
     }
 
+    const isSmaller = isSmallerThanCurrentPlan(
+      selectedId,
+      linodeType || '',
+      currentTypesData
+    );
+
     this.setState({ isLoading: true });
 
-    resizeLinode(linodeId, selectedId, this.state.autoDiskResize)
+    /**
+     * Only set the allow_auto_disk_resize flag to true if both the user
+     * has selected it (this.state.autoDiskResize) and
+     * the flag would be honored (so disable if the current plan
+     * is larger than the target plan).
+     */
+    resizeLinode(linodeId, selectedId, this.state.autoDiskResize && !isSmaller)
       .then(_ => {
         this.setState({ selectedId: '', isLoading: false });
         resetEventsPolling();

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -204,6 +204,12 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
       _shouldEnableAutoResizeDiskOption
     ] = shouldEnableAutoResizeDiskOption(linodeDisks);
 
+    const isSmaller = isSmallerThanCurrentPlan(
+      this.state.selectedId,
+      linodeType || '',
+      currentTypesData
+    );
+
     return (
       <React.Fragment>
         <DocumentTitleSegment segment={`${linodeLabel} - Resize`} />
@@ -261,9 +267,15 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
                 disk or one ext disk and one swap disk on this Linode.`}
               />
             )}
+            {isSmaller && (
+              <HelpIcon
+                className={classes.toolTip}
+                text={`Your disks cannot be automatically resized when moving to a smaller plan.`}
+              />
+            )}
           </Typography>
           <Checkbox
-            disabled={!_shouldEnableAutoResizeDiskOption}
+            disabled={!_shouldEnableAutoResizeDiskOption || isSmaller}
             checked={
               !_shouldEnableAutoResizeDiskOption
                 ? false
@@ -383,6 +395,21 @@ export const shouldEnableAutoResizeDiskOption = (
     (linodeDisks.length === 1 && linodeHasOneExtDisk) ||
     (linodeDisks.length === 2 && linodeHasOneSwapDisk && linodeHasOneExtDisk);
   return [linodeExtDiskLabels[0], shouldEnable];
+};
+
+export const isSmallerThanCurrentPlan = (
+  selectedPlanID: string,
+  currentPlanID: string,
+  types: ExtendedType[]
+) => {
+  const currentType = types.find(thisType => thisType.id === currentPlanID);
+  const nextType = types.find(thisType => thisType.id === selectedPlanID);
+
+  if (!(currentType && nextType)) {
+    return false;
+  }
+
+  return currentType.disk > nextType.disk;
 };
 
 export default compose<CombinedProps, {}>(

--- a/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -282,7 +282,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
           <Checkbox
             disabled={!_shouldEnableAutoResizeDiskOption || isSmaller}
             checked={
-              !_shouldEnableAutoResizeDiskOption
+              !_shouldEnableAutoResizeDiskOption || isSmaller
                 ? false
                 : this.state.autoDiskResize
             }


### PR DESCRIPTION
## Description

Title says it all.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

We already show the "this is too small, resize your disks or delete some" message from Classic when submitting the form with a smaller disk. I just added helper text to the form to let users know why the option is disabled. We could think about disabling these plans in advance of form submit, but that would require additional calculation (which I think we're currently leaving to the API).