### PR TITLE
M3-2990 - TBT Re-add links in rows for Linodes, domains and NBs

### DIFF
--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -117,4 +117,4 @@ class TableRow extends React.Component<CombinedProps> {
 
 const styled = withStyles(styles);
 
-export default withRouter(styled(TableRow));
+export default styled(withRouter(TableRow));

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -117,4 +117,4 @@ class TableRow extends React.Component<CombinedProps> {
 
 const styled = withStyles(styles);
 
-export default styled(withRouter(TableRow));
+export default withRouter(styled(TableRow));

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -84,20 +84,6 @@ type CombinedProps = Props &
   WithUpdatingDomainsProps &
   DispatchProps;
 
-const handleRowClick = (
-  e:
-    | React.ChangeEvent<HTMLTableRowElement>
-    | React.MouseEvent<HTMLAnchorElement, MouseEvent>,
-  props: CombinedProps
-) => {
-  const { domain, id, type, onEdit } = props;
-
-  if (type === 'slave') {
-    e.preventDefault();
-    onEdit(domain, id);
-  }
-};
-
 class DomainsDashboardCard extends React.Component<CombinedProps, State> {
   render() {
     return (
@@ -110,6 +96,18 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
       </DashboardCard>
     );
   }
+
+  handleRowClick = (
+    e: React.ChangeEvent<HTMLTableRowElement>,
+    id: number,
+    domain: string,
+    type: string
+  ) => {
+    if (type === 'slave') {
+      e.preventDefault();
+      this.props.openForEditing(domain, id);
+    }
+  };
 
   renderAction = () =>
     this.props.domainCount > 5 ? (
@@ -155,7 +153,7 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
         key={domain}
         rowLink={
           type === 'slave'
-            ? e => handleRowClick(e, this.props)
+            ? e => this.handleRowClick(e, id, domain, type)
             : `/domains/${id}`
         }
       >

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -172,7 +172,7 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
             <Grid item className={classes.labelGridWrapper}>
               <div className={classes.labelStatusWrapper}>
                 {type !== 'slave' ? (
-                  <Link to={`/domains/${id}`}>
+                  <Link to={`/domains/${id}`} tabIndex={-1}>
                     <Typography
                       variant="h3"
                       className={classes.wrapHeader}

--- a/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -1,5 +1,6 @@
 import { take } from 'ramda';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
 import Hidden from 'src/components/core/Hidden';
 import Paper from 'src/components/core/Paper';
@@ -134,13 +135,15 @@ const NodeBalancersDashboardCard: React.FunctionComponent<
               <EntityIcon variant="nodebalancer" />
             </Grid>
             <Grid item className={classes.labelGridWrapper}>
-              <Typography
-                variant="h3"
-                className={classes.wrapHeader}
-                data-qa-label
-              >
-                {label}
-              </Typography>
+              <Link to={`/nodebalancers/${id}`} tabIndex={-1}>
+                <Typography
+                  variant="h3"
+                  className={classes.wrapHeader}
+                  data-qa-label
+                >
+                  {label}
+                </Typography>
+              </Link>
               <Typography className={classes.description}>
                 {hostname}
               </Typography>
@@ -178,8 +181,8 @@ const withNodeBalancers = NodeBalancerContainer(
   })
 );
 const enhanced = compose<CombinedProps, {}>(
-  styled,
-  withNodeBalancers
+  withNodeBalancers,
+  styled
 );
 
 export default enhanced(NodeBalancersDashboardCard);

--- a/src/features/Domains/DomainTableRow.tsx
+++ b/src/features/Domains/DomainTableRow.tsx
@@ -62,88 +62,92 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const handleRowClick = (
-  e:
-    | React.ChangeEvent<HTMLTableRowElement>
-    | React.MouseEvent<HTMLAnchorElement, MouseEvent>,
-  props: CombinedProps
-) => {
-  const { domain, id, type, onEdit } = props;
+class DomainTableRow extends React.Component<CombinedProps> {
+  handleRowClick = (
+    e:
+      | React.ChangeEvent<HTMLTableRowElement>
+      | React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+    id: number,
+    domain: string,
+    type: string
+  ) => {
+    if (type === 'slave') {
+      e.preventDefault();
+      this.props.onEdit(domain, id);
+    }
+  };
 
-  if (type === 'slave') {
-    e.preventDefault();
-    onEdit(domain, id);
-  }
-};
+  render() {
+    const {
+      classes,
+      domain,
+      id,
+      tags,
+      type,
+      status,
+      onClone,
+      onRemove,
+      onEdit
+    } = this.props;
 
-const DomainTableRow: React.StatelessComponent<CombinedProps> = props => {
-  const {
-    classes,
-    domain,
-    id,
-    tags,
-    type,
-    status,
-    onClone,
-    onRemove,
-    onEdit
-  } = props;
-
-  return (
-    <TableRow
-      key={id}
-      data-qa-domain-cell={domain}
-      className={`${classes.domainRow} ${'fade-in-table'}`}
-      rowLink={
-        type === 'slave' ? e => handleRowClick(e, props) : `/domains/${id}`
-      }
-    >
-      <TableCell parentColumn="Domain" data-qa-domain-label>
-        <Grid container wrap="nowrap" alignItems="center">
-          <Grid item className="py0">
-            <EntityIcon
-              variant="domain"
-              status={status}
-              marginTop={1}
-              loading={status === 'edit_mode'}
-            />
-          </Grid>
-          <Grid item className={classes.domainCellContainer}>
-            <div className={classes.labelStatusWrapper}>
-              {type !== 'slave' ? (
-                <Link to={`/domains/${id}`} tabIndex={-1}>
+    return (
+      <TableRow
+        key={id}
+        data-qa-domain-cell={domain}
+        className={`${classes.domainRow} ${'fade-in-table'}`}
+        rowLink={
+          type === 'slave'
+            ? e => this.handleRowClick(e, id, domain, type)
+            : `/domains/${id}`
+        }
+      >
+        <TableCell parentColumn="Domain" data-qa-domain-label>
+          <Grid container wrap="nowrap" alignItems="center">
+            <Grid item className="py0">
+              <EntityIcon
+                variant="domain"
+                status={status}
+                marginTop={1}
+                loading={status === 'edit_mode'}
+              />
+            </Grid>
+            <Grid item className={classes.domainCellContainer}>
+              <div className={classes.labelStatusWrapper}>
+                {type !== 'slave' ? (
+                  <Link to={`/domains/${id}`} tabIndex={-1}>
+                    <Typography variant="h3" data-qa-label>
+                      {domain}
+                    </Typography>
+                  </Link>
+                ) : (
                   <Typography variant="h3" data-qa-label>
                     {domain}
                   </Typography>
-                </Link>
-              ) : (
-                <Typography variant="h3" data-qa-label>
-                  {domain}
-                </Typography>
-              )}
-            </div>
-            <div className={classes.tagWrapper}>
-              <Tags tags={tags} />
-            </div>
+                )}
+              </div>
+              <div className={classes.tagWrapper}>
+                <Tags tags={tags} />
+              </div>
+            </Grid>
           </Grid>
-        </Grid>
-      </TableCell>
-      <TableCell parentColumn="Type" data-qa-domain-type>
-        {type}
-      </TableCell>
-      <TableCell>
-        <ActionMenu
-          domain={domain}
-          id={id}
-          type={type}
-          onRemove={onRemove}
-          onClone={onClone}
-          onEdit={onEdit}
-        />
-      </TableCell>
-    </TableRow>
-  );
-};
+        </TableCell>
+        <TableCell parentColumn="Type" data-qa-domain-type>
+          {type}
+        </TableCell>
+        <TableCell>
+          <ActionMenu
+            domain={domain}
+            id={id}
+            type={type}
+            onRemove={onRemove}
+            onClone={onClone}
+            onEdit={onEdit}
+          />
+        </TableCell>
+      </TableRow>
+    );
+  }
+}
 
 const styled = withStyles(styles);
 

--- a/src/features/Domains/DomainTableRow.tsx
+++ b/src/features/Domains/DomainTableRow.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import {
   createStyles,
   Theme,
@@ -109,9 +110,17 @@ const DomainTableRow: React.StatelessComponent<CombinedProps> = props => {
           </Grid>
           <Grid item className={classes.domainCellContainer}>
             <div className={classes.labelStatusWrapper}>
-              <Typography variant="h3" data-qa-label>
-                {domain}
-              </Typography>
+              {type !== 'slave' ? (
+                <Link to={`/domains/${id}`} tabIndex={-1}>
+                  <Typography variant="h3" data-qa-label>
+                    {domain}
+                  </Typography>
+                </Link>
+              ) : (
+                <Typography variant="h3" data-qa-label>
+                  {domain}
+                </Typography>
+              )}
             </div>
             <div className={classes.tagWrapper}>
               <Tags tags={tags} />

--- a/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
+++ b/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingTableRows.tsx
@@ -83,7 +83,9 @@ const NodeBalancersLandingTableRows: React.StatelessComponent<
                   <EntityIcon variant="nodebalancer" marginTop={1} />
                 </Grid>
                 <Grid item>
-                  <Typography variant="h3">{nodeBalancer.label}</Typography>
+                  <Link to={`/nodebalancers/${nodeBalancer.id}`} tabIndex={-1}>
+                    <Typography variant="h3">{nodeBalancer.label}</Typography>
+                  </Link>
                 </Grid>
               </Grid>
             </TableCell>

--- a/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
 import {
   createStyles,
@@ -68,7 +69,7 @@ const styles = (theme: Theme) =>
       marginBottom: theme.spacing(1) / 2
     },
     linodeDescription: {
-      paddingTop: theme.spacing(1) / 2
+      paddingTop: 2
     },
     labelStatusWrapper: {
       display: 'flex',
@@ -118,6 +119,7 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
     memory,
     disk,
     vcpus,
+    id,
     image,
     // other props
     classes,
@@ -160,13 +162,15 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
               />
             )}
             <div className={classes.labelStatusWrapper}>
-              <Typography
-                variant="h3"
-                className={classes.wrapHeader}
-                data-qa-label
-              >
-                {label}
-              </Typography>
+              <Link to={`/linodes/${id}`} tabIndex={-1}>
+                <Typography
+                  variant="h3"
+                  className={classes.wrapHeader}
+                  data-qa-label
+                >
+                  {label}
+                </Typography>
+              </Link>
             </div>
             <Typography className={classes.linodeDescription}>
               {description}

--- a/src/themeFactory.ts
+++ b/src/themeFactory.ts
@@ -1288,7 +1288,7 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
             '&$hover': {
               backgroundColor: '#fbfbfb',
               '&:before': {
-                borderLeftColor: primaryColors.main
+                backgroundColor: primaryColors.main
               }
             }
           }
@@ -1302,6 +1302,9 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
         },
         hover: {
           cursor: 'pointer',
+          '& a': {
+            color: primaryColors.text
+          },
           '& a.secondaryLink': {
             color: primaryColors.main,
             '&:hover': {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -594,7 +594,7 @@ export const dark = (options: ThemeOverrides) =>
         },
         hover: {
           '& a': {
-            color: primaryColors.main
+            color: primaryColors.text
           }
         }
       },


### PR DESCRIPTION
## Re-add links in rows for Linodes, domains and NBs

Instead of trying to capture a lot of event on the row, it's probably better to just make the titles for these entities a link so that people have the options to perform regular operations on them. While the feature is not obvious at first, it is a good fallback to have. I also made sure that these links have a negative tabIndex to not add a tab event to the row itself.

this was added for the linodes, domains and NBs entities as well as their dashboard placements

## Type of Change
- Non breaking change ('update', 'change')
