### PR TITLE
M3-3234 Update managed icon on dashboard to align with entity icons

### DIFF
--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/Healthy.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/Healthy.tsx
@@ -8,18 +8,18 @@ import Grid from 'src/components/Grid';
 
 export const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    padding: `${theme.spacing(3) - 4}px`,
+    padding: theme.spacing(2),
     maxWidth: '100%'
   },
   container: {
     flex: 1
   },
   icon: {
-    width: 48,
-    height: 48
+    width: 40,
+    height: 40
   },
   header: {
-    marginBottom: 11
+    marginBottom: 2
   }
 }));
 
@@ -32,11 +32,10 @@ export const Healthy: React.FC<{}> = _ => {
         direction="row"
         alignItems="center"
         className={classes.root}
-        spacing={0}
       >
         <Grid item>
-          <Grid item xs={12} className={classes.icon}>
-            <MonitorOK width={48} height={48} />
+          <Grid item className={classes.icon}>
+            <MonitorOK width={40} height={40} />
           </Grid>
         </Grid>
         <Grid item className={classes.container}>

--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/Healthy.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/Healthy.tsx
@@ -1,10 +1,18 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { compose } from 'recompose';
 
 import MonitorOK from 'src/assets/icons/monitor-ok.svg';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import {
+  makeStyles,
+  Theme,
+  withTheme,
+  WithTheme
+} from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+
+import { COMPACT_SPACING_UNIT } from 'src/themeFactory';
 
 export const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -15,16 +23,17 @@ export const useStyles = makeStyles((theme: Theme) => ({
     flex: 1
   },
   icon: {
-    width: 40,
-    height: 40
-  },
-  header: {
-    marginBottom: 2
+    '& svg': {
+      display: 'flex'
+    }
   }
 }));
 
-export const Healthy: React.FC<{}> = _ => {
+export const Healthy: React.FC<WithTheme> = props => {
   const classes = useStyles();
+
+  const iconSize = props.theme.spacing(1) === COMPACT_SPACING_UNIT ? 32 : 38;
+
   return (
     <>
       <Grid
@@ -34,12 +43,20 @@ export const Healthy: React.FC<{}> = _ => {
         className={classes.root}
       >
         <Grid item>
-          <Grid item className={classes.icon}>
-            <MonitorOK width={40} height={40} />
+          <Grid
+            item
+            style={
+              props.theme.spacing(1) === COMPACT_SPACING_UNIT
+                ? { padding: '0 3px' }
+                : undefined
+            }
+            className={classes.icon}
+          >
+            <MonitorOK width={iconSize} height={iconSize} />
           </Grid>
         </Grid>
         <Grid item className={classes.container}>
-          <Typography variant="h3" className={classes.header}>
+          <Typography variant="h3">
             All Managed Service Monitors are verified.
           </Typography>
           <Typography>
@@ -52,4 +69,6 @@ export const Healthy: React.FC<{}> = _ => {
   );
 };
 
-export default Healthy;
+const enhanced = compose<WithTheme, {}>(withTheme);
+
+export default enhanced(Healthy);

--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/Unhealthy.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/Unhealthy.tsx
@@ -1,18 +1,27 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { compose } from 'recompose';
 
 import MonitorFailed from 'src/assets/icons/monitor-failed.svg';
+import { withTheme, WithTheme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { useStyles } from './Healthy';
+
+import { COMPACT_SPACING_UNIT } from 'src/themeFactory';
 
 interface Props {
   monitorsDown: number;
 }
 
-export const Unhealthy: React.FC<Props> = props => {
+type CombineProps = Props & WithTheme;
+
+export const Unhealthy: React.FC<CombineProps> = props => {
   const classes = useStyles();
   const { monitorsDown } = props;
+
+  const iconSize = props.theme.spacing(1) === COMPACT_SPACING_UNIT ? 32 : 38;
+
   return (
     <>
       <Grid
@@ -23,12 +32,21 @@ export const Unhealthy: React.FC<Props> = props => {
         spacing={0}
       >
         <Grid item>
-          <Grid item xs={12} className={classes.icon}>
-            <MonitorFailed height={48} width={48} />
+          <Grid
+            item
+            xs={12}
+            className={classes.icon}
+            style={
+              props.theme.spacing(1) === COMPACT_SPACING_UNIT
+                ? { padding: '0 3px' }
+                : undefined
+            }
+          >
+            <MonitorFailed height={iconSize} width={iconSize} />
           </Grid>
         </Grid>
         <Grid item className={classes.container}>
-          <Typography variant="h3" className={classes.header}>
+          <Typography variant="h3">
             {monitorsDown} of your Managed Service Monitors{' '}
             {monitorsDown === 1 ? 'has' : 'have'} failed.
           </Typography>
@@ -42,4 +60,6 @@ export const Unhealthy: React.FC<Props> = props => {
   );
 };
 
-export default Unhealthy;
+const enhanced = compose<CombineProps, Props>(withTheme);
+
+export default enhanced(Unhealthy);

--- a/packages/manager/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -28,7 +28,7 @@ const styles = (theme: Theme) =>
       padding: `${theme.spacing(4)}px ${theme.spacing(3)}px`
     },
     card: {
-      marginTop: -8,
+      marginTop: 24,
       [theme.breakpoints.down('sm')]: {
         marginTop: 0
       }


### PR DESCRIPTION
## Update managed icon on dashboard to align with entity icons

There was a discrepancy of styles when having the managed dashboard card on top of other cards. The icon was disproportionate and needed to be adjusted to match the entity icons in order to create a better visual flow.

## Type of Change
- Non breaking change ('update', 'change')

<img width="832" alt="Screen Shot 2019-09-03 at 12 10 11 PM" src="https://user-images.githubusercontent.com/205353/64256281-208c0c00-cef1-11e9-864c-78199701465d.png">
