### PR TITLE
User Preferences Part 3: Theme and Spacing

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -36,14 +36,14 @@ it('renders without crashing', () => {
               switchWrapper: ''
             }}
             userId={123456}
-            profileLoading={false}
+            // profileLoading={false}
             requestAccount={jest.fn()}
             addNotificationsToLinodes={jest.fn()}
             requestDomains={jest.fn()}
             requestImages={jest.fn()}
             requestLinodes={jest.fn()}
             requestNotifications={jest.fn()}
-            requestProfile={jest.fn()}
+            // requestProfile={jest.fn()}
             requestSettings={jest.fn()}
             requestTypes={jest.fn()}
             requestRegions={jest.fn()}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -18,6 +18,7 @@ it('renders without crashing', () => {
             linodes={[]}
             notifications={[]}
             {...mockNodeBalancerActions}
+            profileError={undefined}
             username=""
             isLoggedInAsCustomer={false}
             closeSnackbar={jest.fn()}
@@ -36,14 +37,14 @@ it('renders without crashing', () => {
               switchWrapper: ''
             }}
             userId={123456}
-            // profileLoading={false}
+            profileLoading={false}
             requestAccount={jest.fn()}
             addNotificationsToLinodes={jest.fn()}
             requestDomains={jest.fn()}
             requestImages={jest.fn()}
             requestLinodes={jest.fn()}
             requestNotifications={jest.fn()}
-            // requestProfile={jest.fn()}
+            requestProfile={jest.fn()}
             requestSettings={jest.fn()}
             requestTypes={jest.fn()}
             requestRegions={jest.fn()}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,8 +11,8 @@ import { hasOauthError } from './App';
 
 it('renders without crashing', () => {
   const component = shallow(
-    <LinodeThemeWrapper>
-      <Provider store={store}>
+    <Provider store={store}>
+      <LinodeThemeWrapper>
         <StaticRouter location="/" context={{}}>
           <App
             linodes={[]}
@@ -57,8 +57,8 @@ it('renders without crashing', () => {
             accountLoading={false}
           />
         </StaticRouter>
-      </Provider>
-    </LinodeThemeWrapper>
+      </LinodeThemeWrapper>
+    </Provider>
   );
   expect(component.find('App')).toHaveLength(1);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,6 @@ import { requestImages } from 'src/store/image/image.requests';
 import { requestLinodes } from 'src/store/linodes/linode.requests';
 import { requestTypes } from 'src/store/linodeType/linodeType.requests';
 import { requestNotifications } from 'src/store/notification/notification.requests';
-import { requestProfile } from 'src/store/profile/profile.requests';
 import { requestRegions } from 'src/store/regions/regions.actions';
 import { getAllVolumes } from 'src/store/volume/volume.requests';
 import composeState from 'src/utilities/composeState';
@@ -252,7 +251,6 @@ export class App extends React.Component<CombinedProps, State> {
     perfume.start('InitialRequests');
     const dataFetchingPromises: Promise<any>[] = [
       this.props.requestAccount(),
-      this.props.requestProfile(),
       this.props.requestDomains(),
       this.props.requestImages(),
       this.props.requestLinodes(),
@@ -332,7 +330,6 @@ export class App extends React.Component<CombinedProps, State> {
       classes,
       toggleSpacing,
       toggleTheme,
-      profileLoading,
       linodesError,
       domainsError,
       typesError,
@@ -341,7 +338,6 @@ export class App extends React.Component<CombinedProps, State> {
       regionsError,
       volumesError,
       settingsError,
-      profileError,
       bucketsError,
       accountCapabilities,
       accountLoading,
@@ -367,7 +363,6 @@ export class App extends React.Component<CombinedProps, State> {
         regionsError,
         volumesError,
         settingsError,
-        profileError,
         bucketsError
       )
     ) {
@@ -381,93 +376,86 @@ export class App extends React.Component<CombinedProps, State> {
         </a>
         <DocumentTitleSegment segment="Linode Manager" />
 
-        {profileLoading === false && (
-          <React.Fragment>
-            <>
-              <div className={classes.appFrame}>
-                <SideMenu
-                  open={menuOpen}
-                  closeMenu={this.closeMenu}
-                  toggleTheme={toggleTheme}
-                  toggleSpacing={toggleSpacing}
+        <React.Fragment>
+          <>
+            <div className={classes.appFrame}>
+              <SideMenu
+                open={menuOpen}
+                closeMenu={this.closeMenu}
+                toggleTheme={toggleTheme}
+                toggleSpacing={toggleSpacing}
+              />
+              <main className={classes.content}>
+                <TopMenu
+                  openSideMenu={this.openMenu}
+                  isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
+                  username={this.props.username}
                 />
-                <main className={classes.content}>
-                  <TopMenu
-                    openSideMenu={this.openMenu}
-                    isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
-                    username={this.props.username}
-                  />
-                  <VATBanner />
-                  <div className={classes.wrapper} id="main-content">
-                    <Grid container spacing={0} className={classes.grid}>
-                      <Grid item className={classes.switchWrapper}>
-                        <Switch>
-                          <Route path="/linodes" component={LinodesRoutes} />
-                          <Route path="/volumes" component={Volumes} />
-                          <Route
-                            path="/nodebalancers"
-                            component={NodeBalancers}
-                          />
-                          <Route path="/domains" component={Domains} />
-                          <Route exact path="/managed" component={Managed} />
-                          <Route exact path="/longview" component={Longview} />
-                          <Route exact path="/images" component={Images} />
-                          <Route
-                            path="/stackscripts"
-                            component={StackScripts}
-                          />
-                          {getObjectStorageRoute(
-                            accountLoading,
-                            accountCapabilities,
-                            accountError
-                          )}
-                          {isKubernetesEnabled && (
-                            <Route path="/kubernetes" component={Kubernetes} />
-                          )}
-                          <Route path="/account" component={Account} />
-                          <Route
-                            exact
-                            path="/support/tickets"
-                            component={SupportTickets}
-                          />
-                          <Route
-                            path="/support/tickets/:ticketId"
-                            component={SupportTicketDetail}
-                          />
-                          <Route path="/profile" component={Profile} />
-                          <Route exact path="/support" component={Help} />
-                          <Route
-                            exact
-                            path="/support/search/"
-                            component={SupportSearchLanding}
-                          />
-                          <Route path="/dashboard" component={Dashboard} />
-                          <Route path="/search" component={SearchLanding} />
-                          <Route path="/events" component={EventsLanding} />
-                          <Redirect exact from="/" to="/dashboard" />
-                          <Route component={NotFound} />
-                        </Switch>
-                      </Grid>
+                <VATBanner />
+                <div className={classes.wrapper} id="main-content">
+                  <Grid container spacing={0} className={classes.grid}>
+                    <Grid item className={classes.switchWrapper}>
+                      <Switch>
+                        <Route path="/linodes" component={LinodesRoutes} />
+                        <Route path="/volumes" component={Volumes} />
+                        <Route
+                          path="/nodebalancers"
+                          component={NodeBalancers}
+                        />
+                        <Route path="/domains" component={Domains} />
+                        <Route exact path="/managed" component={Managed} />
+                        <Route exact path="/longview" component={Longview} />
+                        <Route exact path="/images" component={Images} />
+                        <Route path="/stackscripts" component={StackScripts} />
+                        {getObjectStorageRoute(
+                          accountLoading,
+                          accountCapabilities,
+                          accountError
+                        )}
+                        {isKubernetesEnabled && (
+                          <Route path="/kubernetes" component={Kubernetes} />
+                        )}
+                        <Route path="/account" component={Account} />
+                        <Route
+                          exact
+                          path="/support/tickets"
+                          component={SupportTickets}
+                        />
+                        <Route
+                          path="/support/tickets/:ticketId"
+                          component={SupportTicketDetail}
+                        />
+                        <Route path="/profile" component={Profile} />
+                        <Route exact path="/support" component={Help} />
+                        <Route
+                          exact
+                          path="/support/search/"
+                          component={SupportSearchLanding}
+                        />
+                        <Route path="/dashboard" component={Dashboard} />
+                        <Route path="/search" component={SearchLanding} />
+                        <Route path="/events" component={EventsLanding} />
+                        <Redirect exact from="/" to="/dashboard" />
+                        <Route component={NotFound} />
+                      </Switch>
                     </Grid>
-                  </div>
-                </main>
-                <Footer />
-                <WelcomeBanner
-                  open={this.state.welcomeBanner}
-                  onClose={this.closeWelcomeBanner}
-                  data-qa-beta-notice
-                />
-                <ToastNotifications />
-                <DomainDrawer />
-                <VolumeDrawer />
-                <BackupDrawer />
-                {isObjectStorageEnabled(accountCapabilities) && (
-                  <BucketDrawer />
-                )}
-              </div>
-            </>
-          </React.Fragment>
-        )}
+                  </Grid>
+                </div>
+              </main>
+              <Footer />
+              <WelcomeBanner
+                open={this.state.welcomeBanner}
+                onClose={this.closeWelcomeBanner}
+                data-qa-beta-notice
+              />
+              <ToastNotifications />
+              <DomainDrawer />
+              <VolumeDrawer />
+              <BackupDrawer />
+              {isObjectStorageEnabled(accountCapabilities) && <BucketDrawer />}
+            </div>
+          </>
+        </React.Fragment>
       </React.Fragment>
     );
   }
@@ -508,7 +496,6 @@ interface DispatchProps {
   requestImages: () => Promise<Linode.Image[]>;
   requestLinodes: () => Promise<Linode.Linode[]>;
   requestNotifications: () => Promise<Linode.Notification[]>;
-  requestProfile: () => Promise<Linode.Profile>;
   requestSettings: () => Promise<Linode.AccountSettings>;
   requestTypes: () => Promise<Linode.LinodeType[]>;
   requestRegions: () => Promise<Linode.Region[]>;
@@ -530,7 +517,6 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
     requestImages: () => dispatch(requestImages()),
     requestLinodes: () => dispatch(requestLinodes()),
     requestNotifications: () => dispatch(requestNotifications()),
-    requestProfile: () => dispatch(requestProfile()),
     requestSettings: () => dispatch(requestAccountSettings()),
     requestTypes: () => dispatch(requestTypes()),
     requestRegions: () => dispatch(requestRegions()),
@@ -546,8 +532,6 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
 
 interface StateProps {
   /** Profile */
-  profileLoading: boolean;
-  profileError?: Error | Linode.ApiFieldError[];
   linodes: Linode.Linode[];
   linodesError?: Linode.ApiFieldError[];
   domainsError?: Linode.ApiFieldError[];
@@ -570,8 +554,6 @@ interface StateProps {
 
 const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => ({
   /** Profile */
-  profileLoading: state.__resources.profile.loading,
-  profileError: path(['read'], state.__resources.profile.error),
   linodes: state.__resources.linodes.entities,
   linodesError: path(['read'], state.__resources.linodes.error),
   domainsError: state.__resources.domains.error,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import { requestImages } from 'src/store/image/image.requests';
 import { requestLinodes } from 'src/store/linodes/linode.requests';
 import { requestTypes } from 'src/store/linodeType/linodeType.requests';
 import { requestNotifications } from 'src/store/notification/notification.requests';
+import { requestProfile } from 'src/store/profile/profile.requests';
 import { requestRegions } from 'src/store/regions/regions.actions';
 import { getAllVolumes } from 'src/store/volume/volume.requests';
 import composeState from 'src/utilities/composeState';
@@ -253,6 +254,7 @@ export class App extends React.Component<CombinedProps, State> {
       this.props.requestAccount(),
       this.props.requestDomains(),
       this.props.requestImages(),
+      this.props.requestProfile(),
       this.props.requestLinodes(),
       this.props.requestNotifications(),
       this.props.requestSettings(),
@@ -336,6 +338,8 @@ export class App extends React.Component<CombinedProps, State> {
       imagesError,
       notificationsError,
       regionsError,
+      profileLoading,
+      profileError,
       volumesError,
       settingsError,
       bucketsError,
@@ -362,6 +366,7 @@ export class App extends React.Component<CombinedProps, State> {
         notificationsError,
         regionsError,
         volumesError,
+        profileError,
         settingsError,
         bucketsError
       )
@@ -376,86 +381,93 @@ export class App extends React.Component<CombinedProps, State> {
         </a>
         <DocumentTitleSegment segment="Linode Manager" />
 
-        <React.Fragment>
-          <>
-            <div className={classes.appFrame}>
-              <SideMenu
-                open={menuOpen}
-                closeMenu={this.closeMenu}
-                toggleTheme={toggleTheme}
-                toggleSpacing={toggleSpacing}
-              />
-              <main className={classes.content}>
-                <TopMenu
-                  openSideMenu={this.openMenu}
-                  isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
-                  username={this.props.username}
+        {profileLoading === false && (
+          <React.Fragment>
+            <>
+              <div className={classes.appFrame}>
+                <SideMenu
+                  open={menuOpen}
+                  closeMenu={this.closeMenu}
+                  toggleTheme={toggleTheme}
+                  toggleSpacing={toggleSpacing}
                 />
-                <VATBanner />
-                <div className={classes.wrapper} id="main-content">
-                  <Grid container spacing={0} className={classes.grid}>
-                    <Grid item className={classes.switchWrapper}>
-                      <Switch>
-                        <Route path="/linodes" component={LinodesRoutes} />
-                        <Route path="/volumes" component={Volumes} />
-                        <Route
-                          path="/nodebalancers"
-                          component={NodeBalancers}
-                        />
-                        <Route path="/domains" component={Domains} />
-                        <Route exact path="/managed" component={Managed} />
-                        <Route exact path="/longview" component={Longview} />
-                        <Route exact path="/images" component={Images} />
-                        <Route path="/stackscripts" component={StackScripts} />
-                        {getObjectStorageRoute(
-                          accountLoading,
-                          accountCapabilities,
-                          accountError
-                        )}
-                        {isKubernetesEnabled && (
-                          <Route path="/kubernetes" component={Kubernetes} />
-                        )}
-                        <Route path="/account" component={Account} />
-                        <Route
-                          exact
-                          path="/support/tickets"
-                          component={SupportTickets}
-                        />
-                        <Route
-                          path="/support/tickets/:ticketId"
-                          component={SupportTicketDetail}
-                        />
-                        <Route path="/profile" component={Profile} />
-                        <Route exact path="/support" component={Help} />
-                        <Route
-                          exact
-                          path="/support/search/"
-                          component={SupportSearchLanding}
-                        />
-                        <Route path="/dashboard" component={Dashboard} />
-                        <Route path="/search" component={SearchLanding} />
-                        <Route path="/events" component={EventsLanding} />
-                        <Redirect exact from="/" to="/dashboard" />
-                        <Route component={NotFound} />
-                      </Switch>
+                <main className={classes.content}>
+                  <TopMenu
+                    openSideMenu={this.openMenu}
+                    isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
+                    username={this.props.username}
+                  />
+                  <VATBanner />
+                  <div className={classes.wrapper} id="main-content">
+                    <Grid container spacing={0} className={classes.grid}>
+                      <Grid item className={classes.switchWrapper}>
+                        <Switch>
+                          <Route path="/linodes" component={LinodesRoutes} />
+                          <Route path="/volumes" component={Volumes} />
+                          <Route
+                            path="/nodebalancers"
+                            component={NodeBalancers}
+                          />
+                          <Route path="/domains" component={Domains} />
+                          <Route exact path="/managed" component={Managed} />
+                          <Route exact path="/longview" component={Longview} />
+                          <Route exact path="/images" component={Images} />
+                          <Route
+                            path="/stackscripts"
+                            component={StackScripts}
+                          />
+                          {getObjectStorageRoute(
+                            accountLoading,
+                            accountCapabilities,
+                            accountError
+                          )}
+                          {isKubernetesEnabled && (
+                            <Route path="/kubernetes" component={Kubernetes} />
+                          )}
+                          <Route path="/account" component={Account} />
+                          <Route
+                            exact
+                            path="/support/tickets"
+                            component={SupportTickets}
+                          />
+                          <Route
+                            path="/support/tickets/:ticketId"
+                            component={SupportTicketDetail}
+                          />
+                          <Route path="/profile" component={Profile} />
+                          <Route exact path="/support" component={Help} />
+                          <Route
+                            exact
+                            path="/support/search/"
+                            component={SupportSearchLanding}
+                          />
+                          <Route path="/dashboard" component={Dashboard} />
+                          <Route path="/search" component={SearchLanding} />
+                          <Route path="/events" component={EventsLanding} />
+                          <Redirect exact from="/" to="/dashboard" />
+                          <Route component={NotFound} />
+                        </Switch>
+                      </Grid>
                     </Grid>
-                  </Grid>
-                </div>
-              </main>
-              <Footer />
-              <WelcomeBanner
-                open={this.state.welcomeBanner}
-                onClose={this.closeWelcomeBanner}
-                data-qa-beta-notice
-              />
-              <ToastNotifications />
-              <DomainDrawer />
-              <VolumeDrawer />
-              <BackupDrawer />
-              {isObjectStorageEnabled(accountCapabilities) && <BucketDrawer />}
-            </div>
-          </>
-        </React.Fragment>
+                  </div>
+                </main>
+                <Footer />
+                <WelcomeBanner
+                  open={this.state.welcomeBanner}
+                  onClose={this.closeWelcomeBanner}
+                  data-qa-beta-notice
+                />
+                <ToastNotifications />
+                <DomainDrawer />
+                <VolumeDrawer />
+                <BackupDrawer />
+                {isObjectStorageEnabled(accountCapabilities) && (
+                  <BucketDrawer />
+                )}
+              </div>
+            </>
+          </React.Fragment>
+        )}
       </React.Fragment>
     );
   }
@@ -500,6 +512,7 @@ interface DispatchProps {
   requestTypes: () => Promise<Linode.LinodeType[]>;
   requestRegions: () => Promise<Linode.Region[]>;
   requestVolumes: () => Promise<Linode.Volume[]>;
+  requestProfile: () => Promise<Linode.Profile>;
   requestBuckets: () => Promise<Linode.Bucket[]>;
   requestClusters: () => Promise<Linode.Cluster[]>;
   addNotificationsToLinodes: (
@@ -521,6 +534,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
     requestTypes: () => dispatch(requestTypes()),
     requestRegions: () => dispatch(requestRegions()),
     requestVolumes: () => dispatch(getAllVolumes()),
+    requestProfile: () => dispatch(requestProfile()),
     requestBuckets: () => dispatch(getAllBuckets()),
     requestClusters: () => dispatch(requestClusters()),
     addNotificationsToLinodes: (
@@ -532,6 +546,8 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
 
 interface StateProps {
   /** Profile */
+  profileLoading: boolean;
+  profileError?: Error | Linode.ApiFieldError[];
   linodes: Linode.Linode[];
   linodesError?: Linode.ApiFieldError[];
   domainsError?: Linode.ApiFieldError[];
@@ -552,8 +568,10 @@ interface StateProps {
   accountError?: Error | Linode.ApiFieldError[];
 }
 
-const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => ({
+const mapStateToProps: MapState<StateProps, Props> = state => ({
   /** Profile */
+  profileLoading: state.__resources.profile.loading,
+  profileError: path(['read'], state.__resources.profile.error),
   linodes: state.__resources.linodes.entities,
   linodesError: path(['read'], state.__resources.linodes.error),
   domainsError: state.__resources.domains.error,

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -62,7 +62,7 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
   const { children } = props;
 
   return (
-    <PreferenceToggle
+    <PreferenceToggle<'light' | 'dark'>
       preferenceKey="theme"
       preferenceOptions={['light', 'dark']}
       toggleCallbackFn={toggleTheme}
@@ -73,7 +73,7 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
         preference: themeChoice,
         togglePreference: _toggleTheme
       }: ToggleProps<ThemeChoice>) => (
-        <PreferenceToggle
+        <PreferenceToggle<'normal' | 'compact'>
           preferenceKey="spacing"
           preferenceOptions={['normal', 'compact']}
           toggleCallbackFn={toggleSpacing}

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -1,88 +1,233 @@
+import { path } from 'ramda';
 import * as React from 'react';
+import { compose } from 'recompose';
 import { ThemeProvider } from 'src/components/core/styles';
 import { dark, light } from 'src/themes';
-import {
-  Spacing,
-  spacing as spacingStorage,
-  theme as themeStorage
-} from 'src/utilities/storage';
 
-interface State {
-  themeChoice: 'light' | 'dark';
-  spacing: Spacing;
-}
+import { COMPACT_SPACING_UNIT, NORMAL_SPACING_UNIT } from 'src/themeFactory';
+
+import withProfile, {
+  ProfileActionsProps
+} from 'src/containers/profile.container';
+
+type ThemeChoice = 'light' | 'dark';
+type SpacingChoice = 'compact' | 'normal';
+
 type RenderChildren = (
   toggle: () => void,
   spacing: () => void
 ) => React.ReactNode;
+
 interface Props {
   children: RenderChildren | React.ReactNode;
 }
 
 const themes = { light, dark };
 
-class LinodeThemeWrapper extends React.Component<Props, State> {
-  state: State = {
-    themeChoice: 'light',
-    spacing: 'normal'
-  };
+type CombinedProps = Props & ProfileProps & ProfileActionsProps;
 
-  componentDidUpdate() {
+const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
+  const [theme, setTheme] = React.useState<ThemeChoice | undefined>(undefined);
+  const [spacing, setSpacing] = React.useState<SpacingChoice | undefined>(
+    undefined
+  );
+  const [lastUpdated, setLastUpdated] = React.useState<number>(0);
+
+  React.useEffect(() => {
     setTimeout(() => {
       document.body.classList.remove('no-transition');
     }, 500);
-  }
+  });
 
-  componentDidMount() {
-    const themeSetting = themeStorage.get();
-    const spacingSetting = spacingStorage.get();
+  React.useEffect(() => {
+    const debouncedErrorUpdate = setTimeout(() => {
+      /**
+       * we have a profile error, so first GET the preferences
+       * before trying to update them.
+       *
+       * Don't update anything if the GET fails
+       */
+      if (!!props.profileError) {
+        props
+          .getProfile()
+          .then(response => {
+            props.updateProfile({
+              preferences: {
+                ...response.preferences,
+                theme,
+                spacing
+              }
+            });
+          })
+          .catch(() => /** swallow the error */ null);
+      } else {
+        /** only PUT if our preferences are not equal to the spacing and
+         * theme in local state. This might be the case if the user is toggling between
+         * the theme very quickly
+         *
+         * or if the app first loaded and the preferences and local state are equal
+         */
+        if (
+          !!props.preferences &&
+          theme &&
+          spacing
+          // && preferencesHaveBeenUpdated(props.preferences, theme, spacing)
+        ) {
+          props.updateProfile({
+            preferences: {
+              ...props.preferences,
+              theme,
+              spacing
+            }
+          });
+        }
+      }
+    }, 750);
 
-    return this.setState({
-      themeChoice: themeSetting,
-      spacing: spacingSetting
-    });
-  }
+    return () => clearTimeout(debouncedErrorUpdate);
+  }, [theme, spacing]);
 
-  toggleTheme = () => {
+  React.useEffect(() => {
+    /**
+     * This useEffect is strictly for when the app first loads
+     * whether we have a profile error or profile data
+     */
+
+    /**
+     * if for whatever reason we failed to get the preferences data
+     * just fallback to some defaults.
+     *
+     * Do NOT try and PUT to the API - we don't want to overwrite other unrelated preferences
+     */
+    if (!!props.profileError && lastUpdated === 0) {
+      setSpacing('normal');
+      setTheme('light');
+
+      setLastUpdated(Date.now());
+    }
+
+    /**
+     * In the case of when we successfully retrieved preferences for the FIRST time,
+     * set the state to what we got from the server. If the preference
+     * doesn't exist yet in this user's payload, set defaults in local state.
+     */
+    if (!!props.preferences && lastUpdated === 0) {
+      const themeFromAPI = path<ThemeChoice>(['theme'], props.preferences);
+      const spacingFromAPI = path<SpacingChoice>(
+        ['spacing'],
+        props.preferences
+      );
+
+      /** this is the first time the user is setting the user preference */
+      if (!themeFromAPI) {
+        setTheme('light');
+      } else {
+        setTheme(themeFromAPI);
+      }
+
+      /** this is the first time the user is setting the user preference */
+      if (!spacingFromAPI) {
+        setSpacing('normal');
+      } else {
+        setSpacing(spacingFromAPI);
+      }
+
+      /** set local state so we don't repeat any of this previous behavior */
+      setLastUpdated(Date.now());
+    }
+  }, [props.profileError, props.preferences]);
+
+  const toggleTheme = () => {
     document.body.classList.add('no-transition');
-    if (this.state.themeChoice === 'light') {
-      this.setState({ themeChoice: 'dark' });
-      themeStorage.set('dark');
+    if (theme === 'light') {
+      setTheme('dark');
     } else {
-      this.setState({ themeChoice: 'light' });
-      themeStorage.set('light');
+      setTheme('light');
     }
   };
 
-  toggleSpacing = () => {
-    const { spacing } = this.state;
+  const toggleSpacing = () => {
     if (spacing === 'compact') {
-      spacingStorage.set('normal');
-      this.setState({ spacing: 'normal' });
+      setSpacing('normal');
     } else {
-      spacingStorage.set('compact');
-      this.setState({ spacing: 'compact' });
+      setSpacing('compact');
     }
   };
 
-  render() {
-    const { children } = this.props;
-    const { themeChoice } = this.state;
-    const theme = themes[themeChoice];
+  React.useEffect(() => {
+    /** request the profile on app load */
+    props.getProfile();
+  }, []);
 
-    return (
-      <ThemeProvider theme={theme()}>
-        {isRenderChildren(children)
-          ? children(this.toggleTheme, this.toggleSpacing)
-          : children}
-      </ThemeProvider>
-    );
+  const { children } = props;
+
+  if (!theme || !spacing) {
+    return null;
   }
-}
+
+  const themeChoice = themes[theme];
+
+  const spacingUnit =
+    spacing === 'compact' ? COMPACT_SPACING_UNIT : NORMAL_SPACING_UNIT;
+
+  return (
+    <ThemeProvider
+      theme={themeChoice({
+        spacingOverride: spacingUnit
+      })}
+    >
+      {isRenderChildren(children)
+        ? children(toggleTheme, toggleSpacing)
+        : children}
+    </ThemeProvider>
+  );
+};
 const isRenderChildren = (
   c: RenderChildren | React.ReactNode
 ): c is RenderChildren => {
   return typeof c === 'function';
 };
 
-export default LinodeThemeWrapper;
+interface ProfileProps {
+  preferences?: Record<string, any>;
+  profileError?: any;
+  preferencesLastUpdated: number;
+}
+
+const memoized = (component: React.FC<CombinedProps>) =>
+  React.memo(component, (prevProps, nextProps) => {
+    /**
+     * only prevent rendering if the preferences AND profileError
+     * went from being defined to defined or vise versa.
+     *
+     * we don't care to re-render if the preferences have been updated in Redux
+     * state. All the relevant preference state will be handled in the component.
+     * This component only cares about what the preferences are on app load.
+     */
+    return (
+      !(!prevProps.preferences && !!nextProps.preferences) &&
+      !(!!prevProps.preferences && !nextProps.preferences) &&
+      !(!prevProps.profileError && !!nextProps.profileError) &&
+      !(!!prevProps.profileError && !nextProps.profileError) &&
+      /** we only care what the server tells us on app load */
+      !(
+        prevProps.preferencesLastUpdated === 0 &&
+        nextProps.preferencesLastUpdated !== 0
+      )
+    );
+  });
+
+export default compose<CombinedProps, Props>(
+  withProfile<ProfileProps, Props>((ownProps, profile) => ({
+    preferences: path(['preferences'], profile.data),
+    profileError: profile.error,
+    preferencesLastUpdated: profile.lastUpdated
+  })),
+  memoized
+)(LinodeThemeWrapper);
+
+// const preferencesHaveBeenUpdated =
+//   (preferences: Record<string, any>, theme: ThemeChoice, spacing: SpacingChoice) => {
+//     return path(['theme'], preferences) !== theme
+//       || path(['spacing'], preferences) !== spacing
+//   }

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -51,7 +51,12 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
 
   React.useEffect(() => {
     /** request the user preferences on app load */
-    props.getUserPreferences();
+    props
+      .getUserPreferences()
+      .catch(
+        () =>
+          /** swallow the error. PreferenceToggle.tsx handles failures gracefully */ null
+      );
   }, []);
 
   const { children } = props;
@@ -80,7 +85,7 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
             togglePreference: _toggleSpacing
           }: ToggleProps<SpacingChoice>) => (
             <ThemeProvider
-              theme={themes[themeChoice]({
+              theme={safelyGetTheme(themes, themeChoice)({
                 spacingOverride:
                   spacingChoice === 'compact'
                     ? COMPACT_SPACING_UNIT
@@ -96,6 +101,19 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
       )}
     </PreferenceToggle>
   );
+};
+
+/** safely return light theme if the theme choice isn't "light" or "dark" */
+const safelyGetTheme = (
+  themesToChoose: Record<'dark' | 'light', any>,
+  themeChoice: string
+) => {
+  /* tslint:disable */
+  return !!Object.keys(themesToChoose).some(
+    eachTheme => eachTheme === themeChoice
+  )
+    ? themesToChoose[themeChoice]
+    : themesToChoose['light'];
 };
 
 export default compose<CombinedProps, Props>(withPreferences())(

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -1,10 +1,11 @@
-import { equals, path } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import { ThemeProvider } from 'src/components/core/styles';
 import { dark, light } from 'src/themes';
 
 import { COMPACT_SPACING_UNIT, NORMAL_SPACING_UNIT } from 'src/themeFactory';
+
+import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
 
 import withPreferences, {
   PreferencesActionsProps
@@ -30,132 +31,22 @@ interface Props {
 
 const themes = { light, dark };
 
-type CombinedProps = Props & PreferenceProps & PreferencesActionsProps;
+type CombinedProps = Props & PreferencesActionsProps;
 
 const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
-  const [theme, setTheme] = React.useState<ThemeChoice | undefined>(
-    props.theme
-  );
-  const [spacing, setSpacing] = React.useState<SpacingChoice | undefined>(
-    props.spacing
-  );
-  const [lastUpdated, setLastUpdated] = React.useState<number>(0);
-
   React.useEffect(() => {
     setTimeout(() => {
       document.body.classList.remove('no-transition');
     }, 500);
   });
 
-  React.useEffect(() => {
-    const debouncedErrorUpdate = setTimeout(() => {
-      /**
-       * we have a profile error, so first GET the preferences
-       * before trying to update them.
-       *
-       * Don't update anything if the GET fails
-       */
-      if (!!props.preferenceError) {
-        props
-          .getUserPreferences()
-          .then(response => {
-            props.updateUserPreferences({
-              ...response.preferences,
-              theme,
-              spacing
-            });
-          })
-          .catch(() => /** swallow the error */ null);
-      } else {
-        /** only PUT if our preferences are not equal to the spacing and
-         * theme in local state. This might be the case if the user is toggling between
-         * the theme very quickly
-         *
-         * or if the app first loaded and the preferences and local state are equal
-         */
-        if (
-          !!props.preferences &&
-          theme &&
-          spacing
-          // && preferencesHaveBeenUpdated(props.preferences, theme, spacing)
-        ) {
-          props.updateUserPreferences({
-            ...props.preferences,
-            theme,
-            spacing
-          });
-        }
-      }
-    }, 750);
-
-    return () => clearTimeout(debouncedErrorUpdate);
-  }, [theme, spacing]);
-
-  React.useEffect(() => {
-    /**
-     * This useEffect is strictly for when the app first loads
-     * whether we have a profile error or profile data
-     */
-
-    /**
-     * if for whatever reason we failed to get the preferences data
-     * just fallback to some defaults.
-     *
-     * Do NOT try and PUT to the API - we don't want to overwrite other unrelated preferences
-     */
-    if (!!props.preferenceError && lastUpdated === 0) {
-      setSpacing('normal');
-      setTheme('light');
-
-      setLastUpdated(Date.now());
-    }
-
-    /**
-     * In the case of when we successfully retrieved preferences for the FIRST time,
-     * set the state to what we got from the server. If the preference
-     * doesn't exist yet in this user's payload, set defaults in local state.
-     */
-    if (!!props.preferences && lastUpdated === 0) {
-      const themeFromAPI = path<ThemeChoice>(['theme'], props.preferences);
-      const spacingFromAPI = path<SpacingChoice>(
-        ['spacing'],
-        props.preferences
-      );
-
-      /** this is the first time the user is setting the user preference */
-      if (!themeFromAPI) {
-        setTheme('light');
-      } else {
-        setTheme(themeFromAPI);
-      }
-
-      /** this is the first time the user is setting the user preference */
-      if (!spacingFromAPI) {
-        setSpacing('normal');
-      } else {
-        setSpacing(spacingFromAPI);
-      }
-
-      /** set local state so we don't repeat any of this previous behavior */
-      setLastUpdated(Date.now());
-    }
-  }, [props.preferenceError, props.preferences]);
-
   const toggleTheme = () => {
     document.body.classList.add('no-transition');
-    if (theme === 'light') {
-      setTheme('dark');
-    } else {
-      setTheme('light');
-    }
+    /** @todo send to GA */
   };
 
   const toggleSpacing = () => {
-    if (spacing === 'compact') {
-      setSpacing('normal');
-    } else {
-      setSpacing('compact');
-    }
+    /** @todo send to GA */
   };
 
   React.useEffect(() => {
@@ -165,76 +56,48 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
 
   const { children } = props;
 
-  if (!theme || !spacing) {
-    return null;
-  }
-
-  const themeChoice = themes[theme];
-
-  const spacingUnit =
-    spacing === 'compact' ? COMPACT_SPACING_UNIT : NORMAL_SPACING_UNIT;
-
   return (
-    <ThemeProvider
-      theme={themeChoice({
-        spacingOverride: spacingUnit
-      })}
+    <PreferenceToggle
+      preferenceKey="theme"
+      preferenceOptions={['light', 'dark']}
+      toggleCallbackFn={toggleTheme}
+      /** purely for unit test purposes */
+      value={props.theme}
     >
-      {isRenderChildren(children)
-        ? children(toggleTheme, toggleSpacing)
-        : children}
-    </ThemeProvider>
+      {({
+        preference: themeChoice,
+        togglePreference: _toggleTheme
+      }: ToggleProps<ThemeChoice>) => (
+        <PreferenceToggle
+          preferenceKey="spacing"
+          preferenceOptions={['normal', 'compact']}
+          toggleCallbackFn={toggleSpacing}
+          /** purely for unit test purposes */
+          value={props.spacing}
+        >
+          {({
+            preference: spacingChoice,
+            togglePreference: _toggleSpacing
+          }: ToggleProps<SpacingChoice>) => (
+            <ThemeProvider
+              theme={themes[themeChoice]({
+                spacingOverride:
+                  spacingChoice === 'compact'
+                    ? COMPACT_SPACING_UNIT
+                    : NORMAL_SPACING_UNIT
+              })}
+            >
+              {typeof children === 'function'
+                ? (children as RenderChildren)(_toggleTheme, _toggleSpacing)
+                : children}
+            </ThemeProvider>
+          )}
+        </PreferenceToggle>
+      )}
+    </PreferenceToggle>
   );
 };
-const isRenderChildren = (
-  c: RenderChildren | React.ReactNode
-): c is RenderChildren => {
-  return typeof c === 'function';
-};
 
-interface PreferenceProps {
-  preferences?: Record<string, any>;
-  preferenceError?: any;
-  preferencesLastUpdated: number;
-}
-
-const memoized = (component: React.FC<CombinedProps>) =>
-  React.memo(component, (prevProps, nextProps) => {
-    /**
-     * only prevent rendering if the preferences AND profileError
-     * went from being defined to defined or vise versa.
-     *
-     * we don't care to re-render if the preferences have been updated in Redux
-     * state. All the relevant preference state will be handled in the component.
-     * This component only cares about what the preferences are on app load.
-     */
-    return (
-      !(!prevProps.preferences && !!nextProps.preferences) &&
-      !(!!prevProps.preferences && !nextProps.preferences) &&
-      !(!prevProps.preferenceError && !!nextProps.preferenceError) &&
-      !(!!prevProps.preferenceError && !nextProps.preferenceError) &&
-      equals(prevProps.children, nextProps.children) &&
-      /** we only care what the server tells us on app load */
-      !(
-        prevProps.preferencesLastUpdated === 0 &&
-        nextProps.preferencesLastUpdated !== 0
-      )
-    );
-  });
-
-export default compose<CombinedProps, Props>(
-  withPreferences<PreferenceProps, Props>(
-    (ownProps, { data: preferences, error, lastUpdated }) => ({
-      preferences,
-      preferenceError: error,
-      preferencesLastUpdated: lastUpdated
-    })
-  ),
-  memoized
-)(LinodeThemeWrapper);
-
-// const preferencesHaveBeenUpdated =
-//   (preferences: Record<string, any>, theme: ThemeChoice, spacing: SpacingChoice) => {
-//     return path(['theme'], preferences) !== theme
-//       || path(['spacing'], preferences) !== spacing
-//   }
+export default compose<CombinedProps, Props>(withPreferences())(
+  LinodeThemeWrapper
+);

--- a/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
+++ b/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
@@ -12,7 +12,8 @@ const mockState = {
   __resources: {
     notifications: {
       data: [abuseTicketNotification, mockNotification]
-    }
+    },
+    profile: {}
   }
 };
 

--- a/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
+++ b/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
 import { cleanup, render } from 'react-testing-library';
 
-import { abuseTicketNotification } from 'src/__data__/notifications';
+import {
+  abuseTicketNotification,
+  mockNotification
+} from 'src/__data__/notifications';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 import { AbuseTicketBanner } from './AbuseTicketBanner';
+
+import filterAbuseTickets from 'src/store/selectors/getAbuseTicket';
 
 afterEach(cleanup);
 
@@ -44,5 +49,16 @@ describe('Abuse ticket banner', () => {
     );
 
     expect(queryByTestId('abuse-ticket-link')).toBeNull();
+  });
+
+  describe('integration tests', () => {
+    it('should filter out abuse ticket notifications from the store', () => {
+      const tickets = filterAbuseTickets({
+        notifications: {
+          data: [mockNotification, abuseTicketNotification]
+        }
+      } as any);
+      expect(tickets[0].label).toMatch(/abuse/);
+    });
   });
 });

--- a/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
+++ b/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
@@ -1,31 +1,9 @@
 import * as React from 'react';
 import { cleanup, render } from 'react-testing-library';
 
-import {
-  abuseTicketNotification,
-  mockNotification
-} from 'src/__data__/notifications';
+import { abuseTicketNotification } from 'src/__data__/notifications';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
-import Component, { AbuseTicketBanner } from './AbuseTicketBanner';
-
-const mockState = {
-  __resources: {
-    notifications: {
-      data: [abuseTicketNotification, mockNotification]
-    }
-  },
-  preferences: {
-    data: undefined
-  }
-};
-
-jest.mock('src/store', () => ({
-  default: {
-    getState: () => mockState,
-    subscribe: () => jest.fn(),
-    dispatch: () => jest.fn()
-  }
-}));
+import { AbuseTicketBanner } from './AbuseTicketBanner';
 
 afterEach(cleanup);
 
@@ -66,12 +44,5 @@ describe('Abuse ticket banner', () => {
     );
 
     expect(queryByTestId('abuse-ticket-link')).toBeNull();
-  });
-
-  describe('integration tests', () => {
-    it('should filter out abuse ticket notifications from the store', () => {
-      const { queryAllByText } = render(wrapWithTheme(<Component />));
-      expect(queryAllByText(/abuse/)).toHaveLength(1);
-    });
   });
 });

--- a/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
+++ b/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
@@ -12,8 +12,10 @@ const mockState = {
   __resources: {
     notifications: {
       data: [abuseTicketNotification, mockNotification]
-    },
-    profile: {}
+    }
+  },
+  preferences: {
+    data: undefined
   }
 };
 

--- a/src/components/PaginationControls/PaginationControls.test.tsx
+++ b/src/components/PaginationControls/PaginationControls.test.tsx
@@ -5,6 +5,9 @@ import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 
 import PaginationControls from './PaginationControls';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 const getPreviousPageButton = (wrapper: ReactWrapper) =>
   wrapper.find(`WithStyles(PageButton)[data-qa-page-previous]`);
 const getNextPageButton = (wrapper: ReactWrapper) =>
@@ -15,14 +18,16 @@ const getNumberPageButton = (page: string, wrapper: ReactWrapper) =>
 describe('PaginationControls', () => {
   it('should have a previous page button.', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={1}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={1}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
     const previous = getPreviousPageButton(wrapper);
     expect(previous).toHaveLength(1);
@@ -30,14 +35,16 @@ describe('PaginationControls', () => {
 
   it('should have a next page button.', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={1}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={1}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
     const next = getNextPageButton(wrapper);
     expect(next).toHaveLength(1);
@@ -45,14 +52,16 @@ describe('PaginationControls', () => {
 
   it('previous page button should be disabled when on first page', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={1}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={1}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
     const previous = getPreviousPageButton(wrapper);
     expect(previous.prop('disabled')).toBeTruthy();
@@ -60,14 +69,16 @@ describe('PaginationControls', () => {
 
   it('next page button should be disabled when on last page', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={4}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={4}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     const next = getNextPageButton(wrapper);
@@ -76,14 +87,16 @@ describe('PaginationControls', () => {
 
   it('should render a button for each page', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={1}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={1}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     expect(getNumberPageButton('1', wrapper)).toHaveLength(1);
@@ -94,14 +107,16 @@ describe('PaginationControls', () => {
 
   it('should render a button for each page', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={2}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={2}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     expect(getNumberPageButton('2', wrapper).prop('disabled')).toBeTruthy();

--- a/src/components/PreferenceToggle/PreferenceToggle.tsx
+++ b/src/components/PreferenceToggle/PreferenceToggle.tsx
@@ -1,0 +1,218 @@
+import { equals, path } from 'ramda';
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import withPreferences, {
+  PreferencesActionsProps
+} from 'src/containers/preferences.container';
+
+type PreferenceValue = boolean | string | number;
+
+export interface ToggleProps<T> {
+  preference: T;
+  togglePreference: () => T;
+}
+
+interface RenderChildrenProps {
+  preference: PreferenceValue;
+  togglePreference: () => PreferenceValue;
+}
+
+type RenderChildren = (props: RenderChildrenProps) => JSX.Element;
+
+interface Props {
+  preferenceKey: string;
+  preferenceOptions: [PreferenceValue, PreferenceValue];
+  value?: PreferenceValue;
+  toggleCallbackFn?: (value: PreferenceValue) => void;
+  children: RenderChildren;
+}
+
+type CombinedProps = Props & PreferenceProps & PreferencesActionsProps;
+
+const PreferenceToggle: React.FC<CombinedProps> = props => {
+  const {
+    value,
+    preferenceError,
+    preferenceKey,
+    preferenceOptions,
+    toggleCallbackFn,
+    children,
+    preferences
+  } = props;
+
+  React.useEffect(() => {
+    /** make sure out overridden value appears int the list of options to toggle */
+    if (
+      !!value &&
+      !preferenceOptions.find(eachOption => eachOption === value)
+    ) {
+      throw new Error(
+        'Preference Toggle: The passed "value" prop must appear in the list of options'
+      );
+    }
+  }, []);
+
+  /** will be undefined and render-block children unless otherwise specified */
+  const [currentlySetPreference, setPreference] = React.useState<
+    PreferenceValue | undefined
+  >(value);
+  const [lastUpdated, setLastUpdated] = React.useState<number>(0);
+
+  React.useEffect(() => {
+    /**
+     * This useEffect is strictly for when the app first loads
+     * whether we have a preference error or preference data
+     */
+
+    /**
+     * if for whatever reason we failed to get the preferences data
+     * just fallback to some defaults (the first in the list of options).
+     *
+     * Do NOT try and PUT to the API - we don't want to overwrite other unrelated preferences
+     */
+    if (
+      !currentlySetPreference &&
+      !!props.preferenceError &&
+      lastUpdated === 0
+    ) {
+      setPreference(preferenceOptions[0]);
+
+      setLastUpdated(Date.now());
+    }
+
+    /**
+     * In the case of when we successfully retrieved preferences for the FIRST time,
+     * set the state to what we got from the server. If the preference
+     * doesn't exist yet in this user's payload, set defaults in local state.
+     */
+    if (!currentlySetPreference && !!props.preferences && lastUpdated === 0) {
+      const preferenceFromAPI = path<PreferenceValue>(
+        [preferenceKey],
+        props.preferences
+      );
+
+      /** this is the first time the user is setting the user preference */
+      const preferenceToSet = !preferenceFromAPI
+        ? preferenceOptions[0]
+        : preferenceFromAPI;
+
+      setPreference(preferenceToSet);
+
+      /** set local state so we don't repeat any of this previous behavior */
+      setLastUpdated(Date.now());
+    }
+  }, [props.preferenceError, props.preferences]);
+
+  React.useEffect(() => {
+    const debouncedErrorUpdate = setTimeout(() => {
+      /**
+       * we have a preference error, so first GET the preferences
+       * before trying to PUT them.
+       *
+       * Don't update anything if the GET fails
+       */
+      if (!!preferenceError) {
+        props
+          .getUserPreferences()
+          .then(response => {
+            props.updateUserPreferences({
+              ...response.preferences,
+              [preferenceKey]: currentlySetPreference
+            });
+          })
+          .catch(() => /** swallow the error */ null);
+      } else {
+        /**
+         * PUT to /preferences on every toggle, debounced.
+         */
+        if (
+          !!preferences &&
+          currentlySetPreference
+          // && preferencesHaveBeenUpdated(props.preferences, theme, spacing)
+        ) {
+          props.updateUserPreferences({
+            ...props.preferences,
+            [preferenceKey]: currentlySetPreference
+          });
+        }
+      }
+    }, 750);
+
+    return () => clearTimeout(debouncedErrorUpdate);
+  }, [currentlySetPreference]);
+
+  const togglePreference = () => {
+    /** first set local state to the opposite option */
+    const newPreferenceToSet =
+      currentlySetPreference === preferenceOptions[0]
+        ? preferenceOptions[1]
+        : preferenceOptions[0];
+
+    /** set the preference in local state */
+    setPreference(newPreferenceToSet);
+
+    /** invoke our callback prop if we have one */
+    if (toggleCallbackFn) {
+      toggleCallbackFn(newPreferenceToSet);
+    }
+
+    return newPreferenceToSet;
+  };
+
+  /**
+   * render-block the children. We can prevent
+   * render-blocking by passing a default value as a prop
+   *
+   * So if you want to handle local state outside of this component,
+   * you can do so and pass the value explicitly with the _value_ prop
+   */
+  if (!currentlySetPreference) {
+    return null;
+  }
+
+  return typeof children === 'function'
+    ? children({ preference: currentlySetPreference, togglePreference })
+    : null;
+};
+
+interface PreferenceProps {
+  preferences?: Record<string, any>;
+  preferenceError?: any;
+  preferencesLastUpdated: number;
+}
+
+const memoized = (component: React.FC<CombinedProps>) =>
+  React.memo(component, (prevProps, nextProps) => {
+    /**
+     * only prevent rendering if the preferences AND profileError
+     * went from being defined to defined or vise versa.
+     *
+     * we don't care to re-render if the preferences have been updated in Redux
+     * state. All the relevant preference state will be handled in the component.
+     * This component only cares about what the preferences are on app load.
+     */
+    return (
+      !(!prevProps.preferences && !!nextProps.preferences) &&
+      !(!!prevProps.preferences && !nextProps.preferences) &&
+      !(!prevProps.preferenceError && !!nextProps.preferenceError) &&
+      !(!!prevProps.preferenceError && !nextProps.preferenceError) &&
+      equals(prevProps.children, nextProps.children) &&
+      /** we only care what the server tells us on app load */
+      !(
+        prevProps.preferencesLastUpdated === 0 &&
+        nextProps.preferencesLastUpdated !== 0
+      )
+    );
+  });
+
+export default compose<CombinedProps, Props>(
+  withPreferences<PreferenceProps, Props>(
+    (ownProps, { data: preferences, error, lastUpdated }) => ({
+      preferences,
+      preferenceError: error,
+      preferencesLastUpdated: lastUpdated
+    })
+  ),
+  memoized
+)(PreferenceToggle as React.FC<CombinedProps>);

--- a/src/components/PreferenceToggle/PreferenceToggle.tsx
+++ b/src/components/PreferenceToggle/PreferenceToggle.tsx
@@ -20,15 +20,17 @@ interface RenderChildrenProps {
 
 type RenderChildren = (props: RenderChildrenProps) => JSX.Element;
 
-interface Props {
+interface Props<T = PreferenceValue> {
   preferenceKey: string;
-  preferenceOptions: [PreferenceValue, PreferenceValue];
-  value?: PreferenceValue;
+  preferenceOptions: [T, T];
+  value?: T;
   toggleCallbackFn?: (value: PreferenceValue) => void;
   children: RenderChildren;
 }
 
-type CombinedProps = Props & PreferenceProps & PreferencesActionsProps;
+type CombinedProps<T = PreferenceValue> = Props<T> &
+  PreferenceProps &
+  PreferencesActionsProps;
 
 const PreferenceToggle: React.FC<CombinedProps> = props => {
   const {
@@ -46,18 +48,6 @@ const PreferenceToggle: React.FC<CombinedProps> = props => {
     PreferenceValue | undefined
   >(value);
   const [lastUpdated, setLastUpdated] = React.useState<number>(0);
-
-  React.useEffect(() => {
-    /** make sure out overridden value appears int the list of options to toggle */
-    if (
-      !!value &&
-      !preferenceOptions.find(eachOption => eachOption === value)
-    ) {
-      throw new Error(
-        'Preference Toggle: The passed "value" prop must appear in the list of options'
-      );
-    }
-  }, [value]);
 
   React.useEffect(() => {
     /**
@@ -235,7 +225,7 @@ const isUpdatingForTheFirstTime = (
   return prevLastUpdated === 0 && nextLastUpdated !== 0;
 };
 
-export default compose<CombinedProps, Props>(
+export default (compose<CombinedProps, Props>(
   withPreferences<PreferenceProps, Props>(
     (ownProps, { data: preferences, error, lastUpdated }) => ({
       preferences,
@@ -244,4 +234,4 @@ export default compose<CombinedProps, Props>(
     })
   ),
   memoized
-)(PreferenceToggle as React.FC<CombinedProps>);
+)(PreferenceToggle) as unknown) as <T>(props: Props<T>) => React.ReactElement;

--- a/src/components/PreferenceToggle/index.ts
+++ b/src/components/PreferenceToggle/index.ts
@@ -1,0 +1,6 @@
+import { ToggleProps as _ToggleProps } from './PreferenceToggle';
+
+/* tslint:disable */
+export interface ToggleProps<T> extends _ToggleProps<T> {}
+
+export { default } from './PreferenceToggle';

--- a/src/components/PrimaryNav/ThemeToggle.test.tsx
+++ b/src/components/PrimaryNav/ThemeToggle.test.tsx
@@ -15,7 +15,7 @@ describe('ThemeToggle', () => {
       <ThemeToggle
         toggleTheme={jest.fn()}
         classes={mockClasses}
-        theme={light()}
+        theme={light({ spacingOverride: 4 })}
       />
     );
   });

--- a/src/containers/preferences.container.ts
+++ b/src/containers/preferences.container.ts
@@ -17,11 +17,14 @@ export interface PreferencesActionsProps {
 }
 
 export default <TInner extends {}, TOuter extends {}>(
-  mapAccountToProps: (ownProps: TOuter, profile: State) => TInner
+  mapAccountToProps?: (ownProps: TOuter, profile: State) => TInner
 ) =>
   connect(
     (state: ApplicationState, ownProps: TOuter) => {
-      return mapAccountToProps(ownProps, state.preferences);
+      if (mapAccountToProps) {
+        return mapAccountToProps(ownProps, state.preferences);
+      }
+      return undefined;
     },
     (dispatch: ThunkDispatch) => ({
       getUserPreferences: () => dispatch(getUserPreferences()),

--- a/src/containers/preferences.container.ts
+++ b/src/containers/preferences.container.ts
@@ -1,0 +1,31 @@
+import { connect } from 'react-redux';
+import { ApplicationState } from 'src/store';
+
+import { State } from 'src/store/preferences/preferences.reducer';
+import {
+  getUserPreferences,
+  updateUserPreferences
+} from 'src/store/preferences/preferences.requests';
+
+import { ThunkDispatch } from 'src/store/types';
+
+export interface PreferencesActionsProps {
+  getUserPreferences: () => Promise<Record<string, any>>;
+  updateUserPreferences: (
+    params: Record<string, any>
+  ) => Promise<Record<string, any>>;
+}
+
+export default <TInner extends {}, TOuter extends {}>(
+  mapAccountToProps: (ownProps: TOuter, profile: State) => TInner
+) =>
+  connect(
+    (state: ApplicationState, ownProps: TOuter) => {
+      return mapAccountToProps(ownProps, state.preferences);
+    },
+    (dispatch: ThunkDispatch) => ({
+      getUserPreferences: () => dispatch(getUserPreferences()),
+      updateUserPreferences: (payload: Partial<Linode.Profile>) =>
+        dispatch(updateUserPreferences(payload))
+    })
+  );

--- a/src/containers/preferences.container.ts
+++ b/src/containers/preferences.container.ts
@@ -24,7 +24,7 @@ export default <TInner extends {}, TOuter extends {}>(
       if (mapAccountToProps) {
         return mapAccountToProps(ownProps, state.preferences);
       }
-      return undefined;
+      return {};
     },
     (dispatch: ThunkDispatch) => ({
       getUserPreferences: () => dispatch(getUserPreferences()),

--- a/src/containers/profile.container.ts
+++ b/src/containers/profile.container.ts
@@ -1,11 +1,32 @@
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 import { State } from 'src/store/profile/profile.reducer';
+import {
+  requestProfile,
+  updateProfile
+} from 'src/store/profile/profile.requests';
+
+import { ThunkDispatch } from 'src/store/types';
+
+export interface ProfileActionsProps {
+  getProfile: () => Promise<ProfileWithPreferences>;
+  updateProfile: (
+    params: Partial<ProfileWithPreferences>
+  ) => Promise<ProfileWithPreferences>;
+}
 
 export default <TInner extends {}, TOuter extends {}>(
   mapAccountToProps: (ownProps: TOuter, profile: State) => TInner
 ) =>
-  connect((state: ApplicationState, ownProps: TOuter) => {
-    return mapAccountToProps(ownProps, state.__resources.profile);
-  });
+  connect(
+    (state: ApplicationState, ownProps: TOuter) => {
+      return mapAccountToProps(ownProps, state.__resources.profile);
+    },
+    (dispatch: ThunkDispatch) => ({
+      getProfile: () => dispatch(requestProfile()),
+      updateProfile: (payload: Partial<ProfileWithPreferences>) =>
+        dispatch(updateProfile(payload))
+    })
+  );

--- a/src/containers/profile.container.ts
+++ b/src/containers/profile.container.ts
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 
-import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 import { State } from 'src/store/profile/profile.reducer';
 import {
   requestProfile,
@@ -11,10 +10,8 @@ import {
 import { ThunkDispatch } from 'src/store/types';
 
 export interface ProfileActionsProps {
-  getProfile: () => Promise<ProfileWithPreferences>;
-  updateProfile: (
-    params: Partial<ProfileWithPreferences>
-  ) => Promise<ProfileWithPreferences>;
+  getProfile: () => Promise<Linode.Profile>;
+  updateProfile: (params: Partial<Linode.Profile>) => Promise<Linode.Profile>;
 }
 
 export default <TInner extends {}, TOuter extends {}>(
@@ -26,7 +23,7 @@ export default <TInner extends {}, TOuter extends {}>(
     },
     (dispatch: ThunkDispatch) => ({
       getProfile: () => dispatch(requestProfile()),
-      updateProfile: (payload: Partial<ProfileWithPreferences>) =>
+      updateProfile: (payload: Partial<Linode.Profile>) =>
         dispatch(updateProfile(payload))
     })
   );

--- a/src/features/Dashboard/Dashboard.test.tsx
+++ b/src/features/Dashboard/Dashboard.test.tsx
@@ -17,7 +17,7 @@ const props = {
   backupError: undefined,
   entitiesWithGroupsToImport: { linodes: [], domains: [] },
   classes: { root: '' },
-  theme: light()
+  theme: light({ spacingOverride: 8 })
 };
 
 const component = shallow(<Dashboard {...props} />);

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.test.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.test.tsx
@@ -5,31 +5,36 @@ import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 import { NodeBalancersLanding } from './NodeBalancersLanding';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 describe.skip('NodeBalancers', () => {
   const component = mount(
     <StaticRouter context={{}}>
-      <LinodeThemeWrapper>
-        <NodeBalancersLanding
-          {...reactRouterProps}
-          groupByTag={false}
-          toggleGroupByTag={jest.fn()}
-          nodeBalancersLoading={false}
-          nodeBalancersError={undefined}
-          nodeBalancersData={[]}
-          nodeBalancersCount={0}
-          classes={{
-            root: '',
-            title: '',
-            nameCell: '',
-            icon: '',
-            nodeStatus: '',
-            transferred: '',
-            ports: '',
-            ip: '',
-            tagGroup: ''
-          }}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <NodeBalancersLanding
+            {...reactRouterProps}
+            groupByTag={false}
+            toggleGroupByTag={jest.fn()}
+            nodeBalancersLoading={false}
+            nodeBalancersError={undefined}
+            nodeBalancersData={[]}
+            nodeBalancersCount={0}
+            classes={{
+              root: '',
+              title: '',
+              nameCell: '',
+              icon: '',
+              nodeStatus: '',
+              transferred: '',
+              ports: '',
+              ip: '',
+              tagGroup: ''
+            }}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     </StaticRouter>
   );
 

--- a/src/features/Profile/DisplaySettings/EmailChangeForm.test.tsx
+++ b/src/features/Profile/DisplaySettings/EmailChangeForm.test.tsx
@@ -6,21 +6,26 @@ import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 
 import { EmailChangeForm } from './EmailChangeForm';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 describe('Email change form', () => {
   const updateProfile = jest.fn();
 
   const component = mount(
-    <LinodeThemeWrapper>
-      <EmailChangeForm
-        classes={{
-          root: '',
-          title: ''
-        }}
-        username="ThisUser"
-        email="thisuser@example.com"
-        updateProfile={updateProfile}
-      />
-    </LinodeThemeWrapper>
+    <Provider store={store}>
+      <LinodeThemeWrapper theme="dark" spacing="normal">
+        <EmailChangeForm
+          classes={{
+            root: '',
+            title: ''
+          }}
+          username="ThisUser"
+          email="thisuser@example.com"
+          updateProfile={updateProfile}
+        />
+      </LinodeThemeWrapper>
+    </Provider>
   );
 
   it('should render textfields for username and email.', () => {

--- a/src/features/TopMenu/AddNewMenu/AddNewMenuItem.test.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenuItem.test.tsx
@@ -6,34 +6,41 @@ import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 
 import AddNewMenuItem from './AddNewMenuItem';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 describe('AddNewMenuItem', () => {
   it('should render without error', () => {
     shallow(
-      <LinodeThemeWrapper>
-        <AddNewMenuItem
-          index={1}
-          count={1}
-          title="shenanigans"
-          body="These be the stories of shennanigans."
-          ItemIcon={LinodeIcon}
-          onClick={jest.fn()}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <AddNewMenuItem
+            index={1}
+            count={1}
+            title="shenanigans"
+            body="These be the stories of shennanigans."
+            ItemIcon={LinodeIcon}
+            onClick={jest.fn()}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
   });
 
   it('should not render a divider if not the last item', () => {
     const result = mount(
-      <LinodeThemeWrapper>
-        <AddNewMenuItem
-          index={0}
-          count={1}
-          title="shenanigans"
-          body="These be the stories of shennanigans."
-          ItemIcon={LinodeIcon}
-          onClick={jest.fn()}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <AddNewMenuItem
+            index={0}
+            count={1}
+            title="shenanigans"
+            body="These be the stories of shennanigans."
+            ItemIcon={LinodeIcon}
+            onClick={jest.fn()}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     expect(result.find('WithStyles(Divider)')).toHaveLength(0);

--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -7,6 +7,9 @@ import { types } from 'src/__data__/types';
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 import { LinodeResize, shouldEnableAutoResizeDiskOption } from './LinodeResize';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 describe('LinodeResize', () => {
   const mockTypes = types.map(LinodeResize.extendType);
 
@@ -32,27 +35,29 @@ describe('LinodeResize', () => {
 
   it('should render the currently selected plan as a card', () => {
     const componentWithTheme = mount(
-      <LinodeThemeWrapper>
-        <MemoryRouter>
-          <LinodeResize
-            linodeDisks={[]}
-            closeSnackbar={jest.fn()}
-            enqueueSnackbar={jest.fn()}
-            {...reactRouterProps}
-            classes={{
-              root: '',
-              title: '',
-              subTitle: '',
-              currentPlanContainer: ''
-            }}
-            linodeId={12}
-            linodeType={null}
-            currentTypesData={mockTypes}
-            deprecatedTypesData={mockTypes}
-            linodeLabel=""
-          />
-        </MemoryRouter>
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <MemoryRouter>
+            <LinodeResize
+              linodeDisks={[]}
+              closeSnackbar={jest.fn()}
+              enqueueSnackbar={jest.fn()}
+              {...reactRouterProps}
+              classes={{
+                root: '',
+                title: '',
+                subTitle: '',
+                currentPlanContainer: ''
+              }}
+              linodeId={12}
+              linodeType={null}
+              currentTypesData={mockTypes}
+              deprecatedTypesData={mockTypes}
+              linodeLabel=""
+            />
+          </MemoryRouter>
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     const currentSelectionCard = componentWithTheme.find(
@@ -67,28 +72,30 @@ describe('LinodeResize', () => {
     describe('current plan card', () => {
       it('should have a heading of No Assigned Plan', () => {
         const componentWithTheme = mount(
-          <LinodeThemeWrapper>
-            <MemoryRouter>
-              <LinodeResize
-                closeSnackbar={jest.fn()}
-                enqueueSnackbar={jest.fn()}
-                requestNotifications={jest.fn()}
-                linodeDisks={[]}
-                {...reactRouterProps}
-                classes={{
-                  root: '',
-                  title: '',
-                  subTitle: '',
-                  currentPlanContainer: ''
-                }}
-                linodeId={12}
-                linodeType={null}
-                currentTypesData={mockTypes}
-                deprecatedTypesData={mockTypes}
-                linodeLabel=""
-              />
-            </MemoryRouter>
-          </LinodeThemeWrapper>
+          <Provider store={store}>
+            <LinodeThemeWrapper theme="dark" spacing="normal">
+              <MemoryRouter>
+                <LinodeResize
+                  closeSnackbar={jest.fn()}
+                  enqueueSnackbar={jest.fn()}
+                  requestNotifications={jest.fn()}
+                  linodeDisks={[]}
+                  {...reactRouterProps}
+                  classes={{
+                    root: '',
+                    title: '',
+                    subTitle: '',
+                    currentPlanContainer: ''
+                  }}
+                  linodeId={12}
+                  linodeType={null}
+                  currentTypesData={mockTypes}
+                  deprecatedTypesData={mockTypes}
+                  linodeLabel=""
+                />
+              </MemoryRouter>
+            </LinodeThemeWrapper>
+          </Provider>
         );
 
         const currentSelectionCard = componentWithTheme.find(
@@ -105,27 +112,29 @@ describe('LinodeResize', () => {
     describe('current plan card', () => {
       it('should have a heading of Unknown Plan', () => {
         const componentWithTheme = mount(
-          <LinodeThemeWrapper>
-            <MemoryRouter>
-              <LinodeResize
-                closeSnackbar={jest.fn()}
-                linodeDisks={[]}
-                enqueueSnackbar={jest.fn()}
-                {...reactRouterProps}
-                classes={{
-                  root: '',
-                  title: '',
-                  subTitle: '',
-                  currentPlanContainer: ''
-                }}
-                linodeId={12}
-                linodeType={'_something_unexpected_'}
-                currentTypesData={mockTypes}
-                deprecatedTypesData={mockTypes}
-                linodeLabel=""
-              />
-            </MemoryRouter>
-          </LinodeThemeWrapper>
+          <Provider store={store}>
+            <LinodeThemeWrapper theme="dark" spacing="normal">
+              <MemoryRouter>
+                <LinodeResize
+                  closeSnackbar={jest.fn()}
+                  linodeDisks={[]}
+                  enqueueSnackbar={jest.fn()}
+                  {...reactRouterProps}
+                  classes={{
+                    root: '',
+                    title: '',
+                    subTitle: '',
+                    currentPlanContainer: ''
+                  }}
+                  linodeId={12}
+                  linodeType={'_something_unexpected_'}
+                  currentTypesData={mockTypes}
+                  deprecatedTypesData={mockTypes}
+                  linodeLabel=""
+                />
+              </MemoryRouter>
+            </LinodeThemeWrapper>
+          </Provider>
         );
 
         const currentSelectionCard = componentWithTheme.find(

--- a/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
@@ -38,7 +38,7 @@ describe('LinodeRow', () => {
   const mockProps: CombinedProps = {
     classes: mockClasses,
     toggleConfirmation: jest.fn(),
-    theme: light(),
+    theme: light({ spacingOverride: 4 }),
     maintenanceStartTime: '',
     someLinodesHaveMaintenance: false,
     recentEvent: undefined,

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
@@ -21,7 +21,7 @@ describe('LinodeRow', () => {
   const mockProps: CombinedProps = {
     classes: mockClasses,
     toggleConfirmation: jest.fn(),
-    theme: light(),
+    theme: light({ spacingOverride: 4 }),
     maintenanceStartTime: '',
     someLinodesHaveMaintenance: false,
     recentEvent: undefined,

--- a/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
@@ -5,6 +5,9 @@ import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 import { clearDocs, setDocs } from 'src/store/documentation';
 import { ListLinodes } from './LinodesLanding';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 const RoutedListLinodes = withRouter(ListLinodes);
 
 describe('ListLinodes', () => {
@@ -17,63 +20,67 @@ describe('ListLinodes', () => {
 
   it('renders without error', () => {
     shallow(
-      <LinodeThemeWrapper>
-        <StaticRouter location="/" context={{}}>
-          <RoutedListLinodes
-            imagesLoading={false}
-            imagesError={undefined}
-            userTimezone="GMT"
-            userTimezoneLoading={false}
-            someLinodesHaveScheduledMaintenance={true}
-            linodesData={[]}
-            width={'lg'}
-            classes={classes}
-            clearDocs={clearDocs}
-            enqueueSnackbar={jest.fn()}
-            groupByTags={false}
-            linodesCount={0}
-            linodesRequestError={undefined}
-            linodesRequestLoading={false}
-            managed={false}
-            closeSnackbar={jest.fn()}
-            setDocs={setDocs}
-            toggleGroupByTag={jest.fn()}
-            backupsCTA={false}
-            deleteLinode={jest.fn()}
-          />
-        </StaticRouter>
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <StaticRouter location="/" context={{}}>
+            <RoutedListLinodes
+              imagesLoading={false}
+              imagesError={undefined}
+              userTimezone="GMT"
+              userTimezoneLoading={false}
+              someLinodesHaveScheduledMaintenance={true}
+              linodesData={[]}
+              width={'lg'}
+              classes={classes}
+              clearDocs={clearDocs}
+              enqueueSnackbar={jest.fn()}
+              groupByTags={false}
+              linodesCount={0}
+              linodesRequestError={undefined}
+              linodesRequestLoading={false}
+              managed={false}
+              closeSnackbar={jest.fn()}
+              setDocs={setDocs}
+              toggleGroupByTag={jest.fn()}
+              backupsCTA={false}
+              deleteLinode={jest.fn()}
+            />
+          </StaticRouter>
+        </LinodeThemeWrapper>
+      </Provider>
     );
   });
 
   it.skip('renders an empty state with no linodes', () => {
     const component = shallow(
-      <LinodeThemeWrapper>
-        <StaticRouter location="/" context={{}}>
-          <RoutedListLinodes
-            imagesLoading={false}
-            imagesError={undefined}
-            linodesData={[]}
-            width={'lg'}
-            classes={classes}
-            clearDocs={clearDocs}
-            userTimezone="GMT"
-            userTimezoneLoading={false}
-            someLinodesHaveScheduledMaintenance={true}
-            enqueueSnackbar={jest.fn()}
-            groupByTags={false}
-            linodesCount={0}
-            linodesRequestError={undefined}
-            linodesRequestLoading={false}
-            managed={false}
-            closeSnackbar={jest.fn()}
-            setDocs={setDocs}
-            toggleGroupByTag={jest.fn()}
-            backupsCTA={false}
-            deleteLinode={jest.fn()}
-          />
-        </StaticRouter>
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <StaticRouter location="/" context={{}}>
+            <RoutedListLinodes
+              imagesLoading={false}
+              imagesError={undefined}
+              linodesData={[]}
+              width={'lg'}
+              classes={classes}
+              clearDocs={clearDocs}
+              userTimezone="GMT"
+              userTimezoneLoading={false}
+              someLinodesHaveScheduledMaintenance={true}
+              enqueueSnackbar={jest.fn()}
+              groupByTags={false}
+              linodesCount={0}
+              linodesRequestError={undefined}
+              linodesRequestLoading={false}
+              managed={false}
+              closeSnackbar={jest.fn()}
+              setDocs={setDocs}
+              toggleGroupByTag={jest.fn()}
+              backupsCTA={false}
+              deleteLinode={jest.fn()}
+            />
+          </StaticRouter>
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     const emptyState = component.find('ListLinodesEmptyState');
@@ -84,32 +91,34 @@ describe('ListLinodes', () => {
   /** Test is not specific to the LinodesLanding Page */
   it.skip('renders menu actions when the kabob is clicked', () => {
     const component = shallow(
-      <LinodeThemeWrapper>
-        <StaticRouter location="/" context={{}}>
-          <RoutedListLinodes
-            imagesLoading={false}
-            imagesError={undefined}
-            linodesData={[]}
-            width={'lg'}
-            userTimezone="GMT"
-            userTimezoneLoading={false}
-            someLinodesHaveScheduledMaintenance={true}
-            classes={classes}
-            clearDocs={clearDocs}
-            enqueueSnackbar={jest.fn()}
-            groupByTags={false}
-            linodesCount={0}
-            linodesRequestError={undefined}
-            linodesRequestLoading={false}
-            managed={false}
-            closeSnackbar={jest.fn()}
-            setDocs={setDocs}
-            toggleGroupByTag={jest.fn()}
-            backupsCTA={false}
-            deleteLinode={jest.fn()}
-          />
-        </StaticRouter>
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <StaticRouter location="/" context={{}}>
+            <RoutedListLinodes
+              imagesLoading={false}
+              imagesError={undefined}
+              linodesData={[]}
+              width={'lg'}
+              userTimezone="GMT"
+              userTimezoneLoading={false}
+              someLinodesHaveScheduledMaintenance={true}
+              classes={classes}
+              clearDocs={clearDocs}
+              enqueueSnackbar={jest.fn()}
+              groupByTags={false}
+              linodesCount={0}
+              linodesRequestError={undefined}
+              linodesRequestLoading={false}
+              managed={false}
+              closeSnackbar={jest.fn()}
+              setDocs={setDocs}
+              toggleGroupByTag={jest.fn()}
+              backupsCTA={false}
+              deleteLinode={jest.fn()}
+            />
+          </StaticRouter>
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     const kabobButton = component.find('MoreHoriz').first();

--- a/src/features/linodes/LinodesLanding/OverflowIPs.test.tsx
+++ b/src/features/linodes/LinodesLanding/OverflowIPs.test.tsx
@@ -3,14 +3,19 @@ import * as React from 'react';
 
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 import OverflowIPs from './OverflowIPs';
 
 describe('OverflowIPs', () => {
   it('should render without error and display the number of IPs', () => {
     const result = mount(
-      <LinodeThemeWrapper>
-        <OverflowIPs ips={['8.8.8.8']} />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <OverflowIPs ips={['8.8.8.8']} />
+        </LinodeThemeWrapper>
+      </Provider>
     );
     const rendered = result.find('OverflowIPs');
     const numberText = result.find('span').text();
@@ -21,9 +26,11 @@ describe('OverflowIPs', () => {
 
   it('should render each IPAddress when the chip is clicked', () => {
     const result = mount(
-      <LinodeThemeWrapper>
-        <OverflowIPs ips={['8.8.8.8', '8.8.4.4', '192.168.100.112']} />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <OverflowIPs ips={['8.8.8.8', '8.8.4.4', '192.168.100.112']} />
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     const chip = result.find('ForwardRef(Chip)');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,10 +20,10 @@ import Logout from 'src/layouts/Logout';
 import OAuthCallbackPage from 'src/layouts/OAuth';
 import store from 'src/store';
 import 'src/utilities/createImageBitmap';
-import { sendCurrentThemeSettingsEvent } from 'src/utilities/ga';
+// import { sendCurrentThemeSettingsEvent } from 'src/utilities/ga';
 import 'src/utilities/request';
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
-import { spacing as spacingChoice, theme } from 'src/utilities/storage';
+// import { spacing as spacingChoice, theme } from 'src/utilities/storage';
 import App from './App';
 import './events';
 import './index.css';
@@ -39,11 +39,11 @@ const Lish = DefaultLoader({
 initAnalytics(GA_ID, isProduction);
 initTagManager(GTM_ID);
 
-const themeChoice = theme.get() === 'dark' ? 'Dark Theme' : 'Light Theme';
-const spacingMode =
-  spacingChoice.get() === 'compact' ? 'Compact Mode' : 'Normal Mode';
+// const themeChoice = theme.get() === 'dark' ? 'Dark Theme' : 'Light Theme';
+// const spacingMode =
+//   spacingChoice.get() === 'compact' ? 'Compact Mode' : 'Normal Mode';
 
-sendCurrentThemeSettingsEvent(`${themeChoice} | ${spacingMode}`);
+// sendCurrentThemeSettingsEvent(`${themeChoice} | ${spacingMode}`);
 
 /**
  * Send pageviews unless blacklisted.

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -116,6 +116,10 @@ import notifications, {
   defaultState as notificationsDefaultState,
   State as NotificationsState
 } from './notification/notification.reducer';
+import preferences, {
+  defaultState as preferencesState,
+  State as PreferencesState
+} from './preferences/preferences.reducer';
 import { initReselectDevtools } from './selectors';
 
 const reduxDevTools = (window as any).__REDUX_DEVTOOLS_EXTENSION__;
@@ -176,6 +180,7 @@ export interface ApplicationState {
   volumeDrawer: VolumeDrawerState;
   bucketDrawer: BucketDrawerState;
   createLinode: LinodeCreateState;
+  preferences: PreferencesState;
 }
 
 const defaultState: ApplicationState = {
@@ -189,7 +194,8 @@ const defaultState: ApplicationState = {
   tagImportDrawer: tagDrawerDefaultState,
   volumeDrawer: volumeDrawerDefaultState,
   bucketDrawer: bucketDrawerDefaultState,
-  createLinode: linodeCreateDefaultState
+  createLinode: linodeCreateDefaultState,
+  preferences: preferencesState
 };
 
 /**
@@ -226,7 +232,8 @@ const reducers = combineReducers<ApplicationState>({
   volumeDrawer,
   bucketDrawer,
   events,
-  createLinode: linodeCreateReducer
+  createLinode: linodeCreateReducer,
+  preferences
 });
 
 const enhancers = compose(

--- a/src/store/preferences/preferences.reducer.ts
+++ b/src/store/preferences/preferences.reducer.ts
@@ -43,7 +43,8 @@ const reducer: Reducer<State> = reducerWithInitialState(defaultState)
   })
   .case(handleUpdatePreferences.started, state => {
     return {
-      ...state
+      ...state,
+      error: undefined
     };
   })
   .caseWithAction(handleUpdatePreferences.done, (state, action) => {

--- a/src/store/preferences/preferences.reducer.ts
+++ b/src/store/preferences/preferences.reducer.ts
@@ -19,14 +19,19 @@ const reducer: Reducer<State> = reducerWithInitialState(defaultState)
   .case(handleGetPreferences.started, state => {
     return {
       ...state,
-      loading: true,
-      error: undefined
+      loading: true
+      /**
+       * intentionally not resetting error state here because it will cause
+       * the PreferenceToggle.tsx component to re-render, causing the entire app
+       * to re-render unnecessarily
+       */
     };
   })
   .caseWithAction(handleGetPreferences.done, (state, action) => {
     return {
       ...state,
       loading: false,
+      error: undefined,
       lastUpdated: Date.now(),
       data: action.payload.result
     };
@@ -43,8 +48,12 @@ const reducer: Reducer<State> = reducerWithInitialState(defaultState)
   })
   .case(handleUpdatePreferences.started, state => {
     return {
-      ...state,
-      error: undefined
+      ...state
+      /**
+       * intentionally not resetting error state here because it will cause
+       * the PreferenceToggle.tsx component to re-render, causing the entire app
+       * to re-render unnecessarily
+       */
     };
   })
   .caseWithAction(handleUpdatePreferences.done, (state, action) => {
@@ -52,7 +61,8 @@ const reducer: Reducer<State> = reducerWithInitialState(defaultState)
       ...state,
       data: action.payload.result,
       lastUpdated: Date.now(),
-      loading: false
+      loading: false,
+      error: undefined
     };
   })
   .caseWithAction(handleUpdatePreferences.failed, (state, action) => {

--- a/src/store/preferences/preferences.requests.ts
+++ b/src/store/preferences/preferences.requests.ts
@@ -13,7 +13,7 @@ export const getUserPreferences: ThunkActionCreator<
 > = () => dispatch => {
   const { started, done, failed } = handleGetPreferences;
 
-  dispatch(started);
+  dispatch(started());
 
   return _getUserPreferences()
     .then(response => {
@@ -39,7 +39,11 @@ export const updateUserPreferences: ThunkActionCreator<
 > = (payload: Record<string, any>) => dispatch => {
   const { started, done, failed } = handleUpdatePreferences;
 
-  dispatch(started);
+  dispatch(
+    started({
+      params: payload
+    })
+  );
 
   return _updateUserPreferences(payload)
     .then(response => {

--- a/src/store/profile/profile.reducer.ts
+++ b/src/store/profile/profile.reducer.ts
@@ -29,12 +29,18 @@ const reducer: Reducer<State> = (
     /** only set loading if we don't have any data */
     const loading = state.data ? false : true;
 
-    return { ...state, loading, error: undefined };
+    return { ...state, loading };
   }
 
   if (isType(action, getProfileActions.done)) {
     const { result } = action.payload;
-    return { ...state, loading: false, lastUpdated: Date.now(), data: result };
+    return {
+      ...state,
+      error: undefined,
+      loading: false,
+      lastUpdated: Date.now(),
+      data: result
+    };
   }
 
   if (isType(action, getProfileActions.failed)) {
@@ -52,8 +58,8 @@ const reducer: Reducer<State> = (
   if (isType(action, handleUpdateProfile.started)) {
     return {
       ...state,
-      loading: true,
-      error: undefined
+      loading: true
+      // error: undefined
     };
   }
 
@@ -83,6 +89,7 @@ const reducer: Reducer<State> = (
     return {
       ...state,
       loading: false,
+      data: undefined,
       lastUpdated: Date.now(),
       error: {
         update: action.payload.error

--- a/src/store/profile/profile.requests.ts
+++ b/src/store/profile/profile.requests.ts
@@ -55,7 +55,7 @@ export const requestProfile: ThunkActionCreator<
     })
     .catch(error => {
       dispatch(failed({ error }));
-      return error;
+      throw error;
     });
 };
 

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -3,7 +3,6 @@ import createBreakpoints from 'src/components/core/styles/createBreakpoints';
 import createMuiTheme, {
   ThemeOptions
 } from 'src/components/core/styles/createMuiTheme';
-import { spacing as spacingStorage } from 'src/utilities/storage';
 
 /**
  * Augmenting Palette and Palette Options
@@ -65,16 +64,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
   }
 }
 
-type ThemeDefaults = (options: ThemeArguments) => ThemeOptions;
-
-interface ThemeArguments {
-  spacing: 'compact' | 'normal';
-}
-
 const breakpoints = createBreakpoints({});
-
-export const COMPACT_SPACING_UNIT = 4;
-export const NORMAL_SPACING_UNIT = 8;
 
 const primaryColors = {
   main: '#3683dc',
@@ -127,10 +117,16 @@ const visuallyHidden = {
   clip: 'rect(1px, 1px, 1px, 1px)'
 };
 
-const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
-  const spacingUnit =
-    options.spacing === 'compact' ? COMPACT_SPACING_UNIT : NORMAL_SPACING_UNIT;
+export const COMPACT_SPACING_UNIT = 4;
+export const NORMAL_SPACING_UNIT = 8;
 
+export interface ThemeOverrides {
+  spacingOverride: typeof COMPACT_SPACING_UNIT | typeof NORMAL_SPACING_UNIT;
+}
+
+type ThemeDefaults = (options: ThemeOverrides) => ThemeOptions;
+
+const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
   return {
     breakpoints,
     shadows: [
@@ -1359,11 +1355,11 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
   };
 };
 
-export default (options: ThemeOptions) =>
+export default (options: ThemeOptions & ThemeOverrides) =>
   createMuiTheme(
     mergeDeepRight(
       themeDefaults({
-        spacing: spacingStorage.get()
+        spacingOverride: options.spacingOverride
       }),
       options
     )

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,11 +1,12 @@
 import createBreakpoints from 'src/components/core/styles/createBreakpoints';
-import createTheme from './themeFactory';
+import createTheme, { ThemeOverrides } from './themeFactory';
 
 const breakpoints = createBreakpoints({});
 
-export const light = () =>
+export const light = (options: ThemeOverrides) =>
   createTheme({
-    name: 'lightTheme'
+    name: 'lightTheme',
+    ...options
   });
 
 const primaryColors = {
@@ -36,7 +37,7 @@ const iconCircleAnimation = {
   }
 };
 
-export const dark = () =>
+export const dark = (options: ThemeOverrides) =>
   createTheme({
     name: 'darkTheme',
     breakpoints,
@@ -611,5 +612,6 @@ export const dark = () =>
           }
         }
       }
-    }
+    },
+    ...options
   });

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -30,8 +30,6 @@ export const setStorage = (key: string, value: string) => {
   return window.localStorage.setItem(key, value);
 };
 
-const THEME = 'themeChoice';
-const SPACING = 'spacingChoice';
 const PAGE_SIZE = 'PAGE_SIZE';
 const BETA_NOTIFICATION = 'BetaNotification';
 const VAT_NOTIFICATION = 'vatNotification';
@@ -48,8 +46,6 @@ const NONCE = 'authentication/nonce';
 const SCOPES = 'authentication/scopes';
 const EXPIRE = 'authentication/expire';
 
-type Theme = 'dark' | 'light';
-export type Spacing = 'compact' | 'normal';
 export type PageSize = number;
 type Beta = 'open' | 'closed';
 type Notification = 'show' | 'hide';
@@ -71,14 +67,6 @@ export interface Storage {
     nonce: AuthGetAndSet;
     scopes: AuthGetAndSet;
     expire: AuthGetAndSet;
-  };
-  theme: {
-    get: () => Theme;
-    set: (theme: Theme) => void;
-  };
-  spacing: {
-    get: () => Spacing;
-    set: (spacing: Spacing) => void;
   };
   pageSize: {
     get: () => PageSize;
@@ -150,14 +138,6 @@ export const storage: Storage = {
       set: v => setStorage(EXPIRE, v)
     }
   },
-  theme: {
-    get: () => getStorage(THEME, 'light'),
-    set: v => setStorage(THEME, v)
-  },
-  spacing: {
-    get: () => getStorage(SPACING, 'normal'),
-    set: v => setStorage(SPACING, v)
-  },
   pageSize: {
     get: () => {
       return parseInt(getStorage(PAGE_SIZE, '25'), 10);
@@ -221,4 +201,4 @@ export const storage: Storage = {
   }
 };
 
-export const { theme, notifications, views, authentication, spacing } = storage;
+export const { notifications, views, authentication } = storage;

--- a/src/utilities/storybookDecorators.tsx
+++ b/src/utilities/storybookDecorators.tsx
@@ -15,7 +15,7 @@ const ThemeDecorator = (story: Function) => {
   const content = story();
 
   return (
-    <ThemeProvider theme={options[key]()}>
+    <ThemeProvider theme={options[key]({ spacingOverride: 8 })}>
       <CssBaseline />
       {content}
     </ThemeProvider>

--- a/src/utilities/testHelpers.tsx
+++ b/src/utilities/testHelpers.tsx
@@ -20,17 +20,17 @@ createResourcePage = data => ({
 
 export const wrapWithTheme = (ui: any) => {
   return (
-    <LinodeThemeWrapper>
-      <Provider store={store}>
+    <Provider store={store}>
+      <LinodeThemeWrapper theme="dark" spacing="normal">
         <MemoryRouter>{ui}</MemoryRouter>
-      </Provider>
-    </LinodeThemeWrapper>
+      </LinodeThemeWrapper>
+    </Provider>
   );
 };
 
 export const renderWithTheme = (ui: any) => {
   return render(
-    <LinodeThemeWrapper>
+    <LinodeThemeWrapper theme="dark" spacing="normal">
       <MemoryRouter>{ui}</MemoryRouter>
     </LinodeThemeWrapper>
   );


### PR DESCRIPTION
## Description

Observe user preferences when selecting and toggling theme and spacing.

Next PR: Add Analytics back and document usage of TogglePreference component

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

### Note to Reviewers

Some things to note in this PR are

1. Toggling a preference is debounced and will not make any API calls if you keep toggling the preference very quickly
2. `TogglePreference` handles all state internally, but you can override that and handle state externally if needed.
3. `TogglePreference` render blocks by default, unless a `value` prop is passed, and you want to handle state externally.
4. `toggleCallbackFn` does not care if the API PUT requests succeed or fail. It's run immediately after the preference is toggled.