### PR TITLE
Fix: Monitor Action Menu Tests

### DIFF
--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.test.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.test.tsx
@@ -1,13 +1,22 @@
 import { cleanup, render } from '@testing-library/react';
 import * as React from 'react';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import { MonitorActionMenu as ActionMenu } from './MonitorActionMenu';
+import {
+  CombinedProps,
+  MonitorActionMenu as ActionMenu
+} from './MonitorActionMenu';
 
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 
 jest.mock('src/components/ActionMenu/ActionMenu');
 
-const props = {
+const props: CombinedProps = {
+  enqueueSnackbar: jest.fn(),
+  closeSnackbar: jest.fn(),
+  status: 'disabled',
+  monitorID: 1,
+  requestManagedServices: jest.fn(),
+  disableServiceMonitor: jest.fn(),
   ...reactRouterProps
 };
 

--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
@@ -13,7 +13,7 @@ interface Props {
   status: Linode.MonitorStatus;
 }
 
-type CombinedProps = Props & DispatchProps & WithSnackbarProps;
+export type CombinedProps = Props & DispatchProps & WithSnackbarProps;
 
 export class MonitorActionMenu extends React.Component<CombinedProps, {}> {
   createActions = () => {


### PR DESCRIPTION
Builds were failing for typescript reasons