### PR TITLE
M3-696 Add: View managed credentials

### DIFF
--- a/packages/manager/src/__data__/managedCredentials.ts
+++ b/packages/manager/src/__data__/managedCredentials.ts
@@ -1,0 +1,17 @@
+export const credentials = [
+  {
+    id: 1,
+    last_decrypted: '2019-07-01',
+    label: 'credential-1'
+  },
+  {
+    id: 2,
+    last_decrypted: '2019-07-01',
+    label: 'credential-2'
+  },
+  {
+    id: 3,
+    last_decrypted: null,
+    label: 'credential-3'
+  }
+];

--- a/packages/manager/src/__data__/serviceMonitors.ts
+++ b/packages/manager/src/__data__/serviceMonitors.ts
@@ -1,3 +1,5 @@
+import { credentials } from './managedCredentials';
+
 export const monitors: Linode.ManagedServiceMonitor[] = [
   {
     consultation_group: '',
@@ -10,7 +12,7 @@ export const monitors: Linode.ManagedServiceMonitor[] = [
     service_type: 'url',
     notes: '',
     id: 1224,
-    credentials: [],
+    credentials,
     address: 'http://www.example.com',
     body: ''
   },
@@ -40,7 +42,7 @@ export const monitors: Linode.ManagedServiceMonitor[] = [
     service_type: 'url',
     notes: '',
     id: 3456,
-    credentials: [],
+    credentials,
     address: 'http://www.example.com',
     body: ''
   },
@@ -55,7 +57,7 @@ export const monitors: Linode.ManagedServiceMonitor[] = [
     service_type: 'url',
     notes: '',
     id: 3456,
-    credentials: [],
+    credentials,
     address: 'http://www.example.com',
     body: ''
   }

--- a/packages/manager/src/features/Managed/Credentials.tsx
+++ b/packages/manager/src/features/Managed/Credentials.tsx
@@ -1,3 +1,0 @@
-import * as React from 'react';
-
-export default () => <h1>Credentials</h1>;

--- a/packages/manager/src/features/Managed/Credentials/CredentialActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialActionMenu.tsx
@@ -1,0 +1,40 @@
+import { withSnackbar, WithSnackbarProps } from 'notistack';
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+
+interface Props {
+  credentialID: number;
+  label: string;
+  openDialog: (id: number, label: string) => void;
+}
+
+export type CombinedProps = Props & WithSnackbarProps;
+
+export class CredentialActionMenu extends React.Component<CombinedProps, {}> {
+  createActions = () => {
+    const { label, credentialID, openDialog } = this.props;
+
+    return (closeMenu: Function): Action[] => {
+      const actions = [
+        {
+          title: 'Delete',
+          onClick: () => {
+            openDialog(credentialID, label);
+            closeMenu();
+          }
+        }
+      ];
+      return actions;
+    };
+  };
+
+  render() {
+    return <ActionMenu createActions={this.createActions()} />;
+  }
+}
+
+const enhanced = compose<CombinedProps, Props>(withSnackbar);
+
+export default enhanced(CredentialActionMenu);

--- a/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
@@ -4,6 +4,7 @@ import Paper from 'src/components/core/Paper';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
+import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
@@ -35,11 +36,22 @@ export const CredentialList: React.FC<Props> = props => {
         style={{ paddingBottom: 0 }}
       >
         <Grid item>
+          <Typography
+            variant="body1"
+            style={{ fontSize: '1.1em', lineHeight: '1.2em' }}
+          >
+            Please share any credentials our support team may need when
+            responding to a service issue. Credentials are stored encrypted and
+            all decryption attempts are logged. You can revoke credentials at
+            any time by deleting them.
+          </Typography>
+        </Grid>
+        <Grid item>
           <Grid container alignItems="flex-end">
             <Grid item className="pt0">
               <AddNewLink
                 onClick={() => null}
-                label="Add a Credential"
+                label="Add Credentials"
                 disabled
               />
             </Grid>

--- a/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import AddNewLink from 'src/components/AddNewLink';
+import Paper from 'src/components/core/Paper';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/core/TableRow';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Grid from 'src/components/Grid';
+import OrderBy from 'src/components/OrderBy';
+import Paginate from 'src/components/Paginate';
+import PaginationFooter from 'src/components/PaginationFooter';
+import Table from 'src/components/Table';
+import TableCell from 'src/components/TableCell';
+import TableSortCell from 'src/components/TableSortCell';
+
+import CredentialTableContent from './CredentialTableContent';
+
+interface Props {
+  error?: Linode.ApiFieldError[];
+  credentials: Linode.ManagedCredential[];
+  loading: boolean;
+}
+
+export const CredentialList: React.FC<Props> = props => {
+  const { credentials, error, loading } = props;
+
+  return (
+    <>
+      <DocumentTitleSegment segment="Credentials" />
+      <Grid
+        container
+        justify="flex-end"
+        alignItems="flex-end"
+        updateFor={[credentials, error, loading]}
+        style={{ paddingBottom: 0 }}
+      >
+        <Grid item>
+          <Grid container alignItems="flex-end">
+            <Grid item className="pt0">
+              <AddNewLink
+                onClick={() => null}
+                label="Add a Credential"
+                disabled
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+      <OrderBy data={credentials} orderBy={'label'} order={'asc'}>
+        {({ data: orderedData, handleOrderChange, order, orderBy }) => (
+          <Paginate data={orderedData}>
+            {({
+              data,
+              count,
+              handlePageChange,
+              handlePageSizeChange,
+              page,
+              pageSize
+            }) => (
+              <>
+                <Paper>
+                  <Table aria-label="List of Your Managed Credentials">
+                    <TableHead>
+                      <TableRow>
+                        <TableSortCell
+                          active={orderBy === 'label'}
+                          label={'label'}
+                          direction={order}
+                          handleClick={handleOrderChange}
+                          data-qa-credential-label-header
+                        >
+                          Credential
+                        </TableSortCell>
+                        <TableSortCell
+                          active={orderBy === 'last_decrypted'}
+                          label={'last_decrypted'}
+                          direction={order}
+                          handleClick={handleOrderChange}
+                          data-qa-credential-decrypted-header
+                        >
+                          Last Decrypted
+                        </TableSortCell>
+                        <TableCell />
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      <CredentialTableContent
+                        credentials={data}
+                        loading={loading}
+                        error={error}
+                        openDialog={() => null}
+                      />
+                    </TableBody>
+                  </Table>
+                </Paper>
+                <PaginationFooter
+                  count={count}
+                  handlePageChange={handlePageChange}
+                  handleSizeChange={handlePageSizeChange}
+                  page={page}
+                  pageSize={pageSize}
+                  eventCategory="managed credential table"
+                />
+              </>
+            )}
+          </Paginate>
+        )}
+      </OrderBy>
+    </>
+  );
+};
+
+export default CredentialList;

--- a/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import AddNewLink from 'src/components/AddNewLink';
 import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
@@ -16,6 +17,13 @@ import TableSortCell from 'src/components/TableSortCell';
 
 import CredentialTableContent from './CredentialTableContent';
 
+const useStyles = makeStyles((theme: Theme) => ({
+  subHeader: {
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2)
+  }
+}));
+
 interface Props {
   error?: Linode.ApiFieldError[];
   credentials: Linode.ManagedCredential[];
@@ -23,6 +31,7 @@ interface Props {
 }
 
 export const CredentialList: React.FC<Props> = props => {
+  const classes = useStyles();
   const { credentials, error, loading } = props;
 
   return (
@@ -33,17 +42,13 @@ export const CredentialList: React.FC<Props> = props => {
         justify="flex-end"
         alignItems="flex-end"
         updateFor={[credentials, error, loading]}
-        style={{ paddingBottom: 0 }}
       >
-        <Grid item>
-          <Typography
-            variant="body1"
-            style={{ fontSize: '1.1em', lineHeight: '1.2em' }}
-          >
+        <Grid item xs={12}>
+          <Typography variant="subtitle1" className={classes.subHeader}>
             Please share any credentials our support team may need when
-            responding to a service issue. Credentials are stored encrypted and
-            all decryption attempts are logged. You can revoke credentials at
-            any time by deleting them.
+            responding to a service issue.
+            <br /> Credentials are stored encrypted and all decryption attempts
+            are logged. You can revoke credentials at any time by deleting them.
           </Typography>
         </Grid>
         <Grid item>

--- a/packages/manager/src/features/Managed/Credentials/CredentialRow.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialRow.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { createStyles, makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import DateTimeDisplay from 'src/components/DateTimeDisplay';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
+
+import ActionMenu from './CredentialActionMenu';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    label: {
+      width: '30%',
+      [theme.breakpoints.down('sm')]: {
+        width: '100%'
+      }
+    },
+    credentialDescription: {
+      paddingTop: theme.spacing(1) / 2
+    },
+    credentialRow: {
+      '&:before': {
+        display: 'none'
+      }
+    }
+  })
+);
+
+interface Props {
+  credential: Linode.ManagedCredential;
+  openDialog: (id: number, label: string) => void;
+}
+
+type CombinedProps = Props;
+
+export const CredentialRow: React.FunctionComponent<CombinedProps> = props => {
+  const { credential, openDialog } = props;
+  const classes = useStyles();
+
+  return (
+    <TableRow
+      key={credential.id}
+      data-qa-credential-cell={credential.id}
+      data-testid={'credential-row'}
+      className={classes.credentialRow}
+    >
+      <TableCell
+        parentColumn="Credential"
+        className={classes.label}
+        data-qa-credential-label
+      >
+        <Typography variant="h3">{credential.label}</Typography>
+      </TableCell>
+      <TableCell parentColumn="Last Decrypted" data-qa-credential-decrypted>
+        {credential.last_decrypted && (
+          <DateTimeDisplay value={credential.last_decrypted} />
+        )}
+      </TableCell>
+      <TableCell>
+        <ActionMenu
+          credentialID={credential.id}
+          openDialog={openDialog}
+          label={credential.label}
+        />
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default CredentialRow;

--- a/packages/manager/src/features/Managed/Credentials/CredentialTableContent.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialTableContent.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+import TableRowEmpty from 'src/components/TableRowEmptyState';
+import TableRowError from 'src/components/TableRowError';
+import TableRowLoading from 'src/components/TableRowLoading';
+import CredentialRow from './CredentialRow';
+
+interface Props {
+  credentials: Linode.ManagedCredential[];
+  loading: boolean;
+  openDialog: (id: number, label: string) => void;
+  error?: Linode.ApiFieldError[];
+}
+
+export type CombinedProps = Props;
+
+export const CredentialTableContent: React.FC<CombinedProps> = props => {
+  const { error, loading, credentials, openDialog } = props;
+  if (loading) {
+    return <TableRowLoading colSpan={12} />;
+  }
+
+  if (error) {
+    return <TableRowError colSpan={12} message={error[0].reason} />;
+  }
+
+  if (credentials.length === 0) {
+    return (
+      <TableRowEmpty
+        colSpan={12}
+        message={"You don't have any Credentials on your account."}
+      />
+    );
+  }
+
+  return (
+    <>
+      {credentials.map((credential: Linode.ManagedCredential, idx: number) => (
+        <CredentialRow
+          key={`managed-credential-row-${idx}`}
+          credential={credential}
+          openDialog={openDialog}
+        />
+      ))}
+    </>
+  );
+};
+
+export default CredentialTableContent;

--- a/packages/manager/src/features/Managed/Credentials/index.tsx
+++ b/packages/manager/src/features/Managed/Credentials/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './CredentialList';

--- a/packages/manager/src/features/Managed/ManagedLanding.tsx
+++ b/packages/manager/src/features/Managed/ManagedLanding.tsx
@@ -25,6 +25,9 @@ import withFeatureFlagConsumer, {
 import ManagedPlaceholder from './ManagedPlaceholder';
 import SupportWidget from './SupportWidget';
 
+// dummy credential data
+import { credentials } from 'src/__data__/managedCredentials';
+
 const Monitors = DefaultLoader({
   loader: () => import('./Monitors')
 });
@@ -36,6 +39,7 @@ const SSHAccess = DefaultLoader({
 const Credentials = DefaultLoader({
   loader: () => import('./Credentials')
 });
+
 const Contacts = DefaultLoader({
   loader: () => import('./Contacts')
 });
@@ -149,7 +153,9 @@ export class ManagedLanding extends React.Component<CombinedProps, {}> {
                 exact
                 strict
                 path={`${this.props.match.path}/credentials`}
-                component={Credentials}
+                render={() => (
+                  <Credentials loading={false} credentials={credentials} />
+                )}
               />
               <Route
                 exact

--- a/packages/manager/src/features/Managed/ManagedLanding.tsx
+++ b/packages/manager/src/features/Managed/ManagedLanding.tsx
@@ -4,8 +4,7 @@ import {
   Redirect,
   Route,
   RouteComponentProps,
-  Switch,
-  withRouter
+  Switch
 } from 'react-router-dom';
 import { compose } from 'recompose';
 import Breadcrumb from 'src/components/Breadcrumb';
@@ -19,10 +18,8 @@ import DocumentationButton from 'src/components/DocumentationButton';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import TabLink from 'src/components/TabLink';
-import withFeatureFlagConsumer, {
-  FeatureFlagConsumerProps
-} from 'src/containers/withFeatureFlagConsumer.container';
 import { useAPIRequest } from 'src/hooks/useAPIRequest';
+import useFlags from 'src/hooks/useFlags';
 import { getCredentials } from 'src/services/managed';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
@@ -45,7 +42,7 @@ const Contacts = DefaultLoader({
   loader: () => import('./Contacts')
 });
 
-export type CombinedProps = RouteComponentProps<{}> & FeatureFlagConsumerProps;
+export type CombinedProps = RouteComponentProps<{}>;
 
 const docs: Linode.Doc[] = [
   {
@@ -89,11 +86,13 @@ export const ManagedLanding: React.FunctionComponent<CombinedProps> = props => {
     return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
+  const flags = useFlags();
+
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Managed" />
       {/* If the feature isn't enabled, just display the placeholder */}
-      {!props.flags.managed ? (
+      {!flags.managed ? (
         <ManagedPlaceholder />
       ) : (
         <React.Fragment>
@@ -187,10 +186,6 @@ export const ManagedLanding: React.FunctionComponent<CombinedProps> = props => {
   );
 };
 
-const enhanced = compose<CombinedProps, {}>(
-  setDocs(docs),
-  withFeatureFlagConsumer,
-  withRouter
-);
+const enhanced = compose<CombinedProps, {}>(setDocs(docs));
 
 export default enhanced(ManagedLanding);

--- a/packages/manager/src/features/Managed/ManagedLanding.tsx
+++ b/packages/manager/src/features/Managed/ManagedLanding.tsx
@@ -22,11 +22,12 @@ import TabLink from 'src/components/TabLink';
 import withFeatureFlagConsumer, {
   FeatureFlagConsumerProps
 } from 'src/containers/withFeatureFlagConsumer.container';
+import { useAPIRequest } from 'src/hooks/useAPIRequest';
+import { getCredentials } from 'src/services/managed';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { getAll } from 'src/utilities/getAll';
 import ManagedPlaceholder from './ManagedPlaceholder';
 import SupportWidget from './SupportWidget';
-
-// dummy credential data
-import { credentials } from 'src/__data__/managedCredentials';
 
 const Monitors = DefaultLoader({
   loader: () => import('./Monitors')
@@ -46,134 +47,148 @@ const Contacts = DefaultLoader({
 
 export type CombinedProps = RouteComponentProps<{}> & FeatureFlagConsumerProps;
 
-export class ManagedLanding extends React.Component<CombinedProps, {}> {
-  static docs: Linode.Doc[] = [
-    {
-      title: 'Linode Managed',
-      src: 'https://linode.com/docs/platform/linode-managed/',
-      body: `How to configure service monitoring with Linode Managed.`
-    }
-  ];
+const docs: Linode.Doc[] = [
+  {
+    title: 'Linode Managed',
+    src: 'https://linode.com/docs/platform/linode-managed/',
+    body: `How to configure service monitoring with Linode Managed.`
+  }
+];
 
-  tabs = [
+const getAllCredentials = () =>
+  getAll<Linode.ManagedCredential>(getCredentials)().then(
+    response => response.data
+  );
+
+export const ManagedLanding: React.FunctionComponent<CombinedProps> = props => {
+  const { data, error, loading, lastUpdated } = useAPIRequest<
+    Linode.ManagedCredential[]
+  >(getAllCredentials, []);
+  const credentialsError = error
+    ? getAPIErrorOrDefault(error, 'Error retrieving your credentials.')
+    : undefined;
+
+  const tabs = [
     /* NB: These must correspond to the routes inside the Switch */
-    { title: 'Monitors', routeName: `${this.props.match.url}/monitors` },
-    { title: 'SSH Access', routeName: `${this.props.match.url}/ssh-access` },
-    { title: 'Credentials', routeName: `${this.props.match.url}/credentials` },
-    { title: 'Contacts', routeName: `${this.props.match.url}/contacts` }
+    { title: 'Monitors', routeName: `${props.match.url}/monitors` },
+    { title: 'SSH Access', routeName: `${props.match.url}/ssh-access` },
+    { title: 'Credentials', routeName: `${props.match.url}/credentials` },
+    { title: 'Contacts', routeName: `${props.match.url}/contacts` }
   ];
 
-  handleTabChange = (
+  const handleTabChange = (
     event: React.ChangeEvent<HTMLDivElement>,
     value: number
   ) => {
-    const { history } = this.props;
-    const routeName = this.tabs[value].routeName;
+    const { history } = props;
+    const routeName = tabs[value].routeName;
     history.push(`${routeName}`);
   };
 
-  matches = (p: string) => {
-    return Boolean(matchPath(p, { path: this.props.location.pathname }));
+  const matches = (p: string) => {
+    return Boolean(matchPath(p, { path: props.location.pathname }));
   };
 
-  render() {
-    return (
-      <React.Fragment>
-        <DocumentTitleSegment segment="Managed" />
-        {/* If the feature isn't enabled, just display the placeholder */}
-        {!this.props.flags.managed ? (
-          <ManagedPlaceholder />
-        ) : (
-          <React.Fragment>
-            <Box
-              display="flex"
-              flexDirection="row"
-              justifyContent="space-between"
+  return (
+    <React.Fragment>
+      <DocumentTitleSegment segment="Managed" />
+      {/* If the feature isn't enabled, just display the placeholder */}
+      {!props.flags.managed ? (
+        <ManagedPlaceholder />
+      ) : (
+        <React.Fragment>
+          <Box
+            display="flex"
+            flexDirection="row"
+            justifyContent="space-between"
+          >
+            <Breadcrumb
+              pathname={props.location.pathname}
+              labelTitle="Managed"
+              removeCrumbX={1}
+            />
+            <Grid
+              container
+              item
+              direction="row"
+              justify="flex-end"
+              alignItems="center"
+              xs={8}
             >
-              <Breadcrumb
-                pathname={this.props.location.pathname}
-                labelTitle="Managed"
-                removeCrumbX={1}
-              />
-              <Grid
-                container
-                item
-                direction="row"
-                justify="flex-end"
-                alignItems="center"
-                xs={8}
-              >
-                <Grid item>
-                  <SupportWidget />
-                </Grid>
-                <Grid item>
-                  <DocumentationButton href="https://www.linode.com/docs/platform/linode-managed/" />
-                </Grid>
+              <Grid item>
+                <SupportWidget />
               </Grid>
-            </Box>
-            <AppBar position="static" color="default">
-              <Tabs
-                value={this.tabs.findIndex(tab => this.matches(tab.routeName))}
-                onChange={this.handleTabChange}
-                indicatorColor="primary"
-                textColor="primary"
-                variant="scrollable"
-                scrollButtons="on"
-              >
-                {this.tabs.map(tab => (
-                  <Tab
-                    key={tab.title}
-                    data-qa-tab={tab.title}
-                    component={React.forwardRef((forwardedProps, ref) => (
-                      <TabLink
-                        to={tab.routeName}
-                        title={tab.title}
-                        {...forwardedProps}
-                        ref={ref}
-                      />
-                    ))}
-                  />
-                ))}
-              </Tabs>
-            </AppBar>
-            <Switch>
-              <Route
-                exact
-                strict
-                path={`${this.props.match.path}/monitors`}
-                component={Monitors}
-              />
-              <Route
-                exact
-                strict
-                path={`${this.props.match.path}/ssh-access`}
-                component={SSHAccess}
-              />
-              <Route
-                exact
-                strict
-                path={`${this.props.match.path}/credentials`}
-                render={() => (
-                  <Credentials loading={false} credentials={credentials} />
-                )}
-              />
-              <Route
-                exact
-                strict
-                path={`${this.props.match.path}/contacts`}
-                component={Contacts}
-              />
-              <Redirect to={`${this.props.match.path}/monitors`} />
-            </Switch>
-          </React.Fragment>
-        )}
-      </React.Fragment>
-    );
-  }
-}
+              <Grid item>
+                <DocumentationButton href="https://www.linode.com/docs/platform/linode-managed/" />
+              </Grid>
+            </Grid>
+          </Box>
+          <AppBar position="static" color="default">
+            <Tabs
+              value={tabs.findIndex(tab => matches(tab.routeName))}
+              onChange={handleTabChange}
+              indicatorColor="primary"
+              textColor="primary"
+              variant="scrollable"
+              scrollButtons="on"
+            >
+              {tabs.map(tab => (
+                <Tab
+                  key={tab.title}
+                  data-qa-tab={tab.title}
+                  component={React.forwardRef((forwardedProps, ref) => (
+                    <TabLink
+                      to={tab.routeName}
+                      title={tab.title}
+                      {...forwardedProps}
+                      ref={ref}
+                    />
+                  ))}
+                />
+              ))}
+            </Tabs>
+          </AppBar>
+          <Switch>
+            <Route
+              exact
+              strict
+              path={`${props.match.path}/monitors`}
+              component={Monitors}
+            />
+            <Route
+              exact
+              strict
+              path={`${props.match.path}/ssh-access`}
+              component={SSHAccess}
+            />
+            <Route
+              exact
+              strict
+              path={`${props.match.path}/credentials`}
+              render={() => (
+                <Credentials
+                  loading={loading && lastUpdated === 0}
+                  error={credentialsError}
+                  credentials={data}
+                />
+              )}
+            />
+            <Route
+              exact
+              strict
+              path={`${props.match.path}/contacts`}
+              component={Contacts}
+            />
+            <Redirect to={`${props.match.path}/monitors`} />
+          </Switch>
+        </React.Fragment>
+      )}
+    </React.Fragment>
+  );
+};
 
-const enhanced = compose<{}, {}>(
-  setDocs(ManagedLanding.docs),
+const enhanced = compose<CombinedProps, {}>(
+  setDocs(docs),
   withFeatureFlagConsumer,
   withRouter
 );

--- a/packages/manager/src/features/Managed/Monitors/Monitors.tsx
+++ b/packages/manager/src/features/Managed/Monitors/Monitors.tsx
@@ -17,6 +17,7 @@ export const Monitors: React.FC<CombinedProps> = props => {
     monitors,
     requestManagedServices
   } = props;
+
   React.useEffect(() => {
     requestManagedServices().catch(_ => null); // Errors handled in Redux state
   }, [requestManagedServices]);

--- a/packages/manager/src/services/managed/managed.ts
+++ b/packages/manager/src/services/managed/managed.ts
@@ -63,3 +63,16 @@ export const getLinodeSettings = (params?: any, filters?: any) =>
     setXFilter(filters),
     setURL(`${API_ROOT}/managed/linode-settings`)
   ).then(response => response.data);
+
+/**
+ * getCredentials
+ *
+ * Returns a paginated list of Managed Credentials for your account.
+ */
+export const getCredentials = (params?: any, filters?: any) =>
+  Request<Page<Linode.ManagedCredential>>(
+    setMethod('GET'),
+    setParams(params),
+    setXFilter(filters),
+    setURL(`${API_ROOT}/managed/credentials`)
+  ).then(response => response.data);

--- a/packages/manager/src/types/Managed.ts
+++ b/packages/manager/src/types/Managed.ts
@@ -8,7 +8,7 @@ namespace Linode {
     service_type: ServiceType;
     timeout: number;
     region: string | null;
-    credentials: any[]; // @todo
+    credentials: ManagedCredential[]; // @todo
     address: string;
     body: string;
     notes: string;
@@ -31,5 +31,11 @@ namespace Linode {
     user: string;
     ip: string;
     port: number;
+  }
+
+  export interface ManagedCredential {
+    id: number;
+    last_decrypted: string | null;
+    label: string;
   }
 }


### PR DESCRIPTION
## Description

View a list of Credentials on your account at managed/credentials. Adding isn't included yet, so you'll have to use classic to add a few.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

I turned ManagedLanding into a function component so I could use John's new useAPIRequest hook. I don't think this introduced any bugs or performance problems but please check.

The API doesn't yet return last_decrypted, so that field will always be blank for now. I'm not exactly sure what the response will look like (Classic shows the username that did the decrypting), but there's some sample data in __data__ that you can use to get some idea.