### PR TITLE
M3-2941 Font size of <Notice /> in compact mode

### DIFF
--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -79,7 +79,7 @@ const styles = (theme: Theme) => {
     },
     noticeText: {
       color: theme.palette.text.primary,
-      fontSize: theme.spacing(2),
+      fontSize: '1rem',
       lineHeight: `${theme.spacing(2.5)}px`,
       fontFamily: 'LatoWebBold', // we keep this bold at all times
       '& p': {


### PR DESCRIPTION
## Description

Making the font size of notices consistent(16px/1rem) for both theme spacing modes.

## Type of Change
- Bug fix ('fix')