### PR TITLE
M3-3108 Fix issue with css transitions on theme switch

### DIFF
--- a/packages/manager/src/LinodeThemeWrapper.tsx
+++ b/packages/manager/src/LinodeThemeWrapper.tsx
@@ -38,14 +38,10 @@ const themes = { light, dark };
 type CombinedProps = Props & PreferencesActionsProps;
 
 const LinodeThemeWrapper: React.FC<CombinedProps> = props => {
-  React.useEffect(() => {
+  const toggleTheme = (value: ThemeChoice) => {
     setTimeout(() => {
       document.body.classList.remove('no-transition');
     }, 500);
-  });
-
-  const toggleTheme = (value: ThemeChoice) => {
-    document.body.classList.add('no-transition');
     /** send to GA */
     sendThemeToggleEvent(value);
   };

--- a/packages/manager/src/components/PrimaryNav/ThemeToggle.tsx
+++ b/packages/manager/src/components/PrimaryNav/ThemeToggle.tsx
@@ -55,6 +55,11 @@ export class ThemeToggle extends React.Component<CombinedProps> {
     const { classes, toggleTheme, theme } = this.props;
     const { name: themeName } = theme;
 
+    const toggle = () => {
+      toggleTheme();
+      onClickHandler();
+    };
+
     return (
       <div className={classes.switchWrapper}>
         <span
@@ -66,8 +71,7 @@ export class ThemeToggle extends React.Component<CombinedProps> {
           Light
         </span>
         <Toggle
-          onChange={toggleTheme}
-          onClick={() => onClickHandler()}
+          onChange={toggle}
           checked={themeName !== 'lightTheme'}
           className={classNames({
             [classes.toggle]: true,

--- a/packages/manager/src/components/PrimaryNav/ThemeToggle.tsx
+++ b/packages/manager/src/components/PrimaryNav/ThemeToggle.tsx
@@ -44,6 +44,10 @@ interface Props {
   toggleTheme: () => void;
 }
 
+const onClickHandler = () => {
+  document.body.classList.add('no-transition');
+};
+
 type CombinedProps = Props & WithStyles<ClassNames> & WithTheme;
 
 export class ThemeToggle extends React.Component<CombinedProps> {
@@ -63,6 +67,7 @@ export class ThemeToggle extends React.Component<CombinedProps> {
         </span>
         <Toggle
           onChange={toggleTheme}
+          onClick={() => onClickHandler()}
           checked={themeName !== 'lightTheme'}
           className={classNames({
             [classes.toggle]: true,


### PR DESCRIPTION
## Fix issue with css transitions on theme switch

Since switching the theme wrapper to a functional component we experienced some issues with css transitions after the theme switch (we disable all css transitions on theme switch as some elements would get background or color transitions on theme switch). This PR fixes that.

To test, before and after, do a theme switch and open a drawer (ex: create a volume from the create menu)

## Type of Change
- Non breaking change ('update', 'change')