### PR TITLE
M3-3049 M3-3050 Fix: Refresh configs after rebuild; SSH Keys

### DIFF
--- a/src/components/AccessPanel/AccessPanel.tsx
+++ b/src/components/AccessPanel/AccessPanel.tsx
@@ -115,8 +115,6 @@ class AccessPanel extends React.Component<CombinedProps> {
       requestKeys
     } = this.props;
 
-    console.log(sshKeyError);
-
     return (
       <Paper
         className={classNames(

--- a/src/components/AccessPanel/AccessPanel.tsx
+++ b/src/components/AccessPanel/AccessPanel.tsx
@@ -63,6 +63,7 @@ const styled = withStyles(styles);
 interface Props {
   password: string | null;
   error?: string;
+  sshKeyError?: string;
   handleChange: (value: string) => void;
   heading?: string;
   label?: string;
@@ -98,6 +99,7 @@ class AccessPanel extends React.Component<CombinedProps> {
     const {
       classes,
       error,
+      sshKeyError,
       label,
       noPadding,
       required,
@@ -112,6 +114,8 @@ class AccessPanel extends React.Component<CombinedProps> {
       hideHelperText,
       requestKeys
     } = this.props;
+
+    console.log(sshKeyError);
 
     return (
       <Paper
@@ -142,6 +146,7 @@ class AccessPanel extends React.Component<CombinedProps> {
           {users && (
             <UserSSHKeyPanel
               users={users}
+              error={sshKeyError}
               onKeyAddSuccess={requestKeys || (() => null)}
             />
           )}

--- a/src/components/AccessPanel/UserSSHKeyPanel.tsx
+++ b/src/components/AccessPanel/UserSSHKeyPanel.tsx
@@ -166,7 +166,7 @@ const UserSSHKeyPanel: React.FunctionComponent<CombinedProps> = props => {
           )}
         </TableBody>
       </Table>
-      <Button buttonType="primary" onClick={handleOpenDrawer}>
+      <Button buttonType="secondary" onClick={handleOpenDrawer}>
         Add an SSH Key
       </Button>
       <SSHKeyCreationDrawer

--- a/src/components/AccessPanel/UserSSHKeyPanel.tsx
+++ b/src/components/AccessPanel/UserSSHKeyPanel.tsx
@@ -11,6 +11,7 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableHeader from 'src/components/TableHeader';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
+import TableRowError from 'src/components/TableRowError';
 import SSHKeyCreationDrawer from 'src/features/Profile/SSHKeys/SSHKeyCreationDrawer';
 
 export const MAX_SSH_KEYS_DISPLAY = 100;
@@ -64,6 +65,7 @@ export interface UserSSHKeyObject {
 
 interface Props {
   users?: UserSSHKeyObject[];
+  error?: string;
   onKeyAddSuccess: () => void;
 }
 
@@ -92,7 +94,7 @@ const UserSSHKeyPanel: React.FunctionComponent<CombinedProps> = props => {
    * In addition, there's never been any error handling for SSH keys, which maybe we should add.
    */
   const [success, setSuccess] = React.useState<boolean>(false);
-  const { classes, onKeyAddSuccess, users } = props;
+  const { classes, error, onKeyAddSuccess, users } = props;
 
   const handleKeyAddSuccess = () => {
     onKeyAddSuccess();
@@ -133,7 +135,9 @@ const UserSSHKeyPanel: React.FunctionComponent<CombinedProps> = props => {
           </TableRow>
         </TableHead>
         <TableBody>
-          {usersWithKeys.length > 0 ? (
+          {error ? (
+            <TableRowError colSpan={12} message={error} />
+          ) : usersWithKeys.length > 0 ? (
             usersWithKeys.map(
               ({ gravatarUrl, keys, onSSHKeyChange, selected, username }) => (
                 <TableRow

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromAppsContent.tsx
@@ -197,6 +197,7 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
       typeDisplayInfo,
       backupsMonthlyPrice,
       userSSHKeys,
+      sshError,
       requestKeys,
       userCannotCreateLinode,
       selectedImageID,
@@ -328,7 +329,14 @@ class FromAppsContent extends React.PureComponent<CombinedProps, State> {
                 : ''
             }
             error={hasErrorFor('root_pass')}
-            updateFor={[password, errors, userSSHKeys, selectedImageID]}
+            sshKeyError={sshError}
+            updateFor={[
+              password,
+              errors,
+              userSSHKeys,
+              selectedImageID,
+              sshError
+            ]}
             password={password}
             handleChange={updatePassword}
             users={userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.tsx
@@ -106,6 +106,7 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
       typeDisplayInfo,
       backupsMonthlyPrice,
       userSSHKeys,
+      sshError,
       requestKeys,
       userCannotCreateLinode,
       errors,
@@ -211,11 +212,13 @@ export class FromImageContent extends React.PureComponent<CombinedProps> {
                 : ''
             }
             error={hasErrorFor.root_pass}
+            sshKeyError={sshError}
             password={this.props.password}
             handleChange={this.props.updatePassword}
             updateFor={[
               this.props.password,
               errors,
+              sshError,
               userSSHKeys,
               this.props.selectedImageID
             ]}

--- a/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -188,6 +188,7 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
       password,
       imagesData,
       userSSHKeys,
+      sshError,
       userCannotCreateLinode: disabled,
       selectedStackScriptUsername,
       selectedStackScriptLabel,
@@ -312,7 +313,14 @@ export class FromStackScriptContent extends React.PureComponent<CombinedProps> {
                 : ''
             }
             error={hasErrorFor('root_pass')}
-            updateFor={[password, errors, userSSHKeys, selectedImageID]}
+            sshKeyError={sshError}
+            updateFor={[
+              password,
+              errors,
+              userSSHKeys,
+              selectedImageID,
+              sshError
+            ]}
             password={password}
             handleChange={updatePassword}
             users={userSSHKeys.length > 0 && selectedImageID ? userSSHKeys : []}

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -80,6 +80,7 @@ export const RebuildFromImage: React.StatelessComponent<
     imagesData,
     imagesError,
     userSSHKeys,
+    sshError,
     requestKeys,
     linodeId,
     enqueueSnackbar,
@@ -185,10 +186,12 @@ export const RebuildFromImage: React.StatelessComponent<
                 classes,
                 values.root_pass,
                 errors,
+                sshError,
                 userSSHKeys,
                 values.image
               ]}
               error={errors.root_pass}
+              sshKeyError={sshError}
               users={userSSHKeys}
               requestKeys={requestKeys}
               data-qa-access-panel

--- a/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -103,6 +103,7 @@ export const RebuildFromStackScript: React.StatelessComponent<
     classes,
     imagesData,
     userSSHKeys,
+    sshError,
     requestKeys,
     linodeId,
     enqueueSnackbar,
@@ -322,6 +323,7 @@ export const RebuildFromStackScript: React.StatelessComponent<
               updateFor={[values.root_pass, errors, userSSHKeys, ss.id]}
               error={errors.root_pass}
               users={userSSHKeys}
+              sshKeyError={sshError}
               requestKeys={requestKeys}
               data-qa-access-panel
             />

--- a/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
+++ b/src/features/linodes/LinodesDetail/LinodeSettings/ImageAndPassword.tsx
@@ -21,6 +21,7 @@ interface Props {
 
   userSSHKeys: UserSSHKeyObject[];
   requestKeys: () => void;
+  sshError?: string;
 }
 
 type CombinedProps = Props & ContextProps & WithImages;
@@ -38,6 +39,7 @@ export const ImageAndPassword: React.StatelessComponent<
     passwordError,
     requestKeys,
     userSSHKeys,
+    sshError,
     permissions
   } = props;
 
@@ -60,6 +62,7 @@ export const ImageAndPassword: React.StatelessComponent<
         error={passwordError}
         users={userSSHKeys}
         requestKeys={requestKeys}
+        sshKeyError={sshError}
         disabled={disabled}
         disabledReason={
           disabled

--- a/src/features/linodes/userSSHKeyHoc.ts
+++ b/src/features/linodes/userSSHKeyHoc.ts
@@ -11,10 +11,12 @@ import { getEmailHash } from 'src/utilities/gravatar';
 export interface UserSSHKeyProps {
   userSSHKeys: UserSSHKeyObject[];
   requestKeys: () => void;
+  sshError?: string;
 }
 
 export interface State {
   userSSHKeys: UserSSHKeyObject[];
+  sshError?: string;
   resetSSHKeys: () => void;
   requestKeys: () => void;
 }
@@ -69,8 +71,8 @@ export default (Component: React.ComponentType<any>) => {
               ]
             });
           })
-          .catch(error => {
-            return;
+          .catch(() => {
+            this.setState({ sshError: 'Unable to load SSH keys' });
           });
       } else {
         getUsers()
@@ -103,7 +105,10 @@ export default (Component: React.ComponentType<any>) => {
             });
           })
           .catch(() => {
-            /* We don't need to do anything here, we just don't add the keys. */
+            console.log('about to set error state');
+            this.setState({ sshError: 'Unable to load SSH keys' }, () =>
+              console.log(this.state)
+            );
           });
       }
     };

--- a/src/features/linodes/userSSHKeyHoc.ts
+++ b/src/features/linodes/userSSHKeyHoc.ts
@@ -105,10 +105,7 @@ export default (Component: React.ComponentType<any>) => {
             });
           })
           .catch(() => {
-            console.log('about to set error state');
-            this.setState({ sshError: 'Unable to load SSH keys' }, () =>
-              console.log(this.state)
-            );
+            this.setState({ sshError: 'Unable to load SSH keys' });
           });
       }
     };

--- a/src/features/linodes/userSSHKeyHoc.ts
+++ b/src/features/linodes/userSSHKeyHoc.ts
@@ -61,6 +61,7 @@ export default (Component: React.ComponentType<any>) => {
               return;
             }
             this.setState({
+              sshError: undefined,
               userSSHKeys: [
                 this.createUserObject(
                   username,
@@ -83,6 +84,7 @@ export default (Component: React.ComponentType<any>) => {
             }
 
             this.setState({
+              sshError: undefined,
               userSSHKeys: [
                 ...users.reduce((cleanedUsers, user) => {
                   const keys = user.ssh_keys;

--- a/src/store/linodes/linodes.events.ts
+++ b/src/store/linodes/linodes.events.ts
@@ -1,6 +1,7 @@
 import * as moment from 'moment';
 import { Dispatch } from 'redux';
 import { ApplicationState } from 'src/store';
+import { getAllLinodeConfigs } from 'src/store/linodes/config/config.requests';
 import { getAllLinodeDisks } from 'src/store/linodes/disk/disk.requests';
 import { requestLinodeForStore } from 'src/store/linodes/linode.requests';
 import { EventHandler } from 'src/store/types';
@@ -74,12 +75,14 @@ const handleLinodeRebuild = (
         // This is a safety hatch in case the 'finished'
         // event doesn't come through.
         dispatch(getAllLinodeDisks({ linodeId: id }));
+        dispatch(getAllLinodeConfigs({ linodeId: id }));
       }
       return dispatch(requestLinodeForStore(id));
     case 'finished':
     case 'failed':
       // Get the new disks and update the store.
       dispatch(getAllLinodeDisks({ linodeId: id }));
+      dispatch(getAllLinodeConfigs({ linodeId: id }));
       return dispatch(requestLinodeForStore(id));
     default:
       return;


### PR DESCRIPTION
## Description

Fixes two bugs:
- Rebuild a Linode, then try to edit the configuration profile (this was 404'ing; we fixed this for disks, but I forgot about configs. Config IDs change after a Linode is rebuilt, but our Redux store doesn't know this and attempts to access the (deleted) original configs.)
- Log in as a restricted user and try to add an SSH key (these were not displaying; I removed some code I thought was redundant in UserSSHKeyHoc.ts, but requests to both `/profile/ssh-keys` and `/account/users` are necessary to handle the case of a restricted user.)

Also changes the "Add SSH Key" to a secondary button rather than primary.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
