### PR TITLE
Change: Request Type if None Found in /types or /types-legacy

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
@@ -81,9 +81,9 @@ const MutationNotification: React.FC<CombinedProps> = props => {
     }
 
     /** did we find successor meta data in GET /types or GET /types-legacy? */
-    const foundSuccessorInAllTypes = linodeType.successor
-      ? allTypes.find(({ id }) => id === linodeType.successor)
-      : null;
+    const foundSuccessorInAllTypes = allTypes.find(
+      ({ id }) => id === linodeType.successor
+    );
 
     if (allTypes.length > 0 && !!foundSuccessorInAllTypes) {
       setSuccessorMetaData(foundSuccessorInAllTypes);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
@@ -12,7 +12,7 @@ import {
 } from 'src/components/core/styles';
 import Notice from 'src/components/Notice';
 import { resetEventsPolling } from 'src/events';
-import { startMutation } from 'src/services/linodes';
+import { getType, startMutation } from 'src/services/linodes';
 import { ApplicationState } from 'src/store';
 import { requestLinodeForStore } from 'src/store/linodes/linode.requests';
 import {
@@ -53,12 +53,12 @@ type CombinedProps = Props &
   DispatchProps &
   WithStyles<ClassNames>;
 
-const MutationNotification: React.StatelessComponent<CombinedProps> = props => {
+const MutationNotification: React.FC<CombinedProps> = props => {
   const {
     classes,
-    types,
+    types: allTypes,
     linodeId,
-    linodeTypeData,
+    linodeType,
     linodeSpecs,
     enqueueSnackbar,
     openMutationDrawer,
@@ -70,17 +70,41 @@ const MutationNotification: React.StatelessComponent<CombinedProps> = props => {
     updateLinode
   } = props;
 
-  /** Mutate */
-  if (!linodeTypeData) {
-    return null;
-  }
+  const [
+    successorMetaData,
+    setSuccessorMetaData
+  ] = React.useState<Linode.LinodeType | null>(null);
 
-  const successorId = linodeTypeData.successor;
+  React.useEffect(() => {
+    if (!linodeType) {
+      return;
+    }
 
-  const successorType = successorId
-    ? types.find(({ id }) => id === successorId)
-    : null;
-  const { vcpus, network_out, disk, transfer, memory } = linodeTypeData;
+    /** did we find successor meta data in GET /types or GET /types-legacy? */
+    const foundSuccessorInAllTypes = linodeType.successor
+      ? allTypes.find(({ id }) => id === linodeType.successor)
+      : null;
+
+    if (allTypes.length > 0 && !!foundSuccessorInAllTypes) {
+      setSuccessorMetaData(foundSuccessorInAllTypes);
+    } else {
+      /**
+       * this means we couldn't find the Linode's successor in either
+       * GET request to /types or /types-legacy. This is a SUPER edge
+       * case but it *does* happen. An example type that would flatter this
+       * condition would be the "standard-4" plan. In this case, we need to actually
+       * request the successor metadata
+       */
+      if (linodeType.successor) {
+        getType(linodeType.successor)
+          .then(requestedType => {
+            setSuccessorMetaData(requestedType);
+          })
+          /** just silently fail if we couldn't get the data */
+          .catch(e => e);
+      }
+    }
+  }, [allTypes, linodeType]);
 
   const initMutation = () => {
     openMutationDrawer();
@@ -108,14 +132,17 @@ const MutationNotification: React.StatelessComponent<CombinedProps> = props => {
       });
   };
 
-  if (!successorId || !successorType) {
-    return null;
-  }
-
   const usedDiskSpace = addUsedDiskSpace(props.disks);
   const estimatedTimeToUpgradeInMins = Math.ceil(
     usedDiskSpace / MBpsIntraDC / 60
   );
+
+  /** Mutate */
+  if (!linodeType || !successorMetaData) {
+    return null;
+  }
+
+  const { vcpus, network_out, disk, transfer, memory } = linodeType;
 
   return (
     <>
@@ -143,15 +170,21 @@ const MutationNotification: React.StatelessComponent<CombinedProps> = props => {
         error={mutationDrawerError}
         handleClose={closeMutationDrawer}
         mutateInfo={{
-          vcpus: successorType.vcpus !== vcpus ? successorType.vcpus : null,
+          vcpus:
+            successorMetaData.vcpus !== vcpus ? successorMetaData.vcpus : null,
           network_out:
-            successorType.network_out !== network_out
-              ? successorType.network_out
+            successorMetaData.network_out !== network_out
+              ? successorMetaData.network_out
               : null,
-          disk: successorType.disk !== disk ? successorType.disk : null,
+          disk: successorMetaData.disk !== disk ? successorMetaData.disk : null,
           transfer:
-            successorType.transfer !== transfer ? successorType.transfer : null,
-          memory: successorType.memory !== memory ? successorType.memory : null
+            successorMetaData.transfer !== transfer
+              ? successorMetaData.transfer
+              : null,
+          memory:
+            successorMetaData.memory !== memory
+              ? successorMetaData.memory
+              : null
         }}
         currentTypeInfo={{
           vcpus: linodeSpecs.vcpus,
@@ -205,7 +238,7 @@ const enhanced = compose<CombinedProps, Props>(
   withLinodeDetailContext<ContextProps>(({ linode }) => ({
     linodeSpecs: linode.specs,
     linodeId: linode.id,
-    linodeTypeData: linode._type
+    linodeType: linode._type
   })),
   withMutationDrawerState,
   withSnackbar

--- a/packages/manager/src/services/linodes/getLinodeInfo.ts
+++ b/packages/manager/src/services/linodes/getLinodeInfo.ts
@@ -1,4 +1,4 @@
-import { NetworkUtilization } from "linode-js-sdk/lib/account";
+import { NetworkUtilization } from 'linode-js-sdk/lib/account';
 import { API_ROOT } from 'src/constants';
 
 import Request, { setMethod, setParams, setURL, setXFilter } from '../index';
@@ -88,8 +88,6 @@ export const getLinodeKernel = (kernelId: string) =>
  *
  * Return a paginated list of available Linode types.
  * This endpoint does not require authentication.
- *
- * @param linodeId { number } The id of the Linode to retrieve.
  */
 export const getLinodeTypes = () =>
   Request<Page<Type>>(


### PR DESCRIPTION
## Description

Adjusts the Mutation Banner to account for types that don't exist in the response data from `GET /types` or `GET /types-legacy`. 

## To Test

Login to prod-test-003. There you'll find 2 Linodes. 1 with a deprecated plan that exists in `GET /types-legacy` and 1 that doesn't

## Type of Change
- Bug fix ('fix', 'repair', 'bug')