### PR TITLE
Promo codes: Add summary field to promotion

### DIFF
--- a/packages/manager/src/__data__/account.ts
+++ b/packages/manager/src/__data__/account.ts
@@ -1,4 +1,4 @@
-export const activePromotions: Linode.ActivePromotions[] = [
+export const activePromotions: Linode.ActivePromotion[] = [
   {
     description: 'Get $10 off your Linodes',
     expire_dt: '2019-08-20T13:52:21',
@@ -6,7 +6,8 @@ export const activePromotions: Linode.ActivePromotions[] = [
     this_month_credit_remaining: 10,
     label: 'monthly_linode_10_50',
     summary: '$50 off each month for 5 months',
-    credit_monthly_cap: 0
+    credit_monthly_cap: 0,
+    image_url: 'https://my-image.com/image'
   }
 ];
 

--- a/packages/manager/src/__data__/account.ts
+++ b/packages/manager/src/__data__/account.ts
@@ -1,10 +1,11 @@
 export const activePromotions: Linode.ActivePromotions[] = [
   {
     description: 'Get $10 off your Linodes',
-    expire_dt: '2019-08-10T13:52:21',
+    expire_dt: '2019-08-20T13:52:21',
     credit_remaining: 500,
     this_month_credit_remaining: 10,
     label: 'monthly_linode_10_50',
+    summary: '$50 off each month for 5 months',
     credit_monthly_cap: 0
   }
 ];

--- a/packages/manager/src/features/Billing/BillingPanels/PromotionsPanel/PromotionDisplay.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PromotionsPanel/PromotionDisplay.tsx
@@ -23,13 +23,13 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
-  header: string;
   description: string;
+  summary: string;
   expiry: string;
 }
 
 export const PromotionDisplay: React.FC<Props> = props => {
-  const { expiry, description, header } = props;
+  const { expiry, description, summary } = props;
   const classes = useStyles();
   return (
     <Grid
@@ -46,7 +46,7 @@ export const PromotionDisplay: React.FC<Props> = props => {
       </Grid>
       <Grid item className={classes.container}>
         <Typography variant="subtitle2">
-          <strong>{header}</strong>
+          <strong>{summary}</strong>
         </Typography>
         <Typography>{description}</Typography>
       </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/PromotionsPanel/PromotionsPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PromotionsPanel/PromotionsPanel.tsx
@@ -20,7 +20,7 @@ interface StateProps {
   accountLoading: boolean;
   accountError?: Linode.ApiFieldError[];
   accountUpdated: number;
-  promotions: Linode.ActivePromotions[];
+  promotions: Linode.ActivePromotion[];
 }
 
 export type CombinedProps = StateProps;

--- a/packages/manager/src/features/Billing/BillingPanels/PromotionsPanel/PromotionsPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PromotionsPanel/PromotionsPanel.tsx
@@ -58,7 +58,7 @@ export const PromotionsPanel: React.FC<StateProps> = props => {
             key={`promotion-display-${idx}`}
             description={thisPromotion.description}
             expiry={thisPromotion.expire_dt}
-            header={'$50 credit per month for 3 months'}
+            summary={thisPromotion.summary}
           />
         ))
       )}

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -45,7 +45,7 @@ const styles = (theme: Theme) =>
 
 interface StateProps {
   accountBackups: boolean;
-  activePromotions: Linode.ActivePromotions[];
+  activePromotions: Linode.ActivePromotion[];
   linodesWithoutBackups: Linode.Linode[];
   managed: boolean;
   backupError?: Error;

--- a/packages/manager/src/types/Account.ts
+++ b/packages/manager/src/types/Account.ts
@@ -24,7 +24,7 @@ namespace Linode {
     city: string;
     phone: string;
     company: string;
-    active_promotions: ActivePromotions[];
+    active_promotions: ActivePromotion[];
     // [BETA]
     // @todo: Uncomment this when it becomes generally available
     // capabilities: AccountCapability[];
@@ -45,7 +45,7 @@ namespace Linode {
     backups_enabled: boolean;
   }
 
-  export interface ActivePromotions {
+  export interface ActivePromotion {
     label: string;
     description: string;
     summary: string;
@@ -53,6 +53,7 @@ namespace Linode {
     credit_remaining: number;
     this_month_credit_remaining: number;
     credit_monthly_cap: number;
+    image_url: string;
   }
 
   interface CreditCard {

--- a/packages/manager/src/types/Account.ts
+++ b/packages/manager/src/types/Account.ts
@@ -48,6 +48,7 @@ namespace Linode {
   export interface ActivePromotions {
     label: string;
     description: string;
+    summary: string;
     expire_dt: string;
     credit_remaining: number;
     this_month_credit_remaining: number;


### PR DESCRIPTION
## Description

Backend folks have added `summary` and `image_url` fields to each promotion so that we can display header text separate from the description. (We're not using image url atm but maybe we should?)

Note: Unrelated to this specific PR, there will also be a notification for active promotions on your account. I'm not doing anything with that, and calculating the values from the `active_promotions` array on the `account` object. The reason for this is that we would have to do text splitting to match the design on the Dashboard, and we already have access to all the information we need through the aforementioned `active_promotions` object.