### PR TITLE
M3-2992 Feature/wdio v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: node_js
 node_js:
-  - 8.11.2
+  - 10.13.0
 
 cache: yarn
 # services:

--- a/src/components/Breadcrumb/Breadcrumb.spec.js
+++ b/src/components/Breadcrumb/Breadcrumb.spec.js
@@ -1,7 +1,7 @@
 const { navigateToStory, executeInAllStories } = require('../../../e2e/utils/storybook');
 const { constants } = require('../../../e2e/constants');
 
-describe('Breadcrumb Suite', () => { 
+describe('Breadcrumb Suite', () => {
     const component = 'Breadcrumb';
     const childStories = ['Basic Breadcrumb', 'Breadcrumb with custom label', 'Breadcrumb with editable text'];
     const link = '[data-qa-link="true"]';
@@ -17,99 +17,102 @@ describe('Breadcrumb Suite', () => {
         executeInAllStories(component, childStories, () => {
             $(link).waitForDisplayed(constants.wait.normal);
             expect($(link).getAttribute('href'))
-            .withContext(`href link should not be missing`).not.toBeNull();
+              .withContext(`href link should not be missing`).not.toBeNull();
             expect($$(link)[2].getAttribute('href'))
-            .withContext('Url should be').toEqual('http://localhost:6006/linodes/9872893679817/test')
+              .withContext('Url should be').toEqual(`${browser.options.baseUrl}/linodes/9872893679817/test`)
         });
     });
 
-    it('Static text is not editable, and does not contain link', () => {
+    describe('Static text and links', () => {
+      it('Static text is not editable, and does not contain link', () => {
         navigateToStory(component, childStories[0]);
         expect($(editButton).isDisplayed())
-        .withContext(`${editBtnMessage}`).toBe(false);
+          .withContext(`${editBtnMessage}`).toBe(false);
         expect($(staticText).$('..').$('..').getAttribute('href'))
-        .withContext(`href link should be blank`).toBeNull();
-    });
+          .withContext(`href link should be blank`).toBeNull();
+      });
 
-    it('Static text is not editable, and does contain link', () => {
+      it('Static text is not editable, and does contain link', () => {
         navigateToStory(component, childStories[1]);
         expect($(editButton).isDisplayed())
-        .withContext(`${editBtnMessage}`).toBe(false);
+          .withContext(`${editBtnMessage}`).toBe(false);
         expect($$(link)[2].getAttribute('href'))
-        .withContext(`href link should not be blank`).not.toBeNull();
-        
-    });
+          .withContext(`href link should not be blank`).not.toBeNull();
+      });
+    })
 
-    it('Editable text header should be editable, but not contain a link', () => {
+    describe('Editable breadcrumb text', () => {
+      it('Editable text header should be editable, but not contain a link', () => {
         navigateToStory(component, childStories[2]);
         $(editableText).click()
-        expect($(editButton).isDisplayed()).
-        withContext(`edit button should be visible`).toBe(true);
+        expect($(editButton).isDisplayed())
+          .withContext(`edit button should be visible`).toBe(true);
         expect($(editableText).$('..').getAttribute('href'))
-        .withContext(`href link should be blank`).toBeNull();
-    });
+          .withContext(`href link should be blank`).toBeNull();
+      });
 
-    it('Only clicking the edit icon displays the edit input field', () => {
-        executeInAllStories(component, [childStories[2]], () => {
+      it('Only clicking the edit icon displays the edit input field', () => {
+          executeInAllStories(component, [childStories[2]], () => {
             $(editableText).waitForDisplayed(true);
             $(editableText).click();
             expect($(editableTextInput).isDisplayed())
-            .withContext(`text field should not be displayed`).toBe(false);
+              .withContext(`text field should not be displayed`).toBe(false);
             $(editButton).click();
             $(editableTextInput).waitForDisplayed(constants.wait.short);
-        });
-    });
+          });
+      });
 
-    it('Text input field should have a save and close button', () => {
-        navigateToStory(component, childStories[2]);
-        $(editableText).waitForDisplayed(constants.wait.short);
-        $(editableText).click();
-        $(editButton).click();
-        expect($(editableTextInput).isDisplayed())
-        .withContext(`editable text field should displayed`).toBe(true);
-        expect($(saveEditButton).isDisplayed())
-        .withContext(`save edit button should be displayed`).toBe(true);
-        expect($(cancelButton).isDisplayed())
-        .withContext(`cancel button should be displayed`).toBe(true);
-        $('body').click();
-    });
+      it('Text input field should have a save and close button', () => {
+          navigateToStory(component, childStories[2]);
+          $(editableText).waitForDisplayed(constants.wait.short);
+          $(editableText).click();
+          $(editButton).click();
+          expect($(editableTextInput).isDisplayed())
+            .withContext(`editable text field should displayed`).toBe(true);
+          expect($(saveEditButton).isDisplayed())
+            .withContext(`save edit button should be displayed`).toBe(true);
+          expect($(cancelButton).isDisplayed())
+            .withContext(`cancel button should be displayed`).toBe(true);
+          $('body').click();
+      });
 
-    it('Clicking the cancel button clears the text input', () => {
-        navigateToStory(component, childStories[2]);
-        $(editableText).waitForDisplayed(constants.wait.short);
-        const originalValue = $(editableText).getText();
-        $(editableText).click();
-        $(editButton).click();
-        $(editableTextInput).waitForDisplayed(constants.wait.short);
-        $(editableTextInput).setValue('test clear');
-        $(cancelButton).click();
-        expect($(editableText).getText())
-        .withContext(`text should not be changed on cancel`).toEqual(originalValue);
-    });
+      it('Clicking the cancel button clears the text input', () => {
+          navigateToStory(component, childStories[2]);
+          $(editableText).waitForDisplayed(constants.wait.short);
+          const originalValue = $(editableText).getText();
+          $(editableText).click();
+          $(editButton).click();
+          $(editableTextInput).waitForDisplayed(constants.wait.short);
+          $(editableTextInput).setValue('test clear');
+          $(cancelButton).click();
+          expect($(editableText).getText())
+            .withContext(`text should not be changed on cancel`).toEqual(originalValue);
+      });
 
-    it('Clicking the save button saves the text input', () => {
-        navigateToStory(component, childStories[2]);
-        $(editableText).waitForDisplayed(constants.wait.short);
-        const updatedText = 'test save';
-        $(editableText).click();
-        $(editButton).click();
-        $(editableTextInput).waitForDisplayed(constants.wait.short);
-        $(editableTextInput).setValue(updatedText);
-        $(saveEditButton).click();
-        expect($(editableText).getText())
-        .withContext(`text should have been updated`).toEqual(updatedText);
-    });
+      it('Clicking the save button saves the text input', () => {
+          navigateToStory(component, childStories[2]);
+          $(editableText).waitForDisplayed(constants.wait.short);
+          const updatedText = 'test save';
+          $(editableText).click();
+          $(editButton).click();
+          $(editableTextInput).waitForDisplayed(constants.wait.short);
+          $(editableTextInput).setValue(updatedText);
+          $(saveEditButton).click();
+          expect($(editableText).getText())
+            .withContext(`text should have been updated`).toEqual(updatedText);
+      });
 
-    it('Clicking out of the editable input without saving does not save the text input', () => {
-        navigateToStory(component, childStories[2]);
-        $(editableText).waitForDisplayed(constants.wait.short);
-        const originalText = $(editableText).getText();
-        $(editableText).click();
-        $(editButton).click();
-        $(editableTextInput).waitForDisplayed(constants.wait.short);
-        $(editableTextInput).setValue('test do not save input');
-        $('body').click();
-        expect($(editableText).getText())
-        .withContext(`text should not have been saved`).toEqual(originalText);
-    });
+      it('Clicking out of the editable input without saving does not save the text input', () => {
+          navigateToStory(component, childStories[2]);
+          $(editableText).waitForDisplayed(constants.wait.short);
+          const originalText = $(editableText).getText();
+          $(editableText).click();
+          $(editButton).click();
+          $(editableTextInput).waitForDisplayed(constants.wait.short);
+          $(editableTextInput).setValue('test do not save input');
+          $('body').click();
+          expect($(editableText).getText())
+            .withContext(`text should not have been saved`).toEqual(originalText);
+      });
+    })
 });

--- a/src/components/Breadcrumb/Breadcrumb.spec.js
+++ b/src/components/Breadcrumb/Breadcrumb.spec.js
@@ -4,104 +4,112 @@ const { constants } = require('../../../e2e/constants');
 describe('Breadcrumb Suite', () => { 
     const component = 'Breadcrumb';
     const childStories = ['Basic Breadcrumb', 'Breadcrumb with custom label', 'Breadcrumb with editable text'];
-    const link = '[data-qa-link]';
-    const staticText = '[data-qa-label-title]';
-    const editableText = '[data-qa-editable-text]';
+    const link = '[data-qa-link="true"]';
+    const staticText = '[data-qa-label-text="true"]';
+    const editableText = '[data-qa-editable-text="true"]';
     const editableTextInput = `${editableText} input`;
-    const editButton = '[data-testid="editable-text"]';
-    const saveEditButton = '[data-qa-save-edit]';
-    const clearEditButton = '[data-qa-cancel-edit]';
+    const editButton = '[data-qa-edit-button="true"]';
+    const saveEditButton = '[data-qa-save-edit="true"]';
+    const cancelButton = '[data-qa-cancel-edit="true"]';
+    const editBtnMessage = 'edit button should not be displayed'
 
     it('There should be a link in each Breadcrumb story', () => {
         executeInAllStories(component, childStories, () => {
             $(link).waitForDisplayed(constants.wait.normal);
-            expect($(link).getAttribute('href')).not.toBeNull();
+            expect($(link).getAttribute('href'))
+            .withContext(`href link should not be missing`).not.toBeNull();
+            expect($$(link)[2].getAttribute('href'))
+            .withContext('Url should be').toEqual('http://localhost:6006/linodes/9872893679817/test')
         });
     });
 
     it('Static text is not editable, and does not contain link', () => {
         navigateToStory(component, childStories[0]);
-        expect($(editButton).isDisplayed()).toBe(false);
-        expect($(staticText).$('..').$('..').getAttribute('href')).toBeNull();
+        expect($(editButton).isDisplayed())
+        .withContext(`${editBtnMessage}`).toBe(false);
+        expect($(staticText).$('..').$('..').getAttribute('href'))
+        .withContext(`href link should be blank`).toBeNull();
     });
 
-    fit('Static text is not editable, and does contain link', () => {
+    it('Static text is not editable, and does contain link', () => {
         navigateToStory(component, childStories[1]);
-        expect($(editButton).isDisplayed()).toBe(false);
-        expect($(staticText).$('..').$('..').getAttribute('href')).not.toBeNull();
+        expect($(editButton).isDisplayed())
+        .withContext(`${editBtnMessage}`).toBe(false);
+        expect($$(link)[2].getAttribute('href'))
+        .withContext(`href link should not be blank`).not.toBeNull();
+        
     });
 
     it('Editable text header should be editable, but not contain a link', () => {
         navigateToStory(component, childStories[2]);
-        expect($(editButton)).not.toBeNull();
-        expect($(editableText).$('..').getAttribute('href')).toBeNull();
-    });
-
-    it('Editable text header should be editable, and does a link', () => {
-        navigateToStory(component, childStories[3]);
-        expect($(editButton)).not.toBeNull();
-        expect($(editableText).$('..').getAttribute('href')).not.toBeNull();
-        expect($(editableText).$('..').getAttribute('class')).toContain('underlineOnHover');
+        $(editableText).click()
+        expect($(editButton).isDisplayed()).
+        withContext(`edit button should be visible`).toBe(true);
+        expect($(editableText).$('..').getAttribute('href'))
+        .withContext(`href link should be blank`).toBeNull();
     });
 
     it('Only clicking the edit icon displays the edit input field', () => {
-        executeInAllStories(component, [childStories[2], childStories[3]], () => {
+        executeInAllStories(component, [childStories[2]], () => {
             $(editableText).waitForDisplayed(true);
             $(editableText).click();
-            expect($(editableTextInput).isDisplayed()).toBe(false);
+            expect($(editableTextInput).isDisplayed())
+            .withContext(`text field should not be displayed`).toBe(false);
             $(editButton).click();
             $(editableTextInput).waitForDisplayed(constants.wait.short);
         });
     });
 
-    it('Text input field should have a save a clear button', () => {
-        executeInAllStories(component, [childStories[2], childStories[3]], () => {
-            $(editableText).waitForDisplayed(constants.wait.short);
-            $(editableText).click();
-            $(editButton).click();
-            expect($(editableTextInput).isDisplayed()).toBe(true);
-            expect($(saveEditButton).isDisplayed()).toBe(true);
-            expect($(clearEditButton).isDisplayed()).toBe(true);
-            $('body').click();
-        });
+    it('Text input field should have a save and close button', () => {
+        navigateToStory(component, childStories[2]);
+        $(editableText).waitForDisplayed(constants.wait.short);
+        $(editableText).click();
+        $(editButton).click();
+        expect($(editableTextInput).isDisplayed())
+        .withContext(`editable text field should displayed`).toBe(true);
+        expect($(saveEditButton).isDisplayed())
+        .withContext(`save edit button should be displayed`).toBe(true);
+        expect($(cancelButton).isDisplayed())
+        .withContext(`cancel button should be displayed`).toBe(true);
+        $('body').click();
     });
 
-    it('Clicking the clear button clears the text input', () => {
-        executeInAllStories(component, [childStories[2], childStories[3]], () => {
-            $(editableText).waitForDisplayed(constants.wait.short);
-            const originalValue = $(editableText).getText();
-            $(editableText).click();
-            $(editButton).click();
-            $(editableTextInput).waitForDisplayed(constants.wait.short);
-            $(editableTextInput).setValue('test clear');
-            $(clearEditButton).click();
-            expect($(editableText).getText()).toEqual(originalValue);
-        });
+    it('Clicking the cancel button clears the text input', () => {
+        navigateToStory(component, childStories[2]);
+        $(editableText).waitForDisplayed(constants.wait.short);
+        const originalValue = $(editableText).getText();
+        $(editableText).click();
+        $(editButton).click();
+        $(editableTextInput).waitForDisplayed(constants.wait.short);
+        $(editableTextInput).setValue('test clear');
+        $(cancelButton).click();
+        expect($(editableText).getText())
+        .withContext(`text should not be changed on cancel`).toEqual(originalValue);
     });
 
     it('Clicking the save button saves the text input', () => {
-        executeInAllStories(component, [childStories[2], childStories[3]], () => {
-            $(editableText).waitForDisplayed(constants.wait.short);
-            const updatedText = 'test save';
-            $(editableText).click();
-            $(editButton).click();
-            $(editableTextInput).waitForDisplayed(constants.wait.short);
-            $(editableTextInput).setValue(updatedText);
-            $(saveEditButton).click();
-            expect($(editableText).getText()).toEqual(updatedText);
-        });
+        navigateToStory(component, childStories[2]);
+        $(editableText).waitForDisplayed(constants.wait.short);
+        const updatedText = 'test save';
+        $(editableText).click();
+        $(editButton).click();
+        $(editableTextInput).waitForDisplayed(constants.wait.short);
+        $(editableTextInput).setValue(updatedText);
+        $(saveEditButton).click();
+        expect($(editableText).getText())
+        .withContext(`text should have been updated`).toEqual(updatedText);
     });
 
     it('Clicking out of the editable input without saving does not save the text input', () => {
-        executeInAllStories(component, [childStories[2], childStories[3]], () => {
-            $(editableText).waitForDisplayed(constants.wait.short);
-            const originalText = $(editableText).getText();
-            $(editableText).click();
-            $(editButton).click();
-            $(editableTextInput).waitForDisplayed(constants.wait.short);
-            $(editableTextInput).setValue('test do not save input');
-            $('body').click();
-            expect($(editableText).getText()).toEqual(originalText);
-        });
+        navigateToStory(component, childStories[2]);
+        $(editableText).waitForDisplayed(constants.wait.short);
+        const originalText = $(editableText).getText();
+        $(editableText).click();
+        $(editButton).click();
+        $(editableTextInput).waitForDisplayed(constants.wait.short);
+        $(editableTextInput).setValue('test do not save input');
+        $('body').click();
+        expect($(editableText).getText())
+        .withContext(`text should not have been saved`).toEqual(originalText);
     });
 });

--- a/src/components/EntityIcon/EntityIcon.spec.js
+++ b/src/components/EntityIcon/EntityIcon.spec.js
@@ -1,9 +1,11 @@
-const { constants } = require('../../../e2e/constants');
 const { navigateToStory } = require('../../../e2e/utils/storybook');
 
-describe('Entity Icon Suite', () => {
+describe('Entity Icon -', () => {
     const component = 'Entity Icon';
     const childStory = 'Icons';
+    const iconStatusMsg = 'Icon status should be displayed';
+    const iconColorMsg = 'Icon hex color is incorrect';
+    const ariaError = 'incorrect aria label';
 
     const entityIcon = (entity,status,isLoading) => {
         return $(`[data-qa-icon="${entity}"][data-qa-entity-status="${status}"][data-qa-is-loading="${isLoading}"]`);
@@ -14,21 +16,56 @@ describe('Entity Icon Suite', () => {
     });
 
     it('Nodebalancer Icon displays with undefined status', () => {
-        expect(entityIcon('nodebalancer','undefined','false').isVisible()).toBe(true);
-        expect(entityIcon('nodebalancer','undefined','false').getCssProperty('color').parsed.hex).toBe('#e7e7e7');
+        expect(entityIcon('nodebalancer','undefined','false').isDisplayed())
+          .withContext(`${iconStatusMsg}`).toBe(true);
+        expect(entityIcon('nodebalancer','undefined','false').getCSSProperty('color').parsed.hex)
+          .withContext(`${iconColorMsg}`).toBe('#e7e7e7');
+        expect(entityIcon('nodebalancer','undefined','false').getAttribute('aria-label'))
+          .withContext(`${ariaError}`).toBe(`nodebalancer is undefined`)
     });
 
     it('Linode Icon displays with running status', () => {
-        expect(entityIcon('linode','running','false').isVisible()).toBe(true);
-        expect(entityIcon('linode','running','false').getCssProperty('color').parsed.hex).toBe('#00b159');
+        expect(entityIcon('linode','running','false').isDisplayed())
+          .withContext(`${iconStatusMsg} running`).toBe(true);
+        expect(entityIcon('linode','running','false').getCSSProperty('color').parsed.hex)
+          .withContext(`${iconColorMsg}`).toBe('#00b159');
+        expect(entityIcon('linode','running','false').getAttribute('aria-label'))
+          .withContext(`${ariaError}`).toBe('linode is running')
     });
 
     it('Linode Icon displays with offline status', () => {
-        expect(entityIcon('linode','offline','false').isVisible()).toBe(true);
-        expect(entityIcon('linode','offline','false').getCssProperty('color').parsed.hex).toBe('#ca0813');
+        expect(entityIcon('linode','offline','false').isDisplayed())
+          .withContext(`${iconStatusMsg}`).toBe(true);
+        expect(entityIcon('linode','offline','false').getCSSProperty('color').parsed.hex)
+          .withContext(`${iconColorMsg}`).toBe('#ca0813');
+        expect(entityIcon('linode','offline','false').getAttribute('aria-label'))
+          .withContext(`${ariaError}`).toBe(`linode is offline`)
     });
 
     it('Linode Icon displays with loading state', () => {
-        expect(entityIcon('linode','offline','true').isVisible()).toBe(true);
+        expect(entityIcon('linode','loading','true').isDisplayed())
+          .withContext(`${iconStatusMsg}`).toBe(true);
+        expect(entityIcon('linode','loading','true').getCSSProperty('color').parsed.hex)
+          .withContext(`${iconColorMsg}`).toBe('#000000');
+        expect(entityIcon('linode','loading','true').getAttribute('aria-label'))
+          .withContext(`${ariaError}`).toBe(`linode is loading`)
+    });
+
+    it('Domain Icon displays active status', () => {
+        expect(entityIcon('domain','active','false').isDisplayed())
+          .withContext(`Domain icon should be displayed`);
+        expect(entityIcon('domain','active','false').getCSSProperty('color').parsed.hex)
+          .withContext(`Domain icon hex color is incorrect`).toBe('#00b159');
+        expect(entityIcon('domain','active','false').getAttribute('aria-label'))
+          .withContext(`${ariaError}`).toBe(`domain is running`)
+    });
+
+    it('Domain Icon displays disabled status', () => {
+        expect(entityIcon('domain','disabled','false').isDisplayed())
+          .withContext(`Domain icon should be displayed`);
+        expect(entityIcon('domain','disabled','false').getCSSProperty('color').parsed.hex)
+          .withContext(`Domain icon hex color is incorrect`).toBe('#ca0813');
+        expect(entityIcon('domain','disabled','false').getAttribute('aria-label'))
+          .withContext(`${ariaError}`).toBe(`domain is offline`)
     });
 });

--- a/src/components/EntityIcon/EntityIcon.stories.tsx
+++ b/src/components/EntityIcon/EntityIcon.stories.tsx
@@ -14,7 +14,13 @@ storiesOf('Entity Icon', module).add('Icons', () => (
       <EntityIcon variant="linode" status="offline" />
     </div>
     <div>
-      <EntityIcon variant="linode" status="offline" loading />
+      <EntityIcon variant="linode" status="loading" loading />
+    </div>
+    <div>
+      <EntityIcon variant="domain" status="active" />
+    </div>
+    <div>
+      <EntityIcon variant="domain" status="disabled" />
     </div>
   </div>
 ));

--- a/src/components/ErrorState/ErrorState.spec.js
+++ b/src/components/ErrorState/ErrorState.spec.js
@@ -6,21 +6,29 @@ describe('Error State Component Suite', () => {
     const childStories = [
         'with text'
     ]
-    const icon = '[data-qa-error-icon]';
-    const errorMsg = '[data-qa-error-msg]';
+    const icon = '[data-qa-error-icon="true"]';
+    const errorMsg = '[data-qa-error-msg="true"]';
+    const fontValues = { property: 'font', value: 'normal normal 400 normal 16px / 22.4px latowebbold, sans-serif' }
 
     beforeAll(() => {
         navigateToStory(component, childStories[0]);
     });
 
     it('should display error state with text elements', () => {
-        browser.waitForVisible('[data-qa-error-icon]');
+        $(icon).waitForDisplayed();
 
         const errorIcon = $(icon);
         const errorText = $(errorMsg);
 
-        expect(errorIcon.getTagName()).toBe('svg');
-        expect(errorIcon.isVisible()).toBe(true);
-        expect(errorText.getText()).toBe('An error has occured.');
+        expect(errorIcon.getTagName())
+          .withContext(`Incorrect tag name`).toBe('svg');
+        expect(errorIcon.isDisplayed())
+          .withContext(`Error icon should have been displayed`).toBe(true);
+        expect(errorText.getText())
+          .withContext(`Incorrect error text`).toBe('An error has occurred.');
+        expect(errorText.getAttribute('style'))
+          .withContext(`Style should be centered`).toBe(`text-align: center;`);
+        expect(errorText.getCSSProperty('font'))
+          .withContext(`Incorrect font value(s)`).toEqual(fontValues);
     });
 });

--- a/src/components/ErrorState/ErrorState.stories.tsx
+++ b/src/components/ErrorState/ErrorState.stories.tsx
@@ -3,5 +3,5 @@ import * as React from 'react';
 import ErrorState from './ErrorState';
 
 storiesOf('Error Display', module).add('with text', () => (
-  <ErrorState errorText="An error has occured." />
+  <ErrorState errorText="An error has occurred." />
 ));

--- a/src/components/ExpansionPanel/ExpansionPanel.spec.js
+++ b/src/components/ExpansionPanel/ExpansionPanel.spec.js
@@ -1,152 +1,159 @@
 const { constants } = require('../../../e2e/constants');
-const { navigateToStory, executeInAllStories } = require('../../../e2e/utils/storybook');
+const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Expansion Panel Suite', () => {
-    const component = 'ExpansionPanel';
-    const childStories = [
-        'Interactive',
-        'Success!',
-        'Warning!',
-        'Error!',
-        'Asynchronous Content',
-    ];
+  const component = 'ExpansionPanel';
+  const childStories = [
+      'Interactive',
+      'Success!',
+      'Warning!',
+      'Error!',
+      'Asynchronous Content',
+  ];
 
-    const panel = '[data-qa-panel]';
-    const panelSubheading = '[data-qa-panel-subheading]';
-    const gridItem = '[data-qa-grid-item]';
-    const notice = '[data-qa-notice]';
-    let childElements;
+  const panel = '[data-qa-panel]';
+  const panelSubheading = '[data-qa-panel-subheading]';
+  const gridItem = '[data-qa-grid-item]';
+  const notice = '[data-qa-notice]';
+  let childElements;
 
-    function assertNotice() {
-        const noticeMsg = $(notice);
-        expect(noticeMsg.isVisible()).toBe(true);
-        expect(noticeMsg.getText()).toMatch(/([a-z])/ig);
-    }
+  function assertNotice(noticeTxt) {
+    const noticeMsg = $(notice);
+    expect(noticeMsg.isDisplayed())
+      .withContext(`notice message was not displayed`).toBe(true);
+    expect(noticeMsg.getText())
+      .withContext(`Incorrect text found`).toMatch(noticeTxt);
+  }
 
-    function expandAssertGridItem(opposite=false) {
-        browser.click('[data-qa-panel-summary]');
-        browser.waitForVisible(gridItem, 5000, opposite)
-    }
+  function expandAssertGridItem(opposite=false) {
+    $('[data-qa-panel-summary]').click();
+    $(gridItem).waitForDisplayed(5000, opposite)
+  }
 
-    function panelDisplays() {
-        browser.waitForVisible(panel, constants.wait.normal);
+  function panelDisplays(panelMsg) {
+    $(panel).waitForDisplayed(constants.wait.normal);
+    expect($(panelSubheading).getText())
+      .withContext(`Incorrect text found`).toEqual(panelMsg);
+    expect($(panel).isDisplayed())
+      .withContext(`Expansion panel should be displayed`).toBe(true)
+  }
 
-        const expansionPanel = $(panel);
-        const expansionPanelText = $(panelSubheading);
-        expect(expansionPanel.isVisible()).toBe(true);
-        expect(expansionPanelText.getText()).toMatch(/([a-z])/ig);
-    }
-
-    describe('Interactive Suite', () => {
-        beforeAll(() => {
-            navigateToStory(component, childStories[0]);
-            panelDisplays();
-        });
-
-        it('should expand and display message text', () => {
-            expandAssertGridItem();
-        });
-
-        it('should collapse on click', () => {
-            expandAssertGridItem(true);
-        });
+  describe('Interactive Suite', () => {
+    beforeEach(() => {
+      navigateToStory(component, childStories[0]);
+      panelDisplays('The best Linode department is?');
     });
 
-    describe('Success Suite', () => {
-        beforeAll(() => {
-            navigateToStory(component, childStories[1]);
-            panelDisplays();
-        });
-
-        it('should expand on click and display message text', () => {
-            expandAssertGridItem();
-        });
-
-        it('should display success notice message', () => {
-           assertNotice(); 
-        });
-
-        it('should display save and cancel buttons', () => {
-            const buttons = $$('button');
-            const visibleButtons = buttons.filter(b => b.isVisible() && !!b.getText());
-            expect(visibleButtons.length).toBe(2);
-        });
-
-        it('shoulds collapse on click', () => {
-            expandAssertGridItem(true);
-        });
+    it('should expand and display message text', () => {
+      expandAssertGridItem();
     });
 
-    describe('Warning Suite', () => {
-        beforeAll(() => {
-            navigateToStory(component, childStories[2]);
-            panelDisplays();
-        });
+    it('should collapse on click', () => {
+      expandAssertGridItem(true);
+    });
+  });
 
-        it('should expand on click and display message text', () => {
-            expandAssertGridItem();
-        });
-
-        it('should display warning notice message', () => {
-            assertNotice();
-        });
-
-        it('should display save and cancel buttons', () => {
-            const buttons = $$('button');
-            const visibleButtons = buttons.filter(b => b.isVisible() && !!b.getText());
-            expect(visibleButtons.length).toBe(2);
-        });
-
-        it('should collapse on click', () => {
-            expandAssertGridItem(true);
-        });
+  describe('Success Suite', () => {
+    beforeEach(() => {
+      navigateToStory(component, childStories[1]);
+      panelDisplays(`Why is Linode the best?`);
     });
 
-    describe('Error Suite', () => {
-        beforeAll(() => {
-            navigateToStory(component, childStories[3]);
-            panelDisplays();
-        });
-
-        it('should expand on click and display message text', () => {
-            expandAssertGridItem();
-        });
-
-        it('should display error notice message', () => {
-            assertNotice();
-        });
-
-        it('should display save and cancel buttons', () => {
-            const buttons = $$('button');
-            const visibleButtons = buttons.filter(b => b.isVisible() && !!b.getText());
-            expect(visibleButtons.length).toBe(2);
-        });
-
-        it('should collapse on click', () => {
-            expandAssertGridItem(true);
-        });
+    it('should expand on click and display message text', () => {
+      expandAssertGridItem();
     });
 
-    describe('Asynchronous Content Suite', () => {
-        beforeAll(() => {
-            navigateToStory(component, childStories[4]);
-            panelDisplays();
-        });
-
-        it('should expand on click and display loading text', () => {
-            const loadingMsg = 'Loading...';
-            expandAssertGridItem();
-            
-            browser.waitUntil(function() {
-                return browser.getText(gridItem).includes(loadingMsg);
-            }, constants.wait.normal);
-        });
-
-        it('should display message after loaded', () => {
-            const loadedMsg = 'Your patience has been rewarded';
-            browser.waitUntil(function() {
-                return browser.getText(gridItem).includes(loadedMsg);
-            }, constants.wait.normal);
-        });
+    it('should display success notice message', () => {
+      expandAssertGridItem();
+      assertNotice('You did it!');
     });
+
+    it('should display save and cancel buttons', () => {
+      expandAssertGridItem();
+      const buttons = $$('button');
+      const visibleButtons = buttons.filter(b => b.isDisplayed() && !!b.getText());
+      expect(visibleButtons.length).toBe(2);
+    });
+
+    it('should collapse on click', () => {
+      expandAssertGridItem(true);
+    });
+  });
+
+  describe('Warning Suite', () => {
+    beforeEach(() => {
+      navigateToStory(component, childStories[2]);
+      panelDisplays('This is a warning');
+    });
+
+    it('should expand on click and display message text', () => {
+      expandAssertGridItem();
+    });
+
+    it('should display warning notice message', () => {
+      expandAssertGridItem();
+      assertNotice('Careful now...');
+    });
+
+    it('should display save and cancel buttons', () => {
+      expandAssertGridItem();
+      const buttons = $$('button');
+      const visibleButtons = buttons.filter(b => b.isDisplayed() && !!b.getText());
+      expect(visibleButtons.length).toBe(2);
+    });
+
+    it('should collapse on click', () => {
+      expandAssertGridItem(true);
+    });
+  });
+
+  describe('Error Suite', () => {
+    beforeEach(() => {
+      navigateToStory(component, childStories[3]);
+      panelDisplays('Creating a new linode');
+    });
+
+    it('should expand on click and display message text', () => {
+      expandAssertGridItem();
+    });
+
+    it('should display error notice message', () => {
+      expandAssertGridItem();
+      assertNotice('Oh no! Something broke!');
+    });
+
+    it('should display save and cancel buttons', () => {
+      expandAssertGridItem();
+      const buttons = $$('button');
+      const visibleButtons = buttons.filter(b => b.isDisplayed() && !!b.getText());
+      expect(visibleButtons.length).toBe(2);
+    });
+
+    it('should collapse on click', () => {
+      expandAssertGridItem(true);
+    });
+  });
+
+  describe('Asynchronous Content Suite', () => {
+    beforeEach(() => {
+      navigateToStory(component, childStories[4]);
+      panelDisplays('Open to Reveal Asynchronously Loaded Content');
+    });
+
+    it('should expand on click and display loading text', () => {
+      const loadingMsg = 'Loading...';
+      expandAssertGridItem();
+      browser.waitUntil(function() {
+          return $(gridItem).getText().includes(loadingMsg);
+      }, constants.wait.normal);
+    });
+
+    it('should display message after loaded', () => {
+      expandAssertGridItem();
+      const loadedMsg = 'Your patience has been rewarded';
+      browser.waitUntil(function() {
+          return $(gridItem).getText().includes(loadedMsg);
+      }, constants.wait.normal);
+    });
+  });
 });

--- a/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
+++ b/src/components/ExpansionPanel/ExpansionPanel.stories.tsx
@@ -59,10 +59,7 @@ class AsyncContentExample extends React.Component {
 storiesOf('ExpansionPanel', module)
   .add('Interactive', () => (
     <div style={{ padding: 20, backgroundColor: '#f4f4f4' }}>
-      <ExpansionPanel heading="Why is Linode the best?">
-        <p>Customer service!</p>
-      </ExpansionPanel>
-      <ExpansionPanel heading="Why is Linode the best?">
+      <ExpansionPanel heading="The best Linode department is?">
         <p>Customer service!</p>
       </ExpansionPanel>
     </div>
@@ -76,27 +73,13 @@ storiesOf('ExpansionPanel', module)
       >
         <p>Customer service!</p>
       </ExpansionPanel>
-      <ExpansionPanel
-        success="You did it!"
-        heading="Why is Linode the best?"
-        actions={renderActions}
-      >
-        <p>Customer service!</p>
-      </ExpansionPanel>
     </div>
   ))
   .add('Warning!', () => (
     <div style={{ padding: 20, backgroundColor: '#f4f4f4' }}>
       <ExpansionPanel
         warning="Careful now..."
-        heading="Why is Linode the best?"
-        actions={renderActions}
-      >
-        <p>Customer service!</p>
-      </ExpansionPanel>
-      <ExpansionPanel
-        warning="Careful now..."
-        heading="Why is Linode the best?"
+        heading="This is a warning"
         actions={renderActions}
       >
         <p>Customer service!</p>
@@ -107,14 +90,7 @@ storiesOf('ExpansionPanel', module)
     <div style={{ padding: 20, backgroundColor: '#f4f4f4' }}>
       <ExpansionPanel
         error="Oh no! Something broke!"
-        heading="Why is Linode the best?"
-        actions={renderActions}
-      >
-        <p>Customer service!</p>
-      </ExpansionPanel>
-      <ExpansionPanel
-        error="Oh no! Something broke!"
-        heading="Why is Linode the best?"
+        heading="Creating a new linode"
         actions={renderActions}
       >
         <p>Customer service!</p>

--- a/src/components/HelpIcon/HelpIcon.spec.js
+++ b/src/components/HelpIcon/HelpIcon.spec.js
@@ -14,14 +14,14 @@ describe('Help Icon Component Suite', () => {
 
     it('should display icon on the page', () => {
         executeInAllStories(component, childStories, () => {
-            browser.waitForVisible(helpButton);
+            $(helpButton).waitForDisplayed();
         });
     });
 
     it('should display popover text on Mouse Over', () => {
         executeInAllStories(component, childStories, () => {
-            browser.waitForVisible(helpButton);
-            browser.moveToObject(helpButton);
+            $(helpButton).waitForDisplayed();
+            $(helpButton).click();
             expect($(helpButton).getAttribute('aria-describedby')).not.toBeNull();
             expect($(popoverText).getText()).toBe('There is some help text! Yada, yada, yada...');
         });
@@ -29,7 +29,7 @@ describe('Help Icon Component Suite', () => {
 
     it('should hide popover text on Mouse Out', () => {
         executeInAllStories(component, childStories, () => {
-            browser.waitForVisible(helpButton);
+            $(helpButton).waitForDisplayed();
             expect($(helpButton).getAttribute('aria-describedby')).toBeNull();
         });
     });

--- a/src/components/IconTextLink/IconTextLink.spec.js
+++ b/src/components/IconTextLink/IconTextLink.spec.js
@@ -13,23 +13,27 @@ describe('Icon Text Link Suite', () => {
     });
 
     it('should display IconLinkText Components', () => {
-        browser.waitForVisible(iconTextLinkTitle);
+        $(iconTextLinkTitle).waitForDisplayed();
 
         const iconTextLinks = $$(iconTextLinkTitle);
-        iconTextLinks.forEach(e => expect(e.isVisible()).toBe(true));
+        iconTextLinks.forEach(e => expect(e.isDisplayed())
+          .withContext(`Icon titles should be displayed`).toBe(true));
     });
 
     it('should display IconTextLink with link text', () => {
         const iconTextLinks = $$(iconTextLinkTitle);
 
-        iconTextLinks.forEach(e => expect(e.getTagName()).toBe('button'));
-        iconTextLinks.forEach(e => expect(e.getText()).toMatch(/([A-Z])/ig));
+        iconTextLinks.forEach(e => expect(e.getTagName())
+          .withContext(`Incorrect tag name`).toBe('button'));
+        iconTextLinks.forEach(e => expect(e.getText())
+          .withContext(`should be any text`).toMatch(/([A-Z])/ig));
     });
 
     it('should contain an svg icon', () => {
         const iconTextLinks = $$(iconTextLinkTitle);
         iconTextLinks.forEach(e => {
-            expect(e.$('svg').isVisible()).toBe(true);
+            expect(e.$('svg')
+              .withContext(`Icon image should be displayed`).isDisplayed()).toBe(true);
         });
     });
 
@@ -37,27 +41,30 @@ describe('Icon Text Link Suite', () => {
         const iconTextLinks = $$(iconTextLinkTitle);
         iconTextLinks[0].click();
 
-        const alertMsg = browser.alertText();
-        expect(alertMsg).toBe('thanks for clicking!');
+        const alertMsg = browser.getAlertText();
+        expect(alertMsg)
+          .withContext(`Incorrect alert message`).toBe('thanks for clicking!');
     });
 
     it('should dismiss alert on click', () => {
         let alertDisplays = true;
-        browser.alertDismiss();
+        browser.dismissAlert();
         try {
-            browser.alertText();
+            browser.getAlertText();
         } catch (err) {
             alertDisplays = false;
         }
-        expect(alertDisplays).toBe(false);
+        expect(alertDisplays)
+          .withContext(`Alert should be dismissed`).toBe(false);
     });
 
     it('should show a disabled IconTextLink', () => {
-        browser.waitForVisible(iconTextLinkTitle);
+        $(iconTextLinkTitle).waitForDisplayed();
 
         const iconTextLinks = $$(iconTextLinkTitle);
         const disabledLinks = iconTextLinks.map(e => e.getAttribute('class').includes('disabled'));
-        
-        expect(disabledLinks).toContain(true);
+
+        expect(disabledLinks)
+          .withContext(`Links should be disabled`).toContain(true);
     });
 });


### PR DESCRIPTION
## Description
Correct and upgrade breadcrumbs storybook test

## Type of Change
- Breaking change ('break', 'deprecate')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn storybook`

## Note to Reviewers

These updates were to make sure that the breadcrumb storybook tests were able to run again. Also added in some more validation and began using withContext() to add error messaging. You will need to use node v10 to run these tests. All the tests are not running and passing.