### PR TITLE
LKE-728 Change: schema copy

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -374,9 +374,6 @@ export const KubernetesClusterDetail: React.FunctionComponent<
       >
         <Grid item xs={12} className={classes.titleWrapper}>
           <Breadcrumb
-            labelOptions={{
-              linkTo: `/kubernetes`
-            }}
             onEditHandlers={{
               editableTextTitle: cluster.label,
               onEdit: handleLabelChange,

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -364,7 +364,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
 
   return (
     <React.Fragment>
-      <DocumentTitleSegment segment={`Kubernetes Cluster ${'label'}`} />
+      <DocumentTitleSegment segment={`Kubernetes Cluster ${cluster.label}`} />
       <Grid
         container
         justify="space-between"
@@ -377,9 +377,8 @@ export const KubernetesClusterDetail: React.FunctionComponent<
             labelOptions={{
               linkTo: `/kubernetes`
             }}
-            labelTitle={cluster.label}
             onEditHandlers={{
-              editableTextTitle: 'any',
+              editableTextTitle: cluster.label,
               onEdit: handleLabelChange,
               onCancel: resetEditableLabel
             }}

--- a/packages/manager/src/services/kubernetes/kubernetes.schema.ts
+++ b/packages/manager/src/services/kubernetes/kubernetes.schema.ts
@@ -13,7 +13,7 @@ export const clusterLabelSchema = string()
    */
   .matches(
     /^[a-zA-Z0-9-]+$/,
-    'Cluster labels cannot contain special characters or underscores.'
+    'Cluster labels cannot contain special characters, spaces, or underscores.'
   )
   .min(3, 'Length must be between 3 and 32 characters.')
   .max(32, 'Length must be between 3 and 32 characters.');


### PR DESCRIPTION
## Description

Some feedback suggestions from @jnschaeffer :

- Fix error message in our kubernetes.schema label validation.
- Fix page title (was still hardcoded to 'label')
- Don't force uppercasing of cluster label in the breadcrumb view

## Type of Change
- Non breaking change ('update', 'change')
- Breaking change ('break', 'deprecate')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.
