### PR TITLE
M3-703 Add: disable managed service monitor

### DIFF
--- a/packages/manager/src/containers/managedServices.container.ts
+++ b/packages/manager/src/containers/managedServices.container.ts
@@ -2,7 +2,10 @@ import { connect, MapDispatchToProps } from 'react-redux';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { ApplicationState } from 'src/store';
-import { requestManagedServices as _requestManagedServices } from 'src/store/managed/managed.requests';
+import {
+  disableServiceMonitor as _disableServiceMonitor,
+  requestManagedServices as _requestManagedServices
+} from 'src/store/managed/managed.requests';
 import { EntityError } from 'src/store/types';
 
 export interface ManagedProps {
@@ -14,12 +17,15 @@ export interface ManagedProps {
 
 export interface DispatchProps {
   requestManagedServices: () => Promise<any>;
+  disableServiceMonitor: (monitorID: number) => Promise<any>;
 }
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
 ) => ({
-  requestManagedServices: () => dispatch(_requestManagedServices())
+  requestManagedServices: () => dispatch(_requestManagedServices()),
+  disableServiceMonitor: (monitorID: number) =>
+    dispatch(_disableServiceMonitor({ monitorID }))
 });
 
 export default <TInner extends {}, TOuter extends {}>(

--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.test.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render } from '@testing-library/react';
 import * as React from 'react';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import ActionMenu from './MonitorActionMenu';
+import { MonitorActionMenu as ActionMenu } from './MonitorActionMenu';
 
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 

--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
@@ -1,14 +1,28 @@
+import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
+import { compose } from 'recompose';
 
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+import withManagedServices, {
+  DispatchProps
+} from 'src/containers/managedServices.container';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 interface Props {
+  monitorID: number;
   status: Linode.MonitorStatus;
 }
 
-export class MonitorActionMenu extends React.Component<Props, {}> {
+type CombinedProps = Props & DispatchProps & WithSnackbarProps;
+
+export class MonitorActionMenu extends React.Component<CombinedProps, {}> {
   createActions = () => {
-    const { status } = this.props;
+    const {
+      disableServiceMonitor,
+      enqueueSnackbar,
+      monitorID,
+      status
+    } = this.props;
 
     return (closeMenu: Function): Action[] => {
       const actions = [
@@ -19,7 +33,16 @@ export class MonitorActionMenu extends React.Component<Props, {}> {
             }
           : {
               title: 'Disable',
-              onClick: () => closeMenu()
+              onClick: () => {
+                disableServiceMonitor(monitorID).catch(e => {
+                  const errMessage = getAPIErrorOrDefault(
+                    e,
+                    'Error disabling this service Monitor.'
+                  );
+                  enqueueSnackbar(errMessage[0].reason, { variant: 'error' });
+                });
+                closeMenu();
+              }
             }
       ];
       return actions;
@@ -31,4 +54,10 @@ export class MonitorActionMenu extends React.Component<Props, {}> {
   }
 }
 
-export default MonitorActionMenu;
+const enhanced = compose<CombinedProps, Props>(
+  // This is just a quick way to get access to managed Redux actions
+  withManagedServices(() => ({})),
+  withSnackbar
+);
+
+export default enhanced(MonitorActionMenu);

--- a/packages/manager/src/features/Managed/Monitors/MonitorRow.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorRow.tsx
@@ -83,7 +83,7 @@ export const monitorRow: React.FunctionComponent<CombinedProps> = props => {
         <Typography>{monitor.address}</Typography>
       </TableCell>
       <TableCell>
-        <ActionMenu status={monitor.status} />
+        <ActionMenu status={monitor.status} monitorID={monitor.id} />
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/services/managed/managed.ts
+++ b/packages/manager/src/services/managed/managed.ts
@@ -17,3 +17,20 @@ export const getServices = (params?: any, filters?: any) =>
     setXFilter(filters),
     setURL(`${API_ROOT}/managed/services`)
   ).then(response => response.data);
+
+/**
+ * disableServiceMonitor
+ *
+ * Temporarily disables monitoring of a Managed Service.
+ */
+export const disableServiceMonitor = (
+  serviceID: number,
+  params?: any,
+  filters?: any
+) =>
+  Request<Linode.ManagedServiceMonitor>(
+    setMethod('POST'),
+    setParams(params),
+    setXFilter(filters),
+    setURL(`${API_ROOT}/managed/services/${serviceID}/disable`)
+  ).then(response => response.data);

--- a/packages/manager/src/store/managed/managed.actions.ts
+++ b/packages/manager/src/store/managed/managed.actions.ts
@@ -2,8 +2,18 @@ import actionCreatorFactory from 'typescript-fsa';
 
 export const actionCreator = actionCreatorFactory(`@@manager/managed`);
 
+export interface MonitorPayload {
+  monitorID: number;
+}
+
 export const requestServicesActions = actionCreator.async<
   void,
   Linode.ManagedServiceMonitor[],
   Linode.ApiFieldError[]
 >('request');
+
+export const disableServiceMonitorActions = actionCreator.async<
+  MonitorPayload,
+  Linode.ManagedServiceMonitor,
+  Linode.ApiFieldError[]
+>('disable');

--- a/packages/manager/src/store/managed/managed.reducer.ts
+++ b/packages/manager/src/store/managed/managed.reducer.ts
@@ -52,6 +52,10 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       );
     }
 
+    if (isType(action, requestServicesActions.started)) {
+      draft.error!.update = undefined;
+    }
+
     if (isType(action, disableServiceMonitorActions.done)) {
       const { result } = action.payload;
       draft.entities = updateOrAdd(result, state.entities);

--- a/packages/manager/src/store/managed/managed.reducer.ts
+++ b/packages/manager/src/store/managed/managed.reducer.ts
@@ -4,7 +4,11 @@ import { isType } from 'typescript-fsa';
 
 import { EntityError, EntityState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { requestServicesActions } from './managed.actions';
+import updateOrAdd from 'src/utilities/updateOrAdd';
+import {
+  disableServiceMonitorActions,
+  requestServicesActions
+} from './managed.actions';
 
 /**
  * State
@@ -47,6 +51,17 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
         'Error loading your Monitors.'
       );
     }
+
+    if (isType(action, disableServiceMonitorActions.done)) {
+      const { result } = action.payload;
+      draft.entities = updateOrAdd(result, state.entities);
+    }
+
+    if (isType(action, disableServiceMonitorActions.failed)) {
+      const { error } = action.payload;
+      draft.error!.update = error;
+    }
+
     return draft;
   });
 };

--- a/packages/manager/src/store/managed/managed.requests.ts
+++ b/packages/manager/src/store/managed/managed.requests.ts
@@ -1,13 +1,26 @@
-import { getServices } from 'src/services/managed';
+import {
+  disableServiceMonitor as _disable,
+  getServices
+} from 'src/services/managed';
 import { getAll } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
-import { requestServicesActions } from './managed.actions';
+import {
+  disableServiceMonitorActions,
+  MonitorPayload,
+  requestServicesActions
+} from './managed.actions';
 
 const _getAll = getAll(getServices);
+const disableService = (params: MonitorPayload) => _disable(params.monitorID);
 
 const getAllServices = () => _getAll().then(({ data }) => data);
 
 export const requestManagedServices = createRequestThunk(
   requestServicesActions,
   getAllServices
+);
+
+export const disableServiceMonitor = createRequestThunk(
+  disableServiceMonitorActions,
+  disableService
 );


### PR DESCRIPTION
## Description

Use the action menu on the Monitors list to disable an active monitor.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

You'll have to use Classic to create a managed service monitor (first enroll yourself in Managed if you're not). You can curl the api (`POST managed/services/{id}/enable`) to toggle services back on so you don't have to keep creating them.