### PR TITLE
M3-707 Managed: Delete Contact

### DIFF
--- a/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
+++ b/packages/manager/src/components/DeletionDialog/DeletionDialog.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-class DestructiveMonitorDialog extends React.PureComponent<CombinedProps, {}> {
+class DeletionDialog extends React.PureComponent<CombinedProps, {}> {
   renderActions = () => {
     const { onClose, onDelete, loading } = this.props;
     return (
@@ -54,4 +54,4 @@ class DestructiveMonitorDialog extends React.PureComponent<CombinedProps, {}> {
   }
 }
 
-export default DestructiveMonitorDialog;
+export default DeletionDialog;

--- a/packages/manager/src/components/DeletionDialog/index.tsx
+++ b/packages/manager/src/components/DeletionDialog/index.tsx
@@ -1,0 +1,2 @@
+import DeletionDialog from './DeletionDialog';
+export default DeletionDialog;

--- a/packages/manager/src/features/Managed/Contacts/Contacts.tsx
+++ b/packages/manager/src/features/Managed/Contacts/Contacts.tsx
@@ -8,6 +8,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
+import DeletionDialog from 'src/components/DeletionDialog';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import OrderBy from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
@@ -20,8 +21,6 @@ import { useDialog } from 'src/hooks/useDialog';
 import useOpenClose from 'src/hooks/useOpenClose';
 import { deleteContact } from 'src/services/managed';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-// @todo: Make this a generic component
-import { default as ContactDialog } from '../Monitors/MonitorDialog';
 import { ManagedContactGroup, Mode } from './common';
 import ContactDrawer from './ContactsDrawer';
 import ContactTableContact from './ContactsTableContent';
@@ -323,7 +322,7 @@ const Contacts: React.FC<CombinedProps> = props => {
             );
           }}
         </OrderBy>
-        <ContactDialog
+        <DeletionDialog
           open={dialog.isOpen}
           label={dialog.entityLabel || ''}
           loading={dialog.isLoading}

--- a/packages/manager/src/features/Managed/Contacts/ContactsActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsActionMenu.tsx
@@ -4,13 +4,14 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 interface Props {
   contactId: number;
   updateOrAdd: (contact: Linode.ManagedContact) => void;
+  openDialog: (id: number) => void;
   openDrawer: (contactId: number) => void;
 }
 
 export type CombinedProps = Props;
 
 export const ContactsActionMenu: React.FC<CombinedProps> = props => {
-  const { contactId, openDrawer } = props;
+  const { contactId, openDrawer, openDialog } = props;
 
   const createActions = (closeMenu: Function): Action[] => {
     const actions = [
@@ -24,7 +25,8 @@ export const ContactsActionMenu: React.FC<CombinedProps> = props => {
       {
         title: 'Delete',
         onClick: () => {
-          alert('delete contact');
+          openDialog(contactId);
+          closeMenu();
         }
       }
     ];

--- a/packages/manager/src/features/Managed/Contacts/ContactsRow.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsRow.tsx
@@ -7,10 +7,11 @@ interface Props {
   contact: Linode.ManagedContact;
   updateOrAdd: (contact: Linode.ManagedContact) => void;
   openDrawer: (linodeId: number) => void;
+  openDialog: (contactId: number) => void;
 }
 
 export const ContactsRow: React.FunctionComponent<Props> = props => {
-  const { contact, updateOrAdd, openDrawer } = props;
+  const { contact, updateOrAdd, openDrawer, openDialog } = props;
 
   return (
     <TableRow key={contact.id}>
@@ -28,6 +29,7 @@ export const ContactsRow: React.FunctionComponent<Props> = props => {
           contactId={contact.id}
           updateOrAdd={updateOrAdd}
           openDrawer={openDrawer}
+          openDialog={openDialog}
         />
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/Managed/Contacts/ContactsTableContent.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsTableContent.tsx
@@ -14,6 +14,7 @@ interface Props {
   lastUpdated: number;
   updateOrAdd: (contact: Linode.ManagedContact) => void;
   openDrawer: (linodeId: number) => void;
+  openDialog: (contactId: number) => void;
   error?: Linode.ApiFieldError[];
 }
 
@@ -26,6 +27,7 @@ export const ContactsTableContent: React.FC<CombinedProps> = props => {
     lastUpdated,
     updateOrAdd,
     openDrawer,
+    openDialog,
     error
   } = props;
 
@@ -55,6 +57,7 @@ export const ContactsTableContent: React.FC<CombinedProps> = props => {
           updateOrAdd={updateOrAdd}
           contact={contact}
           openDrawer={openDrawer}
+          openDialog={openDialog}
         />
       ))}
     </>

--- a/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
@@ -8,6 +8,7 @@ import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
 import Typography from 'src/components/core/Typography';
+import DeletionDialog from 'src/components/DeletionDialog';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
@@ -28,7 +29,6 @@ import {
   handleGeneralErrors
 } from 'src/utilities/formikErrorUtils';
 
-import { default as CredentialDialog } from '../Monitors/MonitorDialog';
 import CredentialDrawer from './CredentialDrawer';
 import CredentialTableContent from './CredentialTableContent';
 
@@ -188,7 +188,7 @@ export const CredentialList: React.FC<CombinedProps> = props => {
           </Paginate>
         )}
       </OrderBy>
-      <CredentialDialog
+      <DeletionDialog
         open={dialog.isOpen}
         label={dialog.entityLabel || ''}
         loading={dialog.isLoading}

--- a/packages/manager/src/features/Managed/ManagedLanding.tsx
+++ b/packages/manager/src/features/Managed/ManagedLanding.tsx
@@ -196,6 +196,7 @@ export const ManagedLanding: React.FunctionComponent<CombinedProps> = props => {
                   error={contacts.error}
                   lastUpdated={contacts.lastUpdated}
                   transformData={contacts.transformData}
+                  update={contacts.update}
                 />
               )}
             />

--- a/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
@@ -13,6 +13,7 @@ import {
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
+import DeletionDialog from 'src/components/DeletionDialog';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
@@ -33,7 +34,6 @@ import {
 } from 'src/utilities/formikErrorUtils';
 
 import MonitorDrawer from '../MonitorDrawer';
-import MonitorDialog from './MonitorDialog';
 import MonitorTableContent from './MonitorTableContent';
 
 type ClassNames = 'labelHeader';
@@ -209,7 +209,7 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
           </Paginate>
         )}
       </OrderBy>
-      <MonitorDialog
+      <DeletionDialog
         label={dialog.entityLabel || ''}
         onDelete={handleDelete}
         onClose={closeDialog}

--- a/packages/manager/src/services/managed/managed.ts
+++ b/packages/manager/src/services/managed/managed.ts
@@ -200,3 +200,14 @@ export const updateContact = (contactId: number, data: ContactPayload) =>
     setURL(`${API_ROOT}/managed/contacts/${contactId}`),
     setData(data, createContactSchema)
   ).then(response => response.data);
+
+/**
+ * deleteContact
+ *
+ * Deletes a Managed Contact
+ */
+export const deleteContact = (contactId: number) =>
+  Request<{}>(
+    setMethod('DELETE'),
+    setURL(`${API_ROOT}/managed/contacts/${contactId}`)
+  ).then(response => response.data);


### PR DESCRIPTION
## Description

The PR adds the ability to delete a contact from your list of Managed Contacts.

Since this was the third place `MonitorDialog` was used, I moved that component to the `src/components` directory and renamed it `DeletionDialog`. I updated `MonitorTable.tsx` and `CredentialList.tsx` to honor this change.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Go to Managed -> Contacts. You'll need to add contacts in Classic (or https://github.com/linode/manager/pull/5377). Try deleting contacts. Note: deleting groups is not yet supported.