### PR TITLE
M3-2999 Breadcrumb regression on LinodeDetails/Volumes

### DIFF
--- a/src/features/Volumes/VolumesLanding.tsx
+++ b/src/features/Volumes/VolumesLanding.tsx
@@ -143,6 +143,7 @@ interface Props {
   linodeConfigs?: Linode.Config[];
   recentEvent?: Linode.Event;
   readOnly?: boolean;
+  removeBreadCrumb?: boolean;
 }
 
 //
@@ -292,7 +293,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
       volumesError,
       volumesLoading,
       mappedVolumesDataWithLinodes,
-      readOnly
+      readOnly,
+      removeBreadCrumb
     } = this.props;
 
     if (volumesLoading) {
@@ -322,15 +324,19 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
         <Grid
           container
           justify="space-between"
-          alignItems="flex-end"
+          alignItems={removeBreadCrumb ? 'center' : 'flex-end'}
           style={{ paddingBottom: 0 }}
         >
           <Grid item className={classes.titleWrapper}>
-            <Breadcrumb
-              pathname={this.props.location.pathname}
-              labelTitle="Volumes"
-              className={classes.title}
-            />
+            {removeBreadCrumb ? (
+              <Typography variant="h2">Volumes</Typography>
+            ) : (
+              <Breadcrumb
+                pathname={this.props.location.pathname}
+                labelTitle="Volumes"
+                className={classes.title}
+              />
+            )}
           </Grid>
           <Grid item className="p0">
             <FormControlLabel

--- a/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -137,6 +137,7 @@ const LinodesDetailNavigation: React.StatelessComponent<
               linodeRegion={linodeRegion}
               linodeConfigs={linodeConfigs}
               readOnly={readOnly}
+              removeBreadCrumb
               {...routeProps}
             />
           )}


### PR DESCRIPTION
## Description

Adding a new prop to VolumesLanding, `removeBreadCrumb`, that will hide the breadcrumb and display a static header instead. 

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

Please view both `/volumes` to see Breadcrumb still in use, and `LinodeDetails/volumes` to view static heading.
