### PR TITLE
Add: User Preferences

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,13 +11,14 @@ import { hasOauthError } from './App';
 
 it('renders without crashing', () => {
   const component = shallow(
-    <LinodeThemeWrapper>
-      <Provider store={store}>
+    <Provider store={store}>
+      <LinodeThemeWrapper>
         <StaticRouter location="/" context={{}}>
           <App
             linodes={[]}
             notifications={[]}
             {...mockNodeBalancerActions}
+            profileError={undefined}
             username=""
             isLoggedInAsCustomer={false}
             closeSnackbar={jest.fn()}
@@ -57,8 +58,8 @@ it('renders without crashing', () => {
             accountLoading={false}
           />
         </StaticRouter>
-      </Provider>
-    </LinodeThemeWrapper>
+      </LinodeThemeWrapper>
+    </Provider>
   );
   expect(component.find('App')).toHaveLength(1);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -576,7 +576,7 @@ interface StateProps {
 const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => ({
   /** Profile */
   profileLoading: state.__resources.profile.loading,
-  profileError: state.__resources.profile.error,
+  profileError: path(['read'], state.__resources.profile.error),
   linodes: state.__resources.linodes.entities,
   linodesError: path(['read'], state.__resources.linodes.error),
   domainsError: state.__resources.domains.error,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -255,9 +255,9 @@ export class App extends React.Component<CombinedProps, State> {
     perfume.start('InitialRequests');
     const dataFetchingPromises: Promise<any>[] = [
       this.props.requestAccount(),
-      this.props.requestProfile(),
       this.props.requestDomains(),
       this.props.requestImages(),
+      this.props.requestProfile(),
       this.props.requestLinodes(),
       this.props.requestNotifications(),
       this.props.requestSettings(),
@@ -335,16 +335,16 @@ export class App extends React.Component<CombinedProps, State> {
       classes,
       toggleSpacing,
       toggleTheme,
-      profileLoading,
       linodesError,
       domainsError,
       typesError,
       imagesError,
       notificationsError,
       regionsError,
+      profileLoading,
+      profileError,
       volumesError,
       settingsError,
-      profileError,
       bucketsError,
       accountCapabilities,
       accountLoading,
@@ -369,8 +369,8 @@ export class App extends React.Component<CombinedProps, State> {
         notificationsError,
         regionsError,
         volumesError,
-        settingsError,
         profileError,
+        settingsError,
         bucketsError
       )
     ) {
@@ -513,11 +513,11 @@ interface DispatchProps {
   requestImages: () => Promise<Linode.Image[]>;
   requestLinodes: () => Promise<Linode.Linode[]>;
   requestNotifications: () => Promise<Linode.Notification[]>;
-  requestProfile: () => Promise<Linode.Profile>;
   requestSettings: () => Promise<Linode.AccountSettings>;
   requestTypes: () => Promise<Linode.LinodeType[]>;
   requestRegions: () => Promise<Linode.Region[]>;
   requestVolumes: () => Promise<Linode.Volume[]>;
+  requestProfile: () => Promise<Linode.Profile>;
   requestBuckets: () => Promise<Linode.Bucket[]>;
   requestClusters: () => Promise<Linode.Cluster[]>;
   addNotificationsToLinodes: (
@@ -535,11 +535,11 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
     requestImages: () => dispatch(requestImages()),
     requestLinodes: () => dispatch(requestLinodes()),
     requestNotifications: () => dispatch(requestNotifications()),
-    requestProfile: () => dispatch(requestProfile()),
     requestSettings: () => dispatch(requestAccountSettings()),
     requestTypes: () => dispatch(requestTypes()),
     requestRegions: () => dispatch(requestRegions()),
     requestVolumes: () => dispatch(getAllVolumes()),
+    requestProfile: () => dispatch(requestProfile()),
     requestBuckets: () => dispatch(getAllBuckets()),
     requestClusters: () => dispatch(requestClusters()),
     addNotificationsToLinodes: (
@@ -573,7 +573,7 @@ interface StateProps {
   accountError?: Error | Linode.ApiFieldError[];
 }
 
-const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => ({
+const mapStateToProps: MapState<StateProps, Props> = state => ({
   /** Profile */
   profileLoading: state.__resources.profile.loading,
   profileError: path(['read'], state.__resources.profile.error),

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -6,10 +6,14 @@ import { dark, light } from 'src/themes';
 import { COMPACT_SPACING_UNIT, NORMAL_SPACING_UNIT } from 'src/themeFactory';
 
 import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
-
 import withPreferences, {
   PreferencesActionsProps
 } from 'src/containers/preferences.container';
+import {
+  sendCurrentThemeSettingsEvent,
+  sendSpacingToggleEvent,
+  sendThemeToggleEvent
+} from 'src/utilities/ga';
 
 type ThemeChoice = 'light' | 'dark';
 type SpacingChoice = 'compact' | 'normal';
@@ -40,13 +44,20 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
     }, 500);
   });
 
-  const toggleTheme = () => {
+  const toggleTheme = (value: ThemeChoice) => {
     document.body.classList.add('no-transition');
-    /** @todo send to GA */
+    /** send to GA */
+    sendThemeToggleEvent(value);
   };
 
-  const toggleSpacing = () => {
-    /** @todo send to GA */
+  const toggleSpacing = (value: SpacingChoice) => {
+    /** send to GA */
+    sendSpacingToggleEvent(value);
+  };
+
+  const setThemePrefsOnAppLoad = (value: ThemeChoice | SpacingChoice) => {
+    /** send to GA */
+    sendCurrentThemeSettingsEvent(value);
   };
 
   React.useEffect(() => {
@@ -65,9 +76,10 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
     <PreferenceToggle<'light' | 'dark'>
       preferenceKey="theme"
       preferenceOptions={['light', 'dark']}
-      toggleCallbackFn={toggleTheme}
+      toggleCallbackFnDebounced={toggleTheme}
       /** purely for unit test purposes */
       value={props.theme}
+      initialSetCallbackFn={setThemePrefsOnAppLoad}
     >
       {({
         preference: themeChoice,
@@ -76,9 +88,10 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
         <PreferenceToggle<'normal' | 'compact'>
           preferenceKey="spacing"
           preferenceOptions={['normal', 'compact']}
-          toggleCallbackFn={toggleSpacing}
+          toggleCallbackFnDebounced={toggleSpacing}
           /** purely for unit test purposes */
           value={props.spacing}
+          initialSetCallbackFn={setThemePrefsOnAppLoad}
         >
           {({
             preference: spacingChoice,

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -80,6 +80,7 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
       /** purely for unit test purposes */
       value={props.theme}
       initialSetCallbackFn={setThemePrefsOnAppLoad}
+      localStorageKey="themeChoice"
     >
       {({
         preference: themeChoice,
@@ -92,6 +93,7 @@ const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
           /** purely for unit test purposes */
           value={props.spacing}
           initialSetCallbackFn={setThemePrefsOnAppLoad}
+          localStorageKey="spacingChoice"
         >
           {({
             preference: spacingChoice,

--- a/src/LinodeThemeWrapper.tsx
+++ b/src/LinodeThemeWrapper.tsx
@@ -1,88 +1,121 @@
 import * as React from 'react';
+import { compose } from 'recompose';
 import { ThemeProvider } from 'src/components/core/styles';
 import { dark, light } from 'src/themes';
-import {
-  Spacing,
-  spacing as spacingStorage,
-  theme as themeStorage
-} from 'src/utilities/storage';
 
-interface State {
-  themeChoice: 'light' | 'dark';
-  spacing: Spacing;
-}
+import { COMPACT_SPACING_UNIT, NORMAL_SPACING_UNIT } from 'src/themeFactory';
+
+import PreferenceToggle, { ToggleProps } from 'src/components/PreferenceToggle';
+
+import withPreferences, {
+  PreferencesActionsProps
+} from 'src/containers/preferences.container';
+
+type ThemeChoice = 'light' | 'dark';
+type SpacingChoice = 'compact' | 'normal';
+
 type RenderChildren = (
   toggle: () => void,
   spacing: () => void
 ) => React.ReactNode;
+
 interface Props {
   children: RenderChildren | React.ReactNode;
+  /**
+   * override base theme with props
+   * this is mostly so the unit tests work
+   */
+  theme?: ThemeChoice;
+  spacing?: SpacingChoice;
 }
 
 const themes = { light, dark };
 
-class LinodeThemeWrapper extends React.Component<Props, State> {
-  state: State = {
-    themeChoice: 'light',
-    spacing: 'normal'
-  };
+type CombinedProps = Props & PreferencesActionsProps;
 
-  componentDidUpdate() {
+const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
+  React.useEffect(() => {
     setTimeout(() => {
       document.body.classList.remove('no-transition');
     }, 500);
-  }
+  });
 
-  componentDidMount() {
-    const themeSetting = themeStorage.get();
-    const spacingSetting = spacingStorage.get();
-
-    return this.setState({
-      themeChoice: themeSetting,
-      spacing: spacingSetting
-    });
-  }
-
-  toggleTheme = () => {
+  const toggleTheme = () => {
     document.body.classList.add('no-transition');
-    if (this.state.themeChoice === 'light') {
-      this.setState({ themeChoice: 'dark' });
-      themeStorage.set('dark');
-    } else {
-      this.setState({ themeChoice: 'light' });
-      themeStorage.set('light');
-    }
+    /** @todo send to GA */
   };
 
-  toggleSpacing = () => {
-    const { spacing } = this.state;
-    if (spacing === 'compact') {
-      spacingStorage.set('normal');
-      this.setState({ spacing: 'normal' });
-    } else {
-      spacingStorage.set('compact');
-      this.setState({ spacing: 'compact' });
-    }
+  const toggleSpacing = () => {
+    /** @todo send to GA */
   };
 
-  render() {
-    const { children } = this.props;
-    const { themeChoice } = this.state;
-    const theme = themes[themeChoice];
+  React.useEffect(() => {
+    /** request the user preferences on app load */
+    props
+      .getUserPreferences()
+      .catch(
+        () =>
+          /** swallow the error. PreferenceToggle.tsx handles failures gracefully */ null
+      );
+  }, []);
 
-    return (
-      <ThemeProvider theme={theme()}>
-        {isRenderChildren(children)
-          ? children(this.toggleTheme, this.toggleSpacing)
-          : children}
-      </ThemeProvider>
-    );
-  }
-}
-const isRenderChildren = (
-  c: RenderChildren | React.ReactNode
-): c is RenderChildren => {
-  return typeof c === 'function';
+  const { children } = props;
+
+  return (
+    <PreferenceToggle<'light' | 'dark'>
+      preferenceKey="theme"
+      preferenceOptions={['light', 'dark']}
+      toggleCallbackFn={toggleTheme}
+      /** purely for unit test purposes */
+      value={props.theme}
+    >
+      {({
+        preference: themeChoice,
+        togglePreference: _toggleTheme
+      }: ToggleProps<ThemeChoice>) => (
+        <PreferenceToggle<'normal' | 'compact'>
+          preferenceKey="spacing"
+          preferenceOptions={['normal', 'compact']}
+          toggleCallbackFn={toggleSpacing}
+          /** purely for unit test purposes */
+          value={props.spacing}
+        >
+          {({
+            preference: spacingChoice,
+            togglePreference: _toggleSpacing
+          }: ToggleProps<SpacingChoice>) => (
+            <ThemeProvider
+              theme={safelyGetTheme(themes, themeChoice)({
+                spacingOverride:
+                  spacingChoice === 'compact'
+                    ? COMPACT_SPACING_UNIT
+                    : NORMAL_SPACING_UNIT
+              })}
+            >
+              {typeof children === 'function'
+                ? (children as RenderChildren)(_toggleTheme, _toggleSpacing)
+                : children}
+            </ThemeProvider>
+          )}
+        </PreferenceToggle>
+      )}
+    </PreferenceToggle>
+  );
 };
 
-export default LinodeThemeWrapper;
+/** safely return light theme if the theme choice isn't "light" or "dark" */
+const safelyGetTheme = (
+  themesToChoose: Record<'dark' | 'light', any>,
+  themeChoice: string
+) => {
+  /* tslint:disable */
+  return !!Object.keys(themesToChoose).some(
+    eachTheme => eachTheme === themeChoice
+  )
+    ? themesToChoose[themeChoice]
+    : themesToChoose['light'];
+};
+
+export default compose<CombinedProps, Props>(withPreferences())(
+  LinodeThemeWrapper
+);

--- a/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
+++ b/src/components/AbuseTicketBanner/AbuseTicketBanner.test.tsx
@@ -6,23 +6,9 @@ import {
   mockNotification
 } from 'src/__data__/notifications';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
-import Component, { AbuseTicketBanner } from './AbuseTicketBanner';
+import { AbuseTicketBanner } from './AbuseTicketBanner';
 
-const mockState = {
-  __resources: {
-    notifications: {
-      data: [abuseTicketNotification, mockNotification]
-    }
-  }
-};
-
-jest.mock('src/store', () => ({
-  default: {
-    getState: () => mockState,
-    subscribe: () => jest.fn(),
-    dispatch: () => jest.fn()
-  }
-}));
+import filterAbuseTickets from 'src/store/selectors/getAbuseTicket';
 
 afterEach(cleanup);
 
@@ -67,8 +53,12 @@ describe('Abuse ticket banner', () => {
 
   describe('integration tests', () => {
     it('should filter out abuse ticket notifications from the store', () => {
-      const { queryAllByText } = render(wrapWithTheme(<Component />));
-      expect(queryAllByText(/abuse/)).toHaveLength(1);
+      const tickets = filterAbuseTickets({
+        notifications: {
+          data: [mockNotification, abuseTicketNotification]
+        }
+      } as any);
+      expect(tickets[0].label).toMatch(/abuse/);
     });
   });
 });

--- a/src/components/PaginationControls/PaginationControls.test.tsx
+++ b/src/components/PaginationControls/PaginationControls.test.tsx
@@ -5,6 +5,9 @@ import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 
 import PaginationControls from './PaginationControls';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 const getPreviousPageButton = (wrapper: ReactWrapper) =>
   wrapper.find(`WithStyles(PageButton)[data-qa-page-previous]`);
 const getNextPageButton = (wrapper: ReactWrapper) =>
@@ -15,14 +18,16 @@ const getNumberPageButton = (page: string, wrapper: ReactWrapper) =>
 describe('PaginationControls', () => {
   it('should have a previous page button.', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={1}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={1}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
     const previous = getPreviousPageButton(wrapper);
     expect(previous).toHaveLength(1);
@@ -30,14 +35,16 @@ describe('PaginationControls', () => {
 
   it('should have a next page button.', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={1}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={1}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
     const next = getNextPageButton(wrapper);
     expect(next).toHaveLength(1);
@@ -45,14 +52,16 @@ describe('PaginationControls', () => {
 
   it('previous page button should be disabled when on first page', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={1}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={1}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
     const previous = getPreviousPageButton(wrapper);
     expect(previous.prop('disabled')).toBeTruthy();
@@ -60,14 +69,16 @@ describe('PaginationControls', () => {
 
   it('next page button should be disabled when on last page', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={4}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={4}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     const next = getNextPageButton(wrapper);
@@ -76,14 +87,16 @@ describe('PaginationControls', () => {
 
   it('should render a button for each page', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={1}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={1}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     expect(getNumberPageButton('1', wrapper)).toHaveLength(1);
@@ -94,14 +107,16 @@ describe('PaginationControls', () => {
 
   it('should render a button for each page', () => {
     const wrapper = mount(
-      <LinodeThemeWrapper>
-        <PaginationControls
-          onClickHandler={jest.fn()}
-          count={100}
-          page={2}
-          pageSize={25}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <PaginationControls
+            onClickHandler={jest.fn()}
+            count={100}
+            page={2}
+            pageSize={25}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     expect(getNumberPageButton('2', wrapper).prop('disabled')).toBeTruthy();

--- a/src/components/PreferenceToggle/PreferenceToggle.tsx
+++ b/src/components/PreferenceToggle/PreferenceToggle.tsx
@@ -1,0 +1,237 @@
+import { equals, path } from 'ramda';
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import withPreferences, {
+  PreferencesActionsProps
+} from 'src/containers/preferences.container';
+
+type PreferenceValue = boolean | string | number;
+
+export interface ToggleProps<T> {
+  preference: T;
+  togglePreference: () => T;
+}
+
+interface RenderChildrenProps {
+  preference: PreferenceValue;
+  togglePreference: () => PreferenceValue;
+}
+
+type RenderChildren = (props: RenderChildrenProps) => JSX.Element;
+
+interface Props<T = PreferenceValue> {
+  preferenceKey: string;
+  preferenceOptions: [T, T];
+  value?: T;
+  toggleCallbackFn?: (value: PreferenceValue) => void;
+  children: RenderChildren;
+}
+
+type CombinedProps<T = PreferenceValue> = Props<T> &
+  PreferenceProps &
+  PreferencesActionsProps;
+
+const PreferenceToggle: React.FC<CombinedProps> = props => {
+  const {
+    value,
+    preferenceError,
+    preferenceKey,
+    preferenceOptions,
+    toggleCallbackFn,
+    children,
+    preferences
+  } = props;
+
+  /** will be undefined and render-block children unless otherwise specified */
+  const [currentlySetPreference, setPreference] = React.useState<
+    PreferenceValue | undefined
+  >(value);
+  const [lastUpdated, setLastUpdated] = React.useState<number>(0);
+
+  React.useEffect(() => {
+    /**
+     * This useEffect is strictly for when the app first loads
+     * whether we have a preference error or preference data
+     */
+
+    /**
+     * if for whatever reason we failed to get the preferences data
+     * just fallback to some defaults (the first in the list of options).
+     *
+     * Do NOT try and PUT to the API - we don't want to overwrite other unrelated preferences
+     */
+    if (
+      !currentlySetPreference &&
+      !!props.preferenceError &&
+      lastUpdated === 0
+    ) {
+      setPreference(preferenceOptions[0]);
+    }
+
+    /**
+     * In the case of when we successfully retrieved preferences for the FIRST time,
+     * set the state to what we got from the server. If the preference
+     * doesn't exist yet in this user's payload, set defaults in local state.
+     */
+    if (!currentlySetPreference && !!props.preferences && lastUpdated === 0) {
+      const preferenceFromAPI = path<PreferenceValue>(
+        [preferenceKey],
+        props.preferences
+      );
+
+      /** this is the first time the user is setting the user preference */
+      const preferenceToSet = !preferenceFromAPI
+        ? preferenceOptions[0]
+        : preferenceFromAPI;
+
+      setPreference(preferenceToSet);
+    }
+  }, [props.preferenceError, props.preferences]);
+
+  React.useEffect(() => {
+    const debouncedErrorUpdate = setTimeout(() => {
+      /**
+       * we have a preference error, so first GET the preferences
+       * before trying to PUT them.
+       *
+       * Don't update anything if the GET fails
+       */
+      if (!!preferenceError && lastUpdated !== 0) {
+        props
+          .getUserPreferences()
+          .then(response => {
+            props
+              .updateUserPreferences({
+                ...response.preferences,
+                [preferenceKey]: currentlySetPreference
+              })
+              .catch(() => /** swallow the error */ null);
+          })
+          .catch(() => /** swallow the error */ null);
+      } else if (
+        !!preferences &&
+        currentlySetPreference &&
+        lastUpdated !== 0
+        // && preferencesHaveBeenUpdated(props.preferences, theme, spacing)
+      ) {
+        /**
+         * PUT to /preferences on every toggle, debounced.
+         */
+
+        props
+          .updateUserPreferences({
+            ...props.preferences,
+            [preferenceKey]: currentlySetPreference
+          })
+          .catch(() => /** swallow the error */ null);
+      } else if (lastUpdated === 0) {
+        /**
+         * this is the case where the app has just been mounted and the preferences are
+         * being set in local state for the first time
+         */
+        setLastUpdated(Date.now());
+      }
+    }, 500);
+
+    return () => clearTimeout(debouncedErrorUpdate);
+  }, [currentlySetPreference]);
+
+  const togglePreference = () => {
+    /** first set local state to the opposite option */
+    const newPreferenceToSet =
+      currentlySetPreference === preferenceOptions[0]
+        ? preferenceOptions[1]
+        : preferenceOptions[0];
+
+    /** set the preference in local state */
+    setPreference(newPreferenceToSet);
+
+    /** invoke our callback prop if we have one */
+    if (toggleCallbackFn) {
+      toggleCallbackFn(newPreferenceToSet);
+    }
+
+    return newPreferenceToSet;
+  };
+
+  /**
+   * render-block the children. We can prevent
+   * render-blocking by passing a default value as a prop
+   *
+   * So if you want to handle local state outside of this component,
+   * you can do so and pass the value explicitly with the _value_ prop
+   */
+  if (!currentlySetPreference) {
+    return null;
+  }
+
+  return typeof children === 'function'
+    ? children({ preference: currentlySetPreference, togglePreference })
+    : null;
+};
+
+interface PreferenceProps {
+  preferences?: Record<string, any>;
+  preferenceError?: any;
+  preferencesLastUpdated: number;
+}
+
+const memoized = (component: React.FC<CombinedProps>) =>
+  React.memo(component, (prevProps, nextProps) => {
+    /**
+     * only prevent rendering if the preferences AND profileError
+     * went from being defined to defined or vise versa.
+     *
+     * we don't care to re-render if the preferences have been updated in Redux
+     * state. All the relevant preference state will be handled in the component.
+     * This component only cares about what the preferences are on app load.
+     */
+    // console.log(wasUndefinedNowDefined(prevProps.preferenceError, nextProps.preferenceError))
+    const shouldRerender =
+      wasUndefinedNowDefined(prevProps.preferences, nextProps.preferences) ||
+      wasDefinedNowUndefined(prevProps.preferences, nextProps.preferences) ||
+      wasUndefinedNowDefined(
+        prevProps.preferenceError,
+        nextProps.preferenceError
+      ) ||
+      wasDefinedNowUndefined(
+        prevProps.preferenceError,
+        nextProps.preferenceError
+      ) ||
+      !equals(prevProps.children, nextProps.children) ||
+      /** we only care what the server tells us on app load */
+      isUpdatingForTheFirstTime(
+        prevProps.preferencesLastUpdated,
+        nextProps.preferencesLastUpdated
+      );
+
+    /** react memo cares about if the props are equal so set to the opposite */
+    return !shouldRerender;
+  });
+
+const wasUndefinedNowDefined = (prevProp: any, nextProp: any) => {
+  return !prevProp && !!nextProp;
+};
+
+const wasDefinedNowUndefined = (prevProp: any, nextProp: any) => {
+  return !!prevProp && !nextProp;
+};
+
+const isUpdatingForTheFirstTime = (
+  prevLastUpdated: number,
+  nextLastUpdated: number
+) => {
+  return prevLastUpdated === 0 && nextLastUpdated !== 0;
+};
+
+export default (compose<CombinedProps, Props>(
+  withPreferences<PreferenceProps, Props>(
+    (ownProps, { data: preferences, error, lastUpdated }) => ({
+      preferences,
+      preferenceError: error,
+      preferencesLastUpdated: lastUpdated
+    })
+  ),
+  memoized
+)(PreferenceToggle) as unknown) as <T>(props: Props<T>) => React.ReactElement;

--- a/src/components/PreferenceToggle/PreferenceToggle.tsx
+++ b/src/components/PreferenceToggle/PreferenceToggle.tsx
@@ -204,7 +204,6 @@ const memoized = (component: React.FC<CombinedProps>) =>
      * state. All the relevant preference state will be handled in the component.
      * This component only cares about what the preferences are on app load.
      */
-    // console.log(wasUndefinedNowDefined(prevProps.preferenceError, nextProps.preferenceError))
     const shouldRerender =
       wasUndefinedNowDefined(prevProps.preferences, nextProps.preferences) ||
       wasDefinedNowUndefined(prevProps.preferences, nextProps.preferences) ||

--- a/src/components/PreferenceToggle/index.ts
+++ b/src/components/PreferenceToggle/index.ts
@@ -1,0 +1,6 @@
+import { ToggleProps as _ToggleProps } from './PreferenceToggle';
+
+/* tslint:disable */
+export interface ToggleProps<T> extends _ToggleProps<T> {}
+
+export { default } from './PreferenceToggle';

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -21,11 +21,7 @@ import {
 import Grid from 'src/components/Grid';
 import { MapState } from 'src/store/types';
 import { NORMAL_SPACING_UNIT } from 'src/themeFactory';
-import {
-  isKubernetesEnabled,
-  isObjectStorageEnabled
-} from 'src/utilities/accountCapabilities';
-import { sendSpacingToggleEvent, sendThemeToggleEvent } from 'src/utilities/ga';
+import { isObjectStorageEnabled } from 'src/utilities/accountCapabilities';
 import AdditionalMenuItems from './AdditionalMenuItems';
 import SpacingToggle from './SpacingToggle';
 import ThemeToggle from './ThemeToggle';
@@ -402,23 +398,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     this.setState({ anchorEl: undefined });
   };
 
-  handleSpacingToggle = () => {
-    const { toggleSpacing } = this.props;
-    // Checking the previous spacingUnit value to determine which way to switch.
-    const eventLabel = NORMAL_SPACING_UNIT ? 'compact' : 'normal';
-    toggleSpacing();
-    sendSpacingToggleEvent(eventLabel);
-  };
-
-  handleThemeToggle = () => {
-    const { toggleTheme, theme } = this.props;
-    // Checking the previous theme.name value to determine which way to switch.
-    const eventLabel = theme.name === 'darkTheme' ? 'light' : 'dark';
-
-    toggleTheme();
-    sendThemeToggleEvent(eventLabel);
-  };
-
   renderPrimaryLink = (primaryLink: PrimaryLink, isLast: boolean) => {
     const { classes } = this.props;
 
@@ -571,8 +550,8 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
                 className: classes.settingsBackdrop
               }}
             >
-              <ThemeToggle toggleTheme={this.handleThemeToggle} />
-              <SpacingToggle toggleSpacing={this.handleSpacingToggle} />
+              <ThemeToggle toggleTheme={this.props.toggleTheme} />
+              <SpacingToggle toggleSpacing={this.props.toggleSpacing} />
             </Menu>
           </div>
         </Grid>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -21,7 +21,10 @@ import {
 import Grid from 'src/components/Grid';
 import { MapState } from 'src/store/types';
 import { NORMAL_SPACING_UNIT } from 'src/themeFactory';
-import { isObjectStorageEnabled } from 'src/utilities/accountCapabilities';
+import {
+  isKubernetesEnabled,
+  isObjectStorageEnabled
+} from 'src/utilities/accountCapabilities';
 import AdditionalMenuItems from './AdditionalMenuItems';
 import SpacingToggle from './SpacingToggle';
 import ThemeToggle from './ThemeToggle';

--- a/src/components/PrimaryNav/ThemeToggle.test.tsx
+++ b/src/components/PrimaryNav/ThemeToggle.test.tsx
@@ -15,7 +15,7 @@ describe('ThemeToggle', () => {
       <ThemeToggle
         toggleTheme={jest.fn()}
         classes={mockClasses}
-        theme={light()}
+        theme={light({ spacingOverride: 4 })}
       />
     );
   });

--- a/src/containers/preferences.container.ts
+++ b/src/containers/preferences.container.ts
@@ -1,0 +1,34 @@
+import { connect } from 'react-redux';
+import { ApplicationState } from 'src/store';
+
+import { State } from 'src/store/preferences/preferences.reducer';
+import {
+  getUserPreferences,
+  updateUserPreferences
+} from 'src/store/preferences/preferences.requests';
+
+import { ThunkDispatch } from 'src/store/types';
+
+export interface PreferencesActionsProps {
+  getUserPreferences: () => Promise<Record<string, any>>;
+  updateUserPreferences: (
+    params: Record<string, any>
+  ) => Promise<Record<string, any>>;
+}
+
+export default <TInner extends {}, TOuter extends {}>(
+  mapAccountToProps?: (ownProps: TOuter, profile: State) => TInner
+) =>
+  connect(
+    (state: ApplicationState, ownProps: TOuter) => {
+      if (mapAccountToProps) {
+        return mapAccountToProps(ownProps, state.preferences);
+      }
+      return {};
+    },
+    (dispatch: ThunkDispatch) => ({
+      getUserPreferences: () => dispatch(getUserPreferences()),
+      updateUserPreferences: (payload: Partial<Linode.Profile>) =>
+        dispatch(updateUserPreferences(payload))
+    })
+  );

--- a/src/containers/profile.container.ts
+++ b/src/containers/profile.container.ts
@@ -2,10 +2,28 @@ import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 
 import { State } from 'src/store/profile/profile.reducer';
+import {
+  requestProfile,
+  updateProfile
+} from 'src/store/profile/profile.requests';
+
+import { ThunkDispatch } from 'src/store/types';
+
+export interface ProfileActionsProps {
+  getProfile: () => Promise<Linode.Profile>;
+  updateProfile: (params: Partial<Linode.Profile>) => Promise<Linode.Profile>;
+}
 
 export default <TInner extends {}, TOuter extends {}>(
   mapAccountToProps: (ownProps: TOuter, profile: State) => TInner
 ) =>
-  connect((state: ApplicationState, ownProps: TOuter) => {
-    return mapAccountToProps(ownProps, state.__resources.profile);
-  });
+  connect(
+    (state: ApplicationState, ownProps: TOuter) => {
+      return mapAccountToProps(ownProps, state.__resources.profile);
+    },
+    (dispatch: ThunkDispatch) => ({
+      getProfile: () => dispatch(requestProfile()),
+      updateProfile: (payload: Partial<Linode.Profile>) =>
+        dispatch(updateProfile(payload))
+    })
+  );

--- a/src/features/Dashboard/Dashboard.test.tsx
+++ b/src/features/Dashboard/Dashboard.test.tsx
@@ -17,7 +17,7 @@ const props = {
   backupError: undefined,
   entitiesWithGroupsToImport: { linodes: [], domains: [] },
   classes: { root: '' },
-  theme: light()
+  theme: light({ spacingOverride: 8 })
 };
 
 const component = shallow(<Dashboard {...props} />);

--- a/src/features/Dashboard/Dashboard.tsx
+++ b/src/features/Dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { pathOr } from 'ramda';
+import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose } from 'recompose';
@@ -134,7 +134,7 @@ const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
     ),
     userTimezone: pathOr('', ['data', 'timezone'], state.__resources.profile),
     userTimezoneLoading: state.__resources.profile.loading,
-    userTimezoneError: state.__resources.profile.error,
+    userTimezoneError: path(['read'], state.__resources.profile.error),
     someLinodesHaveScheduledMaintenance: linodesData
       ? linodesData.some(eachLinode => !!eachLinode.maintenance)
       : false,

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.test.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.test.tsx
@@ -5,31 +5,36 @@ import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 import { NodeBalancersLanding } from './NodeBalancersLanding';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 describe.skip('NodeBalancers', () => {
   const component = mount(
     <StaticRouter context={{}}>
-      <LinodeThemeWrapper>
-        <NodeBalancersLanding
-          {...reactRouterProps}
-          groupByTag={false}
-          toggleGroupByTag={jest.fn()}
-          nodeBalancersLoading={false}
-          nodeBalancersError={undefined}
-          nodeBalancersData={[]}
-          nodeBalancersCount={0}
-          classes={{
-            root: '',
-            title: '',
-            nameCell: '',
-            icon: '',
-            nodeStatus: '',
-            transferred: '',
-            ports: '',
-            ip: '',
-            tagGroup: ''
-          }}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <NodeBalancersLanding
+            {...reactRouterProps}
+            groupByTag={false}
+            toggleGroupByTag={jest.fn()}
+            nodeBalancersLoading={false}
+            nodeBalancersError={undefined}
+            nodeBalancersData={[]}
+            nodeBalancersCount={0}
+            classes={{
+              root: '',
+              title: '',
+              nameCell: '',
+              icon: '',
+              nodeStatus: '',
+              transferred: '',
+              ports: '',
+              ip: '',
+              tagGroup: ''
+            }}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     </StaticRouter>
   );
 

--- a/src/features/Profile/AuthenticationSettings/AuthenticationSettings.test.tsx
+++ b/src/features/Profile/AuthenticationSettings/AuthenticationSettings.test.tsx
@@ -12,9 +12,7 @@ describe('Authentication settings profile tab', () => {
       ipWhitelisting={true}
       twoFactor={true}
       username={'username'}
-      actions={{
-        updateProfile: update
-      }}
+      updateProfile={update}
       classes={{
         root: '',
         title: ''

--- a/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
+++ b/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
@@ -12,7 +12,6 @@ import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Notice from 'src/components/Notice';
 import { AccountsAndPasswords, SecurityControls } from 'src/documentation';
-import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 import { updateProfile as _updateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import ResetPassword from './ResetPassword';
@@ -133,13 +132,11 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
 };
 
 interface DispatchProps {
-  updateProfile: (
-    v: Partial<ProfileWithPreferences>
-  ) => Promise<ProfileWithPreferences>;
+  updateProfile: (v: Partial<Linode.Profile>) => Promise<Linode.Profile>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
-  updateProfile: (v: Partial<ProfileWithPreferences>) =>
+  updateProfile: (v: Partial<Linode.Profile>) =>
     dispatch(_updateProfile(v) as any)
 });
 

--- a/src/features/Profile/AuthenticationSettings/SecuritySettings.test.tsx
+++ b/src/features/Profile/AuthenticationSettings/SecuritySettings.test.tsx
@@ -13,6 +13,7 @@ describe('Security settings (IP whitelisting) form', () => {
         root: '',
         title: ''
       }}
+      ipWhitelistingEnabled={false}
       onSuccess={onSuccess}
       updateProfile={updateProfile}
     />

--- a/src/features/Profile/AuthenticationSettings/SecuritySettings.tsx
+++ b/src/features/Profile/AuthenticationSettings/SecuritySettings.tsx
@@ -14,8 +14,6 @@ import Toggle from 'src/components/Toggle';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
-import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
-
 type ClassNames = 'root' | 'title';
 
 const styles = (theme: Theme) =>
@@ -32,9 +30,7 @@ const styles = (theme: Theme) =>
 
 interface Props {
   onSuccess: () => void;
-  updateProfile: (
-    v: Partial<Linode.Profile>
-  ) => Promise<ProfileWithPreferences>;
+  updateProfile: (v: Partial<Linode.Profile>) => Promise<Linode.Profile>;
   updateProfileError?: Linode.ApiFieldError[];
   ipWhitelistingEnabled: boolean;
 }

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -18,7 +18,8 @@ import Notice from 'src/components/Notice';
 import Toggle from 'src/components/Toggle';
 import ToggleState from 'src/components/ToggleState';
 import { getTFAToken } from 'src/services/profile';
-import { handleUpdate } from 'src/store/profile/profile.actions';
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
+import { requestProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
@@ -72,7 +73,9 @@ interface Props {
   clearState: () => void;
   twoFactor?: boolean;
   username?: string;
-  updateProfile: (profile: Partial<Linode.Profile>) => void;
+  updateProfile: (
+    profile: Partial<Linode.Profile>
+  ) => Promise<ProfileWithPreferences>;
 }
 
 interface ConfirmDisable {
@@ -147,11 +150,17 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
     });
   };
 
-  confirmToken = (scratchCode: string) => {
-    this.props.actions.updateProfile({
-      ...this.props.profile,
-      two_factor_auth: true
-    });
+  /**
+   * success when TFA is enabled
+   */
+  handleEnableSuccess = (scratchCode: string) => {
+    /**
+     * have redux re-request profile
+     *
+     * we need to do this because we just got a 200 from /profile/tfa
+     * so we need to update the Redux profile state
+     */
+    this.props.refreshProfile();
     this.setState({
       success: 'Two-factor authentication has been enabled.',
       showQRCode: false,
@@ -161,11 +170,17 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
     });
   };
 
-  disableTFASuccess = () => {
-    this.props.actions.updateProfile({
-      ...this.props.profile,
-      two_factor_auth: false
-    });
+  /**
+   * success when TFA is disabled
+   */
+  handleDisableSuccess = () => {
+    /**
+     * have redux re-request profile
+     *
+     * we need to do this because we just got a 200 from /profile/tfa
+     * so we need to update the Redux profile state
+     */
+    this.props.refreshProfile();
     this.setState({
       success: 'Two-factor authentication has been disabled.',
       twoFactorEnabled: false,
@@ -313,7 +328,7 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
                         secret={secret}
                         username={username}
                         loading={loading}
-                        onSuccess={this.confirmToken}
+                        onSuccess={this.handleEnableSuccess}
                         twoFactorConfirmed={twoFactorConfirmed}
                         toggleDialog={toggleScratchDialog}
                       />
@@ -325,7 +340,7 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
                   scratchCode={this.state.scratchCode}
                 />
                 <DisableTwoFactorDialog
-                  onSuccess={this.disableTFASuccess}
+                  onSuccess={this.handleDisableSuccess}
                   open={disable2FAOpen}
                   closeDialog={toggleDisable2FA}
                 />
@@ -341,30 +356,24 @@ export class TwoFactor extends React.Component<CombinedProps, State> {
 const styled = withStyles(styles);
 
 interface StateProps {
-  profile?: Linode.Profile;
   twoFactor?: boolean;
   username?: string;
 }
 
 const mapStateToProps: MapState<StateProps, {}> = state => ({
-  profile: path(['data'], state.__resources.profile),
   twoFactor: path(['data', 'two_factor_auth'], state.__resources.profile),
   username: path(['data', 'username'], state.__resources.profile)
 });
 
 interface DispatchProps {
-  actions: {
-    updateProfile: (v: Partial<Linode.Profile>) => void;
-  };
+  refreshProfile: () => void;
 }
 
-const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
-  dispatch,
-  ownProps
-) => ({
-  actions: {
-    updateProfile: (profile: Linode.Profile) => dispatch(handleUpdate(profile))
-  }
+const mapDispatchToProps: MapDispatchToProps<
+  DispatchProps,
+  Props
+> = dispatch => ({
+  refreshProfile: () => dispatch(requestProfile() as any)
 });
 
 const connected = connect(

--- a/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -18,7 +18,6 @@ import Notice from 'src/components/Notice';
 import Toggle from 'src/components/Toggle';
 import ToggleState from 'src/components/ToggleState';
 import { getTFAToken } from 'src/services/profile';
-import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 import { requestProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -73,9 +72,7 @@ interface Props {
   clearState: () => void;
   twoFactor?: boolean;
   username?: string;
-  updateProfile: (
-    profile: Partial<Linode.Profile>
-  ) => Promise<ProfileWithPreferences>;
+  updateProfile: (profile: Partial<Linode.Profile>) => Promise<Linode.Profile>;
 }
 
 interface ConfirmDisable {

--- a/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
+++ b/src/features/Profile/DisplaySettings/DisplaySettings.test.tsx
@@ -13,9 +13,7 @@ describe('Email change form', () => {
       email="me@this.com"
       timezone="America/Barbados"
       loggedInAsCustomer={false}
-      actions={{
-        updateProfile: update
-      }}
+      updateProfile={update}
       classes={{
         root: '',
         title: ''

--- a/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -1,4 +1,4 @@
-import { compose, path, pathOr } from 'ramda';
+import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { compose as recompose } from 'recompose';
@@ -11,12 +11,11 @@ import {
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { AccountsAndPasswords } from 'src/documentation';
-import { handleUpdate } from 'src/store/profile/profile.actions';
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
+import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import EmailChangeForm from './EmailChangeForm';
 import TimezoneForm from './TimezoneForm';
-
-import { RequestableData } from 'src/store/types';
 
 type ClassNames = 'root' | 'title';
 
@@ -50,8 +49,8 @@ export class DisplaySettings extends React.Component<CombinedProps, State> {
 
   render() {
     const {
-      actions,
       email,
+      updateProfile,
       loggedInAsCustomer,
       loading,
       timezone,
@@ -70,12 +69,12 @@ export class DisplaySettings extends React.Component<CombinedProps, State> {
             <EmailChangeForm
               email={email}
               username={username}
-              updateProfile={actions.updateProfile}
+              updateProfile={updateProfile}
               data-qa-email-change
             />
             <TimezoneForm
               timezone={timezone}
-              updateProfile={actions.updateProfile}
+              updateProfile={updateProfile}
               loggedInAsCustomer={loggedInAsCustomer}
             />
           </React.Fragment>
@@ -103,7 +102,7 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
     loading: profile.loading,
     username: path(['data', 'username'], profile),
     email: path(['data', 'email'], profile),
-    timezone: defaultTimezone(profile),
+    timezone: pathOr<string>('GMT', ['data', 'timezone'], profile),
     loggedInAsCustomer: pathOr(
       false,
       ['authentication', 'loggedInAsCustomer'],
@@ -113,21 +112,12 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
 };
 
 interface DispatchProps {
-  actions: {
-    updateProfile: (v: Linode.Profile) => void;
-  };
+  updateProfile: (v: Linode.Profile) => Promise<ProfileWithPreferences>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
-  actions: {
-    updateProfile: (v: Linode.Profile) => dispatch(handleUpdate(v))
-  }
+  updateProfile: (v: Linode.Profile) => dispatch(handleUpdateProfile(v) as any)
 });
-
-const defaultTimezone = compose(
-  tz => (tz === '' ? 'GMT' : tz),
-  pathOr('GMT', ['data', 'timezone'])
-) as (profile: RequestableData<Linode.Profile>) => string;
 
 const connected = connect(
   mapStateToProps,

--- a/src/features/Profile/DisplaySettings/DisplaySettings.tsx
+++ b/src/features/Profile/DisplaySettings/DisplaySettings.tsx
@@ -11,7 +11,6 @@ import {
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import { AccountsAndPasswords } from 'src/documentation';
-import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import EmailChangeForm from './EmailChangeForm';
@@ -112,7 +111,7 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
 };
 
 interface DispatchProps {
-  updateProfile: (v: Linode.Profile) => Promise<ProfileWithPreferences>;
+  updateProfile: (v: Linode.Profile) => Promise<Linode.Profile>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({

--- a/src/features/Profile/DisplaySettings/EmailChangeForm.test.tsx
+++ b/src/features/Profile/DisplaySettings/EmailChangeForm.test.tsx
@@ -6,21 +6,26 @@ import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 
 import { EmailChangeForm } from './EmailChangeForm';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 describe('Email change form', () => {
   const updateProfile = jest.fn();
 
   const component = mount(
-    <LinodeThemeWrapper>
-      <EmailChangeForm
-        classes={{
-          root: '',
-          title: ''
-        }}
-        username="ThisUser"
-        email="thisuser@example.com"
-        updateProfile={updateProfile}
-      />
-    </LinodeThemeWrapper>
+    <Provider store={store}>
+      <LinodeThemeWrapper theme="dark" spacing="normal">
+        <EmailChangeForm
+          classes={{
+            root: '',
+            title: ''
+          }}
+          username="ThisUser"
+          email="thisuser@example.com"
+          updateProfile={updateProfile}
+        />
+      </LinodeThemeWrapper>
+    </Provider>
   );
 
   it('should render textfields for username and email.', () => {

--- a/src/features/Profile/DisplaySettings/EmailChangeForm.tsx
+++ b/src/features/Profile/DisplaySettings/EmailChangeForm.tsx
@@ -11,10 +11,11 @@ import {
 } from 'src/components/core/styles';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import { updateProfile } from 'src/services/profile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 
 type ClassNames = 'root' | 'title';
 
@@ -32,7 +33,10 @@ const styles = (theme: Theme) =>
 interface Props {
   username: string;
   email: string;
-  updateProfile: (v: Partial<Linode.Profile>) => void;
+  updateProfile: (
+    v: Partial<Linode.Profile>
+  ) => Promise<ProfileWithPreferences>;
+  errors?: Linode.ApiFieldError[];
 }
 
 interface State {
@@ -47,7 +51,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export class EmailChangeForm extends React.Component<CombinedProps, State> {
   state: State = {
     updatedEmail: this.props.email || '',
-    errors: undefined,
+    errors: this.props.errors,
     success: undefined,
     submitting: false
   };
@@ -69,12 +73,13 @@ export class EmailChangeForm extends React.Component<CombinedProps, State> {
     const { updatedEmail } = this.state;
     this.setState({ errors: undefined, submitting: true });
 
-    updateProfile({ email: updatedEmail })
-      .then(response => {
-        this.props.updateProfile(response);
+    this.props
+      .updateProfile({ email: updatedEmail })
+      .then(() => {
         this.setState({
           submitting: false,
-          success: 'Email address updated.'
+          success: 'Email address updated.',
+          errors: undefined
         });
       })
       .catch(error => {

--- a/src/features/Profile/DisplaySettings/EmailChangeForm.tsx
+++ b/src/features/Profile/DisplaySettings/EmailChangeForm.tsx
@@ -15,8 +15,6 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
-import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
-
 type ClassNames = 'root' | 'title';
 
 const styles = (theme: Theme) =>
@@ -33,9 +31,7 @@ const styles = (theme: Theme) =>
 interface Props {
   username: string;
   email: string;
-  updateProfile: (
-    v: Partial<Linode.Profile>
-  ) => Promise<ProfileWithPreferences>;
+  updateProfile: (v: Partial<Linode.Profile>) => Promise<Linode.Profile>;
   errors?: Linode.ApiFieldError[];
 }
 

--- a/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -13,10 +13,10 @@ import {
 import Typography from 'src/components/core/Typography';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
-import { updateProfile } from 'src/services/profile';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
+
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 
 type ClassNames = 'root' | 'title';
 
@@ -36,15 +36,18 @@ const styles = (theme: Theme) =>
 interface Props {
   timezone: string;
   loggedInAsCustomer: boolean;
-  updateProfile: (v: Linode.Profile) => void;
+  updateProfile: (
+    v: Partial<Linode.Profile>
+  ) => Promise<ProfileWithPreferences>;
+  errors?: Linode.ApiFieldError[];
 }
 
 interface State {
   updatedTimezone: Item | null;
   inputValue: string;
-  errors?: Linode.ApiFieldError[];
   submitting: boolean;
   success?: string;
+  errors?: Linode.ApiFieldError[];
 }
 
 interface Timezone {
@@ -75,9 +78,9 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
   state: State = {
     updatedTimezone: null,
     inputValue: '',
-    errors: undefined,
     submitting: false,
-    success: undefined
+    success: undefined,
+    errors: this.props.errors
   };
 
   getTimezone = (timezoneValue: string) => {
@@ -91,7 +94,7 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
     if (timezone) {
       this.setState(set(lensPath(['updatedTimezone']), timezone));
     } else {
-      this.setState({ errors: undefined, success: undefined });
+      this.setState({ success: undefined });
     }
   };
 
@@ -100,22 +103,23 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
     if (!updatedTimezone) {
       return;
     }
-    this.setState({ errors: undefined, submitting: true });
+    this.setState({ submitting: true });
 
-    updateProfile({ timezone: updatedTimezone.value })
-      .then(response => {
-        this.props.updateProfile(response);
+    this.props
+      .updateProfile({ timezone: updatedTimezone.value as string })
+      .then(() => {
         this.setState({
           submitting: false,
-          success: 'Account timezone updated.'
+          success: 'Account timezone updated.',
+          errors: undefined
         });
       })
-      .catch(error => {
+      .catch(e => {
         this.setState(
           {
             submitting: false,
-            errors: getAPIErrorOrDefault(error),
-            success: undefined
+            success: undefined,
+            errors: e
           },
           () => {
             scrollErrorIntoView();

--- a/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -16,8 +16,6 @@ import Notice from 'src/components/Notice';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
-import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
-
 type ClassNames = 'root' | 'title';
 
 const styles = (theme: Theme) =>
@@ -36,9 +34,7 @@ const styles = (theme: Theme) =>
 interface Props {
   timezone: string;
   loggedInAsCustomer: boolean;
-  updateProfile: (
-    v: Partial<Linode.Profile>
-  ) => Promise<ProfileWithPreferences>;
+  updateProfile: (v: Partial<Linode.Profile>) => Promise<Linode.Profile>;
   errors?: Linode.ApiFieldError[];
 }
 

--- a/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/src/features/Profile/LishSettings/LishSettings.tsx
@@ -20,7 +20,6 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { LISH } from 'src/documentation';
-import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -293,9 +292,7 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
 };
 
 interface DispatchProps {
-  updateProfile: (
-    v: Partial<Linode.Profile>
-  ) => Promise<ProfileWithPreferences>;
+  updateProfile: (v: Partial<Linode.Profile>) => Promise<Linode.Profile>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({

--- a/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/src/features/Profile/LishSettings/LishSettings.tsx
@@ -20,8 +20,8 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { LISH } from 'src/documentation';
-import { updateProfile } from 'src/services/profile';
-import { handleUpdate } from 'src/store/profile/profile.actions';
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
+import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorFor from 'src/utilities/getAPIErrorFor';
@@ -84,7 +84,7 @@ interface State {
   submitting: boolean;
   errors?: Linode.ApiFieldError[];
   success?: string;
-  lishAuthMethod?: string;
+  lishAuthMethod: Pick<Linode.Profile, 'lish_auth_method'>;
   authorizedKeys: string[];
   authorizedKeysCount: number;
 }
@@ -94,7 +94,7 @@ type CombinedProps = StateProps & DispatchProps & WithStyles<ClassNames>;
 class LishSettings extends React.Component<CombinedProps, State> {
   state: State = {
     submitting: false,
-    lishAuthMethod: this.props.lishAuthMethod || 'password_keys',
+    lishAuthMethod: this.props.lishAuthMethod || ('password_keys' as any),
     authorizedKeys: this.props.authorizedKeys || [],
     authorizedKeysCount: this.props.authorizedKeys
       ? this.props.authorizedKeys.length
@@ -137,7 +137,7 @@ class LishSettings extends React.Component<CombinedProps, State> {
     ];
 
     const defaultMode = modeOptions.find(eachMode => {
-      return eachMode.value === lishAuthMethod;
+      return (eachMode.value as any) === lishAuthMethod;
     });
 
     return (
@@ -167,7 +167,7 @@ class LishSettings extends React.Component<CombinedProps, State> {
                   name="mode-select"
                   id="mode-select"
                   defaultValue={defaultMode}
-                  onChange={this.onListAuthMethodChange}
+                  onChange={this.onListAuthMethodChange as any}
                   label="Authentication Mode"
                   isClearable={false}
                   errorText={authMethodError}
@@ -224,27 +224,24 @@ class LishSettings extends React.Component<CombinedProps, State> {
 
   onSubmit = () => {
     const { authorizedKeys, lishAuthMethod } = this.state;
-    const { actions } = this.props;
+    const { updateProfile } = this.props;
     const keys = authorizedKeys.filter(v => v !== '');
 
     this.setState({ errors: undefined, submitting: true });
 
     updateProfile({
-      lish_auth_method: lishAuthMethod,
+      lish_auth_method: lishAuthMethod as any,
       authorized_keys: keys
     })
       .then(profileData => {
-        this.setState(
-          {
-            submitting: false,
-            success: 'LISH authentication settings have been updated.',
-            authorizedKeys: profileData.authorized_keys || [],
-            authorizedKeysCount: profileData.authorized_keys
-              ? profileData.authorized_keys.length
-              : 1
-          },
-          () => actions.updateProfile(profileData)
-        );
+        this.setState({
+          submitting: false,
+          success: 'LISH authentication settings have been updated.',
+          authorizedKeys: profileData.authorized_keys || [],
+          authorizedKeysCount: profileData.authorized_keys
+            ? profileData.authorized_keys.length
+            : 1
+        });
       })
       .catch(error => {
         this.setState(
@@ -260,8 +257,9 @@ class LishSettings extends React.Component<CombinedProps, State> {
       });
   };
 
-  onListAuthMethodChange = (e: Item<string>) =>
-    this.setState({ lishAuthMethod: e.value });
+  onListAuthMethodChange = (
+    e: Item<Pick<Linode.Profile, 'lish_auth_method'>>
+  ) => this.setState({ lishAuthMethod: e.value });
 
   onPublicKeyChange = (idx: number) => (
     e: React.ChangeEvent<HTMLInputElement>
@@ -280,7 +278,7 @@ class LishSettings extends React.Component<CombinedProps, State> {
 const styled = withStyles(styles);
 
 interface StateProps {
-  lishAuthMethod?: string;
+  lishAuthMethod?: Pick<Linode.Profile, 'lish_auth_method'>;
   authorizedKeys?: string[];
   loading: boolean;
 }
@@ -295,15 +293,13 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
 };
 
 interface DispatchProps {
-  actions: {
-    updateProfile: (v: Linode.Profile) => void;
-  };
+  updateProfile: (
+    v: Partial<Linode.Profile>
+  ) => Promise<ProfileWithPreferences>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
-  actions: {
-    updateProfile: (v: Linode.Profile) => dispatch(handleUpdate(v))
-  }
+  updateProfile: (v: Linode.Profile) => dispatch(handleUpdateProfile(v) as any)
 });
 
 const connected = connect(

--- a/src/features/Profile/Settings/Settings.tsx
+++ b/src/features/Profile/Settings/Settings.tsx
@@ -14,7 +14,6 @@ import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Toggle from 'src/components/Toggle';
-import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
 import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 
@@ -90,9 +89,7 @@ class ProfileSettings extends React.Component<CombinedProps, State> {
 const styled = withStyles(styles);
 
 interface DispatchProps {
-  updateProfile: (
-    p: Partial<Linode.Profile>
-  ) => Promise<ProfileWithPreferences>;
+  updateProfile: (p: Partial<Linode.Profile>) => Promise<Linode.Profile>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({

--- a/src/features/Profile/Settings/Settings.tsx
+++ b/src/features/Profile/Settings/Settings.tsx
@@ -14,8 +14,8 @@ import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Toggle from 'src/components/Toggle';
-import { updateProfile } from 'src/services/profile';
-import { handleUpdate } from 'src/store/profile/profile.actions';
+import { ProfileWithPreferences } from 'src/store/profile/profile.actions';
+import { updateProfile as handleUpdateProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 
 type ClassNames = 'root' | 'title' | 'label';
@@ -75,13 +75,14 @@ class ProfileSettings extends React.Component<CombinedProps, State> {
   toggle = () => {
     this.setState({ submitting: true });
 
-    updateProfile({ email_notifications: !this.props.status })
-      .then(profile => {
-        this.props.actions.updateProfile(profile);
+    this.props
+      .updateProfile({ email_notifications: !this.props.status })
+      .then(() => {
         this.setState({ submitting: false });
       })
       .catch(() => {
         /* Couldnt really imagine this being an issue... 1*/
+        this.setState({ submitting: false });
       });
   };
 }
@@ -89,15 +90,13 @@ class ProfileSettings extends React.Component<CombinedProps, State> {
 const styled = withStyles(styles);
 
 interface DispatchProps {
-  actions: {
-    updateProfile: (p: Linode.Profile) => void;
-  };
+  updateProfile: (
+    p: Partial<Linode.Profile>
+  ) => Promise<ProfileWithPreferences>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
-  actions: {
-    updateProfile: (p: Linode.Profile) => dispatch(handleUpdate(p))
-  }
+  updateProfile: (p: Linode.Profile) => dispatch(handleUpdateProfile(p) as any)
 });
 
 interface StateProps {

--- a/src/features/TopMenu/AddNewMenu/AddNewMenuItem.test.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenuItem.test.tsx
@@ -6,34 +6,41 @@ import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 
 import AddNewMenuItem from './AddNewMenuItem';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 describe('AddNewMenuItem', () => {
   it('should render without error', () => {
     shallow(
-      <LinodeThemeWrapper>
-        <AddNewMenuItem
-          index={1}
-          count={1}
-          title="shenanigans"
-          body="These be the stories of shennanigans."
-          ItemIcon={LinodeIcon}
-          onClick={jest.fn()}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <AddNewMenuItem
+            index={1}
+            count={1}
+            title="shenanigans"
+            body="These be the stories of shennanigans."
+            ItemIcon={LinodeIcon}
+            onClick={jest.fn()}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
   });
 
   it('should not render a divider if not the last item', () => {
     const result = mount(
-      <LinodeThemeWrapper>
-        <AddNewMenuItem
-          index={0}
-          count={1}
-          title="shenanigans"
-          body="These be the stories of shennanigans."
-          ItemIcon={LinodeIcon}
-          onClick={jest.fn()}
-        />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <AddNewMenuItem
+            index={0}
+            count={1}
+            title="shenanigans"
+            body="These be the stories of shennanigans."
+            ItemIcon={LinodeIcon}
+            onClick={jest.fn()}
+          />
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     expect(result.find('WithStyles(Divider)')).toHaveLength(0);

--- a/src/features/Users/UserDetail.tsx
+++ b/src/features/Users/UserDetail.tsx
@@ -25,7 +25,7 @@ import TabLink from 'src/components/TabLink';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import { getUser, updateUser } from 'src/services/account';
 import { updateProfile } from 'src/services/profile';
-import { handleUpdate } from 'src/store/profile/profile.actions';
+import { requestProfile } from 'src/store/profile/profile.requests';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getGravatarUrl } from 'src/utilities/gravatar';
@@ -196,7 +196,7 @@ class UserDetail extends React.Component<CombinedProps> {
       history,
       match: { path },
       profileUsername,
-      actions: { updateCurrentUser }
+      refreshProfile
     } = this.props;
 
     const { originalUsername, username, restricted } = this.state;
@@ -229,7 +229,7 @@ class UserDetail extends React.Component<CombinedProps> {
          * If the user we updated is the current user, we need to reflect that change at the global level.
          */
         if (profileUsername === originalUsername) {
-          updateCurrentUser(user);
+          refreshProfile();
         }
 
         /**
@@ -253,9 +253,7 @@ class UserDetail extends React.Component<CombinedProps> {
 
   onSaveProfile = () => {
     const { email, originalUsername } = this.state;
-    const {
-      actions: { updateCurrentUser }
-    } = this.props;
+    const { refreshProfile } = this.props;
 
     this.setState({
       profileSuccess: false,
@@ -276,7 +274,7 @@ class UserDetail extends React.Component<CombinedProps> {
          * If the user we updated is the current user, we need to reflect that change at the global level.
          */
         if (profile.username === originalUsername) {
-          updateCurrentUser(profile);
+          refreshProfile();
         }
       })
       .catch(errResponse => {
@@ -448,16 +446,11 @@ const mapStateToProps: MapState<StateProps, {}> = state => ({
 });
 
 interface DispatchProps {
-  actions: {
-    updateCurrentUser: (user: Linode.User | Linode.Profile) => void;
-  };
+  refreshProfile: () => void;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
-  actions: {
-    updateCurrentUser: (u: Linode.User | Linode.Profile) =>
-      dispatch(handleUpdate(u))
-  }
+  refreshProfile: () => dispatch(requestProfile() as any)
 });
 
 const reloadable = reloadableWithRouter<CombinedProps, MatchProps>(

--- a/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeResize/LInodeResize.test.tsx
@@ -11,6 +11,9 @@ import {
   shouldEnableAutoResizeDiskOption
 } from './LinodeResize';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 describe('LinodeResize', () => {
   const mockTypes = types.map(LinodeResize.extendType);
 
@@ -36,27 +39,29 @@ describe('LinodeResize', () => {
 
   it('should render the currently selected plan as a card', () => {
     const componentWithTheme = mount(
-      <LinodeThemeWrapper>
-        <MemoryRouter>
-          <LinodeResize
-            linodeDisks={[]}
-            closeSnackbar={jest.fn()}
-            enqueueSnackbar={jest.fn()}
-            {...reactRouterProps}
-            classes={{
-              root: '',
-              title: '',
-              subTitle: '',
-              currentPlanContainer: ''
-            }}
-            linodeId={12}
-            linodeType={null}
-            currentTypesData={mockTypes}
-            deprecatedTypesData={mockTypes}
-            linodeLabel=""
-          />
-        </MemoryRouter>
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <MemoryRouter>
+            <LinodeResize
+              linodeDisks={[]}
+              closeSnackbar={jest.fn()}
+              enqueueSnackbar={jest.fn()}
+              {...reactRouterProps}
+              classes={{
+                root: '',
+                title: '',
+                subTitle: '',
+                currentPlanContainer: ''
+              }}
+              linodeId={12}
+              linodeType={null}
+              currentTypesData={mockTypes}
+              deprecatedTypesData={mockTypes}
+              linodeLabel=""
+            />
+          </MemoryRouter>
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     const currentSelectionCard = componentWithTheme.find(
@@ -71,28 +76,30 @@ describe('LinodeResize', () => {
     describe('current plan card', () => {
       it('should have a heading of No Assigned Plan', () => {
         const componentWithTheme = mount(
-          <LinodeThemeWrapper>
-            <MemoryRouter>
-              <LinodeResize
-                closeSnackbar={jest.fn()}
-                enqueueSnackbar={jest.fn()}
-                requestNotifications={jest.fn()}
-                linodeDisks={[]}
-                {...reactRouterProps}
-                classes={{
-                  root: '',
-                  title: '',
-                  subTitle: '',
-                  currentPlanContainer: ''
-                }}
-                linodeId={12}
-                linodeType={null}
-                currentTypesData={mockTypes}
-                deprecatedTypesData={mockTypes}
-                linodeLabel=""
-              />
-            </MemoryRouter>
-          </LinodeThemeWrapper>
+          <Provider store={store}>
+            <LinodeThemeWrapper theme="dark" spacing="normal">
+              <MemoryRouter>
+                <LinodeResize
+                  closeSnackbar={jest.fn()}
+                  enqueueSnackbar={jest.fn()}
+                  requestNotifications={jest.fn()}
+                  linodeDisks={[]}
+                  {...reactRouterProps}
+                  classes={{
+                    root: '',
+                    title: '',
+                    subTitle: '',
+                    currentPlanContainer: ''
+                  }}
+                  linodeId={12}
+                  linodeType={null}
+                  currentTypesData={mockTypes}
+                  deprecatedTypesData={mockTypes}
+                  linodeLabel=""
+                />
+              </MemoryRouter>
+            </LinodeThemeWrapper>
+          </Provider>
         );
 
         const currentSelectionCard = componentWithTheme.find(
@@ -109,27 +116,29 @@ describe('LinodeResize', () => {
     describe('current plan card', () => {
       it('should have a heading of Unknown Plan', () => {
         const componentWithTheme = mount(
-          <LinodeThemeWrapper>
-            <MemoryRouter>
-              <LinodeResize
-                closeSnackbar={jest.fn()}
-                linodeDisks={[]}
-                enqueueSnackbar={jest.fn()}
-                {...reactRouterProps}
-                classes={{
-                  root: '',
-                  title: '',
-                  subTitle: '',
-                  currentPlanContainer: ''
-                }}
-                linodeId={12}
-                linodeType={'_something_unexpected_'}
-                currentTypesData={mockTypes}
-                deprecatedTypesData={mockTypes}
-                linodeLabel=""
-              />
-            </MemoryRouter>
-          </LinodeThemeWrapper>
+          <Provider store={store}>
+            <LinodeThemeWrapper theme="dark" spacing="normal">
+              <MemoryRouter>
+                <LinodeResize
+                  closeSnackbar={jest.fn()}
+                  linodeDisks={[]}
+                  enqueueSnackbar={jest.fn()}
+                  {...reactRouterProps}
+                  classes={{
+                    root: '',
+                    title: '',
+                    subTitle: '',
+                    currentPlanContainer: ''
+                  }}
+                  linodeId={12}
+                  linodeType={'_something_unexpected_'}
+                  currentTypesData={mockTypes}
+                  deprecatedTypesData={mockTypes}
+                  linodeLabel=""
+                />
+              </MemoryRouter>
+            </LinodeThemeWrapper>
+          </Provider>
         );
 
         const currentSelectionCard = componentWithTheme.find(

--- a/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -103,7 +103,7 @@ const enhanced = compose<CombinedProps, {}>(
   })),
   withProfile<ProfileProps, {}>((undefined, profile) => ({
     userTimezone: path(['data', 'timezone'], profile),
-    userTimezoneError: profile.error,
+    userTimezoneError: path(['read'], profile.error),
     userTimezoneLoading: profile.loading
   }))
 );

--- a/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
@@ -38,7 +38,7 @@ describe('LinodeRow', () => {
   const mockProps: CombinedProps = {
     classes: mockClasses,
     toggleConfirmation: jest.fn(),
-    theme: light(),
+    theme: light({ spacingOverride: 4 }),
     maintenanceStartTime: '',
     someLinodesHaveMaintenance: false,
     recentEvent: undefined,

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
@@ -21,7 +21,7 @@ describe('LinodeRow', () => {
   const mockProps: CombinedProps = {
     classes: mockClasses,
     toggleConfirmation: jest.fn(),
-    theme: light(),
+    theme: light({ spacingOverride: 4 }),
     maintenanceStartTime: '',
     someLinodesHaveMaintenance: false,
     recentEvent: undefined,

--- a/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
@@ -5,6 +5,9 @@ import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 import { clearDocs, setDocs } from 'src/store/documentation';
 import { ListLinodes } from './LinodesLanding';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 const RoutedListLinodes = withRouter(ListLinodes);
 
 describe('ListLinodes', () => {
@@ -17,63 +20,67 @@ describe('ListLinodes', () => {
 
   it('renders without error', () => {
     shallow(
-      <LinodeThemeWrapper>
-        <StaticRouter location="/" context={{}}>
-          <RoutedListLinodes
-            imagesLoading={false}
-            imagesError={undefined}
-            userTimezone="GMT"
-            userTimezoneLoading={false}
-            someLinodesHaveScheduledMaintenance={true}
-            linodesData={[]}
-            width={'lg'}
-            classes={classes}
-            clearDocs={clearDocs}
-            enqueueSnackbar={jest.fn()}
-            groupByTags={false}
-            linodesCount={0}
-            linodesRequestError={undefined}
-            linodesRequestLoading={false}
-            managed={false}
-            closeSnackbar={jest.fn()}
-            setDocs={setDocs}
-            toggleGroupByTag={jest.fn()}
-            backupsCTA={false}
-            deleteLinode={jest.fn()}
-          />
-        </StaticRouter>
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <StaticRouter location="/" context={{}}>
+            <RoutedListLinodes
+              imagesLoading={false}
+              imagesError={undefined}
+              userTimezone="GMT"
+              userTimezoneLoading={false}
+              someLinodesHaveScheduledMaintenance={true}
+              linodesData={[]}
+              width={'lg'}
+              classes={classes}
+              clearDocs={clearDocs}
+              enqueueSnackbar={jest.fn()}
+              groupByTags={false}
+              linodesCount={0}
+              linodesRequestError={undefined}
+              linodesRequestLoading={false}
+              managed={false}
+              closeSnackbar={jest.fn()}
+              setDocs={setDocs}
+              toggleGroupByTag={jest.fn()}
+              backupsCTA={false}
+              deleteLinode={jest.fn()}
+            />
+          </StaticRouter>
+        </LinodeThemeWrapper>
+      </Provider>
     );
   });
 
   it.skip('renders an empty state with no linodes', () => {
     const component = shallow(
-      <LinodeThemeWrapper>
-        <StaticRouter location="/" context={{}}>
-          <RoutedListLinodes
-            imagesLoading={false}
-            imagesError={undefined}
-            linodesData={[]}
-            width={'lg'}
-            classes={classes}
-            clearDocs={clearDocs}
-            userTimezone="GMT"
-            userTimezoneLoading={false}
-            someLinodesHaveScheduledMaintenance={true}
-            enqueueSnackbar={jest.fn()}
-            groupByTags={false}
-            linodesCount={0}
-            linodesRequestError={undefined}
-            linodesRequestLoading={false}
-            managed={false}
-            closeSnackbar={jest.fn()}
-            setDocs={setDocs}
-            toggleGroupByTag={jest.fn()}
-            backupsCTA={false}
-            deleteLinode={jest.fn()}
-          />
-        </StaticRouter>
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <StaticRouter location="/" context={{}}>
+            <RoutedListLinodes
+              imagesLoading={false}
+              imagesError={undefined}
+              linodesData={[]}
+              width={'lg'}
+              classes={classes}
+              clearDocs={clearDocs}
+              userTimezone="GMT"
+              userTimezoneLoading={false}
+              someLinodesHaveScheduledMaintenance={true}
+              enqueueSnackbar={jest.fn()}
+              groupByTags={false}
+              linodesCount={0}
+              linodesRequestError={undefined}
+              linodesRequestLoading={false}
+              managed={false}
+              closeSnackbar={jest.fn()}
+              setDocs={setDocs}
+              toggleGroupByTag={jest.fn()}
+              backupsCTA={false}
+              deleteLinode={jest.fn()}
+            />
+          </StaticRouter>
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     const emptyState = component.find('ListLinodesEmptyState');
@@ -84,32 +91,34 @@ describe('ListLinodes', () => {
   /** Test is not specific to the LinodesLanding Page */
   it.skip('renders menu actions when the kabob is clicked', () => {
     const component = shallow(
-      <LinodeThemeWrapper>
-        <StaticRouter location="/" context={{}}>
-          <RoutedListLinodes
-            imagesLoading={false}
-            imagesError={undefined}
-            linodesData={[]}
-            width={'lg'}
-            userTimezone="GMT"
-            userTimezoneLoading={false}
-            someLinodesHaveScheduledMaintenance={true}
-            classes={classes}
-            clearDocs={clearDocs}
-            enqueueSnackbar={jest.fn()}
-            groupByTags={false}
-            linodesCount={0}
-            linodesRequestError={undefined}
-            linodesRequestLoading={false}
-            managed={false}
-            closeSnackbar={jest.fn()}
-            setDocs={setDocs}
-            toggleGroupByTag={jest.fn()}
-            backupsCTA={false}
-            deleteLinode={jest.fn()}
-          />
-        </StaticRouter>
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <StaticRouter location="/" context={{}}>
+            <RoutedListLinodes
+              imagesLoading={false}
+              imagesError={undefined}
+              linodesData={[]}
+              width={'lg'}
+              userTimezone="GMT"
+              userTimezoneLoading={false}
+              someLinodesHaveScheduledMaintenance={true}
+              classes={classes}
+              clearDocs={clearDocs}
+              enqueueSnackbar={jest.fn()}
+              groupByTags={false}
+              linodesCount={0}
+              linodesRequestError={undefined}
+              linodesRequestLoading={false}
+              managed={false}
+              closeSnackbar={jest.fn()}
+              setDocs={setDocs}
+              toggleGroupByTag={jest.fn()}
+              backupsCTA={false}
+              deleteLinode={jest.fn()}
+            />
+          </StaticRouter>
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     const kabobButton = component.find('MoreHoriz').first();

--- a/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -560,7 +560,10 @@ const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
     linodesRequestError: path(['error', 'read'], state.__resources.linodes),
     userTimezone: pathOr('', ['data', 'timezone'], state.__resources.profile),
     userTimezoneLoading: state.__resources.profile.loading,
-    userTimezoneError: state.__resources.profile.error
+    userTimezoneError: path<Linode.ApiFieldError[]>(
+      ['read'],
+      state.__resources.profile.error
+    )
   };
 };
 

--- a/src/features/linodes/LinodesLanding/OverflowIPs.test.tsx
+++ b/src/features/linodes/LinodesLanding/OverflowIPs.test.tsx
@@ -3,14 +3,19 @@ import * as React from 'react';
 
 import LinodeThemeWrapper from 'src/LinodeThemeWrapper';
 
+import { Provider } from 'react-redux';
+import store from 'src/store';
+
 import OverflowIPs from './OverflowIPs';
 
 describe('OverflowIPs', () => {
   it('should render without error and display the number of IPs', () => {
     const result = mount(
-      <LinodeThemeWrapper>
-        <OverflowIPs ips={['8.8.8.8']} />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <OverflowIPs ips={['8.8.8.8']} />
+        </LinodeThemeWrapper>
+      </Provider>
     );
     const rendered = result.find('OverflowIPs');
     const numberText = result.find('span').text();
@@ -21,9 +26,11 @@ describe('OverflowIPs', () => {
 
   it('should render each IPAddress when the chip is clicked', () => {
     const result = mount(
-      <LinodeThemeWrapper>
-        <OverflowIPs ips={['8.8.8.8', '8.8.4.4', '192.168.100.112']} />
-      </LinodeThemeWrapper>
+      <Provider store={store}>
+        <LinodeThemeWrapper theme="dark" spacing="normal">
+          <OverflowIPs ips={['8.8.8.8', '8.8.4.4', '192.168.100.112']} />
+        </LinodeThemeWrapper>
+      </Provider>
     );
 
     const chip = result.find('ForwardRef(Chip)');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,10 +20,8 @@ import Logout from 'src/layouts/Logout';
 import OAuthCallbackPage from 'src/layouts/OAuth';
 import store from 'src/store';
 import 'src/utilities/createImageBitmap';
-// import { sendCurrentThemeSettingsEvent } from 'src/utilities/ga';
 import 'src/utilities/request';
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
-// import { spacing as spacingChoice, theme } from 'src/utilities/storage';
 import App from './App';
 import './events';
 import './index.css';
@@ -38,12 +36,6 @@ const Lish = DefaultLoader({
  */
 initAnalytics(GA_ID, isProduction);
 initTagManager(GTM_ID);
-
-// const themeChoice = theme.get() === 'dark' ? 'Dark Theme' : 'Light Theme';
-// const spacingMode =
-//   spacingChoice.get() === 'compact' ? 'Compact Mode' : 'Normal Mode';
-
-// sendCurrentThemeSettingsEvent(`${themeChoice} | ${spacingMode}`);
 
 /**
  * Send pageviews unless blacklisted.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,10 +20,10 @@ import Logout from 'src/layouts/Logout';
 import OAuthCallbackPage from 'src/layouts/OAuth';
 import store from 'src/store';
 import 'src/utilities/createImageBitmap';
-import { sendCurrentThemeSettingsEvent } from 'src/utilities/ga';
+// import { sendCurrentThemeSettingsEvent } from 'src/utilities/ga';
 import 'src/utilities/request';
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
-import { spacing as spacingChoice, theme } from 'src/utilities/storage';
+// import { spacing as spacingChoice, theme } from 'src/utilities/storage';
 import App from './App';
 import './events';
 import './index.css';
@@ -39,11 +39,11 @@ const Lish = DefaultLoader({
 initAnalytics(GA_ID, isProduction);
 initTagManager(GTM_ID);
 
-const themeChoice = theme.get() === 'dark' ? 'Dark Theme' : 'Light Theme';
-const spacingMode =
-  spacingChoice.get() === 'compact' ? 'Compact Mode' : 'Normal Mode';
+// const themeChoice = theme.get() === 'dark' ? 'Dark Theme' : 'Light Theme';
+// const spacingMode =
+//   spacingChoice.get() === 'compact' ? 'Compact Mode' : 'Normal Mode';
 
-sendCurrentThemeSettingsEvent(`${themeChoice} | ${spacingMode}`);
+// sendCurrentThemeSettingsEvent(`${themeChoice} | ${spacingMode}`);
 
 /**
  * Send pageviews unless blacklisted.

--- a/src/services/profile/profile.ts
+++ b/src/services/profile/profile.ts
@@ -90,3 +90,29 @@ export const deleteTrustedDevice = (id: number) =>
     setURL(`${API_ROOT}/profile/devices/${id}`),
     setMethod('DELETE')
   ).then(response => response.data);
+
+/**
+ * getUserPreferences
+ *
+ * Retrieves an arbitrary JSON blob for the purposes of implementing
+ * conditional logic based on preferences the user chooses
+ */
+export const getUserPreferences = () => {
+  return Request<Record<string, any>>(
+    setURL(`${API_ROOT}/profile/preferences`)
+  ).then(response => response.data);
+};
+
+/**
+ * getUserPreferences
+ *
+ * Stores an arbitrary JSON blob for the purposes of implementing
+ * conditional logic based on preferences the user chooses
+ */
+export const updateUserPreferences = (payload: Record<string, any>) => {
+  return Request<Record<string, any>>(
+    setURL(`${API_ROOT}/profile/preferences`),
+    setData(payload),
+    setMethod('PUT')
+  ).then(response => response.data);
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -116,6 +116,10 @@ import notifications, {
   defaultState as notificationsDefaultState,
   State as NotificationsState
 } from './notification/notification.reducer';
+import preferences, {
+  defaultState as preferencesState,
+  State as PreferencesState
+} from './preferences/preferences.reducer';
 import { initReselectDevtools } from './selectors';
 
 const reduxDevTools = (window as any).__REDUX_DEVTOOLS_EXTENSION__;
@@ -176,6 +180,7 @@ export interface ApplicationState {
   volumeDrawer: VolumeDrawerState;
   bucketDrawer: BucketDrawerState;
   createLinode: LinodeCreateState;
+  preferences: PreferencesState;
 }
 
 const defaultState: ApplicationState = {
@@ -189,7 +194,8 @@ const defaultState: ApplicationState = {
   tagImportDrawer: tagDrawerDefaultState,
   volumeDrawer: volumeDrawerDefaultState,
   bucketDrawer: bucketDrawerDefaultState,
-  createLinode: linodeCreateDefaultState
+  createLinode: linodeCreateDefaultState,
+  preferences: preferencesState
 };
 
 /**
@@ -226,7 +232,8 @@ const reducers = combineReducers<ApplicationState>({
   volumeDrawer,
   bucketDrawer,
   events,
-  createLinode: linodeCreateReducer
+  createLinode: linodeCreateReducer,
+  preferences
 });
 
 const enhancers = compose(

--- a/src/store/preferences/preferences.actions.ts
+++ b/src/store/preferences/preferences.actions.ts
@@ -1,0 +1,15 @@
+import { actionCreatorFactory } from 'typescript-fsa';
+
+const actionCreator = actionCreatorFactory(`@@manager/preferences`);
+
+export const handleGetPreferences = actionCreator.async<
+  void,
+  Record<string, any>,
+  Linode.ApiFieldError[]
+>(`get`);
+
+export const handleUpdatePreferences = actionCreator.async<
+  Record<string, any>,
+  Record<string, any>,
+  Linode.ApiFieldError[]
+>(`update`);

--- a/src/store/preferences/preferences.reducer.ts
+++ b/src/store/preferences/preferences.reducer.ts
@@ -1,0 +1,68 @@
+import { Reducer } from 'redux';
+import { reducerWithInitialState } from 'typescript-fsa-reducers';
+import { EntityError, RequestableData } from '../types';
+import {
+  handleGetPreferences,
+  handleUpdatePreferences
+} from './preferences.actions';
+
+export type State = RequestableData<Record<string, any>, EntityError>;
+
+export const defaultState: State = {
+  lastUpdated: 0,
+  loading: false,
+  data: undefined,
+  error: undefined
+};
+
+const reducer: Reducer<State> = reducerWithInitialState(defaultState)
+  .case(handleGetPreferences.started, state => {
+    return {
+      ...state,
+      loading: true,
+      error: undefined
+    };
+  })
+  .caseWithAction(handleGetPreferences.done, (state, action) => {
+    return {
+      ...state,
+      loading: false,
+      lastUpdated: Date.now(),
+      data: action.payload.result
+    };
+  })
+  .caseWithAction(handleGetPreferences.failed, (state, action) => {
+    return {
+      ...state,
+      loading: false,
+      lastUpdated: Date.now(),
+      error: {
+        read: action.payload.error
+      }
+    };
+  })
+  .case(handleUpdatePreferences.started, state => {
+    return {
+      ...state
+    };
+  })
+  .caseWithAction(handleUpdatePreferences.done, (state, action) => {
+    return {
+      ...state,
+      data: action.payload.result,
+      lastUpdated: Date.now(),
+      loading: false
+    };
+  })
+  .caseWithAction(handleUpdatePreferences.failed, (state, action) => {
+    return {
+      ...state,
+      error: {
+        update: action.payload.error
+      },
+      lastUpdated: Date.now()
+    };
+  })
+  .default(state => state);
+
+export default reducer;

--- a/src/store/preferences/preferences.reducer.ts
+++ b/src/store/preferences/preferences.reducer.ts
@@ -19,14 +19,19 @@ const reducer: Reducer<State> = reducerWithInitialState(defaultState)
   .case(handleGetPreferences.started, state => {
     return {
       ...state,
-      loading: true,
-      error: undefined
+      loading: true
+      /**
+       * intentionally not resetting error state here because it will cause
+       * the PreferenceToggle.tsx component to re-render, causing the entire app
+       * to re-render unnecessarily
+       */
     };
   })
   .caseWithAction(handleGetPreferences.done, (state, action) => {
     return {
       ...state,
       loading: false,
+      error: undefined,
       lastUpdated: Date.now(),
       data: action.payload.result
     };
@@ -44,6 +49,11 @@ const reducer: Reducer<State> = reducerWithInitialState(defaultState)
   .case(handleUpdatePreferences.started, state => {
     return {
       ...state
+      /**
+       * intentionally not resetting error state here because it will cause
+       * the PreferenceToggle.tsx component to re-render, causing the entire app
+       * to re-render unnecessarily
+       */
     };
   })
   .caseWithAction(handleUpdatePreferences.done, (state, action) => {
@@ -51,7 +61,8 @@ const reducer: Reducer<State> = reducerWithInitialState(defaultState)
       ...state,
       data: action.payload.result,
       lastUpdated: Date.now(),
-      loading: false
+      loading: false,
+      error: undefined
     };
   })
   .caseWithAction(handleUpdatePreferences.failed, (state, action) => {

--- a/src/store/preferences/preferences.requests.ts
+++ b/src/store/preferences/preferences.requests.ts
@@ -1,0 +1,63 @@
+import {
+  getUserPreferences as _getUserPreferences,
+  updateUserPreferences as _updateUserPreferences
+} from 'src/services/profile';
+import { ThunkActionCreator } from 'src/store/types';
+import {
+  handleGetPreferences,
+  handleUpdatePreferences
+} from './preferences.actions';
+
+export const getUserPreferences: ThunkActionCreator<
+  Promise<Record<string, any>>
+> = () => dispatch => {
+  const { started, done, failed } = handleGetPreferences;
+
+  dispatch(started);
+
+  return _getUserPreferences()
+    .then(response => {
+      dispatch(
+        done({
+          result: response
+        })
+      );
+      return response;
+    })
+    .catch(error => {
+      dispatch(
+        failed({
+          error
+        })
+      );
+      throw error;
+    });
+};
+
+export const updateUserPreferences: ThunkActionCreator<
+  Promise<Record<string, any>>
+> = (payload: Record<string, any>) => dispatch => {
+  const { started, done, failed } = handleUpdatePreferences;
+
+  dispatch(started);
+
+  return _updateUserPreferences(payload)
+    .then(response => {
+      dispatch(
+        done({
+          params: payload,
+          result: response
+        })
+      );
+      return response;
+    })
+    .catch(error => {
+      dispatch(
+        failed({
+          params: payload,
+          error
+        })
+      );
+      throw error;
+    });
+};

--- a/src/store/preferences/preferences.requests.ts
+++ b/src/store/preferences/preferences.requests.ts
@@ -13,7 +13,7 @@ export const getUserPreferences: ThunkActionCreator<
 > = () => dispatch => {
   const { started, done, failed } = handleGetPreferences;
 
-  dispatch(started);
+  dispatch(started());
 
   return _getUserPreferences()
     .then(response => {
@@ -39,7 +39,11 @@ export const updateUserPreferences: ThunkActionCreator<
 > = (payload: Record<string, any>) => dispatch => {
   const { started, done, failed } = handleUpdatePreferences;
 
-  dispatch(started);
+  dispatch(
+    started({
+      params: payload
+    })
+  );
 
   return _updateUserPreferences(payload)
     .then(response => {

--- a/src/store/profile/profile.actions.ts
+++ b/src/store/profile/profile.actions.ts
@@ -2,12 +2,18 @@ import { actionCreatorFactory } from 'typescript-fsa';
 
 const actionCreator = actionCreatorFactory(`@@manager/profile`);
 
+export interface ProfileWithPreferences extends Linode.Profile {
+  preferences: Record<string, any>;
+}
+
 export const getProfileActions = actionCreator.async<
   void,
-  Linode.Profile,
+  ProfileWithPreferences,
   Linode.ApiFieldError[]
 >(`request`);
 
-export const handleUpdate = actionCreator<
-  Partial<Linode.Profile> | Partial<Linode.User>
+export const handleUpdateProfile = actionCreator.async<
+  Partial<ProfileWithPreferences>,
+  Partial<ProfileWithPreferences>,
+  Linode.ApiFieldError[]
 >(`update`);

--- a/src/store/profile/profile.actions.ts
+++ b/src/store/profile/profile.actions.ts
@@ -2,18 +2,14 @@ import { actionCreatorFactory } from 'typescript-fsa';
 
 const actionCreator = actionCreatorFactory(`@@manager/profile`);
 
-export interface ProfileWithPreferences extends Linode.Profile {
-  preferences: Record<string, any>;
-}
-
 export const getProfileActions = actionCreator.async<
   void,
-  ProfileWithPreferences,
+  Linode.Profile,
   Linode.ApiFieldError[]
 >(`request`);
 
 export const handleUpdateProfile = actionCreator.async<
-  Partial<ProfileWithPreferences>,
-  Partial<ProfileWithPreferences>,
+  Partial<Linode.Profile>,
+  Partial<Linode.Profile>,
   Linode.ApiFieldError[]
 >(`update`);

--- a/src/store/profile/profile.reducer.ts
+++ b/src/store/profile/profile.reducer.ts
@@ -29,12 +29,18 @@ const reducer: Reducer<State> = (
     /** only set loading if we don't have any data */
     const loading = state.data ? false : true;
 
-    return { ...state, loading, error: undefined };
+    return { ...state, loading };
   }
 
   if (isType(action, getProfileActions.done)) {
     const { result } = action.payload;
-    return { ...state, loading: false, lastUpdated: Date.now(), data: result };
+    return {
+      ...state,
+      error: undefined,
+      loading: false,
+      lastUpdated: Date.now(),
+      data: result
+    };
   }
 
   if (isType(action, getProfileActions.failed)) {
@@ -52,8 +58,8 @@ const reducer: Reducer<State> = (
   if (isType(action, handleUpdateProfile.started)) {
     return {
       ...state,
-      loading: true,
-      error: undefined
+      loading: true
+      // error: undefined
     };
   }
 
@@ -83,6 +89,7 @@ const reducer: Reducer<State> = (
     return {
       ...state,
       loading: false,
+      data: undefined,
       lastUpdated: Date.now(),
       error: {
         update: action.payload.error

--- a/src/store/profile/profile.reducer.ts
+++ b/src/store/profile/profile.reducer.ts
@@ -2,13 +2,9 @@ import { pathOr } from 'ramda';
 import { Reducer } from 'redux';
 import { isType } from 'typescript-fsa';
 import { EntityError, RequestableData } from '../types';
-import {
-  getProfileActions,
-  handleUpdateProfile,
-  ProfileWithPreferences
-} from './profile.actions';
+import { getProfileActions, handleUpdateProfile } from './profile.actions';
 
-export type State = RequestableData<ProfileWithPreferences, EntityError>;
+export type State = RequestableData<Linode.Profile, EntityError>;
 
 interface Action<T> {
   type: string;
@@ -25,7 +21,7 @@ export const defaultState: State = {
 
 const reducer: Reducer<State> = (
   state: State = defaultState,
-  action: Action<ProfileWithPreferences>
+  action: Action<Linode.Profile>
 ) => {
   if (isType(action, getProfileActions.started)) {
     const {} = action.payload;

--- a/src/store/profile/profile.requests.ts
+++ b/src/store/profile/profile.requests.ts
@@ -55,7 +55,7 @@ export const requestProfile: ThunkActionCreator<
     })
     .catch(error => {
       dispatch(failed({ error }));
-      return error;
+      throw error;
     });
 };
 

--- a/src/store/profile/profile.requests.ts
+++ b/src/store/profile/profile.requests.ts
@@ -1,12 +1,26 @@
 import { pathOr } from 'ramda';
-import { getMyGrants, getProfile } from 'src/services/profile';
+import { Action } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { ActionCreator, Failure, Success } from 'typescript-fsa';
+
+import {
+  getMyGrants,
+  getProfile,
+  getUserPreferences,
+  updateProfile as _updateProfile,
+  updateUserPreferences
+} from 'src/services/profile';
 import { ApplicationState } from 'src/store';
 import { ThunkActionCreator } from 'src/store/types';
-import { getProfileActions } from './profile.actions';
+import {
+  getProfileActions,
+  handleUpdateProfile,
+  ProfileWithPreferences
+} from './profile.actions';
 
 const maybeRequestGrants: (
-  response: Linode.Profile
-) => Promise<Linode.Profile> = profile => {
+  response: ProfileWithPreferences
+) => Promise<ProfileWithPreferences> = profile => {
   if (profile.restricted === false) {
     return Promise.resolve(profile);
   }
@@ -29,14 +43,17 @@ export const getTimezone = (state: ApplicationState, timezone: string) => {
 };
 
 export const requestProfile: ThunkActionCreator<
-  Promise<Linode.Profile>
+  Promise<ProfileWithPreferences>
 > = () => (dispatch, getState) => {
   const { started, done, failed } = getProfileActions;
 
   dispatch(started());
 
-  return getProfile()
-    .then(response => response.data)
+  return Promise.all([getProfile(), getUserPreferences()])
+    .then(([profile, userPrefs]) => ({
+      ...profile.data,
+      preferences: userPrefs
+    }))
     .then(profile => ({
       ...profile,
       timezone: getTimezone(getState(), profile.timezone)
@@ -50,4 +67,81 @@ export const requestProfile: ThunkActionCreator<
       dispatch(failed({ error }));
       return error;
     });
+};
+
+/**
+ * @todo this doesn't let you update grants
+ */
+export const updateProfile: ThunkActionCreator<
+  Promise<Partial<ProfileWithPreferences>>
+> = (payload: Partial<ProfileWithPreferences>) => dispatch => {
+  const { done, failed } = handleUpdateProfile;
+
+  /**
+   * intentionally not setting loading state here. We're going to keep that
+   * at the component level
+   */
+
+  if (!!payload.preferences) {
+    return updateProfileAndPreferences(payload as ProfileWithPreferences)
+      .then(([profile, preferences]) => {
+        return handleUpdateSuccess(
+          payload,
+          {
+            ...profile,
+            preferences
+          },
+          done,
+          dispatch
+        );
+      })
+      .catch(error => {
+        return handleUpdateFailure(payload, error, failed, dispatch);
+      });
+  }
+
+  return _updateProfile(payload)
+    .then(response => handleUpdateSuccess(payload, response, done, dispatch))
+    .catch(err => handleUpdateFailure(payload, err, failed, dispatch));
+};
+
+const updateProfileAndPreferences = (payload: ProfileWithPreferences) => {
+  return Promise.all([
+    _updateProfile(payload),
+    updateUserPreferences(payload.preferences)
+  ]);
+};
+
+const handleUpdateSuccess = (
+  payload: Partial<ProfileWithPreferences>,
+  result: Partial<ProfileWithPreferences>,
+  done: ActionCreator<
+    Success<Partial<ProfileWithPreferences>, Partial<ProfileWithPreferences>>
+  >,
+  dispatch: ThunkDispatch<ApplicationState, undefined, Action<any>>
+) => {
+  dispatch(
+    done({
+      params: payload,
+      result
+    })
+  );
+  return result;
+};
+
+const handleUpdateFailure = (
+  payload: Partial<ProfileWithPreferences>,
+  error: Linode.ApiFieldError[],
+  failed: ActionCreator<
+    Failure<Partial<ProfileWithPreferences>, Linode.ApiFieldError[]>
+  >,
+  dispatch: ThunkDispatch<ApplicationState, undefined, Action<any>>
+) => {
+  dispatch(
+    failed({
+      params: payload,
+      error
+    })
+  );
+  throw error;
 };

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -62,11 +62,11 @@ export interface EntityState<
   error?: E;
 }
 
-export interface RequestableData<D> {
+export interface RequestableData<D, E = Linode.ApiFieldError[]> {
   lastUpdated: number;
   loading: boolean;
   data?: D;
-  error?: Linode.ApiFieldError[];
+  error?: E;
 }
 
 // Rename to RequestableData and delete above when all components are using this pattern

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -3,7 +3,6 @@ import createBreakpoints from 'src/components/core/styles/createBreakpoints';
 import createMuiTheme, {
   ThemeOptions
 } from 'src/components/core/styles/createMuiTheme';
-import { spacing as spacingStorage } from 'src/utilities/storage';
 
 /**
  * Augmenting Palette and Palette Options
@@ -65,16 +64,7 @@ declare module '@material-ui/core/styles/createMuiTheme' {
   }
 }
 
-type ThemeDefaults = (options: ThemeArguments) => ThemeOptions;
-
-interface ThemeArguments {
-  spacing: 'compact' | 'normal';
-}
-
 const breakpoints = createBreakpoints({});
-
-export const COMPACT_SPACING_UNIT = 4;
-export const NORMAL_SPACING_UNIT = 8;
 
 const primaryColors = {
   main: '#3683dc',
@@ -127,10 +117,16 @@ const visuallyHidden = {
   clip: 'rect(1px, 1px, 1px, 1px)'
 };
 
-const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
-  const spacingUnit =
-    options.spacing === 'compact' ? COMPACT_SPACING_UNIT : NORMAL_SPACING_UNIT;
+export const COMPACT_SPACING_UNIT = 4;
+export const NORMAL_SPACING_UNIT = 8;
 
+export interface ThemeOverrides {
+  spacingOverride: typeof COMPACT_SPACING_UNIT | typeof NORMAL_SPACING_UNIT;
+}
+
+type ThemeDefaults = (options: ThemeOverrides) => ThemeOptions;
+
+const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
   return {
     breakpoints,
     shadows: [
@@ -1370,11 +1366,11 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
   };
 };
 
-export default (options: ThemeOptions) =>
+export default (options: ThemeOptions & ThemeOverrides) =>
   createMuiTheme(
     mergeDeepRight(
       themeDefaults({
-        spacing: spacingStorage.get()
+        spacingOverride: options.spacingOverride
       }),
       options
     )

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,11 +1,12 @@
 import createBreakpoints from 'src/components/core/styles/createBreakpoints';
-import createTheme from './themeFactory';
+import createTheme, { ThemeOverrides } from './themeFactory';
 
 const breakpoints = createBreakpoints({});
 
-export const light = () =>
+export const light = (options: ThemeOverrides) =>
   createTheme({
-    name: 'lightTheme'
+    name: 'lightTheme',
+    ...options
   });
 
 const primaryColors = {
@@ -36,7 +37,7 @@ const iconCircleAnimation = {
   }
 };
 
-export const dark = () =>
+export const dark = (options: ThemeOverrides) =>
   createTheme({
     name: 'darkTheme',
     breakpoints,
@@ -617,5 +618,6 @@ export const dark = () =>
           }
         }
       }
-    }
+    },
+    ...options
   });

--- a/src/utilities/ga.ts
+++ b/src/utilities/ga.ts
@@ -52,7 +52,7 @@ export const sendPaginationEvent = (
   });
 };
 
-// src/index.tsx
+// LinodeThemeWrapper.tsx
 export const sendCurrentThemeSettingsEvent = (eventAction: string) => {
   sendEvent({
     category: 'Theme Choice',
@@ -104,7 +104,7 @@ export const sendImportDisplayGroupSubmitEvent = (
   });
 };
 
-// PrimaryNav.tsx
+// LinodeThemeWrapper.tsx
 export const sendSpacingToggleEvent = (eventLabel: string) => {
   sendEvent({
     category: 'Theme Choice',
@@ -113,7 +113,7 @@ export const sendSpacingToggleEvent = (eventLabel: string) => {
   });
 };
 
-// PrimaryNav.tsx
+// LinodeThemeWrapper.tsx
 export const sendThemeToggleEvent = (eventLabel: string) => {
   sendEvent({
     category: 'Theme Choice',

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -30,8 +30,6 @@ export const setStorage = (key: string, value: string) => {
   return window.localStorage.setItem(key, value);
 };
 
-const THEME = 'themeChoice';
-const SPACING = 'spacingChoice';
 const PAGE_SIZE = 'PAGE_SIZE';
 const BETA_NOTIFICATION = 'BetaNotification';
 const VAT_NOTIFICATION = 'vatNotification';
@@ -48,8 +46,6 @@ const NONCE = 'authentication/nonce';
 const SCOPES = 'authentication/scopes';
 const EXPIRE = 'authentication/expire';
 
-type Theme = 'dark' | 'light';
-export type Spacing = 'compact' | 'normal';
 export type PageSize = number;
 type Beta = 'open' | 'closed';
 type Notification = 'show' | 'hide';
@@ -71,14 +67,6 @@ export interface Storage {
     nonce: AuthGetAndSet;
     scopes: AuthGetAndSet;
     expire: AuthGetAndSet;
-  };
-  theme: {
-    get: () => Theme;
-    set: (theme: Theme) => void;
-  };
-  spacing: {
-    get: () => Spacing;
-    set: (spacing: Spacing) => void;
   };
   pageSize: {
     get: () => PageSize;
@@ -150,14 +138,6 @@ export const storage: Storage = {
       set: v => setStorage(EXPIRE, v)
     }
   },
-  theme: {
-    get: () => getStorage(THEME, 'light'),
-    set: v => setStorage(THEME, v)
-  },
-  spacing: {
-    get: () => getStorage(SPACING, 'normal'),
-    set: v => setStorage(SPACING, v)
-  },
   pageSize: {
     get: () => {
       return parseInt(getStorage(PAGE_SIZE, '25'), 10);
@@ -221,4 +201,4 @@ export const storage: Storage = {
   }
 };
 
-export const { theme, notifications, views, authentication, spacing } = storage;
+export const { notifications, views, authentication } = storage;

--- a/src/utilities/storybookDecorators.tsx
+++ b/src/utilities/storybookDecorators.tsx
@@ -15,7 +15,7 @@ const ThemeDecorator = (story: Function) => {
   const content = story();
 
   return (
-    <ThemeProvider theme={options[key]()}>
+    <ThemeProvider theme={options[key]({ spacingOverride: 8 })}>
       <CssBaseline />
       {content}
     </ThemeProvider>

--- a/src/utilities/testHelpers.tsx
+++ b/src/utilities/testHelpers.tsx
@@ -20,17 +20,17 @@ createResourcePage = data => ({
 
 export const wrapWithTheme = (ui: any) => {
   return (
-    <LinodeThemeWrapper>
-      <Provider store={store}>
+    <Provider store={store}>
+      <LinodeThemeWrapper theme="dark" spacing="normal">
         <MemoryRouter>{ui}</MemoryRouter>
-      </Provider>
-    </LinodeThemeWrapper>
+      </LinodeThemeWrapper>
+    </Provider>
   );
 };
 
 export const renderWithTheme = (ui: any) => {
   return render(
-    <LinodeThemeWrapper>
+    <LinodeThemeWrapper theme="dark" spacing="normal">
       <MemoryRouter>{ui}</MemoryRouter>
     </LinodeThemeWrapper>
   );


### PR DESCRIPTION
## Description

Removes local storage for theme and spacing and instead observes user preferences

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## Note to Reviewers

1. The high file-change count is mostly due to tests having to be updated.

## Highlights and Updates

1. New `<PreferenceToggle />` component, which follows a children-as-a-function react pattern. The current preference and callback to toggle the preference are passed down to the children.
   * this also means implementing user preferences elsewhere _should_ be a piece of cake
   * also note that if for whatever reason the GET request to `/preferences` fails, we are not going to `PUT /preferences` until a GET request succeeds. We ABSOLUTELY DO NOT want to overwrite a user's preferences if we can't first successfully know which ones are already set.
2. When you toggle a preference, the UI updates immediately, but any API calls are debounced for 500ms, to prevent too many network requests if the user keeps toggling back-and-forth
3. Each theme is now a function that takes options as an argument.
    * e.g. `dark({ spacingUnit: '4px' })` or `light({ spacingUnit: '8px' })`
4. All Redux Profile logic has been updated to be async instead of sync
    * in other words, we implemented thunks for getting and updating the profile.

## To Test

1. Try toggling back and forth between the theme and spacing
2. Try doing it very quickly
3. Try forcing errors or `GET /preferences` and `PUT /preferences`
4. Try toggling some more
5. Load the app while blocking `/preferences`
6. etc....