### PR TITLE
Reboot confirmation modal

### DIFF
--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
@@ -145,9 +145,13 @@ const Actions: React.FC<ActionsProps> = props => {
       <Button
         onClick={props.onSubmit}
         loading={props.loading}
-        destructive={props.action === 'Power On' || 'Reboot' ? false : true}
+        destructive={
+          ['Power On', 'Reboot'].includes(props.action) ? false : true
+        }
         buttonType={
-          props.action === 'Power On' || 'Reboot' ? 'primary' : 'secondary'
+          ['Power On', 'Reboot'].includes(props.action)
+            ? 'primary'
+            : 'secondary'
         }
       >
         {props.action}

--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
@@ -145,8 +145,10 @@ const Actions: React.FC<ActionsProps> = props => {
       <Button
         onClick={props.onSubmit}
         loading={props.loading}
-        destructive={props.action === 'Power On' ? false : true}
-        buttonType={props.action === 'Power On' ? 'primary' : 'secondary'}
+        destructive={props.action === 'Power On' || 'Reboot' ? false : true}
+        buttonType={
+          props.action === 'Power On' || 'Reboot' ? 'primary' : 'secondary'
+        }
       >
         {props.action}
       </Button>


### PR DESCRIPTION
## Description

Updating `buttonType` and `destructive` props to include reboot action so 'Reboot' matches 'Power On' styling.

## Type of Change
- Non breaking change ('update')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

On Linodes Landing, Use the action menu to initiate the reboot confirmation modal.
