### PR TITLE
[For Release] Add: event types

### DIFF
--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -207,6 +207,18 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     finished: e => `Linode ${e.entity!.label} has been migrated.`
   },
   // This event type isn't currently being displayed, but I added a message here just in case.
+  linode_migrate_datacenter_create: {
+    notification: e =>
+      `Migration for Linode ${e.entity!.label} has been initiated.`
+  },
+  // These are the same as the messages for `linode_migrate`.
+  linode_migrate_datacenter: {
+    scheduled: e => `Linode ${e.entity!.label} is scheduled for migration.`,
+    started: e => `Linode ${e.entity!.label} is being migrated.`,
+    failed: e => `Migration failed for Linode ${e.entity!.label}.`,
+    finished: e => `Linode ${e.entity!.label} has been migrated.`
+  },
+  // This event type isn't currently being displayed, but I added a message here just in case.
   linode_mutate_create: {
     notification: e =>
       `Upgrade for Linode ${e.entity!.label} has been initiated.`
@@ -376,6 +388,12 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   stackscript_revise: {
     notification: e => `StackScript ${e.entity!.label} has been revised.`
+  },
+  tag_create: {
+    notification: e => `Tag ${e.entity!.label} has been created.`
+  },
+  tag_delete: {
+    notification: e => `Tag ${e.entity!.label} has been deleted.`
   },
   tfa_disabled: {
     notification: e => `Two-factor authentication has been disabled.`

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -334,6 +334,18 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: e =>
       `A node on NodeBalancer ${e.entity!.label} has been updated.`
   },
+  oauth_client_create: {
+    notification: e => `OAuth App ${e.entity!.label} has been created.`
+  },
+  oauth_client_update: {
+    notification: e => `OAuth App ${e.entity!.label} has been updated.`
+  },
+  oauth_client_secret_reset: {
+    notification: e => `Secret for OAuth App ${e.entity!.label} has been reset.`
+  },
+  oauth_client_delete: {
+    notification: e => `OAuth App ${e.entity!.label} has been deleted.`
+  },
   password_reset: {
     scheduled: e => `A password reset is scheduled for ${e.entity!.label}.`,
     started: e => `The password for ${e.entity!.label} is being reset.`,
@@ -388,6 +400,16 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: e =>
       `File has been successfully uploaded to support ticket ${e.entity!.label}`
   },
+  token_create: {
+    notification: e => `Token ${e.entity!.label} has been created.`
+  },
+  token_update: {
+    notification: e => `Token ${e.entity!.label} has been updated.`
+  },
+  token_delete: {
+    notification: e => `Token ${e.entity!.label} has been revoked.`
+  },
+
   volume_attach: {
     // @todo Once we have better events, display the name of the attached Linode
     // in these messages.

--- a/packages/manager/src/features/linodes/transitions.ts
+++ b/packages/manager/src/features/linodes/transitions.ts
@@ -21,7 +21,8 @@ export const transitionAction = [
   'disk_imagize',
   'disk_duplicate',
   'linode_mutate',
-  'linode_clone'
+  'linode_clone',
+  'linode_migrate_datacenter'
 ];
 
 export const linodeInTransition = (
@@ -46,12 +47,18 @@ export const transitionText = (
 ): string => {
   // `linode_mutate` is a special case, because we want to display
   // "Upgrading" instead of "Mutate".
+
+  // @todo @tdt: use a map instead (event_type to display name)
   if (recentEvent && recentEvent.action === 'linode_mutate') {
     return 'Upgrading';
   }
 
   if (recentEvent && recentEvent.action === 'linode_clone') {
     return 'Cloning';
+  }
+
+  if (recentEvent && recentEvent.action === 'linode_migrate_datacenter') {
+    return 'Migrating';
   }
 
   let event;

--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -207,5 +207,7 @@ const eventsWithRelevantNotifications: Linode.EventAction[] = [
   'linode_resize_create',
   'linode_migrate',
   'linode_mutate',
-  'linode_mutate_create'
+  'linode_mutate_create',
+  'linode_migrate_datacenter_create',
+  'linode_migrate_datacenter'
 ];

--- a/packages/manager/src/types/index.ts
+++ b/packages/manager/src/types/index.ts
@@ -108,6 +108,8 @@ namespace Linode {
     | 'linode_reboot'
     | 'linode_resize'
     | 'linode_resize_create'
+    | 'linode_migrate_datacenter_create'
+    | 'linode_migrate_datacenter'
     | 'linode_mutate'
     | 'linode_mutate_create'
     | 'linode_rebuild'

--- a/packages/manager/src/utilities/eventUtils.ts
+++ b/packages/manager/src/utilities/eventUtils.ts
@@ -14,5 +14,6 @@ export const removeBlacklistedEvents = (
 // we want to display, because it will be updated via other events with the same ID.
 const blackListedEvents: Linode.EventAction[] = [
   'linode_mutate_create', // This event occurs when an upgrade is first initiated.
-  'linode_resize_create' // This event occurs when a resize is first initiated.
+  'linode_resize_create', // This event occurs when a resize is first initiated.
+  'linode_migrate_datacenter_create' // This event occurs when a cross DC migration is first initiated.
 ];


### PR DESCRIPTION
## Description

This PR adds messaging for the following events:

1. `token_create`
2. `token_update`
3. `token_delete`
4. `oauth_client_create`
5. `oauth_client_update`
6. `oauth_client_secret_reset`
7. `oauth_client_delete`
8. `tag_create`
9. `tag_delete`
10. `linode_migrate_datacenter_create`
11. `linode_migrate_datacenter`

Additional logic was also added to handle cross DC migration progress and status.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

### To test:

**USE STAGING**

1. Create/Rename/Revoke Personal Access Tokens
2. Create/Edit/Delete/Rest Secret for OAuth Apps
3. Create/Delete tags (must be done with API – can't do this in Cloud yet)
4. Initiate cross DC migration (must be done with API – can't do this in Cloud yet)
