### PR TITLE
Change: Observe User Prefs for Domains Group By Tag

### DIFF
--- a/src/features/Domains/DomainsLanding.test.tsx
+++ b/src/features/Domains/DomainsLanding.test.tsx
@@ -9,13 +9,12 @@ const props: CombinedProps = {
   domainsData: domains,
   domainsLoading: false,
   howManyLinodesOnAccount: 0,
+  shouldGroupDomains: true,
   domainActions: {
     createDomain: jest.fn(),
     updateDomain: jest.fn(),
     deleteDomain: jest.fn()
   },
-  groupByTag: true,
-  toggleGroupByTag: jest.fn(),
   classes: {
     domain: '',
     dnsWarning: '',
@@ -41,7 +40,10 @@ window.matchMedia = jest.fn().mockImplementation(query => {
 
 describe('Domains Landing', () => {
   it('should render a notice when there are no Linodes but at least 1 domain', () => {
-    const { getByText } = render(wrapWithTheme(<DomainsLanding {...props} />));
+    const { getByText, debug } = render(
+      wrapWithTheme(<DomainsLanding {...props} />)
+    );
+    debug();
     expect(getByText(/not being served/));
   });
 });

--- a/src/features/Domains/DomainsLanding.test.tsx
+++ b/src/features/Domains/DomainsLanding.test.tsx
@@ -40,10 +40,7 @@ window.matchMedia = jest.fn().mockImplementation(query => {
 
 describe('Domains Landing', () => {
   it('should render a notice when there are no Linodes but at least 1 domain', () => {
-    const { getByText, debug } = render(
-      wrapWithTheme(<DomainsLanding {...props} />)
-    );
-    debug();
+    const { getByText } = render(wrapWithTheme(<DomainsLanding {...props} />));
     expect(getByText(/not being served/));
   });
 });

--- a/src/utilities/storage.ts
+++ b/src/utilities/storage.ts
@@ -45,7 +45,6 @@ const VAT_NOTIFICATION = 'vatNotification';
 const LINODE_VIEW = 'linodesViewStyle';
 const HIDE_DISPLAY_GROUPS_CTA = 'importDisplayGroupsCTA';
 const HAS_IMPORTED_GROUPS = 'hasImportedGroups';
-const GROUP_DOMAINS = `GROUP_DOMAINS`;
 const BACKUPSCTA_DISMISSED = 'BackupsCtaDismissed';
 const TOKEN = 'authentication/token';
 const NONCE = 'authentication/nonce';
@@ -60,11 +59,6 @@ type LinodeView = 'grid' | 'list';
 interface AuthGetAndSet {
   get: () => any;
   set: (value: string) => void;
-}
-
-interface GetAndSetBool {
-  get: () => boolean;
-  set: (v: 'true' | 'false') => void;
 }
 
 export interface Storage {
@@ -106,7 +100,6 @@ export interface Storage {
     get: () => 'true' | 'false';
     set: () => void;
   };
-  groupDomainsByTag: GetAndSetBool;
   BackupsCtaDismissed: {
     get: () => boolean;
     set: (v: 'true' | 'false') => void;
@@ -172,10 +165,6 @@ export const storage: Storage = {
   hasImportedGroups: {
     get: () => getStorage(HAS_IMPORTED_GROUPS),
     set: () => setStorage(HAS_IMPORTED_GROUPS, 'true')
-  },
-  groupDomainsByTag: {
-    get: () => getStorage(GROUP_DOMAINS),
-    set: v => setStorage(GROUP_DOMAINS, v)
   },
   BackupsCtaDismissed: {
     get: () => getStorage(BACKUPSCTA_DISMISSED),


### PR DESCRIPTION
## Description

Observes user preferences when toggling "group by tag" on the Domains landing page.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## To Test

Toggle all existing user preferences (theme, spacing, linode view, and domain group by tag). Make sure they're not overwriting each other and PUT to the API with the correct payload.