### PR TITLE
M3-2969 Change: SSH Key flow

### DIFF
--- a/src/components/AccessPanel/AccessPanel.tsx
+++ b/src/components/AccessPanel/AccessPanel.tsx
@@ -139,10 +139,12 @@ class AccessPanel extends React.Component<CombinedProps> {
             hideStrengthLabel={hideStrengthLabel}
             hideHelperText={hideHelperText}
           />
-          <UserSSHKeyPanel
-            users={users}
-            onKeyAddSuccess={requestKeys || (() => null)}
-          />
+          {users && (
+            <UserSSHKeyPanel
+              users={users}
+              onKeyAddSuccess={requestKeys || (() => null)}
+            />
+          )}
         </div>
       </Paper>
     );

--- a/src/features/linodes/userSSHKeyHoc.ts
+++ b/src/features/linodes/userSSHKeyHoc.ts
@@ -35,6 +35,9 @@ export default (Component: React.ComponentType<any>) => {
       if (!username || !userEmailAddress) {
         return;
       }
+
+      const isSelected = this.isUserSelected(username);
+
       getSSHKeys()
         .then(response => {
           const keys = response.data;
@@ -47,7 +50,8 @@ export default (Component: React.ComponentType<any>) => {
               this.createUserObject(
                 username,
                 userEmailAddress,
-                keys.map(k => k.label)
+                keys.map(k => k.label),
+                isSelected
               )
             ]
           });
@@ -62,6 +66,8 @@ export default (Component: React.ComponentType<any>) => {
           if (!this.mounted || !users || users.length === 0) {
             return;
           }
+
+          const isSelected = this.isUserSelected(username);
 
           this.setState({
             userSSHKeys: [
@@ -79,7 +85,12 @@ export default (Component: React.ComponentType<any>) => {
 
                 return [
                   ...cleanedUsers,
-                  this.createUserObject(user.username, user.email, keys)
+                  this.createUserObject(
+                    user.username,
+                    user.email,
+                    keys,
+                    isSelected
+                  )
                 ];
               }, [])
             ]
@@ -90,7 +101,7 @@ export default (Component: React.ComponentType<any>) => {
         });
     };
 
-    state = {
+    state: State = {
       userSSHKeys: [],
       resetSSHKeys: this.resetSSHKeys,
       requestKeys: this.requestKeys
@@ -122,16 +133,30 @@ export default (Component: React.ComponentType<any>) => {
         )
       }));
 
-    createUserObject = (username: string, email: string, keys: string[]) => ({
+    createUserObject = (
+      username: string,
+      email: string,
+      keys: string[],
+      selected: boolean = false
+    ) => ({
       keys,
       username,
       gravatarUrl: `https://www.gravatar.com/avatar/${getEmailHash(
         email
       )}?d=mp&s=24`,
-      selected: false,
+      selected,
       onSSHKeyChange: (_: any, result: boolean) =>
         this.toggleSSHUserKeys(username, result)
     });
+
+    isUserSelected = (username: string) => {
+      const { userSSHKeys } = this.state;
+
+      const currentUserKeys = userSSHKeys.find(
+        thisKey => thisKey.username === username
+      );
+      return currentUserKeys ? currentUserKeys.selected : false;
+    };
   }
 
   return connected(WrappedComponent);


### PR DESCRIPTION
## Description

Adds two pieces of feedback/follow ons from the POC:

- Disables the SSH panel unless the consumer explicitly passes the `users` prop. This will remove the panel from e.g. the UDF fields.
- Preserves selected state, so after adding a key the list of selected users should be the same as before. 

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

prod-test-004 has 3 users with SSH keys. Toggle away!