### PR TITLE
Change: Stop using region short code in State dropdown

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -1,5 +1,5 @@
 import countryData from 'country-region-data';
-import { Account } from 'linode-js-sdk/lib/account'
+import { Account } from 'linode-js-sdk/lib/account';
 import { defaultTo, lensPath, pathOr, set } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -185,7 +185,7 @@ class UpdateContactInformationPanel extends React.Component<
 
     const regionResults = countryRegions.map(region => {
       return {
-        value: region.shortCode ? region.shortCode : region.name,
+        value: region.name,
         label: region.name
       };
     });


### PR DESCRIPTION
## Description

Some country regions have numeric short codes ([https://en.wikipedia.org/wiki/ISO_3166-2:VN](such as the regions in Vietnam)). Because of this, we shouldn't be sending the ISO 3166 numeric short codes, but instead just send the actual name of the region.

## That Being Said...

The Database _still_ doesn't support special characters, so most of the Vietnam regions, for example, will result in question mark characters when the form is actually submitted and another `GET /account` request is made.

IMO, this is *_not_* something we should be working around.

## Type of Change
- Non breaking change ('update', 'change')