### PR TITLE
M3-3115 Improve link styles for PDF downloads in account

### DIFF
--- a/packages/manager/src/components/CircleProgress/CircleProgress.stories.tsx
+++ b/packages/manager/src/components/CircleProgress/CircleProgress.stories.tsx
@@ -4,6 +4,7 @@ import CircleProgress from './CircleProgress';
 
 storiesOf('Circle Progress Indicator', module)
   .add('Indefinite', () => <CircleProgress noTopMargin />)
+  .add('Mini', () => <CircleProgress mini />)
   .add('Data inside', () => (
     <CircleProgress noTopMargin green variant="static" value={50}>
       <span data-qa-progress-label>Some data</span>

--- a/packages/manager/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesRow.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesRow.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import Button from 'src/components/Button';
+import CircleProgress from 'src/components/CircleProgress';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Currency from 'src/components/Currency';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import Notice from 'src/components/Notice';
@@ -11,6 +12,18 @@ import createMailto from 'src/features/Footer/createMailto';
 import { getInvoiceItems } from 'src/services/account';
 import { getAll } from 'src/utilities/getAll';
 
+const useStyles = makeStyles((theme: Theme) => ({
+  linkContainer: {
+    '& [role="progressbar"]': {
+      width: '14px !important',
+      height: '14px !important',
+      padding: 0,
+      position: 'relative',
+      left: '20%'
+    }
+  }
+}));
+
 interface Props {
   invoice: Linode.Invoice;
   account: Linode.Account;
@@ -20,6 +33,7 @@ type CombinedProps = Props;
 
 const RecentInvoicesRow: React.FC<CombinedProps> = props => {
   const { account, invoice } = props;
+  const classes = useStyles();
 
   const [pdfError, setPDFError] = React.useState<Error | undefined>(undefined);
   const [isGeneratingPDF, setGeneratingPDF] = React.useState<boolean>(false);
@@ -56,7 +70,9 @@ const RecentInvoicesRow: React.FC<CombinedProps> = props => {
   return (
     <TableRow
       key={`invoice-${invoice.id}`}
-      rowLink={`/account/billing/invoices/${invoice.id}`}
+      rowLink={
+        !isGeneratingPDF ? `/account/billing/invoices/${invoice.id}` : undefined
+      }
       data-qa-invoice
     >
       <TableCell parentColumn="Date Created" data-qa-invoice-date>
@@ -70,15 +86,21 @@ const RecentInvoicesRow: React.FC<CombinedProps> = props => {
       </TableCell>
       <TableCell>
         {account && (
-          <Button
-            style={{
-              padding: 0
-            }}
-            onClick={e => _printInvoice(e, account as Linode.Account, invoice)}
-            loading={isGeneratingPDF}
-          >
-            Download PDF
-          </Button>
+          <div className={classes.linkContainer}>
+            {!isGeneratingPDF ? (
+              <a
+                href="#"
+                onClick={e =>
+                  _printInvoice(e, account as Linode.Account, invoice)
+                }
+                className="secondaryLink"
+              >
+                Download PDF
+              </a>
+            ) : (
+              <CircleProgress mini />
+            )}
+          </div>
         )}
         {pdfError && (
           <Notice

--- a/packages/manager/src/features/Billing/BillingPanels/RecentPaymentsPanel/RecentPaymentsPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/RecentPaymentsPanel/RecentPaymentsPanel.tsx
@@ -148,6 +148,7 @@ class RecentPaymentsPanel extends React.Component<CombinedProps, State> {
               onClick={() =>
                 this.printPayment(account.data as Linode.Account, item)
               }
+              className="secondaryLink"
             >
               Download PDF
             </a>


### PR DESCRIPTION
## Improve link styles for PDF downloads in account

<img width="400" alt="Screen Shot 2019-08-07 at 3 54 49 PM" src="https://user-images.githubusercontent.com/205353/62653506-b604a200-b92b-11e9-81c3-dd09de05641e.png">

Links were previously bold (wrong styles, shown above) and I also added a circular progress for the PDF generating duration (there was previously one as it as a button)

## Type of Change
- Non breaking change ('update', 'change')
