### PR TITLE
M3-2967 fix: Group by Tag localStorage state

### DIFF
--- a/src/containers/localStorage.container.ts
+++ b/src/containers/localStorage.container.ts
@@ -7,13 +7,11 @@ const localStorageContainer = <TState, TUpdaters, TOuter>(
     s: Storage
   ) => StateUpdaters<TOuter, TState, StateHandlerMap<TState> & TUpdaters>
 ) => {
-  const state = mapState(storage);
   const handlers = mapHandlers(storage);
-  return withStateHandlers<
-    TState,
-    StateHandlerMap<TState> & TUpdaters,
-    TOuter
-  >(state, handlers);
+  return withStateHandlers<TState, StateHandlerMap<TState> & TUpdaters, TOuter>(
+    () => mapState(storage),
+    handlers
+  );
 };
 
 export default localStorageContainer;

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -17,16 +17,25 @@ export const getStorage = (key: string, fallback?: any) => {
   }
 
   try {
-    localStorageCache[key] = item;
-    return JSON.parse(item as any);
+    // Try to parse as JSON first. This will turn "true" (string) into `true` (boolean).
+    const parsedItem = JSON.parse(item as any);
+    localStorageCache[key] = parsedItem;
+    return parsedItem;
   } catch (e) {
+    // It's okay if we can't parse as JSON -- just use the raw value instead.
     localStorageCache[key] = item;
     return item;
   }
 };
 
 export const setStorage = (key: string, value: string) => {
-  localStorageCache[key] = value;
+  try {
+    // Store parsed JSON if possible.
+    localStorageCache[key] = JSON.parse(value);
+  } catch {
+    // Otherwise just use the raw value.
+    localStorageCache[key] = value;
+  }
   return window.localStorage.setItem(key, value);
 };
 


### PR DESCRIPTION
## Description

This addresses https://github.com/linode/manager/issues/5162.

The "Group By Tag" feature was acting strangely, because of two issues:

1) The `localStorageCache` was not attempting to save values as parsed JSON, as we are doing for accessing values directly from localStorage. This meant that the localStorage value "false" (string) would be parsed as the boolean `false` when accessed the first time, but "false" (string) on subsequent reads. This affected LinodesLanding (and others).

2) There was a similar issue that persistent on VolumesLanding, NodeBalancersLanding, and DomainsLanding, but because of a different issue. Previously, the initialState function in `localStorageContainer` was only being called once, in a closure around `withStateHandlers`. This meant that only the value it got from localStorage the FIRST time was being used, which led to issues with updating seeing updated state later.

This PR fixes both of these issues. Soon we're going to use User Preferences to manage Group By Tag anyway, but these are underlying issues that could affect other components down the road, so it is good to address them.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Please check Group By Tag (and other localStorage features) in multiple browsers.