### PR TITLE
Add: Option to Automatically Create Gmail MX Records

### DIFF
--- a/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/src/components/ActionsPanel/ActionsPanel.tsx
@@ -16,8 +16,8 @@ const styles = (theme: Theme) =>
     root: {
       paddingTop: theme.spacing(2),
       paddingBottom: theme.spacing(1),
-      '& > button': {
-        marginBottom: theme.spacing(1)
+      '& > *': {
+        marginTop: theme.spacing(1)
       },
       '& > :first-child': {
         marginRight: theme.spacing(1)

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -14,9 +14,9 @@ import HelpIcon from 'src/components/HelpIcon';
 type ClassNames =
   | 'root'
   | 'loading'
+  | 'loadingWithText'
   | 'destructive'
   | 'compact'
-  | 'hidden'
   | 'reg';
 
 export interface Props extends ButtonProps {
@@ -26,6 +26,7 @@ export interface Props extends ButtonProps {
   className?: string;
   tooltipText?: string;
   compact?: boolean;
+  loadingText?: string;
 }
 
 const styles = (theme: Theme) =>
@@ -39,6 +40,9 @@ const styles = (theme: Theme) =>
       }
     },
     root: {
+      minWidth: '105px',
+      paddingLeft: theme.spacing(3) + 4,
+      paddingRight: theme.spacing(3) + 4,
       '&.cancel': {
         border: `1px solid transparent`,
         transition: theme.transitions.create(['color', 'border-color']),
@@ -61,14 +65,17 @@ const styles = (theme: Theme) =>
     },
     loading: {
       '& svg': {
-        position: 'absolute',
-        left: 0,
-        top: -3,
-        right: 0,
-        bottom: 0,
         margin: '0 auto',
         width: theme.spacing(1) + 14,
         height: theme.spacing(1) + 14,
+        animation: '$rotate 2s linear infinite'
+      }
+    },
+    loadingWithText: {
+      '& svg': {
+        margin: '0 auto',
+        width: theme.spacing(1) + 8,
+        height: theme.spacing(1) + 8,
         animation: '$rotate 2s linear infinite'
       }
     },
@@ -102,10 +109,8 @@ const styles = (theme: Theme) =>
     },
     compact: {
       paddingLeft: theme.spacing(2) - 2,
-      paddingRight: theme.spacing(2) - 2
-    },
-    hidden: {
-      visibility: 'hidden'
+      paddingRight: theme.spacing(2) - 2,
+      minWidth: '75px'
     },
     reg: {
       display: 'flex',
@@ -142,6 +147,7 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
     tooltipText,
     buttonType,
     compact,
+    loadingText,
     className,
     ...rest
   } = props;
@@ -157,7 +163,8 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
           buttonType,
           {
             [classes.root]: true,
-            [classes.loading]: loading,
+            [classes.loading]: loading && !loadingText,
+            [classes.loadingWithText]: loading && !!loadingText,
             loading,
             [classes.destructive]: destructive,
             [classes.compact]: compact,
@@ -166,14 +173,29 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
           className
         )}
       >
-        {loading && <Reload />}
         <span
           className={classNames({
-            [classes.hidden]: loading,
-            [classes.reg]: !loading
+            [classes.reg]: true
           })}
         >
-          {props.children}
+          {loading ? (
+            loadingText && !compact ? (
+              <React.Fragment>
+                <span
+                  style={{
+                    marginRight: '8px'
+                  }}
+                >
+                  {loadingText}
+                </span>
+                <Reload />
+              </React.Fragment>
+            ) : (
+              <Reload />
+            )
+          ) : (
+            props.children
+          )}
         </span>
         {buttonType === 'remove' && 'Remove'}
       </Button>

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -10,6 +10,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import HelpIcon from 'src/components/HelpIcon';
 
 type CSSClasses = 'root' | 'checked' | 'disabled' | 'warning' | 'error';
@@ -71,13 +72,14 @@ const styles = (theme: Theme) =>
 interface Props extends CheckboxProps {
   variant?: 'warning' | 'error';
   text?: string | JSX.Element;
+  subtext?: string | JSX.Element;
   toolTipText?: string;
 }
 
 type FinalProps = Props & WithStyles<CSSClasses>;
 
 const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
-  const { toolTipText, text, classes, ...rest } = props;
+  const { toolTipText, text, classes, subtext, className, ...rest } = props;
 
   const classnames = classNames({
     [classes.root]: true,
@@ -91,6 +93,7 @@ const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
     return (
       <React.Fragment>
         <FormControlLabel
+          className={className}
           control={
             <Checkbox
               color="primary"
@@ -104,6 +107,7 @@ const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
           label={props.text}
         />
         {toolTipText && <HelpIcon text={toolTipText} />}
+        {subtext && <Typography>{subtext}</Typography>}
       </React.Fragment>
     );
   }

--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -50,7 +50,14 @@ import { getErrorMap } from 'src/utilities/errorUtils';
 
 import { isValidSOAEmail } from './domainUtils';
 
-type ClassNames = 'root' | 'masterIPErrorNotice' | 'addIP';
+import CheckBox from 'src/components/CheckBox';
+
+type ClassNames =
+  | 'root'
+  | 'masterIPErrorNotice'
+  | 'addIP'
+  | 'actionPanel'
+  | 'gmailCheck';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -60,6 +67,14 @@ const styles = (theme: Theme) =>
     },
     addIP: {
       left: -theme.spacing(2) + 3
+    },
+    gmailCheck: {
+      marginTop: theme.spacing(1)
+    },
+    actionPanel: {
+      display: 'flex',
+      flexFlow: 'row wrap',
+      alignItems: 'center'
     }
   });
 
@@ -78,6 +93,8 @@ interface State {
   defaultRecordsSetting: DefaultRecordsType;
   selectedDefaultLinode?: Linode.Linode;
   selectedDefaultNodeBalancer?: Linode.NodeBalancer;
+  loadingText?: string;
+  shouldCreateGmailRecords: boolean;
 }
 
 type CombinedProps = WithStyles<ClassNames> &
@@ -87,11 +104,50 @@ type CombinedProps = WithStyles<ClassNames> &
   StateProps &
   WithSnackbarProps;
 
+const gmailMXRecords = (domainID: number) => {
+  return [
+    /**
+     * see https://support.google.com/a/answer/140034?hl=en
+     * for where this list came from.
+     */
+    createDomainRecord(domainID, {
+      type: 'MX',
+      ttl_sec: 3600,
+      priority: 1,
+      target: 'ASPMX.L.GOOGLE.COM.'
+    }),
+    createDomainRecord(domainID, {
+      type: 'MX',
+      ttl_sec: 3600,
+      priority: 5,
+      target: 'ALT1.ASPMX.L.GOOGLE.COM.'
+    }),
+    createDomainRecord(domainID, {
+      type: 'MX',
+      ttl_sec: 3600,
+      priority: 5,
+      target: 'ALT2.ASPMX.L.GOOGLE.COM.'
+    }),
+    createDomainRecord(domainID, {
+      type: 'MX',
+      ttl_sec: 3600,
+      priority: 10,
+      target: 'ALT3.ASPMX.L.GOOGLE.COM.'
+    }),
+    createDomainRecord(domainID, {
+      type: 'MX',
+      ttl_sec: 3600,
+      priority: 10,
+      target: 'ALT4.ASPMX.L.GOOGLE.COM.'
+    })
+  ];
+};
+
 const generateDefaultDomainRecords = (
   domain: string,
   domainID: number,
-  ipv4?: string,
-  ipv6?: string
+  ipv4: string,
+  ipv6: string | null
 ) => {
   /**
    * at this point, the IPv6 is including the prefix and we need to strip that
@@ -179,7 +235,8 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     masterIPsCount: 1,
     defaultRecordsSetting: 'none',
     selectedDefaultLinode: undefined,
-    selectedDefaultNodeBalancer: undefined
+    selectedDefaultNodeBalancer: undefined,
+    shouldCreateGmailRecords: false
   };
 
   state: State = {
@@ -450,7 +507,16 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               )}
             </React.Fragment>
           )}
-        <ActionsPanel>
+        {isCreatingMasterDomain && (
+          <CheckBox
+            className={classes.gmailCheck}
+            onChange={this.toggleGmailCheckBox}
+            checked={this.state.shouldCreateGmailRecords}
+            text="Automatically Create Gmail MX Records For Me"
+            subtext="If checked, we will create 5 MX records for the Google mail servers."
+          />
+        )}
+        <ActionsPanel className={classes.actionPanel}>
           <Button
             buttonType="primary"
             onClick={this.submit}
@@ -460,9 +526,19 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
           >
             {mode === EDITING ? 'Update' : 'Create'}
           </Button>
-          <Button onClick={this.closeDrawer} buttonType="cancel" data-qa-cancel>
-            Cancel
-          </Button>
+          {!!submitting ? (
+            <span>
+              {this.state.loadingText ? this.state.loadingText : null}
+            </span>
+          ) : (
+            <Button
+              onClick={this.closeDrawer}
+              buttonType="cancel"
+              data-qa-cancel
+            >
+              Cancel
+            </Button>
+          )}
         </ActionsPanel>
       </Drawer>
     );
@@ -484,12 +560,20 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     domainID: number,
     state: Record<string, string> = {}
   ) => {
-    if (type === 'master' && domainID) {
-      this.redirect(domainID, state);
-    } else {
-      this.redirect('', state);
-    }
-    this.closeDrawer();
+    this.setState(
+      {
+        submitting: false,
+        loadingText: ''
+      },
+      () => {
+        if (type === 'master' && domainID) {
+          this.redirect(domainID, state);
+        } else {
+          this.redirect('', state);
+        }
+        this.closeDrawer();
+      }
+    );
   };
 
   handleEmailValidationErrors = () => {
@@ -580,10 +664,50 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
       return;
     }
 
-    this.setState({ submitting: true });
+    this.setState({
+      submitting: true,
+      loadingText: `Creating ${data.domain}...`
+    });
     domainActions
       .createDomain(data)
       .then((domainData: Linode.Domain) => {
+        if (!this.mounted) {
+          return Promise.resolve(domainData);
+        }
+
+        /** attempt to create some default Gmail MX records */
+        if (this.state.shouldCreateGmailRecords) {
+          this.setState({ loadingText: 'Creating your Gmail MX Records...' });
+          return (
+            Promise.all(gmailMXRecords(domainData.id))
+              .then(() => {
+                return Promise.resolve(domainData);
+              })
+              /**
+               * if we fail, just continue on and promise.resolve
+               * Creating domain records shouldn't any processes.
+               * We'll concat all the errors and show them to the user
+               * when we redirect them off to Domain Detail page.
+               */
+              .catch(e => {
+                reportException(
+                  `Default Gmail MX Records could not be created:
+             ${e[0].reason}`,
+                  {
+                    domainID: domainData.id
+                  }
+                );
+                return Promise.resolve({
+                  ...domainData,
+                  error: 'There was an issue creating some Gmail MX records.'
+                });
+              })
+          );
+        }
+
+        return Promise.resolve(domainData);
+      })
+      .then((domainData: Linode.Domain & { error: string }) => {
         if (!this.mounted) {
           return;
         }
@@ -598,14 +722,21 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
          */
         if (type === 'master') {
           if (defaultRecordsSetting === 'linode') {
+            this.setState({ loadingText: 'Creating some default records...' });
             return generateDefaultDomainRecords(
               domainData.domain,
               domainData.id,
-              path(['ipv4', 0], selectedDefaultLinode),
-              path(['ipv6'], selectedDefaultLinode)
+              /**
+               * we did undefined checking above so selectedDefaultLinode is
+               * most certainly defined
+               */
+              selectedDefaultLinode!.ipv4[0],
+              selectedDefaultLinode!.ipv6
             )
               .then(() => {
-                return this.redirectToLandingOrDetail(type, domainData.id);
+                return this.redirectToLandingOrDetail(type, domainData.id, {
+                  recordError: domainData.error
+                });
               })
               .catch((e: Linode.ApiFieldError[]) => {
                 reportException(
@@ -621,17 +752,28 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
                 );
                 return this.redirectToLandingOrDetail(type, domainData.id, {
                   recordError:
-                    'There was an issue creating default domain records.'
+                    /**
+                     * if domainData.error exists, it means there was an issue creating
+                     * Gmail MX records
+                     */
+                    domainData.error
+                      ? 'There were issues creating some Gmail MX records and default domain records.'
+                      : 'There was an issue creating default domain records.'
                 });
               });
           }
 
           if (defaultRecordsSetting === 'nodebalancer') {
+            this.setState({ loadingText: 'Creating some default records...' });
             return generateDefaultDomainRecords(
               domainData.domain,
               domainData.id,
-              path(['ipv4'], selectedDefaultNodeBalancer),
-              path(['ipv6'], selectedDefaultNodeBalancer)
+              /**
+               * we did undefined checking above so selectedDefaultLinode is
+               * most certainly defined
+               */
+              selectedDefaultNodeBalancer!.ipv4,
+              selectedDefaultNodeBalancer!.ipv6
             )
               .then(() => {
                 return this.redirectToLandingOrDetail(type, domainData.id);
@@ -666,6 +808,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
         this.setState(
           {
             submitting: false,
+            loadingText: '',
             errors: getAPIErrorOrDefault(err)
           },
           () => {
@@ -787,6 +930,12 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
   closeDrawer = () => {
     this.resetInternalState();
     this.props.resetDrawer();
+  };
+
+  toggleGmailCheckBox = () => {
+    this.setState({
+      shouldCreateGmailRecords: !this.state.shouldCreateGmailRecords
+    });
   };
 
   updateLabel = (e: React.ChangeEvent<HTMLInputElement>) =>

--- a/src/utilities/ga.ts
+++ b/src/utilities/ga.ts
@@ -230,3 +230,11 @@ export const sendRevokeAccessKeyEvent = () => {
     action: 'Revoke Access Key'
   });
 };
+
+export const createDomainEvent = (action: string, label?: string) => {
+  sendEvent({
+    category: 'Create Domain',
+    action,
+    label
+  });
+};


### PR DESCRIPTION
## Description

Lets the user automatically create Gmail MX records at the time of domain creation.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## To Test

Please throw some monkey wrenches into this workflow. Add some `Promise.rejects` to the `Promise.all` arrays and see if anything seems off.

Test the GA events are working correctly.

![Screen Shot 2019-07-03 at 4 57 35 PM](https://user-images.githubusercontent.com/7387001/60624612-bb625000-9db3-11e9-8442-1be8e6ac8587.png)
