### PR TITLE
M3-2904 Change: Make entity links in Support tickets clickable

### DIFF
--- a/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -3,7 +3,7 @@ import * as classNames from 'classnames';
 import { compose, isEmpty, path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { RouteComponentProps } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import DomainIcon from 'src/assets/addnewmenu/domain.svg';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
 import NodebalIcon from 'src/assets/addnewmenu/nodebalancer.svg';
@@ -27,6 +27,7 @@ import { getTicket, getTicketReplies } from 'src/services/support';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import formatDate from 'src/utilities/formatDate';
+import { getLinkTargets } from 'src/utilities/getEventsActionLink';
 import { getGravatarUrlFromHash } from 'src/utilities/gravatar';
 import ExpandableTicketPanel from '../ExpandableTicketPanel';
 import TicketAttachmentList from '../TicketAttachmentList';
@@ -258,8 +259,12 @@ export class SupportTicketDetail extends React.Component<CombinedProps, State> {
 
   renderEntityLabelWithIcon = () => {
     const { classes } = this.props;
-    const { label, type } = this.state.ticket!.entity;
-    const icon: JSX.Element = this.getEntityIcon(type);
+    const { entity } = this.state.ticket!;
+    if (!entity) {
+      return null;
+    }
+    const icon: JSX.Element = this.getEntityIcon(entity.type);
+    const target = getLinkTargets(entity);
     return (
       <Grid
         container
@@ -271,7 +276,15 @@ export class SupportTicketDetail extends React.Component<CombinedProps, State> {
           {icon}
         </Grid>
         <Grid item>
-          <Typography className={classes.ticketLabel}>{label}</Typography>
+          {target !== null ? (
+            <Link to={target} className="secondaryLink">
+              {entity.label}
+            </Link>
+          ) : (
+            <Typography className={classes.ticketLabel}>
+              {entity.label}
+            </Typography>
+          )}
         </Grid>
       </Grid>
     );

--- a/src/features/Support/SupportTickets/TicketRow.tsx
+++ b/src/features/Support/SupportTickets/TicketRow.tsx
@@ -14,11 +14,21 @@ interface Props {
 }
 
 const renderEntityLink = (ticket: Linode.SupportTicket) => {
+  const target = getLinkTargets(ticket.entity);
   return ticket.entity ? (
-    <Link to={getLinkTargets(ticket.entity)} className="secondaryLink">
-      {ticket.entity.label}
-    </Link>
-  ) : null;
+    target !== null ? (
+      <Link to={target} className="secondaryLink">
+        {ticket.entity.label}
+      </Link>
+    ) : (
+      /**
+       * Ticket has a labeled entity, but the entity no longer exists (or there was some other problem).
+       * Include the label but don't make it a clickable link.
+       */
+      <Typography>{ticket.entity.label}</Typography>
+    )
+  ) : /** This ticket doesn't have an entity; leave the link column blank. */
+  null;
 };
 
 const TicketRow: React.StatelessComponent<Props> = props => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -187,7 +187,7 @@ namespace Linode {
     closed: string | null;
     closable: boolean;
     description: string;
-    entity: any | null;
+    entity: Entity | null;
     gravatar_id: string;
     attachments: string[];
     opened_by: string;

--- a/src/utilities/getEventsActionLink.ts
+++ b/src/utilities/getEventsActionLink.ts
@@ -1,4 +1,8 @@
 import { path } from 'ramda';
+import {
+  EntityType,
+  getEntityByIDFromStore
+} from 'src/utilities/getEntityByIDFromStore';
 
 export default (
   action: Linode.EventAction,
@@ -99,8 +103,22 @@ export default (
 
 export const getLinkTargets = (entity: Linode.Entity | null) => {
   if (entity === null) {
-    return '';
+    return null;
   }
+
+  const entityInStore = getEntityByIDFromStore(
+    entity.type as EntityType,
+    entity.id
+  );
+  /**
+   * If the entity doesn't exist in the store, don't link to it
+   * as it is probably an old ticket re: an entity that
+   * has since been deleted.
+   */
+  if (!entityInStore) {
+    return null;
+  }
+
   switch (entity.type) {
     case 'linode':
       return `/linodes/${entity.id}`;


### PR DESCRIPTION
Update both entity links on SupportTicketDetail and TicketRow to use the same logic:

- If there is no entity assoc with the ticket, don't render an entity label/icon.
- If the entity does not exist in the store, display the label/icon as text.
- If the entity exists, display it as a link to the detail or landing page as
 appropriate.

This logic prevents displaying links to deleted entities, which result in 404s.

Note: If a user navigates directly to one of these pages, due to the length of the initial
load it's possible that the getState() method used to check if the entity still exists
will return an empty state, in which case a valid entity won't be shown as a link.
