### PR TITLE
Fix: Kernel Default Value in Edit Config Drawer

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -397,9 +397,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             <Select
               options={kernelList}
               label="Select a Kernel"
-              defaultValue={kernelList.find(
-                thisKernel => thisKernel.value === kernel
-              )}
+              value={kernelList.find(thisKernel => thisKernel.value === kernel)}
               onChange={this.handleChangeKernel}
               errorText={errorFor('kernel')}
               errorGroup="linode-config-drawer"


### PR DESCRIPTION
## Description

Fixes issue where kernel input was not being populated due to race conditions with the getAllKernels request and how react-select's `defaultValue` props functions.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## To Test

Keep opening and closing the Advanced Config edit drawer and make sure the Kernel input is pre-populated.