### PR TITLE
M3-3175 Remove tags from domains landing table rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ lib
 # misc
 .DS_Store
 
+# local restart script with keys
+restart.sh
+
 # dotenv environment variables file
 .env
 .env.local

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -43,7 +43,6 @@ const styles = (theme: Theme) =>
 interface Props {
   domain: string;
   id: number;
-  tags: string[];
   status: string;
   type: 'master' | 'slave';
   onRemove: (domain: string, domainId: number) => void;

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -9,7 +9,6 @@ import {
 import Typography from 'src/components/core/Typography';
 import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
-import {} from 'src/components/StatusIndicator';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import ActionMenu from './DomainActionMenu';

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -12,13 +12,11 @@ import Grid from 'src/components/Grid';
 import {} from 'src/components/StatusIndicator';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
-import Tags from 'src/components/Tags';
 import ActionMenu from './DomainActionMenu';
 
 type ClassNames =
   | 'domain'
   | 'labelStatusWrapper'
-  | 'tagWrapper'
   | 'domainRow'
   | 'domainCellContainer';
 
@@ -40,12 +38,6 @@ const styles = (theme: Theme) =>
       flexFlow: 'row nowrap',
       alignItems: 'center',
       wordBreak: 'break-all'
-    },
-    tagWrapper: {
-      marginTop: theme.spacing(1) / 2,
-      '& [class*="MuiChip"]': {
-        cursor: 'pointer'
-      }
     }
   });
 
@@ -82,7 +74,6 @@ class DomainTableRow extends React.Component<CombinedProps> {
       classes,
       domain,
       id,
-      tags,
       type,
       status,
       onClone,
@@ -124,9 +115,6 @@ class DomainTableRow extends React.Component<CombinedProps> {
                     {domain}
                   </Typography>
                 )}
-              </div>
-              <div className={classes.tagWrapper}>
-                <Tags tags={tags} />
               </div>
             </Grid>
           </Grid>

--- a/packages/manager/src/features/Domains/ListDomains.tsx
+++ b/packages/manager/src/features/Domains/ListDomains.tsx
@@ -121,7 +121,6 @@ const RenderData: React.StatelessComponent<RenderDataProps> = props => {
           onClone={onClone}
           onEdit={onEdit}
           onRemove={onRemove}
-          tags={domain.tags}
           type={domain.type}
           status={domain.status}
         />

--- a/packages/manager/src/features/Domains/ListGroupedDomains.tsx
+++ b/packages/manager/src/features/Domains/ListGroupedDomains.tsx
@@ -130,7 +130,6 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
                           onClone={onClone}
                           onEdit={onEdit}
                           onRemove={onRemove}
-                          tags={domain.tags}
                           type={domain.type}
                           status={domain.status}
                         />


### PR DESCRIPTION
## Remove tags from domains landing table rows

In order to be consistent with the rest of the landing pages, we should remove the tags from the row since we display tags in the detail pages for all entities.

## Type of Change
- Non breaking change ('update', 'change')
