### PR TITLE
Monitor dashboard card links to /managed/monitors instead of /support…

### DIFF
--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedDashboardCard.tsx
@@ -125,7 +125,7 @@ const getFailedMonitors = (monitors: Linode.ManagedServiceMonitor[]) => {
    * error state; but if all a user's monitors are pending
    * or disabled, they'll all pass the test here and the
    * user will get a message saying that all monitors are
-   * verified. Need to discuss.
+   * verified.
    */
   return monitors.reduce((accum, thisMonitor) => {
     if (thisMonitor.status === 'problem') {

--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/Unhealthy.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/Unhealthy.tsx
@@ -29,13 +29,12 @@ export const Unhealthy: React.FC<Props> = props => {
         </Grid>
         <Grid item className={classes.container}>
           <Typography variant="h3" className={classes.header}>
-            {/** This does not quite match the designs, but we don't have a way of checking failure time yet. */}
             {monitorsDown} of your Managed Service Monitors{' '}
             {monitorsDown === 1 ? 'has' : 'have'} failed.
           </Typography>
           <Typography>
-            Please check your
-            <Link to="/support/tickets"> Support tickets</Link> for details.
+            Please check your{` `}
+            <Link to="/managed/monitors">Monitors</Link> for details.
           </Typography>
         </Grid>
       </Grid>


### PR DESCRIPTION
Description

From design feedback. Update the dashboard managed card to not link to support tickets (since a Monitor can fail and not have a ticket for several minutes or possibly longer.