### PR TITLE
M3-3193 - Fix ToastNotifications test

### DIFF
--- a/packages/manager/src/components/ToastNotifications/ToastNotifications.spec.js
+++ b/packages/manager/src/components/ToastNotifications/ToastNotifications.spec.js
@@ -26,7 +26,7 @@ describe('Toast Notification Suite', () => {
       .withContext(`incorrect variant color`)
       .toBe(color);
     $('[title="Dismiss Notification"]').click();
-    $(toastColor).waitForDisplayed(constants.wait.short, true);
+    $(toastColor).waitForDisplayed(constants.wait.normal, true);
   }
 
   beforeAll(() => {
@@ -62,14 +62,6 @@ describe('Toast Notification Suite', () => {
     checkToastColor('error', 'rgba(205,34,39,1)');
     //info
     checkToastColor('info', 'rgba(54,131,220,1)');
-  });
-
-  it('Toast notification disappears after 4 seconds', () => {
-    notificationButton(variants[0]).click();
-    browser.pause(4500);
-    expect($(toast).isDisplayed())
-      .withContext(`toast message is still displayed after 4 seconds`)
-      .toBe(false);
   });
 
   it('No more than 3 notifications display at once', () => {


### PR DESCRIPTION
## Description
Removing the test for display times on toast notifications. This is because it is actually testing a Toast Notification library and not our code directly. These test were causing intermittent failures in travis ci.

We also need to bump up the timeout for the color verification.

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn storybook:e2e`

## Note to Reviewers

