### PR TITLE
M3-695 SSH Access Part IV: Form

### DIFF
--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -7,10 +7,12 @@ interface Props {
   linodeId: number;
   value: Item<string>;
   handleChange: (ip: string) => void;
+  customizeOptions?: (options: Item<string>[]) => Item<string>[];
+  errorText?: string;
 }
 
 interface WithLinodesProps {
-  linodesData: Linode.Linode[];
+  linode?: Linode.Linode;
   linodesLoading: boolean;
   linodesError?: Linode.ApiFieldError[];
 }
@@ -19,34 +21,41 @@ type CombinedProps = Props & WithLinodesProps;
 
 const IPSelect: React.FC<CombinedProps> = props => {
   const {
-    linodeId,
+    linode,
     value,
     handleChange,
-    linodesData,
     linodesLoading,
-    linodesError
+    linodesError,
+    customizeOptions
   } = props;
 
-  const thisLinode = linodesData.find(linode => linode.id === linodeId);
-  const ips = thisLinode ? [...thisLinode.ipv4, thisLinode.ipv6] : [];
+  const ips: string[] = [];
 
-  const options: Item<string>[] = [
-    {
-      label: 'Any',
-      value: 'any'
-    },
-    ...ips.map(ip => {
-      const removedRange = removeRange(ip);
-      return {
-        label: removedRange,
-        value: removedRange
-      };
-    })
-  ];
+  // If we have a Linode (from Redux) matching the given ID, use it's IPv4 address(es)
+  if (linode) {
+    ips.push(...linode.ipv4);
 
-  const errorText = linodesError
-    ? 'There was an error retrieving your IP addresses.'
-    : '';
+    // If the Linode has an IPv6 address, use it as well.
+    if (linode.ipv6) {
+      ips.push(linode.ipv6);
+    }
+  }
+
+  // Create React-Select-friendly options.
+  let options: Item<string>[] = ips.map(ip => ({ value: ip, label: ip }));
+
+  // If a customizeOptions function was provided, apply it here.
+  if (customizeOptions) {
+    options = customizeOptions(options);
+  }
+
+  let errorText = '';
+
+  if (props.errorText) {
+    errorText = props.errorText;
+  } else if (linodesError) {
+    errorText = "There was an error retrieving this Linode's IP addresses.";
+  }
 
   return (
     <Select
@@ -57,19 +66,21 @@ const IPSelect: React.FC<CombinedProps> = props => {
       onChange={(selected: Item<string>) => handleChange(selected.value)}
       errorText={errorText}
       isClearable={false}
+      placeholder="Select an IP Address..."
     />
   );
 };
 
 const enhanced = compose<CombinedProps, Props>(
-  withLinodes((ownProps, linodesData, linodesLoading, linodesError) => ({
-    ...ownProps,
-    linodesData,
-    linodesLoading,
-    linodesError
-  }))
+  withLinodes<WithLinodesProps, Props>(
+    (ownProps, linodesData, linodesLoading, linodesError) => ({
+      ...ownProps,
+      // Find the Linode in Redux that corresponds with the given ID
+      linode: linodesData.find(linode => linode.id === ownProps.linodeId),
+      linodesLoading,
+      linodesError
+    })
+  )
 );
 
 export default enhanced(IPSelect);
-
-const removeRange = (ip: string) => ip.slice(0, ip.indexOf('/'));

--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -31,7 +31,7 @@ const IPSelect: React.FC<CombinedProps> = props => {
 
   const ips: string[] = [];
 
-  // If we have a Linode (from Redux) matching the given ID, use it's IPv4 address(es)
+  // If we have a Linode (from Redux) matching the given ID, use it's IPv4 address(es).
   if (linode) {
     ips.push(...linode.ipv4);
 
@@ -75,7 +75,7 @@ const enhanced = compose<CombinedProps, Props>(
   withLinodes<WithLinodesProps, Props>(
     (ownProps, linodesData, linodesLoading, linodesError) => ({
       ...ownProps,
-      // Find the Linode in Redux that corresponds with the given ID
+      // Find the Linode in Redux that corresponds with the given ID.
       linode: linodesData.find(linode => linode.id === ownProps.linodeId),
       linodesLoading,
       linodesError

--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+import Select, { Item } from 'src/components/EnhancedSelect/Select';
+import withLinodes from 'src/containers/withLinodes.container';
+
+interface Props {
+  linodeId: number;
+  value: Item<string>;
+  handleChange: (ip: string) => void;
+}
+
+interface WithLinodesProps {
+  linodesData: Linode.Linode[];
+  linodesLoading: boolean;
+  linodesError?: Linode.ApiFieldError[];
+}
+
+type CombinedProps = Props & WithLinodesProps;
+
+const IPSelect: React.FC<CombinedProps> = props => {
+  const {
+    linodeId,
+    value,
+    handleChange,
+    linodesData,
+    linodesLoading,
+    linodesError
+  } = props;
+
+  const thisLinode = linodesData.find(linode => linode.id === linodeId);
+  const ips = thisLinode ? [...thisLinode.ipv4, thisLinode.ipv6] : [];
+
+  const options: Item<string>[] = [
+    {
+      label: 'Any',
+      value: 'any'
+    },
+    ...ips.map(ip => {
+      const removedRange = removeRange(ip);
+      return {
+        label: removedRange,
+        value: removedRange
+      };
+    })
+  ];
+
+  const errorText = linodesError
+    ? 'There was an error retrieving your IP addresses.'
+    : '';
+
+  return (
+    <Select
+      value={options.find(option => option.value === value.value)}
+      label="IP Address"
+      options={options}
+      isLoading={linodesLoading}
+      onChange={(selected: Item<string>) => handleChange(selected.value)}
+      errorText={errorText}
+      isClearable={false}
+    />
+  );
+};
+
+const enhanced = compose<CombinedProps, Props>(
+  withLinodes((ownProps, linodesData, linodesLoading, linodesError) => ({
+    ...ownProps,
+    linodesData,
+    linodesLoading,
+    linodesError
+  }))
+);
+
+export default enhanced(IPSelect);
+
+const removeRange = (ip: string) => ip.slice(0, ip.indexOf('/'));

--- a/packages/manager/src/components/IPSelect/index.ts
+++ b/packages/manager/src/components/IPSelect/index.ts
@@ -1,0 +1,2 @@
+import IPSelect from './IPSelect';
+export default IPSelect;

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -98,8 +98,12 @@ const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
     <Drawer title={title} open={isOpen} onClose={closeDrawer}>
       {!linodeSetting ? null : (
         <>
+          {/* We're intentionally not validating with Formik, because we want to allow "Port" to
+          be transformed before submit. I tried a few different things that were unsatisfactory, and
+          since the services library validates the request anyway, this is what I went with. */}
           <Formik
             initialValues={{
+              // These values are nested this way to mach the API request/response.
               ssh: {
                 access: linodeSetting.ssh.access,
                 user: linodeSetting.ssh.user,
@@ -125,7 +129,7 @@ const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
 
               // API oddity: IP errors come back as {field: 'ip'} instead of {field: 'ssh.ip'} liked we'd expect.
               // tslint:disable-next-line
-              const ipError = errors['ssh.user'] || errors['ip'];
+              const ipError = errors['ssh.ip'] || errors['ip'];
 
               const portError = errors['ssh.port'];
 

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -1,5 +1,29 @@
+import { Formik } from 'formik';
 import * as React from 'react';
+import FormControlLabel from 'src/components/core/FormControlLabel';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
+import Grid from 'src/components/Grid';
+import IPSelect from 'src/components/IPSelect';
+import TextField from 'src/components/TextField';
+import Toggle from 'src/components/Toggle';
+import { updateManagedLinodeSchema } from 'src/services/managed/managed.schema';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    // width: '100%'
+  },
+  ip: {
+    [theme.breakpoints.down('sm')]: {
+      paddingBottom: '0px !important'
+    }
+  },
+  port: {
+    [theme.breakpoints.down('sm')]: {
+      paddingTop: '0px !important'
+    }
+  }
+}));
 
 interface Props {
   isOpen: boolean;
@@ -10,16 +34,96 @@ interface Props {
 type CombinedProps = Props;
 
 const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
   const { isOpen, closeDrawer, linodeSetting } = props;
 
   const title = linodeSetting
     ? `Edit SSH Access for ${linodeSetting.label}`
     : 'Edit SSH Access';
 
+  const onSubmit = () => alert('submit');
+
   return (
     <Drawer title={title} open={isOpen} onClose={closeDrawer}>
-      {/* FORM GOES HERE */}
-      <pre>{JSON.stringify(linodeSetting, null, 2)}</pre>
+      {!linodeSetting ? null : (
+        <>
+          <Formik
+            initialValues={{
+              access: linodeSetting.ssh.access,
+              user: linodeSetting.ssh.user || 'root',
+              port: linodeSetting.ssh.port || 22,
+              ip: linodeSetting.ssh.ip === 'any' ? 'Any' : linodeSetting.ssh.ip
+            }}
+            validationSchema={updateManagedLinodeSchema}
+            validateOnChange={false}
+            validateOnBlur={false}
+            onSubmit={onSubmit}
+          >
+            {({
+              values,
+              errors,
+              status,
+              handleChange,
+              handleBlur,
+              handleSubmit,
+              isSubmitting,
+              setFieldValue
+            }) => {
+              return (
+                <form className={classes.root}>
+                  <FormControlLabel
+                    control={
+                      <Toggle
+                        name="access"
+                        checked={!values.access}
+                        onChange={() => setFieldValue('access', !values.access)}
+                      />
+                    }
+                    label={values.access ? 'Access disabled' : 'Access enabled'}
+                  />
+
+                  <TextField
+                    name="user"
+                    label="User Account"
+                    value={values.user}
+                    error={!!errors.user}
+                    errorText={errors.user}
+                    onChange={handleChange}
+                    onBlur={handleBlur}
+                  />
+
+                  <Grid container>
+                    <Grid item xs={12} md={8} className={classes.ip}>
+                      <IPSelect
+                        linodeId={linodeSetting.id}
+                        value={{
+                          label: values.ip === 'any' ? 'Any' : values.ip,
+                          value: values.ip
+                        }}
+                        handleChange={(ip: string) => setFieldValue('ip', ip)}
+                      />
+                    </Grid>
+
+                    <Grid item xs={12} md={4} className={classes.port}>
+                      <TextField
+                        name="port"
+                        label="Port"
+                        type="number"
+                        value={values.port}
+                        error={!!errors.port}
+                        errorText={errors.port}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                      />
+                    </Grid>
+                  </Grid>
+                </form>
+              );
+            }}
+          </Formik>
+        </>
+      )}
     </Drawer>
   );
 };

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -10,12 +10,11 @@ import IPSelect from 'src/components/IPSelect';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import Toggle from 'src/components/Toggle';
-// @todo: Extract these utils out of Volumes
+import { updateLinodeSettings } from 'src/services/managed';
 import {
   handleFieldErrors,
   handleGeneralErrors
-} from 'src/features/Volumes/VolumeDrawer/utils';
-import { updateLinodeSettings } from 'src/services/managed';
+} from 'src/utilities/formikErrorUtils';
 import { privateIPRegex, removePrefixLength } from 'src/utilities/ipUtils';
 
 const DEFAULTS = {

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -1,18 +1,29 @@
-import { Formik } from 'formik';
+import { Formik, FormikActions } from 'formik';
 import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Drawer from 'src/components/Drawer';
 import Grid from 'src/components/Grid';
 import IPSelect from 'src/components/IPSelect';
+import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import Toggle from 'src/components/Toggle';
-import { updateManagedLinodeSchema } from 'src/services/managed/managed.schema';
+// @todo: Extract these utils out of Volumes
+import {
+  handleFieldErrors,
+  handleGeneralErrors
+} from 'src/features/Volumes/VolumeDrawer/utils';
+import { updateLinodeSettings } from 'src/services/managed';
+import { removePrefixLength } from 'src/utilities/ipUtils';
+
+const DEFAULTS = {
+  user: 'root',
+  port: 22
+};
 
 const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    // width: '100%'
-  },
   ip: {
     [theme.breakpoints.down('sm')]: {
       paddingBottom: '0px !important'
@@ -28,6 +39,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   isOpen: boolean;
   closeDrawer: () => void;
+  updateOne: (linodeSetting: Linode.ManagedLinodeSetting) => void;
   linodeSetting?: Linode.ManagedLinodeSetting;
 }
 
@@ -36,13 +48,51 @@ type CombinedProps = Props;
 const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
-  const { isOpen, closeDrawer, linodeSetting } = props;
+  const { isOpen, closeDrawer, linodeSetting, updateOne } = props;
 
   const title = linodeSetting
     ? `Edit SSH Access for ${linodeSetting.label}`
     : 'Edit SSH Access';
 
-  const onSubmit = () => alert('submit');
+  const onSubmit = (
+    values: Linode.ManagedLinodeSetting,
+    {
+      setErrors,
+      setSubmitting,
+      setStatus
+    }: FormikActions<Linode.ManagedLinodeSetting>
+  ) => {
+    // It probably isn't possible to end up here without linodeSetting,
+    // but we'll include an early return to make TypeScript happy.
+    if (!linodeSetting) {
+      return;
+    }
+
+    // If the user has cleared this field, replace it with the default.
+    const port =
+      !values.ssh.port && values.ssh.port !== 0
+        ? DEFAULTS.port
+        : values.ssh.port;
+
+    updateLinodeSettings(linodeSetting.id, {
+      ssh: { ...values.ssh, port }
+    })
+      .then(updatedLinodeSetting => {
+        setSubmitting(false);
+        updateOne(updatedLinodeSetting);
+        closeDrawer();
+      })
+      .catch(err => {
+        setSubmitting(false);
+        const defaultMessage = `Unable to update SSH Access for this Linode. Please try again later.`;
+        const mapErrorToStatus = (generalError: string) =>
+          setStatus({ generalError });
+
+        setSubmitting(false);
+        handleFieldErrors(setErrors, err);
+        handleGeneralErrors(mapErrorToStatus, err, defaultMessage);
+      });
+  };
 
   return (
     <Drawer title={title} open={isOpen} onClose={closeDrawer}>
@@ -50,14 +100,13 @@ const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
         <>
           <Formik
             initialValues={{
-              access: linodeSetting.ssh.access,
-              user: linodeSetting.ssh.user || 'root',
-              port: linodeSetting.ssh.port || 22,
-              ip: linodeSetting.ssh.ip === 'any' ? 'Any' : linodeSetting.ssh.ip
+              ssh: {
+                access: linodeSetting.ssh.access,
+                user: linodeSetting.ssh.user,
+                ip: linodeSetting.ssh.ip,
+                port: linodeSetting.ssh.port
+              }
             }}
-            validationSchema={updateManagedLinodeSchema}
-            validateOnChange={false}
-            validateOnBlur={false}
             onSubmit={onSubmit}
           >
             {({
@@ -70,55 +119,97 @@ const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
               isSubmitting,
               setFieldValue
             }) => {
+              const { access, user, ip, port } = values.ssh;
+
+              const userError = errors['ssh.user'];
+
+              // API oddity: IP errors come back as {field: 'ip'} instead of {field: 'ssh.ip'} liked we'd expect.
+              // tslint:disable-next-line
+              const ipError = errors['ssh.user'] || errors['ip'];
+
+              const portError = errors['ssh.port'];
+
               return (
-                <form className={classes.root}>
-                  <FormControlLabel
-                    control={
-                      <Toggle
-                        name="access"
-                        checked={!values.access}
-                        onChange={() => setFieldValue('access', !values.access)}
-                      />
-                    }
-                    label={values.access ? 'Access disabled' : 'Access enabled'}
-                  />
+                <>
+                  {status && (
+                    <Notice key={status} text={status.generalError} error />
+                  )}
 
-                  <TextField
-                    name="user"
-                    label="User Account"
-                    value={values.user}
-                    error={!!errors.user}
-                    errorText={errors.user}
-                    onChange={handleChange}
-                    onBlur={handleBlur}
-                  />
+                  <form>
+                    <FormControlLabel
+                      control={
+                        <Toggle
+                          name="ssh.access"
+                          checked={!access}
+                          onChange={() => setFieldValue('ssh.access', !access)}
+                        />
+                      }
+                      label={access ? 'Access disabled' : 'Access enabled'}
+                    />
 
-                  <Grid container>
-                    <Grid item xs={12} md={8} className={classes.ip}>
-                      <IPSelect
-                        linodeId={linodeSetting.id}
-                        value={{
-                          label: values.ip === 'any' ? 'Any' : values.ip,
-                          value: values.ip
-                        }}
-                        handleChange={(ip: string) => setFieldValue('ip', ip)}
-                      />
+                    <TextField
+                      name="ssh.user"
+                      label="User Account"
+                      value={user}
+                      error={!!userError}
+                      errorText={userError}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      placeholder={user || DEFAULTS.user}
+                    />
+
+                    <Grid container>
+                      <Grid item xs={12} md={8} className={classes.ip}>
+                        <IPSelect
+                          linodeId={linodeSetting.id}
+                          value={{
+                            label: ip === 'any' ? 'Any' : ip,
+                            value: ip
+                          }}
+                          customizeOptions={options => [
+                            // The first option should always be "Any".
+                            {
+                              label: 'Any',
+                              value: 'any'
+                            },
+                            // Remove the prefix length from each option.
+                            ...options.map(option => ({
+                              label: removePrefixLength(option.value),
+                              value: removePrefixLength(option.value)
+                            }))
+                          ]}
+                          handleChange={(selectedIp: string) =>
+                            setFieldValue('ssh.ip', selectedIp)
+                          }
+                          errorText={ipError}
+                        />
+                      </Grid>
+
+                      <Grid item xs={12} md={4} className={classes.port}>
+                        <TextField
+                          name="ssh.port"
+                          label="Port"
+                          type="number"
+                          value={port}
+                          error={!!portError}
+                          errorText={portError}
+                          onChange={handleChange}
+                          onBlur={handleBlur}
+                          placeholder={String(port || DEFAULTS.port)}
+                        />
+                      </Grid>
                     </Grid>
-
-                    <Grid item xs={12} md={4} className={classes.port}>
-                      <TextField
-                        name="port"
-                        label="Port"
-                        type="number"
-                        value={values.port}
-                        error={!!errors.port}
-                        errorText={errors.port}
-                        onChange={handleChange}
-                        onBlur={handleBlur}
-                      />
-                    </Grid>
-                  </Grid>
-                </form>
+                    <ActionsPanel>
+                      <Button
+                        buttonType="primary"
+                        onClick={() => handleSubmit()}
+                        loading={isSubmitting}
+                      >
+                        Save
+                      </Button>
+                    </ActionsPanel>
+                  </form>
+                </>
               );
             }}
           </Formik>

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -16,7 +16,7 @@ import {
   handleGeneralErrors
 } from 'src/features/Volumes/VolumeDrawer/utils';
 import { updateLinodeSettings } from 'src/services/managed';
-import { removePrefixLength } from 'src/utilities/ipUtils';
+import { privateIPRegex, removePrefixLength } from 'src/utilities/ipUtils';
 
 const DEFAULTS = {
   user: 'root',
@@ -176,11 +176,16 @@ const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
                               label: 'Any',
                               value: 'any'
                             },
-                            // Remove the prefix length from each option.
-                            ...options.map(option => ({
-                              label: removePrefixLength(option.value),
-                              value: removePrefixLength(option.value)
-                            }))
+                            ...options
+                              // Remove Private IPs
+                              .filter(
+                                option => !privateIPRegex.test(option.value)
+                              )
+                              // Remove the prefix length from each option.
+                              .map(option => ({
+                                label: removePrefixLength(option.value),
+                                value: removePrefixLength(option.value)
+                              }))
                           ]}
                           handleChange={(selectedIp: string) =>
                             setFieldValue('ssh.ip', selectedIp)

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
@@ -25,7 +25,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   linode: {
-    width: '40%'
+    width: '30%'
+  },
+  access: {
+    width: '15%'
+  },
+  ip: {
+    width: '20%'
   }
 }));
 
@@ -85,6 +91,7 @@ const SSHAccessTable: React.FC<{}> = () => {
                               Linode
                             </TableSortCell>
                             <TableSortCell
+                              className={classes.access}
                               active={orderBy === 'ssh:access'}
                               label={'ssh:access'}
                               direction={order}
@@ -103,6 +110,7 @@ const SSHAccessTable: React.FC<{}> = () => {
                               User
                             </TableSortCell>
                             <TableSortCell
+                              className={classes.ip}
                               active={orderBy === 'ssh:ip'}
                               label={'ssh:ip'}
                               direction={order}
@@ -158,6 +166,7 @@ const SSHAccessTable: React.FC<{}> = () => {
         isOpen={drawer.isOpen}
         closeDrawer={drawer.close}
         linodeSetting={data.find(l => l.id === selectedLinodeId)}
+        updateOne={updateOne}
       />
     </>
   );

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -3,6 +3,7 @@ import { compose } from 'recompose';
 
 import { Props as TextFieldProps } from 'src/components/TextField';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
+import { privateIPRegex } from 'src/utilities/ipUtils';
 
 interface Props {
   selectedRegion?: string;
@@ -15,8 +16,6 @@ interface Props {
 }
 
 type CombinedProps = Props;
-
-const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
 
 const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
   const [selectedLinode, setSelectedLinode] = React.useState<number | null>(

--- a/packages/manager/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -9,6 +9,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import ShowMore from 'src/components/ShowMore';
+import { privateIPRegex } from 'src/utilities/ipUtils';
 
 type CSSClasses =
   | 'root'
@@ -104,8 +105,6 @@ interface Props {
   showMore?: boolean;
   showAll?: boolean;
 }
-
-const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;
 
 export const sortIPAddress = (ip1: string, ip2: string) =>
   (privateIPRegex.test(ip1) ? 1 : -1) - (privateIPRegex.test(ip2) ? 1 : -1);

--- a/packages/manager/src/services/managed/managed.schema.ts
+++ b/packages/manager/src/services/managed/managed.schema.ts
@@ -20,13 +20,15 @@ export const createServiceMonitorSchema = object().shape({
     .max(100, 'Body must be 100 characters or less.')
 });
 
+export const sshSettingSchema = object().shape({
+  access: boolean(),
+  user: string().max(32, 'User must be 32 characters or less.'),
+  ip: string(),
+  port: number()
+    .min(1, 'Port must be between 1 and 65535.')
+    .max(65535, 'Port must be between 1 and 65535.')
+});
+
 export const updateManagedLinodeSchema = object({
-  ssh: object({
-    access: boolean(),
-    user: string().max(32),
-    ip: string(),
-    port: number()
-      .min(1)
-      .max(65535)
-  })
+  ssh: sshSettingSchema
 });

--- a/packages/manager/src/utilities/ipUtils.ts
+++ b/packages/manager/src/utilities/ipUtils.ts
@@ -1,0 +1,6 @@
+/**
+ * Removes the prefix length from the end of an IPv6 address.
+ *
+ * @param ip The IPv6 address to remove the prefix length from.
+ */
+export const removePrefixLength = (ip: string) => ip.replace(/\/\d+/, '');

--- a/packages/manager/src/utilities/ipUtils.ts
+++ b/packages/manager/src/utilities/ipUtils.ts
@@ -4,3 +4,8 @@
  * @param ip The IPv6 address to remove the prefix length from.
  */
 export const removePrefixLength = (ip: string) => ip.replace(/\/\d+/, '');
+
+/**
+ * Regex for determining if a string is a private IP Addresses
+ */
+export const privateIPRegex = /^10\.|^172\.1[6-9]\.|^172\.2[0-9]\.|^172\.3[0-1]\.|^192\.168\.|^fd/;


### PR DESCRIPTION
## Description

This PR includes the SSH Access Edit Form inside the drawer. This should be the final PR for this page.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

### To test:
Go to Managed > SSH Access, and edit several Linodes to get a feel for the form.

### New Component:

`<IPSelect />`

This component accepts a Linode ID and will display that Linode's IPv4 and IPv6 addresses as options. Linode data is sourced from Redux. 

It allows a `customizeOptions` function, used by the consumer to apply any desired transformations:

```jsx
<IPSelect 
  linodeId={1234}
  customizeOptions={options => 
    options.map(option => option.label = "CUSTOM LABEL")
  }
/>
```