### PR TITLE
M3-2836 fix: StackScript Drawer state bug

### DIFF
--- a/src/features/StackScripts/StackScriptDrawer.tsx
+++ b/src/features/StackScripts/StackScriptDrawer.tsx
@@ -19,24 +19,23 @@ interface DispatchProps {
   closeDrawer: () => void;
 }
 
-interface StateProps {
+interface Props {
   open: boolean;
   stackScriptId?: number;
 }
 
-type CombinedProps = DispatchProps & StateProps;
+type CombinedProps = DispatchProps & Props;
 
 export class StackScriptDrawer extends React.Component<CombinedProps, State> {
   state: State = {
-    loading: true,
+    loading: false,
     error: false
   };
 
-  componentDidUpdate(prevProps: StateProps) {
+  componentDidUpdate(prevProps: Props, prevState: State) {
     const { stackScriptId } = this.props;
-    const { stackScriptId: prevStackScriptId } = prevProps;
 
-    if (stackScriptId && stackScriptId !== prevStackScriptId) {
+    if (stackScriptId && !prevProps.open && this.props.open) {
       this.setState({ loading: true, stackScript: undefined });
       getStackScript(stackScriptId)
         .then(stackScript => {
@@ -78,9 +77,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   };
 };
 
-const mapStateToProps: MapState<StateProps, {}> = (
-  state: ApplicationState
-) => ({
+const mapStateToProps: MapState<Props, {}> = (state: ApplicationState) => ({
   open: pathOr(false, ['stackScriptDrawer', 'open'], state),
   stackScriptId: path(['stackScriptDrawer', 'stackScriptId'], state)
 });

--- a/src/features/StackScripts/StackScriptDrawer.tsx
+++ b/src/features/StackScripts/StackScriptDrawer.tsx
@@ -48,6 +48,10 @@ export class StackScriptDrawer extends React.Component<CombinedProps, State> {
     }
   }
 
+  componentWillUnmount() {
+    this.props.closeDrawer();
+  }
+
   render() {
     const { open, closeDrawer } = this.props;
     const { stackScript, error, loading } = this.state;


### PR DESCRIPTION
## Description

This was happening because the StackScriptDrawer Redux state was not cleaned up on unmount.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

**To test:**

1. Create -> Linode -> One-click -> Community StackScripts.
2. Click “Show Details” on a StackScript.
3. **Observe:** the drawer opens.
4. Click the browser’s “Back” button”.
5. Click “Community StackScripts”. 
6. **Observe:** the drawer is NOT open
