### PR TITLE
Do GPU error handling in the Axios interceptor

### DIFF
--- a/src/components/GPUError.tsx
+++ b/src/components/GPUError.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+import Typography from 'src/components/core/Typography';
+import SupportLink from 'src/components/SupportLink';
+
+export const GPUError: React.FC<{}> = () => {
+  return (
+    <>
+      <Typography>
+        Additional verification is required to add this service. Please {` `}
+        <SupportLink
+          title="GPU Request"
+          description=""
+          text="open a Support ticket"
+        />
+        .
+      </Typography>
+    </>
+  );
+};

--- a/src/features/OneClickApps/FakeSpec.ts
+++ b/src/features/OneClickApps/FakeSpec.ts
@@ -77,7 +77,7 @@ export const oneClickApps: OCA[] = [
         href: 'https://linode.com/docs/quick-answers/linux/how-to-use-git/'
       }
     ],
-    href: 'about.gitlab.com',
+    href: 'https://about.gitlab.com',
     logo_url: 'assets/gitlab_color.svg'
   },
   {

--- a/src/features/linodes/LinodesCreate/LinodeCreate.tsx
+++ b/src/features/linodes/LinodesCreate/LinodeCreate.tsx
@@ -142,6 +142,7 @@ export class LinodeCreate extends React.PureComponent<
           <FromImageContent
             variant="public"
             imagePanelTitle="Choose a Distribution"
+            showGeneralError={true}
             imagesData={imagesData!}
             regionsData={regionsData!}
             typesData={typesData!}

--- a/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -12,7 +12,6 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 import SelectionCard from 'src/components/SelectionCard';
-import SupportLink from 'src/components/SupportLink';
 import TabbedPanel from 'src/components/TabbedPanel';
 import { Tab } from 'src/components/TabbedPanel/TabbedPanel';
 
@@ -241,35 +240,10 @@ export class SelectPlanPanel extends React.Component<
     );
     const initialTab = tabOrder.indexOf(selectedTypeClass);
 
-    /**
-     * Intercept GPU-related errors to include a link to support/tickets
-     */
-
-    const finalError =
-      error &&
-      selectedID &&
-      selectedID.match(/gpu/) &&
-      error.match(/verification is required/) ? (
-        <>
-          <Typography>
-            Additional verification is required to add this service. Please{' '}
-            {` `}
-            <SupportLink
-              title="GPU Request"
-              description=""
-              text="open a Support ticket"
-            />
-            .
-          </Typography>
-        </>
-      ) : (
-        error
-      );
-
     return (
       <TabbedPanel
         rootClass={`${classes.root} tabbedPanel`}
-        error={finalError}
+        error={error}
         header={header || 'Linode Plan'}
         copy={copy}
         tabs={tabs}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -52,6 +52,7 @@ const styles = (theme: Theme) =>
 interface Props extends BaseFormStateAndHandlers {
   variant?: 'public' | 'private' | 'all';
   imagePanelTitle?: string;
+  showGeneralError?: boolean;
 }
 
 const errorMap = [
@@ -108,6 +109,7 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
       userCannotCreateLinode,
       errors,
       imagePanelTitle,
+      showGeneralError,
       variant
     } = this.props;
 
@@ -137,13 +139,16 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
      * subtab component handles displaying general errors internally, but the
      * issue here is that the FromImageContent isn't nested under
      * sub-tabs, so we need to display general errors here
+     *
+     * NOTE: This only applies to from Distro; "My Images" must be handled
+     * separately.
      */
     const hasErrorFor = getErrorMap(errorMap, errors);
 
     return (
       <React.Fragment>
         <Grid item className={`${classes.main} mlMain py0`}>
-          {hasErrorFor.none && (
+          {hasErrorFor.none && !!showGeneralError && (
             <Notice error spacingTop={8} text={hasErrorFor.none} />
           )}
           <CreateLinodeDisabled isDisabled={userCannotCreateLinode} />

--- a/src/utilities/interceptGPUError.tsx
+++ b/src/utilities/interceptGPUError.tsx
@@ -21,6 +21,9 @@ export const interceptGPUErrors = (
    * but if we do this anywhere else we'll have to update the typings.
    */
   return errors.map(thisError => {
+    if (!thisError.reason) {
+      return thisError;
+    }
     if (
       thisError.reason.match(/verification is required/) &&
       selectedTypeID.match(/gpu/)

--- a/src/utilities/interceptGPUError.tsx
+++ b/src/utilities/interceptGPUError.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { GPUError } from 'src/components/GPUError';
+
+export const interceptGPUErrors = (
+  selectedTypeID?: Linode.LinodeTypeClass,
+  errors?: Linode.ApiFieldError[]
+) => {
+  if (!errors) {
+    return [];
+  } // this will never happen
+  if (!selectedTypeID) {
+    return errors;
+  } // Also shouldn't happen
+  /**
+   * We don't have a good way of identifying this specific error
+   * (which needs to be treated specially with a link to an open,
+   * pre-filled support ticket). Checking the text of the error
+   * and the type string of the plan is the best we can do.
+   *
+   * Passing JSX to an APIFieldError.reason doesn't seem to break anything,
+   * but if we do this anywhere else we'll have to update the typings.
+   */
+  return errors.map(thisError => {
+    if (
+      thisError.reason.match(/verification is required/) &&
+      selectedTypeID.match(/gpu/)
+    ) {
+      return { reason: <GPUError /> };
+    }
+
+    return thisError;
+  });
+};


### PR DESCRIPTION
## Description

The GPU "you need to open a support ticket" error was not GPU- or type-specific, so it was not being replaced as intended. Moved the intercepting logic to the Axios interceptor, where we're doing a simple check based on the error text and whether or not "type" contains "gpu".

Also fixed another (old) bug where general errors were displaying twice on the My Images creation tab.

To test:

Use prod-test-004 (or set your account's reputation to ~10) and try to create a GPU. Anywhere that types can be selected this error can occur (for LinodeResize it shows up in a toast), so please test them all.