### PR TITLE
Fix: Default Value for Selects

### DIFF
--- a/src/components/EnhancedSelect/Select.tsx
+++ b/src/components/EnhancedSelect/Select.tsx
@@ -205,7 +205,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
           })
         }}
         /** let us explicitly pass an empty string */
-        value={value || null}
+        value={value || undefined}
         onBlur={onBlur}
         options={options}
         components={combinedComponents}


### PR DESCRIPTION
## Description

Fixes issue where default value was not populated if one wasn't explicitly provided

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Timezone Form was an offender of this. Please check many selects app-wide.