### PR TITLE
M3-2852: LinodeCreate selected region tab state

### DIFF
--- a/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -157,6 +157,7 @@ class SelectRegionPanel extends React.Component<
         copy={this.props.copy}
         tabs={this.createTabs()}
         initTab={initialTab}
+        key={initialTab}
       />
     );
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,9 +24,10 @@ export const ALGOLIA_APPLICATION_ID =
   process.env.REACT_APP_ALGOLIA_APPLICATION_ID || '';
 export const ALGOLIA_SEARCH_KEY =
   process.env.REACT_APP_ALGOLIA_SEARCH_KEY || '';
-export const LAUNCH_DARKLY_API_KEY = (isProduction
-  ? process.env.REACT_APP_LAUNCH_DARKLY_ID_PRODUCTION
-  : process.env.REACT_APP_LAUNCH_DARKLY_ID_DEV) || '';
+export const LAUNCH_DARKLY_API_KEY =
+  (isProduction
+    ? process.env.REACT_APP_LAUNCH_DARKLY_ID_PRODUCTION
+    : process.env.REACT_APP_LAUNCH_DARKLY_ID_DEV) || '';
 
 /** optional variables */
 export const SENTRY_URL = process.env.REACT_APP_SENTRY_URL;
@@ -146,7 +147,8 @@ export const dcContinent: Record<string, ContinentKey> = {
   'eu-central': 'EU',
   'ap-northeast': 'AS',
   'ca-central': 'NA',
-  'ca-east': 'NA'
+  'ca-east': 'NA',
+  'ap-west': 'AS'
 };
 
 // At this time, the following regions do not support block storage.


### PR DESCRIPTION
## Description

This is a small enhancement. 

Consider a situation where you want to create a new Linode by cloning an existing one. In the Create flow, when you select a Linode, its region is automatically selected, but the tab it falls under _isn't._

The solution I went with is adding a `key` prop, equal to the value of the initialTab. This is a handy React pattern I learned about here: https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests
None.

## Note to Reviewers

**To test:**

1. Have multiple Linodes in multiple regions. 
2. "Create Linode" -> "My Images" -> "Clone Linode".
3. Select a Linode.
4. **Observe:** The tab containing the selected region is selected.