### PR TITLE
Fix: IP Transfer Logic

### DIFF
--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -273,11 +273,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
           <Divider className={classes.containerDivider} />
         </Grid>
         <Grid item className={classes.mobileFieldWrapper}>
-          <TextField
-            disabled
-            value={state.sourceIP}
-            className={classes.ipField}
-          />
+          <TextField value={state.sourceIP} className={classes.ipField} />
         </Grid>
         <Grid item xs={12} className={classes.autoGridsm}>
           <Select
@@ -351,8 +347,8 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
     return (
       <Grid item xs={12} className={classes.autoGridsm}>
         <Select
-          disabled={readOnly || selectedLinodesIPs.length === 1}
-          defaultValue={defaultIP}
+          disabled={readOnly}
+          value={defaultIP}
           options={IPList}
           onChange={this.onSelectedIPChange(sourceIP)}
           textFieldProps={{

--- a/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -281,7 +281,13 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
         </Grid>
         <Grid item xs={12} className={classes.autoGridsm}>
           <Select
-            defaultValue={state.mode}
+            value={
+              state.mode === 'none'
+                ? null
+                : actionsList.find(
+                    eachAction => eachAction.value === state.mode
+                  )
+            }
             options={actionsList}
             textFieldProps={{
               dataAttrs: {
@@ -361,19 +367,22 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
     );
   };
 
-  componentWillReceiveProps(nextProps: CombinedProps) {
-    this.setState({
-      ips: nextProps.ipAddresses.reduce(
-        (state, ip) => ({
-          ...state,
-          [ip]: LinodeNetworkingIPTransferPanel.defaultState(
+  componentDidUpdate(prevProps: CombinedProps) {
+    /**
+     * if new ip addresses were provided as props, massage the data so it matches
+     * the default shape we need to append to state
+     */
+    if (!equals(prevProps.ipAddresses, this.props.ipAddresses)) {
+      this.setState({
+        ips: this.props.ipAddresses.reduce((acc, ip) => {
+          acc[ip] = LinodeNetworkingIPTransferPanel.defaultState(
             ip,
             this.props.linodeID
-          )
-        }),
-        {}
-      )
-    });
+          );
+          return acc;
+        }, {})
+      });
+    }
   }
 
   ipRow = (ipState: IPStates) => {


### PR DESCRIPTION
## Description

Fixes two bugs:

1. While long-running events are happening on a Linode, you cannot interact with the IP transfer panel because it kept re-rendering with every new event and resetting the entire form.

2. While swapping IPs, when selecting different target Linodes, the 4th IP select panel wasn't updating its values to match the IPs associated with the selected Linode.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A

## Note to Reviewers

I also made the executive decision to get rid of the fields being disabled if there's only one value. imo, it's bad UX and implies that something is wrong.