### PR TITLE
Managed SSH Access Settings – clarify defaults

### DIFF
--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -16,11 +16,7 @@ import {
   handleGeneralErrors
 } from 'src/utilities/formikErrorUtils';
 import { privateIPRegex, removePrefixLength } from 'src/utilities/ipUtils';
-
-const DEFAULTS = {
-  user: 'root',
-  port: 22
-};
+import { DEFAULTS } from './common';
 
 const useStyles = makeStyles((theme: Theme) => ({
   ip: {
@@ -67,14 +63,15 @@ const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
       return;
     }
 
-    // If the user has cleared this field, replace it with the default.
+    // If the user has blanked out these fields, exchange in the defaults
+    // for `user` and `port`. We could also choose to NOT send these to
+    // the API to update, but this effectively achieves the same thing.
+    const user = values.ssh.user !== '' ? values.ssh.user : DEFAULTS.user;
     const port =
-      !values.ssh.port && values.ssh.port !== 0
-        ? DEFAULTS.port
-        : values.ssh.port;
+      String(values.ssh.port) !== '' ? values.ssh.port : DEFAULTS.port;
 
     updateLinodeSettings(linodeSetting.id, {
-      ssh: { ...values.ssh, port }
+      ssh: { ...values.ssh, user, port }
     })
       .then(updatedLinodeSetting => {
         setSubmitting(false);

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -140,11 +140,7 @@ const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
                   )}
 
                   <form>
-                    <Typography
-                      variant="body1"
-                      className={classes.helperText}
-                      data-qa-volume-size-help
-                    >
+                    <Typography variant="body1" className={classes.helperText}>
                       We’ll use the default settings for User Account (
                       {DEFAULTS.user}) and Port ({DEFAULTS.port}) if you leave
                       those fields empty.

--- a/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/EditSSHAccessDrawer.tsx
@@ -4,6 +4,7 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import FormControlLabel from 'src/components/core/FormControlLabel';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Grid from 'src/components/Grid';
 import IPSelect from 'src/components/IPSelect';
@@ -28,6 +29,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.down('sm')]: {
       paddingTop: '0px !important'
     }
+  },
+  helperText: {
+    marginBottom: theme.spacing(1) + 2
   }
 }));
 
@@ -136,6 +140,16 @@ const EditSSHAccessDrawer: React.FC<CombinedProps> = props => {
                   )}
 
                   <form>
+                    <Typography
+                      variant="body1"
+                      className={classes.helperText}
+                      data-qa-volume-size-help
+                    >
+                      We’ll use the default settings for User Account (
+                      {DEFAULTS.user}) and Port ({DEFAULTS.port}) if you leave
+                      those fields empty.
+                    </Typography>
+
                     <FormControlLabel
                       control={
                         <Toggle

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
@@ -36,13 +36,13 @@ export const SSHAccessRow: React.FunctionComponent<Props> = props => {
         {isAccessEnabled ? 'Enabled' : 'Disabled'}
       </TableCell>
       <TableCell parentColumn="User" data-qa-managed-user>
-        {linodeSetting.ssh.user ? linodeSetting.ssh.user : 'root'}
+        {linodeSetting.ssh.user}
       </TableCell>
       <TableCell parentColumn="IP" data-qa-managed-ip>
         {linodeSetting.ssh.ip === 'any' ? 'Any' : linodeSetting.ssh.ip}
       </TableCell>
       <TableCell parentColumn="Port" data-qa-managed-port>
-        {linodeSetting.ssh.port ? linodeSetting.ssh.port : 22}
+        {linodeSetting.ssh.port}
       </TableCell>
       <TableCell>
         <ActionMenu

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTable.tsx
@@ -1,3 +1,4 @@
+import produce from 'immer';
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -14,6 +15,7 @@ import { useAPIRequest } from 'src/hooks/useAPIRequest';
 import useOpenClose from 'src/hooks/useOpenClose';
 import { getLinodeSettings } from 'src/services/managed';
 import { getAll } from 'src/utilities/getAll';
+import { DEFAULTS } from './common';
 import EditSSHAccessDrawer from './EditSSHAccessDrawer';
 import SSHAccessTableContent from './SSHAccessTableContent';
 
@@ -60,9 +62,24 @@ const SSHAccessTable: React.FC<{}> = () => {
 
   const drawer = useOpenClose();
 
+  // For all intents and purposes, the default `user` is "root", and the default `port` is 22.
+  // Surprisingly, these are returned as `null` from the API. We want to display the defaults
+  // to the user, though, so we normalize the data here by exchanging `null` for the defaults.
+  const normalizedData: Linode.ManagedLinodeSetting[] = produce(data, draft => {
+    data.forEach((linodeSetting, idx) => {
+      if (linodeSetting.ssh.user === null) {
+        draft[idx].ssh.user = DEFAULTS.user;
+      }
+
+      if (linodeSetting.ssh.port === null) {
+        draft[idx].ssh.port = DEFAULTS.port;
+      }
+    });
+  });
+
   return (
     <>
-      <OrderBy data={data}>
+      <OrderBy data={normalizedData}>
         {({ data: orderedData, handleOrderChange, order, orderBy }) => {
           return (
             <Paginate data={orderedData}>
@@ -165,7 +182,7 @@ const SSHAccessTable: React.FC<{}> = () => {
       <EditSSHAccessDrawer
         isOpen={drawer.isOpen}
         closeDrawer={drawer.close}
-        linodeSetting={data.find(l => l.id === selectedLinodeId)}
+        linodeSetting={normalizedData.find(l => l.id === selectedLinodeId)}
         updateOne={updateOne}
       />
     </>

--- a/packages/manager/src/features/Managed/SSHAccess/common.ts
+++ b/packages/manager/src/features/Managed/SSHAccess/common.ts
@@ -1,0 +1,4 @@
+export const DEFAULTS = {
+  user: 'root',
+  port: 22
+};


### PR DESCRIPTION
## Description

This PR adds clarity to the defaults of `user` and `port` in Managed SSH Access settings. 

For all intents and purposes, the default `user` is "root", and the default `port` is 22. These are returned as `null` from the API. We want to display the defaults to the user, though, so we normalize the data by exchanging `null` for the defaults.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

**To test:**

_Use a Managed account_
1) Create a new Linode.
2) Go to Managed -> SSH Settings.
3) **Observe:** User and Port should be  displayed as "root" and "22".
4) Open the Edit drawer for the settings for that Linode.
5) Give it a custom user and port.
6) **Observe:** this should be successful.
7) Open the Edit drawer again.
8) Clear out the user and port fields.
9) Submit the form.
10) **Observe:** A request was made to set the user and port to "root" and 22. 
