### PR TITLE
M3-699 Add: Edit Managed credential

### DIFF
--- a/packages/manager/src/features/Managed/Credentials/CredentialActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialActionMenu.tsx
@@ -8,16 +8,24 @@ interface Props {
   credentialID: number;
   label: string;
   openDialog: (id: number, label: string) => void;
+  openForEdit: (id: number) => void;
 }
 
 export type CombinedProps = Props & WithSnackbarProps;
 
 export class CredentialActionMenu extends React.Component<CombinedProps, {}> {
   createActions = () => {
-    const { label, credentialID, openDialog } = this.props;
+    const { label, credentialID, openDialog, openForEdit } = this.props;
 
     return (closeMenu: Function): Action[] => {
       const actions = [
+        {
+          title: 'Edit',
+          onClick: () => { 
+            openForEdit(credentialID);
+            closeMenu()
+          }
+        },
         {
           title: 'Delete',
           onClick: () => {

--- a/packages/manager/src/features/Managed/Credentials/CredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialDrawer.tsx
@@ -1,18 +1,17 @@
 import { Formik } from 'formik';
 import * as React from 'react';
-import { string } from 'yup';
 
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import {
-  createCredentialSchema,
-  CredentialPayload
-} from 'src/services/managed';
+import { CredentialPayload } from 'src/services/managed';
+
+import { creationSchema, updateSchema } from './credential.schema';
 
 export interface Props {
+  credential?: Linode.ManagedCredential;
   mode: 'create' | 'edit';
   open: boolean;
   onClose: () => void;
@@ -31,27 +30,18 @@ const titleMap = {
   [modes.EDITING]: 'Edit a Credential'
 };
 
-/**
- * The API does not require a password, but we would like
- * to require it in our UI. This extends the validation
- * schema declared in services/managed.
- */
-const clientCredentialSchema = createCredentialSchema.shape({
-  password: string().required('Password is required.')
-});
-
 const CredentialDrawer: React.FC<CombinedProps> = props => {
-  const { mode, open, onClose, onSubmit } = props;
+  const { credential, mode, open, onClose, onSubmit } = props;
 
   return (
     <Drawer title={titleMap[mode]} open={open} onClose={onClose}>
       <Formik
         initialValues={{
-          label: '',
+          label: credential ? credential.label : '',
           password: '',
           username: ''
         }}
-        validationSchema={clientCredentialSchema}
+        validationSchema={mode === 'create' ? creationSchema : updateSchema}
         validateOnChange={false}
         validateOnBlur={false}
         onSubmit={onSubmit}

--- a/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
@@ -20,7 +20,9 @@ import { useDialog } from 'src/hooks/useDialog';
 import {
   createCredential,
   CredentialPayload,
-  deleteCredential
+  deleteCredential,
+  updateCredential,
+  updatePassword
 } from 'src/services/managed';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import {
@@ -54,6 +56,10 @@ export const CredentialList: React.FC<CombinedProps> = props => {
   const classes = useStyles();
   const { credentials, enqueueSnackbar, error, loading, update } = props;
   const [isDrawerOpen, setDrawerOpen] = React.useState<boolean>(false);
+  const [drawerMode, setDrawerMode] = React.useState<'create' | 'edit'>(
+    'create'
+  );
+  const [editID, setEditID] = React.useState<number>(0);
 
   const {
     dialog,
@@ -78,26 +84,117 @@ export const CredentialList: React.FC<CombinedProps> = props => {
       );
   };
 
-  const submitForm = (
+  const handleSuccess = (cb: any) => {
+    cb(false);
+    setDrawerOpen(false);
+    update();
+  };
+
+  const _handleError = (
+    e: Linode.ApiFieldError[],
+    setSubmitting: any,
+    setErrors: any,
+    setStatus: any,
+    defaultMessage: string
+  ) => {
+    const mapErrorToStatus = (generalError: string) =>
+      setStatus({ generalError });
+
+    setSubmitting(false);
+    handleFieldErrors(setErrors, e);
+    handleGeneralErrors(mapErrorToStatus, e, defaultMessage);
+    setSubmitting(false);
+  };
+
+  const handleCreate = (
     values: CredentialPayload,
     { setSubmitting, setErrors, setStatus }: FormikProps
   ) => {
     createCredential(values)
-      .then(_ => {
-        setSubmitting(false);
-        setDrawerOpen(false);
-        update();
-      })
+      .then(() => handleSuccess(setSubmitting))
       .catch(e => {
-        const defaultMessage = `Unable to create this Credential. Please try again later.`;
-        const mapErrorToStatus = (generalError: string) =>
-          setStatus({ generalError });
-
-        setSubmitting(false);
-        handleFieldErrors(setErrors, e);
-        handleGeneralErrors(mapErrorToStatus, e, defaultMessage);
-        setSubmitting(false);
+        _handleError(
+          e,
+          setSubmitting,
+          setErrors,
+          setStatus,
+          `Unable to create this Credential. Please try again later.`
+        );
       });
+  };
+
+  const handleUpdate = (
+    values: CredentialPayload,
+    { setSubmitting, setErrors, setStatus }: FormikProps
+  ) => {
+    const thisCredential = credentials.find(c => c.id === editID);
+    const promises = [];
+
+    /**
+     * Due to reasons, a PUT to /managed/credentials/id is only
+     * able to update the credential's label. There is a separate endpoint,
+     * /managed/credentials/id/update, which you can POST to in order to
+     * update the password and or username. Since all fields are present in
+     * the drawer, we need to use the standard Promise magic to combine
+     * multiple requests. Here we first check if the user has input any values
+     * or changes; if not, just exit. If the label is changed, do a PUT, and
+     * in parallel do a POST if there have been password or username changes.
+     */
+    if (thisCredential && thisCredential.label !== values.label) {
+      // Label has changed. Update it through /managed/credentials/editID
+      promises.push(updateCredential(editID, { label: values.label }));
+    }
+
+    if (values.password || values.username) {
+      // User has input a new password or username. Update through /update.
+      promises.push(updatePassword(editID, { password: values.password }));
+    }
+
+    if (promises.length === 0) {
+      // Nothing changed, let's get out of here while we still can.
+      setDrawerOpen(false);
+      setSubmitting(false);
+      return;
+    }
+
+    Promise.all(promises)
+      .then(() => {
+        handleSuccess(setSubmitting);
+        enqueueSnackbar('Credential updated successfully', {
+          variant: 'success'
+        });
+      })
+      .catch(err =>
+        _handleError(
+          err,
+          setSubmitting,
+          setErrors,
+          setStatus,
+          'Unable to update this Credential.'
+        )
+      );
+  };
+
+  const submitForm = (values: CredentialPayload, formikProps: FormikProps) => {
+    switch (drawerMode) {
+      case 'edit':
+        return handleUpdate(values, formikProps);
+      case 'create':
+      default:
+        return handleCreate(values, formikProps);
+    }
+  };
+
+  const openForEdit = (credentialID: number) => {
+    setDrawerMode('edit');
+    setEditID(credentialID);
+    setDrawerOpen(true);
+  };
+
+  const handleDrawerClose = () => {
+    setEditID(0);
+    setDrawerOpen(false);
+    setDrawerMode('create');
   };
 
   return (
@@ -171,6 +268,7 @@ export const CredentialList: React.FC<CombinedProps> = props => {
                         loading={loading}
                         error={error}
                         openDialog={openDialog}
+                        openForEdit={openForEdit}
                       />
                     </TableBody>
                   </Table>
@@ -198,9 +296,10 @@ export const CredentialList: React.FC<CombinedProps> = props => {
       />
       <CredentialDrawer
         open={isDrawerOpen}
-        onClose={() => setDrawerOpen(false)}
+        onClose={handleDrawerClose}
         onSubmit={submitForm}
-        mode="create"
+        mode={drawerMode}
+        credential={credentials.find(c => c.id === editID)}
       />
     </>
   );

--- a/packages/manager/src/features/Managed/Credentials/CredentialRow.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialRow.tsx
@@ -29,12 +29,13 @@ const useStyles = makeStyles((theme: Theme) =>
 interface Props {
   credential: Linode.ManagedCredential;
   openDialog: (id: number, label: string) => void;
+  openForEdit: (id: number) => void;
 }
 
 type CombinedProps = Props;
 
 export const CredentialRow: React.FunctionComponent<CombinedProps> = props => {
-  const { credential, openDialog } = props;
+  const { credential, openDialog, openForEdit } = props;
   const classes = useStyles();
 
   return (
@@ -60,6 +61,7 @@ export const CredentialRow: React.FunctionComponent<CombinedProps> = props => {
         <ActionMenu
           credentialID={credential.id}
           openDialog={openDialog}
+          openForEdit={openForEdit}
           label={credential.label}
         />
       </TableCell>

--- a/packages/manager/src/features/Managed/Credentials/CredentialTableContent.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialTableContent.tsx
@@ -9,13 +9,14 @@ interface Props {
   credentials: Linode.ManagedCredential[];
   loading: boolean;
   openDialog: (id: number, label: string) => void;
+  openForEdit: (id: number) => void;
   error?: Linode.ApiFieldError[];
 }
 
 export type CombinedProps = Props;
 
 export const CredentialTableContent: React.FC<CombinedProps> = props => {
-  const { error, loading, credentials, openDialog } = props;
+  const { error, loading, credentials, openDialog, openForEdit } = props;
   if (loading) {
     return <TableRowLoading colSpan={12} />;
   }
@@ -40,6 +41,7 @@ export const CredentialTableContent: React.FC<CombinedProps> = props => {
           key={`managed-credential-row-${idx}`}
           credential={credential}
           openDialog={openDialog}
+          openForEdit={openForEdit}
         />
       ))}
     </>

--- a/packages/manager/src/features/Managed/Credentials/credential.schema.ts
+++ b/packages/manager/src/features/Managed/Credentials/credential.schema.ts
@@ -1,0 +1,13 @@
+import { object, string } from 'yup';
+
+import { createCredentialSchema, credentialLabel, credentialPassword, credentialUsername } from 'src/services/managed';
+
+export const creationSchema = createCredentialSchema.shape({
+  password: string().required('Password is required.')
+});
+
+export const updateSchema = object().shape({
+  label: credentialLabel.notRequired(),
+  password: credentialPassword,
+  username: credentialUsername
+});

--- a/packages/manager/src/services/managed/managed.schema.ts
+++ b/packages/manager/src/services/managed/managed.schema.ts
@@ -33,15 +33,29 @@ export const updateManagedLinodeSchema = object({
   ssh: sshSettingSchema
 });
 
+export const credentialLabel = string()
+  .min(2, 'Label must be between 2 and 75 characters.')
+  .max(75, 'Label must be between 2 and 75 characters.');
+
+export const credentialPassword = string()
+  .notRequired()
+  .max(5000, 'Password must be 5000 characters or less.');
+
+export const credentialUsername = string()
+  .notRequired()
+  .max(5000, 'Username must be 5000 characters or less.');
+
 export const createCredentialSchema = object().shape({
-  label: string()
-    .required('Label is required.')
-    .min(2, 'Label must be between 2 and 75 characters.')
-    .max(75, 'Label must be between 2 and 75 characters.'),
-  username: string()
-    .notRequired()
-    .max(5000, 'Username must be 5000 characters or less.'),
-  password: string()
-    .notRequired()
-    .max(5000, 'Password must be 5000 characters or less.')
+  label: credentialLabel.required('Label is required.'),
+  username: credentialUsername,
+  password: credentialPassword
+});
+
+export const updateCredentialSchema = object().shape({
+  label: credentialLabel.required('Label is required.')
+});
+
+export const updatePasswordSchema = object().shape({
+  username: credentialUsername,
+  password: credentialPassword
 });

--- a/packages/manager/src/services/managed/managed.ts
+++ b/packages/manager/src/services/managed/managed.ts
@@ -10,7 +10,9 @@ import Request, {
 import {
   createCredentialSchema,
   createServiceMonitorSchema,
-  updateManagedLinodeSchema
+  updateCredentialSchema,
+  updateManagedLinodeSchema,
+  updatePasswordSchema
 } from './managed.schema';
 
 // Payload types
@@ -30,6 +32,16 @@ export interface ManagedServicePayload {
 
 export interface CredentialPayload {
   label: string;
+  password?: string;
+  username?: string;
+}
+
+export interface UpdateCredentialPayload {
+  // Not using a Partial<> bc this is the only possible field to update
+  label: string;
+}
+
+export interface UpdatePasswordPayload {
   password?: string;
   username?: string;
 }
@@ -117,6 +129,32 @@ export const getCredentials = (params?: any, filters?: any) =>
     setXFilter(filters),
     setURL(`${API_ROOT}/managed/credentials`)
   ).then(response => response.data);
+
+/**
+ * updateCredential
+ *
+ * Update the label on a Managed Credential on your account.
+ * Other fields (password and username) cannot be changed. (MAYBE? this is confusing)
+ */
+export const updateCredential = (credentialID: number, data: UpdateCredentialPayload) =>
+  Request<Page<Linode.ManagedCredential>>(
+    setMethod('PUT'),
+    setData(data, updateCredentialSchema),
+    setURL(`${API_ROOT}/managed/credentials/${credentialID}`)
+  ).then(response => response.data);
+
+/**
+ * updatePassword
+ *
+ * Update the label on a Managed Credential on your account.
+ * Other fields (password and username) cannot be changed. (MAYBE? this is confusing)
+ */
+export const updatePassword = (credentialID: number, data: UpdatePasswordPayload) =>
+Request<Page<Linode.ManagedCredential>>(
+  setMethod('POST'),
+  setData(data, updatePasswordSchema),
+  setURL(`${API_ROOT}/managed/credentials/${credentialID}/update`)
+).then(response => response.data);
 
 /**
  * deleteCredential


### PR DESCRIPTION
## Description

Adds an Edit action to the Credentials action menu
and an 'edit' mode for the CredentialsDrawer.

This involved refactoring handleSubmit in CredentialsLanding
and using Promise.all to handle requests to separate endpoints
(for cred labels and cred username/passwords). These requests
are made conditionally based on the user's input.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

