### PR TITLE
LKE-691 Add: Node pool polling

### DIFF
--- a/packages/manager/src/containers/kubernetes.container.ts
+++ b/packages/manager/src/containers/kubernetes.container.ts
@@ -23,6 +23,7 @@ import {
 import {
   createNodePool as _createNodePool,
   deleteNodePool as _deleteNodePool,
+  requestNodePoolsForCluster as _requestNodePools,
   updateNodePool as _updateNodePool
 } from 'src/store/kubernetes/nodePools.requests';
 import { EntityError } from 'src/store/types';
@@ -37,6 +38,7 @@ export interface KubernetesProps {
 export interface DispatchProps {
   requestKubernetesClusters: () => void;
   requestClusterForStore: (clusterID: number) => void;
+  requestNodePools: (clusterID: number) => void;
   updateCluster: (
     params: UpdateClusterParams
   ) => Promise<Linode.KubernetesCluster>;
@@ -64,7 +66,9 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   deleteCluster: (params: DeleteClusterParams) =>
     dispatch(_deleteCluster(params)),
   setKubernetesErrors: (newErrors: EntityError) =>
-    dispatch(_setErrors(newErrors))
+    dispatch(_setErrors(newErrors)),
+  requestNodePools: (clusterID: number) =>
+    dispatch(_requestNodePools({ clusterID }))
 });
 
 export default <TInner extends {}, TOuter extends {}>(

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -78,7 +78,7 @@ export interface NodeStatus {
 }
 
 export const getNodeStatus = (linodes: Linode.PoolNodeResponse[]) => {
-  return produce({ ready: 0, not_ready: 0 }, draft => {
+  return produce<NodeStatus, NodeStatus>({ ready: 0, not_ready: 0 }, draft => {
     linodes.forEach(thisLinode => {
       draft[thisLinode.status]++;
     });

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -78,14 +78,11 @@ export interface NodeStatus {
 }
 
 export const getNodeStatus = (linodes: Linode.PoolNodeResponse[]) => {
-  return linodes.reduce(
-    (accum, thisLinode) => {
-      return produce(accum, draft => {
-        draft[thisLinode.status]++;
-      });
-    },
-    { ready: 0, not_ready: 0 }
-  );
+  return produce({ ready: 0, not_ready: 0 }, draft => {
+    linodes.forEach(thisLinode => {
+      draft[thisLinode.status]++;
+    });
+  });
 };
 
 export const getStatusString = (

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -195,7 +195,11 @@ export const KubernetesClusterDetail: React.FunctionComponent<
     Bluebird.map(pools, thisPool => {
       if (thisPool.queuedForAddition) {
         // This pool doesn't exist and needs to be added.
-        return props.createNodePool({ clusterID: cluster.id, ...thisPool });
+        return props.createNodePool({
+          clusterID: cluster.id,
+          count: thisPool.count,
+          type: thisPool.type
+        });
       } else if (thisPool.queuedForDeletion) {
         // Marked for deletion
         return props.deleteNodePool({

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -171,9 +171,18 @@ export const KubernetesClusterDetail: React.FunctionComponent<
     if (props.lastUpdated === 0) {
       props.requestKubernetesClusters();
     } else {
-      const clusterID = props.match.params.clusterID;
-      props.requestClusterForStore(+clusterID);
+      const clusterID = +props.match.params.clusterID;
+      props.requestClusterForStore(clusterID);
     }
+
+    const interval = setInterval(
+      () => props.requestNodePools(+props.match.params.clusterID),
+      10000
+    );
+
+    return () => {
+      clearInterval(interval);
+    };
   }, []);
 
   if (clustersLoadError) {

--- a/packages/manager/src/features/Kubernetes/types.ts
+++ b/packages/manager/src/features/Kubernetes/types.ts
@@ -9,6 +9,7 @@ export interface ExtendedPoolNode {
   count: number;
   type: string;
   clusterID?: number;
+  linodes?: Linode.PoolNodeResponse[];
 }
 export interface ExtendedCluster extends Linode.KubernetesCluster {
   node_pools: PoolNodeWithPrice[];


### PR DESCRIPTION
## Description

ClusterDetail page now includes a (X up, Y down) status notification similar to NodeBalancers. While on the details page, the /pools endpoint will be polled every 10 seconds to keep the status information up to date. 

## Type of Change
- Non breaking change ('update', 'change')

## Notes

There's an API bug that is throwing off the number of linodes in each node pool. And the status of all nodes is always "down" for now. Try to ignore all that! The logic should work