### PR TITLE
M3: Reduce perfume.js noise

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -58,6 +58,8 @@ e.g `Bearer 1232313` or `Admin 1231423`
 
 `REACT_APP_DISABLE_EVENT_THROTTLE`: <Boolean> Whether the app should poll the `/events` endpoint at provided intervals
 
+`REACT_APP_LOG_PERFORMANCE_METRICS`: Set to `'true'` to log performance metrics to the console. Only works in development mode (i.e. while running `yarn start`).
+
 ### Testing Variables
 
 These are environment variables that can be used for automated testing processes

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -53,7 +53,7 @@ Here are a list of all the required and optional environment variables the Manag
 
 `REACT_APP_GTM_ID`: The ID that matches with a configured Google Tag Manager property
 
-`REACT_APP_ACCESS_TOKEN`: Access Token that overrides the token recieved from the Login service.
+`REACT_APP_ACCESS_TOKEN`: Access Token that overrides the token received from the Login service.
 e.g `Bearer 1232313` or `Admin 1231423`
 
 `REACT_APP_DISABLE_EVENT_THROTTLE`: <Boolean> Whether the app should poll the `/events` endpoint at provided intervals

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,9 @@ export const GTM_ID = process.env.REACT_APP_GTM_ID;
 /** for hard-coding token used for API Requests. Example: "Bearer 1234" */
 export const ACCESS_TOKEN = process.env.REACT_APP_ACCESS_TOKEN;
 
+export const LOG_PERFORMANCE_METRICS =
+  !isProduction && process.env.REACT_APP_LOG_PERFORMANCE_METRICS === 'true';
+
 // Features
 export const isObjectStorageEnabledForEnvironment =
   process.env.REACT_APP_IS_OBJECT_STORAGE_ENABLED === 'true';

--- a/src/perfMetrics.ts
+++ b/src/perfMetrics.ts
@@ -1,5 +1,5 @@
 import * as _Perfume from 'perfume.js';
-import { isProduction } from './constants';
+import { LOG_PERFORMANCE_METRICS } from './constants';
 
 // Something is off about the way `perfume.js` is exported, and it behaves
 // differently when running the app vs. running tests. Not sure if this is an
@@ -14,5 +14,5 @@ export const perfume = new Perfume({
   },
   browserTracker: true,
   logPrefix: 'Performance:',
-  logging: !isProduction
+  logging: LOG_PERFORMANCE_METRICS
 });

--- a/src/perfMetrics.ts
+++ b/src/perfMetrics.ts
@@ -12,7 +12,6 @@ export const perfume = new Perfume({
     enable: true,
     timingVar: 'perfMetrics'
   },
-  browserTracker: true,
   logPrefix: 'Performance:',
   logging: LOG_PERFORMANCE_METRICS
 });


### PR DESCRIPTION
## Description

Previously, performance metrics were always logged in the console when running the dev server. I found this to be noisy. Now you need to explicitly set `REACT_APP_LOG_PERFORMANCE_METRICS='true'` in order to see logging of performance metrics in the console.

Also, I removed the browser/OS tracking from the reporting, as it apparently caused errors for some users.