### PR TITLE
fix: Linodes Landing bombing the app when no IPv6

### DIFF
--- a/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { compose } from 'recompose'
+import { compose } from 'recompose';
 import Flag from 'src/assets/icons/flag.svg';
 import Button from 'src/components/Button';
 import Card from 'src/components/core/Card';
@@ -180,8 +180,8 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
               <RegionIndicator region={region} />
             </div>
             <div className={classes.cardSection} data-qa-ips>
-              <IPAddress ips={ipv4} copyRight showAll />
-              <IPAddress ips={[ipv6]} copyRight showAll />
+              {ipv4 && <IPAddress ips={ipv4} copyRight showAll />}
+              {ipv6 && <IPAddress ips={[ipv6]} copyRight showAll />}
             </div>
             <div className={classes.cardSection} data-qa-image>
               {imageLabel}


### PR DESCRIPTION
## Description

It's possible for IPv6 to be disabled on your Linode, which resulted in the app crashing in in LinodesLanding grid view, since we were rendering an IPAddress component with `null`.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Prod test account 9 has a Linode with IPv6 disabled. 
