### PR TITLE
Fix: Wrap SearchItem in RS <Option /> to fix arrow key scrolling

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/components/Option.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/Option.tsx
@@ -2,12 +2,13 @@ import * as React from 'react';
 import _Option, { OptionProps } from 'react-select/lib/components/Option';
 
 interface Props extends OptionProps<any> {
-  value: number;
+  value: number | string;
+  attrs?: Record<string, string>;
 }
 
 const Option: React.StatelessComponent<Props> = props => {
   return (
-    <div data-qa-option={String(props.value)}>
+    <div data-qa-option={String(props.value)} {...props.attrs}>
       <_Option {...props} />
     </div>
   );

--- a/packages/manager/src/features/Help/Panels/SearchItem.tsx
+++ b/packages/manager/src/features/Help/Panels/SearchItem.tsx
@@ -1,6 +1,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
-import { OptionProps } from 'react-select/lib/components/Option';
+import Option, { OptionProps } from 'react-select/lib/components/Option';
 import Arrow from 'src/assets/icons/diagonalArrow.svg';
 import Typography from 'src/components/core/Typography';
 
@@ -23,7 +23,6 @@ const SearchItem: React.StatelessComponent<Props> = props => {
 
   const {
     data,
-    innerProps,
     isFocused,
     selectProps: { classes }
   } = props;
@@ -31,13 +30,13 @@ const SearchItem: React.StatelessComponent<Props> = props => {
   const isFinal = source === 'finalLink';
 
   return (
-    <div
+    <Option
       className={classNames({
         [classes.algoliaRoot]: true,
         [classes.selectedMenuItem]: isFocused
       })}
       data-qa-search-result={source}
-      {...innerProps}
+      {...props}
     >
       {isFinal ? (
         <div className={classes.finalLink}>
@@ -55,7 +54,7 @@ const SearchItem: React.StatelessComponent<Props> = props => {
           <Typography className={classes.source}>{source}</Typography>
         </>
       )}
-    </div>
+    </Option>
   );
 };
 

--- a/packages/manager/src/features/Help/Panels/SearchItem.tsx
+++ b/packages/manager/src/features/Help/Panels/SearchItem.tsx
@@ -1,8 +1,9 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
-import Option, { OptionProps } from 'react-select/lib/components/Option';
+import { OptionProps } from 'react-select/lib/components/Option';
 import Arrow from 'src/assets/icons/diagonalArrow.svg';
 import Typography from 'src/components/core/Typography';
+import Option from 'src/components/EnhancedSelect/components/Option';
 
 interface Props extends OptionProps<any> {
   data: {
@@ -35,7 +36,8 @@ const SearchItem: React.StatelessComponent<Props> = props => {
         [classes.algoliaRoot]: true,
         [classes.selectedMenuItem]: isFocused
       })}
-      data-qa-search-result={source}
+      value={data.label}
+      attrs={{ ['data-qa-search-result']: source }}
       {...props}
     >
       {isFinal ? (


### PR DESCRIPTION
## Description

Algolia search bar (at `/support`) had broken scrolling functionality; the mouse wheel would work, but arrow keys didn't. This is a leftover to-do from moving from Downshift to RS.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')