### PR TITLE
M3-3126 Fix wrong button types for cancel actions

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/CancelAccountDialog.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/CancelAccountDialog.tsx
@@ -149,7 +149,7 @@ interface ActionsProps {
 const Actions: React.FC<ActionsProps> = props => {
   return (
     <ActionsPanel>
-      <Button onClick={props.onClose} buttonType="secondary">
+      <Button onClick={props.onClose} buttonType="cancel">
         Cancel
       </Button>
       <Button

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -1067,7 +1067,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
     <ActionsPanel style={{ padding: 0 }}>
       <Button
         onClick={onClose}
-        buttonType="secondary"
+        buttonType="cancel"
         className="cancel"
         data-qa-cancel-cancel
       >

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/DeleteIPActions.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/DeleteIPActions.tsx
@@ -26,7 +26,9 @@ class DeleteIPActions extends React.PureComponent<CombinedProps> {
     const { handleCancel, loading } = this.props;
     return (
       <ActionsPanel>
-        <Button onClick={handleCancel}>Cancel</Button>
+        <Button onClick={handleCancel} buttonType="cancel">
+          Cancel
+        </Button>
         <Button
           buttonType="secondary"
           destructive

--- a/packages/manager/src/features/linodes/LinodesLanding/DeleteDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DeleteDialog.tsx
@@ -81,7 +81,7 @@ interface ActionsProps {
 const Actions: React.FC<ActionsProps> = props => {
   return (
     <ActionsPanel>
-      <Button onClick={props.onClose} buttonType="secondary">
+      <Button onClick={props.onClose} buttonType="cancel">
         Cancel
       </Button>
       <Button

--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
@@ -139,7 +139,7 @@ interface ActionsProps {
 const Actions: React.FC<ActionsProps> = props => {
   return (
     <ActionsPanel>
-      <Button onClick={props.onClose} buttonType="secondary">
+      <Button onClick={props.onClose} buttonType="cancel">
         Cancel
       </Button>
       <Button


### PR DESCRIPTION
## Fix wrong button types for cancel actions

Finding and replacing the cancel buttons with a "secondary" buttonType prop (should be "cancel") 

## Type of Change
- Non breaking change ('update')