### PR TITLE
M3-692 Add: Managed service monitors in redux

### DIFF
--- a/packages/manager/src/containers/managedServices.container.ts
+++ b/packages/manager/src/containers/managedServices.container.ts
@@ -6,10 +6,10 @@ import { requestManagedServices as _requestManagedServices } from 'src/store/man
 import { EntityError } from 'src/store/types';
 
 export interface ManagedProps {
-  monitors?: Linode.ManagedServiceMonitor[];
+  monitors: Linode.ManagedServiceMonitor[];
   managedLoading: boolean;
   managedError: EntityError;
-  lastUpdated?: number;
+  lastUpdated: number;
 }
 
 export interface DispatchProps {
@@ -27,13 +27,13 @@ export default <TInner extends {}, TOuter extends {}>(
     ownProps: TOuter,
     managedLoading: boolean,
     lastUpdated: number,
-    managedError?: EntityError,
-    services?: Linode.ManagedServiceMonitor[]
+    monitors: Linode.ManagedServiceMonitor[],
+    managedError?: EntityError
   ) => TInner
 ) =>
   connect(
     (state: ApplicationState, ownProps: TOuter) => {
-      const services = state.__resources.managed.entities;
+      const monitors = state.__resources.managed.entities;
       const managedLoading = state.__resources.managed.loading;
       const managedError = state.__resources.managed.error;
       const lastUpdated = state.__resources.managed.lastUpdated;
@@ -42,8 +42,8 @@ export default <TInner extends {}, TOuter extends {}>(
         ownProps,
         managedLoading,
         lastUpdated,
-        managedError,
-        services
+        monitors,
+        managedError
       );
     },
     mapDispatchToProps

--- a/packages/manager/src/containers/managedServices.container.ts
+++ b/packages/manager/src/containers/managedServices.container.ts
@@ -1,0 +1,50 @@
+import { connect, MapDispatchToProps } from 'react-redux';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { ApplicationState } from 'src/store';
+import { requestManagedServices as _requestManagedServices } from 'src/store/managed/managed.requests';
+import { EntityError } from 'src/store/types';
+
+export interface ManagedProps {
+  monitors?: Linode.ManagedServiceMonitor[];
+  managedLoading: boolean;
+  managedError: EntityError;
+  lastUpdated?: number;
+}
+
+export interface DispatchProps {
+  requestManagedServices: () => Promise<any>;
+}
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
+  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
+) => ({
+  requestManagedServices: () => dispatch(_requestManagedServices())
+});
+
+export default <TInner extends {}, TOuter extends {}>(
+  mapManagedServicesToProps: (
+    ownProps: TOuter,
+    managedLoading: boolean,
+    lastUpdated: number,
+    managedError?: EntityError,
+    services?: Linode.ManagedServiceMonitor[]
+  ) => TInner
+) =>
+  connect(
+    (state: ApplicationState, ownProps: TOuter) => {
+      const services = state.__resources.managed.entities;
+      const managedLoading = state.__resources.managed.loading;
+      const managedError = state.__resources.managed.error;
+      const lastUpdated = state.__resources.managed.lastUpdated;
+
+      return mapManagedServicesToProps(
+        ownProps,
+        managedLoading,
+        lastUpdated,
+        managedError,
+        services
+      );
+    },
+    mapDispatchToProps
+  );

--- a/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
@@ -19,7 +19,7 @@ import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableSortCell from 'src/components/TableSortCell';
 
-import MonitorRow from './MonitorRow';
+import MonitorTableContent from './MonitorTableContent';
 
 type ClassNames = 'labelHeader';
 
@@ -32,12 +32,14 @@ const styles = (theme: Theme) =>
 
 interface Props {
   monitors: Linode.ManagedServiceMonitor[];
+  loading: boolean;
+  error?: Linode.ApiFieldError[];
 }
 
 export type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const MonitorTable: React.FC<CombinedProps> = props => {
-  const { classes, monitors } = props;
+  const { classes, error, loading, monitors } = props;
   return (
     <>
       <DocumentTitleSegment segment="Service Monitors" />
@@ -104,17 +106,11 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
                       </TableRow>
                     </TableHead>
                     <TableBody>
-                      {data.map(
-                        (
-                          monitor: Linode.ManagedServiceMonitor,
-                          idx: number
-                        ) => (
-                          <MonitorRow
-                            key={`service-monitor-row-${idx}`}
-                            monitor={monitor}
-                          />
-                        )
-                      )}
+                      <MonitorTableContent
+                        monitors={data}
+                        loading={loading}
+                        error={error}
+                      />
                     </TableBody>
                   </Table>
                 </Paper>

--- a/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
@@ -27,7 +27,7 @@ export const MonitorTableContent: React.FC<CombinedProps> = props => {
     return (
       <TableRowEmpty
         colSpan={12}
-        message={"You don't have any Service Monitors on your account."}
+        message={"You don't have any Monitors on your account."}
       />
     );
   }

--- a/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+
+import TableRowEmpty from 'src/components/TableRowEmptyState';
+import TableRowError from 'src/components/TableRowError';
+import TableRowLoading from 'src/components/TableRowLoading';
+import MonitorRow from './MonitorRow';
+
+interface Props {
+  monitors: Linode.ManagedServiceMonitor[];
+  loading: boolean;
+  error?: Linode.ApiFieldError[];
+}
+
+export type CombinedProps = Props;
+
+export const MonitorTableContent: React.FC<CombinedProps> = props => {
+  const { error, loading, monitors } = props;
+  if (loading) {
+    return <TableRowLoading colSpan={12} />;
+  }
+
+  if (error) {
+    return <TableRowError colSpan={12} message={error[0].reason} />;
+  }
+
+  if (monitors.length === 0) {
+    return (
+      <TableRowEmpty
+        colSpan={12}
+        message={"You don't have any Service Monitors on your account."}
+      />
+    );
+  }
+
+  return (
+    <>
+      {monitors.map((monitor: Linode.ManagedServiceMonitor, idx: number) => (
+        <MonitorRow key={`service-monitor-row-${idx}`} monitor={monitor} />
+      ))}
+    </>
+  );
+};
+
+export default MonitorTableContent;

--- a/packages/manager/src/features/Managed/Monitors/Monitors.tsx
+++ b/packages/manager/src/features/Managed/Monitors/Monitors.tsx
@@ -18,7 +18,7 @@ export const Monitors: React.FC<CombinedProps> = props => {
     requestManagedServices
   } = props;
   React.useEffect(() => {
-    requestManagedServices();
+    requestManagedServices().catch(_ => null); // Errors handled in Redux state
   }, [requestManagedServices]);
 
   return (

--- a/packages/manager/src/features/Managed/Monitors/Monitors.tsx
+++ b/packages/manager/src/features/Managed/Monitors/Monitors.tsx
@@ -1,11 +1,44 @@
 import * as React from 'react';
+import { compose } from 'recompose';
 
+import withManagedServices, {
+  DispatchProps,
+  ManagedProps
+} from 'src/containers/managedServices.container';
 import MonitorTable from './MonitorTable';
 
-import { monitors } from 'src/__data__/serviceMonitors';
+type CombinedProps = ManagedProps & DispatchProps;
 
-export const Monitors: React.FC<{}> = props => {
-  return <MonitorTable monitors={monitors} />;
+export const Monitors: React.FC<CombinedProps> = props => {
+  const {
+    lastUpdated,
+    managedError,
+    managedLoading,
+    monitors,
+    requestManagedServices
+  } = props;
+  React.useEffect(() => {
+    requestManagedServices();
+  }, [requestManagedServices]);
+
+  return (
+    <MonitorTable
+      monitors={monitors || []}
+      loading={managedLoading && lastUpdated === 0}
+      error={managedError.read}
+    />
+  );
 };
 
-export default Monitors;
+const enhanced = compose<CombinedProps, {}>(
+  withManagedServices(
+    (ownProps, managedLoading, lastUpdated, managedError, monitors) => ({
+      ...ownProps,
+      managedLoading,
+      lastUpdated,
+      managedError,
+      monitors
+    })
+  )
+);
+export default enhanced(Monitors);

--- a/packages/manager/src/features/Managed/Monitors/Monitors.tsx
+++ b/packages/manager/src/features/Managed/Monitors/Monitors.tsx
@@ -32,12 +32,12 @@ export const Monitors: React.FC<CombinedProps> = props => {
 
 const enhanced = compose<CombinedProps, {}>(
   withManagedServices(
-    (ownProps, managedLoading, lastUpdated, managedError, monitors) => ({
+    (ownProps, managedLoading, lastUpdated, monitors, managedError) => ({
       ...ownProps,
       managedLoading,
       lastUpdated,
-      managedError,
-      monitors
+      monitors,
+      managedError
     })
   )
 );

--- a/packages/manager/src/services/managed/index.ts
+++ b/packages/manager/src/services/managed/index.ts
@@ -1,0 +1,1 @@
+export * from './managed';

--- a/packages/manager/src/services/managed/managed.ts
+++ b/packages/manager/src/services/managed/managed.ts
@@ -1,0 +1,19 @@
+import { API_ROOT } from 'src/constants';
+import Request, { setMethod, setParams, setURL, setXFilter } from '../index';
+
+// Payload types
+
+type Page<T> = Linode.ResourcePage<T>;
+
+/**
+ * getServices
+ *
+ * Returns a paginated list of Managed Services on your account.
+ */
+export const getServices = (params?: any, filters?: any) =>
+  Request<Page<Linode.ManagedServiceMonitor>>(
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filters),
+    setURL(`${API_ROOT}/managed/services`)
+  ).then(response => response.data);

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -78,6 +78,10 @@ import types, {
   defaultState as defaultTypesState,
   State as TypesState
 } from 'src/store/linodeType/linodeType.reducer';
+import managed, {
+  defaultState as defaultManagedState,
+  State as ManagedState
+} from 'src/store/managed/managed.reducer';
 import nodeBalancers, {
   defaultState as defaultNodeBalancerState,
   State as NodeBalancersState
@@ -142,6 +146,7 @@ const __resourcesDefaultState = {
   domains: defaultDomainsState,
   images: defaultImagesState,
   kubernetes: defaultKubernetesState,
+  managed: defaultManagedState,
   nodePools: defaultNodePoolsState,
   linodes: defaultLinodesState,
   linodeConfigs: defaultLinodeConfigsState,
@@ -163,6 +168,7 @@ export interface ResourcesState {
   domains: DomainsState;
   images: ImagesState;
   kubernetes: KubernetesState;
+  managed: ManagedState;
   nodePools: KubeNodePoolsState;
   linodes: LinodesState;
   linodeConfigs: LinodeConfigsState;
@@ -223,6 +229,7 @@ const __resources = combineReducers({
   linodes,
   linodeConfigs,
   linodeDisks,
+  managed,
   nodeBalancers,
   nodeBalancerConfigs,
   notifications,

--- a/packages/manager/src/store/managed/managed.actions.ts
+++ b/packages/manager/src/store/managed/managed.actions.ts
@@ -1,0 +1,9 @@
+import actionCreatorFactory from 'typescript-fsa';
+
+export const actionCreator = actionCreatorFactory(`@@manager/managed`);
+
+export const requestServicesActions = actionCreator.async<
+  void,
+  Linode.ManagedServiceMonitor[],
+  Linode.ApiFieldError[]
+>('request');

--- a/packages/manager/src/store/managed/managed.reducer.test.ts
+++ b/packages/manager/src/store/managed/managed.reducer.test.ts
@@ -1,0 +1,33 @@
+import { monitors } from 'src/__data__/serviceMonitors';
+
+import { requestServicesActions } from './managed.actions';
+import reducer, { defaultState } from './managed.reducer';
+
+describe('Managed services reducer', () => {
+  it('should handle an initiated request for services', () => {
+    expect(
+      reducer(defaultState, requestServicesActions.started())
+    ).toHaveProperty('loading', true);
+  });
+
+  it('should handle a successful services request', () => {
+    const newState = reducer(
+      { ...defaultState, loading: true },
+      requestServicesActions.done({ result: monitors })
+    );
+    expect(newState).toHaveProperty('entities', monitors);
+    expect(newState).toHaveProperty('loading', false);
+    expect(newState.error!.read).toBeUndefined();
+    expect(newState.results).toHaveLength(monitors.length);
+  });
+
+  it('should handle a failed services request', () => {
+    const mockError = [{ reason: 'no reason' }];
+    const newState = reducer(
+      { ...defaultState, loading: true },
+      requestServicesActions.failed({ error: mockError })
+    );
+    expect(newState.error!.read).toEqual(mockError);
+    expect(newState).toHaveProperty('loading', false);
+  });
+});

--- a/packages/manager/src/store/managed/managed.reducer.ts
+++ b/packages/manager/src/store/managed/managed.reducer.ts
@@ -1,0 +1,49 @@
+import produce from 'immer';
+import { Reducer } from 'redux';
+import { EntityError, EntityState } from 'src/store/types';
+import { isType } from 'typescript-fsa';
+import { requestServicesActions } from './managed.actions';
+
+/**
+ * State
+ */
+
+export type State = EntityState<Linode.ManagedServiceMonitor, EntityError>;
+
+export const defaultState: State = {
+  results: [],
+  entities: [],
+  loading: false,
+  lastUpdated: 0,
+  error: {}
+};
+
+/**
+ * Reducer
+ */
+const reducer: Reducer<State> = (state = defaultState, action) => {
+  return produce(state, draft => {
+    if (isType(action, requestServicesActions.done)) {
+      const { result } = action.payload;
+
+      draft.entities = result;
+      draft.results = result.map(s => s.id);
+      draft.loading = false;
+      draft.lastUpdated = Date.now();
+    }
+
+    if (isType(action, requestServicesActions.started)) {
+      draft.loading = true;
+    }
+
+    if (isType(action, requestServicesActions.failed)) {
+      const { error } = action.payload;
+
+      draft.loading = false;
+      draft.error!.read = error;
+    }
+    return draft;
+  });
+};
+
+export default reducer;

--- a/packages/manager/src/store/managed/managed.reducer.ts
+++ b/packages/manager/src/store/managed/managed.reducer.ts
@@ -1,7 +1,9 @@
 import produce from 'immer';
 import { Reducer } from 'redux';
-import { EntityError, EntityState } from 'src/store/types';
 import { isType } from 'typescript-fsa';
+
+import { EntityError, EntityState } from 'src/store/types';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { requestServicesActions } from './managed.actions';
 
 /**
@@ -40,7 +42,10 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       const { error } = action.payload;
 
       draft.loading = false;
-      draft.error!.read = error;
+      draft.error!.read = getAPIErrorOrDefault(
+        error,
+        'Error loading your Monitors.'
+      );
     }
     return draft;
   });

--- a/packages/manager/src/store/managed/managed.requests.ts
+++ b/packages/manager/src/store/managed/managed.requests.ts
@@ -3,15 +3,15 @@ import { getAll } from 'src/utilities/getAll';
 import { ThunkActionCreator } from '../types';
 import { requestServicesActions } from './managed.actions';
 
-const getAllServices = (clusterID: number) =>
-  getAll<Linode.ManagedServiceMonitor>(() => getServices(clusterID));
+const getAllServices = () =>
+  getAll<Linode.ManagedServiceMonitor>(() => getServices());
 
 export const requestManagedServices: ThunkActionCreator<
   Promise<Linode.KubeNodePoolResponse[]>
-> = ({ clusterID }) => dispatch => {
+> = () => dispatch => {
   dispatch(requestServicesActions.started());
 
-  return getAllServices(clusterID)()
+  return getAllServices()()
     .then(services => {
       return dispatch(
         requestServicesActions.done({

--- a/packages/manager/src/store/managed/managed.requests.ts
+++ b/packages/manager/src/store/managed/managed.requests.ts
@@ -1,26 +1,13 @@
 import { getServices } from 'src/services/managed';
 import { getAll } from 'src/utilities/getAll';
-import { ThunkActionCreator } from '../types';
+import { createRequestThunk } from '../store.helpers';
 import { requestServicesActions } from './managed.actions';
 
-const getAllServices = () =>
-  getAll<Linode.ManagedServiceMonitor>(() => getServices());
+const _getAll = getAll(getServices);
 
-export const requestManagedServices: ThunkActionCreator<
-  Promise<Linode.KubeNodePoolResponse[]>
-> = () => dispatch => {
-  dispatch(requestServicesActions.started());
+const getAllServices = () => _getAll().then(({ data }) => data);
 
-  return getAllServices()()
-    .then(services => {
-      return dispatch(
-        requestServicesActions.done({
-          result: services.data
-        })
-      );
-    })
-    .catch(error => {
-      dispatch(requestServicesActions.failed({ error }));
-      return error;
-    });
-};
+export const requestManagedServices = createRequestThunk(
+  requestServicesActions,
+  getAllServices
+);

--- a/packages/manager/src/store/managed/managed.requests.ts
+++ b/packages/manager/src/store/managed/managed.requests.ts
@@ -1,0 +1,26 @@
+import { getServices } from 'src/services/managed';
+import { getAll } from 'src/utilities/getAll';
+import { ThunkActionCreator } from '../types';
+import { requestServicesActions } from './managed.actions';
+
+const getAllServices = (clusterID: number) =>
+  getAll<Linode.ManagedServiceMonitor>(() => getServices(clusterID));
+
+export const requestManagedServices: ThunkActionCreator<
+  Promise<Linode.KubeNodePoolResponse[]>
+> = ({ clusterID }) => dispatch => {
+  dispatch(requestServicesActions.started());
+
+  return getAllServices(clusterID)()
+    .then(services => {
+      return dispatch(
+        requestServicesActions.done({
+          result: services.data
+        })
+      );
+    })
+    .catch(error => {
+      dispatch(requestServicesActions.failed({ error }));
+      return error;
+    });
+};


### PR DESCRIPTION
## Description

Follow-on to #5303. Uses live data to populate the Monitors table at managed/monitors.
 
- Add services/managed with a `getServices()` method
- Add Redux boilerplate for `requestManagedServices()`
- Add `containers/managedServices.container`
- Add loading states and live data to Monitors.ts

## Type of Change
- Non breaking change ('update', 'change')