### PR TITLE
Change: Add Logic to CSV Link to Prevent CSV Injections

### DIFF
--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.test.ts
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.test.ts
@@ -1,7 +1,7 @@
 import { cleanCSVData } from './DownloadCSV';
 
 describe('should prevent CSV injection attacks', () => {
-  it('should remove all math signs from an array of values', () => {
+  it('should wrap all math signs in double quotes from an array of values', () => {
     expect(cleanCSVData(['+123', '=123', '-123'])).toEqual([
       '"+"123',
       '"="123',
@@ -9,7 +9,7 @@ describe('should prevent CSV injection attacks', () => {
     ]);
   });
 
-  it('should recursively remove all math signs from 2D arrays', () => {
+  it('should recursively wrap all math signs in double quotes from 2D arrays', () => {
     expect(cleanCSVData([['+123'], ['=123'], ['-123']])).toEqual([
       ['"+"123'],
       ['"="123'],
@@ -17,7 +17,7 @@ describe('should prevent CSV injection attacks', () => {
     ]);
   });
 
-  it('should clean values of objects', () => {
+  it('should wrap values of objects in double quotes', () => {
     expect(
       cleanCSVData([
         {

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.test.ts
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.test.ts
@@ -3,17 +3,17 @@ import { cleanCSVData } from './DownloadCSV';
 describe('should prevent CSV injection attacks', () => {
   it('should wrap all math signs in double quotes from an array of values', () => {
     expect(cleanCSVData(['+123', '=123', '-123'])).toEqual([
-      '"+123"',
-      '"=123"',
-      '"-123"'
+      ':+123',
+      ':=123',
+      ':-123'
     ]);
   });
 
   it('should recursively wrap all math signs in double quotes from 2D arrays', () => {
     expect(cleanCSVData([['+123'], ['=123'], ['-123']])).toEqual([
-      ['"+123"'],
-      ['"=123"'],
-      ['"-123"']
+      [':+123'],
+      [':=123'],
+      [':-123']
     ]);
   });
 
@@ -32,13 +32,13 @@ describe('should prevent CSV injection attacks', () => {
       ])
     ).toEqual([
       {
-        key: '"-123"'
+        key: ':-123'
       },
       {
-        key: '"+123"'
+        key: ':+123'
       },
       {
-        key: '"=123"'
+        key: ':=123'
       }
     ]);
   });
@@ -65,17 +65,17 @@ describe('should prevent CSV injection attacks', () => {
     ).toEqual([
       {
         key: {
-          nestedKey: '"+123"'
+          nestedKey: ':+123'
         }
       },
       {
         key: {
-          nestedKey: '"-123"'
+          nestedKey: ':-123'
         }
       },
       {
         key: {
-          nestedKey: '"=123"'
+          nestedKey: ':=123'
         }
       }
     ]);
@@ -110,21 +110,21 @@ describe('should prevent CSV injection attacks', () => {
       {
         key: [
           {
-            nestedKey: '"+123"'
+            nestedKey: ':+123'
           }
         ]
       },
       {
         key: [
           {
-            nestedKey: '"-123"'
+            nestedKey: ':-123'
           }
         ]
       },
       {
         key: [
           {
-            nestedKey: '"=123"'
+            nestedKey: ':=123'
           }
         ]
       }

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.test.ts
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.test.ts
@@ -3,17 +3,17 @@ import { cleanCSVData } from './DownloadCSV';
 describe('should prevent CSV injection attacks', () => {
   it('should wrap all math signs in double quotes from an array of values', () => {
     expect(cleanCSVData(['+123', '=123', '-123'])).toEqual([
-      '"+"123',
-      '"="123',
-      '"-"123'
+      '"+123"',
+      '"=123"',
+      '"-123"'
     ]);
   });
 
   it('should recursively wrap all math signs in double quotes from 2D arrays', () => {
     expect(cleanCSVData([['+123'], ['=123'], ['-123']])).toEqual([
-      ['"+"123'],
-      ['"="123'],
-      ['"-"123']
+      ['"+123"'],
+      ['"=123"'],
+      ['"-123"']
     ]);
   });
 
@@ -32,13 +32,13 @@ describe('should prevent CSV injection attacks', () => {
       ])
     ).toEqual([
       {
-        key: '"-"123'
+        key: '"-123"'
       },
       {
-        key: '"+"123'
+        key: '"+123"'
       },
       {
-        key: '"="123'
+        key: '"=123"'
       }
     ]);
   });
@@ -65,17 +65,17 @@ describe('should prevent CSV injection attacks', () => {
     ).toEqual([
       {
         key: {
-          nestedKey: '"+"123'
+          nestedKey: '"+123"'
         }
       },
       {
         key: {
-          nestedKey: '"-"123'
+          nestedKey: '"-123"'
         }
       },
       {
         key: {
-          nestedKey: '"="123'
+          nestedKey: '"=123"'
         }
       }
     ]);
@@ -110,21 +110,21 @@ describe('should prevent CSV injection attacks', () => {
       {
         key: [
           {
-            nestedKey: '"+"123'
+            nestedKey: '"+123"'
           }
         ]
       },
       {
         key: [
           {
-            nestedKey: '"-"123'
+            nestedKey: '"-123"'
           }
         ]
       },
       {
         key: [
           {
-            nestedKey: '"="123'
+            nestedKey: '"=123"'
           }
         ]
       }

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.test.ts
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.test.ts
@@ -1,0 +1,133 @@
+import { cleanCSVData } from './DownloadCSV';
+
+describe('should prevent CSV injection attacks', () => {
+  it('should remove all math signs from an array of values', () => {
+    expect(cleanCSVData(['+123', '=123', '-123'])).toEqual([
+      '123',
+      '123',
+      '123'
+    ]);
+  });
+
+  it('should recursively remove all math signs from 2D arrays', () => {
+    expect(cleanCSVData([['+123'], ['=123'], ['-123']])).toEqual([
+      ['123'],
+      ['123'],
+      ['123']
+    ]);
+  });
+
+  it('should clean values of objects', () => {
+    expect(
+      cleanCSVData([
+        {
+          key: '-123'
+        },
+        {
+          key: '+123'
+        },
+        {
+          key: '=123'
+        }
+      ])
+    ).toEqual([
+      {
+        key: '123'
+      },
+      {
+        key: '123'
+      },
+      {
+        key: '123'
+      }
+    ]);
+  });
+
+  it('should recursively clean values of objects', () => {
+    expect(
+      cleanCSVData([
+        {
+          key: {
+            nestedKey: '+123'
+          }
+        },
+        {
+          key: {
+            nestedKey: '-123'
+          }
+        },
+        {
+          key: {
+            nestedKey: '=123'
+          }
+        }
+      ])
+    ).toEqual([
+      {
+        key: {
+          nestedKey: '123'
+        }
+      },
+      {
+        key: {
+          nestedKey: '123'
+        }
+      },
+      {
+        key: {
+          nestedKey: '123'
+        }
+      }
+    ]);
+  });
+
+  it('should clean a nested array in a nested object', () => {
+    expect(
+      cleanCSVData([
+        {
+          key: [
+            {
+              nestedKey: '+123'
+            }
+          ]
+        },
+        {
+          key: [
+            {
+              nestedKey: '+123'
+            }
+          ]
+        },
+        {
+          key: [
+            {
+              nestedKey: '+123'
+            }
+          ]
+        }
+      ])
+    ).toEqual([
+      {
+        key: [
+          {
+            nestedKey: '123'
+          }
+        ]
+      },
+      {
+        key: [
+          {
+            nestedKey: '123'
+          }
+        ]
+      },
+      {
+        key: [
+          {
+            nestedKey: '123'
+          }
+        ]
+      }
+    ]);
+  });
+});

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.test.ts
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.test.ts
@@ -3,17 +3,17 @@ import { cleanCSVData } from './DownloadCSV';
 describe('should prevent CSV injection attacks', () => {
   it('should remove all math signs from an array of values', () => {
     expect(cleanCSVData(['+123', '=123', '-123'])).toEqual([
-      '123',
-      '123',
-      '123'
+      '"+"123',
+      '"="123',
+      '"-"123'
     ]);
   });
 
   it('should recursively remove all math signs from 2D arrays', () => {
     expect(cleanCSVData([['+123'], ['=123'], ['-123']])).toEqual([
-      ['123'],
-      ['123'],
-      ['123']
+      ['"+"123'],
+      ['"="123'],
+      ['"-"123']
     ]);
   });
 
@@ -32,13 +32,13 @@ describe('should prevent CSV injection attacks', () => {
       ])
     ).toEqual([
       {
-        key: '123'
+        key: '"-"123'
       },
       {
-        key: '123'
+        key: '"+"123'
       },
       {
-        key: '123'
+        key: '"="123'
       }
     ]);
   });
@@ -65,17 +65,17 @@ describe('should prevent CSV injection attacks', () => {
     ).toEqual([
       {
         key: {
-          nestedKey: '123'
+          nestedKey: '"+"123'
         }
       },
       {
         key: {
-          nestedKey: '123'
+          nestedKey: '"-"123'
         }
       },
       {
         key: {
-          nestedKey: '123'
+          nestedKey: '"="123'
         }
       }
     ]);
@@ -94,14 +94,14 @@ describe('should prevent CSV injection attacks', () => {
         {
           key: [
             {
-              nestedKey: '+123'
+              nestedKey: '-123'
             }
           ]
         },
         {
           key: [
             {
-              nestedKey: '+123'
+              nestedKey: '=123'
             }
           ]
         }
@@ -110,21 +110,21 @@ describe('should prevent CSV injection attacks', () => {
       {
         key: [
           {
-            nestedKey: '123'
+            nestedKey: '"+"123'
           }
         ]
       },
       {
         key: [
           {
-            nestedKey: '123'
+            nestedKey: '"-"123'
           }
         ]
       },
       {
         key: [
           {
-            nestedKey: '123'
+            nestedKey: '"="123'
           }
         ]
       }

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -71,6 +71,8 @@ export const cleanCSVData = (data: any): any => {
   if (`${data}`.match(/[-|+|=]/g)) {
     return `"${data}"`;
   }
+
+  return data;
 };
 
 export default compose<CombinedProps, Props>(React.memo)(DownloadCSV);

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -66,10 +66,11 @@ export const cleanCSVData = (data: any): any => {
 
   /**
    * fairly confident this should be typecast as a string by now
-   * basically, just wrap each operator symbol in a double quote
+   * basically, prefix the cell with : if the first character is a
+   * blacklisted math operator
    */
-  if (`${data}`.match(/[-|+|=]/g)) {
-    return `"${data}"`;
+  if (`${data}`.charAt(0).match(/[-|+|=|*]/g)) {
+    return `:${data}`;
   }
 
   return data;

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -39,16 +39,19 @@ const DownloadCSV: React.FC<CombinedProps> = props => {
  * See M3-3022 for more info.
  */
 export const cleanCSVData = (data: any): any => {
+  /** safety check because typeof null === 'object' */
   if (data === null) {
     return null;
   }
 
+  /** if it's an array, recursively clean each element in the array */
   if (Array.isArray(data)) {
     return data.map(eachValue => {
       return cleanCSVData(eachValue);
     });
   }
 
+  /** if it's an object, recursively sanitize each key value pair */
   if (typeof data === 'object') {
     return Object.keys(data).reduce((acc, eachKey) => {
       acc[eachKey] = cleanCSVData(data[eachKey]);
@@ -56,13 +59,14 @@ export const cleanCSVData = (data: any): any => {
     }, {});
   }
 
+  /** if it's a boolean or number, no need to sanitize */
   if (typeof data === 'boolean' || typeof data === 'number') {
     return data;
   }
 
   /**
    * fairly confident this should be typecast as a string by now
-   * basically, just get rid of operator symbols
+   * basically, just wrap each operator symbol in a double quote
    */
   return (data as string).replace(/[-|+|=]/g, match => `"${match}"`);
 };

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { CSVLink } from 'react-csv';
+import { compose } from 'recompose';
+
+/**
+ * these aren't all the props provided by react-csv
+ * check out the docs for all props: https://github.com/react-csv/react-csv
+ */
+interface Props {
+  data: any[];
+  headers: { label: string; key: string }[];
+  filename: string;
+  className: string;
+}
+
+type CombinedProps = Props;
+
+const DownloadCSV: React.FC<CombinedProps> = props => {
+  return (
+    <CSVLink
+      className={props.className}
+      headers={props.headers}
+      filename={props.filename}
+      data={cleanCSVData(props.data)}
+    >
+      {props.children}
+    </CSVLink>
+  );
+};
+
+/**
+ * prevents CSV injections. Without this logic, a user
+ * could, for example, add a tag of =cmd|' /C calc'!A0
+ * then open the CSV up in Microsoft Excel and it would
+ * automatically open the calculator.
+ *
+ * For now, we're just going to strip "=", "+", and "-"
+ * signs, at the recommendation of hackerone discussions.
+ * See M3-3022 for more info.
+ */
+export const cleanCSVData = (data: any): any => {
+  if (data === null) {
+    return null;
+  }
+
+  if (Array.isArray(data)) {
+    return data.map(eachValue => {
+      return cleanCSVData(eachValue);
+    });
+  }
+
+  if (typeof data === 'object') {
+    return Object.keys(data).reduce((acc, eachKey) => {
+      acc[eachKey] = cleanCSVData(data[eachKey]);
+      return acc;
+    }, {});
+  }
+
+  if (typeof data === 'boolean' || typeof data === 'number') {
+    return data;
+  }
+
+  /**
+   * fairly confident this should be typecast as a string by now
+   * basically, just get rid of operator symbols
+   */
+  return (data as string).replace(/[-|+|=]/g, '');
+};
+
+export default compose<CombinedProps, Props>(React.memo)(DownloadCSV);

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -64,7 +64,7 @@ export const cleanCSVData = (data: any): any => {
    * fairly confident this should be typecast as a string by now
    * basically, just get rid of operator symbols
    */
-  return (data as string).replace(/[-|+|=]/g, '');
+  return (data as string).replace(/[-|+|=]/g, match => `"${match}"`);
 };
 
 export default compose<CombinedProps, Props>(React.memo)(DownloadCSV);

--- a/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
+++ b/packages/manager/src/components/DownloadCSV/DownloadCSV.tsx
@@ -68,7 +68,9 @@ export const cleanCSVData = (data: any): any => {
    * fairly confident this should be typecast as a string by now
    * basically, just wrap each operator symbol in a double quote
    */
-  return (data as string).replace(/[-|+|=]/g, match => `"${match}"`);
+  if (`${data}`.match(/[-|+|=]/g)) {
+    return `"${data}"`;
+  }
 };
 
 export default compose<CombinedProps, Props>(React.memo)(DownloadCSV);

--- a/packages/manager/src/components/DownloadCSV/index.ts
+++ b/packages/manager/src/components/DownloadCSV/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DownloadCSV';

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -3,7 +3,6 @@ import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { parse, stringify } from 'qs';
 import { path, pathOr } from 'ramda';
 import * as React from 'react';
-import { CSVLink } from 'react-csv';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -48,6 +47,8 @@ import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
 
 import PowerDialogOrDrawer, { Action } from '../PowerActionsDialogOrDrawer';
 import DeleteDialog from './DeleteDialog';
+
+import CSVLink from 'src/components/DownloadCSV';
 
 interface State {
   powerDialogOpen: boolean;


### PR DESCRIPTION
🚨 REQUIRES NODE 10 🚨 

## Description

Recursively wraps instances of `+`, `-`, and `=`  in double quotes to prevent CSV injections

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A

## Note to Reviewers

If you have  a windows machine and microsoft excel, try following the steps [here.](https://github.com/linode/manager/pull/5294/files#diff-6bf2769986df56bab95b913bdc2d8867R32) Otherwise, I'm not really sure how to test.