### PR TITLE
LKE Use capability for LKE show/hide

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,6 @@ import { getAllVolumes } from 'src/store/volume/volume.requests';
 import composeState from 'src/utilities/composeState';
 import { notifications } from 'src/utilities/storage';
 import WelcomeBanner from 'src/WelcomeBanner';
-import { isKubernetesEnabled } from './constants';
 import BucketDrawer from './features/ObjectStorage/Buckets/BucketDrawer';
 import { requestClusters } from './store/clusters/clusters.actions';
 import {
@@ -55,7 +54,10 @@ import {
   WithNodeBalancerActions
 } from './store/nodeBalancer/nodeBalancer.containers';
 import { MapState } from './store/types';
-import { isObjectStorageEnabled } from './utilities/accountCapabilities';
+import {
+  isKubernetesEnabled as _isKubernetesEnabled,
+  isObjectStorageEnabled
+} from './utilities/accountCapabilities';
 
 import ErrorState from 'src/components/ErrorState';
 import { addNotificationsToLinodes } from 'src/store/linodes/linodes.actions';
@@ -373,6 +375,8 @@ export class App extends React.Component<CombinedProps, State> {
     ) {
       return null;
     }
+
+    const isKubernetesEnabled = _isKubernetesEnabled(accountCapabilities);
 
     return (
       <React.Fragment>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -19,10 +19,12 @@ import {
   WithTheme
 } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
-import { isKubernetesEnabled } from 'src/constants';
 import { MapState } from 'src/store/types';
 import { NORMAL_SPACING_UNIT } from 'src/themeFactory';
-import { isObjectStorageEnabled } from 'src/utilities/accountCapabilities';
+import {
+  isKubernetesEnabled,
+  isObjectStorageEnabled
+} from 'src/utilities/accountCapabilities';
 import { sendSpacingToggleEvent, sendThemeToggleEvent } from 'src/utilities/ga';
 import AdditionalMenuItems from './AdditionalMenuItems';
 import SpacingToggle from './SpacingToggle';
@@ -301,7 +303,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     });
     // }
 
-    if (isKubernetesEnabled) {
+    if (isKubernetesEnabled(accountCapabilities)) {
       primaryLinks.push({
         display: 'Kubernetes',
         href: '/kubernetes',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,7 +42,7 @@ export const LOG_PERFORMANCE_METRICS =
 export const isObjectStorageEnabledForEnvironment =
   process.env.REACT_APP_IS_OBJECT_STORAGE_ENABLED === 'true';
 
-export const isKubernetesEnabled =
+export const isKubernetesEnabledForEnvironment =
   process.env.REACT_APP_KUBERNETES_ENABLED === 'true';
 
 export const DISABLE_EVENT_THROTTLE =

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -217,7 +217,10 @@ interface StateProps {
   accountCapabilities: Linode.AccountCapability[];
 }
 
-const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
+const mapStateToProps: MapState<StateProps, CombinedProps> = (
+  state,
+  ownProps
+) => {
   return {
     accountCapabilities: pathOr(
       [],
@@ -238,7 +241,7 @@ const connected = connect(
   mapDispatchToProps
 );
 
-export default compose<CombinedProps, Props>(
+export default compose<CombinedProps, {}>(
   connected,
   withRouter,
   styled

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -1,9 +1,11 @@
 import KeyboardArrowDown from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUp from '@material-ui/icons/KeyboardArrowUp';
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, Dispatch } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { bindActionCreators, compose } from 'redux';
+import { compose } from 'recompose';
+import { bindActionCreators } from 'redux';
 import DomainIcon from 'src/assets/addnewmenu/domain.svg';
 import KubernetesIcon from 'src/assets/addnewmenu/kubernetes.svg';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
@@ -17,9 +19,10 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import { isKubernetesEnabled } from 'src/constants';
 import { openForCreating as openDomainDrawerForCreating } from 'src/store/domainDrawer';
+import { MapState } from 'src/store/types';
 import { openForCreating as openVolumeDrawerForCreating } from 'src/store/volumeDrawer';
+import { isKubernetesEnabled } from 'src/utilities/accountCapabilities';
 import AddNewMenuItem, { MenuItems } from './AddNewMenuItem';
 
 type CSSClasses =
@@ -82,7 +85,8 @@ interface State {
 type CombinedProps = Props &
   WithStyles<CSSClasses> &
   RouteComponentProps<{}> &
-  DispatchProps;
+  DispatchProps &
+  StateProps;
 
 const styled = withStyles(styles);
 
@@ -135,7 +139,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
       }
     ];
 
-    if (isKubernetesEnabled) {
+    if (isKubernetesEnabled(this.props.accountCapabilities)) {
       items.push({
         title: 'Kubernetes',
         onClick: e => {
@@ -209,6 +213,20 @@ interface DispatchProps {
   openVolumeDrawerForCreating: () => void;
 }
 
+interface StateProps {
+  accountCapabilities: Linode.AccountCapability[];
+}
+
+const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
+  return {
+    accountCapabilities: pathOr(
+      [],
+      ['__resources', 'account', 'data', 'capabilities'],
+      state
+    )
+  };
+};
+
 const mapDispatchToProps = (dispatch: Dispatch<any>) =>
   bindActionCreators(
     { openDomainDrawerForCreating, openVolumeDrawerForCreating },
@@ -216,11 +234,11 @@ const mapDispatchToProps = (dispatch: Dispatch<any>) =>
   );
 
 const connected = connect(
-  undefined,
+  mapStateToProps,
   mapDispatchToProps
 );
 
-export default compose(
+export default compose<CombinedProps, Props>(
   connected,
   withRouter,
   styled

--- a/src/types/Account.ts
+++ b/src/types/Account.ts
@@ -34,7 +34,8 @@ namespace Linode {
     | 'Linodes'
     | 'NodeBalancers'
     | 'Block Storage'
-    | 'Object Storage';
+    | 'Object Storage'
+    | 'Kubernetes';
 
   export interface AccountSettings {
     managed: boolean;

--- a/src/utilities/accountCapabilities.ts
+++ b/src/utilities/accountCapabilities.ts
@@ -1,7 +1,16 @@
-import { isObjectStorageEnabledForEnvironment } from 'src/constants';
+import {
+  isKubernetesEnabledForEnvironment,
+  isObjectStorageEnabledForEnvironment
+} from 'src/constants';
 
 export const isObjectStorageEnabled = (
   accountCapabilities: Linode.AccountCapability[]
 ) =>
   isObjectStorageEnabledForEnvironment ||
   accountCapabilities.indexOf('Object Storage') > -1;
+
+export const isKubernetesEnabled = (
+  accountCapabilities: Linode.AccountCapability[]
+) =>
+  isKubernetesEnabledForEnvironment ||
+  accountCapabilities.indexOf('Kubernetes') > -1;


### PR DESCRIPTION
## Description

Use the pattern @johnwcallahan did with OBJ to read account.capabilities. Kubernetes routes will be active if:

- .env has been set (REACT_APP_KUBERNETES_ENABLED) OR
- 'Kubernetes' is part of the list returned by account.capabilities.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Try all combinations (deleting from your .env, blocking /account on Charles (from dev services) and deleting 'Kubernetes' from the capabilities list.