### PR TITLE
Fix: Clone Node

### DIFF
--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -154,6 +154,8 @@ class LinodeTextField extends React.Component<CombinedProps> {
        * So e.target on a text field === <input />
        *
        * while e.target on the select variant === { value: 10, name: undefined }
+       *
+       * See GitHub issue: https://github.com/mui-org/material-ui/issues/16470
        */
       if (e.target.value !== cleanedValue) {
         const clonedEvent = {

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -143,14 +143,29 @@ class LinodeTextField extends React.Component<CombinedProps> {
      * invoke the onChange prop if one is provided with the cleaned value.
      */
     if (onChange) {
-      /** create clone of event node */
-      const clonedEvent = {
-        ...e,
-        target: e.target.cloneNode()
-      } as React.ChangeEvent<HTMLInputElement>;
+      /**
+       * create clone of event node only if our cleanedValue
+       * is different from the e.target.value
+       *
+       * This solves for a specific scenario where the e.target on
+       * the MUI TextField select variants were actually a plain object
+       * rather than a DOM node.
+       *
+       * So e.target on a text field === <input />
+       *
+       * while e.target on the select variant === { value: 10, name: undefined }
+       */
+      if (e.target.value !== cleanedValue) {
+        const clonedEvent = {
+          ...e,
+          target: e.target.cloneNode()
+        } as React.ChangeEvent<HTMLInputElement>;
 
-      clonedEvent.target.value = `${cleanedValue}`;
-      onChange(clonedEvent);
+        clonedEvent.target.value = `${cleanedValue}`;
+        onChange(clonedEvent);
+      } else {
+        onChange(e);
+      }
     }
   };
 


### PR DESCRIPTION
## Description

Add conditional logic to only make a shallow copy of the `event.target` if the sanitizedValue is _not_ equal to `event.target.value`

This fixes the issue where changing the select value on a MUI TextField select variant would cause this console error to be thrown and the app to crash:

```
Uncaught TypeError: e.target.cloneNode is not a function
```

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A

## Note to Reviewers

To test, please make sure both regular text fields, number fields, and MUI select fields work properly. Examples of MUI select fields can be found under the Minecraft OCA.