### PR TITLE
fix: run lerna commands with npx

### DIFF
--- a/CLOUD.md
+++ b/CLOUD.md
@@ -58,7 +58,7 @@ These are environment variables that can be used for automated testing processes
 
 Once you have a working `.env` file, you can run the following in the root of the project:
 
-`yarn && lerna bootstrap --scope linode-manager && lerna run start --stream --scope linode-manager`
+`yarn && npx lerna bootstrap --scope linode-manager && npx lerna run start --stream --scope linode-manager`
 
 alternatively, with Docker
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -17,8 +17,8 @@ To start all projects:
 
 While in the root...
 1. Run `yarn` to install all root dependencies.
-2. Run `lerna bootstrap` to install all package dependencies.
-3. Run `lerna run start` to start a development server for all projects
+2. Run `npx lerna bootstrap` to install all package dependencies.
+3. Run `npx lerna run start` to start a development server for all projects
    * additionally, you can add a `--stream` flag to this command to see the output of the development server.
 
 Alternatively, you can run `yarn up` which runs all previous commands.
@@ -28,8 +28,8 @@ Alternatively, you can run `yarn up` which runs all previous commands.
 Starting a single project is similar to the previous instructions with the exception of adding a `--scope` flag to to the command. So for example, starting the Cloud Manager project looks like:
 
 1. Run `yarn` to install all root dependencies.
-2. Run `lerna bootstrap` to install all package dependencies.
-3. Run `lerna run start --scope linode-manager` to start a development server for all projects
+2. Run `npx lerna bootstrap` to install all package dependencies.
+3. Run `npx lerna run start --scope linode-manager` to start a development server for all projects
    * additionally, you can add a `--stream` flag to this command to see the output of the development server.
    * `linode-manager` is the name located in `packages/manager/package.json`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ When you plan on releasing a new version of Cloud Manager:
 8. At this point, run the end-to-end test suite. Please see a team member on instructions how to do so.
 9. When you're ready to make the merge to master AKA release to production, you need to do 2 things: Add the git tag, and ensure the changelog has the correct date. 
 10. Make the date change to CHANGELOG.md if necessary and stage the changes with `git add . && git commit -m "updates changelog date"`.
-11. Then, run `git checkout staging && git add . && lerna version --no-push`
+11. Then, run `git checkout staging && git add . && npx lerna version --no-push`
     * This will prompt you for a new version number, apply the Git tags, and update the version number in the `package.json` of each child project.
     * This will also automatically commit the changes with a generated commit message.
 12. Push changes to staging with `git push origin staging && git push origin --tags`

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,33 +7,33 @@ The unit tests for Linode Cloud Manager are written in Typescript using the [Jes
 To run tests:
 
 ```
-yarn && lerna bootstrap --scope linode-manager && lerna run test --stream --scope linode-manager
+yarn && npx lerna bootstrap --scope linode-manager && npx lerna run test --stream --scope linode-manager
 ```
 
 Or you can run the tests in watch mode with:
 
 ```
-yarn && lerna bootstrap --scope linode-manager && lerna run test --stream --scope linode-manager -- --watch
+yarn && npx lerna bootstrap --scope linode-manager && npx lerna run test --stream --scope linode-manager -- --watch
 ```
 
 To Run a specific file or files in a directory:
 
 ```
-lerna run test --stream --scope linode-manager -- myFile.test.tsx
-lerna run test --stream --scope linode-manager -- src/some-folder
+npx lerna run test --stream --scope linode-manager -- myFile.test.tsx
+npx lerna run test --stream --scope linode-manager -- src/some-folder
 ```
 
 Jest includes pattern matching out of the box, so you can also do things like run all tests whose filename
 contains "Linode" with
 
 ```
-lerna run test --stream --scope linode-manager -- linode
+npx lerna run test --stream --scope linode-manager -- linode
 ```
 
 To run a test in debug mode, add a `debugger` breakpoint inside one of the test cases, then run
 
 ```
-lerna run test:debug --stream --scope linode-manager
+npx lerna run test:debug --stream --scope linode-manager
 ```
 
 Test execution will stop at the debugger statement, and you will be able to use Chrome's normal debugger to step through
@@ -68,34 +68,34 @@ brew cask install java
 ```
 ## Starts the local development environment
 
-yarn && lerna bootstrap --scope linode-manager && lerna run start --stream --scope linode-manager
+yarn && npx lerna bootstrap --scope linode-manager && npx lerna run start --stream --scope linode-manager
 
 ## New shell
 ## Starts selenium (Must be running to execute tests)
 
-lerna run selenium --scope linode-manager --stream
+npx lerna run selenium --scope linode-manager --stream
 
 ## New shell
 ## Executes specs matching e2e/specs/**/*.spec.js
 
-lerna run e2e --scope linode-manager --stream
+npx lerna run e2e --scope linode-manager --stream
 ```
 
 ### Command Line Arguments
 
-The `lerna run e2e` command accepts a number of helpful command line arguments that facilitate
+The `npx lerna run e2e` command accepts a number of helpful command line arguments that facilitate
 writing and running tests locally.
 
 Running an individual spec file:
 
 ```
-lerna run e2e --scope linode-manager --stream -- --file [/path/to/test.spec.js]
+npx lerna run e2e --scope linode-manager --stream -- --file [/path/to/test.spec.js]
 ```
 
 Running E2E suite in a non-default browser
 
 ```
-lerna run e2e --scope linode-manager --stream -- --browser [chrome,firefox,headlessChrome,safari]
+npx lerna run e2e --scope linode-manager --stream -- --browser [chrome,firefox,headlessChrome,safari]
 ```
 
 #### Run Suite in Docker Local Dev Environment
@@ -140,35 +140,35 @@ live in `src/components/ComponentName/ComponentName.spec.js`. The WDIO config li
 ```
 # Starts storybook
 
-lerna run storybook --scope linode-manager --stream
+npx lerna run storybook --scope linode-manager --stream
 
 ## New shell
 ## Starts selenium (Must be running to execute tests)
 
-lerna run seleniun --scope linode-manager --stream
+npx lerna run seleniun --scope linode-manager --stream
 
 ## New shell
 ## Executes specs matching src/components/**/*.spec.js
 
-lerna run storybook:e2e --scope linode-manager --stream
+npx lerna run storybook:e2e --scope linode-manager --stream
 ```
 
 #### Run a Single Test
 ```
 # Executes spec matching src/components/StoryName/StoryName.spec.js
 
-lerna run storybook:e2e --scope linode-manager --stream -- --story StoryName
+npx lerna run storybook:e2e --scope linode-manager --stream -- --story StoryName
 ```
 
 #### Run a Test in Non-Headless Chrome
 
 ```
-lerna run seleniun --scope linode-manager --stream
+npx lerna run seleniun --scope linode-manager --stream
 
 ## New Shell
 ## The --debug flag spawns a visible chrome session
 
-lerna run storybook:e2e --scope linode-manager --stream -- --debug --story StoryName
+npx lerna run storybook:e2e --scope linode-manager --stream -- --debug --story StoryName
 ```
 
 #### Run Suite in Docker Environment
@@ -200,10 +200,10 @@ The axe-core accessibility testing script has been integrated into the webdriver
 ```
 # Starts the local development environment
 
-yarn && lerna bootstrap --scope linode-manager && lerna run start --stream --scope linode-manager
+yarn && npx lerna bootstrap --scope linode-manager && npx lerna run start --stream --scope linode-manager
 
 
-lerna run axe --stream --scope linode-manager
+npx lerna run axe --stream --scope linode-manager
 ```
 
 The test results will be saved as a JSON file with Critical accessibility violations appearing at the top of the list.


### PR DESCRIPTION
## Description

The getting started guide was making the assumption that lerna is installed globally on a user's machine. `npx` users the binary installed in `$PROJECT_ROOT/node_modules/.bin/lerna`. 

## Type of Change
- Docs fix

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests
* None
