### PR TITLE
M3-3070 Fix: Events regressions and add handling for new event types 

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -241,4 +241,4 @@ export const MBpsInterDC = 1.5;
  * be calculated as "clickable" in menus, but for which
  * there is no sensible destination.
  */
-export const nonClickEvents = ['profile_update', 'ipaddress_update'];
+export const nonClickEvents = ['profile_update'];

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -235,3 +235,10 @@ export const MBpsIntraDC = 75;
  * MBps rate for intra DC migrations (AKA Cross-Datacenter migrations )
  */
 export const MBpsInterDC = 1.5;
+
+/**
+ * Events that have entities or otherwise would
+ * be calculated as "clickable" in menus, but for which
+ * there is no sensible destination.
+ */
+export const nonClickEvents = ['profile_update', 'ipaddress_update'];

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -339,7 +339,7 @@ export const renderTableBody = (
   error?: string,
   events?: Linode.Event[]
 ) => {
-  const filteredEvents = removeBlacklistedEvents(events);
+  const filteredEvents = removeBlacklistedEvents(events, ['profile_update']);
 
   if (loading) {
     return <TableRowLoading colSpan={12} data-qa-events-table-loading />;

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsList.tsx
@@ -35,15 +35,21 @@ export const UserEventsList: React.StatelessComponent<
           const success = event.status !== 'failed' && !event.seen;
           const error = event.status === 'failed';
 
-          const onClick = (e: any) => {
-            closeMenu(e);
-          };
-
           const linkPath = createLinkHandlerForNotification(
             event.action,
             event.entity,
             event._deleted
           );
+
+          /**
+           * Events without a link path either refer to a deleted
+           * entity or else don't have an entity/anywhere to point.
+           */
+          const onClick = linkPath
+            ? (e: any) => {
+                closeMenu(e);
+              }
+            : undefined;
 
           return title
             ? [...result, { title, content, success, error, onClick, linkPath }]

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsListItem.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsListItem.tsx
@@ -115,17 +115,26 @@ class UserEventsListItem extends React.Component<CombinedProps> {
         onClick={onClick}
         role="menuitem"
       >
-        <Link
-          to={linkPath ? linkPath : '/'}
-          href="javascript:void(0)"
-          onClick={onClick}
-          className={classes.linkItem}
-        >
-          <Typography variant="h3" className={classes.title}>
-            {title}
-          </Typography>
-          {content && <div className={classes.content}>{content}</div>}
-        </Link>
+        {onClick ? (
+          <Link
+            to={linkPath ? linkPath : '/'}
+            href="javascript:void(0)"
+            onClick={onClick}
+            className={classes.linkItem}
+          >
+            <Typography variant="h3" className={classes.title}>
+              {title}
+            </Typography>
+            {content && <div className={classes.content}>{content}</div>}
+          </Link>
+        ) : (
+          <div className={classes.linkItem}>
+            <Typography variant="h3" className={classes.title}>
+              {title}
+            </Typography>
+            {content && <div className={classes.content}>{content}</div>}
+          </div>
+        )}
       </ListItem>
     );
 

--- a/packages/manager/src/utilities/getEventsActionLink.ts
+++ b/packages/manager/src/utilities/getEventsActionLink.ts
@@ -15,6 +15,18 @@ export default (
   const id = path(['id'], entity);
   const label = path(['label'], entity);
 
+  if (['disk_delete', 'linode_config_delete'].includes(action)) {
+    /**
+     * Special cases that are handled here above the deletion logic;
+     * although these are deletion events, they refer to a Linode,
+     * which still exists; we can therefore provide a link target.
+     */
+    return (e: React.MouseEvent<HTMLElement>) => {
+      e.preventDefault();
+      onClick(`/linodes/${id}/advanced`);
+    };
+  }
+
   if (['user_ssh_key_add', 'user_ssh_key_delete'].includes(action)) {
     return (e: React.MouseEvent<HTMLElement>) => {
       e.preventDefault();

--- a/packages/manager/src/utilities/getEventsActionLink.ts
+++ b/packages/manager/src/utilities/getEventsActionLink.ts
@@ -1,4 +1,5 @@
 import { path } from 'ramda';
+import { nonClickEvents } from 'src/constants';
 import {
   EntityType,
   getEntityByIDFromStore
@@ -12,6 +13,7 @@ export default (
 ) => {
   const type = path(['type'], entity);
   const id = path(['id'], entity);
+  const label = path(['label'], entity);
 
   if (['user_ssh_key_add', 'user_ssh_key_delete'].includes(action)) {
     return (e: React.MouseEvent<HTMLElement>) => {
@@ -35,6 +37,14 @@ export default (
     return;
   }
 
+  /**
+   * Some events have entities etc. but we don't want them to
+   * link anywhere.
+   */
+  if (nonClickEvents.includes(action)) {
+    return;
+  }
+
   /** We require these bits of information to provide a link. */
   if (!type || !id) {
     return;
@@ -42,9 +52,13 @@ export default (
 
   switch (type) {
     case 'linode':
+      const link =
+        action === 'linode_addip'
+          ? `/linodes/${id}/networking`
+          : `/linodes/${id}`;
       return (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault();
-        onClick(`/linodes/${id}`);
+        onClick(link);
       };
 
     case 'ticket':
@@ -94,6 +108,12 @@ export default (
     case 'community_like':
       return () => {
         window.open(entity!.url, '_blank');
+      };
+
+    case 'user':
+      return (e: React.MouseEvent<HTMLElement>) => {
+        e.preventDefault();
+        onClick(`/account/users/${label}/profile`);
       };
 
     default:

--- a/packages/manager/src/utilities/getEventsActionLinkStrings.ts
+++ b/packages/manager/src/utilities/getEventsActionLinkStrings.ts
@@ -10,6 +10,15 @@ export default (
   const id = path(['id'], entity);
   const label = path(['label'], entity);
 
+  if (['disk_delete', 'linode_config_delete'].includes(action)) {
+    /**
+     * Special cases that are handled here above the deletion logic;
+     * although these are deletion events, they refer to a Linode,
+     * which still exists; we can therefore provide a link target.
+     */
+    return `/linodes/${id}/advanced`;
+  }
+
   if (['user_ssh_key_add', 'user_ssh_key_delete'].includes(action)) {
     return `/profile/keys`;
   }

--- a/packages/manager/src/utilities/getEventsActionLinkStrings.ts
+++ b/packages/manager/src/utilities/getEventsActionLinkStrings.ts
@@ -1,4 +1,5 @@
 import { path } from 'ramda';
+import { nonClickEvents } from 'src/constants';
 
 export default (
   action: Linode.EventAction,
@@ -7,6 +8,7 @@ export default (
 ) => {
   const type = path(['type'], entity);
   const id = path(['id'], entity);
+  const label = path(['label'], entity);
 
   if (['user_ssh_key_add', 'user_ssh_key_delete'].includes(action)) {
     return `/profile/keys`;
@@ -14,6 +16,18 @@ export default (
 
   if (['account_settings_update'].includes(action)) {
     return `/account/settings`;
+  }
+
+  if (action === 'linode_addip') {
+    return `/linodes/${id}/networking`;
+  }
+
+  /**
+   * Some events have entities etc. but we don't want them to
+   * link anywhere.
+   */
+  if (nonClickEvents.includes(action)) {
+    return;
   }
 
   /**
@@ -59,6 +73,9 @@ export default (
 
     case 'community_like':
       return entity!.url;
+
+    case 'user':
+      return `/account/users/${label}/profile`;
 
     default:
       return;


### PR DESCRIPTION
## Description

- Fixed regression where all events were clickable in the UserEventsMenu
- Fixed a previously unnoticed bug where events labeled something_delete
  (config_delete, disk_delete) were causing all of the events for the
  corresponding Linode to be unclickable, even if the Linode was still there

- Added click handlers for linode_addip, ipaddress_update, and user_update.

- Filtered profile_update events from the events landing page (request from Chris)

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Notes
As always this section of the app is a pain. There's a lot of duplication that's accumulated, opened a ticket to handle this (next TDT possibly).