### PR TITLE
Fix: Issue with Editable Text Remounting

### DIFF
--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -5,20 +5,6 @@ import { wrapWithTheme } from 'src/utilities/testHelpers';
 import { Breadcrumb, CombinedProps as BreadCrumbProps } from './Breadcrumb';
 
 const props: BreadCrumbProps = {
-  classes: {
-    root: '',
-    preContainer: '',
-    crumbsWrapper: '',
-    crumb: '',
-    noCap: '',
-    crumbLink: '',
-    labelWrapper: '',
-    labelText: '',
-    labelSubtitle: '',
-    editableContainer: '',
-    prefixComponentWrapper: '',
-    slash: ''
-  },
   pathname: '/linodes/9872893679817/test/lastcrumb'
 };
 

--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
@@ -60,9 +60,6 @@ export const Breadcrumb: React.FC<CombinedProps> = props => {
           labelOptions={labelOptions}
         />
       </div>
-      {labelOptions &&
-        labelOptions.suffixComponent &&
-        labelOptions.suffixComponent}
     </div>
   );
 };

--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,116 +1,8 @@
-import * as classNames from 'classnames';
-import { LocationDescriptor } from 'history';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
-import {
-  createStyles,
-  CSSProperties,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
-import EditableText from 'src/components/EditableText';
+import { makeStyles } from 'src/components/core/styles';
+import Crumbs, { CrumbOverridesProps } from './Crumbs';
 
-type ClassNames =
-  | 'root'
-  | 'preContainer'
-  | 'crumbsWrapper'
-  | 'crumb'
-  | 'noCap'
-  | 'crumbLink'
-  | 'labelWrapper'
-  | 'labelText'
-  | 'labelSubtitle'
-  | 'editableContainer'
-  | 'prefixComponentWrapper'
-  | 'slash';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      alignItems: 'flex-start'
-    },
-    preContainer: {
-      display: 'flex',
-      flexWrap: 'wrap',
-      alignItems: 'flex-start',
-      marginTop: -3
-    },
-    crumbsWrapper: {
-      display: 'flex',
-      alignItems: 'center'
-    },
-    crumb: {
-      whiteSpace: 'nowrap',
-      textTransform: 'capitalize',
-      ...theme.typography.h1
-    },
-    noCap: {
-      textTransform: 'initial'
-    },
-    crumbLink: {
-      color: theme.palette.primary.main,
-      '&:hover': {
-        color: theme.palette.primary.light
-      }
-    },
-    labelWrapper: {
-      display: 'flex',
-      flexDirection: 'column'
-    },
-    labelText: {
-      padding: `2px 10px`
-    },
-    labelSubtitle: {
-      margin: '4px 0 0 10px'
-    },
-    editableContainer: {
-      marginLeft: -theme.spacing(1),
-      marginTop: -10,
-      [theme.breakpoints.up('lg')]: {
-        marginTop: -9
-      }
-    },
-    prefixComponentWrapper: {
-      '& svg, & img': {
-        position: 'relative',
-        marginRight: 8,
-        marginLeft: 4,
-        top: -2
-      }
-    },
-    slash: {
-      fontSize: 24,
-      marginLeft: theme.spacing(1),
-      marginRight: theme.spacing(1),
-      color: theme.color.grey1
-    }
-  });
-
-interface EditableProps {
-  onCancel: () => void;
-  onEdit: (value: string) => Promise<any>;
-  errorText?: string;
-  editableTextTitle: string;
-}
-
-interface LabelProps {
-  linkTo?: string;
-  prefixComponent?: JSX.Element | null;
-  prefixStyle?: CSSProperties;
-  suffixComponent?: JSX.Element | null;
-  subtitle?: string;
-  noCap?: boolean;
-}
-
-interface CrumbOverridesProps {
-  position: number;
-  linkTo?: LocationDescriptor;
-  label?: string;
-  noCap?: boolean;
-}
+import { EditableProps, LabelProps } from './types';
 
 export interface Props {
   labelTitle?: string;
@@ -122,164 +14,63 @@ export interface Props {
   pathname: string;
 }
 
-export type CombinedProps = Props & WithStyles<ClassNames>;
+export type CombinedProps = Props;
 
-export class Breadcrumb extends React.Component<CombinedProps> {
-  render() {
-    const {
-      classes,
-      labelTitle,
-      labelOptions,
-      onEditHandlers,
-      removeCrumbX,
-      crumbOverrides,
-      className,
-      pathname
-    } = this.props;
-
-    const url = pathname && pathname.slice(1);
-    const allPaths = url.split('/');
-
-    const removeByIndex = (list: string[], indexToRemove: number) => {
-      return list.filter((value, index) => {
-        return index !== indexToRemove;
-      });
-    };
-
-    const Crumbs = () => {
-      const paths = allPaths;
-      const pathMap = removeCrumbX
-        ? removeByIndex(paths, removeCrumbX - 1)
-        : paths;
-      const lastCrumb = pathMap.slice(-1)[0];
-
-      return (
-        <>
-          {pathMap.slice(0, -1).map((crumb: string, key: number) => {
-            const link =
-              '/' + paths.slice(0, -(paths.length - (key + 1))).join('/');
-            const override =
-              crumbOverrides &&
-              crumbOverrides.find(e => e.position === key + 1);
-
-            return (
-              <div key={key} className={classes.crumbsWrapper}>
-                <Link
-                  to={
-                    crumbOverrides && override
-                      ? override.linkTo
-                        ? override.linkTo
-                        : link
-                      : link
-                  }
-                  data-qa-link
-                >
-                  <Typography
-                    className={classNames({
-                      [classes.crumb]: true,
-                      [classes.crumbLink]: true,
-                      [classes.noCap]: override && override.noCap
-                    })}
-                    data-qa-link-text
-                    data-testid={'link-text'}
-                  >
-                    {crumbOverrides && override
-                      ? override.label
-                        ? override.label
-                        : crumb
-                      : crumb}
-                  </Typography>
-                </Link>
-                <Typography component="span" className={classes.slash}>
-                  /
-                </Typography>
-              </div>
-            );
-          })}
-
-          {labelOptions && labelOptions.prefixComponent && (
-            <>
-              <div
-                className={classes.prefixComponentWrapper}
-                data-qa-prefixwrapper
-                style={labelOptions.prefixStyle && labelOptions.prefixStyle}
-              >
-                {labelOptions.prefixComponent}
-              </div>
-            </>
-          )}
-
-          {labelTitle ? (
-            <div className={classes.labelWrapper}>
-              <Typography
-                variant="h1"
-                className={classNames({
-                  [classes.crumb]: true,
-                  [classes.noCap]: labelOptions && labelOptions.noCap
-                })}
-                data-qa-label-text
-              >
-                {labelTitle}
-              </Typography>
-              {labelOptions && labelOptions.subtitle && (
-                <Typography
-                  variant="body1"
-                  className={classes.labelSubtitle}
-                  data-qa-label-subtitle
-                >
-                  {labelOptions.subtitle}
-                </Typography>
-              )}
-            </div>
-          ) : onEditHandlers ? (
-            <EditableText
-              typeVariant="h2"
-              text={onEditHandlers.editableTextTitle}
-              errorText={onEditHandlers.errorText}
-              onEdit={onEditHandlers.onEdit}
-              onCancel={onEditHandlers.onCancel}
-              labelLink={labelOptions && labelOptions.linkTo}
-              data-qa-editable-text
-              className={classes.editableContainer}
-            />
-          ) : (
-            <div className={classes.labelWrapper}>
-              <Typography
-                className={classNames({
-                  [classes.crumb]: true,
-                  [classes.noCap]: labelOptions && labelOptions.noCap
-                })}
-                data-qa-label-text
-              >
-                {lastCrumb}
-              </Typography>
-              {labelOptions && labelOptions.subtitle && (
-                <Typography
-                  variant="h1"
-                  className={classes.labelSubtitle}
-                  data-qa-label-subtitle
-                >
-                  {labelOptions.subtitle}
-                </Typography>
-              )}
-            </div>
-          )}
-        </>
-      );
-    };
-
-    return (
-      <div className={`${classes.root} ${className}`}>
-        <div className={classes.preContainer}>
-          <Crumbs />
-        </div>
-        {labelOptions &&
-          labelOptions.suffixComponent &&
-          labelOptions.suffixComponent}
-      </div>
-    );
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'flex-start'
+  },
+  preContainer: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'flex-start',
+    marginTop: -3
   }
-}
+});
 
-const styled = withStyles(styles);
-export default styled(Breadcrumb);
+export const Breadcrumb: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const {
+    labelTitle,
+    labelOptions,
+    onEditHandlers,
+    removeCrumbX,
+    crumbOverrides,
+    className,
+    pathname
+  } = props;
+
+  const url = pathname && pathname.slice(1);
+  const allPaths = url.split('/');
+
+  const pathMap = removeCrumbX
+    ? removeByIndex(allPaths, removeCrumbX - 1)
+    : allPaths;
+
+  return (
+    <div className={`${classes.root} ${className}`}>
+      <div className={classes.preContainer}>
+        <Crumbs
+          pathMap={pathMap}
+          onEditHandlers={onEditHandlers}
+          crumbOverrides={crumbOverrides}
+          labelTitle={labelTitle}
+          labelOptions={labelOptions}
+        />
+      </div>
+      {labelOptions &&
+        labelOptions.suffixComponent &&
+        labelOptions.suffixComponent}
+    </div>
+  );
+};
+
+const removeByIndex = (list: string[], indexToRemove: number) => {
+  return list.filter((value, index) => {
+    return index !== indexToRemove;
+  });
+};
+
+export default Breadcrumb;

--- a/packages/manager/src/components/Breadcrumb/Crumbs.tsx
+++ b/packages/manager/src/components/Breadcrumb/Crumbs.tsx
@@ -6,7 +6,7 @@ import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
 import Typography from 'src/components/core/Typography';
-import LastCrumb from './FinalCrumb';
+import FinalCrumb from './FinalCrumb';
 import FinalCrumbPrefix from './FinalCrumbPrefix';
 
 import { EditableProps, LabelProps } from './types';
@@ -127,11 +127,19 @@ const Crumbs: React.FC<CombinedProps> = props => {
         the final crumb has the possibility of being a link, editable text
         or just static text
       */}
-      <LastCrumb
+      <FinalCrumb
         crumb={labelTitle || lastCrumb}
         labelOptions={labelOptions}
         onEditHandlers={onEditHandlers}
       />
+
+      {/* 
+        for appending some SVG or other element after the final crumb.
+        See support ticket detail as an example
+      */}
+      {labelOptions &&
+        labelOptions.suffixComponent &&
+        labelOptions.suffixComponent}
     </>
   );
 };

--- a/packages/manager/src/components/Breadcrumb/Crumbs.tsx
+++ b/packages/manager/src/components/Breadcrumb/Crumbs.tsx
@@ -1,0 +1,139 @@
+import * as classNames from 'classnames';
+import { LocationDescriptor } from 'history';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { compose } from 'recompose';
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+import Typography from 'src/components/core/Typography';
+import LastCrumb from './FinalCrumb';
+import FinalCrumbPrefix from './FinalCrumbPrefix';
+
+import { EditableProps, LabelProps } from './types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  crumbsWrapper: {
+    display: 'flex',
+    alignItems: 'center'
+  },
+  crumb: {
+    whiteSpace: 'nowrap',
+    textTransform: 'capitalize',
+    ...theme.typography.h1
+  },
+  noCap: {
+    textTransform: 'initial'
+  },
+  crumbLink: {
+    color: theme.palette.primary.main,
+    '&:hover': {
+      color: theme.palette.primary.light
+    }
+  },
+  slash: {
+    fontSize: 24,
+    marginLeft: theme.spacing(1),
+    marginRight: theme.spacing(1),
+    color: theme.color.grey1
+  }
+}));
+
+export interface CrumbOverridesProps {
+  position: number;
+  linkTo?: LocationDescriptor;
+  label?: string;
+  noCap?: boolean;
+}
+
+interface Props {
+  pathMap: string[];
+  crumbOverrides?: CrumbOverridesProps[];
+  labelTitle?: string;
+  labelOptions?: LabelProps;
+  onEditHandlers?: EditableProps;
+}
+
+type CombinedProps = Props;
+
+const Crumbs: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const {
+    pathMap,
+    crumbOverrides,
+    labelOptions,
+    labelTitle,
+    onEditHandlers
+  } = props;
+
+  const allCrumbsButLast = pathMap.slice(0, -1);
+  const lastCrumb = pathMap.slice(-1)[0];
+
+  return (
+    <>
+      {allCrumbsButLast.map((crumb: string, key: number) => {
+        const link =
+          '/' + pathMap.slice(0, -(pathMap.length - (key + 1))).join('/');
+        const override =
+          crumbOverrides && crumbOverrides.find(e => e.position === key + 1);
+
+        return (
+          <div key={key} className={classes.crumbsWrapper}>
+            <Link
+              to={
+                crumbOverrides && override
+                  ? override.linkTo
+                    ? override.linkTo
+                    : link
+                  : link
+              }
+              data-qa-link
+            >
+              <Typography
+                className={classNames({
+                  [classes.crumb]: true,
+                  [classes.crumbLink]: true,
+                  [classes.noCap]: override && override.noCap
+                })}
+                data-qa-link-text
+                data-testid={'link-text'}
+              >
+                {crumbOverrides && override
+                  ? override.label
+                    ? override.label
+                    : crumb
+                  : crumb}
+              </Typography>
+            </Link>
+            <Typography component="span" className={classes.slash}>
+              /
+            </Typography>
+          </div>
+        );
+      })}
+
+      {/* 
+        for prepending some SVG or other element before the final crumb.
+        See users detail page for example
+      */}
+      {labelOptions && labelOptions.prefixComponent && (
+        <FinalCrumbPrefix
+          prefixComponent={labelOptions.prefixComponent}
+          prefixStyle={labelOptions.prefixStyle}
+        />
+      )}
+
+      {/* 
+        the final crumb has the possibility of being a link, editable text
+        or just static text
+      */}
+      <LastCrumb
+        crumb={labelTitle || lastCrumb}
+        labelOptions={labelOptions}
+        onEditHandlers={onEditHandlers}
+      />
+    </>
+  );
+};
+
+export default compose<CombinedProps, Props>(React.memo)(Crumbs);

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -1,0 +1,106 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import { compose } from 'recompose';
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+import Typography from 'src/components/core/Typography';
+import EditableText from 'src/components/EditableText';
+import { EditableProps, LabelProps } from './types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  crumb: {
+    whiteSpace: 'nowrap',
+    textTransform: 'capitalize',
+    ...theme.typography.h1
+  },
+  noCap: {
+    textTransform: 'initial'
+  },
+  crumbLink: {
+    color: theme.palette.primary.main,
+    '&:hover': {
+      color: theme.palette.primary.light
+    }
+  },
+  labelWrapper: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  labelText: {
+    padding: `2px 10px`
+  },
+  labelSubtitle: {
+    margin: '4px 0 0 10px'
+  },
+  editableContainer: {
+    marginLeft: -theme.spacing(1),
+    marginTop: -10,
+    [theme.breakpoints.up('lg')]: {
+      marginTop: -9
+    }
+  },
+  slash: {
+    fontSize: 24,
+    marginLeft: theme.spacing(1),
+    marginRight: theme.spacing(1),
+    color: theme.color.grey1
+  }
+}));
+
+interface Props {
+  crumb: string;
+  subtitle?: string;
+  labelOptions?: LabelProps;
+  onEditHandlers?: EditableProps;
+}
+
+type CombinedProps = Props;
+
+const FinalCrumb: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const { crumb, labelOptions, onEditHandlers } = props;
+
+  if (onEditHandlers) {
+    return (
+      <EditableText
+        typeVariant="h2"
+        text={onEditHandlers.editableTextTitle}
+        errorText={onEditHandlers.errorText}
+        onEdit={onEditHandlers.onEdit}
+        onCancel={onEditHandlers.onCancel}
+        labelLink={labelOptions && labelOptions.linkTo}
+        data-qa-editable-text
+        className={classes.editableContainer}
+      />
+    );
+  }
+
+  return (
+    <React.Fragment>
+      <div className={classes.labelWrapper}>
+        <Typography
+          variant="h1"
+          className={classNames({
+            [classes.crumb]: true,
+            [classes.noCap]: labelOptions && labelOptions.noCap
+          })}
+          data-qa-label-text
+        >
+          {crumb}
+        </Typography>
+        {labelOptions && labelOptions.subtitle && (
+          <Typography
+            variant="body1"
+            className={classes.labelSubtitle}
+            data-qa-label-subtitle
+          >
+            {labelOptions.subtitle}
+          </Typography>
+        )}
+      </div>
+    </React.Fragment>
+  );
+};
+
+export default compose<CombinedProps, Props>(React.memo)(FinalCrumb);

--- a/packages/manager/src/components/Breadcrumb/FinalCrumbPrefix.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumbPrefix.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+import { CSSProperties, makeStyles } from 'src/components/core/styles';
+
+const useStyles = makeStyles({
+  prefixComponentWrapper: {
+    '& svg, & img': {
+      position: 'relative',
+      marginRight: 8,
+      marginLeft: 4,
+      top: -2
+    }
+  }
+});
+
+interface Props {
+  prefixStyle?: CSSProperties;
+  prefixComponent: JSX.Element | null;
+}
+
+type CombinedProps = Props;
+
+const FinalCrumbPrefix: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const { prefixComponent, prefixStyle } = props;
+
+  return (
+    <div
+      className={classes.prefixComponentWrapper}
+      data-qa-prefixwrapper
+      style={prefixStyle && prefixStyle}
+    >
+      {prefixComponent}
+    </div>
+  );
+};
+
+export default compose<CombinedProps, Props>(React.memo)(FinalCrumbPrefix);

--- a/packages/manager/src/components/Breadcrumb/types.ts
+++ b/packages/manager/src/components/Breadcrumb/types.ts
@@ -1,0 +1,17 @@
+import { CSSProperties } from 'src/components/core/styles';
+
+export interface LabelProps {
+  linkTo?: string;
+  prefixComponent?: JSX.Element | null;
+  prefixStyle?: CSSProperties;
+  suffixComponent?: JSX.Element | null;
+  subtitle?: string;
+  noCap?: boolean;
+}
+
+export interface EditableProps {
+  onCancel: () => void;
+  onEdit: (value: string) => Promise<any>;
+  errorText?: string;
+  editableTextTitle: string;
+}

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -198,6 +198,9 @@ export class EditableText extends React.Component<FinalProps, State> {
           this.setState({ isEditing: false });
         })
         .catch(e => e);
+    } else {
+      /** otherwise, we've just submitted the form with no value change */
+      this.setState({ isEditing: false });
     }
   };
 


### PR DESCRIPTION
## Description

Previously, there was a bug where

1. Create a Linode
2. Perform some long running action (such as resize)
3. Open up the editable text edit mode
4. Wait - the editable text should exit edit mode automatically

The reason for this is because the editable text component was re-mounting every single time it updated because there was a function being re-instantiated inside the `<BreadCrumb />` component. I removed this logic, but also split the breadcrumb into smaller, more digest-able components, so it's more clear what's happening

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Applicable E2E Tests

N/A