### PR TITLE
Change: Show Tax Banner on Dashboard and Account Landing

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -30,7 +30,6 @@ import Grid from 'src/components/Grid';
 import LandingLoading from 'src/components/LandingLoading';
 import NotFound from 'src/components/NotFound';
 import SideMenu from 'src/components/SideMenu';
-import TaxBanner from 'src/components/TaxBanner';
 import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
 import { events$ } from 'src/events';
 import BackupDrawer from 'src/features/Backups';
@@ -458,7 +457,6 @@ export class App extends React.Component<CombinedProps, State> {
                 username={this.props.username}
               />
               <div className={classes.wrapper} id="main-content">
-                <TaxBanner location={this.props.location} />
                 <Grid container spacing={0} className={classes.grid}>
                   <Grid item className={classes.switchWrapper}>
                     <Switch>

--- a/packages/manager/src/components/TaxBanner/TaxBanner.tsx
+++ b/packages/manager/src/components/TaxBanner/TaxBanner.tsx
@@ -12,41 +12,22 @@ interface Props {
 const VATBanner: React.FC<Props> = props => {
   const flags = useFlags();
 
-  const [shouldShowBanner, setBannerVisibility] = React.useState<boolean>(
-    false
-  );
-
-  React.useEffect(() => {
-    const isBillingPage = props.location.pathname.match(/account[/]billing/);
-
-    /** only change banner visibility if it isn't already set */
-    if (shouldShowBanner && isBillingPage) {
-      setBannerVisibility(false);
-    }
-
-    if (!shouldShowBanner && !isBillingPage) {
-      setBannerVisibility(true);
-    }
-  });
+  const isBillingPage = props.location.pathname.match(/account[/]billing/);
 
   {
     /* 
     launch darkly is responsible for determining who and who doesn't see this banner
     based on country information we send to the service in IdentifyUser.tsx
-
+    
     As of Aug 14, 2019, this is the payload this component expects from LD
-
+    
     {} || {
       tax_name: string;
       date: string;
     }
   */
   }
-  if (
-    shouldShowBanner &&
-    flags.vatBanner &&
-    !!Object.keys(flags.vatBanner).length
-  ) {
+  if (flags.vatBanner && !!Object.keys(flags.vatBanner).length) {
     const { tax_name, date } = flags.vatBanner!;
 
     const taxNameToUpperCase = tax_name.toUpperCase();
@@ -71,10 +52,16 @@ const VATBanner: React.FC<Props> = props => {
                 target="_blank"
               >
                 Tax Information Guide.
-              </a>{' '}
-              To ensure the correct {taxNameToUpperCase} is applied, please
-              verify your <Link to="/account/billing">contact information</Link>{' '}
-              is up to date.
+              </a>
+              {!isBillingPage && (
+                <React.Fragment>
+                  {' '}
+                  To ensure the correct {taxNameToUpperCase} is applied, please
+                  verify your{' '}
+                  <Link to="/account/billing">contact information</Link> is up
+                  to date.
+                </React.Fragment>
+              )}
             </Notice>
           );
         }}

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -5,8 +5,7 @@ import {
   Redirect,
   Route,
   RouteComponentProps,
-  Switch,
-  withRouter
+  Switch
 } from 'react-router-dom';
 import { compose } from 'recompose';
 import Breadcrumb from 'src/components/Breadcrumb';
@@ -20,6 +19,8 @@ import DefaultLoader from 'src/components/DefaultLoader';
 import withProfile, {
   ProfileActionsProps
 } from 'src/containers/profile.container';
+
+import TaxBanner from 'src/components/TaxBanner';
 
 type Props = RouteComponentProps<{}> & ProfileActionsProps & StateProps;
 
@@ -57,6 +58,7 @@ class AccountLanding extends React.Component<Props> {
       match: { url },
       location
     } = this.props;
+
     const matches = (p: string) => {
       return Boolean(matchPath(p, { path: this.props.location.pathname }));
     };
@@ -64,6 +66,7 @@ class AccountLanding extends React.Component<Props> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Account Settings" />
+        <TaxBanner location={location} />
         <Breadcrumb
           pathname={location.pathname}
           labelTitle="Account"
@@ -127,7 +130,6 @@ interface StateProps {
 }
 
 export default compose<Props, {}>(
-  withRouter,
   withProfile<StateProps, {}>((ownProps, { data }) => ({
     isRestrictedUser: pathOr(false, ['restricted'], data)
   }))

--- a/packages/manager/src/features/Dashboard/Dashboard.test.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.test.tsx
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { activePromotions } from 'src/__data__/account';
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { light } from 'src/themes';
 import { Dashboard } from './Dashboard';
 
@@ -22,7 +23,7 @@ const props = {
   theme: light({ spacingOverride: 8 })
 };
 
-const component = shallow(<Dashboard {...props} />);
+const component = shallow(<Dashboard {...props} {...reactRouterProps} />);
 
 describe('Dashboard view', () => {
   describe('Backups CTA card', () => {

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
 import {
@@ -35,6 +36,7 @@ import TransferDashboardCard from './TransferDashboardCard';
 import VolumesDashboardCard from './VolumesDashboardCard';
 
 import MaintenanceBanner from 'src/components/MaintenanceBanner';
+import TaxBanner from 'src/components/TaxBanner';
 
 type ClassNames = 'root';
 
@@ -66,7 +68,8 @@ interface DispatchProps {
 type CombinedProps = StateProps &
   DispatchProps &
   WithStyles<ClassNames> &
-  WithTheme;
+  WithTheme &
+  RouteComponentProps<{}>;
 
 export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
   const {
@@ -76,8 +79,10 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
     backupError,
     linodesWithoutBackups,
     managed,
-    entitiesWithGroupsToImport
+    entitiesWithGroupsToImport,
+    location
   } = props;
+
   const flags = useFlags();
 
   // temporary hack to just use the first active promotion for the promo banner,
@@ -95,6 +100,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
       )}
       <Grid container spacing={3}>
         <AbuseTicketBanner />
+        <TaxBanner location={location} />
         <DocumentTitleSegment segment="Dashboard" />
         <Grid item xs={12}>
           <Typography variant="h1" data-qa-dashboard-header>


### PR DESCRIPTION
## Description

Shows the dashboard on the account landing and dashboard only.

Also conditionally renders "click here" text.

## Type of Change
- Non breaking change ('update', 'change')
