### PR TITLE
M3-3006 Important notice styling

### DIFF
--- a/src/components/Notice/Notice.tsx
+++ b/src/components/Notice/Notice.tsx
@@ -45,6 +45,7 @@ const styles = (theme: Theme) => {
       }
     },
     root: {
+      position: 'relative',
       marginBottom: theme.spacing(2),
       padding: '4px 16px',
       maxWidth: '100%',
@@ -64,7 +65,7 @@ const styles = (theme: Theme) => {
     icon: {
       color: 'white',
       position: 'absolute',
-      left: theme.spacing(1) + 7
+      left: -25
     },
     closeIcon: {
       paddingLeft: theme.spacing(1)


### PR DESCRIPTION
## Description

Adjusts icon placement on important notices:
Compact:
<img width="456" alt="Screen Shot 2019-07-10 at 11 22 57 AM" src="https://user-images.githubusercontent.com/2565527/60982374-00333d00-a306-11e9-9d75-86a7fb3efc16.png">
Normal:
<img width="748" alt="Screen Shot 2019-07-10 at 11 23 08 AM" src="https://user-images.githubusercontent.com/2565527/60982376-00cbd380-a306-11e9-9d5b-c31257210886.png">

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

Please view on multiple breakpoints, and in both theme spacing modes.