### PR TITLE
M3-2988: Fix spelling mistake in LinodeConfigDrawer

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -360,13 +360,13 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             >
               <FormControlLabel
                 value="paravirt"
-                label="Paravirtulization"
+                label="Paravirtualization"
                 disabled={readOnly}
                 control={<Radio />}
               />
               <FormControlLabel
                 value="fullvirt"
-                label="Full-virtulization"
+                label="Full virtualization"
                 disabled={readOnly}
                 control={<Radio />}
               />


### PR DESCRIPTION
Fix spelling of "Paravirtualization" and "Full virtualization" in `LinodeConfigDrawer.tsx`.
 
<img width="245" alt="Screen Shot 2019-07-08 at 4 12 52 PM" src="https://user-images.githubusercontent.com/16911484/60839484-47e98580-a19b-11e9-90fc-a1741637ba85.png">
