### PR TITLE
TDT: Safe access backups.snapshot (fix Sentry error)

### DIFF
--- a/src/utilities/backups.test.ts
+++ b/src/utilities/backups.test.ts
@@ -17,6 +17,21 @@ describe('utilities/backups', () => {
 
       expect(collectBackups(response)).toEqual(automatic);
     });
+
+    it('should not bomb out if "snapshot" comes back as null/undefined from the API', () => {
+      /**
+       * snapshot should never come back as null or undefined from the API, but
+       * we were getting Sentry errors from this function when trying to access snapshot.whatever.
+       * It's unclear how this happens, but we should handle the case without crashing.
+       */
+      const automatic = [{ id: 1 }, { id: 2 }, { id: 3 }];
+      const response = {
+        automatic,
+        snapshot: null
+      } as any;
+
+      expect(collectBackups(response)).toEqual(automatic);
+    });
   });
 
   describe('mostRecentFromResponse', () => {

--- a/src/utilities/backups.ts
+++ b/src/utilities/backups.ts
@@ -2,7 +2,11 @@ export const collectBackups = ({
   automatic,
   snapshot
 }: Linode.LinodeBackupsResponse) =>
-  [...automatic, snapshot.current, snapshot.in_progress].filter(Boolean);
+  [
+    ...automatic,
+    snapshot && snapshot.current,
+    snapshot && snapshot.in_progress
+  ].filter(Boolean);
 
 export const mostRecentFromResponse: (
   r: Linode.LinodeBackupsResponse
@@ -12,7 +16,7 @@ export const mostRecentFromResponse: (
       /** Filter unsuccessful/in-progress backups */
       .filter((backup: Linode.LinodeBackup) => backup.status === 'successful')
 
-      /** Just make sure the backup isnt null somehow. */
+      /** Just make sure the backup isn't null somehow. */
       .filter(
         (backup: Linode.LinodeBackup) => typeof backup.finished === 'string'
       )


### PR DESCRIPTION
## Description

I can't actually reproduce this, and the Sentry error/corresponding Jira ticket are pretty old. But safe access never hurt anyone, so thought I'd put this up for review anyway.

If the API returns `snapshot` as undefined or null, the app will crash when loading backups. It doesn't seem like the API will ever actually do this, but it seems to have happened somehow at least once.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Please give 👍 or 👎 ; no problem just closing this.