### PR TITLE
M3-2934: Better analytics for Volume Creation

### DIFF
--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -110,7 +110,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
       {
         title: 'Volume',
         onClick: e => {
-          this.props.openVolumeDrawerForCreating();
+          this.props.openVolumeDrawerForCreating('addNewMenu');
           this.handleClose();
           e.preventDefault();
         },

--- a/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -110,7 +110,7 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
       {
         title: 'Volume',
         onClick: e => {
-          this.props.openVolumeDrawerForCreating('addNewMenu');
+          this.props.openVolumeDrawerForCreating('Created from Add New Menu');
           this.handleClose();
           e.preventDefault();
         },

--- a/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
@@ -167,7 +167,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
   actions: {
     switchToCreating: () =>
       dispatch(
-        openForCreating('linodeDetails', {
+        openForCreating('Created from Linode Details', {
           linodeId: ownProps.linodeId,
           linodeLabel: ownProps.linodeLabel,
           linodeRegion: ownProps.linodeRegion

--- a/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
@@ -27,10 +27,7 @@ interface Props {
   readOnly?: boolean;
 }
 
-type CombinedProps = Props &
-  StateProps &
-  DispatchProps &
-  VolumesRequests;
+type CombinedProps = Props & StateProps & DispatchProps & VolumesRequests;
 
 /**
  * I had to provide a separate validation schema since the linode_id (which is required by API) is
@@ -170,11 +167,11 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
   actions: {
     switchToCreating: () =>
       dispatch(
-        openForCreating(
-          ownProps.linodeId,
-          ownProps.linodeLabel,
-          ownProps.linodeRegion
-        )
+        openForCreating('linodeDetails', {
+          linodeId: ownProps.linodeId,
+          linodeLabel: ownProps.linodeLabel,
+          linodeRegion: ownProps.linodeRegion
+        })
       )
   }
 });

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -24,10 +24,7 @@ import {
 } from 'src/features/Profile/permissionsHelpers';
 import { CreateVolumeSchema } from 'src/services/volumes/volumes.schema.ts';
 import { MapState } from 'src/store/types';
-import {
-  OpenedVolumeDrawerFrom,
-  openForAttaching
-} from 'src/store/volumeDrawer';
+import { openForAttaching, Origin } from 'src/store/volumeDrawer';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { sendCreateVolumeEvent } from 'src/utilities/ga';
 import ConfigSelect from './ConfigSelect';
@@ -81,7 +78,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
     actions,
     createVolume,
     disabled,
-    openedFrom
+    origin
   } = props;
 
   return (
@@ -111,7 +108,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               `Volume scheduled for creation.`
             );
             // GA Event
-            sendCreateVolumeEvent(`${label}: ${size}GiB`, openedFrom);
+            sendCreateVolumeEvent(`${label}: ${size}GiB`, origin);
           })
           .catch(errorResponse => {
             const defaultMessage = `Unable to create a volume at this time. Please try again later.`;
@@ -293,13 +290,13 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
 
 interface StateProps {
   disabled: boolean;
-  openedFrom?: OpenedVolumeDrawerFrom;
+  origin?: Origin;
 }
 
 const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
   // disabled if the profile is restricted and doesn't have add_volumes grant
   disabled: isRestrictedUser(state) && !hasGrant(state, 'add_volumes'),
-  openedFrom: state.volumeDrawer.openedFrom
+  origin: state.volumeDrawer.origin
 });
 
 const connected = connect(

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -24,7 +24,10 @@ import {
 } from 'src/features/Profile/permissionsHelpers';
 import { CreateVolumeSchema } from 'src/services/volumes/volumes.schema.ts';
 import { MapState } from 'src/store/types';
-import { openForAttaching, Origin } from 'src/store/volumeDrawer';
+import {
+  openForAttaching,
+  Origin as VolumeDrawerOrigin
+} from 'src/store/volumeDrawer';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { sendCreateVolumeEvent } from 'src/utilities/ga';
 import ConfigSelect from './ConfigSelect';
@@ -290,7 +293,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
 
 interface StateProps {
   disabled: boolean;
-  origin?: Origin;
+  origin?: VolumeDrawerOrigin;
 }
 
 const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -24,7 +24,10 @@ import {
 } from 'src/features/Profile/permissionsHelpers';
 import { CreateVolumeSchema } from 'src/services/volumes/volumes.schema.ts';
 import { MapState } from 'src/store/types';
-import { openForAttaching } from 'src/store/volumeDrawer';
+import {
+  OpenedVolumeDrawerFrom,
+  openForAttaching
+} from 'src/store/volumeDrawer';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { sendCreateVolumeEvent } from 'src/utilities/ga';
 import ConfigSelect from './ConfigSelect';
@@ -77,7 +80,8 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
     linodeRegion,
     actions,
     createVolume,
-    disabled
+    disabled,
+    openedFrom
   } = props;
 
   return (
@@ -107,7 +111,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               `Volume scheduled for creation.`
             );
             // GA Event
-            sendCreateVolumeEvent(`${label}: ${size}GiB`);
+            sendCreateVolumeEvent(`${label}: ${size}GiB`, openedFrom);
           })
           .catch(errorResponse => {
             const defaultMessage = `Unable to create a volume at this time. Please try again later.`;
@@ -289,11 +293,13 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, Props> = (
 
 interface StateProps {
   disabled: boolean;
+  openedFrom?: OpenedVolumeDrawerFrom;
 }
 
 const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
   // disabled if the profile is restricted and doesn't have add_volumes grant
-  disabled: isRestrictedUser(state) && !hasGrant(state, 'add_volumes')
+  disabled: isRestrictedUser(state) && !hasGrant(state, 'add_volumes'),
+  openedFrom: state.volumeDrawer.openedFrom
 });
 
 const connected = connect(

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
@@ -21,7 +21,7 @@ import {
 } from 'src/features/Profile/permissionsHelpers';
 import { CreateVolumeSchema } from 'src/services/volumes/volumes.schema.ts';
 import { MapState } from 'src/store/types';
-import { OpenedVolumeDrawerFrom } from 'src/store/volumeDrawer';
+import { Origin } from 'src/store/volumeDrawer';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { sendCreateVolumeEvent } from 'src/utilities/ga';
 import ConfigSelect from './ConfigSelect';
@@ -63,14 +63,7 @@ type CombinedProps = Props &
   StateProps;
 
 const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
-  const {
-    onClose,
-    onSuccess,
-    classes,
-    createVolume,
-    disabled,
-    openedFrom
-  } = props;
+  const { onClose, onSuccess, classes, createVolume, disabled, origin } = props;
   return (
     <Formik
       initialValues={initialValues}
@@ -105,7 +98,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               `Volume scheduled for creation.`
             );
             // GA Event
-            sendCreateVolumeEvent(`${label}: ${size}GiB`, openedFrom);
+            sendCreateVolumeEvent(`${label}: ${size}GiB`, origin);
           })
           .catch(errorResponse => {
             const defaultMessage = `Unable to create a volume at this time. Please try again later.`;
@@ -280,12 +273,12 @@ const initialValues: FormState = {
 
 interface StateProps {
   disabled: boolean;
-  openedFrom?: OpenedVolumeDrawerFrom;
+  origin?: Origin;
 }
 
 const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
   disabled: isRestrictedUser(state) && !hasGrant(state, 'add_volumes'),
-  openedFrom: state.volumeDrawer.openedFrom
+  origin: state.volumeDrawer.origin
 });
 
 const connected = connect(mapStateToProps);

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
@@ -21,6 +21,7 @@ import {
 } from 'src/features/Profile/permissionsHelpers';
 import { CreateVolumeSchema } from 'src/services/volumes/volumes.schema.ts';
 import { MapState } from 'src/store/types';
+import { OpenedVolumeDrawerFrom } from 'src/store/volumeDrawer';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { sendCreateVolumeEvent } from 'src/utilities/ga';
 import ConfigSelect from './ConfigSelect';
@@ -62,7 +63,14 @@ type CombinedProps = Props &
   StateProps;
 
 const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
-  const { onClose, onSuccess, classes, createVolume, disabled } = props;
+  const {
+    onClose,
+    onSuccess,
+    classes,
+    createVolume,
+    disabled,
+    openedFrom
+  } = props;
   return (
     <Formik
       initialValues={initialValues}
@@ -97,7 +105,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               `Volume scheduled for creation.`
             );
             // GA Event
-            sendCreateVolumeEvent(`${label}: ${size}GiB`);
+            sendCreateVolumeEvent(`${label}: ${size}GiB`, openedFrom);
           })
           .catch(errorResponse => {
             const defaultMessage = `Unable to create a volume at this time. Please try again later.`;
@@ -272,10 +280,12 @@ const initialValues: FormState = {
 
 interface StateProps {
   disabled: boolean;
+  openedFrom?: OpenedVolumeDrawerFrom;
 }
 
 const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
-  disabled: isRestrictedUser(state) && !hasGrant(state, 'add_volumes')
+  disabled: isRestrictedUser(state) && !hasGrant(state, 'add_volumes'),
+  openedFrom: state.volumeDrawer.openedFrom
 });
 
 const connected = connect(mapStateToProps);

--- a/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
+++ b/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
@@ -21,7 +21,7 @@ import {
 } from 'src/features/Profile/permissionsHelpers';
 import { CreateVolumeSchema } from 'src/services/volumes/volumes.schema.ts';
 import { MapState } from 'src/store/types';
-import { Origin } from 'src/store/volumeDrawer';
+import { Origin as VolumeDrawerOrigin } from 'src/store/volumeDrawer';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { sendCreateVolumeEvent } from 'src/utilities/ga';
 import ConfigSelect from './ConfigSelect';
@@ -273,7 +273,7 @@ const initialValues: FormState = {
 
 interface StateProps {
   disabled: boolean;
-  origin?: Origin;
+  origin?: VolumeDrawerOrigin;
 }
 
 const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -42,7 +42,7 @@ import {
   openForCreating,
   openForEdit,
   openForResize,
-  Origin
+  Origin as VolumeDrawerOrigin
 } from 'src/store/volumeDrawer';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendGroupByTagEnabledEvent } from 'src/utilities/ga';
@@ -169,7 +169,10 @@ interface DispatchProps {
     volumeSize: number,
     volumeRegion: string
   ) => void;
-  openForCreating: (origin: Origin, linodeOptions?: LinodeOptions) => void;
+  openForCreating: (
+    origin: VolumeDrawerOrigin,
+    linodeOptions?: LinodeOptions
+  ) => void;
   openForConfig: (volumeLabel: string, volumePath: string) => void;
 }
 

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -36,6 +36,8 @@ import { BlockStorage } from 'src/documentation';
 import { resetEventsPolling } from 'src/events';
 import LinodePermissionsError from 'src/features/linodes/LinodesDetail/LinodePermissionsError';
 import {
+  LinodeOptions,
+  OpenedVolumeDrawerFrom,
   openForClone,
   openForConfig,
   openForCreating,
@@ -168,9 +170,8 @@ interface DispatchProps {
     volumeRegion: string
   ) => void;
   openForCreating: (
-    linodeId?: number,
-    linodeLabel?: string,
-    linodeRegion?: string
+    openedDrawerFrom: OpenedVolumeDrawerFrom,
+    linodeOptions?: LinodeOptions
   ) => void;
   openForConfig: (volumeLabel: string, volumePath: string) => void;
 }
@@ -491,10 +492,14 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   openCreateVolumeDrawer = (e: any) => {
     const { linodeId, linodeLabel, linodeRegion } = this.props;
     if (linodeId && linodeLabel && linodeRegion) {
-      return this.props.openForCreating(linodeId, linodeLabel, linodeRegion);
+      return this.props.openForCreating('linodeDetails', {
+        linodeId,
+        linodeLabel,
+        linodeRegion
+      });
     }
 
-    this.props.openForCreating();
+    this.props.openForCreating('volumesLanding');
 
     e.preventDefault();
   };

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -37,12 +37,12 @@ import { resetEventsPolling } from 'src/events';
 import LinodePermissionsError from 'src/features/linodes/LinodesDetail/LinodePermissionsError';
 import {
   LinodeOptions,
-  OpenedVolumeDrawerFrom,
   openForClone,
   openForConfig,
   openForCreating,
   openForEdit,
-  openForResize
+  openForResize,
+  Origin
 } from 'src/store/volumeDrawer';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendGroupByTagEnabledEvent } from 'src/utilities/ga';
@@ -170,7 +170,7 @@ interface DispatchProps {
     volumeRegion: string
   ) => void;
   openForCreating: (
-    openedDrawerFrom: OpenedVolumeDrawerFrom,
+    openedDrawerFrom: Origin,
     linodeOptions?: LinodeOptions
   ) => void;
   openForConfig: (volumeLabel: string, volumePath: string) => void;

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -169,10 +169,7 @@ interface DispatchProps {
     volumeSize: number,
     volumeRegion: string
   ) => void;
-  openForCreating: (
-    openedDrawerFrom: Origin,
-    linodeOptions?: LinodeOptions
-  ) => void;
+  openForCreating: (origin: Origin, linodeOptions?: LinodeOptions) => void;
   openForConfig: (volumeLabel: string, volumePath: string) => void;
 }
 

--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -492,14 +492,14 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   openCreateVolumeDrawer = (e: any) => {
     const { linodeId, linodeLabel, linodeRegion } = this.props;
     if (linodeId && linodeLabel && linodeRegion) {
-      return this.props.openForCreating('linodeDetails', {
+      return this.props.openForCreating('Created from Linode Details', {
         linodeId,
         linodeLabel,
         linodeRegion
       });
     }
 
-    this.props.openForCreating('volumesLanding');
+    this.props.openForCreating('Created from Volumes Landing');
 
     e.preventDefault();
   };

--- a/src/store/volumeDrawer/index.ts
+++ b/src/store/volumeDrawer/index.ts
@@ -47,7 +47,10 @@ interface CreatingForLinode extends Action {
   linodeRegion: string;
 }
 
-export type Origin = 'addNewMenu' | 'volumesLanding' | 'linodeDetails';
+export type Origin =
+  | 'Created from Add New Menu'
+  | 'Created from Volumes Landing'
+  | 'Created from Linode Details';
 
 export interface LinodeOptions {
   linodeId: number;
@@ -221,7 +224,7 @@ export const volumeDrawer: Reducer<State> = (
     return {
       ...state,
       mode: getMode(action),
-      origin: 'linodeDetails',
+      origin: 'Created from Linode Details',
       linodeId,
       linodeLabel,
       linodeRegion

--- a/src/store/volumeDrawer/index.ts
+++ b/src/store/volumeDrawer/index.ts
@@ -14,7 +14,7 @@ export interface State {
   linodeLabel?: string;
   linodeRegion?: string;
   message?: string;
-  openedFrom?: OpenedVolumeDrawerFrom;
+  origin?: Origin;
 }
 
 const actionCreator = actionCreatorFactory(`@@manager/volumesDrawer`);
@@ -47,10 +47,7 @@ interface CreatingForLinode extends Action {
   linodeRegion: string;
 }
 
-export type OpenedVolumeDrawerFrom =
-  | 'addNewMenu'
-  | 'volumesLanding'
-  | 'linodeDetails';
+export type Origin = 'addNewMenu' | 'volumesLanding' | 'linodeDetails';
 
 export interface LinodeOptions {
   linodeId: number;
@@ -58,7 +55,7 @@ export interface LinodeOptions {
   linodeRegion: string;
 }
 export const openForCreating = (
-  openedDrawerFrom: OpenedVolumeDrawerFrom,
+  origin: Origin,
   linodeOptions?: LinodeOptions
 ) => {
   if (linodeOptions) {
@@ -66,11 +63,11 @@ export const openForCreating = (
     return createVolumeForLinode({ linodeId, linodeLabel, linodeRegion });
   }
 
-  return createVolume({ openedDrawerFrom });
+  return createVolume({ origin });
 };
 
 interface CreateVolumePayload {
-  openedDrawerFrom: OpenedVolumeDrawerFrom;
+  origin: Origin;
 }
 
 const createVolume = actionCreator<CreateVolumePayload>(`CREATE_VOLUME`, {
@@ -212,7 +209,7 @@ export const volumeDrawer: Reducer<State> = (
     return {
       ...state,
       mode: getMode(action),
-      openedFrom: action.payload.openedDrawerFrom
+      origin: action.payload.origin
     };
   }
 
@@ -224,7 +221,7 @@ export const volumeDrawer: Reducer<State> = (
     return {
       ...state,
       mode: getMode(action),
-      openedFrom: 'linodeDetails',
+      origin: 'linodeDetails',
       linodeId,
       linodeLabel,
       linodeRegion
@@ -248,7 +245,7 @@ export const volumeDrawer: Reducer<State> = (
       return {
         ...state,
         mode: modes.CLOSED,
-        openedFrom: undefined
+        origin: undefined
       };
 
     case CREATING_FOR_LINODE:

--- a/src/store/volumeDrawer/index.ts
+++ b/src/store/volumeDrawer/index.ts
@@ -14,6 +14,7 @@ export interface State {
   linodeLabel?: string;
   linodeRegion?: string;
   message?: string;
+  openedFrom?: OpenedVolumeDrawerFrom;
 }
 
 const actionCreator = actionCreatorFactory(`@@manager/volumesDrawer`);
@@ -210,7 +211,8 @@ export const volumeDrawer: Reducer<State> = (
   if (isType(action, createVolume)) {
     return {
       ...state,
-      mode: getMode(action)
+      mode: getMode(action),
+      openedFrom: action.payload.openedDrawerFrom
     };
   }
 
@@ -222,6 +224,7 @@ export const volumeDrawer: Reducer<State> = (
     return {
       ...state,
       mode: getMode(action),
+      openedFrom: 'linodeDetails',
       linodeId,
       linodeLabel,
       linodeRegion
@@ -244,7 +247,8 @@ export const volumeDrawer: Reducer<State> = (
     case CLOSE:
       return {
         ...state,
-        mode: modes.CLOSED
+        mode: modes.CLOSED,
+        openedFrom: undefined
       };
 
     case CREATING_FOR_LINODE:

--- a/src/store/volumeDrawer/index.ts
+++ b/src/store/volumeDrawer/index.ts
@@ -46,19 +46,35 @@ interface CreatingForLinode extends Action {
   linodeRegion: string;
 }
 
+export type OpenedVolumeDrawerFrom =
+  | 'addNewMenu'
+  | 'volumesLanding'
+  | 'linodeDetails';
+
+export interface LinodeOptions {
+  linodeId: number;
+  linodeLabel: string;
+  linodeRegion: string;
+}
 export const openForCreating = (
-  linodeId?: number,
-  linodeLabel?: string,
-  linodeRegion?: string
+  openedDrawerFrom: OpenedVolumeDrawerFrom,
+  linodeOptions?: LinodeOptions
 ) => {
-  if (linodeId && linodeLabel && linodeRegion) {
+  if (linodeOptions) {
+    const { linodeId, linodeLabel, linodeRegion } = linodeOptions;
     return createVolumeForLinode({ linodeId, linodeLabel, linodeRegion });
   }
 
-  return createVolume();
+  return createVolume({ openedDrawerFrom });
 };
 
-const createVolume = actionCreator<void>(`CREATE_VOLUME`, { mode: 'creating' });
+interface CreateVolumePayload {
+  openedDrawerFrom: OpenedVolumeDrawerFrom;
+}
+
+const createVolume = actionCreator<CreateVolumePayload>(`CREATE_VOLUME`, {
+  mode: 'creating'
+});
 
 interface CreateVolumeForLinodePayload {
   linodeId: number;

--- a/src/utilities/ga.ts
+++ b/src/utilities/ga.ts
@@ -63,10 +63,13 @@ export const sendCurrentThemeSettingsEvent = (eventAction: string) => {
 
 // CreateVolumeForm.tsx
 // CreateVolumeForLinodeForm.tsx
-export const sendCreateVolumeEvent = (eventLabel: string) => {
+export const sendCreateVolumeEvent = (
+  eventLabel: string,
+  eventAction?: string
+) => {
   sendEvent({
     category: 'Create Volume',
-    action: 'Create Volume',
+    action: eventAction || 'Create Volume',
     label: eventLabel
   });
 };


### PR DESCRIPTION
## Description

Currently there are three places you can open the Volume Drawer. This means there are three potential origins of Volume creation: 

1) "Add New Menu"
2) Volumes Landing
3) Linode Details ("Volumes" tab)

We'd like to include the origin in our GA event.

To accomplish this, I created a new property on the `volumeDrawer` Redux state called `origin`, which is set appropriately when the drawer is opened.

The origin is sent as an action on the GA, so when you look at the events with `Category="Create Volume"` you'll see something like:

![Screen Shot 2019-07-08 at 6 06 34 PM](https://user-images.githubusercontent.com/16911484/60845700-242e3b80-a1ab-11e9-847d-f8afd13c0c3d.png)

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please test all methods of Volumes creation. Test that they work as expected, and that the appropriate GA events are being sent.
