### PR TITLE
Update: Remove label from active_promotions typings

### DIFF
--- a/packages/manager/src/__data__/account.ts
+++ b/packages/manager/src/__data__/account.ts
@@ -4,7 +4,6 @@ export const activePromotions: Linode.ActivePromotion[] = [
     expire_dt: '2019-08-14T23:52:21',
     credit_remaining: '500.00',
     this_month_credit_remaining: '10.00',
-    label: 'monthly_linode_10_50',
     summary: '$50 off each month for 5 months',
     credit_monthly_cap: '50',
     image_url: 'https://my-image.com/image'

--- a/packages/manager/src/types/Account.ts
+++ b/packages/manager/src/types/Account.ts
@@ -46,7 +46,6 @@ namespace Linode {
   }
 
   export interface ActivePromotion {
-    label: string;
     description: string;
     summary: string;
     expire_dt: string | null;


### PR DESCRIPTION
## Description

A field has been removed from the API response. We weren't using it anyway, so this is just to keep the typings up to date.