### PR TITLE
Change: Replace Province/State Select Field with TextField

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -373,6 +373,18 @@ class UpdateContactInformationPanel extends React.Component<
         >
           <Grid container className={classes.stateZip}>
             <Grid item xs={12} sm={7}>
+              {/*
+                @todo use the <EnhancedSelect /> in favor of the
+                <TextField /> when the DB and API remove the 24 character limit.
+
+                The issue here is that the province/state short codes (for a subset of countries)
+                uses the ISO 3316 numeric format, which is not as helpful as just being able
+                to submit the full name of the region. What we'd like to do is PUT /account
+                with the full name of the province/state, but there is a server-side
+                24-character limitation which makes it impossible to submit some provinces.
+
+                Follow DBA-1066 for more information.
+              */}
               {/* <EnhancedSelect
                   label="State / Province"
                   errorText={errorMap.state}

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -1,6 +1,6 @@
 import countryData from 'country-region-data';
 import { Account } from 'linode-js-sdk/lib/account';
-import { defaultTo, lensPath, pathOr, set } from 'ramda';
+import { defaultTo, lensPath, set } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -24,7 +24,7 @@ import composeState from 'src/utilities/composeState';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
-import { Country, Region } from './types';
+import { Country } from './types';
 
 type ClassNames = 'root' | 'mainFormContainer' | 'stateZip';
 
@@ -171,24 +171,24 @@ class UpdateContactInformationPanel extends React.Component<
       }
     );
 
-    const currentCountryResult = countryData.filter((country: Country) =>
-      fields.country
-        ? country.countryShortCode === fields.country
-        : country.countryShortCode === account.country
-    );
+    // const currentCountryResult = countryData.filter((country: Country) =>
+    //   fields.country
+    //     ? country.countryShortCode === fields.country
+    //     : country.countryShortCode === account.country
+    // );
 
-    const countryRegions: Region[] = pathOr(
-      [],
-      ['0', 'regions'],
-      currentCountryResult
-    );
+    // const countryRegions: Region[] = pathOr(
+    //   [],
+    //   ['0', 'regions'],
+    //   currentCountryResult
+    // );
 
-    const regionResults = countryRegions.map(region => {
-      return {
-        value: region.shortCode ? region.shortCode : region.name,
-        label: region.name
-      };
-    });
+    // const regionResults = countryRegions.map(region => {
+    //   return {
+    //     value: region.name,
+    //     label: region.name
+    //   };
+    // });
 
     return (
       <Grid
@@ -373,8 +373,7 @@ class UpdateContactInformationPanel extends React.Component<
         >
           <Grid container className={classes.stateZip}>
             <Grid item xs={12} sm={7}>
-              {fields.country === 'US' || fields.country === 'CA' ? (
-                <EnhancedSelect
+              {/* <EnhancedSelect
                   label="State / Province"
                   errorText={errorMap.state}
                   onChange={this.updateState}
@@ -396,23 +395,22 @@ class UpdateContactInformationPanel extends React.Component<
                       'data-qa-contact-province': true
                     }
                   }}
-                />
-              ) : (
-                <TextField
-                  label="State / Province"
-                  placeholder="Enter a State or Province"
-                  errorText={errorMap.state}
-                  onChange={e =>
-                    this.updateState({
-                      label: e.target.value,
-                      value: e.target.value
-                    })
-                  }
-                  dataAttrs={{
-                    'data-qa-contact-province': true
-                  }}
-                />
-              )}
+                /> */}
+              <TextField
+                label="State / Province"
+                placeholder="Enter a State or Province"
+                errorText={errorMap.state}
+                onChange={e =>
+                  this.updateState({
+                    label: e.target.value,
+                    value: e.target.value
+                  })
+                }
+                dataAttrs={{
+                  'data-qa-contact-province': true
+                }}
+                value={fields.state}
+              />
             </Grid>
             <Grid item xs={12} sm={5}>
               <TextField

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -1,5 +1,5 @@
 import countryData from 'country-region-data';
-import { Account } from 'linode-js-sdk/lib/account'
+import { Account } from 'linode-js-sdk/lib/account';
 import { defaultTo, lensPath, pathOr, set } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -373,29 +373,46 @@ class UpdateContactInformationPanel extends React.Component<
         >
           <Grid container className={classes.stateZip}>
             <Grid item xs={12} sm={7}>
-              <EnhancedSelect
-                label="State / Province"
-                errorText={errorMap.state}
-                onChange={this.updateState}
-                placeholder="Select a State"
-                options={regionResults}
-                isClearable={false}
-                // Explicitly setting the value as an object so the text will populate on selection.
-                // For more info see here: https://github.com/JedWatson/react-select/issues/2674
-                value={
-                  fields.state
-                    ? {
-                        label: fields.state,
-                        value: fields.state
-                      }
-                    : ''
-                }
-                textFieldProps={{
-                  dataAttrs: {
-                    'data-qa-contact-province': true
+              {fields.country === 'US' || fields.country === 'CA' ? (
+                <EnhancedSelect
+                  label="State / Province"
+                  errorText={errorMap.state}
+                  onChange={this.updateState}
+                  placeholder="Select a State"
+                  options={regionResults}
+                  isClearable={false}
+                  // Explicitly setting the value as an object so the text will populate on selection.
+                  // For more info see here: https://github.com/JedWatson/react-select/issues/2674
+                  value={
+                    fields.state
+                      ? {
+                          label: fields.state,
+                          value: fields.state
+                        }
+                      : ''
                   }
-                }}
-              />
+                  textFieldProps={{
+                    dataAttrs: {
+                      'data-qa-contact-province': true
+                    }
+                  }}
+                />
+              ) : (
+                <TextField
+                  label="State / Province"
+                  placeholder="Enter a State or Province"
+                  errorText={errorMap.state}
+                  onChange={e =>
+                    this.updateState({
+                      label: e.target.value,
+                      value: e.target.value
+                    })
+                  }
+                  dataAttrs={{
+                    'data-qa-contact-province': true
+                  }}
+                />
+              )}
             </Grid>
             <Grid item xs={12} sm={5}>
               <TextField


### PR DESCRIPTION
## Description

Closing https://github.com/linode/manager/pull/5420 in favor of this solution

So the issue here is that [some of the country short hand codes](https://github.com/country-regions/country-region-data/blob/master/data.json#L269) are the numeric ISO 3166 format, which is a problem and instead we should just send the full country name.

BUT 

as @Jskobos correctly pointed out [here](https://github.com/linode/manager/pull/5420#pullrequestreview-283180448), the DB and API has a 24 character limit, so sending the full region name just won't work. This is the interim solution until we can up the character limit - just let the user type whatever they want.

## Type of Change
- Non breaking change ('update', 'change')