### PR TITLE
Add: Ability to Create Default Gmail MX Records

### DIFF
--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -16,8 +16,8 @@ const styles = (theme: Theme) =>
     root: {
       paddingTop: theme.spacing(2),
       paddingBottom: theme.spacing(1),
-      '& > button': {
-        marginBottom: theme.spacing(1)
+      '& > *': {
+        marginTop: theme.spacing(1)
       },
       '& > :first-child': {
         marginRight: theme.spacing(1)

--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -17,7 +17,7 @@ type ClassNames =
   | 'destructive'
   | 'compact'
   | 'superCompact'
-  | 'hidden'
+  | 'loadingWithText'
   | 'reg';
 
 export interface Props extends ButtonProps {
@@ -29,6 +29,7 @@ export interface Props extends ButtonProps {
   compact?: boolean;
   deleteText?: string;
   superCompact?: boolean;
+  loadingText?: string;
 }
 
 const styles = (theme: Theme) =>
@@ -42,6 +43,9 @@ const styles = (theme: Theme) =>
       }
     },
     root: {
+      minWidth: '105px',
+      paddingLeft: theme.spacing(3) + 4,
+      paddingRight: theme.spacing(3) + 4,
       '&.cancel': {
         border: `1px solid transparent`,
         transition: theme.transitions.create(['color', 'border-color']),
@@ -75,6 +79,14 @@ const styles = (theme: Theme) =>
         animation: '$rotate 2s linear infinite'
       }
     },
+    loadingWithText: {
+      '& svg': {
+        margin: '0 auto',
+        width: theme.spacing(1) + 8,
+        height: theme.spacing(1) + 8,
+        animation: '$rotate 2s linear infinite'
+      }
+    },
     destructive: {
       borderColor: '#C44742',
       color: '#C44742',
@@ -105,16 +117,14 @@ const styles = (theme: Theme) =>
     },
     compact: {
       paddingLeft: theme.spacing(2) - 2,
-      paddingRight: theme.spacing(2) - 2
+      paddingRight: theme.spacing(2) - 2,
+      minWidth: '75px'
     },
     superCompact: {
       paddingLeft: 0,
       paddingRight: 0,
       paddingTop: theme.spacing(1),
       paddingBottom: theme.spacing(1)
-    },
-    hidden: {
-      visibility: 'hidden'
     },
     reg: {
       display: 'flex',
@@ -150,6 +160,7 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
     destructive,
     deleteText,
     tooltipText,
+    loadingText,
     buttonType,
     compact,
     superCompact,
@@ -168,7 +179,8 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
           buttonType,
           {
             [classes.root]: true,
-            [classes.loading]: loading,
+            [classes.loading]: loading && !loadingText,
+            [classes.loadingWithText]: loading && !!loadingText,
             loading,
             [classes.destructive]: destructive,
             [classes.compact]: compact,
@@ -178,14 +190,29 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
           className
         )}
       >
-        {loading && <Reload />}
         <span
           className={classNames({
-            [classes.hidden]: loading,
-            [classes.reg]: !loading
+            [classes.reg]: true
           })}
         >
-          {props.children}
+          {loading ? (
+            loadingText && !compact ? (
+              <React.Fragment>
+                <span
+                  style={{
+                    marginRight: '8px'
+                  }}
+                >
+                  {loadingText}
+                </span>
+                <Reload />
+              </React.Fragment>
+            ) : (
+              <Reload />
+            )
+          ) : (
+            props.children
+          )}
         </span>
         {buttonType === 'remove' && (deleteText ? deleteText : 'Remove')}
       </Button>

--- a/packages/manager/src/components/CheckBox/CheckBox.tsx
+++ b/packages/manager/src/components/CheckBox/CheckBox.tsx
@@ -10,6 +10,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import HelpIcon from 'src/components/HelpIcon';
 
 type CSSClasses = 'root' | 'checked' | 'disabled' | 'warning' | 'error';
@@ -71,13 +72,14 @@ const styles = (theme: Theme) =>
 interface Props extends CheckboxProps {
   variant?: 'warning' | 'error';
   text?: string | JSX.Element;
+  subtext?: string | JSX.Element;
   toolTipText?: string;
 }
 
 type FinalProps = Props & WithStyles<CSSClasses>;
 
 const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
-  const { toolTipText, text, classes, ...rest } = props;
+  const { toolTipText, text, subtext, className, classes, ...rest } = props;
 
   const classnames = classNames({
     [classes.root]: true,
@@ -91,6 +93,7 @@ const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
     return (
       <React.Fragment>
         <FormControlLabel
+          className={className}
           control={
             <Checkbox
               color="primary"
@@ -104,6 +107,7 @@ const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
           label={props.text}
         />
         {toolTipText && <HelpIcon text={toolTipText} />}
+        {subtext && <Typography>{subtext}</Typography>}
       </React.Fragment>
     );
   }

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -243,3 +243,11 @@ export const sendRevokeAccessKeyEvent = () => {
     action: 'Revoke Access Key'
   });
 };
+
+export const createDomainEvent = (action: string, label?: string) => {
+  sendEvent({
+    category: 'Create Domain',
+    action,
+    label
+  });
+};


### PR DESCRIPTION
## Description

Lets the user automatically create Gmail MX records at the time of domain creation.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## To Test

Please throw some monkey wrenches into this workflow. Add some `Promise.rejects` to the `Promise.all` arrays and see if anything seems off.

Test the GA events are working correctly.

![Screen Shot 2019-07-03 at 4 57 35 PM](https://user-images.githubusercontent.com/7387001/60624612-bb625000-9db3-11e9-8442-1be8e6ac8587.png)
