### PR TITLE
OBJ: Update max length for Bucket label 

### DIFF
--- a/src/services/objectStorage/buckets.schema.ts
+++ b/src/services/objectStorage/buckets.schema.ts
@@ -5,8 +5,7 @@ export const CreateBucketSchema = object({
     .required('Label is required.')
     .matches(/^\S*$/, 'Label must not contain spaces.')
     .ensure()
-    // @todo: What are the actual limits?
-    .min(3, 'Label must be between 3 and 32 characters.')
-    .max(32, 'Label must be 32 characters or less.'),
+    .min(3, 'Label must be between 3 and 63 characters.')
+    .max(63, 'Label must be between 3 and 63 characters.'),
   cluster: string().required('Cluster is required.')
 });


### PR DESCRIPTION
## Description

We now know that the max length for a bucket label is 63. This PR updates the schema.

## Type of Change
- Non breaking change ('update', 'change')

