### PR TITLE
M3-2994 Change: handle RDNS loading state

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
@@ -48,7 +48,7 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
   save = () => {
     const { onClose } = this.props;
     const { rdns, address } = this.state;
-    this.setState({ loading: true });
+    this.setState({ loading: true, errors: undefined });
     updateIP(address!, !rdns || rdns === '' ? null : rdns)
       .then(_ => {
         this.setState({ loading: false });

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
@@ -74,11 +74,17 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
     const timer = setTimeout(this.showDelayText, 5000);
     updateIP(address!, !rdns || rdns === '' ? null : rdns)
       .then(_ => {
+        if (!this.mounted) {
+          return;
+        }
         clearTimeout(timer);
         this.setState({ loading: false, delayText: null });
         onClose();
       })
       .catch(errResponse => {
+        if (!this.mounted) {
+          return;
+        }
         clearTimeout(timer);
         this.setState(
           {

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
@@ -20,6 +20,7 @@ interface Props {
 interface State {
   rdns?: string | null;
   address?: string;
+  loading: boolean;
   errors?: Linode.ApiFieldError[];
 }
 
@@ -28,7 +29,8 @@ type CombinedProps = Props;
 class ViewRangeDrawer extends React.Component<CombinedProps, State> {
   state: State = {
     rdns: this.props.rdns,
-    address: this.props.address
+    address: this.props.address,
+    loading: false
   };
 
   errorResources = {
@@ -46,14 +48,17 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
   save = () => {
     const { onClose } = this.props;
     const { rdns, address } = this.state;
+    this.setState({ loading: true });
     updateIP(address!, !rdns || rdns === '' ? null : rdns)
       .then(_ => {
+        this.setState({ loading: false });
         onClose();
       })
       .catch(errResponse => {
         this.setState(
           {
-            errors: getAPIErrorOrDefault(errResponse)
+            errors: getAPIErrorOrDefault(errResponse),
+            loading: false
           },
           () => {
             scrollErrorIntoView();
@@ -68,7 +73,7 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
 
   render() {
     const { open, onClose } = this.props;
-    const { rdns, errors } = this.state;
+    const { rdns, errors, loading } = this.state;
 
     const hasErrorFor = getAPIErrorsFor(this.errorResources, errors);
 
@@ -93,7 +98,12 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
           )}
 
           <ActionsPanel style={{ marginTop: 16 }}>
-            <Button buttonType="primary" onClick={this.save} data-qa-submit>
+            <Button
+              buttonType="primary"
+              onClick={this.save}
+              loading={loading}
+              data-qa-submit
+            >
               Save
             </Button>
             <Button

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
@@ -35,6 +35,7 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
     delayText: null
   };
 
+  timer: any = undefined;
   mounted: boolean = false;
 
   componentDidMount() {
@@ -43,6 +44,7 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
 
   componentWillUnmount() {
     this.mounted = false;
+    clearTimeout(this.timer);
   }
 
   errorResources = {
@@ -71,13 +73,13 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
     const { onClose } = this.props;
     const { rdns, address } = this.state;
     this.setState({ loading: true, errors: undefined });
-    const timer = setTimeout(this.showDelayText, 5000);
+    this.timer = setTimeout(this.showDelayText, 5000);
     updateIP(address!, !rdns || rdns === '' ? null : rdns)
       .then(_ => {
         if (!this.mounted) {
           return;
         }
-        clearTimeout(timer);
+        clearTimeout(this.timer);
         this.setState({ loading: false, delayText: null });
         onClose();
       })
@@ -85,7 +87,7 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
         if (!this.mounted) {
           return;
         }
-        clearTimeout(timer);
+        clearTimeout(this.timer);
         this.setState(
           {
             errors: getAPIErrorOrDefault(errResponse),


### PR DESCRIPTION
## Description

Added a loading state to the edit RDNS drawer (in the Linode networking tab). Since this usually takes 30 seconds, I also added some "please be patient"-ish helper text.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

This component is still pretty iffy. I opened a tdt ticket for refactoring it to use more up-to-date patterns. We should also consider moving this component to the root level and managing its state through Redux, since the submission action, while technically synchronous, can take ~30 seconds, so if the user closes the drawer and moves to another part of the site, they won't be able to see the result of their request. Toasts might be a better choice for error/success messaging.