### PR TITLE
Add: Middle Click Functionality to Table Rows

### DIFF
--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -97,6 +97,18 @@ class TableRow extends React.Component<CombinedProps> {
 
     return (
       <_TableRow
+        onAuxClick={e => {
+          e.preventDefault();
+          e.stopPropagation();
+          /**
+           * e.button === 1 means "middle click"
+           * see the W3C spec:
+           * https://w3c.github.io/uievents/#event-type-auxclick
+           */
+          if (rowLink && typeof rowLink === 'string' && e.button === 1) {
+            window.open(rowLink, '_blank');
+          }
+        }}
         onClick={(e: any) => rowLink && this.rowClick(e, e, rowLink)} // same argument, different methods (one to stop propagation, one to add the listener for meta/ctrl key)
         onKeyUp={(e: any) =>
           rowLink && e.keyCode === 13 && this.rowClick(e, e, rowLink)


### PR DESCRIPTION
## Description

Implements middle-clicking to open in a new tab for table rows.

`onAuxClick` is not stable and this only really works reliably in Chrome

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A