### PR TITLE
Change: Observe User Prefs for NodeBalancer Group By Tag

### DIFF
--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -46,7 +46,6 @@ const LINODE_VIEW = 'linodesViewStyle';
 const HIDE_DISPLAY_GROUPS_CTA = 'importDisplayGroupsCTA';
 const HAS_IMPORTED_GROUPS = 'hasImportedGroups';
 const GROUP_DOMAINS = `GROUP_DOMAINS`;
-const GROUP_NODEBALANCERS = `GROUP_NODEBALANCERS`;
 const BACKUPSCTA_DISMISSED = 'BackupsCtaDismissed';
 const TOKEN = 'authentication/token';
 const NONCE = 'authentication/nonce';
@@ -108,10 +107,6 @@ export interface Storage {
     set: () => void;
   };
   groupDomainsByTag: GetAndSetBool;
-  groupNodeBalancersByTag: {
-    get: () => boolean;
-    set: (v: 'true' | 'false') => void;
-  };
   BackupsCtaDismissed: {
     get: () => boolean;
     set: (v: 'true' | 'false') => void;
@@ -181,10 +176,6 @@ export const storage: Storage = {
   groupDomainsByTag: {
     get: () => getStorage(GROUP_DOMAINS),
     set: v => setStorage(GROUP_DOMAINS, v)
-  },
-  groupNodeBalancersByTag: {
-    get: () => getStorage(GROUP_NODEBALANCERS),
-    set: v => setStorage(GROUP_NODEBALANCERS, v)
   },
   BackupsCtaDismissed: {
     get: () => getStorage(BACKUPSCTA_DISMISSED),


### PR DESCRIPTION
## Description

Observes user preferences when toggling "group by tag" on the NodeBalancers landing page.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## To Test

Toggle all existing user preferences (theme, spacing, linode view, and nodebalancer group by tag). Make sure they're not overwriting each other and PUT to the API with the correct payload.