### PR TITLE
LKE-615: Update: Add NodePools to Redux

### DIFF
--- a/src/__data__/kubernetes.ts
+++ b/src/__data__/kubernetes.ts
@@ -17,8 +17,7 @@ export const clusters: Linode.KubernetesCluster[] = [
             id: 104,
             status: 'ready'
           }
-        ],
-        lkeid: 35
+        ]
       },
       {
         type: 'g6-standard-8',
@@ -29,8 +28,7 @@ export const clusters: Linode.KubernetesCluster[] = [
             id: 105,
             status: 'ready'
           }
-        ],
-        lkeid: 35
+        ]
       }
     ],
     created: '2019-04-29 18:02:17',
@@ -56,8 +54,7 @@ export const clusters: Linode.KubernetesCluster[] = [
             id: 104,
             status: 'ready'
           }
-        ],
-        lkeid: 35
+        ]
       },
       {
         type: 'g6-standard-8',
@@ -68,8 +65,7 @@ export const clusters: Linode.KubernetesCluster[] = [
             id: 105,
             status: 'ready'
           }
-        ],
-        lkeid: 35
+        ]
       }
     ],
     created: '2019-04-29 18:02:17',

--- a/src/__data__/nodePools.ts
+++ b/src/__data__/nodePools.ts
@@ -1,4 +1,5 @@
-import { ExtendedPoolNode } from 'src/features/Kubernetes/types';
+import { PoolNodeWithPrice } from 'src/features/Kubernetes/types';
+import { ExtendedNodePool } from 'src/store/kubernetes/nodePools.actions';
 
 export const node1 = {
   id: 1,
@@ -30,9 +31,54 @@ export const node4 = {
   totalMonthlyPrice: 1
 };
 
-export const nodePoolRequests: ExtendedPoolNode[] = [
+export const nodePoolRequests: PoolNodeWithPrice[] = [
   node1,
   node2,
   node3,
   node4
 ];
+
+export const pool1: ExtendedNodePool = {
+  id: 1,
+  count: 1,
+  type: 'g6-standard-1',
+  linodes: [
+    {
+      status: 'ready',
+      id: 1
+    }
+  ],
+  clusterID: 10
+};
+
+export const pool2: ExtendedNodePool = {
+  id: 2,
+  count: 2,
+  type: 'g6-standard-1',
+  linodes: [
+    {
+      status: 'ready',
+      id: 1
+    },
+    {
+      status: 'ready',
+      id: 2
+    }
+  ],
+  clusterID: 10
+};
+
+export const pool3: ExtendedNodePool = {
+  id: 3,
+  count: 1,
+  type: 'g6-standard-1',
+  linodes: [
+    {
+      status: 'ready',
+      id: 1
+    }
+  ],
+  clusterID: 10
+};
+
+export const extendedPools = [pool1, pool2, pool3];

--- a/src/containers/kubernetes.container.ts
+++ b/src/containers/kubernetes.container.ts
@@ -3,22 +3,26 @@ import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { ApplicationState } from 'src/store';
 import {
-  CreateNodePoolParams,
   DeleteClusterParams,
-  DeleteNodePoolParams,
   setErrors as _setErrors,
   UpdateClusterParams,
-  UpdateNodePoolParams
 } from 'src/store/kubernetes/kubernetes.actions';
 import {
-  createNodePool as _createNodePool,
   deleteCluster as _deleteCluster,
-  deleteNodePool as _deleteNodePool,
   requestClusterForStore as _requestClusterForStore,
   requestKubernetesClusters as _requestKubernetesClusters,
   updateCluster as _updateCluster,
-  updateNodePool as _updateNodePool
 } from 'src/store/kubernetes/kubernetes.requests';
+import {
+  CreateNodePoolParams,
+  DeleteNodePoolParams,
+  UpdateNodePoolParams
+} from 'src/store/kubernetes/nodePools.actions';
+import {
+  createNodePool as _createNodePool,
+  deleteNodePool as _deleteNodePool,
+  updateNodePool as _updateNodePool
+} from 'src/store/kubernetes/nodePools.requests';
 import { EntityError } from 'src/store/types';
 
 export interface KubernetesProps {

--- a/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -30,7 +30,7 @@ import { getTagsAsStrings } from 'src/utilities/tagUtils';
 
 import KubeCheckoutBar from '.././KubeCheckoutBar';
 import { getMonthlyPrice, KubernetesVersionOptions } from '.././kubeUtils';
-import { ExtendedPoolNode } from '.././types';
+import { PoolNodeWithPrice } from '.././types';
 import NodePoolPanel from './NodePoolPanel';
 
 type ClassNames = 'root' | 'title' | 'sidebar' | 'inner';
@@ -56,7 +56,7 @@ interface State {
   selectedRegion?: string;
   selectedType?: string;
   numberOfLinodes: number;
-  nodePools: ExtendedPoolNode[];
+  nodePools: PoolNodeWithPrice[];
   label?: string;
   tags: Item<string>[];
   version?: Item<string>;
@@ -121,14 +121,14 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
       );
   };
 
-  addPool = (pool: ExtendedPoolNode) => {
+  addPool = (pool: PoolNodeWithPrice) => {
     const { nodePools } = this.state;
     this.setState({
       nodePools: [...nodePools, pool]
     });
   };
 
-  updatePool = (poolIdx: number, updatedPool: ExtendedPoolNode) => {
+  updatePool = (poolIdx: number, updatedPool: PoolNodeWithPrice) => {
     const { nodePools } = this.state;
     const updatedPoolWithPrice = {
       ...updatedPool,
@@ -238,7 +238,7 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
               }
               nodeCount={numberOfLinodes}
               selectedType={selectedType}
-              addNodePool={(pool: ExtendedPoolNode) => this.addPool(pool)}
+              addNodePool={(pool: PoolNodeWithPrice) => this.addPool(pool)}
               deleteNodePool={(poolIdx: number) => this.removePool(poolIdx)}
               handleTypeSelect={(newType: string) => {
                 this.setState({ selectedType: newType });

--- a/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.tsx
+++ b/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.tsx
@@ -14,7 +14,7 @@ import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
-import { ExtendedPoolNode } from '.././types';
+import { PoolNodeWithPrice } from '.././types';
 import NodePoolRow from './NodePoolRow';
 
 type ClassNames = 'root' | 'small';
@@ -37,10 +37,10 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  pools: ExtendedPoolNode[];
+  pools: PoolNodeWithPrice[];
   types: ExtendedType[];
   handleDelete?: (poolIdx: number) => void;
-  updatePool?: (poolIdx: number, updatedPool: ExtendedPoolNode) => void;
+  updatePool?: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
   small?: boolean;
   editable?: boolean;
 }

--- a/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -20,7 +20,7 @@ import SelectPlanPanel, {
 } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
 
 import { getMonthlyPrice } from '.././kubeUtils';
-import { ExtendedPoolNode } from '.././types';
+import { PoolNodeWithPrice } from '.././types';
 import NodePoolDisplayTable from './NodePoolDisplayTable';
 
 type ClassNames = 'root' | 'title' | 'gridItem' | 'countInput';
@@ -54,13 +54,13 @@ interface Props {
   selectedType?: string;
   nodeCount: number;
   hideTable?: boolean;
-  addNodePool: (pool: ExtendedPoolNode) => void;
+  addNodePool: (pool: PoolNodeWithPrice) => void;
   handleTypeSelect: (newType?: string) => void;
   updateNodeCount: (newCount: number) => void;
   // Props only needed if hideTable is false
-  pools?: ExtendedPoolNode[];
+  pools?: PoolNodeWithPrice[];
   deleteNodePool?: (poolIdx: number) => void;
-  updatePool?: (poolIdx: number, updatedPool: ExtendedPoolNode) => void;
+  updatePool?: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;

--- a/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -16,7 +16,7 @@ import TableRow from 'src/components/TableRow';
 import TextField from 'src/components/TextField';
 import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
 import { displayTypeForKubePoolNode } from 'src/features/linodes/presentation';
-import { ExtendedPoolNode } from '.././types';
+import { PoolNodeWithPrice } from '.././types';
 
 type ClassNames =
   | 'root'
@@ -61,12 +61,12 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  pool: ExtendedPoolNode;
+  pool: PoolNodeWithPrice;
   type?: ExtendedType;
   editable: boolean;
   idx: number;
   deletePool?: (poolIdx: number) => void;
-  updatePool?: (poolIdx: number, updatedPool: ExtendedPoolNode) => void;
+  updatePool?: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;

--- a/src/features/Kubernetes/KubeCheckoutBar.tsx
+++ b/src/features/Kubernetes/KubeCheckoutBar.tsx
@@ -5,12 +5,12 @@ import CheckoutBar from 'src/components/CheckoutBar';
 import renderGuard from 'src/components/RenderGuard';
 import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
 import { getTotalClusterMemoryAndCPU, getTotalClusterPrice } from './kubeUtils';
-import { ExtendedPoolNode } from './types';
+import { PoolNodeWithPrice } from './types';
 
 interface Props {
   label: string;
   region?: string;
-  pools: ExtendedPoolNode[];
+  pools: PoolNodeWithPrice[];
   submitting: boolean;
   typesData: ExtendedType[];
   createCluster: () => void;
@@ -56,7 +56,7 @@ export const KubeCheckoutBar: React.FunctionComponent<Props> = props => {
 export const getDisplaySections = (
   label: string,
   region: string | undefined,
-  pools: ExtendedPoolNode[],
+  pools: PoolNodeWithPrice[],
   typesData: ExtendedType[]
 ) => {
   const displaySections = [];

--- a/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -397,10 +397,11 @@ export const KubernetesClusterDetail: React.FunctionComponent<
             }}
             labelTitle={cluster.label}
             onEditHandlers={{
+              editableTextTitle: 'any',
               onEdit: handleLabelChange,
-              onCancel: resetEditableLabel,
-              editableTextTitle: 'any'
+              onCancel: resetEditableLabel
             }}
+            removeCrumbX={2}
             pathname={location.pathname}
             data-qa-breadcrumb
           />

--- a/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -30,7 +30,7 @@ import { downloadFile } from 'src/utilities/downloadFile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import scrollTo from 'src/utilities/scrollTo';
 import { extendCluster, getMonthlyPrice } from '.././kubeUtils';
-import { ExtendedCluster, ExtendedPoolNode } from '.././types';
+import { ExtendedCluster, PoolNodeWithPrice } from '.././types';
 import NodePoolPanel from '../CreateCluster/NodePoolPanel';
 import KubernetesDialog from './KubernetesDialog';
 import KubeSummaryPanel from './KubeSummaryPanel';
@@ -147,7 +147,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
 
   const [editing, setEditing] = React.useState<boolean>(false);
   /** Holds the local state of the cluster's node pools when editing */
-  const [pools, updatePools] = React.useState<ExtendedPoolNode[]>([]);
+  const [pools, updatePools] = React.useState<PoolNodeWithPrice[]>([]);
   /** When adding new pools in the NodePoolPanel component, use these variables. */
   const [selectedType, setSelectedType] = React.useState<string | undefined>(
     undefined
@@ -238,7 +238,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
       });
   };
 
-  const updatePool = (poolIdx: number, updatedPool: ExtendedPoolNode) => {
+  const updatePool = (poolIdx: number, updatedPool: PoolNodeWithPrice) => {
     const updatedPoolWithPrice = {
       ...updatedPool,
       totalMonthlyPrice: getMonthlyPrice(
@@ -266,7 +266,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
     setErrors(undefined);
   };
 
-  const handleAddNodePool = (pool: ExtendedPoolNode) => {
+  const handleAddNodePool = (pool: PoolNodeWithPrice) => {
     if (editing) {
       /** We're already in editing mode, so the list of pool nodes should be accurate */
       updatePools(prevPools => {
@@ -297,7 +297,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
 
   const handleDeletePool = (poolIdx: number) => {
     updatePools(prevPools => {
-      const poolToDelete = path<ExtendedPoolNode>([poolIdx], prevPools);
+      const poolToDelete = path<PoolNodeWithPrice>([poolIdx], prevPools);
       if (poolToDelete) {
         if (poolToDelete.queuedForAddition) {
           /**

--- a/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -17,7 +17,7 @@ import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel
 
 import NodePoolDisplayTable from '../../CreateCluster/NodePoolDisplayTable';
 import { getTotalClusterPrice } from '../../kubeUtils';
-import { ExtendedPoolNode } from '../../types';
+import { PoolNodeWithPrice } from '../../types';
 
 type ClassNames = 'root' | 'button' | 'pricing' | 'ctaOuter' | 'displayTable';
 const styles = (theme: Theme) =>
@@ -48,11 +48,11 @@ interface Props {
   submittingForm: boolean;
   submissionSuccess: boolean;
   submissionError?: Linode.ApiFieldError[];
-  pools: ExtendedPoolNode[];
-  poolsForEdit: ExtendedPoolNode[];
+  pools: PoolNodeWithPrice[];
+  poolsForEdit: PoolNodeWithPrice[];
   types: ExtendedType[];
   toggleEditing: () => void;
-  updatePool: (poolIdx: number, updatedPool: ExtendedPoolNode) => void;
+  updatePool: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
   deletePool: (poolID: number) => void;
   resetForm: () => void;
   submitForm: () => void;

--- a/src/features/Kubernetes/kubeUtils.ts
+++ b/src/features/Kubernetes/kubeUtils.ts
@@ -35,7 +35,7 @@ export const extendCluster = (
   cluster: Linode.KubernetesCluster,
   types: ExtendedType[]
 ): ExtendedCluster => {
-  const pools = responseToExtendedNodePool(cluster.node_pools, types);
+  const pools = responseToExtendedNodePool(cluster.node_pools || [], types);
   const { CPU, RAM } = getTotalClusterMemoryAndCPU(pools, types);
   return {
     ...cluster,

--- a/src/features/Kubernetes/kubeUtils.ts
+++ b/src/features/Kubernetes/kubeUtils.ts
@@ -1,5 +1,5 @@
 import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
-import { ExtendedCluster, ExtendedPoolNode, PoolNode } from './types';
+import { ExtendedCluster, PoolNodeWithPrice, PoolNode } from './types';
 
 // @todo don't hard code this
 export const KubernetesVersionOptions = ['1.13', '1.14'].map(version => ({
@@ -19,7 +19,7 @@ export const getMonthlyPrice = (
   return thisType ? thisType.price.monthly * count : 0;
 };
 
-export const getTotalClusterPrice = (pools: ExtendedPoolNode[]) =>
+export const getTotalClusterPrice = (pools: PoolNodeWithPrice[]) =>
   pools.reduce((accumulator, node) => {
     return node.queuedForDeletion
       ? accumulator // If we're going to delete it, don't include it in the cost
@@ -77,7 +77,7 @@ export const getTotalClusterMemoryAndCPU = (
 export const responseToExtendedNodePool = (
   pools: Linode.KubeNodePoolResponse[],
   types: ExtendedType[]
-): ExtendedPoolNode[] => {
+): PoolNodeWithPrice[] => {
   return pools.map(thisPool => ({
     id: thisPool.id,
     count: thisPool.count,

--- a/src/features/Kubernetes/kubeUtils.ts
+++ b/src/features/Kubernetes/kubeUtils.ts
@@ -1,5 +1,5 @@
 import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
-import { ExtendedCluster, PoolNodeWithPrice, PoolNode } from './types';
+import { ExtendedCluster, PoolNode, PoolNodeWithPrice } from './types';
 
 // @todo don't hard code this
 export const KubernetesVersionOptions = ['1.13', '1.14'].map(version => ({

--- a/src/features/Kubernetes/types.ts
+++ b/src/features/Kubernetes/types.ts
@@ -3,7 +3,7 @@ export interface PoolNode {
   count: number;
 }
 
-export interface ExtendedPoolNode extends PoolNode {
+export interface PoolNodeWithPrice extends PoolNode {
   id: number;
   totalMonthlyPrice: number;
   queuedForDeletion?: boolean;
@@ -22,7 +22,7 @@ export interface ExtendedCluster {
   label: string;
   version: string;
   id: number;
-  node_pools: ExtendedPoolNode[];
+  node_pools: PoolNodeWithPrice[];
   totalMemory: number;
   totalCPU: number;
 }

--- a/src/services/kubernetes/index.ts
+++ b/src/services/kubernetes/index.ts
@@ -1,1 +1,2 @@
 export * from './kubernetes';
+export * from './nodePools';

--- a/src/services/kubernetes/kubernetes.ts
+++ b/src/services/kubernetes/kubernetes.ts
@@ -82,48 +82,6 @@ export const deleteKubernetesCluster = (clusterID: number) =>
     setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}`)
   ).then(response => response.data);
 
-/**
- * createNodePool
- *
- * Adds a node pool to the specified cluster.
- */
-export const createNodePool = (
-  clusterID: number,
-  data: Linode.PoolNodeRequest
-) =>
-  Request<Linode.KubeNodePoolResponse>(
-    setMethod('POST'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools`),
-    setData(data, nodePoolSchema)
-  ).then(response => response.data);
-
-/**
- * updateNodePool
- *
- * Change the type or count of a node pool
- */
-export const updateNodePool = (
-  clusterID: number,
-  nodePoolID: number,
-  data: Linode.PoolNodeRequest
-) =>
-  Request<Linode.KubeNodePoolResponse>(
-    setMethod('PUT'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`),
-    setData(data, nodePoolSchema)
-  ).then(response => response.data);
-
-/**
- * deleteNodePool
- *
- * Delete a single node pool from the specified Cluster.
- */
-export const deleteNodePool = (clusterID: number, nodePoolID: number) =>
-  Request<{}>(
-    setMethod('DELETE'),
-    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
-  ).then(response => response.data);
-
 /** getKubeConfig
  *
  * Returns a base64 encoded string of a cluster's kubeconfig.yaml

--- a/src/services/kubernetes/kubernetes.ts
+++ b/src/services/kubernetes/kubernetes.ts
@@ -7,7 +7,7 @@ import Request, {
   setXFilter
 } from '../index';
 
-import { createKubeClusterSchema, nodePoolSchema } from './kubernetes.schema';
+import { createKubeClusterSchema } from './kubernetes.schema';
 
 // Payload types
 export interface CreateKubeClusterPayload {

--- a/src/services/kubernetes/nodePools.ts
+++ b/src/services/kubernetes/nodePools.ts
@@ -1,0 +1,90 @@
+import { BETA_API_ROOT } from 'src/constants';
+import Request, {
+  setData,
+  setMethod,
+  setParams,
+  setURL,
+  setXFilter
+} from '../index';
+
+import { nodePoolSchema } from './kubernetes.schema';
+
+
+
+// Payload types
+export interface CreateKubeClusterPayload {
+  label?: string; // Label will be assigned by the API if not provided
+  region?: string; // Will be caught by Yup if undefined
+  node_pools: Linode.PoolNodeRequest[];
+  version?: string; // Will be caught by Yup if undefined
+  tags: string[];
+}
+
+type Page<T> = Linode.ResourcePage<T>;
+
+/**
+ * getNodePools
+ *
+ * Gets a list of all node pools associated with the specified cluster
+ */
+export const getNodePools = (clusterID: number, params?: any, filters?: any) =>
+  Request<Page<Linode.KubeNodePoolResponse>>(
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filters),
+    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools`)
+  ).then(response => response.data);
+
+/**
+ * getNodePool
+ *
+ * Returns a single node pool
+ */
+export const getNodePool = (clusterID: number, nodePoolID: number) =>
+  Request<Linode.KubeNodePoolResponse>(
+    setMethod('GET'),
+    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
+  ).then(response => response.data);
+
+
+/**
+ * createNodePool
+ *
+ * Adds a node pool to the specified cluster.
+ */
+export const createNodePool = (
+  clusterID: number,
+  data: Linode.PoolNodeRequest
+) =>
+  Request<Linode.KubeNodePoolResponse>(
+    setMethod('POST'),
+    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools`),
+    setData(data, nodePoolSchema)
+  ).then(response => response.data);
+
+/**
+ * updateNodePool
+ *
+ * Change the type or count of a node pool
+ */
+export const updateNodePool = (
+  clusterID: number,
+  nodePoolID: number,
+  data: Linode.PoolNodeRequest
+) =>
+  Request<Linode.KubeNodePoolResponse>(
+    setMethod('PUT'),
+    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`),
+    setData(data, nodePoolSchema)
+  ).then(response => response.data);
+
+/**
+ * deleteNodePool
+ *
+ * Delete a single node pool from the specified Cluster.
+ */
+export const deleteNodePool = (clusterID: number, nodePoolID: number) =>
+  Request<{}>(
+    setMethod('DELETE'),
+    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
+  ).then(response => response.data);

--- a/src/services/kubernetes/nodePools.ts
+++ b/src/services/kubernetes/nodePools.ts
@@ -9,16 +9,7 @@ import Request, {
 
 import { nodePoolSchema } from './kubernetes.schema';
 
-
-
 // Payload types
-export interface CreateKubeClusterPayload {
-  label?: string; // Label will be assigned by the API if not provided
-  region?: string; // Will be caught by Yup if undefined
-  node_pools: Linode.PoolNodeRequest[];
-  version?: string; // Will be caught by Yup if undefined
-  tags: string[];
-}
 
 type Page<T> = Linode.ResourcePage<T>;
 
@@ -45,7 +36,6 @@ export const getNodePool = (clusterID: number, nodePoolID: number) =>
     setMethod('GET'),
     setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/pools/${nodePoolID}`)
   ).then(response => response.data);
-
 
 /**
  * createNodePool

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -53,6 +53,10 @@ import kubernetes, {
   defaultState as defaultKubernetesState,
   State as KubernetesState
 } from 'src/store/kubernetes/kubernetes.reducer';
+import nodePools, {
+  defaultState as defaultNodePoolsState,
+  State as KubeNodePoolsState
+} from 'src/store/kubernetes/nodePools.reducer';
 import linodeCreateReducer, {
   defaultState as linodeCreateDefaultState,
   State as LinodeCreateState
@@ -134,6 +138,7 @@ const __resourcesDefaultState = {
   domains: defaultDomainsState,
   images: defaultImagesState,
   kubernetes: defaultKubernetesState,
+  nodePools: defaultNodePoolsState,
   linodes: defaultLinodesState,
   linodeConfigs: defaultLinodeConfigsState,
   linodeDisks: defaultLinodeDisksState,
@@ -154,6 +159,7 @@ export interface ResourcesState {
   domains: DomainsState;
   images: ImagesState;
   kubernetes: KubernetesState;
+  nodePools: KubeNodePoolsState;
   linodes: LinodesState;
   linodeConfigs: LinodeConfigsState;
   linodeDisks: LinodeDisksState;
@@ -207,6 +213,7 @@ const __resources = combineReducers({
   domains,
   images,
   kubernetes,
+  nodePools,
   linodes,
   linodeConfigs,
   linodeDisks,

--- a/src/store/kubernetes/kubernetes.actions.ts
+++ b/src/store/kubernetes/kubernetes.actions.ts
@@ -22,10 +22,6 @@ export interface ClusterID {
   clusterID: number;
 }
 
-export interface NodePoolID {
-  nodePoolID: number;
-}
-
 export type UpdateClusterParams = ClusterID & Partial<Linode.KubernetesCluster>;
 export const updateClusterActions = actionCreator.async<
   UpdateClusterParams,
@@ -33,21 +29,6 @@ export const updateClusterActions = actionCreator.async<
   Linode.ApiFieldError[]
 >(`update`);
 
-export type CreateNodePoolParams = ClusterID & Linode.PoolNodeRequest;
-export const createNodePoolActions = actionCreator.async<
-  CreateNodePoolParams,
-  Linode.KubeNodePoolResponse,
-  Linode.ApiFieldError[]
->(`create-node-pool`);
-
-export type UpdateNodePoolParams = ClusterID &
-  NodePoolID &
-  Linode.PoolNodeRequest;
-export const updateNodePoolActions = actionCreator.async<
-  UpdateNodePoolParams,
-  Linode.KubeNodePoolResponse,
-  Linode.ApiFieldError[]
->(`update-node-pool`);
 
 export type DeleteClusterParams = ClusterID;
 export const deleteClusterActions = actionCreator.async<
@@ -56,9 +37,3 @@ export const deleteClusterActions = actionCreator.async<
   Linode.ApiFieldError[]
 >(`delete-cluster`);
 
-export type DeleteNodePoolParams = ClusterID & NodePoolID;
-export const deleteNodePoolActions = actionCreator.async<
-  DeleteNodePoolParams,
-  {},
-  Linode.ApiFieldError[]
->(`delete-node-pool`);

--- a/src/store/kubernetes/kubernetes.reducer.ts
+++ b/src/store/kubernetes/kubernetes.reducer.ts
@@ -3,13 +3,9 @@ import { EntityError, EntityState } from 'src/store/types';
 import updateOrAdd from 'src/utilities/updateOrAdd';
 import { isType } from 'typescript-fsa';
 import {
-  createNodePoolActions,
   deleteClusterActions,
-  deleteNodePoolActions,
   requestClustersActions,
-  setErrors,
   updateClusterActions,
-  updateNodePoolActions,
   upsertCluster
 } from './kubernetes.actions';
 
@@ -80,68 +76,6 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     };
   }
 
-  if (isType(action, createNodePoolActions.done)) {
-    const { result } = action.payload;
-    const cluster = state.entities.find(
-      thisCluster => +thisCluster.id === result.lkeid
-    );
-    if (!cluster) {
-      return state;
-    }
-
-    const updatedCluster = {
-      ...cluster,
-      node_pools: [...cluster.node_pools, result]
-    };
-
-    const update = updateOrAdd(updatedCluster, state.entities);
-
-    return {
-      ...state,
-      entities: update,
-      results: update.map(c => c.id)
-    };
-  }
-
-  if (isType(action, updateNodePoolActions.failed)) {
-    const { error } = action.payload;
-
-    return {
-      ...state,
-      error: {
-        ...state.error,
-        update: error
-      }
-    };
-  }
-
-  if (isType(action, updateNodePoolActions.done)) {
-    const { result } = action.payload;
-    const cluster = state.entities.find(
-      thisCluster => +thisCluster.id === result.lkeid
-    );
-    if (!cluster) {
-      return state;
-    }
-
-    const updatedNodePools = cluster.node_pools.map(thisPool => {
-      return thisPool.id === result.id ? result : thisPool;
-    });
-
-    const updatedCluster = {
-      ...cluster,
-      node_pools: updatedNodePools
-    };
-
-    const update = updateOrAdd(updatedCluster, state.entities);
-
-    return {
-      ...state,
-      entities: update,
-      results: update.map(c => c.id)
-    };
-  }
-
   if (isType(action, deleteClusterActions.done)) {
     const {
       params: { clusterID }
@@ -170,37 +104,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     };
   }
 
-  if (isType(action, deleteNodePoolActions.done)) {
-    const {
-      params: { clusterID, nodePoolID }
-    } = action.payload;
-    const cluster = state.entities.find(
-      thisCluster => thisCluster.id === clusterID
-    );
-    if (!cluster) {
-      return state;
-    }
-    const nodePools = cluster.node_pools.filter(
-      thisPool => thisPool.id !== nodePoolID
-    );
-    const updatedCluster = { ...cluster, node_pools: nodePools };
-    const update = updateOrAdd(updatedCluster, state.entities);
-
-    return {
-      ...state,
-      entities: update,
-      results: update.map(c => c.id)
-    };
-  }
-
-  if (isType(action, setErrors)) {
-    const error = action.payload;
-    return {
-      ...state,
-      error
-    };
-  }
   return state;
-};
+}
 
 export default reducer;

--- a/src/store/kubernetes/kubernetes.requests.ts
+++ b/src/store/kubernetes/kubernetes.requests.ts
@@ -11,12 +11,9 @@ import { getAll } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import { ThunkActionCreator } from '../types';
 import {
-  createNodePoolActions,
   deleteClusterActions,
-  deleteNodePoolActions,
   requestClustersActions,
   updateClusterActions,
-  updateNodePoolActions,
   upsertCluster
 } from './kubernetes.actions';
 
@@ -57,20 +54,4 @@ export const updateCluster = createRequestThunk(
 export const deleteCluster = createRequestThunk(
   deleteClusterActions,
   ({ clusterID }) => _deleteCluster(clusterID)
-);
-
-export const deleteNodePool = createRequestThunk(
-  deleteNodePoolActions,
-  ({ clusterID, nodePoolID }) => _deleteNodePool(clusterID, nodePoolID)
-);
-
-export const createNodePool = createRequestThunk(
-  createNodePoolActions,
-  ({ clusterID, ...data }) => _createNodePool(clusterID, data)
-);
-
-export const updateNodePool = createRequestThunk(
-  updateNodePoolActions,
-  ({ clusterID, nodePoolID, ...data }) =>
-    _updateNodePool(clusterID, nodePoolID, data)
 );

--- a/src/store/kubernetes/kubernetes.requests.ts
+++ b/src/store/kubernetes/kubernetes.requests.ts
@@ -16,6 +16,7 @@ import {
   updateClusterActions,
   upsertCluster
 } from './kubernetes.actions';
+import { requestNodePoolsForCluster } from './nodePools.requests';
 
 const getAllClusters = getAll<Linode.KubernetesCluster>(getKubernetesClusters);
 
@@ -31,6 +32,10 @@ export const requestKubernetesClusters: ThunkActionCreator<
           result: data
         })
       );
+      let i = 0;
+      for (; i < data.length; i++) {
+        dispatch(requestNodePoolsForCluster({ clusterID: data[i].id }));
+      }
       return data;
     })
     .catch(error => {

--- a/src/store/kubernetes/nodePools.actions.ts
+++ b/src/store/kubernetes/nodePools.actions.ts
@@ -1,0 +1,61 @@
+import actionCreatorFactory from 'typescript-fsa';
+
+import { EntityError } from 'src/store/types';
+
+export interface ExtendedNodePool extends Linode.KubeNodePoolResponse {
+  belongsTo: number; // clusterID of the cluster this node is associated with
+}
+
+export const actionCreator = actionCreatorFactory(`@@manager/kubernetes/nodePools`);
+
+export const requestNodePoolsActions = actionCreator.async<
+  void,
+  ExtendedNodePool[],
+  Linode.ApiFieldError[]
+>('request');
+
+export const addOrUpdateNodePool = actionCreator<Linode.KubeNodePoolResponse>(
+  'add_or_update'
+);
+
+export const upsertNodePool = actionCreator<Linode.KubeNodePoolResponse>(`upsert`);
+
+export const setErrors = actionCreator<EntityError>('set-errors');
+
+export interface ClusterID {
+  clusterID: number;
+}
+
+export interface NodePoolID {
+  nodePoolID: number;
+}
+
+export type CreateNodePoolParams = ClusterID & Linode.PoolNodeRequest;
+export const createNodePoolActions = actionCreator.async<
+  CreateNodePoolParams,
+  ExtendedNodePool,
+  Linode.ApiFieldError[]
+>(`create-node-pool`);
+
+export type UpdateNodePoolParams = ClusterID &
+  NodePoolID &
+  Linode.PoolNodeRequest;
+export const updateNodePoolActions = actionCreator.async<
+  UpdateNodePoolParams,
+  ExtendedNodePool,
+  Linode.ApiFieldError[]
+>(`update-node-pool`);
+
+export type DeleteClusterParams = ClusterID;
+export const deleteClusterActions = actionCreator.async<
+  DeleteClusterParams,
+  {},
+  Linode.ApiFieldError[]
+>(`delete-cluster`);
+
+export type DeleteNodePoolParams = ClusterID & NodePoolID;
+export const deleteNodePoolActions = actionCreator.async<
+  DeleteNodePoolParams,
+  {},
+  Linode.ApiFieldError[]
+>(`delete-node-pool`);

--- a/src/store/kubernetes/nodePools.actions.ts
+++ b/src/store/kubernetes/nodePools.actions.ts
@@ -3,10 +3,12 @@ import actionCreatorFactory from 'typescript-fsa';
 import { EntityError } from 'src/store/types';
 
 export interface ExtendedNodePool extends Linode.KubeNodePoolResponse {
-  belongsTo: number; // clusterID of the cluster this node is associated with
+  clusterID: number; // clusterID of the cluster this node is associated with
 }
 
-export const actionCreator = actionCreatorFactory(`@@manager/kubernetes/nodePools`);
+export const actionCreator = actionCreatorFactory(
+  `@@manager/kubernetes/nodePools`
+);
 
 export const requestNodePoolsActions = actionCreator.async<
   void,
@@ -18,7 +20,9 @@ export const addOrUpdateNodePool = actionCreator<Linode.KubeNodePoolResponse>(
   'add_or_update'
 );
 
-export const upsertNodePool = actionCreator<Linode.KubeNodePoolResponse>(`upsert`);
+export const upsertNodePool = actionCreator<Linode.KubeNodePoolResponse>(
+  `upsert`
+);
 
 export const setErrors = actionCreator<EntityError>('set-errors');
 

--- a/src/store/kubernetes/nodePools.reducer.test.ts
+++ b/src/store/kubernetes/nodePools.reducer.test.ts
@@ -1,0 +1,126 @@
+import { extendedPools, pool1, pool2, pool3 } from 'src/__data__/nodePools';
+import {
+  createNodePoolActions,
+  deleteNodePoolActions,
+  requestNodePoolsActions,
+  updateNodePoolActions
+} from './nodePools.actions';
+
+import reducer, { defaultState } from './nodePools.reducer';
+
+/** These aren't used in the reducer, so just using dummy values */
+const mockParams = { clusterID: 1, type: '', count: 1 };
+const mockError = [{ reason: 'Your request failed.' }];
+
+describe('NodePools reducer', () => {
+  describe('requesting NodePools actions', () => {
+    it('should handle successful requests', () => {
+      const newState = reducer(
+        defaultState,
+        requestNodePoolsActions.done({ result: extendedPools })
+      );
+      expect(newState).toHaveProperty('entities');
+      expect(newState.entities).toEqual(extendedPools);
+      expect(newState.results).toHaveLength(extendedPools.length);
+      expect(newState.loading).toBe(false);
+    });
+
+    it('should handle failed requests', () => {
+      const newState = reducer(
+        defaultState,
+        requestNodePoolsActions.failed({ error: mockError })
+      );
+      expect(newState.loading).toBe(false);
+      expect(newState.entities).toEqual([]);
+      expect(newState.error).toEqual({
+        read: mockError
+      });
+    });
+  });
+
+  describe('creating a NodePool', () => {
+    it('should handle a newly create NodePool successfully', () => {
+      const oldState = {
+        ...defaultState,
+        entities: [pool1, pool2],
+        results: [pool1.id, pool2.id]
+      };
+      const newState = reducer(
+        oldState,
+        createNodePoolActions.done({ params: mockParams, result: pool3 })
+      );
+      expect(newState.entities).toEqual([pool1, pool2, pool3]);
+      expect(newState.results).toHaveLength(3);
+    });
+
+    it('should handle creation errors', () => {
+      const newState = reducer(
+        defaultState,
+        createNodePoolActions.failed({ params: mockParams, error: mockError })
+      );
+      expect(newState.error).toHaveProperty('create', mockError);
+    });
+  });
+
+  describe('updating a NodePool', () => {
+    it('should handle a successful update', () => {
+      const updatedPoolNode = { ...pool3, count: 6 };
+      const oldState = {
+        ...defaultState,
+        entities: extendedPools,
+        results: extendedPools.map(p => p.id)
+      };
+      const newState = reducer(
+        oldState,
+        updateNodePoolActions.done({
+          params: { ...mockParams, nodePoolID: 1 },
+          result: updatedPoolNode
+        })
+      );
+      expect(newState.entities).toHaveLength(3);
+      expect(newState.entities).toContain(updatedPoolNode);
+      expect(newState.entities).not.toContain(pool3);
+    });
+
+    it('should handle a failed update', () => {
+      const newState = reducer(
+        defaultState,
+        updateNodePoolActions.failed({
+          params: { ...mockParams, nodePoolID: 1 },
+          error: mockError
+        })
+      );
+      expect(newState.error).toHaveProperty('update', mockError);
+    });
+  });
+
+  describe('deleting a NodePool', () => {
+    it('should handle a successful deletion', () => {
+      const oldState = {
+        ...defaultState,
+        entities: [pool1, pool2, pool3],
+        results: [pool1.id, pool2.id, pool3.id]
+      };
+      const newState = reducer(
+        oldState,
+        deleteNodePoolActions.done({
+          params: { clusterID: Infinity, nodePoolID: pool3.id },
+          result: {}
+        })
+      );
+      expect(newState.entities).toEqual([pool1, pool2]);
+      expect(newState.results).toHaveLength(2);
+    });
+
+    it('should handle deletion errors', () => {
+      const newState = reducer(
+        defaultState,
+        deleteNodePoolActions.failed({
+          params: { clusterID: Infinity, nodePoolID: Infinity },
+          error: mockError
+        })
+      );
+      expect(newState.error).toHaveProperty('delete', mockError);
+    });
+  });
+});

--- a/src/store/kubernetes/nodePools.reducer.ts
+++ b/src/store/kubernetes/nodePools.reducer.ts
@@ -1,0 +1,88 @@
+import { Reducer } from 'redux';
+import { EntityError, EntityState } from 'src/store/types';
+import updateOrAdd from 'src/utilities/updateOrAdd';
+import { isType } from 'typescript-fsa';
+import {
+  createNodePoolActions,
+  deleteNodePoolActions,
+  ExtendedNodePool,
+  setErrors,
+  updateNodePoolActions,
+} from './nodePools.actions';
+
+/**
+ * State
+ */
+
+export type State = EntityState<ExtendedNodePool, EntityError>;
+
+export const defaultState: State = {
+  results: [],
+  entities: [],
+  loading: true,
+  lastUpdated: 0,
+  error: {}
+};
+
+/**
+ * Reducer
+ */
+const reducer: Reducer<State> = (state = defaultState, action) => {
+  if (isType(action, createNodePoolActions.done)) {
+    const { result } = action.payload;
+
+    return {
+      ...state,
+      entities: [...state.entities, result],
+    };
+  }
+
+  if (isType(action, updateNodePoolActions.failed)) {
+    const { error } = action.payload;
+
+    return {
+      ...state,
+      error: {
+        ...state.error,
+        update: error
+      }
+    };
+  }
+
+  if (isType(action, updateNodePoolActions.done)) {
+    const { result } = action.payload;
+
+    const update = updateOrAdd(result, state.entities);
+
+    return {
+      ...state,
+      entities: update,
+      results: update.map(c => c.id)
+    };
+  }
+
+  if (isType(action, deleteNodePoolActions.done)) {
+    const {
+      params: { nodePoolID }
+    } = action.payload;
+
+    const updatedPools = state.entities.filter(thisPool => thisPool.id !== nodePoolID)
+
+    return {
+      ...state,
+      entities: updatedPools,
+      results: updatedPools.map(p => p.id)
+    };
+  }
+
+  if (isType(action, setErrors)) {
+    const error = action.payload;
+    return {
+      ...state,
+      error
+    };
+  }
+  return state;
+};
+
+export default reducer;

--- a/src/store/kubernetes/nodePools.reducer.ts
+++ b/src/store/kubernetes/nodePools.reducer.ts
@@ -6,8 +6,9 @@ import {
   createNodePoolActions,
   deleteNodePoolActions,
   ExtendedNodePool,
+  requestNodePoolsActions,
   setErrors,
-  updateNodePoolActions,
+  updateNodePoolActions
 } from './nodePools.actions';
 
 /**
@@ -28,12 +29,35 @@ export const defaultState: State = {
  * Reducer
  */
 const reducer: Reducer<State> = (state = defaultState, action) => {
+  if (isType(action, requestNodePoolsActions.done)) {
+    const { result } = action.payload;
+
+    return {
+      ...state,
+      entities: [...state.entities, ...result],
+      results: [...state.results, ...result.map(p => p.id)]
+    };
+  }
+
+  if (isType(action, requestNodePoolsActions.failed)) {
+    const { error } = action.payload;
+
+    return {
+      ...state,
+      loading: false,
+      error: {
+        ...state.error,
+        read: error
+      }
+    };
+  }
+
   if (isType(action, createNodePoolActions.done)) {
     const { result } = action.payload;
 
     return {
       ...state,
-      entities: [...state.entities, result],
+      entities: [...state.entities, result]
     };
   }
 
@@ -66,7 +90,9 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       params: { nodePoolID }
     } = action.payload;
 
-    const updatedPools = state.entities.filter(thisPool => thisPool.id !== nodePoolID)
+    const updatedPools = state.entities.filter(
+      thisPool => thisPool.id !== nodePoolID
+    );
 
     return {
       ...state,

--- a/src/store/kubernetes/nodePools.reducer.ts
+++ b/src/store/kubernetes/nodePools.reducer.ts
@@ -35,7 +35,8 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     return {
       ...state,
       entities: [...state.entities, ...result],
-      results: [...state.results, ...result.map(p => p.id)]
+      results: [...state.results, ...result.map(p => p.id)],
+      loading: false
     };
   }
 
@@ -57,7 +58,24 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
     return {
       ...state,
-      entities: [...state.entities, result]
+      entities: [...state.entities, result],
+      results: [...state.results, result.id],
+      error: {
+        ...state.error,
+        create: undefined
+      }
+    };
+  }
+
+  if (isType(action, createNodePoolActions.failed)) {
+    const { error } = action.payload;
+
+    return {
+      ...state,
+      error: {
+        ...state.error,
+        create: error
+      }
     };
   }
 
@@ -98,6 +116,18 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       ...state,
       entities: updatedPools,
       results: updatedPools.map(p => p.id)
+    };
+  }
+
+  if (isType(action, deleteNodePoolActions.failed)) {
+    const { error } = action.payload;
+
+    return {
+      ...state,
+      error: {
+        ...state.error,
+        delete: error
+      }
     };
   }
 

--- a/src/store/kubernetes/nodePools.requests.ts
+++ b/src/store/kubernetes/nodePools.requests.ts
@@ -1,0 +1,81 @@
+import {
+  createNodePool as _createNodePool,
+  deleteNodePool as _deleteNodePool,
+  getNodePool,
+  getNodePools,
+  updateNodePool as _updateNodePool
+} from 'src/services/kubernetes';
+import { getAll } from 'src/utilities/getAll';
+import { createRequestThunk } from '../store.helpers';
+import { ThunkActionCreator } from '../types';
+import {
+  createNodePoolActions,
+  deleteNodePoolActions,
+  ExtendedNodePool,
+  requestNodePoolsActions,
+  updateNodePoolActions,
+  upsertNodePool,
+} from './nodePools.actions';
+
+const getAllNodePools = getAll<Linode.KubeNodePoolResponse>(getNodePools);
+
+export const extendNodePools = (clusterID: number, nodePools: Linode.KubeNodePoolResponse[]): ExtendedNodePool[] => {
+  /**
+   * We store the ID of the associated cluster as part of the entity in the store,
+   * to allow us to map pools to their cluster in the future.
+   */
+  return nodePools.map((thisPool) => extendNodePool(clusterID, thisPool));
+}
+
+const extendNodePool = (clusterID: number, nodePool: Linode.KubeNodePoolResponse) => ({ ...nodePool, belongsTo: clusterID })
+
+
+export const requestNodePoolsForCluster: ThunkActionCreator<
+  Promise<Linode.Cluster[]>
+> = (clusterID) => dispatch => {
+  dispatch(requestNodePoolsActions.started());
+
+  return getAllNodePools(clusterID)
+    .then(({ data }) => {
+      return extendNodePools(clusterID, data)
+    })
+    .then((extendedPools) => {
+      dispatch(
+        requestNodePoolsActions.done({
+          result: extendedPools
+        })
+      );
+      return extendedPools;
+    })
+    .catch(error => {
+      dispatch(requestNodePoolsActions.failed({ error }));
+      return error;
+    });
+};
+
+type RequestNodePoolForStoreThunk = ThunkActionCreator<void>;
+export const requestNodePoolForStore: RequestNodePoolForStoreThunk = (clusterID, nodePoolID) => dispatch => {
+  getNodePool(clusterID, nodePoolID)
+    .then(pool => {
+      return extendNodePool(clusterID, pool)
+    })
+    .then(extendedPool => {
+      return dispatch(upsertNodePool(extendedPool));
+    });
+};
+
+export const deleteNodePool = createRequestThunk(
+  deleteNodePoolActions,
+  ({ clusterID, nodePoolID }) => _deleteNodePool(clusterID, nodePoolID)
+);
+
+export const createNodePool = createRequestThunk(
+  createNodePoolActions,
+  ({ clusterID, ...data }) => _createNodePool(clusterID, data).then(pool => extendNodePool(clusterID, pool))
+);
+
+export const updateNodePool = createRequestThunk(
+  updateNodePoolActions,
+  ({ clusterID, nodePoolID, ...data }) =>
+    _updateNodePool(clusterID, nodePoolID, data).then(pool => extendNodePool(clusterID, pool))
+);

--- a/src/store/kubernetes/nodePools.requests.ts
+++ b/src/store/kubernetes/nodePools.requests.ts
@@ -34,7 +34,7 @@ export const extendNodePools = (
 const extendNodePool = (
   clusterID: number,
   nodePool: Linode.KubeNodePoolResponse
-) => ({ ...nodePool, clusterID: clusterID });
+) => ({ ...nodePool, clusterID });
 
 export const requestNodePoolsForCluster: ThunkActionCreator<
   Promise<Linode.KubeNodePoolResponse[]>

--- a/src/store/kubernetes/nodePools.requests.ts
+++ b/src/store/kubernetes/nodePools.requests.ts
@@ -34,7 +34,7 @@ export const extendNodePools = (
 const extendNodePool = (
   clusterID: number,
   nodePool: Linode.KubeNodePoolResponse
-) => ({ ...nodePool, belongsTo: clusterID });
+) => ({ ...nodePool, clusterID: clusterID });
 
 export const requestNodePoolsForCluster: ThunkActionCreator<
   Promise<Linode.KubeNodePoolResponse[]>

--- a/src/types/Kubernetes.ts
+++ b/src/types/Kubernetes.ts
@@ -14,7 +14,6 @@ namespace Linode {
     count: number;
     id: number;
     linodes: PoolNodeResponse[];
-    lkeid: number;
     type: string;
   }
 


### PR DESCRIPTION
## Description

This separates LKE clusters from LKE node pools; previously API requests to /clusters returned a list of node pools for each cluster.

This involves changing both the services library and the Redux store.

## Type of Change
- Breaking change ('break', 'deprecate')

## Note to Reviewers

Test using dev services; this PR does not use the new Redux state, so you'll have to create a cluster with some pools, then check the Redux dev tools to make sure everything is there and actions were called correctly. Part II will restore the previous app functionality by using node pools from Redux to populate ClusterList and ClusterDetail.

Many of the files changed are just find-and-replace variable renaming.