### PR TITLE
[For Release] Clone Progress Fix

### DIFF
--- a/src/features/linodes/transitions.ts
+++ b/src/features/linodes/transitions.ts
@@ -28,10 +28,13 @@ export const linodeInTransition = (
   status: string,
   recentEvent?: Linode.Event
 ): boolean => {
+  if (!recentEvent) {
+    return false;
+  }
+
   return (
     transitionStatus.includes(status) ||
-    ((recentEvent || false) &&
-      transitionAction.includes(recentEvent.action || '') &&
+    (transitionAction.includes(recentEvent.action || '') &&
       recentEvent.percent_complete !== null &&
       recentEvent.percent_complete < 100)
   );

--- a/src/store/events/event.helpers.ts
+++ b/src/store/events/event.helpers.ts
@@ -131,7 +131,7 @@ export const isEntityEvent = (e: Linode.Event): e is Linode.EntityEvent =>
  * If an event is "completed" it is removed from the inProgressEvents map.
  * Otherwise the inProgressEvents is unchanged.
  *
- * @retuns { [key: number]: number } inProgressEvents: key value pair, where the
+ * @returns { [key: number]: number } inProgressEvents: key value pair, where the
  * key will be the ID of the event and the value will be the percent_complete
  *
  */

--- a/src/store/linodes/linodes.events.ts
+++ b/src/store/linodes/linodes.events.ts
@@ -33,6 +33,7 @@ const linodeEventsHandler: EventHandler = (event, dispatch, getState) => {
     case 'backups_enable':
     case 'backups_cancel':
     case 'disk_imagize':
+    case 'linode_clone':
       return handleLinodeUpdate(dispatch, status, id);
 
     /** Remove Linode */
@@ -42,9 +43,6 @@ const linodeEventsHandler: EventHandler = (event, dispatch, getState) => {
     /** Create Linode */
     case 'linode_create':
       return handleLinodeCreation(dispatch, status, id, getState());
-
-    case 'linode_clone':
-      return handleLinodeClone(dispatch, status, id);
 
     default:
       return;
@@ -70,23 +68,6 @@ const handleLinodeMigrate = (
       // to clear the Migration Imminent notification
       dispatch(requestNotifications());
       return dispatch(requestLinodeForStore(id));
-    default:
-      return;
-  }
-};
-
-const handleLinodeClone = (
-  dispatch: Dispatch<any>,
-  status: Linode.EventStatus,
-  id: number
-) => {
-  switch (status) {
-    case 'failed':
-    case 'finished':
-    case 'scheduled':
-    case 'started':
-      return dispatch(requestLinodeForStore(id));
-
     default:
       return;
   }

--- a/src/store/linodes/linodes.events.ts
+++ b/src/store/linodes/linodes.events.ts
@@ -4,7 +4,7 @@ import { ApplicationState } from 'src/store';
 import { requestLinodeForStore } from 'src/store/linodes/linode.requests';
 import { EventHandler } from 'src/store/types';
 import { requestNotifications } from '../notification/notification.requests';
-import { deleteLinode, updateLinode } from './linodes.actions';
+import { deleteLinode } from './linodes.actions';
 
 const linodeEventsHandler: EventHandler = (event, dispatch, getState) => {
   const { action, entity, status } = event;
@@ -84,14 +84,8 @@ const handleLinodeClone = (
     case 'failed':
     case 'finished':
     case 'scheduled':
-      return dispatch(requestLinodeForStore(id));
-
     case 'started':
-      const action = updateLinode({
-        id,
-        update: existing => ({ ...existing, status: 'cloning' })
-      });
-      return dispatch(action);
+      return dispatch(requestLinodeForStore(id));
 
     default:
       return;


### PR DESCRIPTION
## Description

If the last event that comes downstream from the API has 100% complete but a `status` of `started`, we need to get rid of the loading indicator and progress bar anyway.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A

### To Test

Either clone a Linode or clone a disk and wait until you get an event that is has a `percent_complete` of `100` and a status of `started`. You must NOT get a final event with a `finished` status to test this scenario.