### PR TITLE
Feature/initial requests

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -39,6 +39,7 @@ it('renders without crashing', () => {
             profileLoading={false}
             requestAccount={jest.fn()}
             addNotificationsToLinodes={jest.fn()}
+            initialRequestLinodes={jest.fn()}
             requestDomains={jest.fn()}
             requestImages={jest.fn()}
             requestLinodes={jest.fn()}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,10 @@ import { requestAccountSettings } from 'src/store/accountSettings/accountSetting
 import { getAllBuckets } from 'src/store/bucket/bucket.requests';
 import { requestDomains } from 'src/store/domains/domains.actions';
 import { requestImages } from 'src/store/image/image.requests';
-import { requestLinodes } from 'src/store/linodes/linode.requests';
+import {
+  initialRequest,
+  requestLinodes
+} from 'src/store/linodes/linode.requests';
 import { requestTypes } from 'src/store/linodeType/linodeType.requests';
 import { requestNotifications } from 'src/store/notification/notification.requests';
 import { requestProfile } from 'src/store/profile/profile.requests';
@@ -255,7 +258,7 @@ export class App extends React.Component<CombinedProps, State> {
       this.props.requestProfile(),
       this.props.requestDomains(),
       this.props.requestImages(),
-      this.props.requestLinodes(),
+      this.props.initialRequestLinodes(),
       this.props.requestNotifications(),
       this.props.requestSettings(),
       this.props.requestTypes(),
@@ -306,6 +309,13 @@ export class App extends React.Component<CombinedProps, State> {
     if (notifications.welcome.get() === 'open') {
       this.setState({ welcomeBanner: true });
     }
+
+    /**
+     * Everything has loaded, so now we can request
+     * the remaining Linodes and load them in the background.
+     */
+
+    this.props.requestLinodes();
   }
 
   closeMenu = () => {
@@ -507,6 +517,7 @@ interface DispatchProps {
   requestDomains: () => Promise<Linode.Domain[]>;
   requestImages: () => Promise<Linode.Image[]>;
   requestLinodes: () => Promise<Linode.Linode[]>;
+  initialRequestLinodes: () => Promise<Linode.Linode[]>;
   requestNotifications: () => Promise<Linode.Notification[]>;
   requestProfile: () => Promise<Linode.Profile>;
   requestSettings: () => Promise<Linode.AccountSettings>;
@@ -537,6 +548,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
     requestVolumes: () => dispatch(getAllVolumes()),
     requestBuckets: () => dispatch(getAllBuckets()),
     requestClusters: () => dispatch(requestClusters()),
+    initialRequestLinodes: () => dispatch(initialRequest()),
     addNotificationsToLinodes: (
       _notifications: Linode.Notification[],
       linodes: Linode.Linode[]

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.test.tsx
@@ -19,6 +19,7 @@ const classes = {
 const props = {
   linodesWithoutBackups: 0,
   openBackupDrawer: jest.fn(),
+  loading: false,
   classes
 };
 

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -22,7 +22,8 @@ type ClassNames =
   | 'section'
   | 'sectionLink'
   | 'title'
-  | 'ctaLink';
+  | 'ctaLink'
+  | 'loading';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -59,6 +60,11 @@ const styles = (theme: Theme) =>
     },
     ctaLink: {
       display: 'block'
+    },
+    loading: {
+      width: '100%',
+      display: 'flex',
+      justifyContent: 'center'
     }
   });
 
@@ -84,15 +90,6 @@ export const BackupsDashboardCard: React.StatelessComponent<
 
   if (accountBackups && !linodesWithoutBackups) {
     return null;
-  }
-
-  if (loading) {
-    /**
-     * The information in this card will be inaccurate until all
-     * of our initial requests for Linodes have completed,
-     * so we need a loading state.
-     */
-    return <CircleProgress />;
   }
 
   return (
@@ -130,32 +127,43 @@ export const BackupsDashboardCard: React.StatelessComponent<
           </Paper>
         </Link>
       )}
-      {/* Only show this section if the user has Linodes without backups */}
-      {Boolean(linodesWithoutBackups) && (
-        <a
-          onClick={openBackupDrawer}
-          data-qa-backup-existing
-          className={classes.ctaLink}
-          href="javascript:;"
-        >
-          <Paper
-            className={classNames({
-              [classes.section]: true,
-              [classes.sectionLink]: true
-            })}
+      {loading ? (
+        /**
+         * The information below will be inaccurate until all
+         * of our initial requests for Linodes have completed,
+         * so we need a loading state.
+         */
+        <Paper className={classes.loading}>
+          <CircleProgress mini />
+        </Paper>
+      ) : (
+        /* Only show this section if the user has Linodes without backups */
+        Boolean(linodesWithoutBackups) && (
+          <a
+            onClick={openBackupDrawer}
+            data-qa-backup-existing
+            className={classes.ctaLink}
+            href="javascript:;"
           >
-            <Typography variant="h3" className={classes.itemTitle}>
-              Enable Backups for Existing Linodes
-            </Typography>
-            <Typography variant="body1" data-qa-linodes-message>
-              {`You currently have
-                ${linodesWithoutBackups} ${
-                linodesWithoutBackups > 1 ? 'Linodes' : 'Linode'
-              }
-                without backups. Enable backups to protect your data.`}
-            </Typography>
-          </Paper>
-        </a>
+            <Paper
+              className={classNames({
+                [classes.section]: true,
+                [classes.sectionLink]: true
+              })}
+            >
+              <Typography variant="h3" className={classes.itemTitle}>
+                Enable Backups for Existing Linodes
+              </Typography>
+              <Typography variant="body1" data-qa-linodes-message>
+                {`You currently have
+                     ${linodesWithoutBackups} ${
+                  linodesWithoutBackups > 1 ? 'Linodes' : 'Linode'
+                }
+                   without backups. Enable backups to protect your data.`}
+              </Typography>
+            </Paper>
+          </a>
+        )
       )}
     </DashboardCard>
   );

--- a/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -3,6 +3,7 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
+import CircleProgress from 'src/components/CircleProgress';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -63,6 +64,7 @@ const styles = (theme: Theme) =>
 
 interface Props {
   accountBackups: boolean;
+  loading: boolean;
   linodesWithoutBackups: number;
   openBackupDrawer: () => void;
 }
@@ -75,12 +77,22 @@ export const BackupsDashboardCard: React.StatelessComponent<
   const {
     accountBackups,
     classes,
+    loading,
     linodesWithoutBackups,
     openBackupDrawer
   } = props;
 
   if (accountBackups && !linodesWithoutBackups) {
     return null;
+  }
+
+  if (loading) {
+    /**
+     * The information in this card will be inaccurate until all
+     * of our initial requests for Linodes have completed,
+     * so we need a loading state.
+     */
+    return <CircleProgress />;
   }
 
   return (

--- a/src/features/Dashboard/Dashboard.test.tsx
+++ b/src/features/Dashboard/Dashboard.test.tsx
@@ -7,6 +7,7 @@ const props = {
   accountBackups: false,
   userTimezone: 'GMT',
   userTimezoneLoading: false,
+  linodesLoading: false,
   someLinodesHaveScheduledMaintenance: true,
   actions: {
     openBackupDrawer: jest.fn(),

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -45,6 +45,7 @@ interface StateProps {
   accountBackups: boolean;
   linodesWithoutBackups: Linode.Linode[];
   managed: boolean;
+  linodesLoading: boolean;
   backupError?: Error;
   entitiesWithGroupsToImport: GroupedEntitiesForImport;
   userTimezone: string;
@@ -70,6 +71,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
     accountBackups,
     actions: { openBackupDrawer, openImportDrawer },
     backupError,
+    linodesLoading,
     linodesWithoutBackups,
     managed,
     entitiesWithGroupsToImport
@@ -103,6 +105,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
           {!managed && !backupError && (
             <BackupsDashboardCard
               accountBackups={accountBackups}
+              loading={linodesLoading}
               linodesWithoutBackups={linodesWithoutBackups.length}
               openBackupDrawer={openBackupDrawer}
             />
@@ -125,6 +128,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
 
 const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
   const linodesData = state.__resources.linodes.entities;
+  const linodesLoading = state.__resources.linodes.loading;
 
   return {
     accountBackups: pathOr(
@@ -135,6 +139,7 @@ const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
     userTimezone: pathOr('', ['data', 'timezone'], state.__resources.profile),
     userTimezoneLoading: state.__resources.profile.loading,
     userTimezoneError: state.__resources.profile.error,
+    linodesLoading,
     someLinodesHaveScheduledMaintenance: linodesData
       ? linodesData.some(eachLinode => !!eachLinode.maintenance)
       : false,

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -128,7 +128,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
 
 const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
   const linodesData = state.__resources.linodes.entities;
-  const linodesLoading = state.__resources.linodes.loading;
+  const linodesLoading = !state.__resources.linodes.hasFullyLoaded;
 
   return {
     accountBackups: pathOr(

--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -1,4 +1,4 @@
-import { compose, path, pathOr, prop, sortBy, take } from 'ramda';
+import { compose, path, pathOr, take } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
@@ -193,10 +193,10 @@ const withUpdatingLinodes = connect((state: ApplicationState, ownProps: {}) => {
   return {
     linodes: compose(
       mergeEvents(state.events.events),
-      take(5),
-      sortBy(prop('label'))
+      take(5)
+      // sortBy(prop('label')) this leads to weirdness when the background linodes load
     )(state.__resources.linodes.entities),
-    linodeCount: state.__resources.linodes.entities.length,
+    linodeCount: state.__resources.linodes.linodeCount,
     loading: state.__resources.linodes.loading,
     error: path(['read'], state.__resources.linodes.error)
   };

--- a/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -197,7 +197,9 @@ const withUpdatingLinodes = connect((state: ApplicationState, ownProps: {}) => {
       // sortBy(prop('label')) this leads to weirdness when the background linodes load
     )(state.__resources.linodes.entities),
     linodeCount: state.__resources.linodes.linodeCount,
-    loading: state.__resources.linodes.loading,
+    loading:
+      state.__resources.linodes.loading &&
+      state.__resources.linodes.lastUpdated === 0,
     error: path(['read'], state.__resources.linodes.error)
   };
 });

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -548,7 +548,7 @@ const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
       ['__resources', 'accountSettings', 'data', 'managed'],
       state
     ),
-    linodesCount: state.__resources.linodes.results.length,
+    linodesCount: state.__resources.linodes.linodeCount,
     linodesData,
     someLinodesHaveScheduledMaintenance: linodesData
       ? linodesData.some(

--- a/src/store/linodes/linode.requests.ts
+++ b/src/store/linodes/linode.requests.ts
@@ -58,6 +58,10 @@ export const requestLinodes: ThunkActionCreator<
   const nextPage = store.__resources.linodes.initialLoad ? 2 : 1;
 
   return getAll<Linode.Linode>(getLinodes)({ page: nextPage })
+    .then(response => {
+      dispatch(setLinodeMetadata({ linodeCount: response.results }));
+      return response;
+    })
     .then(getBackupsForLinodes)
     .then(result => {
       dispatch(getLinodesActions.done({ result }));

--- a/src/store/linodes/linode.requests.ts
+++ b/src/store/linodes/linode.requests.ts
@@ -50,7 +50,7 @@ export const rebootLinode = createRequestThunk(
 export const requestLinodes: ThunkActionCreator<
   Promise<Linode.Linode[]>
 > = () => (dispatch, getState) => {
-  dispatch(getLinodesActions.started);
+  dispatch(getLinodesActions.started());
 
   const store = getState();
   /** If we've already fetched the first page, don't do it again */

--- a/src/store/linodes/linodes.actions.ts
+++ b/src/store/linodes/linodes.actions.ts
@@ -38,6 +38,12 @@ export const getLinodesActions = actionCreator.async<
   Linode.ApiFieldError[]
 >('get-all');
 
+export const getInitialLinodesActions = actionCreator.async<
+  void,
+  Linode.Linode[],
+  Linode.ApiFieldError[]
+>('get-initial');
+
 export const getLinodeActions = actionCreator.async<
   LinodeID,
   Linode.Linode,
@@ -71,3 +77,8 @@ export const rebootLinodeActions = actionCreator.async<
   {},
   Linode.ApiFieldError[]
 >('reboot');
+
+export interface Metadata {
+  linodeCount: number;
+}
+export const setLinodeMetadata = actionCreator<Metadata>('set-data');

--- a/src/store/linodes/linodes.reducer.ts
+++ b/src/store/linodes/linodes.reducer.ts
@@ -82,10 +82,6 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
   /** Get ALL */
   if (isType(action, getLinodesActions.started)) {
-    if (state.initialLoad) {
-      // Don't set loading; we want this to run in the background.
-      return state;
-    }
     return {
       ...state,
       loading: true

--- a/src/store/linodes/linodes.reducer.ts
+++ b/src/store/linodes/linodes.reducer.ts
@@ -29,6 +29,7 @@ const getId = <E extends HasNumericID>({ id }: E) => id;
  */
 export interface State extends EntityState<LinodeWithMaintenance, EntityError> {
   initialLoad: boolean;
+  hasFullyLoaded: boolean;
   linodeCount: number;
 }
 
@@ -39,7 +40,8 @@ export const defaultState: State = {
   lastUpdated: 0,
   initialLoad: false,
   linodeCount: 0,
-  error: undefined
+  error: undefined,
+  hasFullyLoaded: false
 };
 
 /**
@@ -106,7 +108,8 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
          * want to get everything rather than
          * have a stale first page.
          */
-        initialLoad: false
+        initialLoad: false,
+        hasFullyLoaded: true
       };
     }
     return {


### PR DESCRIPTION
## Description

I wasn't able to get this fully ironed out. Our data is interrelated, so it's basically impossible to avoid some limited/stale data displayed on the dashboard (e.g., if one of the five Volumes there is attached to the last Linode to load, it'll be listed as "unattached" then suddenly have the Linode label pop in when the requests are complete).