### PR TITLE
M3-2963 FOR RELEASE - Fix Linode Notification Threshold updates not displaying

### DIFF
--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -143,13 +143,8 @@ class LinodeTextField extends React.Component<CombinedProps> {
      * invoke the onChange prop if one is provided with the cleaned value.
      */
     if (onChange) {
-      onChange({
-        ...e,
-        target: {
-          ...e.target,
-          value: cleanedValue as any
-        }
-      });
+      e.target.value = cleanedValue as any;
+      onChange(e);
     }
   };
 

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -90,7 +90,12 @@ interface State {
 
 class LinodeTextField extends React.Component<CombinedProps> {
   state: State = {
-    value: ''
+    /** initialize the state with our passed value if we have one */
+    value:
+      typeof this.props.value === 'string' ||
+      typeof this.props.value === 'number'
+        ? this.props.value
+        : ''
   };
   shouldComponentUpdate(nextProps: CombinedProps, nextState: State) {
     return (
@@ -134,9 +139,17 @@ class LinodeTextField extends React.Component<CombinedProps> {
       value: cleanedValue
     });
 
-    /** invoke the onChange prop if one is provided */
+    /**
+     * invoke the onChange prop if one is provided with the cleaned value.
+     */
     if (onChange) {
-      onChange(e);
+      onChange({
+        ...e,
+        target: {
+          ...e.target,
+          value: cleanedValue as any
+        }
+      });
     }
   };
 
@@ -184,12 +197,12 @@ class LinodeTextField extends React.Component<CombinedProps> {
           {...textFieldProps}
           {...dataAttrs}
           fullWidth
-          /* let us explicitly pass an empty string to the input */
-          value={
-            typeof value === 'string'
-              ? value
-              : this.state.value || this.props.value
-          }
+          /*
+            let us explicitly pass an empty string to the input
+
+            see UserDefinedFieldsPanel.tsx for a verbose explanation why.
+          */
+          value={value}
           onChange={this.handleChange}
           InputLabelProps={{
             ...InputLabelProps,

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -143,8 +143,14 @@ class LinodeTextField extends React.Component<CombinedProps> {
      * invoke the onChange prop if one is provided with the cleaned value.
      */
     if (onChange) {
-      e.target.value = cleanedValue as any;
-      onChange(e);
+      /** create clone of event node */
+      const clonedEvent = {
+        ...e,
+        target: e.target.cloneNode()
+      } as React.ChangeEvent<HTMLInputElement>;
+
+      clonedEvent.target.value = cleanedValue as any;
+      onChange(clonedEvent);
     }
   };
 

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -149,7 +149,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
         target: e.target.cloneNode()
       } as React.ChangeEvent<HTMLInputElement>;
 
-      clonedEvent.target.value = cleanedValue as any;
+      clonedEvent.target.value = `${cleanedValue}`;
       onChange(clonedEvent);
     }
   };

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -185,7 +185,11 @@ class LinodeTextField extends React.Component<CombinedProps> {
           {...dataAttrs}
           fullWidth
           /* let us explicitly pass an empty string to the input */
-          value={typeof value === 'string' ? value : this.state.value}
+          value={
+            typeof value === 'string'
+              ? value
+              : this.state.value || this.props.value
+          }
           onChange={this.handleChange}
           InputLabelProps={{
             ...InputLabelProps,

--- a/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
@@ -119,6 +119,8 @@ class AlertSection extends React.Component<CombinedProps> {
               label={this.props.textTitle}
               type="number"
               value={this.props.value}
+              min={0}
+              max={Infinity}
               disabled={!this.props.state || readOnly}
               InputProps={{
                 endAdornment: (

--- a/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
@@ -118,7 +118,7 @@ class AlertSection extends React.Component<CombinedProps> {
             <TextField
               label={this.props.textTitle}
               type="number"
-              defaultValue={this.props.value}
+              value={this.props.value}
               disabled={!this.props.state || readOnly}
               InputProps={{
                 endAdornment: (

--- a/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/AlertSection.tsx
@@ -118,7 +118,7 @@ class AlertSection extends React.Component<CombinedProps> {
             <TextField
               label={this.props.textTitle}
               type="number"
-              value={this.props.value}
+              defaultValue={this.props.value}
               disabled={!this.props.state || readOnly}
               InputProps={{
                 endAdornment: (

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -291,7 +291,7 @@ export const dark = () =>
       },
       MuiExpansionPanelSummary: {
         root: {
-          '& $focused': {
+          '&$focused': {
             backgroundColor: '#111111'
           },
           backgroundColor: '#32363c',


### PR DESCRIPTION
## M3-2963 Fix Linode Notification Threshold updates not displaying

 Linode --> Settings --> Notification Thresholds

Default value would not be populated on page load - this was due to https://github.com/linode/manager/blob/develop/src/components/TextField.tsx#L187-L188

Added a fix which i hope won't introduce further regressions to some of our TextFields - some poking around should be done to test properly

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
