### PR TITLE
M3-3128 Fix one-click cards display on large breakpoints

### DIFF
--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -51,7 +51,8 @@ const styles = (theme: Theme) =>
     heading: {
       fontFamily: theme.font.bold,
       fontSize: '1rem',
-      color: theme.color.headline
+      color: theme.color.headline,
+      wordBreak: 'break-word'
     },
     subheading: {
       fontSize: '0.875rem',

--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -117,6 +117,7 @@ export class CardBase extends React.Component<CombinedProps> {
         container
         alignItems="center"
         justify="space-between"
+        wrap="nowrap"
         className={`${classes.innerGrid} innerGrid`}
       >
         {renderIcon && (

--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -124,6 +124,7 @@ const styles = (theme: Theme) =>
       display: 'flex',
       justifyContent: 'flex-end',
       color: theme.palette.primary.main,
+      maxWidth: 40,
       '& .circle': {
         transition: theme.transitions.create('fill')
       },


### PR DESCRIPTION
## Fix one-click cards display on large breakpoints

<img width="400" alt="Screen Shot 2019-08-12 at 2 01 22 PM" src="https://user-images.githubusercontent.com/205353/62895542-1e34f880-bd1d-11e9-9cd9-5a98e4c323ff.png">

fixing this ^


## Type of Change
- Bug fix ('bug')

