### PR TITLE
M3-1464 Add: Placeholder to enable Managed

### DIFF
--- a/packages/manager/src/App.test.tsx
+++ b/packages/manager/src/App.test.tsx
@@ -52,6 +52,7 @@ it('renders without crashing.', () => {
             volumesLoading={false}
             domainsLoading={false}
             bucketsLoading={false}
+            accountSettingsLoading={false}
           />
         </StaticRouter>
       </LinodeThemeWrapper>

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -360,6 +360,8 @@ export class App extends React.Component<CombinedProps, State> {
       accountError,
       linodesLoading,
       domainsLoading,
+      accountSettingsError,
+      accountSettingsLoading,
       userId,
       username,
       volumesLoading,
@@ -431,6 +433,9 @@ export class App extends React.Component<CombinedProps, State> {
           profileLoadingOrErrorExists={!!this.props.userId || !!profileError}
           accountLoadingOrErrorExists={
             !!this.props.accountCapabilities || !!accountError
+          }
+          accountSettingsLoadingOrErrorExists={
+            !!accountSettingsLoading === false || !!accountSettingsError
           }
           appIsLoaded={!this.props.appIsLoading}
         />
@@ -595,6 +600,8 @@ interface StateProps {
   domainsLoading: boolean;
   bucketsLoading: boolean;
   accountLoading: boolean;
+  accountSettingsLoading: boolean;
+  accountSettingsError?: Linode.ApiFieldError[];
   nodeBalancersLoading: boolean;
   linodesError?: Linode.ApiFieldError[];
   volumesError?: Linode.ApiFieldError[];
@@ -639,6 +646,15 @@ const mapStateToProps: MapState<StateProps, Props> = state => ({
   accountCapabilities: pathOr(
     [],
     ['__resources', 'account', 'data', 'capabilities'],
+    state
+  ),
+  accountSettingsLoading: pathOr(
+    true,
+    ['__resources', 'accountSettings', 'loading'],
+    state
+  ),
+  accountSettingsError: path(
+    ['__resources', 'accountSettings', 'error'],
     state
   ),
   linodesLoading: state.__resources.linodes.loading,

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -415,27 +415,27 @@ export class App extends React.Component<CombinedProps, State> {
         <DataLoadedListener
           markAppAsLoaded={this.props.markAppAsDoneLoading}
           flagsHaveLoaded={this.state.flagsLoaded}
-          linodesLoadingOrErrorExists={
+          linodesLoadedOrErrorExists={
             linodesLoading === false || !!linodesError
           }
-          volumesLoadingOrErrorExists={
+          volumesLoadedOrErrorExists={
             volumesLoading === false || !!volumesError
           }
-          domainsLoadingOrErrorExists={
+          domainsLoadedOrErrorExists={
             domainsLoading === false || !!domainsError
           }
-          bucketsLoadingOrErrorExists={
+          bucketsLoadedOrErrorExists={
             bucketsLoading === false || !!bucketsError
           }
-          nodeBalancersLoadingOrErrorExists={
+          nodeBalancersLoadedOrErrorExists={
             nodeBalancersLoading === false || !!nodeBalancersError
           }
-          profileLoadingOrErrorExists={!!this.props.userId || !!profileError}
-          accountLoadingOrErrorExists={
-            !!this.props.accountCapabilities || !!accountError
+          profileLoadedOrErrorExists={!!this.props.userId || !!profileError}
+          accountLoadedOrErrorExists={
+            accountLoading === false || !!accountError
           }
-          accountSettingsLoadingOrErrorExists={
-            !!accountSettingsLoading === false || !!accountSettingsError
+          accountSettingsLoadedOrErrorExists={
+            accountSettingsLoading === false || !!accountSettingsError
           }
           appIsLoaded={!this.props.appIsLoading}
         />

--- a/packages/manager/src/components/DataLoadedListener.tsx
+++ b/packages/manager/src/components/DataLoadedListener.tsx
@@ -15,6 +15,7 @@ interface Props {
   nodeBalancersLoadingOrErrorExists: boolean;
   bucketsLoadingOrErrorExists: boolean;
   domainsLoadingOrErrorExists: boolean;
+  accountSettingsLoadingOrErrorExists: boolean;
   markAppAsLoaded: () => void;
   appIsLoaded: boolean;
   flagsHaveLoaded: boolean;
@@ -31,6 +32,7 @@ const DataLoadedListener: React.FC<Props> = props => {
         props.nodeBalancersLoadingOrErrorExists,
         props.bucketsLoadingOrErrorExists,
         props.domainsLoadingOrErrorExists,
+        props.accountSettingsLoadingOrErrorExists,
         props.flagsHaveLoaded
       ) &&
       !props.appIsLoaded
@@ -52,6 +54,7 @@ const shouldMarkAppAsDone = (
   nodeBalancersLoadingOrErrorExists: boolean,
   bucketsLoadingOrErrorExists: boolean,
   domainsLoadingOrErrorExists: boolean,
+  accountSettingsLoadingOrErrorExists: boolean,
   flagsHaveLoaded: boolean
 ): boolean => {
   const pathname = window.location.pathname;
@@ -73,7 +76,8 @@ const shouldMarkAppAsDone = (
       'nodebalancer',
       'object',
       'profile',
-      'account'
+      'account',
+      'managed'
     ].every(eachStr => {
       return !pathname.match(new RegExp(eachStr, 'i'));
     })
@@ -119,6 +123,10 @@ const shouldMarkAppAsDone = (
   }
 
   if (pathname.match(/account/i) && !!accountLoadingOrErrorExists) {
+    return true;
+  }
+
+  if (pathname.match(/managed/i) && !!accountSettingsLoadingOrErrorExists) {
     return true;
   }
 

--- a/packages/manager/src/components/DataLoadedListener.tsx
+++ b/packages/manager/src/components/DataLoadedListener.tsx
@@ -8,14 +8,14 @@ import * as React from 'react';
 import { compose } from 'recompose';
 
 interface Props {
-  profileLoadingOrErrorExists: boolean;
-  accountLoadingOrErrorExists: boolean;
-  linodesLoadingOrErrorExists: boolean;
-  volumesLoadingOrErrorExists: boolean;
-  nodeBalancersLoadingOrErrorExists: boolean;
-  bucketsLoadingOrErrorExists: boolean;
-  domainsLoadingOrErrorExists: boolean;
-  accountSettingsLoadingOrErrorExists: boolean;
+  profileLoadedOrErrorExists: boolean;
+  accountLoadedOrErrorExists: boolean;
+  linodesLoadedOrErrorExists: boolean;
+  volumesLoadedOrErrorExists: boolean;
+  nodeBalancersLoadedOrErrorExists: boolean;
+  bucketsLoadedOrErrorExists: boolean;
+  domainsLoadedOrErrorExists: boolean;
+  accountSettingsLoadedOrErrorExists: boolean;
   markAppAsLoaded: () => void;
   appIsLoaded: boolean;
   flagsHaveLoaded: boolean;
@@ -25,14 +25,14 @@ const DataLoadedListener: React.FC<Props> = props => {
   React.useEffect(() => {
     if (
       shouldMarkAppAsDone(
-        props.profileLoadingOrErrorExists,
-        props.accountLoadingOrErrorExists,
-        props.linodesLoadingOrErrorExists,
-        props.volumesLoadingOrErrorExists,
-        props.nodeBalancersLoadingOrErrorExists,
-        props.bucketsLoadingOrErrorExists,
-        props.domainsLoadingOrErrorExists,
-        props.accountSettingsLoadingOrErrorExists,
+        props.profileLoadedOrErrorExists,
+        props.accountLoadedOrErrorExists,
+        props.linodesLoadedOrErrorExists,
+        props.volumesLoadedOrErrorExists,
+        props.nodeBalancersLoadedOrErrorExists,
+        props.bucketsLoadedOrErrorExists,
+        props.domainsLoadedOrErrorExists,
+        props.accountSettingsLoadedOrErrorExists,
         props.flagsHaveLoaded
       ) &&
       !props.appIsLoaded
@@ -47,14 +47,14 @@ const DataLoadedListener: React.FC<Props> = props => {
 export default compose<Props, Props>(React.memo)(DataLoadedListener);
 
 const shouldMarkAppAsDone = (
-  profileLoadingOrErrorExists: boolean,
-  accountLoadingOrErrorExists: boolean,
-  linodesLoadingOrErrorExists: boolean,
-  volumesLoadingOrErrorExists: boolean,
-  nodeBalancersLoadingOrErrorExists: boolean,
-  bucketsLoadingOrErrorExists: boolean,
-  domainsLoadingOrErrorExists: boolean,
-  accountSettingsLoadingOrErrorExists: boolean,
+  profileLoadedOrErrorExists: boolean,
+  accountLoadedOrErrorExists: boolean,
+  linodesLoadedOrErrorExists: boolean,
+  volumesLoadedOrErrorExists: boolean,
+  nodeBalancersLoadedOrErrorExists: boolean,
+  bucketsLoadedOrErrorExists: boolean,
+  domainsLoadedOrErrorExists: boolean,
+  accountSettingsLoadedOrErrorExists: boolean,
   flagsHaveLoaded: boolean
 ): boolean => {
   const pathname = window.location.pathname;
@@ -87,46 +87,46 @@ const shouldMarkAppAsDone = (
 
   if (
     pathname.match(/dashboard/i) &&
-    (linodesLoadingOrErrorExists &&
-      volumesLoadingOrErrorExists &&
-      nodeBalancersLoadingOrErrorExists &&
-      accountLoadingOrErrorExists &&
-      profileLoadingOrErrorExists &&
-      domainsLoadingOrErrorExists)
+    (linodesLoadedOrErrorExists &&
+      volumesLoadedOrErrorExists &&
+      nodeBalancersLoadedOrErrorExists &&
+      accountLoadedOrErrorExists &&
+      profileLoadedOrErrorExists &&
+      domainsLoadedOrErrorExists)
     /** not checking bucket data here for now */
   ) {
     return true;
   }
 
-  if (pathname.match(/linode/i) && !!linodesLoadingOrErrorExists) {
+  if (pathname.match(/linode/i) && !!linodesLoadedOrErrorExists) {
     return true;
   }
 
-  if (pathname.match(/volume/i) && !!volumesLoadingOrErrorExists) {
+  if (pathname.match(/volume/i) && !!volumesLoadedOrErrorExists) {
     return true;
   }
 
-  if (pathname.match(/nodebalancer/i) && !!nodeBalancersLoadingOrErrorExists) {
+  if (pathname.match(/nodebalancer/i) && !!nodeBalancersLoadedOrErrorExists) {
     return true;
   }
 
-  if (pathname.match(/domain/i) && !!domainsLoadingOrErrorExists) {
+  if (pathname.match(/domain/i) && !!domainsLoadedOrErrorExists) {
     return true;
   }
 
-  if (pathname.match(/object/i) && !!bucketsLoadingOrErrorExists) {
+  if (pathname.match(/object/i) && !!bucketsLoadedOrErrorExists) {
     return true;
   }
 
-  if (pathname.match(/profile/i) && !!profileLoadingOrErrorExists) {
+  if (pathname.match(/profile/i) && !!profileLoadedOrErrorExists) {
     return true;
   }
 
-  if (pathname.match(/account/i) && !!accountLoadingOrErrorExists) {
+  if (pathname.match(/account/i) && !!accountLoadedOrErrorExists) {
     return true;
   }
 
-  if (pathname.match(/managed/i) && !!accountSettingsLoadingOrErrorExists) {
+  if (pathname.match(/managed/i) && !!accountSettingsLoadedOrErrorExists) {
     return true;
   }
 

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -49,6 +49,9 @@ describe('PrimaryNav', () => {
           hasAccountAccess={false}
           accountCapabilities={[]}
           accountLastUpdated={0}
+          isManagedAccount={true}
+          flags={{}}
+          ldClient={{}}
           {...reactRouterProps}
         />
       );
@@ -114,6 +117,9 @@ describe('PrimaryNav', () => {
           hasAccountAccess={true}
           accountCapabilities={[]}
           accountLastUpdated={0}
+          isManagedAccount={true}
+          flags={{}}
+          ldClient={{}}
           {...reactRouterProps}
         />
       );
@@ -143,6 +149,9 @@ describe('PrimaryNav', () => {
           hasAccountAccess={false}
           accountCapabilities={[]}
           accountLastUpdated={0}
+          isManagedAccount={true}
+          flags={{}}
+          ldClient={{}}
           {...reactRouterProps}
         />
       );
@@ -177,6 +186,9 @@ describe('PrimaryNav', () => {
             'Object Storage'
           ]}
           accountLastUpdated={0}
+          isManagedAccount={true}
+          flags={{}}
+          ldClient={{}}
           {...reactRouterProps}
         />
       );

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -47,7 +47,6 @@ describe('PrimaryNav', () => {
           closeMenu={jest.fn()}
           toggleTheme={jest.fn()}
           hasAccountAccess={false}
-          isManagedAccount={false}
           accountCapabilities={[]}
           accountLastUpdated={0}
           {...reactRouterProps}
@@ -93,8 +92,8 @@ describe('PrimaryNav', () => {
       expect(findLinkInPrimaryNav('account')).toHaveLength(0);
     });
 
-    it('should note have a managed link', () => {
-      expect(findLinkInPrimaryNav('managed')).toHaveLength(0);
+    it('should have a managed link', () => {
+      expect(findLinkInPrimaryNav('managed')).toHaveLength(1);
     });
   });
 
@@ -113,7 +112,6 @@ describe('PrimaryNav', () => {
           closeMenu={jest.fn()}
           toggleTheme={jest.fn()}
           hasAccountAccess={true}
-          isManagedAccount={false}
           accountCapabilities={[]}
           accountLastUpdated={0}
           {...reactRouterProps}
@@ -143,7 +141,6 @@ describe('PrimaryNav', () => {
           closeMenu={jest.fn()}
           toggleTheme={jest.fn()}
           hasAccountAccess={false}
-          isManagedAccount={true}
           accountCapabilities={[]}
           accountLastUpdated={0}
           {...reactRouterProps}
@@ -173,7 +170,6 @@ describe('PrimaryNav', () => {
           closeMenu={jest.fn()}
           toggleTheme={jest.fn()}
           hasAccountAccess={false}
-          isManagedAccount={true}
           accountCapabilities={[
             'Linodes',
             'NodeBalancers',

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -1,6 +1,6 @@
 import Settings from '@material-ui/icons/Settings';
 import * as classNames from 'classnames';
-import { AccountCapability, AccountSettings } from 'linode-js-sdk/lib/account';
+import { AccountCapability } from 'linode-js-sdk/lib/account';
 import { Profile } from 'linode-js-sdk/lib/profile';
 import { pathOr } from 'ramda';
 import * as React from 'react';
@@ -270,7 +270,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     // `account.capabilities`.
     if (
       prevProps.hasAccountAccess !== this.props.hasAccountAccess ||
-      prevProps.isManagedAccount !== this.props.isManagedAccount ||
       prevProps.accountLastUpdated !== this.props.accountLastUpdated
     ) {
       this.createMenuItems();
@@ -281,7 +280,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     const {
       hasAccountAccess,
       // isLongviewEnabled,
-      isManagedAccount,
       accountCapabilities
     } = this.props;
 
@@ -333,13 +331,14 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
       });
     }
 
-    if (isManagedAccount) {
-      primaryLinks.push({
-        display: 'Managed',
-        href: '/managed',
-        key: 'managed'
-      });
-    }
+    // All users should now see Managed so they can sign up
+    // if (isManagedAccount) {
+    primaryLinks.push({
+      display: 'Managed',
+      href: '/managed',
+      key: 'managed'
+    });
+    // }
 
     // if(canAccessStackscripts){
     primaryLinks.push({
@@ -567,7 +566,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
 
 interface StateProps {
   hasAccountAccess: boolean;
-  isManagedAccount: boolean;
   // isLongviewEnabled: boolean;
   accountCapabilities: AccountCapability[];
   accountLastUpdated: number;
@@ -586,8 +584,6 @@ const userHasAccountAccess = (profile: Profile) => {
   return Boolean(grants.global.account_access);
 };
 
-const accountHasManaged = (account: AccountSettings) => account.managed;
-
 // const accountHasLongviewSubscription = (account: Linode.AccountSettings) => Boolean(account.longview_subscription);
 
 const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
@@ -598,7 +594,6 @@ const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
   if (!account || !profile) {
     return {
       hasAccountAccess: false,
-      isManagedAccount: false,
       // isLongviewEnabled: false,
       accountCapabilities: [],
       accountLastUpdated
@@ -607,7 +602,6 @@ const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
 
   return {
     hasAccountAccess: userHasAccountAccess(profile),
-    isManagedAccount: accountHasManaged(account),
     // isLongviewEnabled: accountHasLongviewSubscription(account),
     accountCapabilities: pathOr(
       [],

--- a/packages/manager/src/containers/accountSettings.container.ts
+++ b/packages/manager/src/containers/accountSettings.container.ts
@@ -1,0 +1,55 @@
+import { AccountSettings } from 'linode-js-sdk/lib/account';
+import { connect, MapDispatchToProps } from 'react-redux';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { ApplicationState } from 'src/store';
+import { updateSettingsInStore } from 'src/store/accountSettings/accountSettings.actions';
+import { requestAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
+// import { EntityError } from 'src/store/types';
+
+export interface SettingsProps {
+  account?: AccountSettings;
+  accountLoading: boolean;
+  accountError?: Linode.ApiFieldError[];
+  lastUpdated: number;
+}
+
+export interface DispatchProps {
+  requestAccountSettings: () => Promise<any>;
+  updateAccountSettingsInStore: (data: Partial<AccountSettings>) => void;
+}
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
+  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
+) => ({
+  requestAccountSettings: () => dispatch(requestAccountSettings()),
+  updateAccountSettingsInStore: (data: Partial<AccountSettings>) =>
+    dispatch(updateSettingsInStore(data))
+});
+
+export default <TInner extends {}, TOuter extends {}>(
+  mapAccountToProps: (
+    ownProps: TOuter,
+    loading: boolean,
+    lastUpdated: number,
+    accountError?: Linode.ApiFieldError[],
+    accountSettings?: AccountSettings
+  ) => TInner
+) =>
+  connect(
+    (state: ApplicationState, ownProps: TOuter) => {
+      const accountSettings = state.__resources.accountSettings.data;
+      const loading = state.__resources.accountSettings.loading;
+      const accountError = state.__resources.accountSettings.error;
+      const lastUpdated = state.__resources.accountSettings.lastUpdated;
+
+      return mapAccountToProps(
+        ownProps,
+        loading,
+        lastUpdated,
+        accountError, // @todo update this to the new entity error pattern.
+        accountSettings
+      );
+    },
+    mapDispatchToProps
+  );

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -1,4 +1,4 @@
-import { Event } from 'linode-js-sdk/lib/account'
+import { Event } from 'linode-js-sdk/lib/account';
 import { path } from 'ramda';
 import { isProduction } from 'src/constants';
 import { reportException } from 'src/exceptionReporting';
@@ -303,13 +303,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   //   finished: e => ``,
   //   notification: e => ``,
   // },
-  // managed_enabled: {
-  //   scheduled: e => ``,
-  //   started: e => ``,
-  //   failed: e => ``,
-  //   finished: e => ``,
-  //   notification: e => ``,
-  // },
+  managed_enabled: {
+    notification: e => `Managed has been activated on your account.`
+  },
   managed_service_create: {
     notification: e => `Managed service ${e.entity!.label} has been created.`
   },

--- a/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
+++ b/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import ManagedIcon from 'src/assets/icons/managed.svg';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+import Placeholder from 'src/components/Placeholder';
+
+// import { enableManaged } from 'src/services/managed';
+
+const ManagedPlaceholder: React.FC<{}> = props => {
+  const [isOpen, setOpen] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<string | undefined>();
+  const [isLoading, setLoading] = React.useState<boolean>(false);
+
+  const handleClose = () => {
+    setOpen(false);
+    setError(undefined);
+  };
+
+  const handleSubmit = () => {
+    setLoading(true);
+    setTimeout(() => setLoading(false), 2000);
+  };
+
+  const actions = () => (
+    <ActionsPanel>
+      <Button buttonType="cancel" onClick={handleClose} data-qa-cancel>
+        Cancel
+      </Button>
+      <Button
+        buttonType="secondary"
+        destructive
+        onClick={handleSubmit}
+        data-qa-submit-managed-enrollment
+        loading={isLoading}
+      >
+        Enable Managed
+      </Button>
+    </ActionsPanel>
+  );
+
+  return (
+    <>
+      <Placeholder
+        icon={ManagedIcon}
+        title="Linode Managed"
+        copy={`Linode Managed is an amazing feature.`}
+        buttonProps={{
+          onClick: () => setOpen(true),
+          children: 'Add Managed to your Linode account.'
+        }}
+      />
+      <ConfirmationDialog
+        open={isOpen}
+        error={error}
+        onClose={() => handleClose()}
+        title="Are you sure?"
+        actions={actions}
+      >
+        <Typography>
+          The Managed service is billed at $100 monthly per Linode on your
+          account. You currently have 4 Linodes for a cost of $400/month.
+        </Typography>
+      </ConfirmationDialog>
+    </>
+  );
+};
+
+export default ManagedPlaceholder;

--- a/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
+++ b/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
@@ -1,23 +1,51 @@
+import { AccountSettings } from 'linode-js-sdk/lib/account';
 import * as React from 'react';
 import ManagedIcon from 'src/assets/icons/managed.svg';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
+import ExternalLink from 'src/components/ExternalLink';
 import Placeholder from 'src/components/Placeholder';
 import withLinodes from 'src/containers/withLinodes.container';
 import { pluralize } from 'src/utilities/pluralize';
 
 import { enableManaged } from 'src/services/managed';
 
+const copy = (
+  <>
+    <Typography>
+      Let us worry about your infrastructure, so you can get back to worrying
+      about your business. Linode Managed helps keep your systems up and running
+      with our team of Linode experts responding to monitoring events, so you
+      can sleep well. Linode Managed includes 24/7 monitoring and incident
+      responses, backups and Longview Pro. +$100/mo per Linode.{` `}
+    </Typography>
+    <Typography>
+      <ExternalLink
+        link="https://linode.com/managed"
+        text="Learn more about Managed."
+      />
+    </Typography>
+  </>
+);
+
 export interface StateProps {
   linodeCount: number;
 }
 
-const ManagedPlaceholder: React.FC<StateProps> = props => {
+export interface Props {
+  update: (data: Partial<AccountSettings>) => void;
+}
+
+export type CombinedProps = Props & StateProps;
+
+const ManagedPlaceholder: React.FC<CombinedProps> = props => {
   const [isOpen, setOpen] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();
   const [isLoading, setLoading] = React.useState<boolean>(false);
+
+  const { update } = props;
 
   const handleClose = () => {
     setOpen(false);
@@ -32,7 +60,10 @@ const ManagedPlaceholder: React.FC<StateProps> = props => {
   const handleSubmit = () => {
     setLoading(true);
     enableManaged()
-      .then(handleClose)
+      .then(() => {
+        handleClose();
+        update({ managed: true });
+      })
       .catch(handleError);
   };
 
@@ -58,10 +89,10 @@ const ManagedPlaceholder: React.FC<StateProps> = props => {
       <Placeholder
         icon={ManagedIcon}
         title="Linode Managed"
-        copy={`Linode Managed is an amazing feature.`}
+        copy={copy}
         buttonProps={{
           onClick: () => setOpen(true),
-          children: 'Add Managed to your Linode account.'
+          children: 'Upgrade to Managed now!'
         }}
       />
       <ConfirmationDialog

--- a/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
+++ b/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
@@ -103,10 +103,10 @@ const ManagedPlaceholder: React.FC<CombinedProps> = props => {
         actions={actions}
       >
         <Typography>
-          The Managed service is billed at $100 monthly per Linode on your
-          account. You currently have{' '}
-          {pluralize('Linode', 'Linodes', props.linodeCount)} for a cost of $
-          {`${props.linodeCount * 100}/month`}.
+          Managed is billed at $100 monthly per Linode on your account. You
+          currently have{' '}
+          <strong>{pluralize('Linode', 'Linodes', props.linodeCount)}</strong>{' '}
+          for a cost of <strong>${`${props.linodeCount * 100}/month`}</strong>.
         </Typography>
       </ConfirmationDialog>
     </>

--- a/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
+++ b/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
@@ -75,7 +75,7 @@ const ManagedPlaceholder: React.FC<CombinedProps> = props => {
         Cancel
       </Button>
       <Button
-        buttonType="secondary"
+        buttonType="primary"
         onClick={handleSubmit}
         data-qa-submit-managed-enrollment
         loading={isLoading}

--- a/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
+++ b/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
@@ -1,4 +1,5 @@
 import { AccountSettings } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ManagedIcon from 'src/assets/icons/managed.svg';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -52,13 +53,14 @@ const ManagedPlaceholder: React.FC<CombinedProps> = props => {
     setError(undefined);
   };
 
-  const handleError = (e: Linode.ApiFieldError[]) => {
+  const handleError = (e: APIError[]) => {
     setError(e[0].reason);
     setLoading(false);
   };
 
   const handleSubmit = () => {
     setLoading(true);
+    setError(undefined);
     enableManaged()
       .then(() => {
         handleClose();
@@ -74,7 +76,6 @@ const ManagedPlaceholder: React.FC<CombinedProps> = props => {
       </Button>
       <Button
         buttonType="secondary"
-        destructive
         onClick={handleSubmit}
         data-qa-submit-managed-enrollment
         loading={isLoading}
@@ -103,10 +104,13 @@ const ManagedPlaceholder: React.FC<CombinedProps> = props => {
         actions={actions}
       >
         <Typography>
-          Managed is billed at $100 monthly per Linode on your account. You
-          currently have{' '}
-          <strong>{pluralize('Linode', 'Linodes', props.linodeCount)}</strong>{' '}
-          for a cost of <strong>${`${props.linodeCount * 100}/month`}</strong>.
+          Linode Managed costs an additional $100/mo per Linode. {` `}
+          You currently have{` `}
+          <strong>
+            {pluralize('Linode', 'Linodes', props.linodeCount)}
+          </strong>{' '}
+          on your account. This will increase your projected monthly bill by{' '}
+          <strong>${`${props.linodeCount * 100}/month`}</strong>. Are you sure?{' '}
         </Typography>
       </ConfirmationDialog>
     </>

--- a/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
+++ b/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
@@ -15,14 +15,14 @@ import { enableManaged } from 'src/services/managed';
 
 const copy = (
   <>
-    <Typography>
+    <Typography variant="subtitle1">
       Let us worry about your infrastructure, so you can get back to worrying
       about your business. Linode Managed helps keep your systems up and running
       with our team of Linode experts responding to monitoring events, so you
       can sleep well. Linode Managed includes 24/7 monitoring and incident
       responses, backups and Longview Pro. +$100/mo per Linode.{` `}
     </Typography>
-    <Typography>
+    <Typography variant="subtitle1" style={{ marginTop: 8 }}>
       <ExternalLink
         link="https://linode.com/managed"
         text="Learn more about Managed."

--- a/packages/manager/src/features/Managed/ManagedLanding.tsx
+++ b/packages/manager/src/features/Managed/ManagedLanding.tsx
@@ -1,53 +1,18 @@
 import { AccountSettings } from 'linode-js-sdk/lib/account';
 import * as React from 'react';
-import {
-  matchPath,
-  Redirect,
-  Route,
-  RouteComponentProps,
-  Switch
-} from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
-import AppBar from 'src/components/core/AppBar';
-import Box from 'src/components/core/Box';
-import Tab from 'src/components/core/Tab';
-import Tabs from 'src/components/core/Tabs';
-import DefaultLoader from 'src/components/DefaultLoader';
 import setDocs from 'src/components/DocsSidebar/setDocs';
-import DocumentationButton from 'src/components/DocumentationButton';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
-import Grid from 'src/components/Grid';
-import TabLink from 'src/components/TabLink';
 import withAccountSettings, {
   DispatchProps as SettingsDispatchProps
 } from 'src/containers/accountSettings.container';
-import { useAPIRequest } from 'src/hooks/useAPIRequest';
 import useFlags from 'src/hooks/useFlags';
-import { getCredentials, getManagedContacts } from 'src/services/managed';
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { getAll } from 'src/utilities/getAll';
 import EnableManagedPlaceholder from './EnableManagedPlaceholder';
+import ManagedLandingContent from './ManagedLandingContent';
 import ManagedPlaceholder from './ManagedPlaceholder';
-import SupportWidget from './SupportWidget';
-
-const Monitors = DefaultLoader({
-  loader: () => import('./Monitors')
-});
-
-const SSHAccess = DefaultLoader({
-  loader: () => import('./SSHAccess')
-});
-
-const Credentials = DefaultLoader({
-  loader: () => import('./Credentials')
-});
-
-const Contacts = DefaultLoader({
-  loader: () => import('./Contacts')
-});
 
 export interface StateProps {
   accountSettings: AccountSettings;
@@ -68,63 +33,14 @@ const docs: Linode.Doc[] = [
   }
 ];
 
-const getAllCredentials = () =>
-  getAll<Linode.ManagedCredential>(getCredentials)().then(
-    response => response.data
-  );
-
-// We need to "Get All" on this request in order to handle Groups
-// as a quasi-independent entity.
-const getAllContacts = () =>
-  getAll<Linode.ManagedContact>(getManagedContacts)().then(res => res.data);
-
 export const ManagedLanding: React.FunctionComponent<CombinedProps> = props => {
   const {
     accountSettings,
     accountSettingsError,
     accountSettingsLastUpdated,
-    accountSettingsLoading
+    accountSettingsLoading,
+    ...routeComponentProps
   } = props;
-
-  const credentials = useAPIRequest<Linode.ManagedCredential[]>(
-    getAllCredentials,
-    [],
-    [accountSettings]
-  );
-
-  const contacts = useAPIRequest<Linode.ManagedContact[]>(
-    getAllContacts,
-    [],
-    [accountSettings]
-  );
-
-  const credentialsError = credentials.error
-    ? getAPIErrorOrDefault(
-        credentials.error,
-        'Error retrieving your credentials.'
-      )
-    : undefined;
-
-  const tabs = [
-    /* NB: These must correspond to the routes inside the Switch */
-    { title: 'Monitors', routeName: `${props.match.url}/monitors` },
-    { title: 'SSH Access', routeName: `${props.match.url}/ssh-access` },
-    { title: 'Credentials', routeName: `${props.match.url}/credentials` },
-    { title: 'Contacts', routeName: `${props.match.url}/contacts` }
-  ];
-
-  const handleTabChange = (
-    event: React.ChangeEvent<HTMLDivElement>,
-    value: number
-  ) => {
-    const { history } = props;
-    const routeName = tabs[value].routeName;
-    history.push(`${routeName}`);
-  };
-
-  const matches = (p: string) => {
-    return Boolean(matchPath(p, { path: props.location.pathname }));
-  };
 
   const flags = useFlags();
   const isManaged = accountSettings && accountSettings.managed;
@@ -154,100 +70,7 @@ export const ManagedLanding: React.FunctionComponent<CombinedProps> = props => {
         <EnableManagedPlaceholder update={props.updateAccountSettingsInStore} />
       );
     }
-    return (
-      <React.Fragment>
-        <Box display="flex" flexDirection="row" justifyContent="space-between">
-          <Breadcrumb
-            pathname={props.location.pathname}
-            labelTitle="Managed"
-            removeCrumbX={1}
-          />
-          <Grid
-            container
-            item
-            direction="row"
-            justify="flex-end"
-            alignItems="center"
-            xs={8}
-          >
-            <Grid item>
-              <SupportWidget />
-            </Grid>
-            <Grid item>
-              <DocumentationButton href="https://www.linode.com/docs/platform/linode-managed/" />
-            </Grid>
-          </Grid>
-        </Box>
-        <AppBar position="static" color="default">
-          <Tabs
-            value={tabs.findIndex(tab => matches(tab.routeName))}
-            onChange={handleTabChange}
-            indicatorColor="primary"
-            textColor="primary"
-            variant="scrollable"
-            scrollButtons="on"
-          >
-            {tabs.map(tab => (
-              <Tab
-                key={tab.title}
-                data-qa-tab={tab.title}
-                component={React.forwardRef((forwardedProps, ref) => (
-                  <TabLink
-                    to={tab.routeName}
-                    title={tab.title}
-                    {...forwardedProps}
-                    ref={ref}
-                  />
-                ))}
-              />
-            ))}
-          </Tabs>
-        </AppBar>
-        <Switch>
-          <Route
-            exact
-            strict
-            path={`${props.match.path}/monitors`}
-            component={Monitors}
-          />
-          <Route
-            exact
-            strict
-            path={`${props.match.path}/ssh-access`}
-            component={SSHAccess}
-          />
-          <Route
-            exact
-            strict
-            path={`${props.match.path}/credentials`}
-            render={() => (
-              <Credentials
-                loading={credentials.loading && credentials.lastUpdated === 0}
-                error={credentialsError}
-                credentials={credentials.data}
-                update={credentials.update}
-              />
-            )}
-          />
-          <Route
-            exact
-            strict
-            path={`${props.match.path}/contacts`}
-            render={() => (
-              <Contacts
-                contacts={contacts.data}
-                loading={contacts.loading && contacts.lastUpdated === 0}
-                error={contacts.error}
-                lastUpdated={contacts.lastUpdated}
-                transformData={contacts.transformData}
-                update={contacts.update}
-              />
-            )}
-          />
-          <Redirect to={`${props.match.path}/monitors`} />
-        </Switch>
-      </React.Fragment>
-    );
+    return <ManagedLandingContent {...routeComponentProps} />;
   };
 
   return (

--- a/packages/manager/src/features/Managed/ManagedLanding.tsx
+++ b/packages/manager/src/features/Managed/ManagedLanding.tsx
@@ -88,10 +88,15 @@ export const ManagedLanding: React.FunctionComponent<CombinedProps> = props => {
 
   const credentials = useAPIRequest<Linode.ManagedCredential[]>(
     getAllCredentials,
-    []
+    [],
+    [accountSettings]
   );
 
-  const contacts = useAPIRequest<Linode.ManagedContact[]>(getAllContacts, []);
+  const contacts = useAPIRequest<Linode.ManagedContact[]>(
+    getAllContacts,
+    [],
+    [accountSettings]
+  );
 
   const credentialsError = credentials.error
     ? getAPIErrorOrDefault(

--- a/packages/manager/src/features/Managed/ManagedLanding.tsx
+++ b/packages/manager/src/features/Managed/ManagedLanding.tsx
@@ -100,7 +100,7 @@ export const ManagedLanding: React.FunctionComponent<CombinedProps> = props => {
   };
 
   const flags = useFlags();
-  const isManaged = false;
+  const isManaged = true;
 
   /**
    * Temporary logic since we currently have 3 states:

--- a/packages/manager/src/features/Managed/ManagedLandingContent.tsx
+++ b/packages/manager/src/features/Managed/ManagedLandingContent.tsx
@@ -1,0 +1,184 @@
+import * as React from 'react';
+import {
+  matchPath,
+  Redirect,
+  Route,
+  RouteComponentProps,
+  Switch
+} from 'react-router-dom';
+import Breadcrumb from 'src/components/Breadcrumb';
+import AppBar from 'src/components/core/AppBar';
+import Box from 'src/components/core/Box';
+import Tab from 'src/components/core/Tab';
+import Tabs from 'src/components/core/Tabs';
+import DefaultLoader from 'src/components/DefaultLoader';
+import DocumentationButton from 'src/components/DocumentationButton';
+import Grid from 'src/components/Grid';
+import TabLink from 'src/components/TabLink';
+import { useAPIRequest } from 'src/hooks/useAPIRequest';
+import { getCredentials, getManagedContacts } from 'src/services/managed';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { getAll } from 'src/utilities/getAll';
+import SupportWidget from './SupportWidget';
+
+const Monitors = DefaultLoader({
+  loader: () => import('./Monitors')
+});
+
+const SSHAccess = DefaultLoader({
+  loader: () => import('./SSHAccess')
+});
+
+const Credentials = DefaultLoader({
+  loader: () => import('./Credentials')
+});
+
+const Contacts = DefaultLoader({
+  loader: () => import('./Contacts')
+});
+
+export type CombinedProps = {} & RouteComponentProps<{}>;
+
+const getAllCredentials = () =>
+  getAll<Linode.ManagedCredential>(getCredentials)().then(
+    response => response.data
+  );
+
+// We need to "Get All" on this request in order to handle Groups
+// as a quasi-independent entity.
+const getAllContacts = () =>
+  getAll<Linode.ManagedContact>(getManagedContacts)().then(res => res.data);
+
+export const ManagedLandingContent: React.FC<CombinedProps> = props => {
+  const credentials = useAPIRequest<Linode.ManagedCredential[]>(
+    getAllCredentials,
+    []
+  );
+
+  const contacts = useAPIRequest<Linode.ManagedContact[]>(getAllContacts, []);
+
+  const tabs = [
+    /* NB: These must correspond to the routes inside the Switch */
+    { title: 'Monitors', routeName: `${props.match.url}/monitors` },
+    { title: 'SSH Access', routeName: `${props.match.url}/ssh-access` },
+    { title: 'Credentials', routeName: `${props.match.url}/credentials` },
+    { title: 'Contacts', routeName: `${props.match.url}/contacts` }
+  ];
+
+  const credentialsError = credentials.error
+    ? getAPIErrorOrDefault(
+        credentials.error,
+        'Error retrieving your credentials.'
+      )
+    : undefined;
+
+  const handleTabChange = (
+    event: React.ChangeEvent<HTMLDivElement>,
+    value: number
+  ) => {
+    const { history } = props;
+    const routeName = tabs[value].routeName;
+    history.push(`${routeName}`);
+  };
+
+  const matches = (p: string) => {
+    return Boolean(matchPath(p, { path: props.location.pathname }));
+  };
+
+  return (
+    <React.Fragment>
+      <Box display="flex" flexDirection="row" justifyContent="space-between">
+        <Breadcrumb
+          pathname={props.location.pathname}
+          labelTitle="Managed"
+          removeCrumbX={1}
+        />
+        <Grid
+          container
+          item
+          direction="row"
+          justify="flex-end"
+          alignItems="center"
+          xs={8}
+        >
+          <Grid item>
+            <SupportWidget />
+          </Grid>
+          <Grid item>
+            <DocumentationButton href="https://www.linode.com/docs/platform/linode-managed/" />
+          </Grid>
+        </Grid>
+      </Box>
+      <AppBar position="static" color="default">
+        <Tabs
+          value={tabs.findIndex(tab => matches(tab.routeName))}
+          onChange={handleTabChange}
+          indicatorColor="primary"
+          textColor="primary"
+          variant="scrollable"
+          scrollButtons="on"
+        >
+          {tabs.map(tab => (
+            <Tab
+              key={tab.title}
+              data-qa-tab={tab.title}
+              component={React.forwardRef((forwardedProps, ref) => (
+                <TabLink
+                  to={tab.routeName}
+                  title={tab.title}
+                  {...forwardedProps}
+                  ref={ref}
+                />
+              ))}
+            />
+          ))}
+        </Tabs>
+      </AppBar>
+      <Switch>
+        <Route
+          exact
+          strict
+          path={`${props.match.path}/monitors`}
+          component={Monitors}
+        />
+        <Route
+          exact
+          strict
+          path={`${props.match.path}/ssh-access`}
+          component={SSHAccess}
+        />
+        <Route
+          exact
+          strict
+          path={`${props.match.path}/credentials`}
+          render={() => (
+            <Credentials
+              loading={credentials.loading && credentials.lastUpdated === 0}
+              error={credentialsError}
+              credentials={credentials.data}
+              update={credentials.update}
+            />
+          )}
+        />
+        <Route
+          exact
+          strict
+          path={`${props.match.path}/contacts`}
+          render={() => (
+            <Contacts
+              contacts={contacts.data}
+              loading={contacts.loading && contacts.lastUpdated === 0}
+              error={contacts.error}
+              lastUpdated={contacts.lastUpdated}
+              transformData={contacts.transformData}
+              update={contacts.update}
+            />
+          )}
+        />
+        <Redirect to={`${props.match.path}/monitors`} />
+      </Switch>
+    </React.Fragment>
+  );
+};
+
+export default ManagedLandingContent;

--- a/packages/manager/src/hooks/useAPIRequest.ts
+++ b/packages/manager/src/hooks/useAPIRequest.ts
@@ -1,4 +1,5 @@
 import produce from 'immer';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { useEffect, useState } from 'react';
 
 interface UseAPIRequest<T> {
@@ -27,7 +28,7 @@ interface UseAPIRequest<T> {
  * Get account info:
  *
  * ```typescript
- * const { data, loading, lastUpdated, error } = useAPIData<Linode.Account | null>(
+ * const { data, loading, lastUpdated, error } = useAPIData<Account | null>(
  *  getAccountInfo,
  *  null // Initial value of `data`
  * );
@@ -57,14 +58,13 @@ export const useAPIRequest = <T>(
   deps: any[] = []
 ): UseAPIRequest<T> => {
   const [data, setData] = useState<T>(initialData);
-  const [error, setError] = useState<Linode.ApiFieldError[] | undefined>(
-    undefined
-  );
+  const [error, setError] = useState<APIError[] | undefined>(undefined);
   const [loading, setLoading] = useState<boolean>(false);
   const [lastUpdated, setLastUpdated] = useState<number>(0);
 
   const _request = () => {
     setLoading(true);
+    setError(undefined);
     request()
       .then(responseData => {
         setLoading(false);

--- a/packages/manager/src/services/managed/managed.ts
+++ b/packages/manager/src/services/managed/managed.ts
@@ -54,6 +54,22 @@ export interface ContactPayload {
 }
 
 /**
+ * enableManaged
+ *
+ * This is an undocumented endpoint that enables the Managed feature
+ * on your account. This service is billed at $100/month/Linode.
+ *
+ * Should this live in /account?
+ *
+ */
+
+export const enableManaged = () =>
+  Request<{}>(
+    setMethod('POST'),
+    setURL(`${API_ROOT}/account/settings/managed-enable`)
+  );
+
+/**
  * getServices
  *
  * Returns a paginated list of Managed Services on your account.

--- a/packages/manager/src/services/managed/managed.ts
+++ b/packages/manager/src/services/managed/managed.ts
@@ -56,7 +56,7 @@ export interface ContactPayload {
 /**
  * enableManaged
  *
- * This is an undocumented endpoint that enables the Managed feature
+ * Enables the Managed feature
  * on your account. This service is billed at $100/month/Linode.
  *
  * Should this live in /account?

--- a/packages/manager/src/store/accountSettings/accountSettings.actions.ts
+++ b/packages/manager/src/store/accountSettings/accountSettings.actions.ts
@@ -1,4 +1,5 @@
-import { AccountSettings } from 'linode-js-sdk/lib/account'
+import { AccountSettings } from 'linode-js-sdk/lib/account';
+import actionCreatorFactory from 'typescript-fsa';
 
 // TYPES
 export interface Action {
@@ -6,6 +7,8 @@ export interface Action {
   error?: Linode.ApiFieldError[];
   data?: any;
 }
+
+export const actionCreator = actionCreatorFactory(`@@manager/account/settings`);
 
 type ActionCreator = (...args: any[]) => Action;
 
@@ -40,3 +43,7 @@ export const handleUpdateError: ActionCreator = (
   type: UPDATE_ERROR,
   error
 });
+
+export const updateSettingsInStore = actionCreator<Partial<AccountSettings>>(
+  'update-store'
+);

--- a/packages/manager/src/store/accountSettings/accountSettings.reducer.ts
+++ b/packages/manager/src/store/accountSettings/accountSettings.reducer.ts
@@ -1,4 +1,6 @@
-import { AccountSettings } from 'linode-js-sdk/lib/account'
+import produce from 'immer';
+import { AccountSettings } from 'linode-js-sdk/lib/account';
+import { isType } from 'typescript-fsa';
 import { RequestableData } from '../types';
 import {
   Action,
@@ -6,7 +8,8 @@ import {
   LOAD,
   SUCCESS,
   UPDATE,
-  UPDATE_ERROR
+  UPDATE_ERROR,
+  updateSettingsInStore
 } from './accountSettings.actions';
 
 export type State = RequestableData<AccountSettings> & {
@@ -23,7 +26,15 @@ export const defaultState: State = {
 };
 
 // REDUCER
+// @todo Update this to current patterns.
 export default (state: State = defaultState, action: Action) => {
+  if (isType(action, updateSettingsInStore)) {
+    const settings = action.payload;
+    return produce(state, draft => {
+      draft.data = { ...state.data!, ...settings }; // data shouldn't be initialized as undefined...
+    });
+  }
+
   switch (action.type) {
     case LOAD:
       return { ...state, loading: true };


### PR DESCRIPTION
## Description

If:

- you don't have Managed on your account; and
- flags.managed is active

going to /managed will show a new Placeholder with a button to enable Managed

## Type of Change
- Breaking change ('break', 'deprecate')


## Note to Reviewers

- I tried to keep this small, so touched the accountSettings Redux stuff as little as possible. It uses our most ancient patterns though and is in dire need of a refactor. Will try to do that in another PR.

- Copy is not final