### PR TITLE
Fix: UDFs not Resetting on App/StackScript Change

### DIFF
--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -204,7 +204,8 @@ class Select extends React.PureComponent<CombinedProps, {}> {
             [classes.hideLabel]: hideLabel
           })
         }}
-        value={value}
+        /** let us explicitly pass an empty string */
+        value={value || ''}
         onBlur={onBlur}
         options={options}
         components={combinedComponents}

--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -205,7 +205,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
           })
         }}
         /** let us explicitly pass an empty string */
-        value={value || ''}
+        value={value || null}
         onBlur={onBlur}
         options={options}
         components={combinedComponents}

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -158,6 +158,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
       InputProps,
       InputLabelProps,
       SelectProps,
+      value,
       dataAttrs,
       ...textFieldProps
     } = this.props;
@@ -183,7 +184,8 @@ class LinodeTextField extends React.Component<CombinedProps> {
           {...textFieldProps}
           {...dataAttrs}
           fullWidth
-          value={this.props.value || this.state.value}
+          /* let us explicitly pass an empty string to the input */
+          value={typeof value === 'string' ? value : this.state.value}
           onChange={this.handleChange}
           InputLabelProps={{
             ...InputLabelProps,

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedMultiSelect.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedMultiSelect.tsx
@@ -5,10 +5,17 @@ import RenderGuard from 'src/components/RenderGuard';
 
 interface Props {
   updateFormState: (key: string, value: any) => void;
-  udf_data: Linode.StackScript.UserDefinedField;
   field: Linode.StackScript.UserDefinedField;
   isOptional: boolean;
   error?: string;
+  /**
+   * value will end up being a comma-seperated list
+   * something like TCP,TCPIP,Helloworld
+   *
+   * reason for this is because that's the format the API
+   * accepts
+   */
+  value: string;
 }
 
 interface State {
@@ -34,7 +41,18 @@ class UserDefinedMultiSelect extends React.Component<CombinedProps, State> {
 
   render() {
     const { manyof } = this.state;
-    const { error, field, isOptional } = this.props;
+    const { error, field, isOptional, value: propValue } = this.props;
+
+    /**
+     * if we don't have any options selected for this multivalue
+     * UDF, just pass undefined as the value, so the form is reset
+     */
+    const value = !!propValue
+      ? propValue.split(',').map(eachValue => ({
+          label: eachValue,
+          value: eachValue
+        }))
+      : undefined;
 
     const manyOfOptions = manyof.map((choice: string) => {
       return {
@@ -49,6 +67,7 @@ class UserDefinedMultiSelect extends React.Component<CombinedProps, State> {
         <Select
           label={field.label}
           {...!isOptional && '*'}
+          value={value}
           isMulti={true}
           onChange={this.handleSelectManyOf}
           options={manyOfOptions}

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedSelect.tsx
@@ -27,7 +27,7 @@ const styles = (theme: Theme) =>
 
 interface Props {
   updateFormState: (key: string, value: any) => void;
-  udf_data: Linode.StackScript.UserDefinedField;
+  value: string;
   field: Linode.StackScript.UserDefinedField;
   isOptional: boolean;
   error?: string;
@@ -53,7 +53,7 @@ class UserDefinedSelect extends React.Component<CombinedProps, State> {
 
   render() {
     const { oneof } = this.state;
-    const { udf_data, error, field, classes, isOptional } = this.props;
+    const { value, error, field, classes, isOptional } = this.props;
 
     /* Display a select if there are more than 2 oneof options, otherwise display as radio. */
     if (oneof.length > 2) {
@@ -63,7 +63,7 @@ class UserDefinedSelect extends React.Component<CombinedProps, State> {
           <TextField
             label={field.label}
             onChange={this.handleSelectOneOf}
-            value={udf_data[field.name]}
+            value={value}
             // small={isOptional}
             select
           >
@@ -94,10 +94,7 @@ class UserDefinedSelect extends React.Component<CombinedProps, State> {
                   control={
                     <Radio
                       name={choice}
-                      checked={
-                        !!udf_data[field.name] &&
-                        udf_data[field.name] === choice
-                      }
+                      checked={!!value && value === choice}
                       /*
                       NOTE: Although the API returns a default value and we're auto selecting
                       a value for the user, it is not necessary to store this value

--- a/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/FieldTypes/UserDefinedText.tsx
@@ -23,17 +23,17 @@ interface Props {
   isPassword?: boolean;
   field: Linode.StackScript.UserDefinedField;
   updateFormState: (key: string, value: any) => void;
-  udf_data: Linode.StackScript.UserDefinedField;
   isOptional: boolean;
   placeholder?: string;
   error?: string;
+  value: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 class UserDefinedText extends React.Component<CombinedProps, {}> {
   renderTextField = () => {
-    const { udf_data, error, field, placeholder, isOptional } = this.props;
+    const { error, field, placeholder, isOptional } = this.props;
 
     return (
       <React.Fragment>
@@ -41,29 +41,21 @@ class UserDefinedText extends React.Component<CombinedProps, {}> {
           required={!isOptional}
           onChange={this.handleUpdateText}
           label={field.label}
-          value={udf_data[field.name] || ''}
           errorText={error}
           // small={isOptional}
           helperText={placeholder}
+          value={this.props.value}
         />
       </React.Fragment>
     );
   };
 
   renderPasswordField = () => {
-    const {
-      udf_data,
-      error,
-      field,
-      placeholder,
-      isOptional,
-      classes
-    } = this.props;
+    const { error, field, placeholder, isOptional, classes } = this.props;
 
     return (
       <AccessPanel
         required={!isOptional}
-        password={udf_data[field.name] || ''}
         handleChange={this.handleUpdatePassword}
         label={field.label}
         noPadding
@@ -73,6 +65,7 @@ class UserDefinedText extends React.Component<CombinedProps, {}> {
         className={!isOptional ? classes.accessPanel : ''}
         isOptional={isOptional}
         hideHelperText
+        password={this.props.value}
       />
     );
   };

--- a/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -60,15 +60,16 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
     const { udf_data, handleChange } = this.props;
     // if the 'default' key is returned from the API, the field is optional
     const isOptional = field.hasOwnProperty('default');
+
     if (isMultiSelect(field)) {
       return (
         <Grid item xs={12} lg={5} key={field.name}>
           <UserDefinedMultiSelect
             key={field.name}
             field={field}
-            udf_data={udf_data}
+            value={udf_data[field.name] || ''}
             updateFormState={handleChange}
-            updateFor={[udf_data[field.name], error]}
+            updateFor={[field.label, udf_data[field.name], error]}
             isOptional={isOptional}
             error={error}
           />
@@ -81,8 +82,8 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
           <UserDefinedSelect
             field={field}
             updateFormState={handleChange}
-            udf_data={udf_data}
-            updateFor={[udf_data[field.name], error]}
+            value={udf_data[field.name] || ''}
+            updateFor={[field.label, udf_data[field.name], error]}
             isOptional={isOptional}
             key={field.name}
             error={error}
@@ -94,11 +95,29 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
       return (
         <Grid item xs={12} lg={5} key={field.name}>
           <UserDefinedText
+            /**
+             * we explicitly passing the value to solve for the situation
+             * where you're switching between stackscripts or one-click-apps
+             * and the same UDF with the same label appears in both stackscripts.
+             *
+             * The problem here is that unless we explicitly pass the value,
+             * the form state will be reset but because MUI handles the
+             * value internally, the pre-inputted value will still exist in the
+             * textfield
+             *
+             * To test the incorrect behavior, try removing the "value" prop here,
+             * navigate to the One-Click app creation flow, click on MERN, fill out
+             * a DB password, then switch to LAMP. You'll see the value will
+             * still be in the form field.
+             *
+             * This comment is wordy as heck but it's important that we never remove this
+             * prop or that bug will return
+             */
+            value={udf_data[field.name] || ''}
             updateFormState={handleChange}
             isPassword={true}
             field={field}
-            udf_data={udf_data}
-            updateFor={[udf_data[field.name], error]}
+            updateFor={[field.label, udf_data[field.name], error]}
             isOptional={isOptional}
             placeholder={field.example}
             error={error}
@@ -109,10 +128,11 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
     return (
       <Grid item xs={12} lg={5} key={field.name}>
         <UserDefinedText
+          /** see comment above for why we're passing the value prop */
+          value={udf_data[field.name] || ''}
           updateFormState={handleChange}
           field={field}
-          udf_data={udf_data}
-          updateFor={[udf_data[field.name], error]}
+          updateFor={[field.label, udf_data[field.name], error]}
           isOptional={isOptional}
           placeholder={field.example}
           error={error}

--- a/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -334,8 +334,9 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     return getLabel(arg1, arg2, arg3);
   };
 
-  submitForm: HandleSubmit = (type, payload, linodeID?: number) => {
+  submitForm: HandleSubmit = (payload, linodeID?: number) => {
     const { createType } = this.props;
+
     /**
      * run a certain linode action based on the type
      * if clone, run clone service request and upsert linode
@@ -355,7 +356,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       );
     }
 
-    if (type === 'createFromBackup' && !this.state.selectedBackupID) {
+    if (createType === 'fromBackup' && !this.state.selectedBackupID) {
       /* a backup selection is also required */
       this.setState(
         {
@@ -368,7 +369,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       return;
     }
 
-    if (type === 'createFromStackScript' && !this.state.selectedStackScriptID) {
+    if (createType === 'fromStackScript' && !this.state.selectedStackScriptID) {
       return this.setState(
         () => ({
           errors: [
@@ -382,7 +383,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       );
     }
 
-    if (type === 'createFromApp' && !this.state.selectedStackScriptID) {
+    if (createType === 'fromApp' && !this.state.selectedStackScriptID) {
       return this.setState(
         () => ({
           errors: [

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -144,7 +144,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps> {
       tags
     } = this.props;
 
-    handleSubmitForm('createFromApp', {
+    handleSubmitForm({
       region: selectedRegionID,
       type: selectedTypeID,
       stackscript_id: selectedStackScriptID,

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromBackupsContent.tsx
@@ -150,7 +150,7 @@ export class FromBackupsContent extends React.Component<CombinedProps, State> {
 
     const tagsToAdd = tags ? tags.map(item => item.value) : undefined;
 
-    this.props.handleSubmitForm('createFromBackup', {
+    this.props.handleSubmitForm({
       region: selectedRegionID,
       type: selectedTypeID,
       private_ip: privateIPEnabled,

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -75,7 +75,7 @@ export type CombinedProps = Props &
 export class FromImageContent extends React.PureComponent<CombinedProps> {
   /** create the Linode */
   createLinode = () => {
-    this.props.handleSubmitForm('create', {
+    this.props.handleSubmitForm({
       type: this.props.selectedTypeID,
       region: this.props.selectedRegionID,
       image: this.props.selectedImageID,

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromLinodeContent.tsx
@@ -70,7 +70,6 @@ export class FromLinodeContent extends React.PureComponent<CombinedProps> {
 
   cloneLinode = () => {
     return this.props.handleSubmitForm(
-      'clone',
       {
         region: this.props.selectedRegionID,
         type: this.props.selectedTypeID,

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -149,7 +149,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
       tags
     } = this.props;
 
-    handleSubmitForm('createFromStackScript', {
+    handleSubmitForm({
       region: selectedRegionID,
       type: selectedTypeID,
       stackscript_id: selectedStackScriptID,

--- a/src/features/linodes/LinodesCreate/types.ts
+++ b/src/features/linodes/LinodesCreate/types.ts
@@ -82,12 +82,6 @@ export interface ReduxStateProps {
 }
 
 export type HandleSubmit = (
-  type:
-    | 'create'
-    | 'clone'
-    | 'createFromStackScript'
-    | 'createFromBackup'
-    | 'createFromApp',
   payload: CreateLinodeRequest,
   linodeID?: number
 ) => void;


### PR DESCRIPTION
## Description

Previously, there was an issue where:

1. Navigate to Create OCA flow
2. Select MERN
3. Then Select LAMP
4. Observe - the UDF for `dbpass` was unchanged, even though one is supposed to be Mongo while the other MySQL

This also uncovered a more apparent issue. We're not clearing form values when a user switches between Apps/StackScripts that have the same UDF label.

So for example

1. Create 2 SSs that have the same UDFs
2. Select 1st SS
3. Fill out all UDFs
4. Switch to second StackScript
5. Observe - form fields are still filled out, despite the parent state being cleared.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A

## To Test

1. Create 2 StackScripts with the script below
2. go to creation flow and select first stackscript
3. Fill out UDFs
4. select second stackscript
5. Try to submit form
6. You _should_ see the form submission error out with empty UDF fields

```
#!/bin/bash
#yu di efs
#
# <UDF name="DB_PASSWORD"		Label="MySQL root Password" />
# <UDF name="username"		Label="username" />
# <UDF name="allow" label="Allowed services" example="Punch holes in the firewall for these services. SSH is already open (see Restrict SSH)." default="" manyOf="FTP Server: TCP 21,Telnet: TCP 23,SMTP: TCP 25,DNS Server: TCP/UDP 53,Web Server: TCP 80,POP3 Mail Service: TCP 110,NTP Service: UDP 123,IMAP Mail Service: TCP 143,SSL Web Server: TCP 443,Mail Submission: TCP 587,SSL IMAP Server: TCP 993,OpenVPN Server: UDP 1194,IRC Server: TCP 6667">
# <udf name="sshd_protocol" label="SSH Protocol" oneOf="1,2,1 and 2" />
# <udf name="sshd_passwordauth" label="SSH Password Authentication" oneOf="No,Yes" />
echo "hello world"
```
