### PR TITLE
M3-2780 POC - request unknown image info on LinodeDetails

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -84,6 +84,8 @@ class SummaryPanel extends React.Component<CombinedProps, State> {
   state: State = { imageLabel: this.props.image ? this.props.image.label : '' };
 
   componentDidMount() {
+    // If this is a deprecated image, and therefore we have no image data already available,
+    // request the image data directly.
     if (!this.props.image && this.props.linodeImageId) {
       getImage(this.props.linodeImageId)
         .then(image => {

--- a/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -16,6 +16,7 @@ import styled, { StyleProps } from 'src/containers/SummaryPanels.styles';
 import withImage from 'src/containers/withImage.container';
 import withMostRecentBackup from 'src/containers/withMostRecentBackup.container';
 import IPAddress from 'src/features/linodes/LinodesLanding/IPAddress';
+import { getImage } from 'src/services/images';
 import {
   LinodeActionsProps,
   withLinodeActions
@@ -75,15 +76,32 @@ type CombinedProps = LinodeContextProps &
   StyleProps &
   WithStyles<ClassNames>;
 
-class SummaryPanel extends React.Component<CombinedProps> {
-  renderImage = () => {
-    const { image } = this.props;
+interface State {
+  imageLabel: string;
+}
 
-    return (
-      <span>
-        {image ? image.label : image === null ? 'No Image' : 'Unknown Image'}
-      </span>
-    );
+class SummaryPanel extends React.Component<CombinedProps, State> {
+  state: State = { imageLabel: this.props.image ? this.props.image.label : '' };
+
+  componentDidMount() {
+    if (!this.props.image && this.props.linodeImageId) {
+      getImage(this.props.linodeImageId)
+        .then(image => {
+          this.setState({
+            imageLabel: image.label
+          });
+        })
+        .catch(err => {
+          // Displaying an error message is probably less preferable than doing nothing,
+          // so we do nothing here.
+        });
+    }
+  }
+
+  renderImage = () => {
+    const { imageLabel } = this.state;
+
+    return imageLabel ? <span>{imageLabel}</span> : null;
   };
 
   updateTags = async (tags: string[]) => {
@@ -194,7 +212,7 @@ interface WithImage {
 
 interface LinodeContextProps {
   linodeId: number;
-  linodeImageId: string;
+  linodeImageId: string | null;
   linodeIpv4: any;
   linodeIpv6: any;
   linodeRegion: string;

--- a/src/utilities/safeGetImageLabel/safeGetImageLabel.test.ts
+++ b/src/utilities/safeGetImageLabel/safeGetImageLabel.test.ts
@@ -6,8 +6,8 @@ describe('safeGetImageLabel', () => {
     expect(safeGetImageLabel(images, null)).toBe('');
   });
 
-  it('should return "Unknown Image" if the slug does not exist in the image data', () => {
-    expect(safeGetImageLabel(images, 'duhhhhhhhhhh')).toBe('Unknown Image');
+  it('should return an empty string if the slug does not exist in the image data', () => {
+    expect(safeGetImageLabel(images, 'duhhhhhhhhhh')).toBe('');
   });
 
   it('should return "Fedora 23"', () => {

--- a/src/utilities/safeGetImageLabel/safeGetImageLabel.ts
+++ b/src/utilities/safeGetImageLabel/safeGetImageLabel.ts
@@ -1,5 +1,5 @@
 /**
- * returns either the Image label or "Unknown Image," depending on whether the image can
+ * returns either the Image label or an empty string, depending on whether the image can
  * be found in the API data
  *
  * If no slug is available, return an empty string so nothing will display in the description.
@@ -11,9 +11,7 @@ export const safeGetImageLabel = (
   images: Linode.Image[],
   slug: string | null
 ): string => {
-  if (!slug) {
-    return '';
-  }
   const iv = images.find(i => i.id === slug);
-  return iv ? iv.label : 'Unknown Image';
+
+  return iv ? iv.label : '';
 };


### PR DESCRIPTION
## Description

Many deprecated images aren’t returned in the general GET `/images` call. We’ve been displaying “Unknown Image” for these LInodes. A deprecated image’s label can still be retrieved by hitting `/images/{imageId}`. 

This POC makes that API call on Linode Summary if we have an `imageId`, but can’t find the image in our general list of images in Redux.

I didn’t worry about loading or error states, as I’m not sure they’re needed for this. Also, I chose to remove “Unknown Image” on the Linodes Listing page, and to ONLY make this special API call on Linodes Detail.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests
None.

## Note to Reviewers

To Test: 

1. Use Charles to include a deprecated imageId (e.g. linode/ubuntu14.10) for one of your Linodes. 
2. View LinodesLanding and Linodes Detail.
