### PR TITLE
LKE: use beta endpoint

### DIFF
--- a/src/features/Kubernetes/kubeUtils.ts
+++ b/src/features/Kubernetes/kubeUtils.ts
@@ -33,7 +33,7 @@ export const getTotalClusterMemoryAndCPU = (
   pools: PoolNode[],
   types: ExtendedType[]
 ) => {
-  if (!types) {
+  if (!types || !pools) {
     return { RAM: 0, CPU: 0 };
   }
   return pools.reduce(

--- a/src/services/kubernetes/kubernetes.ts
+++ b/src/services/kubernetes/kubernetes.ts
@@ -30,7 +30,7 @@ export const getKubernetesClusters = (params?: any, filters?: any) =>
     setMethod('GET'),
     setParams(params),
     setXFilter(filters),
-    setURL(`${API_ROOT}/lke/clusters`)
+    setURL(`${API_ROOT}beta/lke/clusters`)
   ).then(response => response.data);
 
 /**
@@ -41,10 +41,10 @@ export const getKubernetesClusters = (params?: any, filters?: any) =>
 export const createKubernetesCluster = (data: CreateKubeClusterPayload) =>
   Request<Linode.KubernetesCluster>(
     setMethod('POST'),
-    setURL(`${API_ROOT}/lke/clusters`),
+    setURL(`${API_ROOT}beta/lke/clusters`),
     setData(data, createKubeClusterSchema)
-  ).then(response => response.data)
- 
+  ).then(response => response.data);
+
 /** getKubeConfig
  *
  * Returns a base64 encoded string of a cluster's kubeconfig.yaml
@@ -55,5 +55,5 @@ export const createKubernetesCluster = (data: CreateKubeClusterPayload) =>
 export const getKubeConfig = (clusterId: string) =>
   Request<Linode.KubeConfigResponse>(
     setMethod('GET'),
-    setURL(`${API_ROOT}/lke/clusters/${clusterId}/kubeconfig`)
+    setURL(`${API_ROOT}beta/lke/clusters/${clusterId}/kubeconfig`)
   ).then(response => response.data);


### PR DESCRIPTION
## Description

Use beta API prefix for LKE endpoints.

Also includes a temporary fix to keep the Cluster Landing page from crashing. 