### PR TITLE
Show 'Enabled' text for backups if Managed user

### DIFF
--- a/src/features/Account/AutoBackups.tsx
+++ b/src/features/Account/AutoBackups.tsx
@@ -102,7 +102,7 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = props => {
                   />
                 }
                 label={
-                  backups_enabled
+                  backups_enabled || isManagedCustomer
                     ? 'Enabled (Auto enroll all new Linodes in Backups)'
                     : "Disabled (Don't enroll new Linodes in Backups automatically)"
                 }


### PR DESCRIPTION
## Description

This was caught in Sprint Review. We should display the "Enabled" label text if the user has backups enabled OR they are a managed customer.

## Note to Reviewers

**To test:**

1) Be a Managed user.
2) Go to Account -> Settings.
3) Under "Backup Auto Enrollment" you should see appropriate toggle state and label text:
<img width="695" alt="Screen Shot 2019-06-28 at 3 54 17 PM" src="https://user-images.githubusercontent.com/16911484/60367812-27f8db80-99bd-11e9-8895-1d2a2208c448.png">

