### PR TITLE
Blacklist profile_update from the user events menu

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -731,3 +731,14 @@ which generally call API methods from the services library and dispatch multiple
     store.clearActions();
   });
   ```
+
+### Events Filtering
+
+The Linode API returns a large list of events to update the user of activity on their account. Some of these events
+are redundant in our UI. For example, a user might update their email, see "Email updated successfully" in the form,
+then receive a notification in the upper-right events menu when the `profile_update` event is received from the API.
+These events can be hidden by adding them to the blacklist in `UserEventsMenu.tsx`. They will then appear in the 
+events landing list, any activity feeds, etc., but not in the UserEventsMenu in the top right of the view.
+
+Other events, specifically relating to mutations, should be ignored by the app altogether. To add a globally ignored
+event, update the GLOBAL_EVENTS_BLACKLIST array in `src/constants`.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -225,3 +225,13 @@ export const EU_COUNTRIES = [
   'SK', // Slovakia
   'GB' // United Kingdom
 ];
+
+export const GLOBAL_EVENTS_BLACKLIST = [
+  // We don't want to display these events because they precede similar events.
+  // Example: when a user clicks the button to upgrade a Linode, we immediately
+  // get a `linode_mutate_create` event from the API. Moments later, we get back
+  // ANOTHER event, `linode_mutate`, with a status of `scheduled`. That's the event
+  // we want to display, because it will be updated via other events with the same ID.
+  'linode_mutate_create', // This event occurs when an upgrade is first initiated.
+  'linode_resize_create' // This event occurs when a resize is first initiated.
+] as Linode.EventAction[];

--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -125,6 +125,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     // finished: e => `${e.entity!.label}`,
     notification: e => `Image ${e.entity!.label} has been deleted.`
   },
+  ipaddress_update: {
+    notification: e => `An IP address has been updated on your account.`
+  },
   linode_addip: {
     notification: e => `An IP has been added to ${e.entity!.label}.`
   },

--- a/src/features/Events/EventsLanding.tsx
+++ b/src/features/Events/EventsLanding.tsx
@@ -27,7 +27,6 @@ import { getEvents } from 'src/services/account';
 import { ApplicationState } from 'src/store';
 import { setDeletedEvents } from 'src/store/events/event.helpers';
 import areEntitiesLoading from 'src/store/selectors/entitiesLoading';
-import { removeBlacklistedEvents } from 'src/utilities/eventUtils';
 
 import { ExtendedEvent } from 'src/store/events/event.helpers';
 import { filterUniqueEvents, shouldUpdateEvents } from './Event.helpers';
@@ -339,7 +338,7 @@ export const renderTableBody = (
   error?: string,
   events?: Linode.Event[]
 ) => {
-  const filteredEvents = removeBlacklistedEvents(events);
+  const _events = events || [];
 
   if (loading) {
     return <TableRowLoading colSpan={12} data-qa-events-table-loading />;
@@ -351,7 +350,7 @@ export const renderTableBody = (
         data-qa-events-table-error
       />
     );
-  } else if (filteredEvents.length === 0) {
+  } else if (_events.length === 0) {
     return (
       <TableRowEmptyState
         colSpan={12}
@@ -362,7 +361,7 @@ export const renderTableBody = (
   } else {
     return (
       <>
-        {filteredEvents.map((thisEvent, idx) => (
+        {_events.map((thisEvent, idx) => (
           <EventRow
             entityId={entityId}
             key={`event-list-item-${idx}`}

--- a/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
@@ -16,7 +16,7 @@ import {
 import { getNumUnseenEvents } from 'src/store/events/event.helpers';
 import { markAllSeen } from 'src/store/events/event.request';
 import { MapState, ThunkDispatch } from 'src/store/types';
-import { removeBlacklistedEvents } from 'src/utilities/eventUtils';
+import { hideBlacklistedEvents } from 'src/utilities/eventUtils';
 import UserEventsButton from './UserEventsButton';
 import UserEventsList from './UserEventsList';
 
@@ -88,7 +88,8 @@ export class UserEventsMenu extends React.Component<CombinedProps, State> {
       history: { push }
     } = this.props;
 
-    const filteredEvents = removeBlacklistedEvents(events, blacklistedEvents);
+    const _events = hideBlacklistedEvents(events, blacklistedEvents);
+    const filteredEvents = _events.filter(thisEvent => !thisEvent._hidden);
     const unseenCount = getNumUnseenEvents(filteredEvents);
 
     return (

--- a/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
@@ -22,6 +22,14 @@ import UserEventsList from './UserEventsList';
 
 type ClassNames = 'root' | 'dropDown' | 'viewAll';
 
+/**
+ * This blacklist is for events which should be hidden only in this menu;
+ * these events will still appear in EventsLanding and ActivitySummary.
+ * To globally filter an event, add it to GLOBAL_EVENTS_BLACKLIST in
+ * src/constants.
+ */
+const blacklistedEvents = ['profile_update'] as Linode.EventAction[];
+
 const styles = (theme: Theme) =>
   createStyles({
     root: {
@@ -80,7 +88,7 @@ export class UserEventsMenu extends React.Component<CombinedProps, State> {
       history: { push }
     } = this.props;
 
-    const filteredEvents = removeBlacklistedEvents(events);
+    const filteredEvents = removeBlacklistedEvents(events, blacklistedEvents);
     const unseenCount = getNumUnseenEvents(filteredEvents);
 
     return (

--- a/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -18,7 +18,6 @@ import {
   shouldUpdateEvents
 } from 'src/features/Events/Event.helpers';
 import { ExtendedEvent } from 'src/store/events/event.helpers';
-import { removeBlacklistedEvents } from 'src/utilities/eventUtils';
 
 type ClassNames = 'root' | 'header' | 'viewMore';
 
@@ -133,7 +132,7 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
     const { classes, linodeId } = this.props;
     const { events, error, loading } = this.state;
 
-    const filteredEvents = removeBlacklistedEvents(events);
+    const _events = events || [];
 
     return (
       <>
@@ -153,7 +152,7 @@ export class ActivitySummary extends React.Component<CombinedProps, State> {
         </Grid>
         <Paper className={classes.root}>
           <ActivitySummaryContent
-            events={filteredEvents.slice(0, 5)}
+            events={_events.slice(0, 5)}
             error={error}
             loading={loading}
           />

--- a/src/store/events/event.request.ts
+++ b/src/store/events/event.request.ts
@@ -4,6 +4,7 @@ import {
   markEventSeen
 } from 'src/services/account/events';
 import { dateFormat } from 'src/time';
+import { removeBlacklistedEvents } from 'src/utilities/eventUtils';
 import { generatePollingFilter } from 'src/utilities/requestFilters';
 import { ThunkActionCreator } from '../types';
 import { addEvents, updateEventsAsSeen } from './event.actions';
@@ -27,6 +28,8 @@ export const getEvents: ThunkActionCreator<Promise<Linode.Event[]>> = () => (
   return (
     _getEvents({ page_size: 25 }, filters)
       .then(response => response.data)
+      // This will remove globally blacklisted events, which will not appear anywhere in the app.
+      .then(removeBlacklistedEvents)
       /**
        * There is where we set _initial on the events. In the default state of events the
        * mostRecentEventTime is set to epoch. On the completion of the first successful events

--- a/src/store/events/event.request.ts
+++ b/src/store/events/event.request.ts
@@ -4,7 +4,7 @@ import {
   markEventSeen
 } from 'src/services/account/events';
 import { dateFormat } from 'src/time';
-import { removeBlacklistedEvents } from 'src/utilities/eventUtils';
+import { hideBlacklistedEvents } from 'src/utilities/eventUtils';
 import { generatePollingFilter } from 'src/utilities/requestFilters';
 import { ThunkActionCreator } from '../types';
 import { addEvents, updateEventsAsSeen } from './event.actions';
@@ -26,10 +26,10 @@ export const getEvents: ThunkActionCreator<Promise<Linode.Event[]>> = () => (
   );
 
   return (
-    _getEvents({ page_size: 25 }, filters)
+    _getEvents({ page_size: 100 }, filters)
       .then(response => response.data)
       // This will remove globally blacklisted events, which will not appear anywhere in the app.
-      .then(removeBlacklistedEvents)
+      .then(hideBlacklistedEvents)
       /**
        * There is where we set _initial on the events. In the default state of events the
        * mostRecentEventTime is set to epoch. On the completion of the first successful events

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,6 +97,7 @@ namespace Linode {
     | 'domain_record_delete'
     | 'image_update'
     | 'image_delete'
+    | 'ipaddress_update'
     | 'linode_addip'
     | 'linode_boot'
     | 'linode_clone'
@@ -163,6 +164,7 @@ namespace Linode {
     time_remaining: null | number;
     username: string;
     _initial?: boolean;
+    _hidden?: boolean;
   }
   /**
    * Represents an event which has an entity. For use with type guards.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -123,6 +123,7 @@ namespace Linode {
     | 'nodebalancer_update'
     | 'nodebalancer_delete'
     | 'password_reset'
+    | 'profile_update'
     | 'stackscript_create'
     | 'stackscript_update'
     | 'stackscript_delete'

--- a/src/utilities/eventUtils.ts
+++ b/src/utilities/eventUtils.ts
@@ -1,9 +1,13 @@
 import { GLOBAL_EVENTS_BLACKLIST } from 'src/constants';
 
 // Removes events we don't want to display.
-export const removeBlacklistedEvents = (
+export const hideBlacklistedEvents = (
   events: Linode.Event[] = [],
   blacklist = GLOBAL_EVENTS_BLACKLIST
 ) => {
-  return events.filter(eachEvent => !blacklist.includes(eachEvent.action));
+  return events.map(eachEvent => {
+    return blacklist.includes(eachEvent.action)
+      ? { ...eachEvent, _hidden: true }
+      : { ...eachEvent, _hidden: false };
+  });
 };

--- a/src/utilities/eventUtils.ts
+++ b/src/utilities/eventUtils.ts
@@ -1,16 +1,9 @@
-// Removes events we don't want to display.
-export const removeBlacklistedEvents = (events: Linode.Event[] = []) => {
-  return events.filter(
-    eachEvent => !blackListedEvents.includes(eachEvent.action)
-  );
-};
+import { GLOBAL_EVENTS_BLACKLIST } from 'src/constants';
 
-// We don't want to display these events because they precede similar events.
-// Example: when a user clicks the button to upgrade a Linode, we immediately
-// get a `linode_mutate_create` event from the API. Moments later, we get back
-// ANOTHER event, `linode_mutate`, with a status of `scheduled`. That's the event
-// we want to display, because it will be updated via other events with the same ID.
-const blackListedEvents: Linode.EventAction[] = [
-  'linode_mutate_create', // This event occurs when an upgrade is first initiated.
-  'linode_resize_create' // This event occurs when a resize is first initiated.
-];
+// Removes events we don't want to display.
+export const removeBlacklistedEvents = (
+  events: Linode.Event[] = [],
+  blacklist = GLOBAL_EVENTS_BLACKLIST
+) => {
+  return events.filter(eachEvent => !blacklist.includes(eachEvent.action));
+};


### PR DESCRIPTION
## Description

Allows us to blacklist events in different locations. This PR specifically removes the `profile_update` event from the UserEventsMenu, but displays these events on the events landing page.

## Type of Change
- Non breaking change ('update', 'change')


## Note to Reviewers

Trigger some profile events (toggling a Linodes group by tag or updating your email) and make sure they show up on landing but don't trigger notifications in the top right menu.