### PR TITLE
LKE-693: Node Pool Input Updates

### DIFF
--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -58,7 +58,7 @@ const styles = (theme: Theme) =>
       }
     },
     tiny: {
-      width: '3em'
+      width: '3.6em'
     }
   });
 
@@ -70,6 +70,7 @@ interface BaseProps {
   className?: any;
   expand?: boolean;
   small?: boolean;
+  // Currently only used for LKE node pool inputs
   tiny?: boolean;
   /**
    * number amounts allowed in textfield

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -27,7 +27,8 @@ type ClassNames =
   | 'disabled'
   | 'removeButton'
   | 'removeButtonWrapper'
-  | 'editableCount';
+  | 'editableCount'
+  | 'priceTableCell';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -58,6 +59,10 @@ const styles = (theme: Theme) =>
       [theme.breakpoints.down('sm')]: {
         alignItems: 'flex-end'
       }
+    },
+    priceTableCell: {
+      // prevents position shift as price grows/shrinks
+      minWidth: 130
     }
   });
 
@@ -148,7 +153,7 @@ export const NodePoolRow: React.FunctionComponent<CombinedProps> = props => {
           <Typography>{getStatusString(pool.count, pool.linodes)}</Typography>
         )}
       </TableCell>
-      <TableCell parentColumn="Pricing">
+      <TableCell parentColumn="Pricing" className={classes.priceTableCell}>
         <Typography>{`${displayPrice(pool.totalMonthlyPrice)}/mo`}</Typography>
       </TableCell>
       <TableCell className={classes.removeButtonWrapper}>


### PR DESCRIPTION
## Description

• Adjusting width of textfield input for node pool count (On the create flow, and under cluster details page for both 'add node pool' panel and 'edit node pools' panel)

• Preventing jumping/shifting that was happening if user edited their node pool count (from a 1 digit to 3 digit number, for instance)

## Type of Change
- Non breaking change ('update')