### PR TITLE
User Preferences Part 4: Re-Add Google Analytics

### DIFF
--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -6,10 +6,14 @@ import { dark, light } from 'src/themes';
 import { COMPACT_SPACING_UNIT, NORMAL_SPACING_UNIT } from 'src/themeFactory';
 
 import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
-
 import withPreferences, {
   PreferencesActionsProps
 } from 'src/containers/preferences.container';
+import {
+  sendCurrentThemeSettingsEvent,
+  sendSpacingToggleEvent,
+  sendThemeToggleEvent
+} from 'src/utilities/ga';
 
 type ThemeChoice = 'light' | 'dark';
 type SpacingChoice = 'compact' | 'normal';
@@ -40,13 +44,20 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
     }, 500);
   });
 
-  const toggleTheme = () => {
+  const toggleTheme = (value: ThemeChoice) => {
     document.body.classList.add('no-transition');
-    /** @todo send to GA */
+    /** send to GA */
+    sendThemeToggleEvent(value);
   };
 
-  const toggleSpacing = () => {
-    /** @todo send to GA */
+  const toggleSpacing = (value: SpacingChoice) => {
+    /** send to GA */
+    sendSpacingToggleEvent(value);
+  };
+
+  const setThemePrefsOnAppLoad = (value: ThemeChoice | SpacingChoice) => {
+    /** send to GA */
+    sendCurrentThemeSettingsEvent(value);
   };
 
   React.useEffect(() => {
@@ -68,6 +79,7 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
       toggleCallbackFn={toggleTheme}
       /** purely for unit test purposes */
       value={props.theme}
+      initialSetCallbackFn={setThemePrefsOnAppLoad}
     >
       {({
         preference: themeChoice,
@@ -79,6 +91,7 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
           toggleCallbackFn={toggleSpacing}
           /** purely for unit test purposes */
           value={props.spacing}
+          initialSetCallbackFn={setThemePrefsOnAppLoad}
         >
           {({
             preference: spacingChoice,

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -76,7 +76,7 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
     <PreferenceToggle<'light' | 'dark'>
       preferenceKey="theme"
       preferenceOptions={['light', 'dark']}
-      toggleCallbackFn={toggleTheme}
+      toggleCallbackFnDebounced={toggleTheme}
       /** purely for unit test purposes */
       value={props.theme}
       initialSetCallbackFn={setThemePrefsOnAppLoad}
@@ -88,7 +88,7 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
         <PreferenceToggle<'normal' | 'compact'>
           preferenceKey="spacing"
           preferenceOptions={['normal', 'compact']}
-          toggleCallbackFn={toggleSpacing}
+          toggleCallbackFnDebounced={toggleSpacing}
           /** purely for unit test purposes */
           value={props.spacing}
           initialSetCallbackFn={setThemePrefsOnAppLoad}

--- a/src/components/PreferenceToggle/PreferenceToggle.tsx
+++ b/src/components/PreferenceToggle/PreferenceToggle.tsx
@@ -25,6 +25,7 @@ interface Props<T = PreferenceValue> {
   preferenceOptions: [T, T];
   value?: T;
   toggleCallbackFn?: (value: T) => void;
+  toggleCallbackFnDebounced?: (value: T) => void;
   initialSetCallbackFn?: (value: T) => void;
   children: RenderChildren;
 }
@@ -39,6 +40,7 @@ const PreferenceToggle: React.FC<CombinedProps> = props => {
     preferenceError,
     preferenceKey,
     preferenceOptions,
+    toggleCallbackFnDebounced,
     toggleCallbackFn,
     children,
     preferences
@@ -109,6 +111,11 @@ const PreferenceToggle: React.FC<CombinedProps> = props => {
        * Don't update anything if the GET fails
        */
       if (!!preferenceError && lastUpdated !== 0) {
+        /** invoke our callback prop if we have one */
+        if (toggleCallbackFnDebounced && currentlySetPreference) {
+          toggleCallbackFnDebounced(currentlySetPreference);
+        }
+
         props
           .getUserPreferences()
           .then(response => {
@@ -129,13 +136,17 @@ const PreferenceToggle: React.FC<CombinedProps> = props => {
         /**
          * PUT to /preferences on every toggle, debounced.
          */
-
         props
           .updateUserPreferences({
             ...props.preferences,
             [preferenceKey]: currentlySetPreference
           })
           .catch(() => /** swallow the error */ null);
+
+        /** invoke our callback prop if we have one */
+        if (toggleCallbackFnDebounced && currentlySetPreference) {
+          toggleCallbackFnDebounced(currentlySetPreference);
+        }
       } else if (lastUpdated === 0) {
         /**
          * this is the case where the app has just been mounted and the preferences are

--- a/src/components/PreferenceToggle/PreferenceToggle.tsx
+++ b/src/components/PreferenceToggle/PreferenceToggle.tsx
@@ -95,7 +95,7 @@ const PreferenceToggle: React.FC<CombinedProps> = props => {
 
       setPreference(preferenceToSet);
 
-      /** run callback function is passed one */
+      /** run callback function if passed one */
       if (props.initialSetCallbackFn) {
         props.initialSetCallbackFn(preferenceToSet);
       }
@@ -127,12 +127,7 @@ const PreferenceToggle: React.FC<CombinedProps> = props => {
               .catch(() => /** swallow the error */ null);
           })
           .catch(() => /** swallow the error */ null);
-      } else if (
-        !!preferences &&
-        currentlySetPreference &&
-        lastUpdated !== 0
-        // && preferencesHaveBeenUpdated(props.preferences, theme, spacing)
-      ) {
+      } else if (!!preferences && currentlySetPreference && lastUpdated !== 0) {
         /**
          * PUT to /preferences on every toggle, debounced.
          */

--- a/src/components/PreferenceToggle/PreferenceToggle.tsx
+++ b/src/components/PreferenceToggle/PreferenceToggle.tsx
@@ -24,7 +24,8 @@ interface Props<T = PreferenceValue> {
   preferenceKey: string;
   preferenceOptions: [T, T];
   value?: T;
-  toggleCallbackFn?: (value: PreferenceValue) => void;
+  toggleCallbackFn?: (value: T) => void;
+  initialSetCallbackFn?: (value: T) => void;
   children: RenderChildren;
 }
 
@@ -66,7 +67,12 @@ const PreferenceToggle: React.FC<CombinedProps> = props => {
       !!props.preferenceError &&
       lastUpdated === 0
     ) {
-      setPreference(preferenceOptions[0]);
+      const preferenceToSet = preferenceOptions[0];
+      setPreference(preferenceToSet);
+
+      if (props.initialSetCallbackFn) {
+        props.initialSetCallbackFn(preferenceToSet);
+      }
     }
 
     /**
@@ -86,6 +92,11 @@ const PreferenceToggle: React.FC<CombinedProps> = props => {
         : preferenceFromAPI;
 
       setPreference(preferenceToSet);
+
+      /** run callback function is passed one */
+      if (props.initialSetCallbackFn) {
+        props.initialSetCallbackFn(preferenceToSet);
+      }
     }
   }, [props.preferenceError, props.preferences]);
 

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -23,7 +23,6 @@ import { isKubernetesEnabled } from 'src/constants';
 import { MapState } from 'src/store/types';
 import { NORMAL_SPACING_UNIT } from 'src/themeFactory';
 import { isObjectStorageEnabled } from 'src/utilities/accountCapabilities';
-import { sendSpacingToggleEvent, sendThemeToggleEvent } from 'src/utilities/ga';
 import AdditionalMenuItems from './AdditionalMenuItems';
 import SpacingToggle from './SpacingToggle';
 import ThemeToggle from './ThemeToggle';
@@ -379,23 +378,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     this.setState({ anchorEl: undefined });
   };
 
-  handleSpacingToggle = () => {
-    const { toggleSpacing } = this.props;
-    // Checking the previous spacingUnit value to determine which way to switch.
-    const eventLabel = NORMAL_SPACING_UNIT ? 'compact' : 'normal';
-    toggleSpacing();
-    sendSpacingToggleEvent(eventLabel);
-  };
-
-  handleThemeToggle = () => {
-    const { toggleTheme, theme } = this.props;
-    // Checking the previous theme.name value to determine which way to switch.
-    const eventLabel = theme.name === 'darkTheme' ? 'light' : 'dark';
-
-    toggleTheme();
-    sendThemeToggleEvent(eventLabel);
-  };
-
   renderPrimaryLink = (primaryLink: PrimaryLink, isLast: boolean) => {
     const { classes } = this.props;
 
@@ -548,8 +530,8 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
                 className: classes.settingsBackdrop
               }}
             >
-              <ThemeToggle toggleTheme={this.handleThemeToggle} />
-              <SpacingToggle toggleSpacing={this.handleSpacingToggle} />
+              <ThemeToggle toggleTheme={this.props.toggleTheme} />
+              <SpacingToggle toggleSpacing={this.props.toggleSpacing} />
             </Menu>
           </div>
         </Grid>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,10 +20,8 @@ import Logout from 'src/layouts/Logout';
 import OAuthCallbackPage from 'src/layouts/OAuth';
 import store from 'src/store';
 import 'src/utilities/createImageBitmap';
-// import { sendCurrentThemeSettingsEvent } from 'src/utilities/ga';
 import 'src/utilities/request';
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
-// import { spacing as spacingChoice, theme } from 'src/utilities/storage';
 import App from './App';
 import './events';
 import './index.css';
@@ -38,12 +36,6 @@ const Lish = DefaultLoader({
  */
 initAnalytics(GA_ID, isProduction);
 initTagManager(GTM_ID);
-
-// const themeChoice = theme.get() === 'dark' ? 'Dark Theme' : 'Light Theme';
-// const spacingMode =
-//   spacingChoice.get() === 'compact' ? 'Compact Mode' : 'Normal Mode';
-
-// sendCurrentThemeSettingsEvent(`${themeChoice} | ${spacingMode}`);
 
 /**
  * Send pageviews unless blacklisted.

--- a/src/utilities/ga.ts
+++ b/src/utilities/ga.ts
@@ -52,7 +52,7 @@ export const sendPaginationEvent = (
   });
 };
 
-// src/index.tsx
+// LinodeThemeWrapper.tsx
 export const sendCurrentThemeSettingsEvent = (eventAction: string) => {
   sendEvent({
     category: 'Theme Choice',
@@ -104,7 +104,7 @@ export const sendImportDisplayGroupSubmitEvent = (
   });
 };
 
-// PrimaryNav.tsx
+// LinodeThemeWrapper.tsx
 export const sendSpacingToggleEvent = (eventLabel: string) => {
   sendEvent({
     category: 'Theme Choice',
@@ -113,7 +113,7 @@ export const sendSpacingToggleEvent = (eventLabel: string) => {
   });
 };
 
-// PrimaryNav.tsx
+// LinodeThemeWrapper.tsx
 export const sendThemeToggleEvent = (eventLabel: string) => {
   sendEvent({
     category: 'Theme Choice',


### PR DESCRIPTION
## Description

Re-adds GA tracking for theme and spacing.

Regression: Since we're using a render props component, we cannot successfully send both the theme and spacing choices in one event anymore, since each has its own handlers for when a preference is initially set.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A