### PR TITLE
Change: Do Not Create DNS Records for nulled IPv6 Linodes

### DIFF
--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -104,7 +104,7 @@ const generateDefaultDomainRecords = (
   const cleanedIPv6 =
     ipv6 && ipv6.includes('/') ? ipv6.substr(0, ipv6.indexOf('/')) : ipv6;
 
-  return Promise.all([
+  const baseIPv4Requests = [
     createDomainRecord(domainID, {
       type: 'A',
       target: ipv4
@@ -118,27 +118,36 @@ const generateDefaultDomainRecords = (
       type: 'A',
       target: ipv4,
       name: 'mail'
-    }),
-    createDomainRecord(domainID, {
-      type: 'AAAA',
-      target: cleanedIPv6
-    }),
-    createDomainRecord(domainID, {
-      type: 'AAAA',
-      target: cleanedIPv6,
-      name: 'www'
-    }),
-    createDomainRecord(domainID, {
-      type: 'AAAA',
-      target: cleanedIPv6,
-      name: 'mail'
-    }),
-    createDomainRecord(domainID, {
-      type: 'MX',
-      priority: 10,
-      target: `mail.${domain}`
     })
-  ]);
+  ];
+
+  return Promise.all(
+    /** ipv6 can be null so don't try to create domain records in that case */
+    !!cleanedIPv6
+      ? [
+          ...baseIPv4Requests,
+          createDomainRecord(domainID, {
+            type: 'AAAA',
+            target: cleanedIPv6
+          }),
+          createDomainRecord(domainID, {
+            type: 'AAAA',
+            target: cleanedIPv6,
+            name: 'www'
+          }),
+          createDomainRecord(domainID, {
+            type: 'AAAA',
+            target: cleanedIPv6,
+            name: 'mail'
+          }),
+          createDomainRecord(domainID, {
+            type: 'MX',
+            priority: 10,
+            target: `mail.${domain}`
+          })
+        ]
+      : baseIPv4Requests
+  );
 };
 
 const masterIPsLens = lensPath(['master_ips']);

--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -416,8 +416,12 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               />
               {!errorMap.defaultLinode && (
                 <FormHelperText>
-                  We'll automatically create domain records for both the first
-                  IPv4 and IPv6 on this Linode.
+                  {this.state.selectedDefaultLinode &&
+                  !this.state.selectedDefaultLinode.ipv6
+                    ? `We'll automatically create domains for the first IPv4 address on this
+                    Linode.`
+                    : `We'll automatically create domain records for both the first
+                    IPv4 and IPv6 addresses on this Linode.`}
                 </FormHelperText>
               )}
             </React.Fragment>
@@ -436,8 +440,12 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               />
               {!errorMap.defaultNodeBalancer && (
                 <FormHelperText>
-                  We'll automatically create domain records for both the first
-                  IPv4 and IPv6 on this NodeBalancer.
+                  {this.state.selectedDefaultNodeBalancer &&
+                  !this.state.selectedDefaultNodeBalancer.ipv6
+                    ? `We'll automatically create domains for the first IPv4 address on this
+                  NodeBalancer.`
+                    : `We'll automatically create domain records for both the first
+                  IPv4 and IPv6 addresses on this NodeBalancer.`}
                 </FormHelperText>
               )}
             </React.Fragment>


### PR DESCRIPTION
## Description

If a Linode does not have IPv6 enabled, do not attempt to create default DNS records for it 

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A