### PR TITLE
LKE fixes

### DIFF
--- a/packages/manager/src/containers/kubernetes.container.ts
+++ b/packages/manager/src/containers/kubernetes.container.ts
@@ -97,7 +97,7 @@ export default <TInner extends {}, TOuter extends {}>(
       const lastUpdated = state.__resources.kubernetes.lastUpdated;
       const nodePoolsLoading =
         state.__resources.nodePools.loading &&
-        state.__resources.nodePools.lastUpdated === 0;
+        state.__resources.nodePools.entities.length === 0;
 
       return mapKubernetesToProps(
         ownProps,

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.tsx
@@ -62,8 +62,7 @@ export const NodePoolDisplayTable: React.FunctionComponent<
     types,
     updatePool
   } = props;
-  console.log(loading);
-  console.log(pools);
+
   return (
     <Table
       tableClass={classNames({

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.tsx
@@ -62,6 +62,8 @@ export const NodePoolDisplayTable: React.FunctionComponent<
     types,
     updatePool
   } = props;
+  console.log(loading);
+  console.log(pools);
   return (
     <Table
       tableClass={classNames({

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -89,8 +89,11 @@ export const getStatusString = (
   count: number,
   linodes?: Linode.PoolNodeResponse[]
 ) => {
+  if (!count) {
+    return '';
+  }
   if (!linodes || linodes.length === 0) {
-    return String(count);
+    return `${count} (0 up, ${count} down)`;
   }
   const status = getNodeStatus(linodes);
   return `${count} (${status.ready} up, ${status.not_ready} down)`;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -164,16 +164,8 @@ export const KubernetesClusterDetail: React.FunctionComponent<
   const [deleting, setDeleting] = React.useState<boolean>(false);
 
   React.useEffect(() => {
-    /**
-     * Eventually the clusters request will probably be made from App.tsx
-     * (to facilitate searching), but for now if a user navigates directly
-     * to this url without going through KubernetesLanding the clusters won't have
-     * been requested yet.
-     */
-    if (props.lastUpdated === 0) {
-      props.requestKubernetesClusters();
-    } else {
-      const clusterID = +props.match.params.clusterID;
+    const clusterID = +props.match.params.clusterID;
+    if (clusterID) {
       props.requestClusterForStore(clusterID);
     }
 
@@ -192,7 +184,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
   }
 
   if (
-    (clustersLoading && lastUpdated !== 0) ||
+    (clustersLoading && lastUpdated === 0) ||
     nodePoolsLoading ||
     typesLoading
   ) {

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -76,6 +76,7 @@ const withKubernetes = KubernetesContainer(
     clusters,
     clustersError,
     clustersLoading,
+    lastUpdated,
     nodePoolsLoading
   })
 );

--- a/packages/manager/src/store/kubernetes/kubernetes.reducer.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.reducer.ts
@@ -19,7 +19,7 @@ export type State = EntityState<Linode.KubernetesCluster, EntityError>;
 export const defaultState: State = {
   results: [],
   entities: [],
-  loading: true,
+  loading: false,
   lastUpdated: 0,
   error: {}
 };

--- a/packages/manager/src/store/kubernetes/kubernetes.requests.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.requests.ts
@@ -27,16 +27,15 @@ export const requestKubernetesClusters: ThunkActionCreator<
 
   return getAllClusters()
     .then(({ data }) => {
-      dispatch(
-        requestClustersActions.done({
-          result: data
-        })
-      );
       let i = 0;
       for (; i < data.length; i++) {
         dispatch(requestNodePoolsForCluster({ clusterID: data[i].id }));
       }
-      return data;
+      return dispatch(
+        requestClustersActions.done({
+          result: data
+        })
+      );
     })
     .catch(error => {
       dispatch(requestClustersActions.failed({ error }));
@@ -47,6 +46,7 @@ export const requestKubernetesClusters: ThunkActionCreator<
 type RequestClusterForStoreThunk = ThunkActionCreator<void>;
 export const requestClusterForStore: RequestClusterForStoreThunk = clusterID => dispatch => {
   getKubernetesCluster(clusterID).then(cluster => {
+    dispatch(requestNodePoolsForCluster({ clusterID }));
     return dispatch(upsertCluster(cluster));
   });
 };

--- a/packages/manager/src/store/kubernetes/nodePools.reducer.ts
+++ b/packages/manager/src/store/kubernetes/nodePools.reducer.ts
@@ -21,7 +21,7 @@ export type State = EntityState<ExtendedNodePool, EntityError>;
 export const defaultState: State = {
   results: [],
   entities: [],
-  loading: true,
+  loading: false,
   lastUpdated: 0,
   error: {}
 };


### PR DESCRIPTION
## Description

Found a few issues:

- Sometimes `count` is defined for a `node_pool` but `linodes` is an empty array. In this case, confirmed with the LKE folks that we should still display "(0 up, {count} down)" in the table.
- Loading states were still a little screwy. Updated the logic to fix them.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

