### PR TITLE
M3-3238 Fix: Backups and clones always labeled as "Debian"

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -126,6 +126,12 @@ const trimOneClickFromLabel = (script: StackScript) => {
   };
 };
 
+const isNonDefaultImageType = (prevType: string, type: string) => {
+  return ['fromStackScript', 'fromBackup', 'fromLinode'].some(
+    thisEntry => prevType !== thisEntry && type === thisEntry
+  );
+};
+
 class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   params = getParamsFromUrl(this.props.location.search);
 
@@ -142,10 +148,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
      * defaulting to Debian 9 because it's possible the user chooses a stackscript
      * that isn't compatible with the defaulted image
      */
-    if (
-      prevProps.createType !== 'fromStackScript' &&
-      this.props.createType === 'fromStackScript'
-    ) {
+    if (isNonDefaultImageType(prevProps.createType, this.props.createType)) {
       this.setState({ selectedImageID: undefined });
     }
   }
@@ -278,7 +281,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   setUDFs = (udfs: any[]) => this.setState({ udfs });
 
   generateLabel = () => {
-    const { getLabel, imagesData, regionsData } = this.props;
+    const { createType, getLabel, imagesData, regionsData } = this.props;
     const {
       selectedImageID,
       selectedRegionID,
@@ -326,9 +329,13 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       arg2 = selectedRegion ? selectedRegion.id : '';
     }
 
-    if (this.props.createType === 'fromLinode') {
+    if (createType === 'fromLinode') {
       // @todo handle any other custom label cases we'd like to have here
       arg3 = 'clone';
+    }
+
+    if (createType === 'fromBackup') {
+      arg3 = 'backup';
     }
 
     return getLabel(arg1, arg2, arg3);

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -126,8 +126,10 @@ const trimOneClickFromLabel = (script: StackScript) => {
   };
 };
 
+const nonImageCreateTypes = ['fromStackScript', 'fromBackup', 'fromLinode'];
+
 const isNonDefaultImageType = (prevType: string, type: string) => {
-  return ['fromStackScript', 'fromBackup', 'fromLinode'].some(
+  return nonImageCreateTypes.some(
     thisEntry => prevType !== thisEntry && type === thisEntry
   );
 };
@@ -144,9 +146,9 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
 
   componentDidUpdate(prevProps: CombinedProps) {
     /**
-     * if we're clicking on the stackscript create flow, we need to stop
-     * defaulting to Debian 9 because it's possible the user chooses a stackscript
-     * that isn't compatible with the defaulted image
+     * When switching to a creation flow where
+     * having a pre-selected image is problematic,
+     * deselect it.
      */
     if (isNonDefaultImageType(prevProps.createType, this.props.createType)) {
       this.setState({ selectedImageID: undefined });
@@ -164,11 +166,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
         selectedLinodeID: isNaN(+params.linodeID) ? undefined : +params.linodeID
       });
     }
-    if (
-      ['fromStackScript', 'fromBackup', 'fromLinode'].includes(
-        this.props.createType
-      )
-    ) {
+    if (nonImageCreateTypes.includes(this.props.createType)) {
       // If we're navigating directly to e.g. the clone page, don't select an image by default
       this.setState({ selectedImageID: undefined });
     }
@@ -323,6 +321,12 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
           ? selectedImage.vendor
           : selectedImage.label
         : '';
+
+      if (createType === 'fromApp') {
+        // All 1-clicks are Debian so this isn't useful information.
+        // Once an app is
+        arg1 = '';
+      }
     }
 
     if (selectedRegionID) {

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -164,6 +164,14 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
         selectedLinodeID: isNaN(+params.linodeID) ? undefined : +params.linodeID
       });
     }
+    if (
+      ['fromStackScript', 'fromBackup', 'fromLinode'].includes(
+        this.props.createType
+      )
+    ) {
+      // If we're navigating directly to e.g. the clone page, don't select an image by default
+      this.setState({ selectedImageID: undefined });
+    }
     this.setState({ appInstancesLoading: true });
     getOneClickApps()
       // Don't display One-Click Helpers to the user


### PR DESCRIPTION
This is more of a quick fix; we always intended to update the default labeling logic post-1Click but never did, so I made a ticket for that too.

This prevents 'debian' being set as the label for creation flows where no image is selected/submitted (Cloning and backups).