### PR TITLE
M3-2964 Change: Add username to Event rows

### DIFF
--- a/src/features/Events/EventRow.test.tsx
+++ b/src/features/Events/EventRow.test.tsx
@@ -1,12 +1,13 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Row, RowProps } from './EventRow';
+import { maybeRemoveTrailingPeriod, Row, RowProps } from './EventRow';
 
-const message = 'This is a message';
+const message = 'this is a message.';
 const props: RowProps = {
   message,
   type: 'linode',
   created: '2018-01-01',
+  username: null,
   classes: {
     root: '',
     message: ''
@@ -44,5 +45,24 @@ describe('EventRow component', () => {
     row.setProps({ entityId: 0 });
     tableRowProps = row.find('WithStyles(withRouter(TableRow))').props();
     expect(tableRowProps.rowLink).toBeDefined();
+  });
+
+  it('should display the message with a username if one exists', () => {
+    expect(row.find(`[data-qa-event-message]`).text()).toBe(
+      'this is a message.'
+    );
+    row.setProps({ username: 'marty' });
+    expect(row.find(`[data-qa-event-message]`).text()).toBe(
+      'this is a message by marty.'
+    );
+  });
+});
+
+describe('utilities', () => {
+  it('should remove trailing periods', () => {
+    expect(maybeRemoveTrailingPeriod('hello world.')).toBe('hello world');
+    expect(maybeRemoveTrailingPeriod('hello wor..ld')).toBe('hello wor..ld');
+    expect(maybeRemoveTrailingPeriod('hello world')).toBe('hello world');
+    expect(maybeRemoveTrailingPeriod('hello. world')).toBe('hello. world');
   });
 });

--- a/src/features/Events/EventRow.tsx
+++ b/src/features/Events/EventRow.tsx
@@ -67,6 +67,7 @@ export const EventRow: React.StatelessComponent<CombinedProps> = props => {
     status: pathOr(undefined, ['status'], entity),
     type,
     entityId,
+    username: event.username,
     classes
   };
 
@@ -80,6 +81,7 @@ export interface RowProps extends WithStyles<ClassNames> {
   type: 'linode' | 'domain' | 'nodebalancer' | 'stackscript' | 'volume';
   status?: string;
   created: string;
+  username: string | null;
 }
 
 export const Row: React.StatelessComponent<RowProps> = props => {
@@ -90,7 +92,8 @@ export const Row: React.StatelessComponent<RowProps> = props => {
     message,
     status,
     type,
-    created
+    created,
+    username
   } = props;
 
   /** Some event types may not be handled by our system (or new types
@@ -123,7 +126,9 @@ export const Row: React.StatelessComponent<RowProps> = props => {
           data-qa-event-message
           variant="body1"
         >
-          {message}
+          {username
+            ? `${maybeRemoveTrailingPeriod(message)} by ${username}.`
+            : message}
         </Typography>
       </TableCell>
       <TableCell parentColumn={'Time'} data-qa-event-created-cell compact>
@@ -142,3 +147,11 @@ const enhanced = compose<CombinedProps, Props & RenderGuardProps>(
 );
 
 export default enhanced(EventRow);
+
+export const maybeRemoveTrailingPeriod = (string: string) => {
+  const lastChar = string[string.length - 1];
+  if (lastChar === '.') {
+    return string.substr(0, string.length - 1);
+  }
+  return string;
+};

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -9,7 +9,10 @@ import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import Grid from 'src/components/Grid';
 import eventMessageGenerator from 'src/eventMessageGenerator';
-import { onUnfound } from 'src/features/Events/EventRow';
+import {
+  maybeRemoveTrailingPeriod,
+  onUnfound
+} from 'src/features/Events/EventRow';
 
 type ClassNames = 'root';
 
@@ -48,7 +51,11 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
       data-qa-activity-row
     >
       <Grid item>
-        <Typography>{message}</Typography>
+        <Typography>
+          {event.username
+            ? `${maybeRemoveTrailingPeriod(message)} by ${event.username}.`
+            : message}
+        </Typography>
       </Grid>
       <Grid item>
         <DateTimeDisplay value={event.created} humanizeCutoff={'month'} />


### PR DESCRIPTION
## Description

At customer request, we are now including the username of the user who initiated the event in the Events Landing and Linode Activity Panel

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A