### PR TITLE
M3-2996 Settings option not showing in Linode Action dropdown unless backups are enabled

### DIFF
--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -1,8 +1,11 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
+// import { render } from 'react-testing-library';
 import { extendedTypes } from 'src/__data__/ExtendedType';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { CombinedProps, LinodeActionMenu } from './LinodeActionMenu';
+
+// import { wrapWithTheme } from 'src/utilities/testHelpers';
 
 const props: CombinedProps = {
   linodeId: 123,
@@ -13,7 +16,8 @@ const props: CombinedProps = {
     schedule: {
       window: null,
       day: null
-    }
+    },
+    enabled: false
   },
   linodeStatus: '',
   noImage: false,
@@ -22,8 +26,58 @@ const props: CombinedProps = {
   ...reactRouterProps
 };
 
+// const includesActions = (actions: string[], query: any) => {
+//   for (const action of actions) {
+//     expect(query(action)).toBeInTheDocument();
+//   }
+// };
+
 describe('LinodeActionMenu', () => {
   const wrapper = shallow<LinodeActionMenu>(<LinodeActionMenu {...props} />);
+
+  //   it('should include standard Linode actions', () => {
+  //     const { queryByText } = render(
+  //       wrapWithTheme(<LinodeActionMenu {...props} />)
+  //     );
+  //     includesActions(
+  //       ['Launch Console', 'Clone', 'Resize', 'Settings', 'Delete'],
+  //       queryByText
+  //     );
+  //   });
+
+  // it('should render a Power On action if Linode is powered off', () => {
+  //   const { queryByText } = render(
+  //     wrapWithTheme(<LinodeActionMenu {...props} linodeStatus="offline" />)
+  //   );
+  //   expect(queryByText('Power On')).toBeInTheDocument();
+  //   expect(queryByText('Power Off')).not.toBeInTheDocument();
+  //   expect(queryByText('Reboot')).not.toBeInTheDocument();
+  // });
+
+  // it('should render Power Off and Reboot actions if Linode is powered on', () => {
+  //   const { queryByText } = render(
+  //     wrapWithTheme(<LinodeActionMenu {...props} linodeStatus="running" />)
+  //   );
+  //   expect(queryByText('Reboot')).toBeInTheDocument();
+  //   expect(queryByText('Power Off')).toBeInTheDocument();
+  //   expect(queryByText('Power On')).not.toBeInTheDocument();
+  // });
+
+  // it('should render an Enable Backups action if Backups are not enabled', () => {
+  //   const { queryByText } = render(
+  //     wrapWithTheme(<LinodeActionMenu {...props} linodeBackups.enabled={false} />)
+  //   );
+  //   expect(queryByText('Enable Backups')).toBeInTheDocument();
+  //   expect(queryByText('View Backups')).not.toBeInTheDocument();
+  // });
+
+  // it('should render a View Backups action (and not show Enable Backups) if Backups are already enabled', () => {
+  //   const { queryByText } = render(
+  //     wrapWithTheme(<LinodeActionMenu {...props} linodeBackups.enabled={true} />)
+  //   );
+  //   expect(queryByText('View Backups')).toBeInTheDocument();
+  //   expect(queryByText('Enable Backups')).not.toBeInTheDocument();
+  // });
 
   describe('buildQueryStringForLinodeClone', () => {
     it('returns `type`, `subtype`, and `linodeID` params', () => {

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -26,58 +26,8 @@ const props: CombinedProps = {
   ...reactRouterProps
 };
 
-// const includesActions = (actions: string[], query: any) => {
-//   for (const action of actions) {
-//     expect(query(action)).toBeInTheDocument();
-//   }
-// };
-
 describe('LinodeActionMenu', () => {
   const wrapper = shallow<LinodeActionMenu>(<LinodeActionMenu {...props} />);
-
-  //   it('should include standard Linode actions', () => {
-  //     const { queryByText } = render(
-  //       wrapWithTheme(<LinodeActionMenu {...props} />)
-  //     );
-  //     includesActions(
-  //       ['Launch Console', 'Clone', 'Resize', 'Settings', 'Delete'],
-  //       queryByText
-  //     );
-  //   });
-
-  // it('should render a Power On action if Linode is powered off', () => {
-  //   const { queryByText } = render(
-  //     wrapWithTheme(<LinodeActionMenu {...props} linodeStatus="offline" />)
-  //   );
-  //   expect(queryByText('Power On')).toBeInTheDocument();
-  //   expect(queryByText('Power Off')).not.toBeInTheDocument();
-  //   expect(queryByText('Reboot')).not.toBeInTheDocument();
-  // });
-
-  // it('should render Power Off and Reboot actions if Linode is powered on', () => {
-  //   const { queryByText } = render(
-  //     wrapWithTheme(<LinodeActionMenu {...props} linodeStatus="running" />)
-  //   );
-  //   expect(queryByText('Reboot')).toBeInTheDocument();
-  //   expect(queryByText('Power Off')).toBeInTheDocument();
-  //   expect(queryByText('Power On')).not.toBeInTheDocument();
-  // });
-
-  // it('should render an Enable Backups action if Backups are not enabled', () => {
-  //   const { queryByText } = render(
-  //     wrapWithTheme(<LinodeActionMenu {...props} linodeBackups.enabled={false} />)
-  //   );
-  //   expect(queryByText('Enable Backups')).toBeInTheDocument();
-  //   expect(queryByText('View Backups')).not.toBeInTheDocument();
-  // });
-
-  // it('should render a View Backups action (and not show Enable Backups) if Backups are already enabled', () => {
-  //   const { queryByText } = render(
-  //     wrapWithTheme(<LinodeActionMenu {...props} linodeBackups.enabled={true} />)
-  //   );
-  //   expect(queryByText('View Backups')).toBeInTheDocument();
-  //   expect(queryByText('Enable Backups')).not.toBeInTheDocument();
-  // });
 
   describe('buildQueryStringForLinodeClone', () => {
     it('returns `type`, `subtype`, and `linodeID` params', () => {

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -1,11 +1,8 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-// import { render } from 'react-testing-library';
 import { extendedTypes } from 'src/__data__/ExtendedType';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { CombinedProps, LinodeActionMenu } from './LinodeActionMenu';
-
-// import { wrapWithTheme } from 'src/utilities/testHelpers';
 
 const props: CombinedProps = {
   linodeId: 123,
@@ -16,8 +13,7 @@ const props: CombinedProps = {
     schedule: {
       window: null,
       day: null
-    },
-    enabled: false
+    }
   },
   linodeStatus: '',
   noImage: false,

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -249,7 +249,7 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
       }
 
       if (!linodeBackups.enabled) {
-        actions.splice(-2, 1, {
+        actions.splice(4, 1, {
           title: 'Enable Backups',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             sendLinodeActionMenuItemEvent('Enable Backups');

--- a/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -166,15 +166,29 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
           },
           ...readOnlyProps
         },
-        {
-          title: 'View Backups',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            sendLinodeActionMenuItemEvent('Navigate to Backups Page');
-            push(`/linodes/${linodeId}/backup`);
-            e.preventDefault();
-            e.stopPropagation();
-          }
-        },
+        linodeBackups.enabled
+          ? {
+              title: 'View Backups',
+              onClick: (e: React.MouseEvent<HTMLElement>) => {
+                sendLinodeActionMenuItemEvent('Navigate to Backups Page');
+                push(`/linodes/${linodeId}/backup`);
+                e.preventDefault();
+                e.stopPropagation();
+              }
+            }
+          : {
+              title: 'Enable Backups',
+              onClick: (e: React.MouseEvent<HTMLElement>) => {
+                sendLinodeActionMenuItemEvent('Enable Backups');
+                push({
+                  pathname: `/linodes/${linodeId}/backup`,
+                  state: { enableOnLoad: true }
+                });
+                e.preventDefault();
+                e.stopPropagation();
+              },
+              ...readOnlyProps
+            },
         {
           title: 'Settings',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
@@ -246,22 +260,6 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
             ...readOnlyProps
           }
         );
-      }
-
-      if (!linodeBackups.enabled) {
-        actions.splice(4, 1, {
-          title: 'Enable Backups',
-          onClick: (e: React.MouseEvent<HTMLElement>) => {
-            sendLinodeActionMenuItemEvent('Enable Backups');
-            push({
-              pathname: `/linodes/${linodeId}/backup`,
-              state: { enableOnLoad: true }
-            });
-            e.preventDefault();
-            e.stopPropagation();
-          },
-          ...readOnlyProps
-        });
       }
 
       return actions;


### PR DESCRIPTION
## Description

'Settings' action was being removed if backups weren't enabled. You should now always see 'Settings' in the dropdown (and only `Enable` or `View Backups` depending on if you have backups enabled)

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

Please check linodes with and without enabled backups. Also please note I created a follow-up ticket to update our tests for this as well.
