### PR TITLE
M3-3056 England, Singapore, and Tokyo Flag's are not rendering under "Region" using Firefox

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -29,7 +29,7 @@
     "chart.js": "^2.7.2",
     "classnames": "^2.2.5",
     "copy-to-clipboard": "^3.0.8",
-    "flag-icon-css": "^3.0.0",
+    "flag-icon-css": "^3.3.0",
     "font-logos": "^0.10.0",
     "formik": "^1.3.2",
     "he": "^1.2.0",

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -47,7 +47,13 @@ type ClassNames = 'root';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      marginTop: theme.spacing(3)
+      marginTop: theme.spacing(3),
+      '& svg': {
+        '& g': {
+          // Super hacky fix for Firefox rendering of some flag icons that had a clip-path property.
+          clipPath: 'none !important' as 'none'
+        }
+      }
     }
   });
 

--- a/packages/manager/yarn.lock
+++ b/packages/manager/yarn.lock
@@ -8226,10 +8226,10 @@ first-input-delay@0.1.3:
   resolved "https://registry.yarnpkg.com/first-input-delay/-/first-input-delay-0.1.3.tgz#5506fb95a9537ba9706096b9c159bfd3f38f6f62"
   integrity sha512-hZ1mI+BWYIBr8jlp2bDPnRvnmSICBxpZRwdc0nhiQn2uyMxSKZEBbkO8V0/s26AMeX8p/AD4g09+liRrhXvKKQ==
 
-flag-icon-css@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/flag-icon-css/-/flag-icon-css-3.2.1.tgz#ff269388e25e29d54b39699e88d76c3141a7cc70"
-  integrity sha512-0t7zPm2crM2cBIm3epZQ+EmiHuzgFNTTSMUMkWlrztDDGL+y31D+eY8zaB9zYCzJGAsn4KEMAKY+jCU1mt9jwg==
+flag-icon-css@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/flag-icon-css/-/flag-icon-css-3.3.0.tgz#7772461e4480d3d86da5962f02120a2825688433"
+  integrity sha512-u5lCGVExrJJRykNGd//ZrBU5Bkt0LTZJFSuG+Az/pwcHgzDeFwomwFbsgVtI1aJd6ysyHsx+5UGrA+nhSGd4yw==
 
 flat-cache@^1.2.1:
   version "1.3.4"


### PR DESCRIPTION
## Description

The listed flags in the Create flow were not displaying for Firefox; the CSS addition fixes that. I think it's kinda hacky, but there doesn't seem to be any other explanation or solution.

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

This issue was only occurring in Firefox, but all browsers should be checked to ensure this fix doesn't regress anywhere else.
