### PR TITLE
Add catch() for OBJ requests

### DIFF
--- a/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -59,17 +59,22 @@ export const ObjectStorageLanding: React.FunctionComponent<
       requestClusters
     } = props;
 
-    // When OBJ is generally available, consider moving
-    // these requests to App.tsx like other entities.
+    /**
+     * @todo: Move these requests to App.tsx like other entities when OBJ is generally available.
+     */
 
     // Request buckets if we haven't already
     if (bucketsLastUpdated === 0) {
-      requestBuckets();
+      requestBuckets().catch(err => {
+        /** We choose to do nothing, relying on the Redux error state. */
+      });
     }
 
     // Request clusters if we haven't already
     if (clustersLastUpdated === 0) {
-      requestClusters();
+      requestClusters().catch(err => {
+        /** We choose to do nothing, relying on the Redux error state. */
+      });
     }
   }, []);
 


### PR DESCRIPTION
## Description

This fixes a console error.

This wasn't an issue originally, but when I moved these requests from `App.tsx` to `ObjectStorageLanding.tsx` in [this PR](https://github.com/linode/manager/pull/4916/files#diff-46ef2374da6211486f3a408db68b2bcbL228) , we lost the `catch()` handling that happens there.  (See: [App.tsx](https://github.com/linode/manager/blob/develop/src/App.tsx#L270)).

Note that from the user's POV, nothing changes, since the error handling is done by Redux.

## Note to Reviewers

1. Request block `*bucket*` and `*cluster*` 
2. Visit OBJ
3. **Observe:** no uncaught errors in the console.
