### PR TITLE
M3-3131 Fix wrong instances of css animations in JSS

### DIFF
--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -75,7 +75,7 @@ const styles = (theme: Theme) =>
     },
     '& .insidePath path': {
       opacity: 0,
-      animation: 'fadeIn .2s ease-in-out forwards .3s',
+      animation: '$fadeIn .2s ease-in-out forwards .3s',
       stroke: theme.palette.primary.main
     },
     '& .bucket.insidePath path': {

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -237,8 +237,7 @@ export const dark = (options: ThemeOverrides) =>
             minWidth: 100,
             '& svg': {
               width: 22,
-              height: 22,
-              animation: '$rotate 2s linear infinite'
+              height: 22
             }
           }
         }


### PR DESCRIPTION
##  Fix wrong instances of css animations in JSS

This small fixes remove some of the console warnings in the pre commit hook for our tests:

```
PASS src/features/Kubernetes/CreateCluster/NodePoolDisplayTable.test.tsx
linode-manager:   ● Console
linode-manager:     console.warn node_modules/tiny-warning/dist/tiny-warning.cjs.js:13
linode-manager:       Warning: [JSS] Referenced keyframes rule "rotate" is not defined.
linode-manager:     console.warn node_modules/tiny-warning/dist/tiny-warning.cjs.js:13
linode-manager:       Warning: [JSS] Referenced keyframes rule "rotate" is not defined.
linode-manager: PASS src/features/linodes/LinodesCreate/TabbedContent/FromImageContent.test.tsx
linode-manager: PASS src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.test.tsx (31.13s)
linode-manager:   ● Console
linode-manager:     console.warn node_modules/tiny-warning/dist/tiny-warning.cjs.js:13
linode-manager:       Warning: [JSS] Referenced keyframes rule "rotate" is not defined.
linode-manager:     console.warn node_modules/tiny-warning/dist/tiny-warning.cjs.js:13
linode-manager:       Warning: [JSS] Referenced keyframes rule "rotate" is not defined.
linode-manager:     console.warn node_modules/tiny-warning/dist/tiny-warning.cjs.js:13
linode-manager:       Warning: [JSS] Referenced keyframes rule "rotate" is not defined.
linode-manager: PASS src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx (32.082s)
linode-manager:   ● Console
linode-manager:     console.warn node_modules/tiny-warning/dist/tiny-warning.cjs.js:13
linode-manager:       Warning: [JSS] Referenced keyframes rule "rotate" is not defined.
linode-manager:     console.warn node_modules/tiny-warning/dist/tiny-warning.cjs.js:13
linode-manager:       Warning: [JSS] Referenced keyframes rule "rotate" is not defined.
linode-manager:     console.warn node_modules/tiny-warning/dist/tiny-warning.cjs.js:13
linode-manager:       Warning: [JSS] Referenced keyframes rule "rotate" is not defined.
```

## Type of Change
- Bug fix ('fix')
