### PR TITLE
M3-22886 [for release]: Remove VAT banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,8 +22,8 @@ import Grid from 'src/components/Grid';
 import LandingLoading from 'src/components/LandingLoading';
 import NotFound from 'src/components/NotFound';
 import SideMenu from 'src/components/SideMenu';
-import VATBanner from 'src/components/VATBanner';
 /** @todo: Uncomment when we deploy with LD */
+// import VATBanner from 'src/components/VATBanner';
 // import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
 import { events$ } from 'src/events';
 import BackupDrawer from 'src/features/Backups';
@@ -403,7 +403,8 @@ export class App extends React.Component<CombinedProps, State> {
                     isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
                     username={this.props.username}
                   />
-                  <VATBanner />
+                  {/* @todo: Uncomment when we deploy with LD */}
+                  {/* <VATBanner /> */}
                   <div className={classes.wrapper} id="main-content">
                     <Grid container spacing={0} className={classes.grid}>
                       <Grid item className={classes.switchWrapper}>


### PR DESCRIPTION
## Description

The VAT banner will likely be coming back at some point, hidden/displayed with feature flags. For the time being, I commented out the component in App.tsx.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Set your country to one in the EU, remove your Tax ID if you have one, and clear the local storage value for hiding the VAT banner. Previously, under these conditions, you should see the banner. With this PR, you shouldn't.
