### PR TITLE
User Preferences Part 1

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -571,7 +571,7 @@ interface StateProps {
 const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => ({
   /** Profile */
   profileLoading: state.__resources.profile.loading,
-  profileError: state.__resources.profile.error,
+  profileError: path(['read'], state.__resources.profile.error),
   linodes: state.__resources.linodes.entities,
   linodesError: path(['read'], state.__resources.linodes.error),
   domainsError: state.__resources.domains.error,

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { pathOr } from 'ramda';
+import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose } from 'recompose';
@@ -134,7 +134,7 @@ const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
     ),
     userTimezone: pathOr('', ['data', 'timezone'], state.__resources.profile),
     userTimezoneLoading: state.__resources.profile.loading,
-    userTimezoneError: state.__resources.profile.error,
+    userTimezoneError: path(['read'], state.__resources.profile.error),
     someLinodesHaveScheduledMaintenance: linodesData
       ? linodesData.some(eachLinode => !!eachLinode.maintenance)
       : false,

--- a/src/features/Profile/AuthenticationSettings/AuthenticationSettings.test.tsx
+++ b/src/features/Profile/AuthenticationSettings/AuthenticationSettings.test.tsx
@@ -12,9 +12,7 @@ describe('Authentication settings profile tab', () => {
       ipWhitelisting={true}
       twoFactor={true}
       username={'username'}
-      actions={{
-        updateProfile: update
-      }}
+      updateProfile={update}
       classes={{
         root: '',
         title: ''

--- a/src/features/Profile/AuthenticationSettings/SecuritySettings.test.tsx
+++ b/src/features/Profile/AuthenticationSettings/SecuritySettings.test.tsx
@@ -13,6 +13,7 @@ describe('Security settings (IP whitelisting) form', () => {
         root: '',
         title: ''
       }}
+      ipWhitelistingEnabled={false}
       onSuccess={onSuccess}
       updateProfile={updateProfile}
     />

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -18,7 +18,8 @@ import Notice from 'src/components/Notice';
 import Toggle from 'src/components/Toggle';
 import ToggleState from 'src/components/ToggleState';
 import { getTFAToken } from 'src/services/profile';
-import { handleUpdate } from 'src/store/profile/profile.actions';
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
+import { requestProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
@@ -72,7 +73,9 @@ interface Props {
   clearState: () => void;
   twoFactor?: boolean;
   username?: string;
-  updateProfile: (profile: Partial<Linode.Profile>) => void;
+  updateProfile: (
+    profile: Partial<Linode.Profile>
+  ) => Promise<ProfileWithPreferences>;
 }
 
 interface ConfirmDisable {
@@ -147,11 +150,17 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
     });
   };
 
-  confirmToken = (scratchCode: string) => {
-    this.props.actions.updateProfile({
-      ...this.props.profile,
-      two_factor_auth: true
-    });
+  /**
+   * success when TFA is enabled
+   */
+  handleEnableSuccess = (scratchCode: string) => {
+    /**
+     * have redux re-request profile
+     *
+     * we need to do this because we just got a 200 from /profile/tfa
+     * so we need to update the Redux profile state
+     */
+    this.props.refreshProfile();
     this.setState({
       success: 'Two-factor authentication has been enabled.',
       showQRCode: false,
@@ -161,11 +170,17 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
     });
   };
 
-  disableTFASuccess = () => {
-    this.props.actions.updateProfile({
-      ...this.props.profile,
-      two_factor_auth: false
-    });
+  /**
+   * success when TFA is disabled
+   */
+  handleDisableSuccess = () => {
+    /**
+     * have redux re-request profile
+     *
+     * we need to do this because we just got a 200 from /profile/tfa
+     * so we need to update the Redux profile state
+     */
+    this.props.refreshProfile();
     this.setState({
       success: 'Two-factor authentication has been disabled.',
       twoFactorEnabled: false,
@@ -313,7 +328,7 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
                         secret={secret}
                         username={username}
                         loading={loading}
-                        onSuccess={this.confirmToken}
+                        onSuccess={this.handleEnableSuccess}
                         twoFactorConfirmed={twoFactorConfirmed}
                         toggleDialog={toggleScratchDialog}
                       />
@@ -325,7 +340,7 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
                   scratchCode={this.state.scratchCode}
                 />
                 <DisableTwoFactorDialog
-                  onSuccess={this.disableTFASuccess}
+                  onSuccess={this.handleDisableSuccess}
                   open={disable2FAOpen}
                   closeDialog={toggleDisable2FA}
                 />
@@ -341,30 +356,24 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
 const styled = withStyles(styles);
 
 interface StateProps {
-  profile?: Linode.Profile;
   twoFactor?: boolean;
   username?: string;
 }
 
 const mapStateToProps: MapState<StateProps, {}> = state => ({
-  profile: path(['data'], state.__resources.profile),
   twoFactor: path(['data', 'two_factor_auth'], state.__resources.profile),
   username: path(['data', 'username'], state.__resources.profile)
 });
 
 interface DispatchProps {
-  actions: {
-    updateProfile: (v: Partial<Linode.Profile>) => void;
-  };
+  refreshProfile: () => void;
 }
 
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
-  dispatch,
-  ownProps
-) => ({
-  actions: {
-    updateProfile: (profile: Linode.Profile) => dispatch(handleUpdate(profile))
-  }
+const mapDispatchToProps: MapDispatchToProps<
+  DispatchProps,
+  Props
+> = dispatch => ({
+  refreshProfile: () => dispatch(requestProfile() as any)
 });
 
 const connected = connect(

--- a/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
+++ b/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
@@ -13,9 +13,7 @@ describe('Email change form', () => {
       email="me@this.com"
       timezone="America/Barbados"
       loggedInAsCustomer={false}
-      actions={{
-        updateProfile: update
-      }}
+      updateProfile={update}
       classes={{
         root: '',
         title: ''

--- a/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -1,4 +1,4 @@
-import { compose, path, pathOr } from 'ramda';
+import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose as recompose } from 'recompose';
@@ -11,12 +11,11 @@ import {
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { AccountsAndPasswords } from 'src/documentation';
-import { handleUpdate } from 'src/store/profile/profile.actions';
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
+import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import EmailChangeForm from './EmailChangeForm';
 import TimezoneForm from './TimezoneForm';
-
-import { RequestableData } from 'src/store/types';
 
 type ClassNames = 'root' | 'title';
 
@@ -50,8 +49,8 @@ export class DisplaySettings extends React.Component<CombinedProps, State> {
 
   render() {
     const {
-      actions,
       email,
+      updateProfile,
       loggedInAsCustomer,
       loading,
       timezone,
@@ -70,12 +69,12 @@ export class DisplaySettings extends React.Component<CombinedProps, State> {
             <EmailChangeForm
               email={email}
               username={username}
-              updateProfile={actions.updateProfile}
+              updateProfile={updateProfile}
               data-qa-email-change
             />
             <TimezoneForm
               timezone={timezone}
-              updateProfile={actions.updateProfile}
+              updateProfile={updateProfile}
               loggedInAsCustomer={loggedInAsCustomer}
             />
           </React.Fragment>
@@ -103,7 +102,7 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
     loading: profile.loading,
     username: path(['data', 'username'], profile),
     email: path(['data', 'email'], profile),
-    timezone: defaultTimezone(profile),
+    timezone: pathOr<string>('GMT', ['data', 'timezone'], profile),
     loggedInAsCustomer: pathOr(
       false,
       ['authentication', 'loggedInAsCustomer'],
@@ -113,21 +112,12 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
 };
 
 interface DispatchProps {
-  actions: {
-    updateProfile: (v: Linode.Profile) => void;
-  };
+  updateProfile: (v: Linode.Profile) => Promise<ProfileWithPreferences>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
-  actions: {
-    updateProfile: (v: Linode.Profile) => dispatch(handleUpdate(v))
-  }
+  updateProfile: (v: Linode.Profile) => dispatch(handleUpdateProfile(v) as any)
 });
-
-const defaultTimezone = compose(
-  tz => (tz === '' ? 'GMT' : tz),
-  pathOr('GMT', ['data', 'timezone'])
-) as (profile: RequestableData<Linode.Profile>) => string;
 
 const connected = connect(
   mapStateToProps,

--- a/src/features/Profile/DisplaySettings/EmailChangeForm.tsx
+++ b/src/features/Profile/DisplaySettings/EmailChangeForm.tsx
@@ -11,10 +11,11 @@ import {
 } from 'src/components/core/styles';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import { updateProfile } from 'src/services/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 
 type ClassNames = 'root' | 'title';
 
@@ -32,7 +33,10 @@ const styles = (theme: Theme) =>
 interface Props {
   username: string;
   email: string;
-  updateProfile: (v: Partial<Linode.Profile>) => void;
+  updateProfile: (
+    v: Partial<Linode.Profile>
+  ) => Promise<ProfileWithPreferences>;
+  errors?: Linode.ApiFieldError[];
 }
 
 interface State {
@@ -47,7 +51,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export class EmailChangeForm extends React.Component<CombinedProps, State> {
   state: State = {
     updatedEmail: this.props.email || '',
-    errors: undefined,
+    errors: this.props.errors,
     success: undefined,
     submitting: false
   };
@@ -69,12 +73,13 @@ export class EmailChangeForm extends React.Component<CombinedProps, State> {
     const { updatedEmail } = this.state;
     this.setState({ errors: undefined, submitting: true });
 
-    updateProfile({ email: updatedEmail })
-      .then(response => {
-        this.props.updateProfile(response);
+    this.props
+      .updateProfile({ email: updatedEmail })
+      .then(() => {
         this.setState({
           submitting: false,
-          success: 'Email address updated.'
+          success: 'Email address updated.',
+          errors: undefined
         });
       })
       .catch(error => {

--- a/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -13,10 +13,10 @@ import {
 import Typography from 'src/components/core/Typography';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
-import { updateProfile } from 'src/services/profile';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 
 type ClassNames = 'root' | 'title';
 
@@ -36,15 +36,18 @@ const styles = (theme: Theme) =>
 interface Props {
   timezone: string;
   loggedInAsCustomer: boolean;
-  updateProfile: (v: Linode.Profile) => void;
+  updateProfile: (
+    v: Partial<Linode.Profile>
+  ) => Promise<ProfileWithPreferences>;
+  errors?: Linode.ApiFieldError[];
 }
 
 interface State {
   updatedTimezone: Item | null;
   inputValue: string;
-  errors?: Linode.ApiFieldError[];
   submitting: boolean;
   success?: string;
+  errors?: Linode.ApiFieldError[];
 }
 
 interface Timezone {
@@ -75,9 +78,9 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
   state: State = {
     updatedTimezone: null,
     inputValue: '',
-    errors: undefined,
     submitting: false,
-    success: undefined
+    success: undefined,
+    errors: this.props.errors
   };
 
   getTimezone = (timezoneValue: string) => {
@@ -91,7 +94,7 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
     if (timezone) {
       this.setState(set(lensPath(['updatedTimezone']), timezone));
     } else {
-      this.setState({ errors: undefined, success: undefined });
+      this.setState({ success: undefined });
     }
   };
 
@@ -100,22 +103,23 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
     if (!updatedTimezone) {
       return;
     }
-    this.setState({ errors: undefined, submitting: true });
+    this.setState({ submitting: true });
 
-    updateProfile({ timezone: updatedTimezone.value })
-      .then(response => {
-        this.props.updateProfile(response);
+    this.props
+      .updateProfile({ timezone: updatedTimezone.value as string })
+      .then(() => {
         this.setState({
           submitting: false,
-          success: 'Account timezone updated.'
+          success: 'Account timezone updated.',
+          errors: undefined
         });
       })
-      .catch(error => {
+      .catch(e => {
         this.setState(
           {
             submitting: false,
-            errors: getAPIErrorOrDefault(error),
-            success: undefined
+            success: undefined,
+            errors: e
           },
           () => {
             scrollErrorIntoView();

--- a/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/src/features/Profile/LishSettings/LishSettings.tsx
@@ -20,8 +20,8 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { LISH } from 'src/documentation';
-import { updateProfile } from 'src/services/profile';
-import { handleUpdate } from 'src/store/profile/profile.actions';
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
+import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
@@ -84,7 +84,7 @@ interface State {
   submitting: boolean;
   errors?: Linode.ApiFieldError[];
   success?: string;
-  lishAuthMethod?: string;
+  lishAuthMethod: Pick<Linode.Profile, 'lish_auth_method'>;
   authorizedKeys: string[];
   authorizedKeysCount: number;
 }
@@ -94,7 +94,7 @@ type CombinedProps = StateProps & DispatchProps & WithStyles<ClassNames>;
 class LishSettings extends React.Component<CombinedProps, State> {
   state: State = {
     submitting: false,
-    lishAuthMethod: this.props.lishAuthMethod || 'password_keys',
+    lishAuthMethod: this.props.lishAuthMethod || ('password_keys' as any),
     authorizedKeys: this.props.authorizedKeys || [],
     authorizedKeysCount: this.props.authorizedKeys
       ? this.props.authorizedKeys.length
@@ -137,7 +137,7 @@ class LishSettings extends React.Component<CombinedProps, State> {
     ];
 
     const defaultMode = modeOptions.find(eachMode => {
-      return eachMode.value === lishAuthMethod;
+      return (eachMode.value as any) === lishAuthMethod;
     });
 
     return (
@@ -167,7 +167,7 @@ class LishSettings extends React.Component<CombinedProps, State> {
                   name="mode-select"
                   id="mode-select"
                   defaultValue={defaultMode}
-                  onChange={this.onListAuthMethodChange}
+                  onChange={this.onListAuthMethodChange as any}
                   label="Authentication Mode"
                   isClearable={false}
                   errorText={authMethodError}
@@ -224,27 +224,24 @@ class LishSettings extends React.Component<CombinedProps, State> {
 
   onSubmit = () => {
     const { authorizedKeys, lishAuthMethod } = this.state;
-    const { actions } = this.props;
+    const { updateProfile } = this.props;
     const keys = authorizedKeys.filter(v => v !== '');
 
     this.setState({ errors: undefined, submitting: true });
 
     updateProfile({
-      lish_auth_method: lishAuthMethod,
+      lish_auth_method: lishAuthMethod as any,
       authorized_keys: keys
     })
       .then(profileData => {
-        this.setState(
-          {
-            submitting: false,
-            success: 'LISH authentication settings have been updated.',
-            authorizedKeys: profileData.authorized_keys || [],
-            authorizedKeysCount: profileData.authorized_keys
-              ? profileData.authorized_keys.length
-              : 1
-          },
-          () => actions.updateProfile(profileData)
-        );
+        this.setState({
+          submitting: false,
+          success: 'LISH authentication settings have been updated.',
+          authorizedKeys: profileData.authorized_keys || [],
+          authorizedKeysCount: profileData.authorized_keys
+            ? profileData.authorized_keys.length
+            : 1
+        });
       })
       .catch(error => {
         this.setState(
@@ -260,8 +257,9 @@ class LishSettings extends React.Component<CombinedProps, State> {
       });
   };
 
-  onListAuthMethodChange = (e: Item<string>) =>
-    this.setState({ lishAuthMethod: e.value });
+  onListAuthMethodChange = (
+    e: Item<Pick<Linode.Profile, 'lish_auth_method'>>
+  ) => this.setState({ lishAuthMethod: e.value });
 
   onPublicKeyChange = (idx: number) => (
     e: React.ChangeEvent<HTMLInputElement>
@@ -280,7 +278,7 @@ class LishSettings extends React.Component<CombinedProps, State> {
 const styled = withStyles(styles);
 
 interface StateProps {
-  lishAuthMethod?: string;
+  lishAuthMethod?: Pick<Linode.Profile, 'lish_auth_method'>;
   authorizedKeys?: string[];
   loading: boolean;
 }
@@ -295,15 +293,13 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
 };
 
 interface DispatchProps {
-  actions: {
-    updateProfile: (v: Linode.Profile) => void;
-  };
+  updateProfile: (
+    v: Partial<Linode.Profile>
+  ) => Promise<ProfileWithPreferences>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
-  actions: {
-    updateProfile: (v: Linode.Profile) => dispatch(handleUpdate(v))
-  }
+  updateProfile: (v: Linode.Profile) => dispatch(handleUpdateProfile(v) as any)
 });
 
 const connected = connect(

--- a/src/features/Profile/Settings/Settings.tsx
+++ b/src/features/Profile/Settings/Settings.tsx
@@ -14,8 +14,8 @@ import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Toggle from 'src/components/Toggle';
-import { updateProfile } from 'src/services/profile';
-import { handleUpdate } from 'src/store/profile/profile.actions';
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
+import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 
 type ClassNames = 'root' | 'title' | 'label';
@@ -75,13 +75,14 @@ class ProfileSettings extends React.Component<CombinedProps, State> {
   toggle = () => {
     this.setState({ submitting: true });
 
-    updateProfile({ email_notifications: !this.props.status })
-      .then(profile => {
-        this.props.actions.updateProfile(profile);
+    this.props
+      .updateProfile({ email_notifications: !this.props.status })
+      .then(() => {
         this.setState({ submitting: false });
       })
       .catch(() => {
         /* Couldnt really imagine this being an issue... 1*/
+        this.setState({ submitting: false });
       });
   };
 }
@@ -89,15 +90,13 @@ class ProfileSettings extends React.Component<CombinedProps, State> {
 const styled = withStyles(styles);
 
 interface DispatchProps {
-  actions: {
-    updateProfile: (p: Linode.Profile) => void;
-  };
+  updateProfile: (
+    p: Partial<Linode.Profile>
+  ) => Promise<ProfileWithPreferences>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
-  actions: {
-    updateProfile: (p: Linode.Profile) => dispatch(handleUpdate(p))
-  }
+  updateProfile: (p: Linode.Profile) => dispatch(handleUpdateProfile(p) as any)
 });
 
 interface StateProps {

--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -25,7 +25,7 @@ import TabLink from 'src/components/TabLink';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import { getUser, updateUser } from 'src/services/account';
 import { updateProfile } from 'src/services/profile';
-import { handleUpdate } from 'src/store/profile/profile.actions';
+import { requestProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getGravatarUrl } from 'src/utilities/gravatar';
@@ -196,7 +196,7 @@ class UserDetail extends React.Component<CombinedProps> {
       history,
       match: { path },
       profileUsername,
-      actions: { updateCurrentUser }
+      refreshProfile
     } = this.props;
 
     const { originalUsername, username, restricted } = this.state;
@@ -229,7 +229,7 @@ class UserDetail extends React.Component<CombinedProps> {
          * If the user we updated is the current user, we need to reflect that change at the global level.
          */
         if (profileUsername === originalUsername) {
-          updateCurrentUser(user);
+          refreshProfile();
         }
 
         /**
@@ -253,9 +253,7 @@ class UserDetail extends React.Component<CombinedProps> {
 
   onSaveProfile = () => {
     const { email, originalUsername } = this.state;
-    const {
-      actions: { updateCurrentUser }
-    } = this.props;
+    const { refreshProfile } = this.props;
 
     this.setState({
       profileSuccess: false,
@@ -276,7 +274,7 @@ class UserDetail extends React.Component<CombinedProps> {
          * If the user we updated is the current user, we need to reflect that change at the global level.
          */
         if (profile.username === originalUsername) {
-          updateCurrentUser(profile);
+          refreshProfile();
         }
       })
       .catch(errResponse => {
@@ -448,16 +446,11 @@ const mapStateToProps: MapState<StateProps, {}> = state => ({
 });
 
 interface DispatchProps {
-  actions: {
-    updateCurrentUser: (user: Linode.User | Linode.Profile) => void;
-  };
+  refreshProfile: () => void;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
-  actions: {
-    updateCurrentUser: (u: Linode.User | Linode.Profile) =>
-      dispatch(handleUpdate(u))
-  }
+  refreshProfile: () => dispatch(requestProfile() as any)
 });
 
 const reloadable = reloadableWithRouter<CombinedProps, MatchProps>(

--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -103,7 +103,7 @@ const enhanced = compose<CombinedProps, {}>(
   })),
   withProfile<ProfileProps, {}>((undefined, profile) => ({
     userTimezone: path(['data', 'timezone'], profile),
-    userTimezoneError: profile.error,
+    userTimezoneError: path(['read'], profile.error),
     userTimezoneLoading: profile.loading
   }))
 );

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -560,7 +560,10 @@ const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
     linodesRequestError: path(['error', 'read'], state.__resources.linodes),
     userTimezone: pathOr('', ['data', 'timezone'], state.__resources.profile),
     userTimezoneLoading: state.__resources.profile.loading,
-    userTimezoneError: state.__resources.profile.error
+    userTimezoneError: path<Linode.ApiFieldError[]>(
+      ['read'],
+      state.__resources.profile.error
+    )
   };
 };
 

--- a/src/services/profile/profile.ts
+++ b/src/services/profile/profile.ts
@@ -90,3 +90,29 @@ export const deleteTrustedDevice = (id: number) =>
     setURL(`${API_ROOT}/profile/devices/${id}`),
     setMethod('DELETE')
   ).then(response => response.data);
+
+/**
+ * getUserPreferences
+ *
+ * Retrieves an arbitrary JSON blob for the purposes of implementing
+ * conditional logic based on preferences the user chooses
+ */
+export const getUserPreferences = () => {
+  return Request<Record<string, any>>(
+    setURL(`${API_ROOT}/profile/preferences`)
+  ).then(response => response.data);
+};
+
+/**
+ * getUserPreferences
+ *
+ * Stores an arbitrary JSON blob for the purposes of implementing
+ * conditional logic based on preferences the user chooses
+ */
+export const updateUserPreferences = (payload: Record<string, any>) => {
+  return Request<Record<string, any>>(
+    setURL(`${API_ROOT}/profile/preferences`),
+    setData(payload),
+    setMethod('PUT')
+  ).then(response => response.data);
+};

--- a/src/store/profile/profile.actions.ts
+++ b/src/store/profile/profile.actions.ts
@@ -2,12 +2,18 @@ import { actionCreatorFactory } from 'typescript-fsa';
 
 const actionCreator = actionCreatorFactory(`@@manager/profile`);
 
+export interface ProfileWithPreferences extends Linode.Profile {
+  preferences: Record<string, any>;
+}
+
 export const getProfileActions = actionCreator.async<
   void,
-  Linode.Profile,
+  ProfileWithPreferences,
   Linode.ApiFieldError[]
 >(`request`);
 
-export const handleUpdate = actionCreator<
-  Partial<Linode.Profile> | Partial<Linode.User>
+export const handleUpdateProfile = actionCreator.async<
+  Partial<ProfileWithPreferences>,
+  Partial<ProfileWithPreferences>,
+  Linode.ApiFieldError[]
 >(`update`);

--- a/src/store/profile/profile.requests.ts
+++ b/src/store/profile/profile.requests.ts
@@ -1,12 +1,26 @@
 import { pathOr } from 'ramda';
-import { getMyGrants, getProfile } from 'src/services/profile';
+import { Action } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { ActionCreator, Failure, Success } from 'typescript-fsa';
+
+import {
+  getMyGrants,
+  getProfile,
+  getUserPreferences,
+  updateProfile as _updateProfile,
+  updateUserPreferences
+} from 'src/services/profile';
 import { ApplicationState } from 'src/store';
 import { ThunkActionCreator } from 'src/store/types';
-import { getProfileActions } from './profile.actions';
+import {
+  getProfileActions,
+  handleUpdateProfile,
+  ProfileWithPreferences
+} from './profile.actions';
 
 const maybeRequestGrants: (
-  response: Linode.Profile
-) => Promise<Linode.Profile> = profile => {
+  response: ProfileWithPreferences
+) => Promise<ProfileWithPreferences> = profile => {
   if (profile.restricted === false) {
     return Promise.resolve(profile);
   }
@@ -29,14 +43,17 @@ export const getTimezone = (state: ApplicationState, timezone: string) => {
 };
 
 export const requestProfile: ThunkActionCreator<
-  Promise<Linode.Profile>
+  Promise<ProfileWithPreferences>
 > = () => (dispatch, getState) => {
   const { started, done, failed } = getProfileActions;
 
   dispatch(started());
 
-  return getProfile()
-    .then(response => response.data)
+  return Promise.all([getProfile(), getUserPreferences()])
+    .then(([profile, userPrefs]) => ({
+      ...profile.data,
+      preferences: userPrefs
+    }))
     .then(profile => ({
       ...profile,
       timezone: getTimezone(getState(), profile.timezone)
@@ -50,4 +67,81 @@ export const requestProfile: ThunkActionCreator<
       dispatch(failed({ error }));
       return error;
     });
+};
+
+/**
+ * @todo this doesn't let you update grants
+ */
+export const updateProfile: ThunkActionCreator<
+  Promise<Partial<ProfileWithPreferences>>
+> = (payload: Partial<ProfileWithPreferences>) => dispatch => {
+  const { done, failed } = handleUpdateProfile;
+
+  /**
+   * intentionally not setting loading state here. We're going to keep that
+   * at the component level
+   */
+
+  if (!!payload.preferences) {
+    return updateProfileAndPreferences(payload as ProfileWithPreferences)
+      .then(([profile, preferences]) => {
+        return handleUpdateSuccess(
+          payload,
+          {
+            ...profile,
+            preferences
+          },
+          done,
+          dispatch
+        );
+      })
+      .catch(error => {
+        return handleUpdateFailure(payload, error, failed, dispatch);
+      });
+  }
+
+  return _updateProfile(payload)
+    .then(response => handleUpdateSuccess(payload, response, done, dispatch))
+    .catch(err => handleUpdateFailure(payload, err, failed, dispatch));
+};
+
+const updateProfileAndPreferences = (payload: ProfileWithPreferences) => {
+  return Promise.all([
+    _updateProfile(payload),
+    updateUserPreferences(payload.preferences)
+  ]);
+};
+
+const handleUpdateSuccess = (
+  payload: Partial<ProfileWithPreferences>,
+  result: Partial<ProfileWithPreferences>,
+  done: ActionCreator<
+    Success<Partial<ProfileWithPreferences>, Partial<ProfileWithPreferences>>
+  >,
+  dispatch: ThunkDispatch<ApplicationState, undefined, Action<any>>
+) => {
+  dispatch(
+    done({
+      params: payload,
+      result
+    })
+  );
+  return result;
+};
+
+const handleUpdateFailure = (
+  payload: Partial<ProfileWithPreferences>,
+  error: Linode.ApiFieldError[],
+  failed: ActionCreator<
+    Failure<Partial<ProfileWithPreferences>, Linode.ApiFieldError[]>
+  >,
+  dispatch: ThunkDispatch<ApplicationState, undefined, Action<any>>
+) => {
+  dispatch(
+    failed({
+      params: payload,
+      error
+    })
+  );
+  throw error;
 };

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -62,11 +62,11 @@ export interface EntityState<
   error?: E;
 }
 
-export interface RequestableData<D> {
+export interface RequestableData<D, E = Linode.ApiFieldError[]> {
   lastUpdated: number;
   loading: boolean;
   data?: D;
-  error?: Linode.ApiFieldError[];
+  error?: E;
 }
 
 // Rename to RequestableData and delete above when all components are using this pattern


### PR DESCRIPTION
This does not implement any actual PUTing to `/profile/preferences`

## Description

This PR accomplishes one goal: Change `updateProfile` in Redux from being a synchronous action to an asynchronous one.

So what was done

1. Created `start`, `done`, and `failed` actions on `updateProfile` along with loading, error, and data states.
2. Components now subscribe to `read` state on the `error` object
3. Adds `preferences` as a new key-value pair on the `profile.data` object
4. Adds conditional logic to the `updateProfile` action creator to maybeUpdateUserPreferences if the user preferences are included in the PUT payload.

What still needs work
1. User grants are a key-value pair on the `profile.data` object, so we need to make sure when we PUT `/profile`, grants get updated as well if they exist in the PUT payload
2. Implement PUT requests for `/profile/preferences`

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A