### PR TITLE
M3-3008 Fix domain record validation

### DIFF
--- a/src/features/Domains/DomainRecordDrawer.tsx
+++ b/src/features/Domains/DomainRecordDrawer.tsx
@@ -28,7 +28,11 @@ import defaultNumeric from 'src/utilities/defaultNumeric';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { isValidDomainRecord, isValidSOAEmail } from './domainUtils';
+import {
+  isValidCNAME,
+  isValidDomainRecord,
+  isValidSOAEmail
+} from './domainUtils';
 
 const TextField: React.StatelessComponent<TextFieldProps> = props => (
   <_TextField {...props} />
@@ -493,8 +497,11 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
      * This should be done on the API side, but several breaking
      * configurations will currently succeed on their end.
      */
+    const _domain = pathOr('', ['name'], data);
+    const invalidCNAME =
+      data.type === 'CNAME' && !isValidCNAME(_domain, records);
 
-    if (!isValidDomainRecord(pathOr('', ['name'], data), records)) {
+    if (!isValidDomainRecord(_domain, records) || invalidCNAME) {
       const error = {
         field: 'name',
         reason: 'Record conflict - CNAMES must be unique'

--- a/src/features/Domains/domainUtils.test.ts
+++ b/src/features/Domains/domainUtils.test.ts
@@ -1,5 +1,9 @@
 import { domainRecords as records } from 'src/__data__/domains';
-import { isValidDomainRecord, isValidSOAEmail } from './domainUtils';
+import {
+  isValidCNAME,
+  isValidDomainRecord,
+  isValidSOAEmail
+} from './domainUtils';
 
 describe('Domain-related utilities', () => {
   describe('Validating email addresses', () => {
@@ -21,6 +25,16 @@ describe('Domain-related utilities', () => {
         false
       );
       expect(isValidSOAEmail('admin@example.com', 'www.google.com')).toBe(true);
+    });
+  });
+
+  describe('Validating CNAME records', () => {
+    it('should prevent users from creating a CNAME record that would create a conflict', () => {
+      expect(isValidCNAME('host', records)).toBe(false);
+    });
+
+    it('should allow the creation of a new, unique CNAME', () => {
+      expect(isValidCNAME('new-domain', records)).toBe(true);
     });
   });
 

--- a/src/features/Domains/domainUtils.ts
+++ b/src/features/Domains/domainUtils.ts
@@ -31,3 +31,7 @@ export const isUniqueHostname = (
     record => record.type === 'CNAME' && record.name === hostname
   );
 };
+
+export const isValidCNAME = (cname: string, records: Linode.DomainRecord[]) => {
+  return !records.some(thisRecord => thisRecord.name === cname);
+};


### PR DESCRIPTION
## Description

Left off a check when I added this validation.

1. create TXT record with host 'domain'
2. create CNAME with host 'domain'

should error. Currently only errors if you reverse the steps.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
