### PR TITLE
LKE-783 Add cluster label to filename when downloading kubeconfig

### DIFF
--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu.test.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu.test.tsx
@@ -16,6 +16,7 @@ requests.getKubeConfig = jest
 
 const props = {
   clusterId: 123456,
+  clusterLabel: 'my-cluster',
   enqueueSnackbar: jest.fn(),
   closeSnackbar: jest.fn(),
   openDialog: jest.fn()

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu.tsx
@@ -10,6 +10,7 @@ import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 
 interface Props {
   clusterId: number;
+  clusterLabel: string;
   openDialog: () => void;
 }
 
@@ -18,7 +19,7 @@ type CombinedProps = Props & WithSnackbarProps;
 export const ClusterActionMenu: React.FunctionComponent<
   CombinedProps
 > = props => {
-  const { clusterId, enqueueSnackbar, openDialog } = props;
+  const { clusterId, clusterLabel, enqueueSnackbar, openDialog } = props;
   const createActions = () => {
     return (closeMenu: Function): Action[] => {
       const actions = [
@@ -50,7 +51,7 @@ export const ClusterActionMenu: React.FunctionComponent<
         // Convert to utf-8 from base64
         try {
           const decodedFile = window.atob(response.kubeconfig);
-          downloadFile('kubeconfig.yaml', decodedFile);
+          downloadFile(`${clusterLabel}-kubeconfig.yaml`, decodedFile);
         } catch (e) {
           reportException(e, {
             'Encoded response': response.kubeconfig

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterRow.tsx
@@ -89,6 +89,7 @@ export const ClusterRow: React.FunctionComponent<CombinedProps> = props => {
       <TableCell>
         <ActionMenu
           clusterId={cluster.id}
+          clusterLabel={cluster.label}
           openDialog={() =>
             openDeleteDialog(cluster.id, cluster.label, cluster.node_pools)
           }

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigPanel.tsx
@@ -113,7 +113,7 @@ export const KubeConfigPanel: React.FC<CombinedProps> = props => {
     fetchKubeConfig()
       .then(decodedFile => {
         if (decodedFile) {
-          downloadFile('kubeconfig.yaml', decodedFile);
+          downloadFile(`${clusterLabel}-kubeconfig.yaml`, decodedFile);
         } else {
           // There was a parsing error, the user will see an error toast.
           return;


### PR DESCRIPTION
## Description

Add the cluster label to kubeconfig filename when downloading (e.g. `my-cluster-kubeconfig.yaml`)