### PR TITLE
M3-711 Add SupportWidget to Managed landing

### DIFF
--- a/packages/manager/src/assets/icons/ticket-blue.svg
+++ b/packages/manager/src/assets/icons/ticket-blue.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="20" viewBox="0 0 26 20">
+  <path fill="none" stroke="#3683DC" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.2" d="M3.5 4.5L13.5 4.5M3.5 7.5L13.5 7.5M3.5 10.5L20.5 10.5M3.5 13.5L20.5 13.5M19.5.793C19.313.605 19.058.5 18.793.5L1.5.5C.948.5.5.948.5 1.5L.5 16.5C.5 17.052.948 17.5 1.5 17.5L22.5 17.5C23.052 17.5 23.5 17.052 23.5 16.5L23.5 5.207C23.5 4.942 23.395 4.687 23.207 4.5L19.5.793z" transform="translate(1 1)"/>
+</svg>

--- a/packages/manager/src/features/Managed/ManagedLanding.tsx
+++ b/packages/manager/src/features/Managed/ManagedLanding.tsx
@@ -17,11 +17,13 @@ import DefaultLoader from 'src/components/DefaultLoader';
 import setDocs from 'src/components/DocsSidebar/setDocs';
 import DocumentationButton from 'src/components/DocumentationButton';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Grid from 'src/components/Grid';
 import TabLink from 'src/components/TabLink';
 import withFeatureFlagConsumer, {
   FeatureFlagConsumerProps
 } from 'src/containers/withFeatureFlagConsumer.container';
 import ManagedPlaceholder from './ManagedPlaceholder';
+import SupportWidget from './SupportWidget';
 
 const Monitors = DefaultLoader({
   loader: () => import('./Monitors')
@@ -89,7 +91,20 @@ export class ManagedLanding extends React.Component<CombinedProps, {}> {
                 labelTitle="Managed"
                 removeCrumbX={1}
               />
-              <DocumentationButton href="https://www.linode.com/docs/platform/linode-managed/" />
+              <Grid
+                container
+                direction="row"
+                justify="flex-end"
+                alignItems="center"
+                xs={8}
+              >
+                <Grid item>
+                  <SupportWidget />
+                </Grid>
+                <Grid item>
+                  <DocumentationButton href="https://www.linode.com/docs/platform/linode-managed/" />
+                </Grid>
+              </Grid>
             </Box>
             <AppBar position="static" color="default">
               <Tabs

--- a/packages/manager/src/features/Managed/ManagedLanding.tsx
+++ b/packages/manager/src/features/Managed/ManagedLanding.tsx
@@ -93,6 +93,7 @@ export class ManagedLanding extends React.Component<CombinedProps, {}> {
               />
               <Grid
                 container
+                item
                 direction="row"
                 justify="flex-end"
                 alignItems="center"

--- a/packages/manager/src/features/Managed/SupportWidget.tsx
+++ b/packages/manager/src/features/Managed/SupportWidget.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { compose } from 'recompose';
+
+import TicketIcon from 'src/assets/icons/ticket-blue.svg';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import IconTextLink from 'src/components/IconTextLink';
+
+import { AttachmentError } from 'src/features/Support/SupportTicketDetail/SupportTicketDetail';
+import SupportTicketDrawer from 'src/features/Support/SupportTickets/SupportTicketDrawer';
+
+type ClassNames = 'root';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      padding: `0 ${theme.spacing(1) + 4}px`
+    }
+  });
+
+export type CombinedProps = WithStyles<ClassNames> & RouteComponentProps<{}>;
+
+export const SupportWidget: React.FC<CombinedProps> = props => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const { classes, history } = props;
+  const onTicketCreated = (
+    ticketId: number,
+    attachmentErrors: AttachmentError[] = []
+  ) => {
+    history.push({
+      pathname: `/support/tickets/${ticketId}`,
+      state: { attachmentErrors }
+    });
+  };
+  return (
+    <>
+      <IconTextLink
+        className={classes.root}
+        SideIcon={TicketIcon}
+        text="Open Support Ticket"
+        title="Open Support Ticket"
+        onClick={() => setOpen(true)}
+      />
+      <SupportTicketDrawer
+        open={open}
+        onClose={() => setOpen(false)}
+        onSuccess={onTicketCreated}
+      />
+    </>
+  );
+};
+
+const styled = withStyles(styles);
+const enhanced = compose<CombinedProps, {}>(
+  styled,
+  React.memo,
+  withRouter
+);
+export default enhanced(SupportWidget);

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -256,17 +256,15 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
     }
     this.composeState([
       set(L.entity_type, e.value),
-      set(L.entity_id, undefined),
+      set(L.entity_id, null),
       set(L.inputValue, ''),
       set(L.data, []),
       set(L.errors, undefined)
     ]);
   };
 
-  handleEntityIDChange = (selected: Item) => {
-    if (selected) {
-      this.setState(set(L.entity_id, selected.value));
-    }
+  handleEntityIDChange = (selected: Item | null) => {
+    this.setState(set(L.entity_id, selected ? selected.value : null));
   };
 
   getHasNoEntitiesMessage = (): string => {
@@ -453,9 +451,14 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
       { label: 'None/General', value: 'general' }
     ];
 
-    const defaultTopic = topicOptions.find(eachTopic => {
+    const selectedTopic = topicOptions.find(eachTopic => {
       return eachTopic.value === ticket.entity_type;
     });
+
+    const selectedEntity =
+      data.find(
+        thisEntity => thisEntity.value === this.state.ticket.entity_id
+      ) || null;
 
     return (
       <Drawer
@@ -475,7 +478,7 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
         <Select
           options={topicOptions}
           label="What is this regarding?"
-          defaultValue={defaultTopic}
+          value={selectedTopic}
           onChange={this.handleEntityTypeChange}
           data-qa-ticket-entity-type
           placeholder="Choose a Product"
@@ -486,7 +489,7 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
           <>
             <Select
               options={data}
-              defaultValue={ticket.entity_id}
+              value={selectedEntity}
               disabled={data.length === 0}
               errorText={inputError}
               placeholder={`Select a ${entityIdtoNameMap[ticket.entity_type]}`}


### PR DESCRIPTION
## Description

Open a Support ticket from the Managed landing page.

Additionally, fixed a regression in the ticket drawer where the selected entity wasn't clearing when you selected a different entity type.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Use the testing LD key, and make sure the `managed` flag is toggled on.