### PR TITLE
Add: Cookie Warning Message

### DIFF
--- a/src/components/CookieWarning.tsx
+++ b/src/components/CookieWarning.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import { reportException } from 'src/exceptionReporting';
+
+const CookieWarning: React.FC<{}> = () => {
+  React.useEffect(() => {
+    reportException(
+      'A user just tried to load Cloud Manager without cookies enabled'
+    );
+  }, []);
+
+  return (
+    <div
+      style={{
+        margin: '1em'
+      }}
+    >
+      You do not have cookies enabled for this site. In order to interact with
+      the Linode Cloud Manager, please enable cookies for cloud.linode.com and
+      login.linode.com
+      <a
+        href="https://orteil.dashnet.org/cookieclicker/"
+        target="_blank"
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          right: 0,
+          margin: '1em'
+        }}
+      >
+        :)
+      </a>
+    </div>
+  );
+};
+
+export default compose<{}, {}>(React.memo)(CookieWarning);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-router-dom';
 import { initAnalytics, initTagManager } from 'src/analytics';
 import AuthenticationWrapper from 'src/components/AuthenticationWrapper';
+import CookieWarning from 'src/components/CookieWarning';
 import DefaultLoader from 'src/components/DefaultLoader';
 import SnackBar from 'src/components/SnackBar';
 import { GA_ID, GA_ID_2, GTM_ID, isProduction } from 'src/constants';
@@ -101,14 +102,20 @@ const renderAuthentication = () => (
 );
 
 ReactDOM.render(
-  <Provider store={store}>
-    <Router>
-      <Switch>
-        {/* A place to go that prevents the app from loading while injecting OAuth tokens */}
-        <Route exact path="/null" render={renderNull} />
-        <Route render={renderAuthentication} />
-      </Switch>
-    </Router>
-  </Provider>,
+  <React.Fragment>
+    {navigator.cookieEnabled ? (
+      <Provider store={store}>
+        <Router>
+          <Switch>
+            {/* A place to go that prevents the app from loading while injecting OAuth tokens */}
+            <Route exact path="/null" render={renderNull} />
+            <Route render={renderAuthentication} />
+          </Switch>
+        </Router>
+      </Provider>
+    ) : (
+      <CookieWarning />
+    )}
+  </React.Fragment>,
   document.getElementById('root') as HTMLElement
 );


### PR DESCRIPTION
## Description

For uses with cookies disabled (or blocking cookies for cloud.linode.com), we show a warning that the user must enable cookies before browsing the app and report to Sentry.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## To Test

Block cookies for localhost:3000 and browse the app. https://support.google.com/chrome/answer/95647?co=GENIE.Platform%3DDesktop&hl=en