### PR TITLE
OBJ fix console errors

### DIFF
--- a/src/features/ObjectStorage/Buckets/BucketLanding.test.tsx
+++ b/src/features/ObjectStorage/Buckets/BucketLanding.test.tsx
@@ -6,10 +6,13 @@ import { BucketLanding } from './BucketLanding';
 describe('ObjectStorageLanding', () => {
   const wrapper = shallow(
     <BucketLanding
+      createBucket={jest.fn()}
       bucketsData={buckets}
       bucketsLoading={false}
       openBucketDrawer={jest.fn()}
       closeBucketDrawer={jest.fn()}
+      classes={{ root: '', confirmationCopy: '' }}
+      deleteBucket={jest.fn()}
     />
   );
 

--- a/src/features/ObjectStorage/Buckets/BucketLanding.tsx
+++ b/src/features/ObjectStorage/Buckets/BucketLanding.tsx
@@ -28,6 +28,7 @@ import bucketRequestsContainer, {
 } from 'src/containers/bucketRequests.container';
 import useOpenClose from 'src/hooks/useOpenClose';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
+import { sendDeleteBucketEvent } from 'src/utilities/ga';
 import { readableBytes } from 'src/utilities/unitConversions';
 import ListBuckets from './ListBuckets';
 

--- a/src/features/ObjectStorage/Buckets/BucketLanding.tsx
+++ b/src/features/ObjectStorage/Buckets/BucketLanding.tsx
@@ -1,23 +1,154 @@
 import * as React from 'react';
 import { compose } from 'recompose';
 import BucketIcon from 'src/assets/icons/entityIcons/bucket.svg';
+import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
+import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
 import Placeholder from 'src/components/Placeholder';
+import TextField from 'src/components/TextField';
 import bucketContainer, { StateProps } from 'src/containers/bucket.container';
 import bucketDrawerContainer, {
   DispatchProps
 } from 'src/containers/bucketDrawer.container';
+import bucketRequestsContainer, {
+  BucketsRequests
+} from 'src/containers/bucketRequests.container';
+import useOpenClose from 'src/hooks/useOpenClose';
+import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
+import { readableBytes } from 'src/utilities/unitConversions';
 import ListBuckets from './ListBuckets';
 
-type CombinedProps = StateProps & DispatchProps;
+type ClassNames = 'root' | 'confirmationCopy';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {},
+    confirmationCopy: {
+      marginTop: theme.spacing(1)
+    }
+  });
+
+type CombinedProps = StateProps &
+  DispatchProps &
+  WithStyles<ClassNames> &
+  BucketsRequests;
 
 export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
-  const { bucketsData, bucketsLoading, bucketsError, openBucketDrawer } = props;
+  const {
+    classes,
+    bucketsData,
+    bucketsLoading,
+    bucketsError,
+    openBucketDrawer
+  } = props;
+
+  const removeBucketConfirmationDialog = useOpenClose();
+  const [bucketToRemove, setBucketToRemove] = React.useState<
+    Linode.Bucket | undefined
+  >(undefined);
+  const [isLoading, setIsLoading] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<string>('');
+  const [confirmBucketName, setConfirmBucketName] = React.useState<string>('');
+
+  const handleClickRemove = (bucket: Linode.Bucket) => {
+    setBucketToRemove(bucket);
+    setError('');
+    removeBucketConfirmationDialog.open();
+  };
+
+  const removeBucket = () => {
+    const { deleteBucket } = props;
+
+    // This shouldn't happen, but just in case (and to get TS to quit complaining...)
+    if (!bucketToRemove) {
+      return;
+    }
+
+    setError('');
+    setIsLoading(true);
+
+    const { cluster, label } = bucketToRemove;
+    // Passing in `force: 1` as a param to delete ALL items within
+    // the bucket before deleting the bucket itself.
+    deleteBucket({ cluster, label, params: { force: 1 } })
+      .then(() => {
+        removeBucketConfirmationDialog.close();
+        setIsLoading(false);
+
+        // @analytics
+        sendDeleteBucketEvent(cluster);
+      })
+      .catch(e => {
+        setIsLoading(false);
+        const errorText = getErrorStringOrDefault(e, 'Error removing bucket.');
+        setError(errorText);
+      });
+  };
+
+  const actions = () => (
+    <ActionsPanel>
+      <Button
+        buttonType="cancel"
+        onClick={() => {
+          removeBucketConfirmationDialog.close();
+        }}
+        data-qa-cancel
+      >
+        Cancel
+      </Button>
+      <Button
+        buttonType="secondary"
+        destructive
+        onClick={removeBucket}
+        data-qa-submit-rebuild
+        loading={isLoading}
+        disabled={
+          bucketToRemove ? confirmBucketName !== bucketToRemove.label : true
+        }
+      >
+        Delete
+      </Button>
+    </ActionsPanel>
+  );
+
+  const deleteBucketConfirmationMessage = bucketToRemove ? (
+    <React.Fragment>
+      {bucketToRemove.size > 0 ? (
+        <Typography>
+          This bucket contains{' '}
+          <strong>
+            {bucketToRemove.objects}{' '}
+            {bucketToRemove.objects === 1 ? 'object' : 'objects'}
+          </strong>{' '}
+          totalling{' '}
+          <strong>{readableBytes(bucketToRemove.size).formatted}</strong> that
+          will be deleted along with the bucket. Deleting a bucket is permanent
+          and can't be undone.
+        </Typography>
+      ) : (
+        <Typography>
+          Deleting a bucket is permanent and can't be undone.
+        </Typography>
+      )}
+      <Typography className={classes.confirmationCopy}>
+        To confirm deletion, type the name of the bucket ({bucketToRemove.label}
+        ) in the field below:
+      </Typography>
+    </React.Fragment>
+  ) : null;
 
   if (bucketsLoading) {
     return <RenderLoading data-qa-loading-state />;
@@ -46,12 +177,32 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
               orderBy,
               order,
               handleOrderChange,
+              handleClickRemove,
               data: orderedData
             };
             return <ListBuckets {...listBucketsProps} />;
           }}
         </OrderBy>
       </Grid>
+      <ConfirmationDialog
+        open={removeBucketConfirmationDialog.isOpen}
+        onClose={() => {
+          removeBucketConfirmationDialog.close();
+        }}
+        title={
+          bucketToRemove ? `Delete ${bucketToRemove.label}` : 'Delete bucket'
+        }
+        actions={actions}
+        error={error}
+      >
+        {deleteBucketConfirmationMessage}
+        <TextField
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setConfirmBucketName(e.target.value)
+          }
+          expand
+        />
+      </ConfirmationDialog>
     </React.Fragment>
   );
 };
@@ -85,8 +236,12 @@ const RenderEmpty: React.StatelessComponent<{
   );
 };
 
+const styled = withStyles(styles);
+
 const enhanced = compose<CombinedProps, {}>(
+  styled,
   bucketContainer,
+  bucketRequestsContainer,
   bucketDrawerContainer
 );
 

--- a/src/features/ObjectStorage/Buckets/ClusterSelect.tsx
+++ b/src/features/ObjectStorage/Buckets/ClusterSelect.tsx
@@ -29,11 +29,13 @@ export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
     label: formatRegion(eachCluster.region)
   }));
 
-  // If there's only one option, we want it to selected by default.
-  // If it isn't already selected, call `onChange` with it so Formik knows about it.
-  if (options.length === 1 && selectedCluster !== options[0].value) {
-    onChange(options[0].value);
-  }
+  React.useEffect(() => {
+    // If there's only one option, we want it to selected by default.
+    // If it isn't already selected, call `onChange` with it so Formik knows about it.
+    if (options.length === 1 && selectedCluster !== options[0].value) {
+      onChange(options[0].value);
+    }
+  }, []);
 
   // Error could be: 1. General Clusters error, 2. Field error, 3. Nothing
   const errorText = clustersError

--- a/src/features/ObjectStorage/Buckets/ListBuckets.test.tsx
+++ b/src/features/ObjectStorage/Buckets/ListBuckets.test.tsx
@@ -11,8 +11,7 @@ describe('ListBuckets', () => {
       orderBy="label"
       order="asc"
       handleOrderChange={jest.fn()}
-      createBucket={jest.fn()}
-      deleteBucket={jest.fn()}
+      handleClickRemove={jest.fn()}
     />
   );
 

--- a/src/features/ObjectStorage/Buckets/ListBuckets.tsx
+++ b/src/features/ObjectStorage/Buckets/ListBuckets.tsx
@@ -1,8 +1,5 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import ActionsPanel from 'src/components/ActionsPanel';
-import Button from 'src/components/Button';
-import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -12,21 +9,12 @@ import {
 } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
-import Typography from 'src/components/core/Typography';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableSortCell from 'src/components/TableSortCell';
-import TextField from 'src/components/TextField';
-import bucketRequestsContainer, {
-  BucketsRequests
-} from 'src/containers/bucketRequests.container';
-import useOpenClose from 'src/hooks/useOpenClose';
-import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
-import { sendDeleteBucketEvent } from 'src/utilities/ga';
-import { readableBytes } from 'src/utilities/unitConversions';
 import BucketTableRow from './BucketTableRow';
 
 type ClassNames = 'root' | 'label' | 'confirmationCopy';
@@ -36,9 +24,6 @@ const styles = (theme: Theme) =>
     root: {},
     label: {
       paddingLeft: 65
-    },
-    confirmationCopy: {
-      marginTop: theme.spacing(1)
     }
   });
 
@@ -47,107 +32,20 @@ interface Props {
   orderBy: string;
   order: 'asc' | 'desc';
   handleOrderChange: (orderBy: string, order?: 'asc' | 'desc') => void;
+  handleClickRemove: (bucket: Linode.Bucket) => void;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames> & BucketsRequests;
+type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
-  const { data, orderBy, order, handleOrderChange, classes } = props;
-
-  const removeBucketConfirmationDialog = useOpenClose();
-  const [bucketToRemove, setBucketToRemove] = React.useState<
-    Linode.Bucket | undefined
-  >(undefined);
-  const [isLoading, setIsLoading] = React.useState<boolean>(false);
-  const [error, setError] = React.useState<string>('');
-  const [confirmBucketName, setConfirmBucketName] = React.useState<string>('');
-
-  const handleClickRemove = (bucket: Linode.Bucket) => {
-    setBucketToRemove(bucket);
-    setError('');
-    removeBucketConfirmationDialog.open();
-  };
-
-  const removeBucket = () => {
-    const { deleteBucket } = props;
-
-    // This shouldn't happen, but just in case (and to get TS to quit complaining...)
-    if (!bucketToRemove) {
-      return;
-    }
-
-    setError('');
-    setIsLoading(true);
-
-    const { cluster, label } = bucketToRemove;
-    // Passing in `force: 1` as a param to delete ALL items within
-    // the bucket before deleting the bucket itself.
-    deleteBucket({ cluster, label, params: { force: 1 } })
-      .then(() => {
-        removeBucketConfirmationDialog.close();
-        setIsLoading(false);
-
-        // @analytics
-        sendDeleteBucketEvent(cluster);
-      })
-      .catch(e => {
-        setIsLoading(false);
-        const errorText = getErrorStringOrDefault(e, 'Error removing bucket.');
-        setError(errorText);
-      });
-  };
-
-  const actions = () => (
-    <ActionsPanel>
-      <Button
-        buttonType="cancel"
-        onClick={() => {
-          removeBucketConfirmationDialog.close();
-        }}
-        data-qa-cancel
-      >
-        Cancel
-      </Button>
-      <Button
-        buttonType="secondary"
-        destructive
-        onClick={removeBucket}
-        data-qa-submit-rebuild
-        loading={isLoading}
-        disabled={
-          bucketToRemove ? confirmBucketName !== bucketToRemove.label : true
-        }
-      >
-        Delete
-      </Button>
-    </ActionsPanel>
-  );
-
-  const deleteBucketConfirmationMessage = bucketToRemove ? (
-    <React.Fragment>
-      {bucketToRemove.size > 0 ? (
-        <Typography>
-          This bucket contains{' '}
-          <strong>
-            {bucketToRemove.objects}{' '}
-            {bucketToRemove.objects === 1 ? 'object' : 'objects'}
-          </strong>{' '}
-          totalling{' '}
-          <strong>{readableBytes(bucketToRemove.size).formatted}</strong> that
-          will be deleted along with the bucket. Deleting a bucket is permanent
-          and can't be undone.
-        </Typography>
-      ) : (
-        <Typography>
-          Deleting a bucket is permanent and can't be undone.
-        </Typography>
-      )}
-      <Typography className={classes.confirmationCopy}>
-        To confirm deletion, type the name of the bucket ({bucketToRemove.label}
-        ) in the field below:
-      </Typography>
-    </React.Fragment>
-  ) : null;
+  const {
+    data,
+    orderBy,
+    order,
+    handleOrderChange,
+    handleClickRemove,
+    classes
+  } = props;
 
   return (
     <Paginate data={data} pageSize={25}>
@@ -227,27 +125,6 @@ export const ListBuckets: React.StatelessComponent<CombinedProps> = props => {
             handleSizeChange={handlePageSizeChange}
             eventCategory="object storage landing"
           />
-          <ConfirmationDialog
-            open={removeBucketConfirmationDialog.isOpen}
-            onClose={() => {
-              removeBucketConfirmationDialog.close();
-            }}
-            title={
-              bucketToRemove
-                ? `Delete ${bucketToRemove.label}`
-                : 'Delete bucket'
-            }
-            actions={actions}
-            error={error}
-          >
-            {deleteBucketConfirmationMessage}
-            <TextField
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setConfirmBucketName(e.target.value)
-              }
-              expand
-            />
-          </ConfirmationDialog>
         </React.Fragment>
       )}
     </Paginate>
@@ -277,9 +154,6 @@ const RenderData: React.StatelessComponent<RenderDataProps> = props => {
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, Props>(
-  styled,
-  bucketRequestsContainer
-);
+const enhanced = compose<CombinedProps, Props>(styled);
 
 export default enhanced(ListBuckets);


### PR DESCRIPTION
## Description
 
This PR fixes two console errors from React:

1) State error when typing in Label field (CreateBucketForm).
2) State error when deleting your last bucket.

The **first** was an easy fix – just needed to wrap the initial form setting in `React.useEffect()` in `<ClusterSelect />`.

The **second** required restructuring BucketsLanding and ListBuckets. Previously, the structure was:

```
-- BucketsLanding
    | -- ListBuckets (handles bucket deletion)
           | -- ConfirmationModal
```

This sometimes caused an issue when deleting your last bucket. Now the structure is:

```
-- BucketsLanding (handles bucket deletion)
    | -- ListBuckets 
    | -- ConfirmationModal
```

It should have been this way to begin with – my bad.

**Note** that there's not much _new_ code ... I just moved several chunks from `ListBuckets.tsx` to `BucketsLanding.tsx`.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

To test, make sure everything to do with buckets is working as expected, and that you're not getting console errors.
