### PR TITLE
LKE Fix: negative number inputs

### DIFF
--- a/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -171,9 +171,11 @@ const Panel: React.FunctionComponent<CombinedProps> = props => {
         <TextField
           tiny
           type="number"
+          min={1}
+          max={Infinity}
           value={nodeCount}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            updateNodeCount(+e.target.value)
+            updateNodeCount(Math.max(+e.target.value, 1))
           }
           errorText={countError}
         />

--- a/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -82,9 +82,14 @@ export const NodePoolRow: React.FunctionComponent<CombinedProps> = props => {
             small
             tiny
             type="number"
+            min={1}
+            max={Infinity}
             value={pool.count}
             onChange={e =>
-              handleUpdate(idx, { ...pool, count: +e.target.value })
+              handleUpdate(idx, {
+                ...pool,
+                count: Math.max(+e.target.value, 1)
+              })
             }
           />
         ) : (

--- a/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -241,7 +241,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
       });
     } else {
       /** From a static state, adding a node pool should trigger editing state */
-      setEditing(true);
+      toggleEditing();
       /** Make sure the list of node pools is correct */
       updatePools([
         ...cluster.node_pools,


### PR DESCRIPTION
## Description

Update the TextFields to use recently added `min` and `max` logic. I'm not crazy about the UX here, but talked to @asauber about this, and one way or the other we should prevent node_counts of 0, as well as negative ones.

This PR also fixes a glitch where the success/error state would persist if re-entering the editing state by adding a new node pool.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Maybe it would be better to have default values for min and max props; something like `if typeof min === 'number' && !typeof max === number then max = Infinity`. What do you think @martinmckenna?