### PR TITLE
Inter-DC Migration Part 4: Add CTA on Advanced Tab with GA Integration

### DIFF
--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -287,7 +287,9 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
 
   const errorMap = getErrorMap(['disk_size'], state.errors);
 
-  const recentEvent = linodeEvents[0];
+  const firstEventWithProgress = (linodeEvents || []).find(
+    eachEvent => typeof eachEvent.percent_complete === 'number'
+  );
 
   const selectedLinode = linodesData.find(
     eachLinode => eachLinode.id === state.selectedLinodeId
@@ -318,7 +320,9 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
           onEditHandlers: undefined
         }}
       />
-      {linodeInTransition(linodeStatus, recentEvent) && <LinodeBusyStatus />}
+      {linodeInTransition(linodeStatus, firstEventWithProgress) && (
+        <LinodeBusyStatus />
+      )}
       <Grid container className={classes.root}>
         <Grid item xs={12} md={8} lg={9}>
           <Paper className={classes.paper}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeAdvancedConfigurationsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeAdvancedConfigurationsPanel.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
 import {
@@ -14,11 +15,18 @@ import LinodeConfigs from './LinodeConfigs';
 import LinodeDisks from './LinodeDisks';
 import LinodeDiskSpace from './LinodeDiskSpace';
 
-type ClassNames = 'root' | 'title' | 'paper' | 'main' | 'sidebar';
+import { sendMigrationNavigationEvent } from 'src/utilities/ga';
+
+type ClassNames =
+  | 'root'
+  | 'title'
+  | 'paper'
+  | 'migrationHeader'
+  | 'migrationCopy'
+  | 'sidebar';
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {},
     title: {
       marginBottom: theme.spacing(2)
     },
@@ -27,7 +35,12 @@ const styles = (theme: Theme) =>
       paddingTop: theme.spacing(1),
       marginBottom: theme.spacing(3)
     },
-    main: {},
+    migrationHeader: {
+      paddingTop: theme.spacing()
+    },
+    migrationCopy: {
+      marginTop: theme.spacing()
+    },
     sidebar: {
       marginTop: -theme.spacing(2),
       [theme.breakpoints.up('md')]: {
@@ -42,11 +55,11 @@ class LinodeAdvancedConfigurationsPanel extends React.PureComponent<
   CombinedProps
 > {
   render() {
-    const { classes, disks, linodeTotalDisk } = this.props;
+    const { classes, disks, linodeTotalDisk, linodeID } = this.props;
 
     return (
       <Grid container>
-        <Grid item xs={12} md={7} lg={9} className={classes.main}>
+        <Grid item xs={12} md={7} lg={9}>
           <Typography variant="h2" className={classes.title}>
             Advanced Configurations
           </Typography>
@@ -55,6 +68,24 @@ class LinodeAdvancedConfigurationsPanel extends React.PureComponent<
           </Paper>
           <Paper className={classes.paper}>
             <LinodeDisks />
+          </Paper>
+          <Paper className={classes.paper}>
+            <Typography variant="h3" className={classes.migrationHeader}>
+              Configure a Migration
+            </Typography>
+            <Typography className={classes.migrationCopy}>
+              Migrating your Linode across datacenters is as simple as a few
+              clicks.
+              <Link
+                to={`/linodes/${linodeID}/migrate`}
+                onClick={() =>
+                  sendMigrationNavigationEvent(`/linodes/${linodeID}/migrate`)
+                }
+              >
+                {' '}
+                Click here to get started migrating your Linode.
+              </Link>
+            </Typography>
           </Paper>
         </Grid>
         <Grid item xs={12} md={5} lg={3} className={classes.sidebar}>
@@ -70,11 +101,13 @@ class LinodeAdvancedConfigurationsPanel extends React.PureComponent<
 interface LinodeContextProps {
   linodeTotalDisk: number;
   disks: Linode.Disk[];
+  linodeID: number;
 }
 
 const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeTotalDisk: linode.specs.disk,
-  disks: linode._disks
+  disks: linode._disks,
+  linodeID: linode.id
 }));
 
 const styled = withStyles(styles);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeAdvancedConfigurationsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeAdvancedConfigurationsPanel.tsx
@@ -79,7 +79,7 @@ class LinodeAdvancedConfigurationsPanel extends React.PureComponent<
               <Link
                 to={`/linodes/${linodeID}/migrate`}
                 onClick={() =>
-                  sendMigrationNavigationEvent(`/linodes/${linodeID}/migrate`)
+                  sendMigrationNavigationEvent(`/advanced`)
                 }
               >
                 {' '}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -110,7 +110,7 @@ interface Props {
   label: string;
   status: Linode.LinodeStatus;
   disabled?: boolean;
-  recentEvent?: Linode.Event;
+  linodeEvents?: Linode.Event[];
   linodeConfigs: Linode.Config[];
 }
 
@@ -165,7 +165,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
       status,
       classes,
       disabled,
-      recentEvent,
+      linodeEvents,
       linodeConfigs
     } = this.props;
     const {
@@ -174,7 +174,11 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
 
     const hasNoConfigs = linodeConfigs.length === 0;
 
-    const isBusy = linodeInTransition(status, recentEvent);
+    const firstEventWithPercent = (linodeEvents || []).find(
+      eachEvent => typeof eachEvent.percent_complete === 'number'
+    );
+
+    const isBusy = linodeInTransition(status, firstEventWithPercent);
     const isRunning = !isBusy && status === 'running';
     const isOffline = !isBusy && status === 'offline';
     const buttonText = () => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeBusyStatus.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeBusyStatus.tsx
@@ -1,4 +1,3 @@
-import { head } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
@@ -29,19 +28,27 @@ const styles = (theme: Theme) =>
 
 interface LinodeDetailContextProps {
   status: string;
-  recentEvent?: Linode.Event;
+  linodeEvents?: Linode.Event[];
 }
 
 type CombinedProps = LinodeDetailContextProps & WithStyles<ClassNames>;
 
 const LinodeBusyStatus: React.StatelessComponent<CombinedProps> = props => {
-  const { classes, status, recentEvent } = props;
-  const value = (recentEvent && recentEvent.percent_complete) || 1;
+  const { classes, status, linodeEvents } = props;
+
+  const firstEventWithProgress = (linodeEvents || []).find(
+    eachEvent => typeof eachEvent.percent_complete === 'number'
+  );
+
+  const value = firstEventWithProgress
+    ? (firstEventWithProgress.percent_complete as number)
+    : 1;
+
   return (
     <Paper className={classes.root}>
       <div className={classes.status}>
         <Typography>
-          {transitionText(status, recentEvent)}: {value}%
+          {transitionText(status, firstEventWithProgress)}: {value}%
         </Typography>
       </div>
       <LinearProgress value={value} />
@@ -55,7 +62,7 @@ const enhanced = compose<CombinedProps, {}>(
   styled,
   withLinodeDetailContext(({ linode }) => ({
     status: linode.status,
-    recentEvent: head(linode._events)
+    linodeEvents: linode._events
   }))
 );
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -144,7 +144,7 @@ const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
         </Button>
         <LinodePowerControl
           status={linode.status}
-          recentEvent={linode._events[0]}
+          linodeEvents={linode._events}
           id={linode.id}
           label={linode.label}
           disabled={disabled}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -11,14 +11,18 @@ type CombinedProps = LinodeContext;
 
 const LinodeDetailHeader: React.StatelessComponent<CombinedProps> = props => {
   const { linodeEvents, linodeStatus, linodeDisks } = props;
-  const recentEvent = linodeEvents[0];
+  const firstEventWithProgress = (linodeEvents || []).find(
+    eachEvent => typeof eachEvent.percent_complete === 'number'
+  );
 
   return (
     <React.Fragment>
       <MutationNotification disks={linodeDisks} />
       <Notifications />
       <LinodeControls />
-      {linodeInTransition(linodeStatus, recentEvent) && <LinodeBusyStatus />}
+      {linodeInTransition(linodeStatus, firstEventWithProgress) && (
+        <LinodeBusyStatus />
+      )}
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -25,6 +25,8 @@ import { MapState } from 'src/store/types';
 
 import { Action as BootAction } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 
+import { sendMigrationNavigationEvent } from 'src/utilities/ga';
+
 export interface Props {
   linodeId: number;
   linodeLabel: string;
@@ -157,6 +159,7 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
         {
           title: 'Migrate',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendMigrationNavigationEvent('/linodes');
             sendLinodeActionMenuItemEvent('Migrate');
             push({
               pathname: `/linodes/${linodeId}/migrate`

--- a/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
@@ -62,10 +62,12 @@ const ConfigureForm: React.FC<CombinedProps> = props => {
       </div>
       <RegionSelect
         className={classes.select}
-        regions={props.allRegions.map(eachRegion => ({
-          ...eachRegion,
-          display: dcDisplayNames[eachRegion.id]
-        }))}
+        regions={props.allRegions
+          .filter(eachRegion => eachRegion.id !== props.currentRegion)
+          .map(eachRegion => ({
+            ...eachRegion,
+            display: dcDisplayNames[eachRegion.id]
+          }))}
         handleSelection={props.handleSelectRegion}
         selectedID={props.selectedRegion}
         errorText={props.errorText}

--- a/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
@@ -1,3 +1,4 @@
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -38,7 +39,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
-  currentRegion: string;
+  currentRegion: { region: string; countryCode: string };
   allRegions: Linode.Region[];
   handleSelectRegion: (id: string) => void;
   selectedRegion: string | null;
@@ -55,15 +56,15 @@ const ConfigureForm: React.FC<CombinedProps> = props => {
       <Typography variant="h3">Configure Migration</Typography>
       <Typography>Current Region:</Typography>
       <div className={classes.currentRegion}>
-        {flags[props.currentRegion.substr(0, 2)]()}
+        {pathOr(() => null, [props.currentRegion.countryCode], flags)()}
         <Typography>{`${getHumanReadableCountry(
-          props.currentRegion
-        )}: ${formatRegion(props.currentRegion)}`}</Typography>
+          props.currentRegion.region
+        )}: ${formatRegion(props.currentRegion.region)}`}</Typography>
       </div>
       <RegionSelect
         className={classes.select}
         regions={props.allRegions
-          .filter(eachRegion => eachRegion.id !== props.currentRegion)
+          .filter(eachRegion => eachRegion.id !== props.currentRegion.region)
           .map(eachRegion => ({
             ...eachRegion,
             display: dcDisplayNames[eachRegion.id]

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.test.ts
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.test.ts
@@ -1,0 +1,17 @@
+import { getCountryCodeFromSlug } from './MigrateLanding';
+
+describe('Utility Functions', () => {
+  it('should return the correct country code based on country slugs', () => {
+    expect(getCountryCodeFromSlug('ap-west')).toBe('in');
+    expect(getCountryCodeFromSlug('ca-central')).toBe('ca');
+    expect(getCountryCodeFromSlug('us-central')).toBe('us');
+    expect(getCountryCodeFromSlug('us-east')).toBe('us');
+    expect(getCountryCodeFromSlug('us-west')).toBe('us');
+    expect(getCountryCodeFromSlug('us-southeast')).toBe('us');
+    expect(getCountryCodeFromSlug('eu-west')).toBe('uk');
+    expect(getCountryCodeFromSlug('ap-south')).toBe('sg');
+    expect(getCountryCodeFromSlug('eu-central')).toBe('de');
+    expect(getCountryCodeFromSlug('ap-northeast')).toBe('jp');
+    expect(getCountryCodeFromSlug('pppppppppp')).toBe('us');
+  });
+});

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
@@ -305,7 +305,7 @@ const getDisabledReason = (
   return '';
 };
 
-const getCountryCodeFromSlug = (regionSlug: string) => {
+export const getCountryCodeFromSlug = (regionSlug: string) => {
   if (regionSlug.match(/ap-north/i)) {
     return 'jp';
   }

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
@@ -26,7 +26,6 @@ import { linodeInTransition } from '../transitions';
 
 import CautionNotice from './CautionNotice';
 import ConfigureForm from './ConfigureForm';
-import MigrationImminentNotice from './MigrationImminentNotice';
 
 import { scheduleOrQueueMigration } from 'src/services/linodes/linodeActions.ts';
 
@@ -177,10 +176,14 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
       <Typography className={classes.details} variant="h2">
         {newLabel}
       </Typography>
-      <MigrationImminentNotice
+      {/*
+         commenting out for now because we need further clarification from
+         stakeholders about whether or not we want to prevent multiple cross-datacenter migrations.
+         */}
+      {/* <MigrationImminentNotice
         linodeID={props.linodeId}
         notifications={notifications}
-      />
+      /> */}
       <CautionNotice
         linodeVolumes={props.linodeVolumes}
         setConfirmed={setConfirmed}
@@ -211,7 +214,7 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
 
 interface LinodeContextProps {
   linodeId: number;
-  region: string;
+  region: { region: string; countryCode: string };
   label: string;
   linodeStatus: Linode.LinodeStatus;
   linodeSpecs: Linode.LinodeSpecs;
@@ -224,7 +227,10 @@ interface LinodeContextProps {
 
 const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeId: linode.id,
-  region: linode.region,
+  region: {
+    region: linode.region,
+    countryCode: getCountryCodeFromSlug(linode.region)
+  },
   type: linode.type,
   label: linode.label,
   image: linode.image,
@@ -275,21 +281,54 @@ const getDisabledReason = (
     }
   }
 
-  if (
-    !!notifications.find(eachNotification => {
-      return (
-        eachNotification.label.match(/migrat/i) &&
-        eachNotification.entity &&
-        eachNotification.entity.id === linodeID
-      );
-    })
-  ) {
-    return 'Your Linode is already scheduled for a migration';
-  }
+  /**
+   * commenting this out for now because we need further clarification
+   * from stakeholders about if we want people to overwrite existing migrations.
+   */
+
+  // if (
+  //   !!notifications.find(eachNotification => {
+  //     return (
+  //       eachNotification.label.match(/migrat/i) &&
+  //       eachNotification.entity &&
+  //       eachNotification.entity.id === linodeID
+  //     );
+  //   })
+  // ) {
+  //   return 'Your Linode is already scheduled for a migration';
+  // }
 
   if (linodeStatus !== 'offline') {
     return 'Your Linode must be shut down first.';
   }
 
   return '';
+};
+
+const getCountryCodeFromSlug = (regionSlug: string) => {
+  if (regionSlug.match(/ap-north/i)) {
+    return 'jp';
+  }
+
+  if (regionSlug.match(/ap-south/i)) {
+    return 'sg';
+  }
+
+  if (regionSlug.match(/eu-cent/i)) {
+    return 'de';
+  }
+
+  if (regionSlug.match(/eu/i)) {
+    return 'uk';
+  }
+
+  if (regionSlug.match(/ap-west/i)) {
+    return 'in';
+  }
+
+  if (regionSlug.match(/ca-cent/i)) {
+    return 'ca';
+  }
+
+  return 'us';
 };

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrationImminentNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrationImminentNotice.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import Notice from 'src/components/Notice';
+import SupportLink from 'src/components/SupportLink';
+
+interface Props {
+  notifications: Linode.Notification[];
+  linodeID: number;
+  className?: string;
+}
+type CombinedProps = Props;
+
+const MigrationImminentNotice: React.FC<CombinedProps> = props => {
+  const migrationScheduledForThisLinode = !!props.notifications.find(
+    eachNotification => {
+      return (
+        eachNotification.label.match(/migrat/i) &&
+        eachNotification.entity &&
+        eachNotification.entity.id === props.linodeID
+      );
+    }
+  );
+
+  return (
+    <React.Fragment>
+      {migrationScheduledForThisLinode ? (
+        <Notice
+          className={props.className}
+          spacingTop={16}
+          warning
+          text={
+            <React.Fragment>
+              Your Linode is already scheduled to be migrated. Please open a{' '}
+              <SupportLink
+                text="support ticket"
+                title="Request to overwrite existing migration"
+              />{' '}
+              if you would like to request this migration be overwritten.
+            </React.Fragment>
+          }
+        />
+      ) : null}
+    </React.Fragment>
+  );
+};
+
+export default compose<CombinedProps, Props>(React.memo)(
+  MigrationImminentNotice
+);

--- a/packages/manager/src/utilities/formatRegion.ts
+++ b/packages/manager/src/utilities/formatRegion.ts
@@ -38,7 +38,7 @@ export const getHumanReadableCountry = (regionSlug: string) => {
   if (regionSlug.match(/(de|uk|eu)/gim)) {
     return 'Europe';
   }
-  if (regionSlug.match(/(jp|sg|in)/gim)) {
+  if (regionSlug.match(/(jp|sg|in|ap)/gim)) {
     return 'Asia';
   }
   return 'Other';

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -243,3 +243,13 @@ export const sendRevokeAccessKeyEvent = () => {
     action: 'Revoke Access Key'
   });
 };
+
+/**
+ * meant to be sent to GA upon navigating to `/linodes/${linodeID}/migrate`
+ */
+export const sendMigrationNavigationEvent = (pathNavigatedFrom: string) => {
+  sendEvent({
+    category: 'Migration Navigation',
+    action: `From ${pathNavigatedFrom}`
+  });
+};


### PR DESCRIPTION
## Description

Adds CTA to the Advanced tab on the Linode detail screen. Also incorporates GA to track navigation on both that page and the Linode Action Menu.

## Highlights

* Adds Banner if `migration_imminent` notification exists that the user cannot schedule another migration to replace the existing one, with a CTA to open a support ticket if they really want to do it
* Fixes a bug where if you do the following, you will not see a progress bar for your Linode
   * 1. Do some long running event
   * 2. Change the Linode label
* Adds CTA to Advanced tab to navigate to the Migrate workflow.

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

N/A

## API Issues

If you

1. POST to `/migrate`
2. POST again before the migration starts

You will notice that GET `/notifications` still returns a `migration_imminent` payload, even after the migration is started. This means that the banner letting the user know "the migration is about to begin" appears even when the migration is kicked off.