### PR TITLE
M3-695 SSH Access Part III: Action Menu and Drawer scaffold

### DIFF
--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -2,9 +2,9 @@ import * as React from 'react';
 import Drawer from 'src/components/Drawer';
 
 interface Props {
-  linodeSetting?: Linode.ManagedLinodeSetting;
   isOpen: boolean;
   closeDrawer: () => void;
+  linodeSetting?: Linode.ManagedLinodeSetting;
 }
 
 type CombinedProps = Props;

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -12,13 +12,14 @@ type CombinedProps = Props;
 const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
   const { isOpen, closeDrawer, linodeSetting } = props;
 
-  const drawerTitle = linodeSetting
+  const title = linodeSetting
     ? `Edit SSH Access for ${linodeSetting.label}`
     : 'Edit SSH Access';
 
   return (
-    <Drawer title={drawerTitle} open={isOpen} onClose={closeDrawer}>
-      SSH Access Drawer
+    <Drawer title={title} open={isOpen} onClose={closeDrawer}>
+      {/* FORM GOES HERE */}
+      <pre>{JSON.stringify(linodeSetting, null, 2)}</pre>
     </Drawer>
   );
 };

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import Drawer from 'src/components/Drawer';
 
-import { makeStyles, Theme } from 'src/components/core/styles';
-
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {}
-}));
-
 interface Props {
   linodeSetting?: Linode.ManagedLinodeSetting;
   isOpen: boolean;
@@ -17,7 +11,6 @@ type CombinedProps = Props;
 
 const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
   const { isOpen, closeDrawer, linodeSetting } = props;
-  const classes = useStyles();
 
   const drawerTitle = linodeSetting
     ? `Edit SSH Access for ${linodeSetting.label}`

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import Drawer from 'src/components/Drawer';
+
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {}
+}));
+
+interface Props {
+  linodeSetting?: Linode.ManagedLinodeSetting;
+  isOpen: boolean;
+  closeDrawer: () => void;
+}
+
+type CombinedProps = Props;
+
+const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
+  const { isOpen, closeDrawer, linodeSetting } = props;
+  const classes = useStyles();
+
+  const drawerTitle = linodeSetting
+    ? `Edit SSH Access for ${linodeSetting.label}`
+    : 'Edit SSH Access';
+
+  return (
+    <Drawer title={drawerTitle} open={isOpen} onClose={closeDrawer}>
+      SSH Access Drawer
+    </Drawer>
+  );
+};
+
+export default EditSSHAccessDrawer;

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.test.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import * as React from 'react';
+import { includesActions, wrapWithTheme } from 'src/utilities/testHelpers';
+import {
+  CombinedProps,
+  SSHAccessActionMenu as ActionMenu
+} from './SSHAccessActionMenu';
+
+jest.mock('src/components/ActionMenu/ActionMenu');
+
+const mockOpenDrawer = jest.fn();
+
+const props: CombinedProps = {
+  enqueueSnackbar: jest.fn(),
+  closeSnackbar: jest.fn(),
+  linodeId: 1,
+  isEnabled: true,
+  requestSettings: jest.fn(),
+  openDrawer: mockOpenDrawer
+};
+
+afterEach(cleanup);
+
+describe('SSH Access Action Menu', () => {
+  it('should include basic actions', () => {
+    const { queryByText } = render(wrapWithTheme(<ActionMenu {...props} />));
+    includesActions(['Edit'], queryByText);
+  });
+
+  it('should include Enable if access on the Linode is disabled', () => {
+    const { queryByText } = render(
+      wrapWithTheme(<ActionMenu {...props} isEnabled={false} />)
+    );
+    expect(queryByText('Enable')).toBeInTheDocument();
+    expect(queryByText('Disable')).not.toBeInTheDocument();
+  });
+
+  it('should include Disable if access on the Linode is enabled', () => {
+    const { queryByText } = render(
+      wrapWithTheme(<ActionMenu {...props} isEnabled={true} />)
+    );
+    expect(queryByText('Disable')).toBeInTheDocument();
+    expect(queryByText('Enable')).not.toBeInTheDocument();
+  });
+
+  it('should open the drawer when "Edit" option is clicked', () => {
+    const { getByText } = render(wrapWithTheme(<ActionMenu {...props} />));
+    fireEvent.click(getByText('Edit'));
+    expect(mockOpenDrawer).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.test.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.test.tsx
@@ -11,12 +11,12 @@ jest.mock('src/components/ActionMenu/ActionMenu');
 const mockOpenDrawer = jest.fn();
 
 const props: CombinedProps = {
-  enqueueSnackbar: jest.fn(),
-  closeSnackbar: jest.fn(),
   linodeId: 1,
   isEnabled: true,
-  requestSettings: jest.fn(),
-  openDrawer: mockOpenDrawer
+  updateOne: jest.fn(),
+  openDrawer: mockOpenDrawer,
+  enqueueSnackbar: jest.fn(),
+  closeSnackbar: jest.fn()
 };
 
 afterEach(cleanup);
@@ -27,7 +27,7 @@ describe('SSH Access Action Menu', () => {
     includesActions(['Edit'], queryByText);
   });
 
-  it('should include Enable if access on the Linode is disabled', () => {
+  it('should include Enable if access to the Linode is disabled', () => {
     const { queryByText } = render(
       wrapWithTheme(<ActionMenu {...props} isEnabled={false} />)
     );
@@ -35,7 +35,7 @@ describe('SSH Access Action Menu', () => {
     expect(queryByText('Disable')).not.toBeInTheDocument();
   });
 
-  it('should include Disable if access on the Linode is enabled', () => {
+  it('should include Disable if access to the Linode is enabled', () => {
     const { queryByText } = render(
       wrapWithTheme(<ActionMenu {...props} isEnabled={true} />)
     );

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
@@ -39,7 +39,7 @@ export const SSHAccessActionMenu: React.FC<CombinedProps> = props => {
                 })
                 .catch(err => {
                   handleError(
-                    'Error disabling SSH access for this Linode.',
+                    'Error disabling SSH Access for this Linode.',
                     err
                   );
                 });
@@ -60,7 +60,7 @@ export const SSHAccessActionMenu: React.FC<CombinedProps> = props => {
                 })
                 .catch(err => {
                   handleError(
-                    'Error enabling SSH access for this Linode.',
+                    'Error enabling SSH Access for this Linode.',
                     err
                   );
                 });

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
@@ -7,7 +7,7 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 interface Props {
   linodeId: number;
-  access: boolean;
+  isEnabled: boolean;
   requestSettings: () => void;
   openDrawer: (linodeId: number) => void;
 }
@@ -16,7 +16,7 @@ export type CombinedProps = Props & WithSnackbarProps;
 
 export const SSHAccessActionMenu: React.FC<CombinedProps> = props => {
   const {
-    access,
+    isEnabled,
     linodeId,
     enqueueSnackbar,
     requestSettings,
@@ -25,24 +25,20 @@ export const SSHAccessActionMenu: React.FC<CombinedProps> = props => {
 
   const createActions = (closeMenu: Function): Action[] => {
     const actions = [
-      /**
-       * Reminder of API oddity:
-       * When linodeSetting.ssh.access === true, access is DISABLED
-       * When linodeSetting.ssh.access === false, access is ENABLED
-       * @todo: Change this if/when API is fixed.
-       */
       {
-        title: access ? 'Enable' : 'Disable',
+        title: isEnabled ? 'Disable' : 'Enable',
         onClick: () => {
           updateLinodeSettings(linodeId, {
-            ssh: { access: !access }
+            ssh: { access: isEnabled }
+            // @todo: When API oddity is fixed, use the following instead:
+            // ssh: { access: isEnabled ? false : true }
           })
             .then(() => requestSettings())
             .catch(err => {
               const errMessage = getAPIErrorOrDefault(
                 err,
                 `Error ${
-                  access ? 'enabling' : 'disabling'
+                  isEnabled ? 'disabling' : 'enabling'
                 } SSH access for this Linode.`
               );
               enqueueSnackbar(errMessage[0].reason, { variant: 'error' });

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
@@ -1,0 +1,69 @@
+import { withSnackbar, WithSnackbarProps } from 'notistack';
+import * as React from 'react';
+import { compose } from 'recompose';
+import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+import { updateLinodeSettings } from 'src/services/managed';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
+interface Props {
+  linodeId: number;
+  access: boolean;
+  requestSettings: () => void;
+  openDrawer: (linodeId: number) => void;
+}
+
+export type CombinedProps = Props & WithSnackbarProps;
+
+export const SSHAccessActionMenu: React.FC<CombinedProps> = props => {
+  const {
+    access,
+    linodeId,
+    enqueueSnackbar,
+    requestSettings,
+    openDrawer
+  } = props;
+
+  const createActions = (closeMenu: Function): Action[] => {
+    const actions = [
+      /**
+       * Reminder of API oddity:
+       * When linodeSetting.ssh.access === true, access is DISABLED
+       * When linodeSetting.ssh.access === false, access is ENABLED
+       * @todo: Change this if/when API is fixed.
+       */
+      {
+        title: access ? 'Enable' : 'Disable',
+        onClick: () => {
+          updateLinodeSettings(linodeId, {
+            ssh: { access: !access }
+          })
+            .then(() => requestSettings())
+            .catch(err => {
+              const errMessage = getAPIErrorOrDefault(
+                err,
+                `Error ${
+                  access ? 'enabling' : 'disabling'
+                } SSH access for this Linode.`
+              );
+              enqueueSnackbar(errMessage[0].reason, { variant: 'error' });
+            });
+          closeMenu();
+        }
+      },
+      {
+        title: 'Edit',
+        onClick: () => {
+          closeMenu();
+          openDrawer(linodeId);
+        }
+      }
+    ];
+    return actions;
+  };
+
+  return <ActionMenu createActions={createActions} />;
+};
+
+const enhanced = compose<CombinedProps, Props>(withSnackbar);
+
+export default enhanced(SSHAccessActionMenu);

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
@@ -12,6 +12,17 @@ interface Props {
 export const SSHAccessRow: React.FunctionComponent<Props> = props => {
   const { linodeSetting, requestSettings, openDrawer } = props;
 
+  /**
+   * NOTE: Currently the following API exists in production:
+   *
+   * When linodeSetting.ssh.access == true, access is DISABLED
+   * When linodeSetting.ssh.access == false, access is ENABLED
+   *
+   * If/when this bug is fixed, the following definition should be used:
+   * const isAccessEnabled = linodeSetting.ssh.access;
+   */
+  const isAccessEnabled = !linodeSetting.ssh.access;
+
   return (
     <TableRow
       key={linodeSetting.id}
@@ -22,9 +33,7 @@ export const SSHAccessRow: React.FunctionComponent<Props> = props => {
         {linodeSetting.label}
       </TableCell>
       <TableCell parentColumn="SSH Access" data-qa-managed-ssh-access>
-        {/* NOTE: There's currently an API oddity where `ssh.access: true` means access is DISABLED.
-        If/when this bug is fixed, this logic should be adjusted too. */}
-        {!linodeSetting.ssh.access ? 'Enabled' : 'Disabled'}
+        {isAccessEnabled ? 'Enabled' : 'Disabled'}
       </TableCell>
       <TableCell parentColumn="User" data-qa-managed-user>
         {linodeSetting.ssh.user ? linodeSetting.ssh.user : 'root'}
@@ -38,7 +47,7 @@ export const SSHAccessRow: React.FunctionComponent<Props> = props => {
       <TableCell>
         <ActionMenu
           linodeId={linodeSetting.id}
-          access={linodeSetting.ssh.access}
+          isEnabled={isAccessEnabled}
           requestSettings={requestSettings}
           openDrawer={openDrawer}
         />

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
@@ -5,12 +5,12 @@ import ActionMenu from './SSHAccessActionMenu';
 
 interface Props {
   linodeSetting: Linode.ManagedLinodeSetting;
-  requestSettings: () => void;
+  updateOne: (linodeSetting: Linode.ManagedLinodeSetting) => void;
   openDrawer: (linodeId: number) => void;
 }
 
 export const SSHAccessRow: React.FunctionComponent<Props> = props => {
-  const { linodeSetting, requestSettings, openDrawer } = props;
+  const { linodeSetting, updateOne, openDrawer } = props;
 
   /**
    * NOTE: Currently the following API oddity exists in production:
@@ -48,7 +48,7 @@ export const SSHAccessRow: React.FunctionComponent<Props> = props => {
         <ActionMenu
           linodeId={linodeSetting.id}
           isEnabled={isAccessEnabled}
-          requestSettings={requestSettings}
+          updateOne={updateOne}
           openDrawer={openDrawer}
         />
       </TableCell>

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
@@ -13,7 +13,7 @@ export const SSHAccessRow: React.FunctionComponent<Props> = props => {
   const { linodeSetting, requestSettings, openDrawer } = props;
 
   /**
-   * NOTE: Currently the following API exists in production:
+   * NOTE: Currently the following API oddity exists in production:
    *
    * When linodeSetting.ssh.access == true, access is DISABLED
    * When linodeSetting.ssh.access == false, access is ENABLED

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
@@ -1,13 +1,16 @@
 import * as React from 'react';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
+import ActionMenu from './SSHAccessActionMenu';
 
 interface Props {
   linodeSetting: Linode.ManagedLinodeSetting;
+  requestSettings: () => void;
+  openDrawer: (linodeId: number) => void;
 }
 
 export const SSHAccessRow: React.FunctionComponent<Props> = props => {
-  const { linodeSetting } = props;
+  const { linodeSetting, requestSettings, openDrawer } = props;
 
   return (
     <TableRow
@@ -32,7 +35,14 @@ export const SSHAccessRow: React.FunctionComponent<Props> = props => {
       <TableCell parentColumn="Port" data-qa-managed-port>
         {linodeSetting.ssh.port ? linodeSetting.ssh.port : 22}
       </TableCell>
-      {/* @todo: action menu */}
+      <TableCell>
+        <ActionMenu
+          linodeId={linodeSetting.id}
+          access={linodeSetting.ssh.access}
+          requestSettings={requestSettings}
+          openDrawer={openDrawer}
+        />
+      </TableCell>
     </TableRow>
   );
 };

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
@@ -41,16 +41,9 @@ const SSHAccessTable: React.FC<{}> = () => {
     Linode.ManagedLinodeSetting[]
   >(request, []);
 
-  const [linodeIdForEditing, setLinodeIdForEditing] = React.useState<number>(0);
+  const [selectedLinodeId, setSelectedLinodeId] = React.useState<number>(0);
 
-  const { isOpen, open, close } = useOpenClose();
-
-  const openDrawer = (linodeId: number) => {
-    setLinodeIdForEditing(linodeId);
-    open();
-  };
-
-  const linodeSetting = data.find(l => l.id === linodeIdForEditing);
+  const drawer = useOpenClose();
 
   return (
     <>
@@ -128,7 +121,10 @@ const SSHAccessTable: React.FC<{}> = () => {
                             loading={loading}
                             lastUpdated={lastUpdated}
                             requestSettings={update}
-                            openDrawer={openDrawer}
+                            openDrawer={(linodeId: number) => {
+                              setSelectedLinodeId(linodeId);
+                              drawer.open();
+                            }}
                             error={error}
                           />
                         </TableBody>
@@ -150,9 +146,9 @@ const SSHAccessTable: React.FC<{}> = () => {
         }}
       </OrderBy>
       <EditSSHAccessDrawer
-        isOpen={isOpen}
-        linodeSetting={linodeSetting}
-        closeDrawer={close}
+        isOpen={drawer.isOpen}
+        closeDrawer={drawer.close}
+        linodeSetting={data.find(l => l.id === selectedLinodeId)}
       />
     </>
   );

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
@@ -37,9 +37,16 @@ const request = () =>
 const SSHAccessTable: React.FC<{}> = () => {
   const classes = useStyles();
 
-  const { data, loading, lastUpdated, update, error } = useAPIRequest<
+  const { data, loading, lastUpdated, transformData, error } = useAPIRequest<
     Linode.ManagedLinodeSetting[]
   >(request, []);
+
+  const updateOne = (linodeSetting: Linode.ManagedLinodeSetting) => {
+    transformData(draft => {
+      const idx = draft.findIndex(l => l.id === linodeSetting.id);
+      draft[idx] = linodeSetting;
+    });
+  };
 
   const [selectedLinodeId, setSelectedLinodeId] = React.useState<number>(0);
 
@@ -120,7 +127,7 @@ const SSHAccessTable: React.FC<{}> = () => {
                             linodeSettings={paginatedData}
                             loading={loading}
                             lastUpdated={lastUpdated}
-                            requestSettings={update}
+                            updateOne={updateOne}
                             openDrawer={(linodeId: number) => {
                               setSelectedLinodeId(linodeId);
                               drawer.open();

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
@@ -11,8 +11,10 @@ import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableSortCell from 'src/components/TableSortCell';
 import { useAPIRequest } from 'src/hooks/useAPIRequest';
+import useOpenClose from 'src/hooks/useOpenClose';
 import { getLinodeSettings } from 'src/services/managed';
 import { getAll } from 'src/utilities/getAll';
+import EditSSHAccessDrawer from './EditSSHAccessDrawer';
 import SSHAccessTableContent from './SSHAccessTableContent';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -35,9 +37,20 @@ const request = () =>
 const SSHAccessTable: React.FC<{}> = () => {
   const classes = useStyles();
 
-  const { data, loading, lastUpdated, error } = useAPIRequest<
+  const { data, loading, lastUpdated, update, error } = useAPIRequest<
     Linode.ManagedLinodeSetting[]
   >(request, []);
+
+  const [linodeIdForEditing, setLinodeIdForEditing] = React.useState<number>(0);
+
+  const { isOpen, open, close } = useOpenClose();
+
+  const openDrawer = (linodeId: number) => {
+    setLinodeIdForEditing(linodeId);
+    open();
+  };
+
+  const linodeSetting = data.find(l => l.id === linodeIdForEditing);
 
   return (
     <>
@@ -105,6 +118,7 @@ const SSHAccessTable: React.FC<{}> = () => {
                             >
                               Port
                             </TableSortCell>
+                            {/* Empty TableCell for action menu */}
                             <TableCell />
                           </TableRow>
                         </TableHead>
@@ -113,6 +127,8 @@ const SSHAccessTable: React.FC<{}> = () => {
                             linodeSettings={paginatedData}
                             loading={loading}
                             lastUpdated={lastUpdated}
+                            requestSettings={update}
+                            openDrawer={openDrawer}
                             error={error}
                           />
                         </TableBody>
@@ -133,6 +149,11 @@ const SSHAccessTable: React.FC<{}> = () => {
           );
         }}
       </OrderBy>
+      <EditSSHAccessDrawer
+        isOpen={isOpen}
+        linodeSetting={linodeSetting}
+        closeDrawer={close}
+      />
     </>
   );
 };

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
@@ -48,7 +48,9 @@ const SSHAccessTable: React.FC<{}> = () => {
     });
   };
 
-  const [selectedLinodeId, setSelectedLinodeId] = React.useState<number>(0);
+  const [selectedLinodeId, setSelectedLinodeId] = React.useState<number | null>(
+    null
+  );
 
   const drawer = useOpenClose();
 

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTableContent.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTableContent.tsx
@@ -18,12 +18,12 @@ export type CombinedProps = Props;
 
 export const SSHAccessTableContent: React.FC<CombinedProps> = props => {
   const {
-    error,
+    linodeSettings,
     loading,
     lastUpdated,
     updateOne,
-    linodeSettings,
-    openDrawer
+    openDrawer,
+    error
   } = props;
 
   if (loading && lastUpdated === 0) {

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTableContent.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTableContent.tsx
@@ -9,7 +9,7 @@ interface Props {
   linodeSettings: Linode.ManagedLinodeSetting[];
   loading: boolean;
   lastUpdated: number;
-  requestSettings: () => void;
+  updateOne: (linodeSetting: Linode.ManagedLinodeSetting) => void;
   openDrawer: (linodeId: number) => void;
   error?: Linode.ApiFieldError[];
 }
@@ -21,8 +21,8 @@ export const SSHAccessTableContent: React.FC<CombinedProps> = props => {
     error,
     loading,
     lastUpdated,
+    updateOne,
     linodeSettings,
-    requestSettings,
     openDrawer
   } = props;
 
@@ -50,7 +50,7 @@ export const SSHAccessTableContent: React.FC<CombinedProps> = props => {
         (linodeSetting: Linode.ManagedLinodeSetting, idx: number) => (
           <SSHAccessRow
             key={`linode-setting-row-${idx}`}
-            requestSettings={requestSettings}
+            updateOne={updateOne}
             linodeSetting={linodeSetting}
             openDrawer={openDrawer}
           />

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTableContent.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTableContent.tsx
@@ -9,15 +9,24 @@ interface Props {
   linodeSettings: Linode.ManagedLinodeSetting[];
   loading: boolean;
   lastUpdated: number;
+  requestSettings: () => void;
+  openDrawer: (linodeId: number) => void;
   error?: Linode.ApiFieldError[];
 }
 
 export type CombinedProps = Props;
 
 export const SSHAccessTableContent: React.FC<CombinedProps> = props => {
-  const { error, loading, lastUpdated, linodeSettings } = props;
+  const {
+    error,
+    loading,
+    lastUpdated,
+    linodeSettings,
+    requestSettings,
+    openDrawer
+  } = props;
 
-  if (loading) {
+  if (loading && lastUpdated === 0) {
     return <TableRowLoading colSpan={12} />;
   }
 
@@ -41,7 +50,9 @@ export const SSHAccessTableContent: React.FC<CombinedProps> = props => {
         (linodeSetting: Linode.ManagedLinodeSetting, idx: number) => (
           <SSHAccessRow
             key={`linode-setting-row-${idx}`}
+            requestSettings={requestSettings}
             linodeSetting={linodeSetting}
+            openDrawer={openDrawer}
           />
         )
       )}

--- a/packages/manager/src/hooks/useAPIRequest.ts
+++ b/packages/manager/src/hooks/useAPIRequest.ts
@@ -4,6 +4,7 @@ interface UseAPIRequest<T> {
   data: T;
   loading: boolean;
   lastUpdated: number;
+  update: () => void;
   error?: Linode.ApiFieldError[];
 }
 
@@ -58,7 +59,7 @@ export const useAPIRequest = <T>(
   const [loading, setLoading] = useState<boolean>(false);
   const [lastUpdated, setLastUpdated] = useState<number>(0);
 
-  useEffect(() => {
+  const _request = () => {
     setLoading(true);
     request()
       .then(responseData => {
@@ -70,7 +71,9 @@ export const useAPIRequest = <T>(
         setLoading(false);
         setError(err);
       });
-  }, deps);
+  };
 
-  return { data, loading, lastUpdated, error };
+  useEffect(() => _request(), deps);
+
+  return { data, loading, lastUpdated, error, update: _request };
 };

--- a/packages/manager/src/hooks/useAPIRequest.ts
+++ b/packages/manager/src/hooks/useAPIRequest.ts
@@ -1,3 +1,4 @@
+import produce from 'immer';
 import { useEffect, useState } from 'react';
 
 interface UseAPIRequest<T> {
@@ -5,8 +6,11 @@ interface UseAPIRequest<T> {
   loading: boolean;
   lastUpdated: number;
   update: () => void;
+  transformData: (fn: (data: T) => void) => void;
   error?: Linode.ApiFieldError[];
 }
+
+// @todo: write a README for this hook.
 
 /**
  *
@@ -75,5 +79,9 @@ export const useAPIRequest = <T>(
 
   useEffect(() => _request(), deps);
 
-  return { data, loading, lastUpdated, error, update: _request };
+  const transformData = (fn: (data: T) => void) => {
+    setData(produce<T, T>(data, fn));
+  };
+
+  return { data, loading, lastUpdated, error, update: _request, transformData };
 };

--- a/packages/manager/src/services/managed/managed.schema.ts
+++ b/packages/manager/src/services/managed/managed.schema.ts
@@ -1,0 +1,12 @@
+import { boolean, number, object, string } from 'yup';
+
+export const updateManagedLinodeSchema = object({
+  ssh: object({
+    access: boolean(),
+    user: string().max(32),
+    ip: string(),
+    port: number()
+      .min(1)
+      .max(65535)
+  })
+});

--- a/packages/manager/src/services/managed/managed.ts
+++ b/packages/manager/src/services/managed/managed.ts
@@ -1,5 +1,12 @@
 import { API_ROOT } from 'src/constants';
-import Request, { setMethod, setParams, setURL, setXFilter } from '../index';
+import Request, {
+  setData,
+  setMethod,
+  setParams,
+  setURL,
+  setXFilter
+} from '../index';
+import { updateManagedLinodeSchema } from './managed.schema';
 
 // Payload types
 
@@ -62,4 +69,20 @@ export const getLinodeSettings = (params?: any, filters?: any) =>
     setParams(params),
     setXFilter(filters),
     setURL(`${API_ROOT}/managed/linode-settings`)
+  ).then(response => response.data);
+
+/**
+ * updateLinodeSettings
+ *
+ * Updates a single Linode's Managed settings.
+ *
+ */
+export const updateLinodeSettings = (
+  linodeId: number,
+  data: { ssh: Partial<Linode.ManagedSSHSetting> }
+) =>
+  Request<Linode.ManagedLinodeSetting>(
+    setURL(`${API_ROOT}/managed/linode-settings/${linodeId}`),
+    setMethod('PUT'),
+    setData(data, updateManagedLinodeSchema)
   ).then(response => response.data);


### PR DESCRIPTION
## Description

**Part III** includes the Action Menu and scaffolding for the drawer.

_Still to come in Part IV: SSH Access form (in the drawer)._

I've made a few changes so that the `useAPIRequest` hook exposes two additional methods to the consumer:

- `update()`, which will re-run the request. This actually isn't used in the final version of this PR, but will be useful nonetheless, so I left it in.

- `transformData()`, which accepts a function and uses Immer.js to mutate the data. It can be used like this:

```typescript
const { data, transformData } = useAPIRequest(someRequest, []);

// Update one element
const updateOne = (linodeSetting) => {
  transformData(draft => {
    const idx = draft.findIndex(l => l.id === linodeSetting.id);
    draft[idx] = linodeSetting;
  });
};

// When `updateOne()` is called, the component will be re-rendered with the new data.
```

The idea here is that, instead of requesting ALL Linode Settings after enabling/disabling one, we manually update ONE (similar to the `updateOrAdd` Redux helper method). This leads to a more fluid UI and reduces unnecessary API requests.

## Type of Change
- Non breaking change ('update', 'change')