### PR TITLE
Add: Ability to use multiple GA IDs

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -36,8 +36,12 @@ const initGTM = (w: any, d: any, s: any, l: any, i: any) => {
  * @param gaId Your Google Analytics Tracking ID
  * @param production current environment of the app
  */
-export const initAnalytics = (gaId?: string, production: boolean = false) => {
-  if (!gaId) {
+export const initAnalytics = (
+  production: boolean,
+  ...gaIDs: (string | undefined)[]
+) => {
+  /** if no GA IDs exist */
+  if (gaIDs.every(eachID => !eachID)) {
     return;
   }
 
@@ -47,7 +51,13 @@ export const initAnalytics = (gaId?: string, production: boolean = false) => {
 
   gaInit(window, document, 'script', url, 'ga', {}, {});
 
-  (window as any).ga('create', gaId, 'auto');
+  gaIDs.forEach(eachID => {
+    if (!eachID) {
+      return;
+    }
+    (window as any).ga('create', eachID, 'auto');
+  });
+
   (window as any).ga('send', 'pageview');
 };
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -29,6 +29,11 @@ const initGTM = (w: any, d: any, s: any, l: any, i: any) => {
 };
 /* tslint:enable */
 
+interface Tracker {
+  id?: string;
+  name?: string;
+}
+
 /**
  * Initiates Google Analytics Tracking Script.
  * Should be called when the app loads
@@ -36,10 +41,7 @@ const initGTM = (w: any, d: any, s: any, l: any, i: any) => {
  * @param gaId Your Google Analytics Tracking ID
  * @param production current environment of the app
  */
-export const initAnalytics = (
-  production: boolean,
-  ...gaIDs: (string | undefined)[]
-) => {
+export const initAnalytics = (production: boolean, ...gaIDs: Tracker[]) => {
   /** if no GA IDs exist */
   if (gaIDs.every(eachID => !eachID)) {
     return;
@@ -52,13 +54,16 @@ export const initAnalytics = (
   gaInit(window, document, 'script', url, 'ga', {}, {});
 
   gaIDs.forEach(eachID => {
-    if (!eachID) {
+    /** if we don't have an ID, don't init GA */
+    if (!eachID.id) {
       return;
     }
-    (window as any).ga('create', eachID, 'auto');
-  });
 
-  (window as any).ga('send', 'pageview');
+    const trackerSend = eachID.name ? `${eachID.name}.send` : 'send';
+
+    (window as any).ga('create', eachID.id, 'auto', eachID.name);
+    (window as any).ga(trackerSend, 'pageview');
+  });
 };
 
 /**

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -43,7 +43,7 @@ interface Tracker {
  */
 export const initAnalytics = (production: boolean, ...gaIDs: Tracker[]) => {
   /** if no GA IDs exist */
-  if (gaIDs.every(eachID => !eachID)) {
+  if (!gaIDs || gaIDs.every(eachID => !eachID.id)) {
     return;
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,6 +35,7 @@ export const LOGIN_SESSION_LIFETIME_MS = 45 * 60 * 1000;
 export const OAUTH_TOKEN_REFRESH_TIMEOUT = LOGIN_SESSION_LIFETIME_MS / 2;
 /** Google Analytics and Tag Manager */
 export const GA_ID = process.env.REACT_APP_GA_ID;
+export const GA_ID_2 = process.env.REACT_APP_GA_ID_2;
 export const GTM_ID = process.env.REACT_APP_GTM_ID;
 /** for hard-coding token used for API Requests. Example: "Bearer 1234" */
 export const ACCESS_TOKEN = process.env.REACT_APP_ACCESS_TOKEN;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ import { initAnalytics, initTagManager } from 'src/analytics';
 import AuthenticationWrapper from 'src/components/AuthenticationWrapper';
 import DefaultLoader from 'src/components/DefaultLoader';
 import SnackBar from 'src/components/SnackBar';
-import { GA_ID, GTM_ID, isProduction } from 'src/constants';
+import { GA_ID, GA_ID_2, GTM_ID, isProduction } from 'src/constants';
 import 'src/exceptionReporting';
 import LoginAsCustomerCallback from 'src/layouts/LoginAsCustomerCallback';
 import Logout from 'src/layouts/Logout';
@@ -34,7 +34,7 @@ const Lish = DefaultLoader({
 /*
  * Initialize Analytic and Google Tag Manager
  */
-initAnalytics(GA_ID, isProduction);
+initAnalytics(isProduction, GA_ID, GA_ID_2);
 initTagManager(GTM_ID);
 
 /**

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,16 @@ const Lish = DefaultLoader({
 /*
  * Initialize Analytic and Google Tag Manager
  */
-initAnalytics(isProduction, GA_ID, GA_ID_2);
+initAnalytics(
+  isProduction,
+  {
+    id: GA_ID
+  },
+  {
+    id: GA_ID_2,
+    name: 'linodecom'
+  }
+);
 initTagManager(GTM_ID);
 
 /**

--- a/src/utilities/ga.ts
+++ b/src/utilities/ga.ts
@@ -1,4 +1,5 @@
 import { event } from 'react-ga';
+import { GA_ID, GA_ID_2 } from 'src/constants';
 
 interface AnalyticsEvent {
   category: string;
@@ -11,7 +12,16 @@ interface AnalyticsEvent {
  * Will throw error unless analytics is initialized
  */
 export const sendEvent = (eventPayload: AnalyticsEvent) => {
-  event(eventPayload, ['linodecom']);
+  /**
+   * this is assuming your second GA_ID is going to be the linode.com
+   * property, which seems bad, but there's no real way to enforce that with env vars
+   */
+  const additionalNames = GA_ID_2 ? ['linodecom'] : undefined;
+
+  /** only send events if we have at least 1 GA ID */
+  return [GA_ID, GA_ID_2].some(eachID => !!eachID)
+    ? event(eventPayload, additionalNames)
+    : undefined;
 };
 
 // LinodeActionMenu.tsx

--- a/src/utilities/ga.ts
+++ b/src/utilities/ga.ts
@@ -11,7 +11,7 @@ interface AnalyticsEvent {
  * Will throw error unless analytics is initialized
  */
 export const sendEvent = (eventPayload: AnalyticsEvent) => {
-  event(eventPayload);
+  event(eventPayload, ['linodecom']);
 };
 
 // LinodeActionMenu.tsx


### PR DESCRIPTION
## Description

Adds ability to use multiple GA IDs (we are going to add linode.com GA ID)

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

### To Test

Add both cloud and linode.com GA IDs to your `.env` and trigger some events