### PR TITLE
M3-2247: Unit Tests for Clone Configs/Disks

### DIFF
--- a/src/__data__/disks.ts
+++ b/src/__data__/disks.ts
@@ -38,4 +38,14 @@ export const extDisk2: Linode.Disk = {
   id: 19040625
 };
 
+export const extDisk3: Linode.Disk = {
+  updated: '2018-08-05T18:16:08',
+  label: 'Custom Disk which matches config',
+  created: '2018-08-06T18:15:43',
+  filesystem: 'ext4',
+  status: 'ready',
+  size: 10000,
+  id: 18795181
+};
+
 export const disks = [extDisk, swapDisk];

--- a/src/features/linodes/CloneLanding/Configs.test.tsx
+++ b/src/features/linodes/CloneLanding/Configs.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { cleanup, fireEvent, render } from 'react-testing-library';
+import { linodeConfigs } from 'src/__data__/linodeConfigs';
+import { wrapWithTheme } from 'src/utilities/testHelpers';
+import { CombinedProps as ConfigsProps, Configs } from './Configs';
+
+afterEach(cleanup);
+
+const mockHandleSelect = jest.fn();
+
+const props: ConfigsProps = {
+  configs: linodeConfigs,
+  configSelection: { 9859511: { isSelected: false, associatedDiskIds: [] } },
+  handleSelect: (id: number) => mockHandleSelect(id),
+  classes: { root: '' }
+};
+
+describe('Configs', () => {
+  it('renders a row for each config', () => {
+    const { getByText } = render(wrapWithTheme(<Configs {...props} />));
+    linodeConfigs.forEach(eachConfig => {
+      expect(getByText(eachConfig.label)).toBeDefined();
+    });
+  });
+
+  it('fires the handle event when clicked', () => {
+    const { getByTestId } = render(wrapWithTheme(<Configs {...props} />));
+    linodeConfigs.forEach(eachConfig => {
+      const checkbox = getByTestId(`checkbox-${eachConfig.id}`).parentNode;
+      fireEvent.click(checkbox as any);
+      expect(mockHandleSelect).toHaveBeenCalledWith(eachConfig.id);
+    });
+  });
+
+  it('renders an empty state when no configs', () => {
+    const { getByText, getByTestId } = render(
+      wrapWithTheme(<Configs {...props} configs={[]} />)
+    );
+
+    expect(getByTestId('table-row-empty')).toBeDefined();
+    expect(getByText('No items to display.')).toBeDefined();
+  });
+});

--- a/src/features/linodes/CloneLanding/Configs.tsx
+++ b/src/features/linodes/CloneLanding/Configs.tsx
@@ -32,7 +32,7 @@ interface Props {
   handleSelect: (id: number) => void;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+export type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const Configs: React.FC<CombinedProps> = props => {
   const { classes, configs, handleSelect, configSelection } = props;
@@ -66,6 +66,7 @@ export const Configs: React.FC<CombinedProps> = props => {
                           checked={configSelection[config.id].isSelected}
                           onChange={() => handleSelect(config.id)}
                           text={config.label}
+                          data-testid={`checkbox-${config.id}`}
                         />
                       </TableCell>
                     </TableRow>

--- a/src/features/linodes/CloneLanding/Disks.test.tsx
+++ b/src/features/linodes/CloneLanding/Disks.test.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+import { cleanup, fireEvent, render } from 'react-testing-library';
+import { extDisk3, swapDisk } from 'src/__data__/disks';
+import { wrapWithTheme } from 'src/utilities/testHelpers';
+import { CombinedProps as DisksProps, Disks } from './Disks';
+
+afterEach(cleanup);
+
+const disks = [extDisk3, swapDisk];
+
+const mockHandleSelect = jest.fn();
+
+const props: DisksProps = {
+  disks,
+  diskSelection: {
+    18795181: { isSelected: false, associatedConfigIds: [] },
+    19040624: { isSelected: false, associatedConfigIds: [9859511] }
+  },
+  selectedConfigIds: [],
+  handleSelect: (id: number) => mockHandleSelect(id),
+  classes: { root: '', labelCol: '', sizeCol: '', tableCell: '' }
+};
+
+describe('Disks', () => {
+  it('renders a row for each disk', () => {
+    const { getByText } = render(wrapWithTheme(<Disks {...props} />));
+    disks.forEach(eachDisk => {
+      expect(getByText(eachDisk.label)).toBeDefined();
+    });
+  });
+
+  it('fires the handle event when clicked', () => {
+    const { getByTestId } = render(wrapWithTheme(<Disks {...props} />));
+    disks.forEach(eachDisk => {
+      const checkbox = getByTestId(`checkbox-${eachDisk.id}`).parentNode;
+      fireEvent.click(checkbox as any);
+      expect(mockHandleSelect).toHaveBeenCalledWith(eachDisk.id);
+    });
+  });
+
+  it('renders an empty state when no configs', () => {
+    const { getByText, getByTestId } = render(
+      wrapWithTheme(<Disks {...props} disks={[]} />)
+    );
+    expect(getByTestId('table-row-empty')).toBeDefined();
+    expect(getByText('No items to display.')).toBeDefined();
+  });
+
+  it('checks the disk if the associated config is selected', () => {
+    const { getByTestId } = render(
+      wrapWithTheme(<Disks {...props} selectedConfigIds={[9859511]} />)
+    );
+    const checkbox: any = getByTestId(`checkbox-19040624`).lastElementChild;
+    expect(checkbox.children[0]).toHaveAttribute('checked');
+  });
+});

--- a/src/features/linodes/CloneLanding/Disks.tsx
+++ b/src/features/linodes/CloneLanding/Disks.tsx
@@ -41,9 +41,9 @@ interface Props {
   handleSelect: (id: number) => void;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+export type CombinedProps = Props & WithStyles<ClassNames>;
 
-export const Configs: React.FC<CombinedProps> = props => {
+export const Disks: React.FC<CombinedProps> = props => {
   const {
     classes,
     disks,
@@ -101,6 +101,7 @@ export const Configs: React.FC<CombinedProps> = props => {
                                 checked={isDiskSelected || isConfigSelected}
                                 disabled={isConfigSelected}
                                 onChange={() => handleSelect(disk.id)}
+                                data-testid={`checkbox-${disk.id}`}
                               />
                             </TableCell>
                             <TableCell>{disk.size} MB</TableCell>
@@ -130,4 +131,4 @@ export const Configs: React.FC<CombinedProps> = props => {
 const styled = withStyles(styles);
 const enhanced = compose<CombinedProps, Props>(styled);
 
-export default enhanced(Configs);
+export default enhanced(Disks);

--- a/src/features/linodes/CloneLanding/utilities.test.ts
+++ b/src/features/linodes/CloneLanding/utilities.test.ts
@@ -7,24 +7,6 @@ import {
 } from './utilities';
 
 describe('utilities', () => {
-  describe('getEstimatedCloneTime', () => {
-    it('gives a humanized estimate', () => {
-      expect(getEstimatedCloneTime(50000, 'sameDatacenter')).toBe('37 minutes');
-    });
-
-    it('gives a different result based on the DC mode', () => {
-      expect(getEstimatedCloneTime(70000, 'sameDatacenter')).toBe('an hour');
-      expect(getEstimatedCloneTime(70000, 'differentDatacenter')).toBe(
-        '11 hours'
-      );
-    });
-
-    it('handles edge cases', () => {
-      expect(getEstimatedCloneTime(0, 'sameDatacenter')).toBe('a few seconds');
-      expect(getEstimatedCloneTime(40000000, 'sameDatacenter')).toBe('20 days');
-    });
-  });
-
   describe('getAllDisks', () => {
     const extendedConfig: ExtendedConfig = {
       ...linodeConfigs[0],
@@ -57,6 +39,24 @@ describe('utilities', () => {
         19040624,
         19040625
       ]);
+    });
+  });
+
+  describe('getEstimatedCloneTime', () => {
+    it('gives a humanized estimate', () => {
+      expect(getEstimatedCloneTime(50000, 'sameDatacenter')).toBe('37 minutes');
+    });
+
+    it('gives a different result based on the DC mode', () => {
+      expect(getEstimatedCloneTime(70000, 'sameDatacenter')).toBe('an hour');
+      expect(getEstimatedCloneTime(70000, 'differentDatacenter')).toBe(
+        '11 hours'
+      );
+    });
+
+    it('handles edge cases', () => {
+      expect(getEstimatedCloneTime(0, 'sameDatacenter')).toBe('a few seconds');
+      expect(getEstimatedCloneTime(40000000, 'sameDatacenter')).toBe('20 days');
     });
   });
 });

--- a/src/features/linodes/CloneLanding/utilities.test.ts
+++ b/src/features/linodes/CloneLanding/utilities.test.ts
@@ -1,12 +1,112 @@
 import { disks, extDisk2, extDiskCopy } from 'src/__data__/disks';
 import { linodeConfigs } from 'src/__data__/linodeConfigs';
 import {
+  cloneLandingReducer,
+  CloneLandingState,
   ExtendedConfig,
   getAllDisks,
   getEstimatedCloneTime
 } from './utilities';
 
 describe('utilities', () => {
+  describe('reducer', () => {
+    const baseState: CloneLandingState = {
+      configSelection: {
+        1000: {
+          isSelected: true,
+          associatedDiskIds: []
+        }
+      },
+      diskSelection: {
+        2000: {
+          isSelected: false,
+          associatedConfigIds: []
+        }
+      },
+      isSubmitting: false,
+      selectedLinodeId: null
+    };
+
+    it('toggles given config', () => {
+      const newState = cloneLandingReducer(baseState, {
+        type: 'toggleConfig',
+        id: 1000
+      });
+      expect(newState.configSelection[1000].isSelected).toBe(false);
+    });
+
+    it('toggles given disk', () => {
+      const newState = cloneLandingReducer(baseState, {
+        type: 'toggleDisk',
+        id: 2000
+      });
+      expect(newState.diskSelection[2000].isSelected).toBe(true);
+    });
+
+    it('sets the selectedLinodeId', () => {
+      const newState = cloneLandingReducer(baseState, {
+        type: 'setSelectedLinodeId',
+        id: 3000
+      });
+      expect(newState.selectedLinodeId).toBe(3000);
+    });
+
+    it('sets submitting', () => {
+      const newState = cloneLandingReducer(baseState, {
+        type: 'setSubmitting',
+        value: true
+      });
+      expect(newState.isSubmitting).toBe(true);
+    });
+
+    it('sets errors', () => {
+      const newState = cloneLandingReducer(baseState, {
+        type: 'setErrors',
+        errors: [{ reason: 'ERROR' }]
+      });
+      expect(newState.errors).toEqual([{ reason: 'ERROR' }]);
+    });
+
+    it('clears all', () => {
+      const state: CloneLandingState = {
+        ...baseState,
+        diskSelection: {
+          2000: {
+            isSelected: true,
+            associatedConfigIds: []
+          }
+        },
+        selectedLinodeId: 3000,
+        errors: [{ reason: 'ERROR' }]
+      };
+
+      const newState = cloneLandingReducer(state, {
+        type: 'clearAll'
+      });
+      expect(newState.configSelection[1000].isSelected).toBe(false);
+      expect(newState.diskSelection[2000].isSelected).toBe(false);
+      expect(newState.selectedLinodeId).toBe(null);
+      expect(newState.errors).toBe(undefined);
+    });
+
+    it('clears errors after each type of input change', () => {
+      const state: CloneLandingState = {
+        ...baseState,
+        errors: [{ reason: 'ERROR' }]
+      };
+      expect(
+        cloneLandingReducer(state, { type: 'toggleConfig', id: 1000 }).errors
+      ).toBe(undefined);
+      expect(
+        cloneLandingReducer(state, { type: 'toggleDisk', id: 2000 }).errors
+      ).toBe(undefined);
+      expect(
+        cloneLandingReducer(state, { type: 'setSelectedLinodeId', id: 3000 })
+          .errors
+      ).toBe(undefined);
+    });
+  });
+
   describe('getAllDisks', () => {
     const extendedConfig: ExtendedConfig = {
       ...linodeConfigs[0],

--- a/src/features/linodes/CloneLanding/utilities.ts
+++ b/src/features/linodes/CloneLanding/utilities.ts
@@ -5,7 +5,7 @@ import { append, compose, flatten, map, uniqBy } from 'ramda';
  * TYPES
  */
 
-interface CloneLandingState {
+export interface CloneLandingState {
   configSelection: ConfigSelection;
   diskSelection: DiskSelection;
   selectedLinodeId: number | null;

--- a/src/features/linodes/CloneLanding/utilities.ts
+++ b/src/features/linodes/CloneLanding/utilities.ts
@@ -160,7 +160,7 @@ export const createInitialCloneLandingState = (
   };
 
   // Mapping of diskIds to an array of associated configIds
-  const diskConfigMap: Record<number, number[]> = [];
+  const diskConfigMap: Record<number, number[]> = {};
 
   configs.forEach(eachConfig => {
     // We default `isSelected` to `false`, unless this config was
@@ -189,7 +189,7 @@ export const createInitialCloneLandingState = (
     const isSelected = eachDisk.id === preSelectedDiskId;
 
     // Since we built the mapping earlier, we can just grab them here
-    const associatedConfigIds = diskConfigMap[eachDisk.id];
+    const associatedConfigIds = diskConfigMap[eachDisk.id] || [];
 
     state.diskSelection[eachDisk.id] = {
       isSelected,


### PR DESCRIPTION
## Description

More unit tests for the Clone Configs/Disks feature.

You'll probably need to clear out `node_modules` since this doesn't have the MUI update. 

This is the last PR into the feature branch. Once it's merged I'll rebase against `develop`.

**To test:** `yarn test src/features/linodes/CloneLanding/`
