### PR TITLE
M3-2974 Fix progress button loading icon

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -63,7 +63,7 @@ const styles = (theme: Theme) =>
       '& svg': {
         position: 'absolute',
         left: 0,
-        top: 0,
+        top: -3,
         right: 0,
         bottom: 0,
         margin: '0 auto',

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -358,11 +358,6 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
             color: primaryColors.light
           }
         },
-        // flat: {
-        //   '&.cancel:hover': {
-        //     backgroundColor: 'transparent'
-        //   }
-        // },
         containedPrimary: {
           '&:hover, &:focus': {
             backgroundColor: primaryColors.light
@@ -430,8 +425,7 @@ const themeDefaults: ThemeDefaults = (options: ThemeArguments) => {
             minWidth: 100,
             '& svg': {
               width: 22,
-              height: 22,
-              animation: 'rotate 2s linear infinite'
+              height: 22
             }
           }
         }


### PR DESCRIPTION
## M3-2974 Fix progress button loading icon

The loading icon was not spinning for some of the button variations - This can be tested in storybook or for instance the delete Linode confirmation button.

## Type of Change
- Non breaking change ('update', 'change')

