### PR TITLE
Add: Inter-DC Migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ lib
 **/linode-js-sdk/index.js
 **/linode-js-sdk/index.d.ts
 
-
 # editor configuration
 .vscode
 .idea

--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -5,7 +5,6 @@ import CreatableSelect, {
   Props as CreatableSelectProps
 } from 'react-select/lib/Creatable';
 import { Props as SelectProps } from 'react-select/lib/Select';
-import { StylesConfig } from 'react-select/lib/styles';
 import { withStyles, WithStyles } from 'src/components/core/styles';
 import { Props as TextFieldProps } from 'src/components/TextField';
 /* TODO will be refactoring enhanced select to be an abstraction.
@@ -43,40 +42,8 @@ interface ActionMeta {
   action: string;
 }
 
-interface ActionMeta {
-  action: string;
-}
-
 export interface NoOptionsMessageProps {
   inputValue: string;
-}
-
-export interface EnhancedSelectProps {
-  options?: Item[] | GroupType[];
-  className?: string;
-  components?: any;
-  disabled?: boolean;
-  isClearable?: boolean;
-  isMulti?: boolean;
-  isLoading?: boolean;
-  variant?: 'creatable';
-  value?: Item | Item[] | null;
-  label?: string;
-  placeholder?: string;
-  errorText?: string;
-  styleOverrides?: StylesConfig;
-  onChange: (selected: Item | Item[] | null, actionMeta: ActionMeta) => void;
-  createNew?: (inputValue: string) => void;
-  onInputChange?: (inputValue: string, actionMeta: ActionMeta) => void;
-  loadOptions?: (inputValue: string) => Promise<Item | Item[]> | undefined;
-  filterOption?: (option: Item, inputValue: string) => boolean | null;
-  medium?: boolean;
-  small?: boolean;
-  guidance?: string | React.ReactNode;
-  noMarginTop?: boolean;
-  inline?: boolean;
-  hideLabel?: boolean;
-  errorGroup?: string;
 }
 
 // Material-UI versions of several React-Select components.
@@ -93,19 +60,41 @@ const _components = {
   LoadingIndicator
 };
 
-type CombinedProps = EnhancedSelectProps &
-  WithStyles<ClassNames> &
-  BaseSelectProps &
-  CreatableProps;
+type CombinedProps = WithStyles<ClassNames> & BaseSelectProps & CreatableProps;
 
-interface BaseSelectProps extends SelectProps<any> {
-  classes: any;
+export interface BaseSelectProps
+  extends Omit<SelectProps<any>, 'onChange' | 'value'> {
+  classes?: any;
   /*
    textFieldProps isn't native to react-select
    but we're using the MUI select element so any props that
    can be passed to the MUI TextField element can be passed here
   */
   textFieldProps?: TextFieldProps;
+  /**
+   * errorText and label both passed to textFieldProps
+   * @todo consider just putting this under textFieldProps
+   */
+  errorText?: string;
+  label?: string;
+  /** alias for isDisabled */
+  disabled?: boolean;
+  variant?: 'creatable';
+  /** retyped this */
+  value?: Item | Item[] | null;
+  /** making this required */
+  onChange: (selected: Item | Item[] | null, actionMeta: ActionMeta) => void;
+  /** alias for onCreateOption */
+  createNew?: (inputValue: string) => void;
+  loadOptions?: (inputValue: string) => Promise<Item | Item[]> | undefined;
+  /** the rest are props we've added ourselves */
+  medium?: boolean;
+  small?: boolean;
+  noMarginTop?: boolean;
+  inline?: boolean;
+  hideLabel?: boolean;
+  errorGroup?: string;
+  guidance?: string | React.ReactNode;
 }
 
 interface CreatableProps extends CreatableSelectProps<any> {}
@@ -129,7 +118,6 @@ class Select extends React.PureComponent<CombinedProps, {}> {
       onChange,
       onInputChange,
       options,
-      styleOverrides,
       value,
       variant,
       noOptionsMessage,
@@ -158,7 +146,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
      * The components passed in as props will be merged with the overrides we are already using, with the passed components
      * taking precedence.
      */
-    const combinedComponents = { ..._components, ...components };
+    const combinedComponents: any = { ..._components, ...components };
 
     // If async, pass loadOptions instead of options. A Select can't be both Creatable and Async.
     // (AsyncCreatable exists, but we have not adapted it.)
@@ -182,7 +170,6 @@ class Select extends React.PureComponent<CombinedProps, {}> {
           [classes.root]: true
         })}
         classNamePrefix="react-select"
-        styles={styleOverrides}
         /*
           textFieldProps isn't native to react-select
           but we're using the MUI select element so any props that
@@ -192,6 +179,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
           ...textFieldProps,
           label,
           errorText,
+          errorGroup,
           disabled,
           InputLabelProps: {
             shrink: true

--- a/packages/manager/src/components/EnhancedSelect/index.tsx
+++ b/packages/manager/src/components/EnhancedSelect/index.tsx
@@ -1,4 +1,8 @@
-import EnhancedSelect, { Item as _Item } from './Select';
+import EnhancedSelect, {
+  BaseSelectProps as _BaseSelectProps,
+  Item as _Item
+} from './Select';
 /* tslint:disable */
 export interface Item extends _Item {}
+export interface BaseSelectProps extends _BaseSelectProps {}
 export default EnhancedSelect;

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionOption.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionOption.tsx
@@ -1,0 +1,51 @@
+import classNames from 'classnames';
+import * as React from 'react';
+import { OptionProps } from 'react-select/lib/components/Option';
+import Option from 'src/components/EnhancedSelect/components/Option';
+import { Item } from 'src/components/EnhancedSelect/Select';
+
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Grid from 'src/components/Grid';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    padding: theme.spacing(1)
+  },
+  focused: {
+    backgroundColor: theme.palette.primary.main,
+    color: 'white'
+  }
+}));
+
+export interface RegionItem extends Item<string> {
+  flag: () => JSX.Element | null;
+  country: string;
+}
+interface RegionOptionProps extends OptionProps<string> {
+  data: RegionItem;
+}
+
+type CombinedProps = RegionOptionProps;
+
+export const RegionOption: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+  const { data, label } = props;
+  return (
+    <Option
+      className={classNames({
+        [classes.root]: true,
+        [classes.focused]: props.isFocused
+      })}
+      value={data.value}
+      attrs={{ ['data-qa-region-select-item']: data.value }}
+      {...props}
+    >
+      <Grid container direction="row" alignItems="center" justify="flex-start">
+        <Grid item>{data.flag && data.flag()}</Grid>
+        <Grid item>{label}</Grid>
+      </Grid>
+    </Option>
+  );
+};
+
+export default RegionOption;

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.test.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.test.tsx
@@ -1,5 +1,5 @@
 import { extendedRegions } from 'src/__data__/regionsData';
-import { getRegionOptions, getSelectedRegionById } from './SelectRegionPanel';
+import { getRegionOptions, getSelectedRegionById } from './RegionSelect';
 
 const fakeRegion = { ...extendedRegions[0], country: 'NZ' };
 

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -23,7 +23,7 @@ export interface ExtendedRegion extends Linode.Region {
 interface Props extends Omit<BaseSelectProps, 'onChange'> {
   regions: ExtendedRegion[];
   handleSelection: (id: string) => void;
-  selectedID?: string;
+  selectedID: string | null;
 }
 
 export const flags = {
@@ -38,6 +38,7 @@ export const flags = {
     />
   ),
   uk: () => <UK width="32" height="24" viewBox="0 0 640 480" />,
+  eu: () => <UK width="32" height="24" viewBox="0 0 640 480" />,
   de: () => <DE width="32" height="24" viewBox="0 0 720 480" />,
   ca: () => <CA width="32" height="24" viewBox="0 0 640 480" />,
   in: () => <IN width="32" height="24" viewBox="0 0 640 480" />
@@ -62,7 +63,7 @@ export const getRegionOptions = (regions: ExtendedRegion[]) => {
     if (thisRegion.country.match(/(us|ca)/)) {
       return 'North America';
     }
-    if (thisRegion.country.match(/(de|uk)/)) {
+    if (thisRegion.country.match(/(de|uk|eu)/)) {
       return 'Europe';
     }
     if (thisRegion.country.match(/(jp|sg|in)/)) {

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -1,0 +1,164 @@
+import CA from 'flag-icon-css/flags/4x3/ca.svg';
+import DE from 'flag-icon-css/flags/4x3/de.svg';
+import UK from 'flag-icon-css/flags/4x3/gb.svg';
+import IN from 'flag-icon-css/flags/4x3/in.svg';
+import JP from 'flag-icon-css/flags/4x3/jp.svg';
+import SG from 'flag-icon-css/flags/4x3/sg.svg';
+import US from 'flag-icon-css/flags/4x3/us.svg';
+import { groupBy, pathOr } from 'ramda';
+import * as React from 'react';
+import { compose } from 'recompose';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Select, {
+  BaseSelectProps,
+  GroupType
+} from 'src/components/EnhancedSelect/Select';
+
+import RegionOption, { RegionItem } from './RegionOption';
+
+export interface ExtendedRegion extends Linode.Region {
+  display: string;
+}
+
+interface Props extends Omit<BaseSelectProps, 'onChange'> {
+  regions: ExtendedRegion[];
+  handleSelection: (id: string) => void;
+  selectedID?: string;
+}
+
+export const flags = {
+  us: () => <US width="32" height="24" viewBox="0 0 720 480" />,
+  sg: () => <SG width="32" height="24" viewBox="0 0 640 480" />,
+  jp: () => (
+    <JP
+      width="32"
+      height="24"
+      viewBox="0 0 640 480"
+      style={{ backgroundColor: '#fff' }}
+    />
+  ),
+  uk: () => <UK width="32" height="24" viewBox="0 0 640 480" />,
+  de: () => <DE width="32" height="24" viewBox="0 0 720 480" />,
+  ca: () => <CA width="32" height="24" viewBox="0 0 640 480" />,
+  in: () => <IN width="32" height="24" viewBox="0 0 640 480" />
+};
+
+export const selectStyles = {
+  menuList: (base: any) => ({ ...base, maxHeight: `60vh !important` })
+};
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    '& svg': {
+      '& g': {
+        // Super hacky fix for Firefox rendering of some flag icons that had a clip-path property.
+        clipPath: 'none !important' as 'none'
+      }
+    }
+  }
+}));
+
+export const getRegionOptions = (regions: ExtendedRegion[]) => {
+  const groupedRegions = groupBy<ExtendedRegion>(thisRegion => {
+    if (thisRegion.country.match(/(us|ca)/)) {
+      return 'North America';
+    }
+    if (thisRegion.country.match(/(de|uk)/)) {
+      return 'Europe';
+    }
+    if (thisRegion.country.match(/(jp|sg|in)/)) {
+      return 'Asia';
+    }
+    return 'Other';
+  }, regions);
+  return ['North America', 'Europe', 'Asia', 'Other'].reduce(
+    (accum, thisGroup) => {
+      if (
+        !groupedRegions[thisGroup] ||
+        groupedRegions[thisGroup].length === 0
+      ) {
+        return accum;
+      }
+      return [
+        ...accum,
+        {
+          label: thisGroup,
+          options: groupedRegions[thisGroup]
+            .map(thisRegion => ({
+              label: thisRegion.display,
+              value: thisRegion.id,
+              flag: pathOr(
+                () => null,
+                [thisRegion.country.toLocaleLowerCase()],
+                flags
+              ),
+              country: thisRegion.country
+            }))
+            .sort(sortRegions)
+        }
+      ];
+    },
+    []
+  );
+};
+
+export const getSelectedRegionById = (
+  regionID: string,
+  options: GroupType[]
+) => {
+  const regions = options.reduce(
+    (accum, thisGroup) => [...accum, ...thisGroup.options],
+    []
+  );
+  return regions.find(thisRegion => regionID === thisRegion.value);
+};
+
+const sortRegions = (region1: RegionItem, region2: RegionItem) => {
+  // By country desc so USA is on top
+  if (region1.country > region2.country) {
+    return -1;
+  }
+  if (region1.country < region2.country) {
+    return 1;
+  }
+  // Alphabetically by display name, which is the city
+  if (region1.label < region2.label) {
+    return -1;
+  }
+  if (region1.label > region2.label) {
+    return 1;
+  }
+  return 0;
+};
+
+const SelectRegionPanel: React.FC<Props> = props => {
+  const {
+    disabled,
+    handleSelection,
+    regions,
+    selectedID,
+    ...restOfReactSelectProps
+  } = props;
+
+  const classes = useStyles();
+
+  const options = getRegionOptions(regions);
+
+  return (
+    <div className={classes.root}>
+      <Select
+        isClearable={false}
+        value={getSelectedRegionById(selectedID || '', options)}
+        label="Select a region"
+        disabled={disabled}
+        placeholder="Regions"
+        options={options}
+        onChange={(selection: RegionItem) => handleSelection(selection.value)}
+        components={{ Option: RegionOption }}
+        styles={selectStyles}
+        {...restOfReactSelectProps}
+      />
+    </div>
+  );
+};
+
+export default compose<Props, Props>(React.memo)(SelectRegionPanel);

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/index.ts
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/index.ts
@@ -1,0 +1,6 @@
+import { ExtendedRegion as _ExtendedRegion } from './RegionSelect';
+
+/* tslint:disable */
+export interface ExtendedRegion extends _ExtendedRegion {}
+
+export { flags, default } from './RegionSelect';

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -1,11 +1,3 @@
-import CA from 'flag-icon-css/flags/4x3/ca.svg';
-import DE from 'flag-icon-css/flags/4x3/de.svg';
-import UK from 'flag-icon-css/flags/4x3/gb.svg';
-import IN from 'flag-icon-css/flags/4x3/in.svg';
-import JP from 'flag-icon-css/flags/4x3/jp.svg';
-import SG from 'flag-icon-css/flags/4x3/sg.svg';
-import US from 'flag-icon-css/flags/4x3/us.svg';
-import { groupBy, pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
@@ -16,35 +8,11 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Select, { GroupType } from 'src/components/EnhancedSelect/Select';
 import RenderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
 
-import RegionOption, { RegionItem } from './RegionOption';
-
-const flags = {
-  us: () => <US width="32" height="24" viewBox="0 0 720 480" />,
-  sg: () => <SG width="32" height="24" viewBox="0 0 640 480" />,
-  jp: () => (
-    <JP
-      width="32"
-      height="24"
-      viewBox="0 0 640 480"
-      style={{ backgroundColor: '#fff' }}
-    />
-  ),
-  uk: () => <UK width="32" height="24" viewBox="0 0 640 480" />,
-  de: () => <DE width="32" height="24" viewBox="0 0 720 480" />,
-  ca: () => <CA width="32" height="24" viewBox="0 0 640 480" />,
-  in: () => <IN width="32" height="24" viewBox="0 0 640 480" />
-};
-
-export const selectStyles = {
-  menuList: (base: any) => ({ ...base, maxHeight: `60vh !important` })
-};
-
-export interface ExtendedRegion extends Linode.Region {
-  display: string;
-}
+import RegionSelect, {
+  ExtendedRegion
+} from 'src/components/EnhancedSelect/variants/RegionSelect';
 
 type ClassNames = 'root';
 
@@ -71,79 +39,6 @@ interface Props {
   disabled?: boolean;
 }
 
-export const getRegionOptions = (regions: ExtendedRegion[]) => {
-  const groupedRegions = groupBy<ExtendedRegion>(thisRegion => {
-    if (thisRegion.country.match(/(us|ca)/)) {
-      return 'North America';
-    }
-    if (thisRegion.country.match(/(de|uk)/)) {
-      return 'Europe';
-    }
-    if (thisRegion.country.match(/(jp|sg|in)/)) {
-      return 'Asia';
-    }
-    return 'Other';
-  }, regions);
-  return ['North America', 'Europe', 'Asia', 'Other'].reduce(
-    (accum, thisGroup) => {
-      if (
-        !groupedRegions[thisGroup] ||
-        groupedRegions[thisGroup].length === 0
-      ) {
-        return accum;
-      }
-      return [
-        ...accum,
-        {
-          label: thisGroup,
-          options: groupedRegions[thisGroup]
-            .map(thisRegion => ({
-              label: thisRegion.display,
-              value: thisRegion.id,
-              flag: pathOr(
-                () => null,
-                [thisRegion.country.toLocaleLowerCase()],
-                flags
-              ),
-              country: thisRegion.country
-            }))
-            .sort(sortRegions)
-        }
-      ];
-    },
-    []
-  );
-};
-
-export const getSelectedRegionById = (
-  regionID: string,
-  options: GroupType[]
-) => {
-  const regions = options.reduce(
-    (accum, thisGroup) => [...accum, ...thisGroup.options],
-    []
-  );
-  return regions.find(thisRegion => regionID === thisRegion.value);
-};
-
-const sortRegions = (region1: RegionItem, region2: RegionItem) => {
-  // By country desc so USA is on top
-  if (region1.country > region2.country) {
-    return -1;
-  }
-  if (region1.country < region2.country) {
-    return 1;
-  }
-  // Alphabetically by display name, which is the city
-  if (region1.label < region2.label) {
-    return -1;
-  }
-  if (region1.label > region2.label) {
-    return 1;
-  }
-  return 0;
-};
-
 const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
   const {
     classes,
@@ -158,8 +53,6 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
   if (props.regions.length === 0) {
     return null;
   }
-
-  const options = getRegionOptions(regions);
 
   return (
     <>
@@ -178,17 +71,12 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
             to find the best region for your current location.
           </Typography>
         )}
-        <Select
-          isClearable={false}
-          value={getSelectedRegionById(selectedID || '', options)}
-          label="Select a region"
+        <RegionSelect
           errorText={error}
           disabled={disabled}
-          placeholder="Regions"
-          options={options}
-          onChange={(selection: RegionItem) => handleSelection(selection.value)}
-          components={{ Option: RegionOption }}
-          styleOverrides={selectStyles}
+          handleSelection={handleSelection}
+          regions={regions}
+          selectedID={selectedID}
         />
       </Paper>
     </>

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -76,7 +76,7 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
           disabled={disabled}
           handleSelection={handleSelection}
           regions={regions}
-          selectedID={selectedID}
+          selectedID={selectedID || null}
         />
       </Paper>
     </>

--- a/packages/manager/src/components/SelectRegionPanel/index.ts
+++ b/packages/manager/src/components/SelectRegionPanel/index.ts
@@ -1,7 +1,1 @@
-import SelectRegionPanel, {
-  ExtendedRegion as _ExtendedRegion
-} from './SelectRegionPanel';
-/* tslint:disable */
-export interface ExtendedRegion extends _ExtendedRegion {}
-
-export default SelectRegionPanel;
+export { default } from './SelectRegionPanel';

--- a/packages/manager/src/containers/regions.container.ts
+++ b/packages/manager/src/containers/regions.container.ts
@@ -5,30 +5,39 @@ export interface DefaultProps {
   regionsData: Linode.Region[];
   regionsError?: Linode.ApiFieldError[];
   regionsLoading: boolean;
+  regionsLastUpdated: number;
 }
 
 const defaultMap: (p: InjectedProps) => DefaultProps = ({
   data,
   error,
-  loading
+  loading,
+  lastUpdated
 }) => ({
   regionsData: data,
   regionsError: error,
-  regionsLoading: loading
+  regionsLoading: loading,
+  regionsLastUpdated: lastUpdated
 });
 
 interface InjectedProps {
   data: Linode.Region[];
   error?: Linode.ApiFieldError[];
   loading: boolean;
+  lastUpdated: number;
 }
 
 const mapStateToPropsFactory = <MappedProps>(
   updater: (v: InjectedProps) => MappedProps
 ) => (state: ApplicationState): MappedProps => {
-  const { entities: data, loading, error } = state.__resources.regions;
+  const {
+    entities: data,
+    loading,
+    error,
+    lastUpdated
+  } = state.__resources.regions;
 
-  return updater({ data, loading, error });
+  return updater({ data, loading, error, lastUpdated });
 };
 
 const regionsContainer = <MappedProps>(

--- a/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -205,7 +205,9 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
             isClearable={false}
             inputValue={inputValue}
             options={options}
-            components={{ Option: SearchItem, DropdownIndicator: () => null }}
+            components={
+              { Option: SearchItem, DropdownIndicator: () => null } as any
+            }
             onChange={this.handleSelect}
             onInputChange={this.onInputValueChange}
             placeholder="Search for answers..."
@@ -213,7 +215,7 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
               [classes.enhancedSelectWrapper]: true,
               [classes.enhancedSelectWrapperCompact]: spacingMode === 'compact'
             })}
-            styleOverrides={selectStyles}
+            styles={selectStyles}
             value={false}
           />
         </div>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -32,9 +32,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
 import Notice from 'src/components/Notice';
-import SelectRegionPanel, {
-  ExtendedRegion
-} from 'src/components/SelectRegionPanel';
+import SelectRegionPanel from 'src/components/SelectRegionPanel';
 import { Tag } from 'src/components/TagsInput';
 import { dcDisplayCountry, dcDisplayNames } from 'src/constants';
 import regionsContainer from 'src/containers/regions.container';
@@ -58,6 +56,8 @@ import {
   NodeBalancerConfigFieldsWithStatus,
   transformConfigsForRequest
 } from './utils';
+
+import { ExtendedRegion } from 'src/components/EnhancedSelect/variants/RegionSelect';
 
 type ClassNames = 'root' | 'main' | 'sidebar' | 'title';
 

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -194,7 +194,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
                 : 'Search for Linodes, Volumes, NodeBalancers, Domains, Tags...'
             }
             components={{ Control, Option }}
-            styleOverrides={selectStyles}
+            styles={selectStyles}
             openMenuOnFocus={false}
             openMenuOnClick={false}
             filterOption={this.filterResults}

--- a/packages/manager/src/features/Volumes/VolumeDrawer/RegionSelect.test.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/RegionSelect.test.tsx
@@ -25,6 +25,7 @@ describe('Region Select', () => {
       value=""
       regionsData={regionsData}
       regionsLoading={false}
+      regionsLastUpdated={0}
     />
   );
 

--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -287,7 +287,9 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
 
   const errorMap = getErrorMap(['disk_size'], state.errors);
 
-  const recentEvent = linodeEvents[0];
+  const firstEventWithProgress = (linodeEvents || []).find(
+    eachEvent => typeof eachEvent.percent_complete === 'number'
+  );
 
   const selectedLinode = linodesData.find(
     eachLinode => eachLinode.id === state.selectedLinodeId
@@ -318,7 +320,9 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
           onEditHandlers: undefined
         }}
       />
-      {linodeInTransition(linodeStatus, recentEvent) && <LinodeBusyStatus />}
+      {linodeInTransition(linodeStatus, firstEventWithProgress) && (
+        <LinodeBusyStatus />
+      )}
       <Grid container className={classes.root}>
         <Grid item xs={12} md={8} lg={9}>
           <Paper className={classes.paper}>

--- a/packages/manager/src/features/linodes/LinodesCreate/types.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/types.ts
@@ -1,4 +1,4 @@
-import { ExtendedRegion } from 'src/components/SelectRegionPanel';
+import { ExtendedRegion } from 'src/components/EnhancedSelect/variants/RegionSelect';
 import { Tag } from 'src/components/TagsInput';
 import { State as userSSHKeysProps } from 'src/features/linodes/userSSHKeyHoc';
 import { CreateLinodeRequest } from 'src/services/linodes';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeAdvancedConfigurationsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeAdvancedConfigurationsPanel.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
 import {
@@ -14,11 +15,18 @@ import LinodeConfigs from './LinodeConfigs';
 import LinodeDisks from './LinodeDisks';
 import LinodeDiskSpace from './LinodeDiskSpace';
 
-type ClassNames = 'root' | 'title' | 'paper' | 'main' | 'sidebar';
+import { sendMigrationNavigationEvent } from 'src/utilities/ga';
+
+type ClassNames =
+  | 'root'
+  | 'title'
+  | 'paper'
+  | 'migrationHeader'
+  | 'migrationCopy'
+  | 'sidebar';
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {},
     title: {
       marginBottom: theme.spacing(2)
     },
@@ -27,7 +35,12 @@ const styles = (theme: Theme) =>
       paddingTop: theme.spacing(1),
       marginBottom: theme.spacing(3)
     },
-    main: {},
+    migrationHeader: {
+      paddingTop: theme.spacing()
+    },
+    migrationCopy: {
+      marginTop: theme.spacing()
+    },
     sidebar: {
       marginTop: -theme.spacing(2),
       [theme.breakpoints.up('md')]: {
@@ -42,11 +55,11 @@ class LinodeAdvancedConfigurationsPanel extends React.PureComponent<
   CombinedProps
 > {
   render() {
-    const { classes, disks, linodeTotalDisk } = this.props;
+    const { classes, disks, linodeTotalDisk, linodeID } = this.props;
 
     return (
       <Grid container>
-        <Grid item xs={12} md={7} lg={9} className={classes.main}>
+        <Grid item xs={12} md={7} lg={9}>
           <Typography variant="h2" className={classes.title}>
             Advanced Configurations
           </Typography>
@@ -55,6 +68,24 @@ class LinodeAdvancedConfigurationsPanel extends React.PureComponent<
           </Paper>
           <Paper className={classes.paper}>
             <LinodeDisks />
+          </Paper>
+          <Paper className={classes.paper}>
+            <Typography variant="h3" className={classes.migrationHeader}>
+              Configure a Migration
+            </Typography>
+            <Typography className={classes.migrationCopy}>
+              Migrating your Linode across datacenters is as simple as a few
+              clicks.
+              <Link
+                to={`/linodes/${linodeID}/migrate`}
+                onClick={() =>
+                  sendMigrationNavigationEvent(`/advanced`)
+                }
+              >
+                {' '}
+                Click here to get started migrating your Linode.
+              </Link>
+            </Typography>
           </Paper>
         </Grid>
         <Grid item xs={12} md={5} lg={3} className={classes.sidebar}>
@@ -70,11 +101,13 @@ class LinodeAdvancedConfigurationsPanel extends React.PureComponent<
 interface LinodeContextProps {
   linodeTotalDisk: number;
   disks: Linode.Disk[];
+  linodeID: number;
 }
 
 const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeTotalDisk: linode.specs.disk,
-  disks: linode._disks
+  disks: linode._disks,
+  linodeID: linode.id
 }));
 
 const styled = withStyles(styles);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodePowerControl/LinodePowerControl.tsx
@@ -110,7 +110,7 @@ interface Props {
   label: string;
   status: Linode.LinodeStatus;
   disabled?: boolean;
-  recentEvent?: Linode.Event;
+  linodeEvents?: Linode.Event[];
   linodeConfigs: Linode.Config[];
 }
 
@@ -165,7 +165,7 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
       status,
       classes,
       disabled,
-      recentEvent,
+      linodeEvents,
       linodeConfigs
     } = this.props;
     const {
@@ -174,7 +174,11 @@ export class LinodePowerButton extends React.Component<CombinedProps, State> {
 
     const hasNoConfigs = linodeConfigs.length === 0;
 
-    const isBusy = linodeInTransition(status, recentEvent);
+    const firstEventWithPercent = (linodeEvents || []).find(
+      eachEvent => typeof eachEvent.percent_complete === 'number'
+    );
+
+    const isBusy = linodeInTransition(status, firstEventWithPercent);
     const isRunning = !isBusy && status === 'running';
     const isOffline = !isBusy && status === 'offline';
     const buttonText = () => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeBusyStatus.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeBusyStatus.tsx
@@ -1,4 +1,3 @@
-import { head } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
@@ -29,19 +28,27 @@ const styles = (theme: Theme) =>
 
 interface LinodeDetailContextProps {
   status: string;
-  recentEvent?: Linode.Event;
+  linodeEvents?: Linode.Event[];
 }
 
 type CombinedProps = LinodeDetailContextProps & WithStyles<ClassNames>;
 
 const LinodeBusyStatus: React.StatelessComponent<CombinedProps> = props => {
-  const { classes, status, recentEvent } = props;
-  const value = (recentEvent && recentEvent.percent_complete) || 1;
+  const { classes, status, linodeEvents } = props;
+
+  const firstEventWithProgress = (linodeEvents || []).find(
+    eachEvent => typeof eachEvent.percent_complete === 'number'
+  );
+
+  const value = firstEventWithProgress
+    ? (firstEventWithProgress.percent_complete as number)
+    : 1;
+
   return (
     <Paper className={classes.root}>
       <div className={classes.status}>
         <Typography>
-          {transitionText(status, recentEvent)}: {value}%
+          {transitionText(status, firstEventWithProgress)}: {value}%
         </Typography>
       </div>
       <LinearProgress value={value} />
@@ -55,7 +62,7 @@ const enhanced = compose<CombinedProps, {}>(
   styled,
   withLinodeDetailContext(({ linode }) => ({
     status: linode.status,
-    recentEvent: head(linode._events)
+    linodeEvents: linode._events
   }))
 );
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetail.tsx
@@ -31,6 +31,10 @@ const LinodesDetailNavigation = DefaultLoader({
   loader: () => import('./LinodesDetailNavigation')
 });
 
+const MigrateLanding = DefaultLoader({
+  loader: () => import('../MigrateLanding')
+});
+
 interface MatchProps {
   linodeId?: string;
 }
@@ -75,6 +79,7 @@ const LinodeDetail: React.StatelessComponent<CombinedProps> = props => {
         have to reload all the configs, disks, etc. once we get to the CloneLanding page.
         */}
         <Route path={`${path}/clone`} component={CloneLanding} />
+        <Route path={`${path}/migrate`} component={MigrateLanding} />
         <Route
           render={() => (
             <React.Fragment>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -144,7 +144,7 @@ const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
         </Button>
         <LinodePowerControl
           status={linode.status}
-          recentEvent={linode._events[0]}
+          linodeEvents={linode._events}
           id={linode.id}
           label={linode.label}
           disabled={disabled}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeDetailHeader.tsx
@@ -11,14 +11,18 @@ type CombinedProps = LinodeContext;
 
 const LinodeDetailHeader: React.StatelessComponent<CombinedProps> = props => {
   const { linodeEvents, linodeStatus, linodeDisks } = props;
-  const recentEvent = linodeEvents[0];
+  const firstEventWithProgress = (linodeEvents || []).find(
+    eachEvent => typeof eachEvent.percent_complete === 'number'
+  );
 
   return (
     <React.Fragment>
       <MutationNotification disks={linodeDisks} />
       <Notifications />
       <LinodeControls />
-      {linodeInTransition(linodeStatus, recentEvent) && <LinodeBusyStatus />}
+      {linodeInTransition(linodeStatus, firstEventWithProgress) && (
+        <LinodeBusyStatus />
+      )}
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -13,6 +13,7 @@ const props: CombinedProps = {
   readOnly: false,
   typesLoading: false,
   regionsData: [],
+  regionsLastUpdated: 0,
   regionsLoading: false,
   openPowerActionDialog: jest.fn(),
   linodeBackups: {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -25,6 +25,8 @@ import { MapState } from 'src/store/types';
 
 import { Action as BootAction } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 
+import { sendMigrationNavigationEvent } from 'src/utilities/ga';
+
 export interface Props {
   linodeId: number;
   linodeLabel: string;
@@ -157,6 +159,7 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
         {
           title: 'Migrate',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendMigrationNavigationEvent('/linodes');
             sendLinodeActionMenuItemEvent('Migrate');
             push({
               pathname: `/linodes/${linodeId}/migrate`

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -155,6 +155,18 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
           ...readOnlyProps
         },
         {
+          title: 'Migrate',
+          onClick: (e: React.MouseEvent<HTMLElement>) => {
+            sendLinodeActionMenuItemEvent('Migrate');
+            push({
+              pathname: `/linodes/${linodeId}/migrate`
+            });
+            e.preventDefault();
+            e.stopPropagation();
+          },
+          ...readOnlyProps
+        },
+        {
           title: 'Resize',
           onClick: (e: React.MouseEvent<HTMLElement>) => {
             sendLinodeActionMenuItemEvent('Navigate to Resize Page');

--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -73,7 +73,7 @@ const CautionNotice: React.FC<CombinedProps> = props => {
         </li>
         <li>Your Linode will be powered off.</li>
         <li>
-          Block Storage can't be migrated to other regions.
+          Block Storage can't be migrated to other regions.{' '}
           {amountOfAttachedVolumes > 0 && (
             <React.Fragment>
               The following

--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
@@ -48,7 +49,7 @@ const CautionNotice: React.FC<CombinedProps> = props => {
       <ul>
         <li>
           You'll be assigned new IPv4 and IPv6 addresses, which will be
-          accessible once your migration is complete
+          accessible once your migration is complete.
         </li>
         <li>
           Any existing backups with the Linode Backup Service will not be
@@ -57,15 +58,21 @@ const CautionNotice: React.FC<CombinedProps> = props => {
         </li>
         <li>
           Any DNS records (including Reverse DNS) will need to be updated. You
-          can use the DNS Manager or Configure Your Linode for Reverse DNS
-          (rDNS).
+          can use the <Link to="/domains">DNS Manager</Link> or{' '}
+          <a
+            href="https://linode.com/docs/networking/dns/configure-your-linode-for-reverse-dns/"
+            target="_blank"
+          >
+            Configure Your Linode for Reverse DNS (rDNS).
+          </a>
         </li>
         <li>Your Linode will be powered off.</li>
         {props.linodeVolumes && (
           <React.Fragment>
             <li>
               Block Storage can't be migrated to other regions. The following
-              volumes will be detached from this Linode:
+              {props.linodeVolumes.length > 1 ? ' volumes' : ' volume'} will be
+              detached from this Linode:
             </li>
             <ul className={classes.volumes}>
               {props.linodeVolumes.map(eachVolume => {

--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -33,13 +33,18 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
-  linodeVolumes?: Linode.Volume[];
+  linodeVolumes: Linode.Volume[];
+  hasConfirmed: boolean;
+  setConfirmed: (value: boolean) => void;
+  error?: string;
 }
 
 type CombinedProps = Props;
 
 const CautionNotice: React.FC<CombinedProps> = props => {
   const classes = useStyles();
+
+  const amountOfAttachedVolumes = props.linodeVolumes.length;
 
   return (
     <Notice warning className={classes.root} spacingTop={24}>
@@ -67,22 +72,29 @@ const CautionNotice: React.FC<CombinedProps> = props => {
           </a>
         </li>
         <li>Your Linode will be powered off.</li>
-        {props.linodeVolumes && (
-          <React.Fragment>
-            <li>
-              Block Storage can't be migrated to other regions. The following
-              {props.linodeVolumes.length > 1 ? ' volumes' : ' volume'} will be
+        <li>
+          Block Storage can't be migrated to other regions.
+          {amountOfAttachedVolumes > 0 && (
+            <React.Fragment>
+              The following
+              {amountOfAttachedVolumes > 1 ? ' volumes' : ' volume'} will be
               detached from this Linode:
-            </li>
-            <ul className={classes.volumes}>
-              {props.linodeVolumes.map(eachVolume => {
-                return <li key={eachVolume.id}>{eachVolume.label}</li>;
-              })}
-            </ul>
-          </React.Fragment>
-        )}
+              <ul className={classes.volumes}>
+                {props.linodeVolumes.map(eachVolume => {
+                  return <li key={eachVolume.id}>{eachVolume.label}</li>;
+                })}
+              </ul>
+            </React.Fragment>
+          )}
+        </li>
       </ul>
-      <Checkbox text="Accept" className={classes.checkbox} />
+      {props.error && <Notice error text={props.error} />}
+      <Checkbox
+        text="Accept"
+        className={classes.checkbox}
+        onChange={() => props.setConfirmed(!props.hasConfirmed)}
+        checked={props.hasConfirmed}
+      />
     </Notice>
   );
 };

--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+import Checkbox from 'src/components/CheckBox';
+import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    backgroundColor: theme.bg.white,
+    '& ul:first-of-type': {
+      fontFamily: theme.font.normal,
+      '& li': {
+        marginBottom: theme.spacing()
+      }
+    }
+  },
+  header: {
+    marginTop: theme.spacing(2),
+    marginLeft: theme.spacing(2)
+  },
+  volumes: {
+    marginTop: theme.spacing(),
+    '& li': {
+      fontFamily: theme.font.bold
+    }
+  },
+  checkbox: {
+    marginLeft: theme.spacing(2)
+  }
+}));
+
+interface Props {
+  linodeVolumes?: Linode.Volume[];
+}
+
+type CombinedProps = Props;
+
+const CautionNotice: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  return (
+    <Notice warning className={classes.root} spacingTop={24}>
+      <Typography className={classes.header}>
+        <strong>Caution:</strong>
+      </Typography>
+      <ul>
+        <li>
+          You'll be assigned new IPv4 and IPv6 addresses, which will be
+          accessible once your migration is complete
+        </li>
+        <li>
+          Any existing backups with the Linode Backup Service will not be
+          migrated. Once your migration is complete, your backups will start
+          over on their existing schedule.
+        </li>
+        <li>
+          Any DNS records (including Reverse DNS) will need to be updated. You
+          can use the DNS Manager or Configure Your Linode for Reverse DNS
+          (rDNS).
+        </li>
+        <li>Your Linode will be powered off.</li>
+        {props.linodeVolumes && (
+          <React.Fragment>
+            <li>
+              Block Storage can't be migrated to other regions. The following
+              volumes will be detached from this Linode:
+            </li>
+            <ul className={classes.volumes}>
+              {props.linodeVolumes.map(eachVolume => {
+                return <li key={eachVolume.id}>{eachVolume.label}</li>;
+              })}
+            </ul>
+          </React.Fragment>
+        )}
+      </ul>
+      <Checkbox text="Accept" className={classes.checkbox} />
+    </Notice>
+  );
+};
+
+export default compose<CombinedProps, Props>(React.memo)(CautionNotice);

--- a/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+import Paper from 'src/components/core/Paper';
+import Typography from 'src/components/core/Typography';
+import { flags } from 'src/components/EnhancedSelect/variants/RegionSelect';
+
+import {
+  formatRegion,
+  getHumanReadableCountry
+} from 'src/utilities/formatRegion';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    padding: theme.spacing(4),
+    '& > p:first-of-type': {
+      marginTop: theme.spacing(2),
+      marginBottom: theme.spacing(1.5),
+      fontSize: theme.spacing(2),
+      fontFamily: theme.font.bold
+    }
+  },
+  currentRegion: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    '& svg': {
+      marginRight: theme.spacing()
+    }
+  }
+}));
+
+interface Props {
+  currentRegion: string;
+}
+
+type CombinedProps = Props;
+
+const ConfigureForm: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  return (
+    <Paper className={classes.root}>
+      <Typography variant="h3">Configure Migration</Typography>
+      <Typography>Current Region:</Typography>
+      <div className={classes.currentRegion}>
+        {flags[props.currentRegion.substr(0, 2)]()}
+        <Typography>{`${getHumanReadableCountry(
+          props.currentRegion
+        )}: ${formatRegion(props.currentRegion)}`}</Typography>
+      </div>
+    </Paper>
+  );
+};
+
+export default compose<CombinedProps, Props>(React.memo)(ConfigureForm);

--- a/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
@@ -4,8 +4,11 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 
 import Paper from 'src/components/core/Paper';
 import Typography from 'src/components/core/Typography';
-import { flags } from 'src/components/EnhancedSelect/variants/RegionSelect';
+import RegionSelect, {
+  flags
+} from 'src/components/EnhancedSelect/variants/RegionSelect';
 
+import { dcDisplayNames } from 'src/constants';
 import {
   formatRegion,
   getHumanReadableCountry
@@ -15,7 +18,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     padding: theme.spacing(4),
     '& > p:first-of-type': {
-      marginTop: theme.spacing(2),
+      marginTop: theme.spacing(4),
       marginBottom: theme.spacing(1.5),
       fontSize: theme.spacing(2),
       fontFamily: theme.font.bold
@@ -28,11 +31,18 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& svg': {
       marginRight: theme.spacing()
     }
+  },
+  select: {
+    marginTop: theme.spacing(2)
   }
 }));
 
 interface Props {
   currentRegion: string;
+  allRegions: Linode.Region[];
+  handleSelectRegion: (id: string) => void;
+  selectedRegion: string | null;
+  errorText?: string;
 }
 
 type CombinedProps = Props;
@@ -50,6 +60,20 @@ const ConfigureForm: React.FC<CombinedProps> = props => {
           props.currentRegion
         )}: ${formatRegion(props.currentRegion)}`}</Typography>
       </div>
+      <RegionSelect
+        className={classes.select}
+        regions={props.allRegions.map(eachRegion => ({
+          ...eachRegion,
+          display: dcDisplayNames[eachRegion.id]
+        }))}
+        handleSelection={props.handleSelectRegion}
+        selectedID={props.selectedRegion}
+        errorText={props.errorText}
+        menuPlacement="top"
+        styles={{
+          menuList: (base: any) => ({ ...base, maxHeight: `30vh !important` })
+        }}
+      />
     </Paper>
   );
 };

--- a/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
@@ -1,3 +1,4 @@
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -38,7 +39,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
-  currentRegion: string;
+  currentRegion: { region: string; countryCode: string };
   allRegions: Linode.Region[];
   handleSelectRegion: (id: string) => void;
   selectedRegion: string | null;
@@ -55,17 +56,19 @@ const ConfigureForm: React.FC<CombinedProps> = props => {
       <Typography variant="h3">Configure Migration</Typography>
       <Typography>Current Region:</Typography>
       <div className={classes.currentRegion}>
-        {flags[props.currentRegion.substr(0, 2)]()}
+        {pathOr(() => null, [props.currentRegion.countryCode], flags)()}
         <Typography>{`${getHumanReadableCountry(
-          props.currentRegion
-        )}: ${formatRegion(props.currentRegion)}`}</Typography>
+          props.currentRegion.region
+        )}: ${formatRegion(props.currentRegion.region)}`}</Typography>
       </div>
       <RegionSelect
         className={classes.select}
-        regions={props.allRegions.map(eachRegion => ({
-          ...eachRegion,
-          display: dcDisplayNames[eachRegion.id]
-        }))}
+        regions={props.allRegions
+          .filter(eachRegion => eachRegion.id !== props.currentRegion.region)
+          .map(eachRegion => ({
+            ...eachRegion,
+            display: dcDisplayNames[eachRegion.id]
+          }))}
         handleSelection={props.handleSelectRegion}
         selectedID={props.selectedRegion}
         errorText={props.errorText}

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.test.ts
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.test.ts
@@ -1,0 +1,17 @@
+import { getCountryCodeFromSlug } from './MigrateLanding';
+
+describe('Utility Functions', () => {
+  it('should return the correct country code based on country slugs', () => {
+    expect(getCountryCodeFromSlug('ap-west')).toBe('in');
+    expect(getCountryCodeFromSlug('ca-central')).toBe('ca');
+    expect(getCountryCodeFromSlug('us-central')).toBe('us');
+    expect(getCountryCodeFromSlug('us-east')).toBe('us');
+    expect(getCountryCodeFromSlug('us-west')).toBe('us');
+    expect(getCountryCodeFromSlug('us-southeast')).toBe('us');
+    expect(getCountryCodeFromSlug('eu-west')).toBe('uk');
+    expect(getCountryCodeFromSlug('ap-south')).toBe('sg');
+    expect(getCountryCodeFromSlug('eu-central')).toBe('de');
+    expect(getCountryCodeFromSlug('ap-northeast')).toBe('jp');
+    expect(getCountryCodeFromSlug('pppppppppp')).toBe('us');
+  });
+});

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
@@ -1,39 +1,66 @@
 import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 
+import Button from 'src/components/Button';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Error from 'src/components/ErrorState';
+import HelpIcon from 'src/components/HelpIcon';
+import Loading from 'src/components/LandingLoading';
+import Notice from 'src/components/Notice';
 
 import { withLinodeDetailContext } from '../LinodesDetail/linodeDetailContext';
 import LinodeControls from '../LinodesDetail/LinodesDetailHeader/LinodeControls';
-import MutationNotification from '../LinodesDetail/LinodesDetailHeader/MutationNotification';
 import Notifications from '../LinodesDetail/LinodesDetailHeader/Notifications';
 import LinodeBusyStatus from '../LinodesDetail/LinodeSummary/LinodeBusyStatus';
 
+import { resetEventsPolling } from 'src/events';
 import { displayType } from 'src/features/linodes/presentation';
 import { ApplicationState } from 'src/store';
 import getLinodeDescription from 'src/utilities/getLinodeDescription';
+import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import { linodeInTransition } from '../transitions';
 
 import CautionNotice from './CautionNotice';
 import ConfigureForm from './ConfigureForm';
 
+import { scheduleOrQueueMigration } from 'src/services/linodes/linodeActions.ts';
+
+import withRegions, {
+  DefaultProps as RegionProps
+} from 'src/containers/regions.container';
+
 const useStyles = makeStyles((theme: Theme) => ({
   details: {
+    marginTop: theme.spacing(2)
+  },
+  actionWrapper: {
     marginTop: theme.spacing(2)
   }
 }));
 
-type CombinedProps = LinodeContextProps & WithTypesAndImages;
+type CombinedProps = LinodeContextProps &
+  WithTypesAndImages &
+  RegionProps &
+  RouteComponentProps<{}>;
 
 const MigrateLanding: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
+  const [selectedRegion, handleSelectRegion] = React.useState<string | null>(
+    null
+  );
+  const [regionError, setRegionError] = React.useState<string>('');
+  const [acceptError, setAcceptError] = React.useState<string>('');
+  const [APIError, setAPIError] = React.useState<string>('');
+  const [hasConfirmed, setConfirmed] = React.useState<boolean>(false);
+  const [isLoading, setLoading] = React.useState<boolean>(false);
+
   const {
     label,
-    disks,
     linodeId,
     region,
     linodeStatus,
@@ -42,8 +69,50 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
     types,
     type,
     image,
-    images
+    images,
+    regionsData,
+    regionsError,
+    regionsLoading,
+    regionsLastUpdated
   } = props;
+
+  React.useEffect(() => {
+    scrollErrorIntoView();
+  }, [regionError, APIError, acceptError]);
+
+  const handleMigrate = () => {
+    setRegionError('');
+    setAcceptError('');
+    setAPIError('');
+
+    /** region is an optional param so enforce it client-side */
+    if (!selectedRegion) {
+      setRegionError('Please select a region.');
+    }
+
+    if (!hasConfirmed) {
+      setAcceptError('Please accept the conditions of this migration.');
+    }
+
+    if (!selectedRegion || !hasConfirmed) {
+      return;
+    }
+
+    setLoading(true);
+
+    return scheduleOrQueueMigration(linodeId, {
+      region: selectedRegion
+    })
+      .then(() => {
+        resetEventsPolling();
+        setLoading(false);
+        props.history.push(`/linodes/${linodeId}`);
+      })
+      .catch((e: Linode.ApiFieldError[]) => {
+        setLoading(false);
+        setAPIError(e[0].reason);
+      });
+  };
 
   const recentEvent = linodeEvents[0];
 
@@ -52,14 +121,33 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
     linodeSpecs.memory,
     linodeSpecs.disk,
     linodeSpecs.vcpus,
-    image.id,
+    image ? image.id : null,
     images
+  );
+
+  if (regionsLoading && regionsLastUpdated === 0) {
+    return <Loading shouldDelay />;
+  }
+
+  if (regionsError) {
+    return (
+      <Error errorText="There was an issue loading configuration options." />
+    );
+  }
+
+  if (regionsData.length === 0 && regionsLastUpdated !== 0) {
+    return null;
+  }
+
+  const disabledText = getDisabledReason(
+    props.recentEvents,
+    props.linodeStatus
   );
 
   return (
     <React.Fragment>
       <DocumentTitleSegment segment="Migrate" />
-      <MutationNotification disks={disks} />
+      {APIError && <Notice error text={APIError} />}
       <Notifications />
       <LinodeControls
         breadcrumbProps={{
@@ -80,8 +168,30 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
       <Typography className={classes.details} variant="h2">
         {newLabel}
       </Typography>
-      <CautionNotice linodeVolumes={props.linodeVolumes} />
-      <ConfigureForm currentRegion={region} />
+      <CautionNotice
+        linodeVolumes={props.linodeVolumes}
+        setConfirmed={setConfirmed}
+        hasConfirmed={hasConfirmed}
+        error={acceptError}
+      />
+      <ConfigureForm
+        currentRegion={region}
+        allRegions={regionsData}
+        handleSelectRegion={handleSelectRegion}
+        selectedRegion={selectedRegion}
+        errorText={regionError}
+      />
+      <div className={classes.actionWrapper}>
+        <Button
+          disabled={!!disabledText}
+          buttonType="primary"
+          onClick={handleMigrate}
+          loading={isLoading}
+        >
+          Enter Migration Queue
+        </Button>
+        {!!disabledText && <HelpIcon text={disabledText} />}
+      </div>
     </React.Fragment>
   );
 };
@@ -89,7 +199,6 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
 interface LinodeContextProps {
   linodeId: number;
   region: string;
-  disks: Linode.Disk[];
   label: string;
   linodeStatus: Linode.LinodeStatus;
   linodeSpecs: Linode.LinodeSpecs;
@@ -97,19 +206,20 @@ interface LinodeContextProps {
   type: string | null;
   image: Linode.Image;
   linodeVolumes: Linode.Volume[];
+  recentEvents: Linode.Event[];
 }
 
 const linodeContext = withLinodeDetailContext(({ linode }) => ({
   linodeId: linode.id,
   region: linode.region,
-  disks: linode._disks,
   type: linode.type,
   label: linode.label,
   image: linode.image,
   linodeSpecs: linode.specs,
   linodeStatus: linode.status,
   linodeEvents: linode._events,
-  linodeVolumes: linode._volumes
+  linodeVolumes: linode._volumes,
+  recentEvents: linode._events
 }));
 
 interface WithTypesAndImages {
@@ -130,6 +240,24 @@ const withTypes = connect(mapStateToProps);
 
 export default compose<CombinedProps, {}>(
   withTypes,
+  withRegions(),
   linodeContext,
   React.memo
 )(MigrateLanding);
+
+const getDisabledReason = (events: Linode.Event[], linodeStatus: string) => {
+  if (events[0]) {
+    if (
+      events[0].action === 'linode_migrate_datacenter' &&
+      events[0].percent_complete !== 100
+    ) {
+      return `Your Linode is currently being migrated.`;
+    }
+  }
+
+  if (linodeStatus !== 'offline') {
+    return 'Your Linode must be shut down first.';
+  }
+
+  return '';
+};

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import { connect, MapStateToProps } from 'react-redux';
+import { compose } from 'recompose';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { withLinodeDetailContext } from '../LinodesDetail/linodeDetailContext';
+import LinodeControls from '../LinodesDetail/LinodesDetailHeader/LinodeControls';
+import MutationNotification from '../LinodesDetail/LinodesDetailHeader/MutationNotification';
+import Notifications from '../LinodesDetail/LinodesDetailHeader/Notifications';
+import LinodeBusyStatus from '../LinodesDetail/LinodeSummary/LinodeBusyStatus';
+import { linodeInTransition } from '../transitions';
+
+import Typography from 'src/components/core/Typography';
+import { displayType } from 'src/features/linodes/presentation';
+import { ApplicationState } from 'src/store';
+import getLinodeDescription from 'src/utilities/getLinodeDescription';
+import CautionNotice from './CautionNotice';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  details: {
+    marginTop: theme.spacing(2)
+  }
+}));
+
+type CombinedProps = LinodeContextProps & WithTypesAndImages;
+
+const MigrateLanding: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const {
+    label,
+    disks,
+    linodeId,
+    linodeStatus,
+    linodeEvents,
+    linodeSpecs,
+    types,
+    type,
+    image,
+    images
+  } = props;
+
+  const recentEvent = linodeEvents[0];
+
+  const newLabel = getLinodeDescription(
+    displayType(type, types || []),
+    linodeSpecs.memory,
+    linodeSpecs.disk,
+    linodeSpecs.vcpus,
+    image.id,
+    images
+  );
+
+  return (
+    <React.Fragment>
+      <DocumentTitleSegment segment="Migrate" />
+      <MutationNotification disks={disks} />
+      <Notifications />
+      <LinodeControls
+        breadcrumbProps={{
+          removeCrumbX: 4,
+          crumbOverrides: [
+            {
+              label,
+              position: 2,
+              linkTo: {
+                pathname: `/linodes/${linodeId}/summary`
+              },
+              noCap: true
+            }
+          ]
+        }}
+      />
+      {linodeInTransition(linodeStatus, recentEvent) && <LinodeBusyStatus />}
+      <Typography className={classes.details} variant="h2">
+        {newLabel}
+      </Typography>
+      <CautionNotice linodeVolumes={props.linodeVolumes} />
+    </React.Fragment>
+  );
+};
+
+interface LinodeContextProps {
+  linodeId: number;
+  region: string;
+  disks: Linode.Disk[];
+  label: string;
+  linodeStatus: Linode.LinodeStatus;
+  linodeSpecs: Linode.LinodeSpecs;
+  linodeEvents: Linode.Event[];
+  type: string | null;
+  image: Linode.Image;
+  linodeVolumes: Linode.Volume[];
+}
+
+const linodeContext = withLinodeDetailContext(({ linode }) => ({
+  linodeId: linode.id,
+  region: linode.region,
+  disks: linode._disks,
+  type: linode.type,
+  label: linode.label,
+  image: linode.image,
+  linodeSpecs: linode.specs,
+  linodeStatus: linode.status,
+  linodeEvents: linode._events,
+  linodeVolumes: linode._volumes
+}));
+
+interface WithTypesAndImages {
+  types: Linode.LinodeType[];
+  images: Linode.Image[];
+}
+
+const mapStateToProps: MapStateToProps<
+  WithTypesAndImages,
+  {},
+  ApplicationState
+> = (state, ownProps) => ({
+  types: state.__resources.types.entities,
+  images: state.__resources.images.entities
+});
+
+const withTypes = connect(mapStateToProps);
+
+export default compose<CombinedProps, {}>(
+  withTypes,
+  linodeContext,
+  React.memo
+)(MigrateLanding);

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
@@ -1,20 +1,24 @@
 import * as React from 'react';
 import { connect, MapStateToProps } from 'react-redux';
 import { compose } from 'recompose';
+
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+
 import { withLinodeDetailContext } from '../LinodesDetail/linodeDetailContext';
 import LinodeControls from '../LinodesDetail/LinodesDetailHeader/LinodeControls';
 import MutationNotification from '../LinodesDetail/LinodesDetailHeader/MutationNotification';
 import Notifications from '../LinodesDetail/LinodesDetailHeader/Notifications';
 import LinodeBusyStatus from '../LinodesDetail/LinodeSummary/LinodeBusyStatus';
-import { linodeInTransition } from '../transitions';
 
-import Typography from 'src/components/core/Typography';
 import { displayType } from 'src/features/linodes/presentation';
 import { ApplicationState } from 'src/store';
 import getLinodeDescription from 'src/utilities/getLinodeDescription';
+import { linodeInTransition } from '../transitions';
+
 import CautionNotice from './CautionNotice';
+import ConfigureForm from './ConfigureForm';
 
 const useStyles = makeStyles((theme: Theme) => ({
   details: {
@@ -31,6 +35,7 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
     label,
     disks,
     linodeId,
+    region,
     linodeStatus,
     linodeEvents,
     linodeSpecs,
@@ -76,6 +81,7 @@ const MigrateLanding: React.FC<CombinedProps> = props => {
         {newLabel}
       </Typography>
       <CautionNotice linodeVolumes={props.linodeVolumes} />
+      <ConfigureForm currentRegion={region} />
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrationImminentNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrationImminentNotice.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import Notice from 'src/components/Notice';
+import SupportLink from 'src/components/SupportLink';
+
+interface Props {
+  notifications: Linode.Notification[];
+  linodeID: number;
+  className?: string;
+}
+type CombinedProps = Props;
+
+const MigrationImminentNotice: React.FC<CombinedProps> = props => {
+  const migrationScheduledForThisLinode = !!props.notifications.find(
+    eachNotification => {
+      return (
+        eachNotification.label.match(/migrat/i) &&
+        eachNotification.entity &&
+        eachNotification.entity.id === props.linodeID
+      );
+    }
+  );
+
+  return (
+    <React.Fragment>
+      {migrationScheduledForThisLinode ? (
+        <Notice
+          className={props.className}
+          spacingTop={16}
+          warning
+          text={
+            <React.Fragment>
+              Your Linode is already scheduled to be migrated. Please open a{' '}
+              <SupportLink
+                text="support ticket"
+                title="Request to overwrite existing migration"
+              />{' '}
+              if you would like to request this migration be overwritten.
+            </React.Fragment>
+          }
+        />
+      ) : null}
+    </React.Fragment>
+  );
+};
+
+export default compose<CombinedProps, Props>(React.memo)(
+  MigrationImminentNotice
+);

--- a/packages/manager/src/features/linodes/MigrateLanding/index.ts
+++ b/packages/manager/src/features/linodes/MigrateLanding/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MigrateLanding';

--- a/packages/manager/src/services/linodes/linodeActions.ts
+++ b/packages/manager/src/services/linodes/linodeActions.ts
@@ -208,8 +208,12 @@ export const startMutation = (linodeID: number) => {
  *
  * @param linodeId { number } The id of the Linode to be migrated.
  */
-export const scheduleOrQueueMigration = (linodeID: number) =>
+export const scheduleOrQueueMigration = (
+  linodeID: number,
+  payload?: { region: string }
+) =>
   Request<{}>(
     setURL(`${API_ROOT}/linode/instances/${linodeID}/migrate`),
+    setData(payload),
     setMethod('POST')
   );

--- a/packages/manager/src/utilities/formatRegion.ts
+++ b/packages/manager/src/utilities/formatRegion.ts
@@ -30,12 +30,12 @@ export const formatRegion = (region: string) => {
 
 export const getHumanReadableCountry = (regionSlug: string) => {
   if (regionSlug.match(/(us)/gim)) {
-    return 'North America';
+    return 'United States';
   }
   if (regionSlug.match(/(ca)/gim)) {
     return 'Canada';
   }
-  if (regionSlug.match(/(de|uk)/gim)) {
+  if (regionSlug.match(/(de|uk|eu)/gim)) {
     return 'Europe';
   }
   if (regionSlug.match(/(jp|sg|in)/gim)) {

--- a/packages/manager/src/utilities/formatRegion.ts
+++ b/packages/manager/src/utilities/formatRegion.ts
@@ -27,3 +27,19 @@ export const formatRegion = (region: string) => {
   // const country = dcDisplayCountry[region];
   // return `${country || ''} ${city || ''}`;
 };
+
+export const getHumanReadableCountry = (regionSlug: string) => {
+  if (regionSlug.match(/(us)/gim)) {
+    return 'North America';
+  }
+  if (regionSlug.match(/(ca)/gim)) {
+    return 'Canada';
+  }
+  if (regionSlug.match(/(de|uk)/gim)) {
+    return 'Europe';
+  }
+  if (regionSlug.match(/(jp|sg|in)/gim)) {
+    return 'Asia';
+  }
+  return 'Other';
+};

--- a/packages/manager/src/utilities/formatRegion.ts
+++ b/packages/manager/src/utilities/formatRegion.ts
@@ -38,7 +38,7 @@ export const getHumanReadableCountry = (regionSlug: string) => {
   if (regionSlug.match(/(de|uk|eu)/gim)) {
     return 'Europe';
   }
-  if (regionSlug.match(/(jp|sg|in)/gim)) {
+  if (regionSlug.match(/(jp|sg|in|ap)/gim)) {
     return 'Asia';
   }
   return 'Other';

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -243,3 +243,13 @@ export const sendRevokeAccessKeyEvent = () => {
     action: 'Revoke Access Key'
   });
 };
+
+/**
+ * meant to be sent to GA upon navigating to `/linodes/${linodeID}/migrate`
+ */
+export const sendMigrationNavigationEvent = (pathNavigatedFrom: string) => {
+  sendEvent({
+    category: 'Migration Navigation',
+    action: `From ${pathNavigatedFrom}`
+  });
+};


### PR DESCRIPTION
## Description

Adds Inter-DC (cross-datacenter) Migrations for Linodes

## Type of Change
- Non breaking change ('update', 'change')

## Highlights

* Refactors our abstracted react-select component props
* Abstracts out new Region Select for re-use
* Adds _migrate_ navigation link to Kebab and /advanced tab.
* Fixes issue with long-running events not showing progress if another non-progress event has happened on the Linode.