### PR TITLE
M3-2894 Zone file tooltip

### DIFF
--- a/src/features/Domains/DomainActionMenu.tsx
+++ b/src/features/Domains/DomainActionMenu.tsx
@@ -55,7 +55,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         {
           title: 'Zone File',
           tooltip:
-            "Currently we don't support this action, but will in the future.",
+            "Currently we don't support this action but will in the future.",
           disabled: true,
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             closeMenu();
@@ -108,7 +108,7 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         {
           title: 'Zone File',
           tooltip:
-            "Currently we don't support this action, but will in the future.",
+            "Currently we don't support this action but will in the future.",
           disabled: true,
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             closeMenu();

--- a/src/features/Domains/DomainActionMenu.tsx
+++ b/src/features/Domains/DomainActionMenu.tsx
@@ -54,6 +54,8 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         },
         {
           title: 'Zone File',
+          tooltip:
+            "Currently we don't support this action, but will in the future.",
           disabled: true,
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             closeMenu();
@@ -105,6 +107,8 @@ class LinodeActionMenu extends React.Component<CombinedProps> {
         },
         {
           title: 'Zone File',
+          tooltip:
+            "Currently we don't support this action, but will in the future.",
           disabled: true,
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             closeMenu();


### PR DESCRIPTION
## Description

Adding a tooltip for the Zone File action on domains. This will eventually be actionable but until then we want users to be presented with a little more information than prior to the tooltip. 

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

Go to `/domains`, click the kebob of a master and/or slave domain, and view the tooltip for the 'Zone File' action.
