### PR TITLE
M3-3206 Skip Toast color test

### DIFF
--- a/packages/manager/src/components/ToastNotifications/ToastNotifications.spec.js
+++ b/packages/manager/src/components/ToastNotifications/ToastNotifications.spec.js
@@ -51,7 +51,7 @@ describe('Toast Notification Suite', () => {
     $(toast).waitForDisplayed(constants.wait.normal, true);
   });
 
-  it('Toast notifications have correct color', () => {
+  xit('Toast notifications have correct color', () => {
     //default
     checkToastColor('default', 'rgba(0,0,0,0)');
     //success


### PR DESCRIPTION
Skipping ToastNotifications color test.

## Description
This test is failing at times because the toast notification is staying on the screen longer than it should. Until we figure out why that is happening we are skipping this test.

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn storybook:e2e`

## Note to Reviewers

test is no longer running.
