### PR TITLE
stop on spec failure, set bail count to 100

### DIFF
--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -131,7 +131,7 @@ exports.config = {
     //
     // If you only want to run your tests until a specific amount of tests have failed use
     // bail (default is 0 - don't bail, run all tests).
-    bail: 0,
+    bail: 100,
     //
     // Saves a screenshot to a given path if a command fails.
     // screenshotPath: './e2e/errorShots/',
@@ -206,7 +206,7 @@ exports.config = {
         expectationResultHandler: function(passed, assertion) {
             // do something
         },
-        stopOnSpecFailure: false,
+        stopOnSpecFailure: true,
     },
 
     mountebankConfig: {


### PR DESCRIPTION
## Description

If a test in a spec fails, stop running that spec entirely. This config will ultimately reduce the total number of tests, but give a more accurate count of how many tests are currently failing.

Also, set the bail count to 100, so if there's a 100 test failures to just exit since we know somethings wrong at that point (like the login service being down, etc)

We had this set up before, but we

## Type of Change
- Test fix ('fix', 'repair', 'bug')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. We'll run these on CI and compare the results

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
