### PR TITLE
Change: Enhance Sentry Reporting for Events

### DIFF
--- a/src/eventMessageGenerator.test.ts
+++ b/src/eventMessageGenerator.test.ts
@@ -8,7 +8,7 @@ describe('getEventMessage', () => {
     };
     const result = getEventMessage(mockEvent as Linode.Event);
 
-    expect(result).toBeUndefined();
+    expect(result).toBe('__unknown__');
   });
 
   it('should filter mangled events', () => {
@@ -19,7 +19,7 @@ describe('getEventMessage', () => {
     };
     const result = getEventMessage(mockEvent as Linode.Event);
 
-    expect(result).toBeUndefined();
+    expect(result).toBe('');
   });
 
   it('should call the message generator with the event', () => {

--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -432,10 +432,7 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   }
 };
 
-export default (
-  e: Linode.Event,
-  onError?: (e: Linode.Event, err: Error) => void
-): string => {
+export default (e: Linode.Event): string => {
   const fn = path<EventMessageCreator>(
     [e.action, e.status],
     eventMessageCreators
@@ -458,10 +455,6 @@ export default (
   try {
     message = fn(e);
   } catch (error) {
-    /** invoke our error callback if we have one */
-    if (onError) {
-      onError(e, error);
-    }
     /** report our error to sentry */
     reportException('Known API Event Received with Error', {
       event_data: e,

--- a/src/exceptionReporting.ts
+++ b/src/exceptionReporting.ts
@@ -56,7 +56,7 @@ if (SENTRY_URL) {
       'Cannot redefine property: play',
       /** material-ui errors */
       'e.touches is undefined',
-      "method 'closest'",
+      "Object doesn't support property or method 'closest'",
       'target.className.indexOf is not a function',
       "can't access dead object",
       /** paypal errors */

--- a/src/features/Events/EventRow.tsx
+++ b/src/features/Events/EventRow.tsx
@@ -40,12 +40,6 @@ interface Props {
   entityId?: number;
 }
 
-export const onUnfound = (event: ExtendedEvent) => {
-  return `Event: ${event.action}${
-    event.entity ? ` on ${event.entity.label}` : ''
-  }`;
-};
-
 type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{}>;
 
 export const EventRow: React.StatelessComponent<CombinedProps> = props => {
@@ -63,7 +57,7 @@ export const EventRow: React.StatelessComponent<CombinedProps> = props => {
   const rowProps = {
     created: event.created,
     linkTarget,
-    message: eventMessageGenerator(event, onUnfound),
+    message: eventMessageGenerator(event),
     status: pathOr(undefined, ['status'], entity),
     type,
     entityId,

--- a/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -3,25 +3,11 @@ import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { compose } from 'recompose';
 import eventMessageGenerator from 'src/eventMessageGenerator';
-import { reportException } from 'src/exceptionReporting';
 import { ExtendedEvent } from 'src/store/events/event.helpers';
 import createLinkHandlerForNotification from 'src/utilities/getEventsActionLinkStrings';
 import UserEventsListItem, {
   Props as UserEventsListItemProps
 } from './UserEventsListItem';
-
-const reportUnfoundEvent = (event: Linode.Event) =>
-  process.env.NODE_ENV === 'production'
-    ? reportException
-    : // tslint:disable-next-line
-      console.log('Unknown API event received.', {
-        extra: { event }
-      });
-
-const reportEventError = (e: Linode.Event, err: Error) =>
-  process.env.NODE_ENV === 'production'
-    ? reportException(err)
-    : console.log('Event Error', err); /* tslint:disable-line */
 
 interface Props {
   events?: Linode.Event[];
@@ -39,11 +25,7 @@ export const UserEventsList: React.StatelessComponent<
     <React.Fragment>
       {(events as ExtendedEvent[])
         .reduce((result, event): UserEventsListItemProps[] => {
-          const title = eventMessageGenerator(
-            event,
-            reportUnfoundEvent as any,
-            reportEventError
-          );
+          const title = eventMessageGenerator(event);
           let content = `${moment(`${event.created}Z`).fromNow()}`;
 
           if (event.username) {

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -9,10 +9,7 @@ import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import Grid from 'src/components/Grid';
 import eventMessageGenerator from 'src/eventMessageGenerator';
-import {
-  maybeRemoveTrailingPeriod,
-  onUnfound
-} from 'src/features/Events/EventRow';
+import { maybeRemoveTrailingPeriod } from 'src/features/Events/EventRow';
 
 type ClassNames = 'root';
 
@@ -35,7 +32,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
   const { classes, event } = props;
 
-  const message = eventMessageGenerator(event, onUnfound);
+  const message = eventMessageGenerator(event);
 
   if (!message) {
     return null;


### PR DESCRIPTION
## Description

This PR does a couple things

1. Moves the `onUnfound` logic inside of the `eventMessageGenerator` rather than having to explicitly pass a callback
2. Adds more descriptive sentry errors with the full event payload, so we can properly debug.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A