### PR TITLE
M3-3032 Change: Require user to type label to confirm Linode deletion

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -8,6 +8,7 @@ import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import PanelErrorBoundary from 'src/components/PanelErrorBoundary';
+import TextField from 'src/components/TextField';
 import { resetEventsPolling } from 'src/events';
 import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
 import {
@@ -16,6 +17,23 @@ import {
 } from 'src/store/linodes/linode.containers';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+
+type ClassNames = 'root' | 'confirmationCopy';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {},
+    confirmationCopy: {
+      marginTop: theme.spacing(1)
+    }
+  });
+
 interface Props {
   linodeId: number;
   linodeLabel: string;
@@ -23,17 +41,20 @@ interface Props {
 
 interface State {
   open: boolean;
+  confirmationText: string;
   errors?: Linode.ApiFieldError[];
 }
 
 type CombinedProps = Props &
   ContextProps &
   LinodeActionsProps &
-  RouteComponentProps<{}>;
+  RouteComponentProps<{}> &
+  WithStyles<ClassNames>;
 
 class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
   state: State = {
-    open: false
+    open: false,
+    confirmationText: ''
   };
 
   deleteLinode = () => {
@@ -59,7 +80,7 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
   };
 
   closeDeleteDialog = () => {
-    this.setState({ open: false });
+    this.setState({ open: false, confirmationText: '' });
   };
 
   render() {
@@ -94,6 +115,16 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
             Are you sure you want to delete your Linode? This will result in
             permanent data loss.
           </Typography>
+          <Typography className={this.props.classes.confirmationCopy}>
+            To confirm deletion, type the name of the Linode (
+            {this.props.linodeLabel}) in the field below:
+          </Typography>
+          <TextField
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              this.setState({ confirmationText: e.target.value })
+            }
+            expand
+          />
         </ConfirmationDialog>
       </React.Fragment>
     );
@@ -109,6 +140,7 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
         Cancel
       </Button>
       <Button
+        disabled={this.state.confirmationText !== this.props.linodeLabel}
         buttonType="secondary"
         destructive
         onClick={this.deleteLinode}
@@ -134,7 +166,8 @@ const enhanced = compose<CombinedProps, Props>(
   errorBoundary,
   linodeContext,
   withRouter,
-  withLinodeActions
+  withLinodeActions,
+  withStyles(styles)
 );
 
 export default enhanced(LinodeSettingsDeletePanel) as React.ComponentType<

--- a/packages/manager/src/features/linodes/LinodesLanding/DeleteDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DeleteDialog.tsx
@@ -4,7 +4,16 @@ import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Dialog from 'src/components/ConfirmationDialog';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import TextField from 'src/components/TextField';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {},
+  confirmationCopy: {
+    marginTop: theme.spacing(1)
+  }
+}));
 
 interface Props {
   linodeID?: number;
@@ -21,6 +30,9 @@ const DeleteLinodeDialog: React.FC<CombinedProps> = props => {
   const [errors, setErrors] = React.useState<
     Linode.ApiFieldError[] | undefined
   >(undefined);
+  const [confirmationText, setConfirmationText] = React.useState<string>('');
+
+  const classes = useStyles();
 
   React.useEffect(() => {
     if (props.open) {
@@ -29,6 +41,7 @@ const DeleteLinodeDialog: React.FC<CombinedProps> = props => {
        */
       setErrors(undefined);
       setDeleting(false);
+      setConfirmationText('');
     }
   }, [props.open]);
 
@@ -58,6 +71,7 @@ const DeleteLinodeDialog: React.FC<CombinedProps> = props => {
       error={errors ? errors[0].reason : ''}
       actions={
         <Actions
+          disabled={confirmationText !== props.linodeLabel}
           onClose={props.onClose}
           loading={isDeleting}
           onSubmit={handleSubmit}
@@ -68,6 +82,16 @@ const DeleteLinodeDialog: React.FC<CombinedProps> = props => {
         Are you sure you want to delete your Linode? This will result in
         permanent data loss.
       </Typography>
+      <Typography className={classes.confirmationCopy}>
+        To confirm deletion, type the name of the Linode ({props.linodeLabel})
+        in the field below:
+      </Typography>
+      <TextField
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setConfirmationText(e.target.value)
+        }
+        expand
+      />
     </Dialog>
   );
 };
@@ -76,6 +100,7 @@ interface ActionsProps {
   onClose: () => void;
   onSubmit: () => void;
   loading: boolean;
+  disabled: boolean;
 }
 
 const Actions: React.FC<ActionsProps> = props => {
@@ -85,6 +110,7 @@ const Actions: React.FC<ActionsProps> = props => {
         Cancel
       </Button>
       <Button
+        disabled={props.disabled}
         onClick={props.onSubmit}
         loading={props.loading}
         destructive


### PR DESCRIPTION
## Description

This follows the pattern established in Object Storage and LKE.

Now that we have this pattern in 4 different places, it'd be nice to consolidate into one component. I created a TDT items for this, since it will be a medium-ish effort that will change several existing components.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

This affects both Linode deletion confirmation modals:

1) LinodesLanding
2) LinodeDetails -> Settings 