### PR TITLE
Add identify-user logic to App.tsx

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -198,6 +198,7 @@ interface State {
   menuOpen: boolean;
   welcomeBanner: boolean;
   hasError: boolean;
+  flagsLoaded: boolean;
 }
 
 type CombinedProps = Props &
@@ -214,7 +215,12 @@ export class App extends React.Component<CombinedProps, State> {
   state: State = {
     menuOpen: false,
     welcomeBanner: false,
-    hasError: false
+    hasError: false,
+    flagsLoaded: false
+  };
+
+  setFlagsLoaded = () => {
+    this.setState({ flagsLoaded: true });
   };
 
   maybeAddNotificationsToLinodes = (additionalCondition: boolean = true) => {
@@ -378,9 +384,10 @@ export class App extends React.Component<CombinedProps, State> {
           Skip to main content
         </a>
         {/** Update the LD client with the user's id as soon as we know it */}
-        <IdentifyUser userID={userId} />
+        <IdentifyUser userID={userId} setFlagsLoaded={this.setFlagsLoaded} />
         <DataLoadedListener
           markAppAsLoaded={this.props.markAppAsDoneLoading}
+          flagsHaveLoaded={this.state.flagsLoaded}
           linodesLoadingOrErrorExists={
             linodesLoading === false || !!linodesError
           }

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -25,7 +25,7 @@ import NotFound from 'src/components/NotFound';
 import SideMenu from 'src/components/SideMenu';
 /** @todo: Uncomment when we deploy with LD */
 // import VATBanner from 'src/components/VATBanner';
-// import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
+import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
 import { events$ } from 'src/events';
 import BackupDrawer from 'src/features/Backups';
 import DomainDrawer from 'src/features/Domains/DomainDrawer';
@@ -50,6 +50,8 @@ import ErrorState from 'src/components/ErrorState';
 import { handleLoadingDone } from 'src/store/initialLoad/initialLoad.actions';
 import { addNotificationsToLinodes } from 'src/store/linodes/linodes.actions';
 import { formatDate } from 'src/utilities/formatDate';
+
+import IdentifyUser from './IdentifyUser';
 
 shim(); // allows for .finally() usage
 
@@ -335,6 +337,7 @@ export class App extends React.Component<CombinedProps, State> {
       accountError,
       linodesLoading,
       domainsLoading,
+      userId,
       volumesLoading,
       bucketsLoading,
       nodeBalancersLoading
@@ -374,6 +377,8 @@ export class App extends React.Component<CombinedProps, State> {
         <a href="#main-content" className="visually-hidden">
           Skip to main content
         </a>
+        {/** Update the LD client with the user's id as soon as we know it */}
+        <IdentifyUser userID={userId} />
         <DataLoadedListener
           markAppAsLoaded={this.props.markAppAsDoneLoading}
           linodesLoadingOrErrorExists={
@@ -626,9 +631,8 @@ export default compose(
   connected,
   styled,
   withDocumentTitleProvider,
-  withSnackbar
-  /** @todo: Uncomment when we deploy with LD */
-  // withFeatureFlagProvider
+  withSnackbar,
+  withFeatureFlagProvider
 )(App);
 
 export const hasOauthError = (

--- a/packages/manager/src/IdentifyUser.tsx
+++ b/packages/manager/src/IdentifyUser.tsx
@@ -4,6 +4,7 @@ import { useLDClient } from 'src/containers/withFeatureFlagProvider.container';
 
 interface Props {
   userID?: number;
+  setFlagsLoaded: () => void;
 }
 
 /**
@@ -14,13 +15,21 @@ interface Props {
  */
 
 export const IdentifyUser: React.FC<Props> = props => {
-  const { userID } = props;
+  const { setFlagsLoaded, userID } = props;
   const client = useLDClient();
   React.useEffect(() => {
     if (client && userID) {
-      client.identify({
-        key: md5(String(userID))
-      });
+      client
+        .identify({
+          key: md5(String(userID))
+        })
+        .then(() => setFlagsLoaded())
+        /**
+         * We could handle this in other ways, but for now don't let a
+         * LD bung-up block the app from loading.
+         */
+
+        .catch(() => setFlagsLoaded());
     }
   }, [client, userID]);
 

--- a/packages/manager/src/IdentifyUser.tsx
+++ b/packages/manager/src/IdentifyUser.tsx
@@ -1,0 +1,30 @@
+import * as md5 from 'md5';
+import * as React from 'react';
+import { useLDClient } from 'src/containers/withFeatureFlagProvider.container';
+
+interface Props {
+  userID?: number;
+}
+
+/**
+ * This has to be a FC rather than just a function
+ * to use the useLDClient hook. We could pass in
+ * the client as a prop, but the parents are class components
+ * and this is a good side-effect usage of useEffect().
+ */
+
+export const IdentifyUser: React.FC<Props> = props => {
+  const { userID } = props;
+  const client = useLDClient();
+  React.useEffect(() => {
+    if (client && userID) {
+      client.identify({
+        key: md5(String(userID))
+      });
+    }
+  }, [client, userID]);
+
+  return null;
+};
+
+export default IdentifyUser;

--- a/packages/manager/src/components/DataLoadedListener.tsx
+++ b/packages/manager/src/components/DataLoadedListener.tsx
@@ -17,6 +17,7 @@ interface Props {
   domainsLoadingOrErrorExists: boolean;
   markAppAsLoaded: () => void;
   appIsLoaded: boolean;
+  flagsHaveLoaded: boolean;
 }
 
 const DataLoadedListener: React.FC<Props> = props => {
@@ -29,7 +30,8 @@ const DataLoadedListener: React.FC<Props> = props => {
         props.volumesLoadingOrErrorExists,
         props.nodeBalancersLoadingOrErrorExists,
         props.bucketsLoadingOrErrorExists,
-        props.domainsLoadingOrErrorExists
+        props.domainsLoadingOrErrorExists,
+        props.flagsHaveLoaded
       ) &&
       !props.appIsLoaded
     ) {
@@ -49,9 +51,15 @@ const shouldMarkAppAsDone = (
   volumesLoadingOrErrorExists: boolean,
   nodeBalancersLoadingOrErrorExists: boolean,
   bucketsLoadingOrErrorExists: boolean,
-  domainsLoadingOrErrorExists: boolean
+  domainsLoadingOrErrorExists: boolean,
+  flagsHaveLoaded: boolean
 ): boolean => {
   const pathname = window.location.pathname;
+
+  if (!flagsHaveLoaded) {
+    // We're still waiting for feature flags. Don't load the app.
+    return false;
+  }
 
   /**
    * if we're not on a route that we recognize,

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -26,9 +26,7 @@ export const ALGOLIA_APPLICATION_ID =
 export const ALGOLIA_SEARCH_KEY =
   process.env.REACT_APP_ALGOLIA_SEARCH_KEY || '';
 export const LAUNCH_DARKLY_API_KEY =
-  (isProduction
-    ? process.env.REACT_APP_LAUNCH_DARKLY_ID_PRODUCTION
-    : process.env.REACT_APP_LAUNCH_DARKLY_ID_DEV) || '';
+  process.env.REACT_APP_LAUNCH_DARKLY_ID || '';
 
 /** optional variables */
 export const SENTRY_URL = process.env.REACT_APP_SENTRY_URL;

--- a/packages/manager/src/containers/withFeatureFlagProvider.container.ts
+++ b/packages/manager/src/containers/withFeatureFlagProvider.container.ts
@@ -1,7 +1,16 @@
-import { withLDProvider } from 'launchdarkly-react-client-sdk';
+import { useLDClient, withLDProvider } from 'launchdarkly-react-client-sdk';
 
 import { LAUNCH_DARKLY_API_KEY } from 'src/constants';
 
+export { useLDClient };
+
 export default withLDProvider({
-  clientSideID: LAUNCH_DARKLY_API_KEY
+  clientSideID: LAUNCH_DARKLY_API_KEY,
+  /**
+   * Initialize the app with an anonymous user.
+   */
+  user: {
+    key: 'anonymous',
+    anonymous: true
+  }
 });


### PR DESCRIPTION
## Description

I think it works this time! h/t to @martinmckenna for the splash screen (which I know may or may not be included in this release; it really should be since it ties this together).

To test:
- Set up a conditional use of a flag anywhere in the app:
  - `import useFlags from 'src/hooks/useFlags'`
  - `const flags = useFlags();`
  - `if (flags.demo) { renderFeature(): }`

I used the maintenance banner in Dashboard.tsx, since it's rendered on app load. `flags.demo` is `true` for anonymous users (before we have /profile data), and `false` for all other users.

You should never see the banner (or feature you've flagged).

## Type of Change
- Non breaking change ('update', 'change')