### PR TITLE
[For release] M3-3194: Add warning text to "Detach Volume" dialog

### DIFF
--- a/packages/manager/src/features/Volumes/DestructiveVolumeDialog.tsx
+++ b/packages/manager/src/features/Volumes/DestructiveVolumeDialog.tsx
@@ -2,8 +2,24 @@ import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Notice from 'src/components/Notice';
+
+type ClassNames = 'warningCopy';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    warningCopy: {
+      color: theme.color.red,
+      marginBottom: theme.spacing(2)
+    }
+  });
 
 interface Props {
   open: boolean;
@@ -14,9 +30,10 @@ interface Props {
   onDelete: () => void;
   volumeLabel: string;
   linodeLabel: string;
+  poweredOff: boolean;
 }
 
-type CombinedProps = Props;
+type CombinedProps = Props & WithStyles<ClassNames>;
 
 class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
   renderActions = () => {
@@ -48,7 +65,14 @@ class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
   };
 
   render() {
-    const { error, volumeLabel: label, linodeLabel } = this.props;
+    const {
+      classes,
+      error,
+      volumeLabel: label,
+      linodeLabel,
+      poweredOff,
+      mode
+    } = this.props;
     const title = {
       detach: `Detach ${label ? label : 'Volume'}?`,
       delete: `Delete ${label ? label : 'Volume'}?`
@@ -62,8 +86,19 @@ class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
         actions={this.renderActions}
       >
         {error && <Notice error text={error} />}
+
+        {/* In 'detach' mode, show a warning if the Linode is powered on. */}
+        {mode === 'detach' && !poweredOff && (
+          <Typography className={classes.warningCopy}>
+            <strong>Warning:</strong> This operation could cause data loss.
+            Please power off the Linode first or make sure it isn't currently
+            writing to the volume before continuing. If this volume is currently
+            mounted, detaching it could cause your Linode to restart.
+          </Typography>
+        )}
+
         <Typography>
-          Are you sure you want to {this.props.mode} this Volume
+          Are you sure you want to {mode} this Volume
           {`${linodeLabel ? ` from ${linodeLabel}?` : '?'}`}
         </Typography>
       </ConfirmationDialog>
@@ -71,4 +106,4 @@ class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
   }
 }
 
-export default DestructiveVolumeDialog;
+export default withStyles(styles)(DestructiveVolumeDialog);

--- a/packages/manager/src/features/Volumes/RenderVolumeData.tsx
+++ b/packages/manager/src/features/Volumes/RenderVolumeData.tsx
@@ -24,7 +24,8 @@ export interface RenderVolumeDataProps {
   handleDetach: (
     volumeId: number,
     volumeLabel: string,
-    linodeLabel: string
+    linodeLabel: string,
+    poweredOff: boolean
   ) => void;
   handleDelete: (volumeId: number, volumeLabel: string) => void;
 }

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -104,7 +104,8 @@ interface Props {
   handleDetach: (
     volumeId: number,
     volumeLabel: string,
-    linodeLabel: string
+    linodeLabel: string,
+    poweredOff: boolean
   ) => void;
   handleDelete: (volumeId: number, volumeLabel: string) => void;
 }

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -18,7 +18,8 @@ export interface Props {
   onDetach: (
     volumeId: number,
     volumeLabel: string,
-    linodeLabel: string
+    linodeLabel: string,
+    poweredOff: boolean
   ) => void;
   poweredOff: boolean;
   onDelete: (volumeId: number, volumeLabel: string) => void;
@@ -61,8 +62,14 @@ export class VolumesActionMenu extends React.Component<CombinedProps> {
   };
 
   handleDetach = () => {
-    const { volumeId, onDetach, volumeLabel, linodeLabel } = this.props;
-    onDetach(volumeId, volumeLabel, linodeLabel);
+    const {
+      volumeId,
+      onDetach,
+      volumeLabel,
+      linodeLabel,
+      poweredOff
+    } = this.props;
+    onDetach(volumeId, volumeLabel, linodeLabel, poweredOff);
   };
 
   handleDelete = () => {

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -190,6 +190,7 @@ interface State {
     volumeLabel: string;
     volumeId?: number;
     linodeLabel: string;
+    poweredOff?: boolean;
     error?: string;
   };
 }
@@ -258,7 +259,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   handleDetach = (
     volumeId: number,
     volumeLabel: string,
-    linodeLabel: string
+    linodeLabel: string,
+    poweredOff: boolean
   ) => {
     this.setState({
       destructiveDialog: {
@@ -267,6 +269,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
         volumeId,
         volumeLabel,
         linodeLabel,
+        poweredOff,
         error: undefined
       }
     });
@@ -392,6 +395,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           error={this.state.destructiveDialog.error}
           volumeLabel={this.state.destructiveDialog.volumeLabel}
           linodeLabel={this.state.destructiveDialog.linodeLabel}
+          poweredOff={this.state.destructiveDialog.poweredOff || false}
           mode={this.state.destructiveDialog.mode}
           onClose={this.closeDestructiveDialog}
           onDetach={this.detachVolume}


### PR DESCRIPTION
## Description

Detaching a volume from a Linode that is currently running can cause problems. Classic Manager displays some warning text if a user tries to do this. With this PR, that warning text is include in DestructiveVolumeDialog if the Linode is powered on.

This involved: 

- Making DestructiveVolumeDialog a styled component.
- Following the prop chain to include the existing `poweredOff` prop where necessary.

<img width="599" alt="Screen Shot 2019-08-26 at 1 28 55 PM" src="https://user-images.githubusercontent.com/16911484/63710114-5d2b7980-c806-11e9-9f97-d854b976f658.png">

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please try detaching volumes from Linodes in different states. Try other volume dialogs/functionality as well.