### PR TITLE
M3-3025 fix: Update CloneLanding state when configs or disks change

### DIFF
--- a/src/__data__/linodeConfigs.ts
+++ b/src/__data__/linodeConfigs.ts
@@ -39,3 +39,42 @@ export const linodeConfigs: Linode.Config[] = [
     kernel: 'linode/grub2'
   }
 ];
+export const linodeConfig2: Linode.Config = {
+  created: '2018-06-26T16:05:28',
+  memory_limit: 0,
+  updated: '2018-06-26T16:05:28',
+  comments: '',
+  virt_mode: 'paravirt',
+  id: 1234,
+  run_level: 'default',
+  helpers: {
+    distro: true,
+    network: true,
+    modules_dep: true,
+    devtmpfs_automount: true,
+    updatedb_disabled: true
+  },
+  root_device: '/dev/sda',
+  label: 'My Arch Linux Disk Profile',
+  initrd: null,
+  devices: {
+    sdc: {
+      volume_id: 8702,
+      disk_id: null
+    },
+    sda: {
+      volume_id: null,
+      disk_id: 18795181
+    },
+    sdd: null,
+    sdf: null,
+    sdb: {
+      volume_id: null,
+      disk_id: 18795182
+    },
+    sdh: null,
+    sdg: null,
+    sde: null
+  },
+  kernel: 'linode/grub2'
+};

--- a/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -143,7 +143,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
   const stringifiedConfigIds = JSON.stringify(configs.map(c => c.id));
   const stringifiedDiskIds = JSON.stringify(disks.map(d => d.id));
 
-  // Update configs and disks if they change (which will happen after )
+  // Update configs and disks if they change
   React.useEffect(() => {
     dispatch({
       type: 'syncConfigsDisks',
@@ -155,12 +155,12 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
   }, [stringifiedConfigIds, stringifiedDiskIds]);
 
   // A config and/or disk can be selected via query param. Memoized
-  // so it can be used as a dep in the useEffect's that consume it.
+  // so it can be used as a dep in the useEffects that consume it.
   const queryParams = React.useMemo(() => getParamsFromUrl(location.search), [
     location.search
   ]);
 
-  // Toggle config if one is specified as a query param.
+  // Toggle config if one is specified as a query param, and that config exists in our state.
   React.useEffect(() => {
     const configFromQS = Number(queryParams.selectedConfig);
     if (configFromQS && state.configSelection[configFromQS]) {
@@ -168,7 +168,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
     }
   }, [queryParams]);
 
-  // Toggle disk if one is specified as a query param.
+  // Toggle disk if one is specified as a query param, and that disk exists in our state.
   React.useEffect(() => {
     const diskFromQS = Number(queryParams.selectedDisk);
     if (diskFromQS && state.diskSelection[diskFromQS]) {
@@ -199,26 +199,26 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
 
   const clearAll = () => dispatch({ type: 'clearAll' });
 
-  // Filter out configs we don't already have in our configSelection
-  const safeConfigs = configs.filter(
-    eachConfig => state.configSelection[eachConfig.id] !== undefined
+  // The configs we know about in our configSelection state.
+  const configsInState = configs.filter(eachConfig =>
+    state.configSelection.hasOwnProperty(eachConfig.id)
   );
-
-  // Filter out disks we don't already have in our configSelection
-  const safeDisks = disks.filter(
-    eachDisk => state.diskSelection[eachDisk.id] !== undefined
-  );
-
-  const selectedConfigs = safeConfigs.filter(
+  // The configs that are selected.
+  const selectedConfigs = configsInState.filter(
     eachConfig => state.configSelection[eachConfig.id].isSelected
   );
-
+  // IDs of selected configs.
   const selectedConfigIds = selectedConfigs.map(eachConfig => eachConfig.id);
 
-  const selectedDisks = safeDisks.filter(
+  // The disks we know about in our diskSelection state.
+  const disksInState = disks.filter(eachDisk =>
+    state.diskSelection.hasOwnProperty(eachDisk.id)
+  );
+  // The disks that are selected.
+  const selectedDisks = disksInState.filter(
     eachDisk => state.diskSelection[eachDisk.id].isSelected
   );
-
+  // IDs of selected disks.
   const selectedDiskIds = selectedDisks.map(eachDisk => eachDisk.id);
 
   const handleClone = () => {
@@ -357,7 +357,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
               render={() => (
                 <div className={classes.outerContainer}>
                   <Configs
-                    configs={safeConfigs}
+                    configs={configsInState}
                     configSelection={state.configSelection}
                     handleSelect={toggleConfig}
                   />
@@ -377,7 +377,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
                   </Typography>
                   <div className={classes.diskContainer}>
                     <Disks
-                      disks={safeDisks}
+                      disks={disksInState}
                       diskSelection={state.diskSelection}
                       selectedConfigIds={selectedConfigIds}
                       handleSelect={toggleDisk}
@@ -398,7 +398,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
             // If a selected disk is associated with a selected config, we
             // don't want it to appear in the Details component, since
             // cloning the config takes precedence.
-            selectedDisks={safeDisks.filter(disk => {
+            selectedDisks={disksInState.filter(disk => {
               return (
                 // This disk has been individually selected ...
                 state.diskSelection[disk.id].isSelected &&

--- a/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -160,18 +160,18 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
     location.search
   ]);
 
-  // Toggle config if one is specified as a query param, and that config exists in our state.
+  // Toggle config if a valid configId is specified as a query param.
   React.useEffect(() => {
     const configFromQS = Number(queryParams.selectedConfig);
-    if (configFromQS && state.configSelection[configFromQS]) {
+    if (configFromQS) {
       return dispatch({ type: 'toggleConfig', id: configFromQS });
     }
   }, [queryParams]);
 
-  // Toggle disk if one is specified as a query param, and that disk exists in our state.
+  // Toggle disk if a valid diskId is specified as a query param.
   React.useEffect(() => {
     const diskFromQS = Number(queryParams.selectedDisk);
-    if (diskFromQS && state.diskSelection[diskFromQS]) {
+    if (diskFromQS) {
       return dispatch({ type: 'toggleDisk', id: diskFromQS });
     }
   }, [queryParams]);

--- a/src/features/linodes/CloneLanding/Configs.tsx
+++ b/src/features/linodes/CloneLanding/Configs.tsx
@@ -56,7 +56,10 @@ export const Configs: React.FC<Props> = props => {
                     <TableRow key={config.id} data-qa-config={config.label}>
                       <TableCell>
                         <CheckBox
-                          checked={configSelection[config.id].isSelected}
+                          checked={
+                            configSelection[config.id] &&
+                            configSelection[config.id].isSelected
+                          }
                           onChange={() => handleSelect(config.id)}
                           text={config.label}
                           data-testid={`checkbox-${config.id}`}

--- a/src/features/linodes/CloneLanding/Disks.tsx
+++ b/src/features/linodes/CloneLanding/Disks.tsx
@@ -66,6 +66,7 @@ export const Disks: React.FC<Props> = props => {
                     ) : (
                       paginatedData.map((disk: Linode.Disk) => {
                         const isDiskSelected =
+                          diskSelection[disk.id] &&
                           diskSelection[disk.id].isSelected;
 
                         const isConfigSelected =

--- a/src/features/linodes/CloneLanding/utilities.test.ts
+++ b/src/features/linodes/CloneLanding/utilities.test.ts
@@ -1,10 +1,10 @@
 import { disks, extDisk2, extDisk3, extDiskCopy } from 'src/__data__/disks';
-import { linodeConfigs } from 'src/__data__/linodeConfigs';
+import { linodeConfigs, linodeConfig2 } from 'src/__data__/linodeConfigs';
 import {
   attachAssociatedDisksToConfigs,
   cloneLandingReducer,
   CloneLandingState,
-  createInitialCloneLandingState,
+  createConfigDiskSelection,
   ExtendedConfig,
   getAllDisks,
   getAssociatedDisks,
@@ -92,6 +92,72 @@ describe('utilities', () => {
       expect(newState.errors).toBe(undefined);
     });
 
+    it('adds configs', () => {
+      const state: CloneLandingState = { ...baseState };
+      const newState = cloneLandingReducer(state, {
+        type: 'syncConfigsDisks',
+        configs: linodeConfigs,
+        disks: []
+      });
+      linodeConfigs.forEach(eachConfig => {
+        expect(newState.configSelection).toHaveProperty(String(eachConfig.id));
+      });
+    });
+
+    it('adds disks', () => {
+      const state: CloneLandingState = { ...baseState };
+      const newState = cloneLandingReducer(state, {
+        type: 'syncConfigsDisks',
+        configs: [],
+        disks
+      });
+      disks.forEach(eachDisk => {
+        expect(newState.diskSelection).toHaveProperty(String(eachDisk.id));
+      });
+    });
+
+    it('considers selected configs', () => {
+      const state: CloneLandingState = {
+        ...baseState,
+        configSelection: {
+          1234: {
+            isSelected: true,
+            associatedDiskIds: []
+          }
+        }
+      };
+      const newState = cloneLandingReducer(state, {
+        type: 'syncConfigsDisks',
+        configs: [...linodeConfigs, linodeConfig2],
+        disks: []
+      });
+      expect(newState.configSelection['1234']).toHaveProperty(
+        'isSelected',
+        true
+      );
+    });
+
+    it('considers selected disks', () => {
+      const state: CloneLandingState = {
+        ...baseState,
+        diskSelection: {
+          19040623: {
+            isSelected: true,
+            associatedConfigIds: []
+          }
+        }
+      };
+      const newState = cloneLandingReducer(state, {
+        type: 'syncConfigsDisks',
+        configs: [],
+        disks
+      });
+      expect(newState.diskSelection['19040623']).toHaveProperty(
+        'isSelected',
+        true
+      );
+    });
+
     it('clears errors after each type of input change', () => {
       const state: CloneLandingState = {
         ...baseState,
@@ -110,9 +176,9 @@ describe('utilities', () => {
     });
   });
 
-  describe('createInitialCloneLandingState', () => {
+  describe('createConfigDiskSelection', () => {
     it('defaults isSelected to false for each config and disk', () => {
-      const state = createInitialCloneLandingState(linodeConfigs, disks);
+      const state = createConfigDiskSelection(linodeConfigs, disks);
       linodeConfigs.forEach(eachConfig => {
         expect(state.configSelection[eachConfig.id].isSelected).toBe(false);
       });
@@ -125,7 +191,7 @@ describe('utilities', () => {
     it('sets isSelected to true if pre-selected IDs are set', () => {
       const configId = linodeConfigs[0].id;
       const diskId = disks[0].id;
-      const state = createInitialCloneLandingState(
+      const state = createConfigDiskSelection(
         linodeConfigs,
         disks,
         [configId],
@@ -136,7 +202,7 @@ describe('utilities', () => {
     });
 
     it('adds associated disk and config IDs', () => {
-      const state = createInitialCloneLandingState(linodeConfigs, [extDisk3]);
+      const state = createConfigDiskSelection(linodeConfigs, [extDisk3]);
       const configId = linodeConfigs[0].id;
       const diskId = extDisk3.id;
 
@@ -149,28 +215,10 @@ describe('utilities', () => {
       ).toBe(true);
     });
 
-    it('defaults isSubmitting to false', () => {
-      const state = createInitialCloneLandingState(linodeConfigs, disks);
-      expect(state.isSubmitting).toBe(false);
-    });
-
-    it('defaults selectedLinodeId to null', () => {
-      const state = createInitialCloneLandingState(linodeConfigs, disks);
-      expect(state.selectedLinodeId).toBe(null);
-    });
-
-    it('defaults errors to undefined', () => {
-      const state = createInitialCloneLandingState(linodeConfigs, disks);
-      expect(state.errors).toBeUndefined();
-    });
-
     it('works when there are no configs or disks', () => {
-      const state = createInitialCloneLandingState([], []);
+      const state = createConfigDiskSelection([], []);
       expect(state.configSelection).toEqual({});
       expect(state.diskSelection).toEqual({});
-      expect(state.isSubmitting).toBe(false);
-      expect(state.selectedLinodeId).toBe(null);
-      expect(state.errors).toBeUndefined();
     });
   });
 

--- a/src/features/linodes/CloneLanding/utilities.test.ts
+++ b/src/features/linodes/CloneLanding/utilities.test.ts
@@ -128,8 +128,8 @@ describe('utilities', () => {
       const state = createInitialCloneLandingState(
         linodeConfigs,
         disks,
-        configId,
-        diskId
+        [configId],
+        [diskId]
       );
       expect(state.configSelection[configId].isSelected).toBe(true);
       expect(state.diskSelection[diskId].isSelected).toBe(true);

--- a/src/features/linodes/CloneLanding/utilities.test.ts
+++ b/src/features/linodes/CloneLanding/utilities.test.ts
@@ -1,5 +1,5 @@
 import { disks, extDisk2, extDisk3, extDiskCopy } from 'src/__data__/disks';
-import { linodeConfigs, linodeConfig2 } from 'src/__data__/linodeConfigs';
+import { linodeConfig2, linodeConfigs } from 'src/__data__/linodeConfigs';
 import {
   attachAssociatedDisksToConfigs,
   cloneLandingReducer,

--- a/src/features/linodes/CloneLanding/utilities.ts
+++ b/src/features/linodes/CloneLanding/utilities.ts
@@ -146,7 +146,7 @@ export const cloneLandingReducer = (
         errors: undefined
       };
 
-    // We're going to create new configSelection and diskSelection, based on the
+    // We're going to create new configSelection and diskSelection based on the
     // given configs and disks, and the elements already selected in the current state.
     case 'syncConfigsDisks':
       const { configs, disks } = action;

--- a/src/features/linodes/CloneLanding/utilities.ts
+++ b/src/features/linodes/CloneLanding/utilities.ts
@@ -84,6 +84,12 @@ export const cloneLandingReducer = (
   switch (action.type) {
     case 'toggleConfig':
       id = action.id;
+
+      // If the ID isn't in configSelection, return the state unchanged.
+      if (!state.configSelection[id]) {
+        return state;
+      }
+
       return {
         ...state,
         configSelection: {
@@ -99,6 +105,12 @@ export const cloneLandingReducer = (
       };
     case 'toggleDisk':
       id = action.id;
+
+      // If the ID isn't in diskSelection, return the state unchanged.
+      if (!state.diskSelection[id]) {
+        return state;
+      }
+
       return {
         ...state,
         diskSelection: {


### PR DESCRIPTION
## Description

The problem:

1. Open the Config/Disk Clone page.
2. In another tab, delete a disk.
3. **Observe:** in a few seconds, the Clone page will crash.

This was because `disks` (from LinodeDetailContext) changed, but the CloneLanding `useReducer` state did _not_  change.

Now, the state changes whenever there is a change to `configs` or `disks`, via `useEffect`.

To achieve this without a lot of wasteful re-renders required moving some things around. This blog post (actually a mini-book) was particularly helpful in understanding the ins and outs `useEffect()`: https://overreacted.io/a-complete-guide-to-useeffect/

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

- `configs` won't change when you delete a config in another tab, because we're not listening for that event (will do another PR).
- Try multiple combinations: navigating to CloneLanding with preselected disks, configs, without, etc.
