### PR TITLE
M3-3044 Change: Make search link the first option in Algolia search bar

### DIFF
--- a/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -98,13 +98,6 @@ const styles = (theme: Theme) =>
     }
   });
 
-/* Need to override the default RS filtering; otherwise entities whose label
- * doesn't match the search term will be automatically filtered, meaning that
- * searching by tag won't work. */
-const filterResults = (option: Item, inputValue: string) => {
-  return true;
-};
-
 interface State {
   inputValue: string;
 }
@@ -138,8 +131,8 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
     const { inputValue } = this.state;
     const options = [...docs, ...community];
     return [
-      ...options,
-      { value: 'search', label: inputValue, data: { source: 'finalLink' } }
+      { value: 'search', label: inputValue, data: { source: 'finalLink' } },
+      ...options
     ];
   };
 
@@ -215,7 +208,6 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
               [classes.enhancedSelectWrapperCompact]: spacingMode === 'compact'
             })}
             styleOverrides={selectStyles}
-            filterOption={filterResults}
             value={false}
           />
         </div>

--- a/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -156,6 +156,9 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
     }
     const { history } = this.props;
     const { inputValue } = this.state;
+    if (!inputValue) {
+      return;
+    }
     const href = pathOr('', ['data', 'href'], selected);
     if (selected.value === 'search') {
       const link = this.getLinkTarget(inputValue);
@@ -167,6 +170,9 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
 
   handleSubmit = () => {
     const { inputValue } = this.state;
+    if (!inputValue) {
+      return;
+    }
     const { history } = this.props;
     const link = this.getLinkTarget(inputValue);
     history.push(link);


### PR DESCRIPTION
In an attempt to make the search landing more prominent, move the
final search option in the Algolia search bar on the Get Help landing
page, which is a link to the search landing page, to the top of the
results list.

Now, when users type in a search query and press Enter, they'll be
taken to the search landing page. If they click on one of the results
in the dropdown, or scroll down to an option with the arrow keys,
they'll be taken (as before) to the external link for that result.
