### PR TITLE
[For release] Handle profile update event

### DIFF
--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -337,6 +337,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     failed: e => `Password reset failed for Linode ${e.entity!.label}.`,
     finished: e => `Password has been reset on Linode ${e.entity!.label}.`
   },
+  profile_update: {
+    notification: e => `${e.username}'s profile has been updated.`
+  },
   // payment_submitted: {
   //   scheduled: e => ``,
   //   started: e => ``,

--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -338,7 +338,7 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     finished: e => `Password has been reset on Linode ${e.entity!.label}.`
   },
   profile_update: {
-    notification: e => `${e.username}'s profile has been updated.`
+    notification: e => `Your profile has been updated.`
   },
   // payment_submitted: {
   //   scheduled: e => ``,


### PR DESCRIPTION
## Description

API release includes a `profile_update` event which we weren't handling. This event should probably be swallowed rather than show up in the user events bell, but we can save that for our ongoing events audit.

Please let me know what you think about the message. I think it'll almost always be redundant "Jared's profile has been updated by Jared" but thought it was worth it.