### PR TITLE
Fix overflow in react selects

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -51,7 +51,6 @@ export const styles = (theme: Theme) =>
       },
       '& .react-select__value-container': {
         width: '100%',
-        overflow: 'initial',
         '& > div': {
           width: '100%'
         },
@@ -188,8 +187,7 @@ export const styles = (theme: Theme) =>
       padding: 0,
       display: 'flex',
       color: theme.palette.text.primary,
-      cursor: 'pointer',
-      overflow: 'hidden'
+      cursor: 'pointer'
     },
     noOptionsMessage: {
       padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`

--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -188,7 +188,8 @@ export const styles = (theme: Theme) =>
       padding: 0,
       display: 'flex',
       color: theme.palette.text.primary,
-      cursor: 'pointer'
+      cursor: 'pointer',
+      overflow: 'hidden'
     },
     noOptionsMessage: {
       padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`

--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -63,7 +63,7 @@ const _components = {
 type CombinedProps = WithStyles<ClassNames> & BaseSelectProps & CreatableProps;
 
 export interface BaseSelectProps
-  extends Omit<SelectProps<any>, 'onChange' | 'value'> {
+  extends Omit<SelectProps<any>, 'onChange' | 'value' | 'onFocus'> {
   classes?: any;
   /*
    textFieldProps isn't native to react-select
@@ -87,6 +87,7 @@ export interface BaseSelectProps
   /** alias for onCreateOption */
   createNew?: (inputValue: string) => void;
   loadOptions?: (inputValue: string) => Promise<Item | Item[]> | undefined;
+  onFocus?: any;
   /** the rest are props we've added ourselves */
   medium?: boolean;
   small?: boolean;
@@ -131,6 +132,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
       inline,
       hideLabel,
       errorGroup,
+      onFocus,
       ...restOfProps
     } = this.props;
 
@@ -207,6 +209,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
         noOptionsMessage={this.props.noOptionsMessage || (() => 'No results')}
         menuPlacement={this.props.menuPlacement || 'auto'}
         onMenuClose={onMenuClose}
+        onFocus={onFocus}
       />
     );
   }

--- a/packages/manager/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SelectPlaceholder.tsx
@@ -15,7 +15,6 @@ const styles = (theme: Theme) =>
     root: {
       position: 'absolute',
       left: '10px',
-      width: '100%',
       wordWrap: 'normal',
       whiteSpace: 'nowrap',
       overflow: 'hidden',

--- a/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
+++ b/packages/manager/src/components/EnhancedSelect/components/SingleValue.tsx
@@ -9,9 +9,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     flexFlow: 'row nowrap',
     alignItems: 'center',
-    paddingLeft: `30px !important`
+    paddingLeft: `45px !important`
   },
   icon: {
+    marginLeft: theme.spacing(1) - 2,
     marginRight: theme.spacing(1),
     fontSize: '1.8em',
     position: 'absolute'

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -1,19 +1,16 @@
 import produce from 'immer';
 import { Image } from 'linode-js-sdk/lib/images';
-import { equals } from 'ramda';
+import { equals, groupBy } from 'ramda';
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import { BaseSelectProps } from 'src/components/EnhancedSelect/Select';
-
-import Grid from 'src/components/Grid';
-
-import { groupBy } from 'ramda';
-
 import Select, { GroupType, Item } from 'src/components/EnhancedSelect';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
 import { arePropsEqual } from 'src/utilities/arePropsEqual';
+import { BaseSelectProps } from 'src/components/EnhancedSelect/Select';
+import Grid from 'src/components/Grid';
+import Notice from 'src/components/Notice';
 import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
 
 import { distroIcons } from './icons';
@@ -163,6 +160,7 @@ export const ImageSelect: React.FC<Props> = props => {
                   placeholder="Choose an image"
                   options={options}
                   onChange={onChange}
+                  onFocus={onChange}
                   value={getSelectedOptionFromGroupedOptions(
                     selectedImageID || '',
                     options

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -10,7 +10,7 @@ import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
 import { arePropsEqual } from 'src/utilities/arePropsEqual';
 import { BaseSelectProps } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
-import Notice from 'src/components/Notice';
+import { arePropsEqual } from 'src/utilities/arePropsEqual';
 import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
 
 import { distroIcons } from './icons';

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -7,14 +7,12 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Select, { GroupType, Item } from 'src/components/EnhancedSelect';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
-import { arePropsEqual } from 'src/utilities/arePropsEqual';
 import { BaseSelectProps } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import { arePropsEqual } from 'src/utilities/arePropsEqual';
 import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
 import { distroIcons } from './icons';
 import ImageOption from './ImageOption';
-
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -12,9 +12,9 @@ import { BaseSelectProps } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import { arePropsEqual } from 'src/utilities/arePropsEqual';
 import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
-
 import { distroIcons } from './icons';
 import ImageOption from './ImageOption';
+
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -744,7 +744,10 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
           },
           '&$focused': {
             borderColor: primaryColors.main,
-            boxShadow: '0 0 2px 1px #e1edfa'
+            boxShadow: '0 0 2px 1px #e1edfa',
+            '& .select-option-icon': {
+              paddingLeft: `30px !important`
+            }
           },
           '&$error': {
             borderColor: '#ca0813'


### PR DESCRIPTION
## Description
<img width="1711" alt="Screen Shot 2019-09-06 at 3 16 03 PM" src="https://user-images.githubusercontent.com/1624067/64454577-4fed7500-d0b9-11e9-8616-8c7c139e4d17.png">

One could argue that anyone who triggers this deserves it, but might as well patch it up.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

