### PR TITLE
M3-3014 Add: Show Linode tax ID on invoices for users in EU

### DIFF
--- a/packages/manager/e2e/pageobjects/account/invoice.page.js
+++ b/packages/manager/e2e/pageobjects/account/invoice.page.js
@@ -7,14 +7,14 @@ class Invoice extends Page {
     get invoiceID() { return $('[data-qa-invoice-id]'); }
     get invoiceTotal() { return $('[data-qa-total]'); }
     get landingInvoiceTotal() { return $('[data-qa-total]'); }
-    get descritionRows() { return $$('[data-qa-descrition]'); }
+    get descriptionRows() { return $$('[data-qa-description]'); }
     get fromRows() { return $$('data-qa-from'); }
     get toRows() { return $$('[data-qa-to]'); }
     get quantityRows() { return $$('[data-qa-quantity]'); }
     get unitPriceRows() { return $$('[data-qa-unit-price]'); }
     get amountRows() { return $$('[data-qa-amount]'); }
     get openPrintableInvoice() { return $('[data-qa-printable-invoice]'); }
-    //Prinatable page
+    //Printable page
     get linodeLogo() { return $('[data-qa-linode-logo]'); }
     get remitToHeader() { return $('[data-qa-remit-to]'); }
     get invoiceToHeader() { return $('[data-qa-invoice-to]'); }

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -226,6 +226,8 @@ export const EU_COUNTRIES = [
   'GB' // United Kingdom
 ];
 
+export const LINODE_EU_TAX_ID = 'EU372008859';
+
 /**
  * MBps rate for intra DC migrations (AKA Mutations)
  */

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -74,7 +74,7 @@ const RenderData: React.StatelessComponent<{
           {paginatedData.map(
             ({ label, from, to, quantity, unit_price, amount, tax, total }) => (
               <TableRow key={`${label}-${from}-${to}`}>
-                <TableCell parentColumn="Description" data-qa-descrition>
+                <TableCell parentColumn="Description" data-qa-description>
                   {label}
                 </TableCell>
                 <TableCell parentColumn="From" data-qa-from>

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -128,7 +128,7 @@ const addLeftHeader = (
   addLine('Philadelphia, PA 19106');
   addLine('USA');
   if (isInEU) {
-    addLine(`Tax ID: ${LINODE_EU_TAX_ID}`);
+    addLine(`Linode Tax ID: ${LINODE_EU_TAX_ID}`);
   }
 };
 

--- a/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
+++ b/packages/manager/src/features/Billing/PdfGenerator/PdfGenerator.ts
@@ -3,6 +3,7 @@ import { pathOr, splitEvery } from 'ramda';
 import formatDate from 'src/utilities/formatDate';
 import LinodeLogo from './LinodeLogo';
 
+import { EU_COUNTRIES, LINODE_EU_TAX_ID } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
 
 const leftMargin = 15; // space that needs to be applied to every parent element
@@ -91,7 +92,8 @@ const formatDescription = (desc?: string) => {
   }
 
   const [entityLabel, entityID] = descChunks[1].split(' ');
-  return `${descChunks[0]}\r\n${truncateLabel(entityLabel)}\r\n${entityID}`;
+  const cleanedType = descChunks[0].replace(/\(pending upgrade\)/, '');
+  return `${cleanedType}\r\n${truncateLabel(entityLabel)}\r\n${entityID}`;
 };
 
 const addLeftHeader = (
@@ -99,7 +101,8 @@ const addLeftHeader = (
   page: number,
   pages: number,
   date: string | null,
-  type: string
+  type: string,
+  isInEU: boolean
 ) => {
   const addLine = (text: string, fontSize = 9) => {
     doc.text(text, leftMargin, currentLine, { charSpace: 0.75 });
@@ -124,6 +127,9 @@ const addLeftHeader = (
   addLine('249 Arch St.');
   addLine('Philadelphia, PA 19106');
   addLine('USA');
+  if (isInEU) {
+    addLine(`Tax ID: ${LINODE_EU_TAX_ID}`);
+  }
 };
 
 const addRightHeader = (doc: jsPDF, account: Linode.Account) => {
@@ -347,7 +353,14 @@ export const printInvoice = (
     // Create a separate page for each set of invoice items
     itemsChunks.forEach((itemsChunk, index) => {
       doc.addImage(LinodeLogo, 'JPEG', 150, 5, 120, 50);
-      addLeftHeader(doc, index + 1, itemsChunks.length, date, 'Invoice');
+      addLeftHeader(
+        doc,
+        index + 1,
+        itemsChunks.length,
+        date,
+        'Invoice',
+        EU_COUNTRIES.includes(account.country)
+      );
       addRightHeader(doc, account);
 
       /** only show tax ID if there is one provided */
@@ -478,7 +491,14 @@ export const printPayment = (
     };
 
     doc.addImage(LinodeLogo, 'JPEG', 150, 5, 120, 50);
-    addLeftHeader(doc, 1, 1, date, 'Payment');
+    addLeftHeader(
+      doc,
+      1,
+      1,
+      date,
+      'Payment',
+      EU_COUNTRIES.includes(account.country)
+    );
     addRightHeader(doc, account);
     addTitle(doc, { text: `Receipt for Payment #${payment.id}` });
     addTable();


### PR DESCRIPTION
## Description

- View a bunch of invoice PDFs, moving your country setting in and out of the EU. This doesn't quite break the layout of the PDF, which is finicky so I left it as is. Let me know if we need to add additional space (conditionally) to account for this row.

- I also stripped "(pending upgrade)" from Linode type descriptions, as this was breaking the PDF layout.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

AFAICT no tests actually use the typo I fixed, but I can't actually run them atm so not 100% sure.
