### PR TITLE
M3-3257 Increase font size for enabling managed confirmation modal

### DIFF
--- a/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
+++ b/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
@@ -100,7 +100,7 @@ const ManagedPlaceholder: React.FC<CombinedProps> = props => {
         title="Just to confirm..."
         actions={actions}
       >
-        <Typography>
+        <Typography variant="subtitle1">
           Linode Managed is billed at{' '}
           <strong>$100 per month per Linode.</strong> {` `}
           You currently have{` `}


### PR DESCRIPTION
##  Increase font size for enabling managed confirmation modal

<img width="706" alt="Screen Shot 2019-09-06 at 2 54 52 PM" src="https://user-images.githubusercontent.com/205353/64453354-5dedc680-d0b6-11e9-83bc-0e5ca350f8c7.png">


## Type of Change
- Non breaking change ('update')
