### PR TITLE
LKE-615 Fix node pools

### DIFF
--- a/src/__data__/kubernetes.ts
+++ b/src/__data__/kubernetes.ts
@@ -1,36 +1,10 @@
+import { pool1 } from 'src/__data__/nodePools';
+
 export const clusters: Linode.KubernetesCluster[] = [
   {
     tags: ['spam', 'eggs'],
     region: 'us-central',
     label: 'cluster-1',
-    node_pools: [
-      {
-        type: 'g6-standard-4',
-        count: 2,
-        id: 69,
-        linodes: [
-          {
-            id: 103,
-            status: 'ready'
-          },
-          {
-            id: 104,
-            status: 'ready'
-          }
-        ]
-      },
-      {
-        type: 'g6-standard-8',
-        count: 1,
-        id: 70,
-        linodes: [
-          {
-            id: 105,
-            status: 'ready'
-          }
-        ]
-      }
-    ],
     created: '2019-04-29 18:02:17',
     id: 35,
     status: 'running',
@@ -40,34 +14,6 @@ export const clusters: Linode.KubernetesCluster[] = [
     tags: ['spam', 'eggs'],
     region: 'us-central',
     label: 'cluster-2',
-    node_pools: [
-      {
-        type: 'g6-standard-4',
-        count: 2,
-        id: 69,
-        linodes: [
-          {
-            id: 103,
-            status: 'ready'
-          },
-          {
-            id: 104,
-            status: 'ready'
-          }
-        ]
-      },
-      {
-        type: 'g6-standard-8',
-        count: 1,
-        id: 70,
-        linodes: [
-          {
-            id: 105,
-            status: 'ready'
-          }
-        ]
-      }
-    ],
     created: '2019-04-29 18:02:17',
     id: 34,
     status: 'running',
@@ -78,6 +24,7 @@ export const clusters: Linode.KubernetesCluster[] = [
 export const extendedClusters = clusters.map(cluster => {
   return {
     ...cluster,
+    node_pools: [pool1],
     totalMemory: 10,
     totalCPU: 2
   };

--- a/src/__data__/nodePools.ts
+++ b/src/__data__/nodePools.ts
@@ -1,47 +1,10 @@
 import { PoolNodeWithPrice } from 'src/features/Kubernetes/types';
 import { ExtendedNodePool } from 'src/store/kubernetes/nodePools.actions';
 
-export const node1 = {
-  id: 1,
-  type: 'g5-standard-1',
-  count: 1,
-  totalMonthlyPrice: 5,
-  queuedForAddition: true
-};
-
-export const node2 = {
-  id: 2,
-  type: 'g5-standard-2',
-  count: 5,
-  totalMonthlyPrice: 50,
-  queuedForDeletion: true
-};
-
-export const node3 = {
-  id: 3,
-  type: 'g5-standard-2',
-  count: 6,
-  totalMonthlyPrice: 50
-};
-
-export const node4 = {
-  id: 4,
-  type: 'g6-standard-2',
-  count: 1,
-  totalMonthlyPrice: 1
-};
-
-export const nodePoolRequests: PoolNodeWithPrice[] = [
-  node1,
-  node2,
-  node3,
-  node4
-];
-
 export const pool1: ExtendedNodePool = {
   id: 1,
   count: 1,
-  type: 'g6-standard-1',
+  type: 'g5-standard-1',
   linodes: [
     {
       status: 'ready',
@@ -53,8 +16,8 @@ export const pool1: ExtendedNodePool = {
 
 export const pool2: ExtendedNodePool = {
   id: 2,
-  count: 2,
-  type: 'g6-standard-1',
+  count: 5,
+  type: 'g5-standard-2',
   linodes: [
     {
       status: 'ready',
@@ -71,7 +34,7 @@ export const pool2: ExtendedNodePool = {
 export const pool3: ExtendedNodePool = {
   id: 3,
   count: 1,
-  type: 'g6-standard-1',
+  type: 'g5-standard-1',
   linodes: [
     {
       status: 'ready',
@@ -82,3 +45,32 @@ export const pool3: ExtendedNodePool = {
 };
 
 export const extendedPools = [pool1, pool2, pool3];
+
+export const node1 = {
+  ...pool1,
+  totalMonthlyPrice: 5,
+  queuedForAddition: true
+};
+
+export const node2 = {
+  ...pool2,
+  totalMonthlyPrice: 50,
+  queuedForDeletion: true
+};
+
+export const node3 = {
+  ...pool3,
+  totalMonthlyPrice: 50
+};
+
+export const node4 = {
+  ...pool3,
+  totalMonthlyPrice: 1
+};
+
+export const nodePoolRequests: PoolNodeWithPrice[] = [
+  node1,
+  node2,
+  node3,
+  node4
+];

--- a/src/containers/kubernetes.container.ts
+++ b/src/containers/kubernetes.container.ts
@@ -1,17 +1,19 @@
 import { connect, MapDispatchToProps } from 'react-redux';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
+
+import { extendCluster } from 'src/features/Kubernetes/kubeUtils';
 import { ApplicationState } from 'src/store';
 import {
   DeleteClusterParams,
   setErrors as _setErrors,
-  UpdateClusterParams,
+  UpdateClusterParams
 } from 'src/store/kubernetes/kubernetes.actions';
 import {
   deleteCluster as _deleteCluster,
   requestClusterForStore as _requestClusterForStore,
   requestKubernetesClusters as _requestKubernetesClusters,
-  updateCluster as _updateCluster,
+  updateCluster as _updateCluster
 } from 'src/store/kubernetes/kubernetes.requests';
 import {
   CreateNodePoolParams,
@@ -74,7 +76,14 @@ export default <TInner extends {}, TOuter extends {}>(
 ) =>
   connect(
     (state: ApplicationState, ownProps: TOuter) => {
-      const clusters = state.__resources.kubernetes.entities;
+      const _clusters = state.__resources.kubernetes.entities;
+      // Add node pool and pricing data to clusters
+      const nodePools = state.__resources.nodePools.entities;
+      const types = state.__resources.types.entities;
+      const clusters = _clusters.map(thisCluster =>
+        extendCluster(thisCluster, nodePools, types)
+      );
+
       const clustersLoading = state.__resources.kubernetes.loading;
       const clustersError = state.__resources.kubernetes.error || {};
       const lastUpdated = state.__resources.kubernetes.lastUpdated;

--- a/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -23,7 +23,6 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableSortCell from 'src/components/TableSortCell';
 import withTypes, { WithTypesProps } from 'src/containers/types.container';
-import { extendCluster } from './../kubeUtils';
 import { ExtendedCluster } from './../types';
 import ClusterRow from './ClusterRow';
 
@@ -50,14 +49,7 @@ type CombinedProps = Props &
   WithStyles<ClassNames>;
 
 export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
-  const { classes, clusters, history, typesData } = props;
-  /**
-   * Not ideal having this run on render, but interactions on this view
-   * don't generally trigger re-renders.
-   */
-  const extendedClusters: ExtendedCluster[] = clusters.map(cluster =>
-    extendCluster(cluster, typesData || [])
-  );
+  const { classes, clusters, history } = props;
 
   return (
     <React.Fragment>
@@ -85,7 +77,7 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
           </Grid>
         </Grid>
       </Grid>
-      <OrderBy data={extendedClusters} orderBy={'label'} order={'asc'}>
+      <OrderBy data={clusters} orderBy={'label'} order={'asc'}>
         {({ data: orderedData, handleOrderChange, order, orderBy }) => (
           <Paginate data={orderedData}>
             {({

--- a/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -29,7 +29,7 @@ import { getKubeConfig } from 'src/services/kubernetes';
 import { downloadFile } from 'src/utilities/downloadFile';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import scrollTo from 'src/utilities/scrollTo';
-import { extendCluster, getMonthlyPrice } from '.././kubeUtils';
+import { getMonthlyPrice } from '.././kubeUtils';
 import { ExtendedCluster, PoolNodeWithPrice } from '.././types';
 import NodePoolPanel from '../CreateCluster/NodePoolPanel';
 import KubernetesDialog from './KubernetesDialog';
@@ -512,12 +512,8 @@ const withCluster = KubeContainer<
   {},
   WithTypesProps & RouteComponentProps<{ clusterID: string }>
 >((ownProps, clustersLoading, lastUpdated, clustersError, clustersData) => {
-  const thisCluster = clustersData.find(
-    c => +c.id === +ownProps.match.params.clusterID
-  );
-  const cluster = thisCluster
-    ? extendCluster(thisCluster, ownProps.typesData || [])
-    : null;
+  const cluster =
+    clustersData.find(c => +c.id === +ownProps.match.params.clusterID) || null;
   return {
     ...ownProps,
     cluster,

--- a/src/features/Kubernetes/kubeUtils.test.ts
+++ b/src/features/Kubernetes/kubeUtils.test.ts
@@ -9,6 +9,8 @@ import {
 
 const mockNodePool = {
   id: 6,
+  clusterID: 1,
+  linodes: [],
   type: extendedTypes[0].id,
   count: 4,
   totalMonthlyPrice: 10
@@ -16,6 +18,8 @@ const mockNodePool = {
 
 const badNodePool = {
   id: 7,
+  clusterID: 2,
+  linodes: [],
   type: 'not-a-real-type',
   count: 1,
   totalMonthlyPrice: 0
@@ -47,13 +51,13 @@ describe('helper functions', () => {
     it('should sum up the total CPU cores of all nodes', () => {
       expect(
         getTotalClusterMemoryAndCPU(nodePoolRequests, extendedTypes)
-      ).toHaveProperty('CPU', 23); // 1 Nanode (1CPU) + 5 2GB (2CPU each)
+      ).toHaveProperty('CPU', 13);
     });
 
     it('should sum up the total RAM of all pools', () => {
       expect(
         getTotalClusterMemoryAndCPU(nodePoolRequests, extendedTypes)
-      ).toHaveProperty('RAM', 47104); // 2048 + (5 * 4096)
+      ).toHaveProperty('RAM', 26624);
     });
 
     it("should return 0 if it can't match the data", () => {

--- a/src/features/Kubernetes/types.ts
+++ b/src/features/Kubernetes/types.ts
@@ -1,27 +1,17 @@
-export interface PoolNode {
-  type: string;
-  count: number;
-}
-
-export interface PoolNodeWithPrice extends PoolNode {
+export interface PoolNodeWithPrice extends ExtendedPoolNode {
   id: number;
   totalMonthlyPrice: number;
   queuedForDeletion?: boolean;
   queuedForAddition?: boolean;
 }
 
-/** @todo DRY; this is duplicated from Kubernetes.ts. Unable to override node_pools,
- * so the duplication avoids an unwanted dependency (since the types/ directory belongs
- * to the API wrapper and shouldn't refer to any Manager-specific types).
- */
-export interface ExtendedCluster {
-  created: string;
-  region: string;
-  tags: string[];
-  status: string; // @todo enum this
-  label: string;
-  version: string;
+export interface ExtendedPoolNode {
   id: number;
+  count: number;
+  type: string;
+  clusterID?: number;
+}
+export interface ExtendedCluster extends Linode.KubernetesCluster {
   node_pools: PoolNodeWithPrice[];
   totalMemory: number;
   totalCPU: number;

--- a/src/store/kubernetes/nodePools.reducer.ts
+++ b/src/store/kubernetes/nodePools.reducer.ts
@@ -32,6 +32,11 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   if (isType(action, requestNodePoolsActions.done)) {
     const { result } = action.payload;
 
+    // If there's nothing to add, return the state unchanged.
+    if (result.length === 0) {
+      return state;
+    }
+
     /**
      * This action payload is the current node pools for a single
      * cluster. We need to add them to state, but make sure

--- a/src/store/kubernetes/nodePools.reducer.ts
+++ b/src/store/kubernetes/nodePools.reducer.ts
@@ -32,10 +32,21 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   if (isType(action, requestNodePoolsActions.done)) {
     const { result } = action.payload;
 
+    /**
+     * This action payload is the current node pools for a single
+     * cluster. We need to add them to state, but make sure
+     * that we don't re-add existing ones for that cluster.
+     */
+    const clusterID = result[0].clusterID;
+    const filteredPools = state.entities.filter(
+      thisPool => thisPool.clusterID !== clusterID
+    );
+    const newPools = [...filteredPools, ...result];
+
     return {
       ...state,
-      entities: [...state.entities, ...result],
-      results: [...state.results, ...result.map(p => p.id)],
+      entities: newPools,
+      results: newPools.map(p => p.id),
       loading: false
     };
   }

--- a/src/types/Kubernetes.ts
+++ b/src/types/Kubernetes.ts
@@ -7,7 +7,6 @@ namespace Linode {
     label: string;
     version: string;
     id: number;
-    node_pools: KubeNodePoolResponse[];
   }
 
   export interface KubeNodePoolResponse {


### PR DESCRIPTION
## Description

Brings the LKE section back up to where it was before the API changed. Viewing, editing, adding, and deleting clusters should work normally.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Tests and __data__ fixes have a big footprint here. Major changes are in the kubernetes.container, where we're adding node pools before passing them on to the consumer; typing updates; and a fix to the reducer (which was concatenating responses, causing the size and price of a cluster to increase linearly every time you clicked back to /kubernetes).