### PR TITLE
Add a create new button for Linode Landing

### DIFF
--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.styles.ts
@@ -5,7 +5,12 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 
-type ClassNames = 'title' | 'tagGroup' | 'CSVlinkContainer' | 'CSVlink';
+type ClassNames =
+  | 'title'
+  | 'tagGroup'
+  | 'CSVlinkContainer'
+  | 'CSVlink'
+  | 'addNewLink';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -24,6 +29,10 @@ const styles = (theme: Theme) =>
     },
     CSVlinkContainer: {
       marginTop: theme.spacing(1)
+    },
+    addNewLink: {
+      marginBottom: -3,
+      marginLeft: 15
     }
   });
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.test.tsx
@@ -15,7 +15,8 @@ describe('ListLinodes', () => {
     title: '',
     tagGroup: '',
     CSVlinkContainer: '',
-    CSVlink: ''
+    CSVlink: '',
+    addNewLink: ''
   };
 
   it('renders without error', () => {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -8,6 +8,7 @@ import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 import { AnyAction } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
+import AddNewLink from 'src/components/AddNewLink';
 import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
 import FormControlLabel from 'src/components/core/FormControlLabel';
@@ -303,6 +304,14 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                                   status={linodeViewPreference}
                                 />
                               </Hidden>
+
+                              <AddNewLink
+                                onClick={e => {
+                                  this.props.history.push('/linodes/create');
+                                }}
+                                label="Add a Linode"
+                                className={classes.addNewLink}
+                              />
                             </Grid>
                             <Grid item xs={12}>
                               <OrderBy

--- a/packages/manager/src/features/linodes/LinodesLanding/ToggleBox.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ToggleBox.tsx
@@ -21,8 +21,7 @@ type CSSClasses =
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      margin: 8,
-      marginRight: -8
+      margin: 8
     },
     button: {
       borderWidth: 1,


### PR DESCRIPTION
## Description

Adds a 'Create New Linode' button on the Linode Landing to match the pattern for other entity landing pages.

## Type of Change
- Non breaking change ('update')

