### PR TITLE
M3-2879: Update Redux state shape for Domains

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -597,7 +597,7 @@ const mapStateToProps: MapState<StateProps, Props> = state => ({
   profileError: path(['read'], state.__resources.profile.error),
   linodes: state.__resources.linodes.entities,
   linodesError: path(['read'], state.__resources.linodes.error),
-  domainsError: state.__resources.domains.error,
+  domainsError: state.__resources.domains.error.read,
   imagesError: state.__resources.images.error,
   notifications: state.__resources.notifications.data,
   notificationsError: state.__resources.notifications.error,

--- a/src/containers/domains.container.ts
+++ b/src/containers/domains.container.ts
@@ -10,12 +10,12 @@ import {
   deleteDomain,
   updateDomain
 } from 'src/store/domains/domains.requests';
-import { ThunkDispatch } from 'src/store/types';
+import { EntityError, ThunkDispatch } from 'src/store/types';
 
 export interface StateProps {
   domainsData?: Linode.Domain[];
   domainsLoading: boolean;
-  domainsError?: Linode.ApiFieldError[];
+  domainsError: EntityError;
 }
 
 export interface DomainActionsProps {
@@ -30,8 +30,8 @@ export default <InnerStateProps extends {}, TOuter extends {}>(
   mapDomainsToProps: (
     ownProps: TOuter,
     domainsLoading: boolean,
-    domains?: Linode.Domain[],
-    domainsError?: Linode.ApiFieldError[]
+    domainsError: EntityError,
+    domains?: Linode.Domain[]
   ) => InnerStateProps
 ) =>
   connect(
@@ -39,8 +39,8 @@ export default <InnerStateProps extends {}, TOuter extends {}>(
       return mapDomainsToProps(
         ownProps,
         state.__resources.domains.loading,
-        state.__resources.domains.entities,
-        state.__resources.domains.error
+        state.__resources.domains.error,
+        state.__resources.domains.data
       );
     },
     (dispatch: ThunkDispatch) => ({

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -179,19 +179,21 @@ interface WithUpdatingDomainsProps {
   error?: Linode.ApiFieldError[];
 }
 
-const withUpdatingDomains = connect((state: ApplicationState, ownProps: {}) => {
-  const domainState = state.__resources.domains;
-  return {
-    domains: compose(
-      mergeEvents(state.events.events),
-      take(5),
-      sortBy(prop('domain'))
-    )(domainState.data),
-    loading: domainState.loading,
-    domainCount: domainState.results || 0,
-    error: domainState.error
-  };
-});
+const withUpdatingDomains = connect(
+  (state: ApplicationState, ownProps: {}): WithUpdatingDomainsProps => {
+    const domainState = state.__resources.domains;
+    return {
+      domains: compose(
+        mergeEvents(state.events.events),
+        take(5),
+        sortBy(prop('domain'))
+      )(domainState.data),
+      loading: domainState.loading,
+      domainCount: domainState.results || 0,
+      error: domainState.error.read
+    };
+  }
+);
 
 const mergeEvents = (events: Linode.Event[]) => (domains: Linode.Domain[]) =>
   events.reduce((updatedDomains, event) => {

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -188,7 +188,7 @@ const withUpdatingDomains = connect((state: ApplicationState, ownProps: {}) => {
       sortBy(prop('domain'))
     )(domainState.data),
     loading: domainState.loading,
-    domainCount: domainState.data ? domainState.data.length : 0,
+    domainCount: domainState.results || 0,
     error: domainState.error
   };
 });

--- a/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -180,15 +180,16 @@ interface WithUpdatingDomainsProps {
 }
 
 const withUpdatingDomains = connect((state: ApplicationState, ownProps: {}) => {
+  const domainState = state.__resources.domains;
   return {
     domains: compose(
       mergeEvents(state.events.events),
       take(5),
       sortBy(prop('domain'))
-    )(state.__resources.domains.entities),
-    loading: state.__resources.domains.loading,
-    domainCount: state.__resources.domains.entities.length,
-    error: state.__resources.domains.error
+    )(domainState.data),
+    loading: domainState.loading,
+    domainCount: domainState.data ? domainState.data.length : 0,
+    error: domainState.error
   };
 });
 

--- a/src/features/Domains/DomainDetail.tsx
+++ b/src/features/Domains/DomainDetail.tsx
@@ -87,7 +87,7 @@ const DomainDetail: React.FC<CombinedProps> = props => {
   }
 
   /** Error State */
-  if (domainsError) {
+  if (domainsError.read) {
     return (
       <ErrorState errorText="There was an error retrieving your domain. Please reload and try again." />
     );
@@ -143,7 +143,7 @@ interface DomainProps extends Omit<StateProps, 'domainsData'> {
 export default compose<CombinedProps, {}>(
   reloaded,
   domainsContainer<DomainProps, RouteComponentProps<{ domainId?: string }>>(
-    (ownProps, domainsLoading, domains, domainsError) => ({
+    (ownProps, domainsLoading, domainsError, domains) => ({
       domainsError,
       domainsLoading,
       domain: !domains

--- a/src/features/Domains/DomainDrawer.tsx
+++ b/src/features/Domains/DomainDrawer.tsx
@@ -844,11 +844,7 @@ interface StateProps {
 
 const mapStateToProps = (state: ApplicationState) => {
   const id = path(['domainDrawer', 'id'], state);
-  const domainEntities = pathOr(
-    [],
-    ['__resources', 'domains', 'entities'],
-    state
-  );
+  const domainEntities = pathOr([], ['__resources', 'domains', 'data'], state);
   const domainProps = domainEntities.find(
     (domain: Linode.Domain) => domain.id === path(['domainDrawer', 'id'], state)
   );

--- a/src/features/Domains/DomainsLanding.test.tsx
+++ b/src/features/Domains/DomainsLanding.test.tsx
@@ -8,6 +8,7 @@ import { CombinedProps, DomainsLanding } from './DomainsLanding';
 const props: CombinedProps = {
   domainsData: domains,
   domainsLoading: false,
+  domainsError: {},
   howManyLinodesOnAccount: 0,
   domainActions: {
     createDomain: jest.fn(),

--- a/src/features/Domains/DomainsLanding.tsx
+++ b/src/features/Domains/DomainsLanding.tsx
@@ -224,7 +224,7 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
       return <RenderLoading />;
     }
 
-    if (domainsError) {
+    if (domainsError.read) {
       return <RenderError />;
     }
 
@@ -455,7 +455,7 @@ export const connected = connect(
 export default compose<CombinedProps, {}>(
   setDocs(DomainsLanding.docs),
   domainsContainer<DomainStateProps, {}>(
-    (ownProps, domainsLoading, domains, domainsError) => ({
+    (ownProps, domainsLoading, domainsError, domains) => ({
       domainsData: domains,
       domainsError,
       domainsLoading

--- a/src/store/domains/domains.actions.ts
+++ b/src/store/domains/domains.actions.ts
@@ -75,12 +75,14 @@ export const requestDomainForStore: RequestDomainForStoreThunk = id => (
   dispatch,
   getState
 ) => {
-  const { results } = getState().__resources.domains;
+  const { data } = getState().__resources.domains;
+
+  const ids = data ? data.map(domain => domain.id) : [];
 
   getDomain(id)
     .then(response => response)
     .then(domain => {
-      if (results.includes(id)) {
+      if (ids.includes(id)) {
         return dispatch(upsertDomain(domain));
       }
       return dispatch(upsertDomain(domain));

--- a/src/store/domains/domains.actions.ts
+++ b/src/store/domains/domains.actions.ts
@@ -23,7 +23,10 @@ const actionCreator = actionCreatorFactory(`@@manager/domains`);
 
 export const getDomainsRequest = actionCreator('request');
 
-export const getDomainsSuccess = actionCreator<Linode.Domain[]>('success');
+export const getDomainsSuccess = actionCreator<{
+  data: Linode.Domain[];
+  results: number;
+}>('success');
 
 export const getDomainsFailure = actionCreator<Linode.ApiFieldError[]>('fail');
 
@@ -57,7 +60,7 @@ export const requestDomains: ThunkActionCreator<
 
   return getAll<Linode.Domain>(getDomains)()
     .then(domains => {
-      dispatch(getDomainsSuccess(domains.data));
+      dispatch(getDomainsSuccess(domains));
       return domains;
     })
     .catch(err => {

--- a/src/store/domains/domains.reducer.ts
+++ b/src/store/domains/domains.reducer.ts
@@ -120,7 +120,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
     return {
       ...state,
-      data: data.filter(domain => domain.id !== domainId),
+      data: filteredData,
       results: filteredData.length
     };
   }

--- a/src/store/domains/domains.reducer.ts
+++ b/src/store/domains/domains.reducer.ts
@@ -1,5 +1,5 @@
 import { Reducer } from 'redux';
-import { EntityState } from 'src/store/types';
+import { RequestableDataWithEntityError } from 'src/store/types';
 import updateOrAdd from 'src/utilities/updateOrAdd';
 import { isType } from 'typescript-fsa';
 import {
@@ -12,20 +12,19 @@ import {
   updateDomainActions,
   upsertDomain
 } from './domains.actions';
-import { entitiesFromPayload, resultsFromPayload } from './domains.helpers';
+import { entitiesFromPayload } from './domains.helpers';
 
 /**
  * State
  */
 
-export type State = EntityState<Linode.Domain>;
+export type State = RequestableDataWithEntityError<Linode.Domain[]>;
 
 export const defaultState: State = {
-  results: [],
-  entities: [],
+  data: [],
   loading: true,
   lastUpdated: 0,
-  error: undefined
+  error: {}
 };
 
 /**
@@ -43,8 +42,8 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     const { payload } = action;
     return {
       ...state,
-      entities: entitiesFromPayload(payload),
-      results: resultsFromPayload(payload),
+      data: entitiesFromPayload(payload),
+      results: payload.length,
       lastUpdated: Date.now(),
       loading: false
     };
@@ -54,63 +53,75 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     const { payload } = action;
     return {
       ...state,
-      error: payload,
+      error: {
+        read: payload
+      },
       loading: false
     };
   }
 
   if (isType(action, upsertDomain)) {
     const { payload } = action;
-    const updated = updateOrAdd(payload, state.entities);
+    const updated = updateOrAdd(payload, state.data);
 
     return {
       ...state,
-      entities: updated,
-      results: updated.map(domain => domain.id)
+      data: updated,
+      results: updated.length
     };
   }
 
   if (isType(action, deleteDomain)) {
     const { payload } = action;
-    const { entities, results } = state;
+    const { data } = state;
+
+    if (!data) {
+      return state;
+    }
 
     return {
       ...state,
-      entities: entities.filter(domain => domain.id !== payload),
-      results: results.filter(id => id !== payload)
+      data: data.filter(domain => domain.id !== payload),
+      results: data.length
     };
   }
 
   if (isType(action, createDomainActions.done)) {
     const { result } = action.payload;
-    const updated = updateOrAdd(result, state.entities);
+    const updated = updateOrAdd(result, state.data);
 
     return {
       ...state,
-      entities: updated,
-      results: updated.map(domain => domain.id)
+      data: updated,
+      results: updated.length
     };
   }
 
   if (isType(action, updateDomainActions.done)) {
     const { result } = action.payload;
-    const updated = updateOrAdd(result, state.entities);
+    const updated = updateOrAdd(result, state.data);
 
     return {
       ...state,
-      entities: updated,
-      results: updated.map(domain => domain.id)
+      data: updated,
+      results: updated.length
     };
   }
 
   if (isType(action, deleteDomainActions.done)) {
     const { domainId } = action.payload.params;
-    const { entities, results } = state;
+    const { data } = state;
+
+    if (!data) {
+      return state;
+    }
+
+    const filteredData = data.filter(domain => domain.id !== domainId);
 
     return {
       ...state,
-      entities: entities.filter(domain => domain.id !== domainId),
-      results: results.filter(id => id !== domainId)
+      data: data.filter(domain => domain.id !== domainId),
+      results: filteredData.length
     };
   }
 

--- a/src/store/domains/domains.reducer.ts
+++ b/src/store/domains/domains.reducer.ts
@@ -39,11 +39,13 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   }
 
   if (isType(action, getDomainsSuccess)) {
-    const { payload } = action;
+    const {
+      payload: { data, results }
+    } = action;
     return {
       ...state,
-      data: entitiesFromPayload(payload),
-      results: payload.length,
+      data: entitiesFromPayload(data),
+      results,
       lastUpdated: Date.now(),
       loading: false
     };

--- a/src/store/domains/domains.reducer.ts
+++ b/src/store/domains/domains.reducer.ts
@@ -81,10 +81,12 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       return state;
     }
 
+    const filteredData = data.filter(domain => domain.id !== payload);
+
     return {
       ...state,
-      data: data.filter(domain => domain.id !== payload),
-      results: data.length
+      data: filteredData,
+      results: filteredData.length
     };
   }
 

--- a/src/store/selectors/entitiesErrors.ts
+++ b/src/store/selectors/entitiesErrors.ts
@@ -20,7 +20,7 @@ export const linodesErrorSelector = (state: State) => {
 export const volumesErrorSelector = (state: State) => false; //  Boolean(state.volumes.error && state.volumes.error.length > 0)
 export const nodeBalsErrorSelector = (state: State) => false; //  Boolean(state.nodebalancers.error && state.nodebalancers.error.length > 0)
 export const domainsErrorSelector = (state: State) =>
-  Boolean(state.domains.error && state.domains.error.length > 0);
+  Object.keys(state.domains.error).length > 0;
 export const imagesErrorSelector = (state: State) =>
   Boolean(state.images.error && state.images.error.length > 0);
 export const typesErrorSelector = (state: State) =>

--- a/src/store/selectors/entitiesLoading.ts
+++ b/src/store/selectors/entitiesLoading.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { ApplicationState } from 'src/store';
-import { EntityError } from 'src/store/types';
+import { EntityError, RequestableDataWithEntityError } from 'src/store/types';
 
 type State = ApplicationState['__resources'];
 
@@ -26,15 +26,16 @@ export const domainsSelector = (state: State) => state.domains;
 export const imagesSelector = (state: State) => state.images;
 export const typesSelector = (state: State) => state.types;
 
-const isInitialLoad = (e: Resource<any, any>) =>
-  e.loading && e.lastUpdated === 0;
+const isInitialLoad = (
+  e: Resource<any, any> | RequestableDataWithEntityError<any>
+) => e.loading && e.lastUpdated === 0;
 
 export default createSelector<
   State,
   Resource<Linode.Linode[], EntityError>,
   Resource<Linode.Volume[]>,
   Resource<Linode.NodeBalancer[][]>,
-  Resource<Linode.Domain[]>,
+  RequestableDataWithEntityError<Linode.Domain[]>,
   Resource<Linode.Image[]>,
   Resource<Linode.LinodeType[]>,
   boolean

--- a/src/store/selectors/getEntitiesWithGroupsToImport.test.tsx
+++ b/src/store/selectors/getEntitiesWithGroupsToImport.test.tsx
@@ -4,7 +4,7 @@ import { entitiesWithGroupsToImport } from './getEntitiesWithGroupsToImport';
 const state = {
   __resources: {
     linodes: { entities: linodes },
-    domains: { entities: domains }
+    domains: { data: domains }
   }
 };
 

--- a/src/store/selectors/getEntitiesWithGroupsToImport.tsx
+++ b/src/store/selectors/getEntitiesWithGroupsToImport.tsx
@@ -52,7 +52,7 @@ export const extractProps = (entity: GroupedEntity) => ({
 const linodeSelector = (state: ApplicationState) =>
   state.__resources.linodes.entities;
 const domainSelector = (state: ApplicationState) =>
-  state.__resources.domains.entities;
+  state.__resources.domains.data || [];
 
 // Selector that returns Linodes and Domains that have a GROUP without
 // corresponding TAG.

--- a/src/store/selectors/getSearchEntities.ts
+++ b/src/store/selectors/getSearchEntities.ts
@@ -122,7 +122,7 @@ const volumeSelector = ({ volumes }: State) => Object.values(volumes.itemsById);
 const nodebalSelector = ({ nodeBalancers }: State) =>
   Object.values(nodeBalancers.itemsById);
 const imageSelector = (state: State) => state.images.entities;
-const domainSelector = (state: State) => state.domains.entities;
+const domainSelector = (state: State) => state.domains.data || [];
 const typesSelector = (state: State) => state.types.entities;
 
 export default createSelector<

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -74,6 +74,7 @@ export interface RequestableDataWithEntityError<D> {
   lastUpdated: number;
   loading: boolean;
   data?: D;
+  results?: number;
   error: EntityError;
 }
 

--- a/src/utilities/getEntityByIDFromStore.ts
+++ b/src/utilities/getEntityByIDFromStore.ts
@@ -48,7 +48,10 @@ const _getEntityByIDFromStore = (
     case 'nodebalancer':
       return nodeBalancers.itemsById[entityID];
     case 'domain':
-      return domains.entities.find(domain => entityID === domain.id);
+      if (!domains.data) {
+        return;
+      }
+      return domains.data.find(domain => entityID === domain.id);
     case 'volume':
       return volumes.itemsById[entityID];
     default:

--- a/src/utilities/updateOrAdd.ts
+++ b/src/utilities/updateOrAdd.ts
@@ -1,6 +1,9 @@
 import { append, update } from 'ramda';
 
-export default <T extends { id: string | number }>(item: T, items: T[]) => {
+export default <T extends { id: string | number }>(
+  item: T,
+  items: T[] = []
+) => {
   if (items.length === 0) {
     return [item];
   }


### PR DESCRIPTION
## Description

This PR restructures the Redux state shape of Domains. Previously it was `EntityState`, now it's `RequestableDataWithEntityError`.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Nothing from the user's point of view should change. Test domain actions and error states.
