### PR TITLE
Try a different approach for blacklisting events

### DIFF
--- a/src/eventMessageGenerator.ts
+++ b/src/eventMessageGenerator.ts
@@ -164,6 +164,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     finished: e =>
       `Linode ${e.entity!.label} has booted (Host initiated restart).`
   },
+  ipaddress_update: {
+    notification: e => `An IP address has been updated on your account.`
+  },
   lish_boot: {
     scheduled: e =>
       `Linode ${e.entity!.label} is scheduled to boot (Lish initiated boot).`,
@@ -434,6 +437,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   user_ssh_key_delete: {
     notification: e => `An SSH key has been removed from your profile.`
+  },
+  user_update: {
+    notification: e => `User ${e.entity!.label} has been updated.`
   }
 };
 

--- a/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
+++ b/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
@@ -80,7 +80,7 @@ export class UserEventsMenu extends React.Component<CombinedProps, State> {
       history: { push }
     } = this.props;
 
-    const filteredEvents = removeBlacklistedEvents(events);
+    const filteredEvents = removeBlacklistedEvents(events, ['profile_update']);
     const unseenCount = getNumUnseenEvents(filteredEvents);
 
     return (

--- a/src/utilities/eventUtils.ts
+++ b/src/utilities/eventUtils.ts
@@ -1,8 +1,10 @@
 // Removes events we don't want to display.
-export const removeBlacklistedEvents = (events: Linode.Event[] = []) => {
-  return events.filter(
-    eachEvent => !blackListedEvents.includes(eachEvent.action)
-  );
+export const removeBlacklistedEvents = (
+  events: Linode.Event[] = [],
+  blacklist: string[] = []
+) => {
+  const _blacklist = [...blackListedEvents, ...blacklist];
+  return events.filter(eachEvent => !_blacklist.includes(eachEvent.action));
 };
 
 // We don't want to display these events because they precede similar events.


### PR DESCRIPTION
## Description

There are enough edge/special cases that I'm giving up on trying to reduce duplication for now. `removeBlacklistedEvents` now takes an optional "extra" blacklist, so that each consumer can filter out events in addition to the global blacklist. This is used to filter `profile_update` events from Events Landing.

Also adds handling for new events `ipaddress_update` and `user_update` .
