### PR TITLE
LKE-692 Change: update success message when editing node pools

### DIFF
--- a/packages/manager/src/containers/kubernetes.container.ts
+++ b/packages/manager/src/containers/kubernetes.container.ts
@@ -33,6 +33,7 @@ export interface KubernetesProps {
   clustersLoading: boolean;
   clustersError: EntityError;
   lastUpdated?: number;
+  nodePoolsLoading?: boolean;
 }
 
 export interface DispatchProps {

--- a/packages/manager/src/containers/kubernetes.container.ts
+++ b/packages/manager/src/containers/kubernetes.container.ts
@@ -94,7 +94,9 @@ export default <TInner extends {}, TOuter extends {}>(
       const clustersLoading = state.__resources.kubernetes.loading;
       const clustersError = state.__resources.kubernetes.error || {};
       const lastUpdated = state.__resources.kubernetes.lastUpdated;
-      const nodePoolsLoading = state.__resources.nodePools.loading;
+      const nodePoolsLoading =
+        state.__resources.nodePools.loading &&
+        state.__resources.nodePools.lastUpdated === 0;
 
       return mapKubernetesToProps(
         ownProps,

--- a/packages/manager/src/containers/kubernetes.container.ts
+++ b/packages/manager/src/containers/kubernetes.container.ts
@@ -77,7 +77,8 @@ export default <TInner extends {}, TOuter extends {}>(
     clustersLoading: boolean,
     lastUpdated: number,
     clustersError: EntityError,
-    clusters: Linode.KubernetesCluster[]
+    clusters: Linode.KubernetesCluster[],
+    nodePoolsLoading: boolean
   ) => TInner
 ) =>
   connect(
@@ -93,13 +94,15 @@ export default <TInner extends {}, TOuter extends {}>(
       const clustersLoading = state.__resources.kubernetes.loading;
       const clustersError = state.__resources.kubernetes.error || {};
       const lastUpdated = state.__resources.kubernetes.lastUpdated;
+      const nodePoolsLoading = state.__resources.nodePools.loading;
 
       return mapKubernetesToProps(
         ownProps,
         clustersLoading,
         lastUpdated,
         clustersError,
-        clusters
+        clusters,
+        nodePoolsLoading
       );
     },
     mapDispatchToProps

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.test.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.test.tsx
@@ -11,6 +11,7 @@ const props = {
   types: extendedTypes,
   pools: nodePoolRequests,
   editable: true,
+  loading: false,
   handleDelete: jest.fn(),
   handleChange: jest.fn(),
   updatePool: jest.fn()

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.tsx
@@ -13,6 +13,7 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
+import TableRowLoading from 'src/components/TableRowLoading';
 import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
 import { PoolNodeWithPrice } from '.././types';
 import NodePoolRow from './NodePoolRow';
@@ -39,6 +40,7 @@ const styles = (theme: Theme) =>
 interface Props {
   pools: PoolNodeWithPrice[];
   types: ExtendedType[];
+  loading: boolean;
   handleDelete?: (poolIdx: number) => void;
   updatePool?: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
   small?: boolean;
@@ -54,6 +56,7 @@ export const NodePoolDisplayTable: React.FunctionComponent<
     classes,
     editable,
     handleDelete,
+    loading,
     pools,
     small,
     types,
@@ -76,7 +79,9 @@ export const NodePoolDisplayTable: React.FunctionComponent<
         </TableRow>
       </TableHead>
       <TableBody>
-        {pools.length === 0 ? (
+        {loading ? (
+          <TableRowLoading colSpan={12} />
+        ) : pools.length === 0 ? (
           <TableRowEmptyState
             colSpan={12}
             message={"You haven't added any node pools yet."}

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -191,6 +191,7 @@ const Panel: React.FunctionComponent<CombinedProps> = props => {
           <NodePoolDisplayTable
             small
             editable
+            loading={false} // When creating we never need to load node pools from the API
             pools={pools || []}
             types={types}
             handleDelete={(poolIdx: number) => deleteNodePool!(poolIdx)}

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -117,6 +117,7 @@ interface KubernetesContainerProps {
   clustersLoadError?: Linode.ApiFieldError[];
   clusterDeleteError?: Linode.ApiFieldError[];
   lastUpdated: number;
+  nodePoolsLoading: boolean;
 }
 
 type CombinedProps = WithTypesProps &
@@ -136,6 +137,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
     clustersLoading,
     lastUpdated,
     location,
+    nodePoolsLoading,
     typesData,
     typesError,
     typesLoading
@@ -445,6 +447,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
               pools={cluster.node_pools}
               poolsForEdit={pools}
               types={typesData || []}
+              loading={nodePoolsLoading}
             />
           </Grid>
           <Grid item xs={12}>
@@ -496,18 +499,29 @@ const styled = withStyles(styles);
 const withCluster = KubeContainer<
   {},
   WithTypesProps & RouteComponentProps<{ clusterID: string }>
->((ownProps, clustersLoading, lastUpdated, clustersError, clustersData) => {
-  const cluster =
-    clustersData.find(c => +c.id === +ownProps.match.params.clusterID) || null;
-  return {
-    ...ownProps,
-    cluster,
-    lastUpdated,
+>(
+  (
+    ownProps,
     clustersLoading,
-    clustersLoadError: clustersError.read,
-    clusterDeleteError: clustersError.delete
-  };
-});
+    lastUpdated,
+    clustersError,
+    clustersData,
+    nodePoolsLoading
+  ) => {
+    const cluster =
+      clustersData.find(c => +c.id === +ownProps.match.params.clusterID) ||
+      null;
+    return {
+      ...ownProps,
+      cluster,
+      lastUpdated,
+      clustersLoading,
+      clustersLoadError: clustersError.read,
+      clusterDeleteError: clustersError.delete,
+      nodePoolsLoading
+    };
+  }
+);
 
 const enhanced = compose<CombinedProps, {}>(
   styled,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -518,7 +518,7 @@ const withCluster = KubeContainer<
       clustersLoading,
       clustersLoadError: clustersError.read,
       clusterDeleteError: clustersError.delete,
-      nodePoolsLoading
+      nodePoolsLoading: nodePoolsLoading && lastUpdated === 0
     };
   }
 );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -364,6 +364,8 @@ export const KubernetesClusterDetail: React.FunctionComponent<
     return cluster.label;
   };
 
+  console.log(nodePoolsLoading);
+
   return (
     <React.Fragment>
       <DocumentTitleSegment segment={`Kubernetes Cluster ${'label'}`} />
@@ -518,7 +520,7 @@ const withCluster = KubeContainer<
       clustersLoading,
       clustersLoadError: clustersError.read,
       clusterDeleteError: clustersError.delete,
-      nodePoolsLoading: nodePoolsLoading && lastUpdated === 0
+      nodePoolsLoading
     };
   }
 );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -191,7 +191,11 @@ export const KubernetesClusterDetail: React.FunctionComponent<
     return <ErrorState errorText="Unable to load cluster data." />;
   }
 
-  if ((clustersLoading && lastUpdated !== 0) || typesLoading) {
+  if (
+    (clustersLoading && lastUpdated !== 0) ||
+    nodePoolsLoading ||
+    typesLoading
+  ) {
     return <CircleProgress />;
   }
   if (cluster === null) {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -364,8 +364,6 @@ export const KubernetesClusterDetail: React.FunctionComponent<
     return cluster.label;
   };
 
-  console.log(nodePoolsLoading);
-
   return (
     <React.Fragment>
       <DocumentTitleSegment segment={`Kubernetes Cluster ${'label'}`} />

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -61,6 +61,14 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
+const successMsg = (
+  <Typography variant="body1">
+    Your node pools are being updated. You can run{' '}
+    <code>kubectl get nodes -o wide</code> to check the current status of your
+    cluster's nodes.
+  </Typography>
+);
+
 export const NodePoolsDisplay: React.FunctionComponent<
   CombinedProps
 > = props => {
@@ -103,7 +111,7 @@ export const NodePoolsDisplay: React.FunctionComponent<
         </Grid>
         {submissionSuccess && (
           <Grid item xs={12}>
-            <Notice success text="Your node pools are being updated." />
+            <Notice success text={successMsg} />
           </Grid>
         )}
         {submissionError && submissionError.length > 0 && (

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -51,6 +51,7 @@ interface Props {
   pools: PoolNodeWithPrice[];
   poolsForEdit: PoolNodeWithPrice[];
   types: ExtendedType[];
+  loading: boolean;
   toggleEditing: () => void;
   updatePool: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
   deletePool: (poolID: number) => void;
@@ -67,6 +68,7 @@ export const NodePoolsDisplay: React.FunctionComponent<
     classes,
     deletePool,
     editing,
+    loading,
     pools,
     poolsForEdit,
     resetForm,
@@ -113,13 +115,18 @@ export const NodePoolsDisplay: React.FunctionComponent<
           {editing ? (
             <NodePoolDisplayTable
               editable
+              loading={loading}
               pools={poolsForEdit}
               types={types}
               handleDelete={deletePool}
               updatePool={updatePool}
             />
           ) : (
-            <NodePoolDisplayTable pools={pools} types={types} />
+            <NodePoolDisplayTable
+              pools={pools}
+              types={types}
+              loading={loading}
+            />
           )}
         </Grid>
         <Grid item xs={12}>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 
 import Button from 'src/components/Button';
-import CopyTooltip from 'src/components/CopyTooltip';
+// import CopyTooltip from 'src/components/CopyTooltip';
 import Grid from 'src/components/core/Grid';
 import Paper from 'src/components/core/Paper';
 import {
@@ -75,7 +75,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const command = 'kubectl get nodes -o wide';
+// const command = 'kubectl get nodes -o wide';
 
 export const NodePoolsDisplay: React.FunctionComponent<
   CombinedProps
@@ -172,14 +172,14 @@ export const NodePoolsDisplay: React.FunctionComponent<
             </Button>
           </Grid>
         </Grid>
-        <Grid item className={classes.footer}>
+        {/* <Grid item className={classes.footer}>
           <Typography>
             You can run
             <code className={classes.code}>{command}</code>
             <CopyTooltip text={command} />
             for more detailed information about the nodes in your cluster.
           </Typography>
-        </Grid>
+        </Grid> */}
       </Grid>
     </Paper>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 
 import Button from 'src/components/Button';
+import CopyTooltip from 'src/components/CopyTooltip';
 import Grid from 'src/components/core/Grid';
 import Paper from 'src/components/core/Paper';
 import {
@@ -19,7 +20,14 @@ import NodePoolDisplayTable from '../../CreateCluster/NodePoolDisplayTable';
 import { getTotalClusterPrice } from '../../kubeUtils';
 import { PoolNodeWithPrice } from '../../types';
 
-type ClassNames = 'root' | 'button' | 'pricing' | 'ctaOuter' | 'displayTable';
+type ClassNames =
+  | 'root'
+  | 'button'
+  | 'pricing'
+  | 'ctaOuter'
+  | 'displayTable'
+  | 'code'
+  | 'footer';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
@@ -40,6 +48,12 @@ const styles = (theme: Theme) =>
     },
     displayTable: {
       width: '100%'
+    },
+    code: {
+      padding: theme.spacing(1)
+    },
+    footer: {
+      marginTop: theme.spacing(2)
     }
   });
 
@@ -61,13 +75,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const successMsg = (
-  <Typography variant="body1">
-    Your node pools are being updated. You can run{' '}
-    <code>kubectl get nodes -o wide</code> to check the current status of your
-    cluster's nodes.
-  </Typography>
-);
+const command = 'kubectl get nodes -o wide';
 
 export const NodePoolsDisplay: React.FunctionComponent<
   CombinedProps
@@ -111,7 +119,7 @@ export const NodePoolsDisplay: React.FunctionComponent<
         </Grid>
         {submissionSuccess && (
           <Grid item xs={12}>
-            <Notice success text={successMsg} />
+            <Notice success text={'Your node pools are being updated.'} />
           </Grid>
         )}
         {submissionError && submissionError.length > 0 && (
@@ -163,6 +171,14 @@ export const NodePoolsDisplay: React.FunctionComponent<
               Clear Changes
             </Button>
           </Grid>
+        </Grid>
+        <Grid item className={classes.footer}>
+          <Typography>
+            You can run
+            <code className={classes.code}>{command}</code>
+            <CopyTooltip text={command} />
+            for more detailed information about the nodes in your cluster.
+          </Typography>
         </Grid>
       </Grid>
     </Paper>

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -20,6 +20,8 @@ export const KubernetesLanding: React.FunctionComponent<
     clusters,
     clustersError,
     clustersLoading,
+    nodePoolsLoading,
+    lastUpdated,
     deleteCluster,
     requestKubernetesClusters,
     setKubernetesErrors
@@ -43,7 +45,7 @@ export const KubernetesLanding: React.FunctionComponent<
     );
   }
 
-  if (clustersLoading) {
+  if ((clustersLoading && lastUpdated === 0) || nodePoolsLoading) {
     return <CircleProgress />;
   }
 
@@ -62,11 +64,19 @@ export const KubernetesLanding: React.FunctionComponent<
 };
 
 const withKubernetes = KubernetesContainer(
-  (ownProps, clustersLoading, lastUpdated, clustersError, clusters) => ({
+  (
+    ownProps,
+    clustersLoading,
+    lastUpdated,
+    clustersError,
+    clusters,
+    nodePoolsLoading
+  ) => ({
     ...ownProps,
     clusters,
     clustersError,
-    clustersLoading
+    clustersLoading,
+    nodePoolsLoading
   })
 );
 

--- a/packages/manager/src/store/kubernetes/nodePools.reducer.ts
+++ b/packages/manager/src/store/kubernetes/nodePools.reducer.ts
@@ -33,8 +33,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
   return produce(state, draft => {
     if (isType(action, requestNodePoolsActions.done)) {
       const { result } = action.payload;
-
-      // If there's nothing to add, return the state unchanged.
+      // If this condition is false we don't have to update the state
       if (result.length !== 0) {
         /**
          * This action payload is the current node pools for a single

--- a/packages/manager/src/store/kubernetes/nodePools.reducer.ts
+++ b/packages/manager/src/store/kubernetes/nodePools.reducer.ts
@@ -1,3 +1,4 @@
+import produce from 'immer';
 import { Reducer } from 'redux';
 import { EntityError, EntityState } from 'src/store/types';
 import updateOrAdd from 'src/utilities/updateOrAdd';
@@ -56,55 +57,44 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     };
   }
 
+  if (isType(action, requestNodePoolsActions.started)) {
+    return produce(state, draft => {
+      draft.loading = true;
+    });
+  }
+
   if (isType(action, requestNodePoolsActions.failed)) {
     const { error } = action.payload;
 
-    return {
-      ...state,
-      loading: false,
-      error: {
-        ...state.error,
-        read: error
-      }
-    };
+    return produce(state, draft => {
+      (draft.loading = false), (draft.error!.read = error);
+    });
   }
 
   if (isType(action, createNodePoolActions.done)) {
     const { result } = action.payload;
 
-    return {
-      ...state,
-      entities: [...state.entities, result],
-      results: [...state.results, result.id],
-      error: {
-        ...state.error,
-        create: undefined
-      }
-    };
+    return produce(state, draft => {
+      draft.entities.push(result),
+        draft.results.push(result.id),
+        (draft.error!.create = undefined);
+    });
   }
 
   if (isType(action, createNodePoolActions.failed)) {
     const { error } = action.payload;
 
-    return {
-      ...state,
-      error: {
-        ...state.error,
-        create: error
-      }
-    };
+    return produce(state, draft => {
+      draft.error!.create = error;
+    });
   }
 
   if (isType(action, updateNodePoolActions.failed)) {
     const { error } = action.payload;
 
-    return {
-      ...state,
-      error: {
-        ...state.error,
-        update: error
-      }
-    };
+    return produce(state, draft => {
+      draft.error!.update = error;
+    });
   }
 
   if (isType(action, updateNodePoolActions.done)) {
@@ -112,11 +102,10 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
     const update = updateOrAdd(result, state.entities);
 
-    return {
-      ...state,
-      entities: update,
-      results: update.map(c => c.id)
-    };
+    return produce(state, draft => {
+      draft.entities = update;
+      draft.results = update.map(c => c.id);
+    });
   }
 
   if (isType(action, deleteNodePoolActions.done)) {
@@ -128,31 +117,25 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       thisPool => thisPool.id !== nodePoolID
     );
 
-    return {
-      ...state,
-      entities: updatedPools,
-      results: updatedPools.map(p => p.id)
-    };
+    return produce(state, draft => {
+      draft.entities = updatedPools;
+      draft.results = updatedPools.map(p => p.id);
+    });
   }
 
   if (isType(action, deleteNodePoolActions.failed)) {
     const { error } = action.payload;
 
-    return {
-      ...state,
-      error: {
-        ...state.error,
-        delete: error
-      }
-    };
+    return produce(state, draft => {
+      draft.error!.delete = error;
+    });
   }
 
   if (isType(action, setErrors)) {
     const error = action.payload;
-    return {
-      ...state,
-      error
-    };
+    return produce(state, draft => {
+      draft.error = error;
+    });
   }
   return state;
 };

--- a/packages/manager/src/store/kubernetes/nodePools.reducer.ts
+++ b/packages/manager/src/store/kubernetes/nodePools.reducer.ts
@@ -48,8 +48,9 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
 
         draft.entities = newPools;
         draft.results = newPools.map(p => p.id);
-        draft.loading = false;
       }
+      draft.loading = false;
+      draft.lastUpdated = Date.now();
     }
 
     if (isType(action, requestNodePoolsActions.started)) {
@@ -66,9 +67,9 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     if (isType(action, createNodePoolActions.done)) {
       const { result } = action.payload;
 
-      draft.entities.push(result),
-        draft.results.push(result.id),
-        (draft.error!.create = undefined);
+      draft.entities.push(result);
+      draft.results.push(result.id);
+      draft.error!.create = undefined;
     }
 
     if (isType(action, createNodePoolActions.failed)) {


### PR DESCRIPTION
## Description

- New success message (may or may not stick)
- Loading state for node pools panel (they were previously relying on the cluster loading, but node pools are now extra requests so the loading experience was bad).

## Type of Change
- Non breaking change ('update', 'change')

