### PR TITLE
OBJ-58 Part III: Folder Traversal

### DIFF
--- a/packages/manager/src/components/EntityIcon/EntityIcon.tsx
+++ b/packages/manager/src/components/EntityIcon/EntityIcon.tsx
@@ -2,6 +2,8 @@ import * as classNames from 'classnames';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
+// @todo: What is the actual folder icon?
+import FolderIcon from 'src/assets/icons/entityIcons/bucket.svg';
 import BucketIcon from 'src/assets/icons/entityIcons/bucket.svg';
 import DomainIcon from 'src/assets/icons/entityIcons/domain.svg';
 import KubeIcon from 'src/assets/icons/entityIcons/kubernetes.svg';
@@ -81,7 +83,8 @@ export type Variant =
   | 'stackscript'
   | 'kube'
   | 'bucket'
-  | 'object';
+  | 'object'
+  | 'folder';
 
 interface Props {
   variant: Variant;
@@ -103,7 +106,8 @@ const iconMap = {
   stackscript: StackScriptIcon,
   kube: KubeIcon,
   bucket: BucketIcon,
-  object: ObjectIcon
+  object: ObjectIcon,
+  folder: FolderIcon
 };
 
 const getIcon = (variant: Variant) => {

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -152,8 +152,7 @@ export const dcDisplayCountry = {
 };
 
 export const objectStorageClusterDisplay: Record<Linode.ClusterID, string> = {
-  'us-east-1': 'Newark, NJ',
-  alpha: 'Newark, NJ'
+  'us-east-1': 'Newark, NJ'
 };
 
 export type ContinentKey = 'NA' | 'EU' | 'AS';
@@ -276,3 +275,17 @@ export const nonClickEvents = ['profile_update'];
  * A bucket can be accessed at: {bucket}.{cluster}.OBJECT_STORAGE_ROOT
  */
 export const OBJECT_STORAGE_ROOT = 'linodeobjects.com';
+
+/**
+ * This delimiter is used to retrieve objects at just one hierarchical level.
+ * As an example, assume the following objects are in a bucket:
+ *
+ * file1.txt
+ * my-folder/file2.txt
+ * my-folder/file3.txt
+ *
+ * Retrieving an object-list with a delimiter of '/' will return `file1.txt`
+ * only. This mechanism, in combination with "prefix" and "marker", allow us
+ * to simulate folder traversal of a bucket.
+ */
+export const OBJECT_STORAGE_DELIMITER = '/';

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -152,7 +152,8 @@ export const dcDisplayCountry = {
 };
 
 export const objectStorageClusterDisplay: Record<Linode.ClusterID, string> = {
-  'us-east-1': 'Newark, NJ'
+  'us-east-1': 'Newark, NJ',
+  alpha: 'Newark, NJ'
 };
 
 export type ContinentKey = 'NA' | 'EU' | 'AS';

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -83,6 +83,7 @@ const BucketDetail: React.FC<CombinedProps> = props => {
     setAllObjectsFetched(false);
     setLoading(true);
     setGeneralError(undefined);
+    setData([]);
     getObjectList(clusterId, bucketName, { delimiter, prefix, page_size })
       .then(response => {
         setLoading(false);
@@ -111,6 +112,7 @@ const BucketDetail: React.FC<CombinedProps> = props => {
     if (!tail) {
       return;
     }
+
     setLoading(true);
     setNextPageError(undefined);
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -102,6 +102,9 @@ const BucketDetail: React.FC<CombinedProps> = props => {
     getObjectList(clusterId, bucketName, {
       delimiter,
       prefix,
+      // `marker` is used for Object Storage pagination. It is the name of
+      // the last file of the current set. Specifying a marker will get you
+      // the next X number of objects after the marker.
       marker: tail.name
     })
       .then(response => {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import Waypoint from 'react-waypoint';
@@ -48,13 +49,13 @@ const BucketDetail: React.FC<CombinedProps> = props => {
   const [loading, setLoading] = React.useState<boolean>(false);
 
   const [generalError, setGeneralError] = React.useState<
-    Linode.ApiFieldError[] | undefined
+    APIError[] | undefined
   >(undefined);
 
   // Errors that happen when fetching the next page should be kept separate,
   // since we don't want to bomb the whole object listing table.
   const [nextPageError, setNextPageError] = React.useState<
-    Linode.ApiFieldError[] | undefined
+    APIError[] | undefined
   >(undefined);
 
   // This lets us know if we've reached the end of our bucket or folder,

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import EntityIcon from 'src/components/EntityIcon';
+import Grid from 'src/components/Grid';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
+
+// Keep this for when we display URL on hover
+// import { generateObjectUrl } from '../utilities';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    cursor: 'pointer',
+    '& div': {
+      cursor: 'pointer'
+    }
+  },
+  folderNameWrapper: {
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center',
+    wordBreak: 'break-all'
+  },
+  folderName: {
+    color: theme.palette.primary.main
+  }
+}));
+
+interface Props {
+  folderName: string;
+  displayName: string;
+}
+
+type CombinedProps = Props & RouteComponentProps<{}>;
+
+const FolderTableRow: React.FC<CombinedProps> = props => {
+  const { folderName, displayName } = props;
+
+  const classes = useStyles();
+
+  const handleClick = () => {
+    props.history.push({ search: `?prefix=${folderName}` });
+  };
+
+  return (
+    <TableRow className={classes.root} key={folderName} rowLink={handleClick}>
+      <TableCell parentColumn="Object">
+        <Grid container wrap="nowrap" alignItems="center">
+          <Grid item className="py0">
+            <EntityIcon variant="folder" size={20} />
+          </Grid>
+          <Grid item>
+            <div className={classes.folderNameWrapper}>
+              <Typography variant="h3" className={classes.folderName}>
+                {displayName}
+              </Typography>
+            </div>
+          </Grid>
+        </Grid>
+      </TableCell>
+      <TableCell parentColumn="Size" />
+      <TableCell parentColumn="Region" />
+      <TableCell parentColumn="Last Modified" />
+    </TableRow>
+  );
+};
+
+export default withRouter(FolderTableRow);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
@@ -11,8 +12,8 @@ interface Props {
   bucketName: string;
   data: ExtendedObject[];
   loading: boolean;
-  error?: Linode.ApiFieldError[];
-  nextPageError?: Linode.ApiFieldError[];
+  error?: APIError[];
+  nextPageError?: APIError[];
   prefix: string;
 }
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -47,10 +47,7 @@ const ObjectTableContent: React.FC<Props> = props => {
 
   if (isFolderEmpty) {
     return (
-      <TableRowEmptyState
-        colSpan={6}
-        message="No objects matching this prefix."
-      />
+      <TableRowEmptyState colSpan={6} message="No matching Objects found." />
     );
   }
 

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -1,23 +1,24 @@
 import * as React from 'react';
-
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
-
+import { ExtendedObject, isFolder } from '../utilities';
+import FolderTableRow from './FolderTableRow';
 import ObjectTableRow from './ObjectTableRow';
 
 interface Props {
   clusterId: Linode.ClusterID;
   bucketName: string;
-  data: Linode.Object[];
+  data: ExtendedObject[];
   loading: boolean;
   error?: Linode.ApiFieldError[];
+  prefix: string;
 }
 
 const ObjectTable: React.FC<Props> = props => {
-  const { clusterId, bucketName, data, loading, error } = props;
+  const { clusterId, bucketName, data, loading, error, prefix } = props;
 
-  if (loading) {
+  if (loading && data.length === 0) {
     return <TableRowLoading colSpan={6} />;
   }
 
@@ -41,16 +42,34 @@ const ObjectTable: React.FC<Props> = props => {
 
   return (
     <>
-      {data.map(object => (
-        <ObjectTableRow
-          key={object.name}
-          clusterId={clusterId}
-          bucketName={bucketName}
-          objectName={object.name}
-          objectSize={object.size}
-          objectLastModified={object.last_modified}
-        />
-      ))}
+      {data.map(object => {
+        console.log(object.displayName);
+        if (!object.displayName || object.displayName.endsWith('/')) {
+          return null;
+        }
+
+        if (isFolder(object)) {
+          return (
+            <FolderTableRow
+              key={object.name}
+              folderName={object.name}
+              displayName={object.displayName}
+            />
+          );
+        }
+
+        return (
+          <ObjectTableRow
+            key={object.name}
+            clusterId={clusterId}
+            bucketName={bucketName}
+            objectName={object.displayName}
+            objectSize={object.size}
+            objectLastModified={object.last_modified}
+          />
+        );
+      })}
+      {loading && <TableRowLoading colSpan={12} transparent />}
     </>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -77,8 +77,14 @@ const ObjectTableContent: React.FC<Props> = props => {
             clusterId={clusterId}
             bucketName={bucketName}
             objectName={object._displayName}
-            objectSize={object.size}
-            objectLastModified={object.last_modified}
+            /**
+             * In reality, if there's no `size` or `last_modified`, we're
+             * probably dealing with a folder and will have already returned
+             * `null`. The OR fallbacks are to make TSC happy, and to safeguard
+             * in the event of the data being something we don't expect.
+             */
+            objectSize={object.size || 0}
+            objectLastModified={object.last_modified || ''}
           />
         );
       })}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
@@ -72,4 +72,4 @@ const ObjectTableRow: React.FC<Props> = props => {
   );
 };
 
-export default ObjectTableRow;
+export default React.memo(ObjectTableRow);

--- a/packages/manager/src/features/ObjectStorage/utilities.test.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.test.ts
@@ -1,0 +1,88 @@
+import { basename, extendObject, isFolder } from './utilities';
+
+const folder: Linode.Object = {
+  name: 'my-folder',
+  etag: null,
+  last_modified: null,
+  owner: null,
+  size: null
+};
+const object1: Linode.Object = {
+  name: 'file1.txt',
+  etag: '4agr3fbzvf4haf86bGFdac325c6bfga27',
+  last_modified: '2019-09-05T12:00:00.000Z',
+  owner: '912b4786-d307-11e9-bb65-2a2ae2dbcce4',
+  size: 0
+};
+const object2: Linode.Object = {
+  name: 'my-folder/file2.txt',
+  etag: '4agr3fbzvf4haf86bGFdac325c6bfga27',
+  last_modified: '2019-09-05T12:00:00.000Z',
+  owner: '912b4786-d307-11e9-bb65-2a2ae2dbcce4',
+  size: 0
+};
+const object3: Linode.Object = {
+  name: 'my-folder/',
+  etag: '4agr3fbzvf4haf86bGFdac325c6bfga27',
+  last_modified: '2019-09-05T12:00:00.000Z',
+  owner: '912b4786-d307-11e9-bb65-2a2ae2dbcce4',
+  size: 0
+};
+
+describe('Object Storage utilities', () => {
+  describe('isFolder', () => {
+    it('returns `true` if the object has null for fields except `name`', () => {
+      expect(isFolder(folder)).toBe(true);
+      const notAFolder = {
+        ...folder,
+        etag: 'my-etag'
+      };
+      expect(isFolder(notAFolder)).toBe(false);
+      expect(isFolder(object1)).toBe(false);
+    });
+  });
+
+  describe('basename', () => {
+    it('returns the portion of the pathname AFTER the last slash', () => {
+      const pathname = 'my-folder/file1.txt';
+      expect(basename(pathname)).toBe('file1.txt');
+    });
+    it('works if there are multiple slashes', () => {
+      const pathname = 'my-folder/nested-folder/file2.txt';
+      expect(basename(pathname)).toBe('file2.txt');
+    });
+    it('returns the original input if there are no slashes', () => {
+      const pathname = 'file3.txt';
+      expect(basename(pathname)).toBe(pathname);
+    });
+    it('handles custom delimiters', () => {
+      const pathname = 'my-folder;file4.txt';
+      expect(basename(pathname, ';')).toBe('file4.txt');
+    });
+  });
+
+  describe('extendObject', () => {
+    it('adds a _displayName field, which is the basename', () => {
+      expect(extendObject(object2, '')).toHaveProperty(
+        '_displayName',
+        'file2.txt'
+      );
+    });
+    it('adds an _isFolder field, which is `true` if the object can be considered a folder', () => {
+      expect(extendObject(folder, '')).toHaveProperty('_isFolder', true);
+      expect(extendObject(object2, '')).toHaveProperty('_isFolder', false);
+    });
+    it("adds an _shouldDisplayObject field, which should be `true` if the object doesn't equal the prefix", () => {
+      expect(extendObject(object3, '')).toHaveProperty(
+        '_shouldDisplayObject',
+        true
+      );
+      expect(extendObject(object3, 'my-folder/')).toHaveProperty(
+        '_shouldDisplayObject',
+        false
+      );
+    });
+  });
+});
+
+extendObject(object1, 'hello');

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -1,4 +1,4 @@
-import { OBJECT_STORAGE_ROOT } from 'src/constants';
+import { OBJECT_STORAGE_DELIMITER, OBJECT_STORAGE_ROOT } from 'src/constants';
 
 export const generateObjectUrl = (
   clusterId: Linode.ClusterID,
@@ -23,7 +23,10 @@ export const isFolder = (object: Linode.Object) =>
  * @example
  * basename('my-path/folder/test.txt') // test.txt
  */
-export const basename = (path: string, delimiter = '/'): string => {
+export const basename = (
+  path: string,
+  delimiter = OBJECT_STORAGE_DELIMITER
+): string => {
   const idx = path.lastIndexOf(delimiter);
 
   // If the delimiter is not found in the string, there's nothing to do.

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -11,3 +11,39 @@ export const generateObjectUrl = (
     absolute: 'https://' + path
   };
 };
+
+// If an Object does not have an etag, last_modified, owner, or size, it can
+// be considered a "folder".
+export const isFolder = (object: Linode.Object) =>
+  !object.etag && !object.last_modified && !object.owner && !object.size;
+
+export const isCurrentDirectory = (object: Linode.Object, prefix: string) => {
+  return prefix.endsWith('/') && object.name === prefix;
+};
+
+/**
+ * Returns the basename of the given path
+ *
+ * @example
+ * basename('my-path/folder/test.txt') // test.txt
+ */
+export const basename = (path: string, delimiter = '/') => {
+  return path.substr(path.lastIndexOf(delimiter) + 1);
+};
+
+export const formatFolderName = (folderName: string, delimiter = '/') => {
+  return basename(folderName.substr(0, folderName.length - 1));
+};
+
+export interface ExtendedObject extends Linode.Object {
+  displayName: string;
+}
+
+export const extendObject = (object: Linode.Object): ExtendedObject => {
+  return {
+    ...object,
+    displayName: isFolder(object)
+      ? formatFolderName(object.name)
+      : basename(object.name)
+  };
+};

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -17,12 +17,8 @@ export const generateObjectUrl = (
 export const isFolder = (object: Linode.Object) =>
   !object.etag && !object.last_modified && !object.owner && !object.size;
 
-export const isCurrentDirectory = (object: Linode.Object, prefix: string) => {
-  return prefix.endsWith('/') && object.name === prefix;
-};
-
 /**
- * Returns the basename of the given path
+ * Returns the basename of the given path.
  *
  * @example
  * basename('my-path/folder/test.txt') // test.txt

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -38,24 +38,11 @@ export const basename = (path: string, delimiter = '/'): string => {
   return path.substr(idx + 1);
 };
 
-export const formatFolderName = (folderName: string, delimiter = '/') => {
-  return basename(folderName.substr(0, folderName.length - 1));
-};
-
 export interface ExtendedObject extends Linode.Object {
   _isFolder: boolean;
   _displayName: string;
   _shouldDisplayObject: boolean;
 }
-
-/**
- * There are 3 conceptual types of objects:
- *
- * 1. Plain, objects (thinK: files).
- * 2. "Folders", which are really just objects whose name ends with a slash.
- * 3.
- *
- */
 
 export const extendObject = (
   object: Linode.Object,

--- a/packages/manager/src/services/objectStorage/buckets.ts
+++ b/packages/manager/src/services/objectStorage/buckets.ts
@@ -70,20 +70,23 @@ export const deleteBucket = ({
     setMethod('DELETE')
   );
 
+export interface ObjectListParams {
+  delimiter?: string;
+  marker?: string;
+  prefix?: string;
+}
 /**
  * Returns a list of Objects in a given Bucket.
  */
-export const getBucketObjects = (
+export const getObjectList = (
   clusterId: string,
   bucketName: string,
-  params?: any,
-  filters?: any
+  params?: ObjectListParams
 ) =>
-  Request<Page<Linode.Object>>(
+  Request<{ data: Linode.Object[] }>(
     setMethod('GET'),
     setParams(params),
-    setXFilter(filters),
     setURL(
-      `${BETA_API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/objects`
+      `${BETA_API_ROOT}/object-storage/buckets/${clusterId}/${bucketName}/object-list`
     )
   ).then(response => response.data);

--- a/packages/manager/src/services/objectStorage/buckets.ts
+++ b/packages/manager/src/services/objectStorage/buckets.ts
@@ -74,6 +74,7 @@ export interface ObjectListParams {
   delimiter?: string;
   marker?: string;
   prefix?: string;
+  page_size?: number;
 }
 /**
  * Returns a list of Objects in a given Bucket.

--- a/packages/manager/src/types/ObjectStorage.ts
+++ b/packages/manager/src/types/ObjectStorage.ts
@@ -25,10 +25,10 @@ namespace Linode {
   }
 
   export interface Object {
-    size: number; // Size of object in bytes
-    owner: string;
-    etag: string;
-    last_modified: string; // Date
+    size: number | null; // Size of object in bytes
+    owner: string | null;
+    etag: string | null;
+    last_modified: string | null; // Date
     name: string;
   }
 

--- a/packages/manager/src/types/ObjectStorage.ts
+++ b/packages/manager/src/types/ObjectStorage.ts
@@ -33,5 +33,5 @@ namespace Linode {
   }
 
   // Enum containing IDs for each Cluster
-  export type ClusterID = 'us-east-1';
+  export type ClusterID = 'us-east-1' | 'alpha';
 }

--- a/packages/manager/src/types/ObjectStorage.ts
+++ b/packages/manager/src/types/ObjectStorage.ts
@@ -33,5 +33,5 @@ namespace Linode {
   }
 
   // Enum containing IDs for each Cluster
-  export type ClusterID = 'us-east-1' | 'alpha';
+  export type ClusterID = 'us-east-1';
 }


### PR DESCRIPTION
## Description

This still has a little way to go, but I thought it'd be wise to go ahead and get some feedback. Requested changes can go in this PR or another (since this is going to a feature branch).

This PR contains the basic mechanisms for "folder traversal" of a Object Storage bucket. 

## How this works

There are three mechanisms used for folder traversal: **prefix**, **delimiter**, and **marker**.

### Prefix

In reality, a bucket is only capable of holding flat objects. For organization, objects can grouped together using a common prefix:

`my-folder/file1.txt`
`my-folder/file2.txt`

In this example, it would be appropriate to display these two objects as belonging to a folder called `my-folder`.

We can specify a `prefix` when hitting the `/object-list` endpoint. This ensures that all objects returned BEGIN with the provided prefix.

### Delimiter

The delimiter lets you limit results to one hierarchal level. Consider the following objects:

`file1.txt`
`my-folder/file2.txt`

If we only want to see objects at the "top level", we can specify a delimiter of `"/"`. This will return `file1.txt` only.

### Marker

We use a `marker` to get paginated results. **Results are not paginated with our usual pattern.** It is not possible to get a _specific_ page of objects. We must pass a `marker` (the name of object) to `/object-list`, and it will give us a page of objects _following_ the marker.

As an example, assume the following objects in a bucket: 

`file1.txt`
... (1-99)
`file100.txt`
`file101.txt`

We make a request to get the first 100 objects. We then pass make another request to `/object-list` with a marker of `file100.txt`. We'll get back `file101.txt`.

**Because of the way this mechanism works, objects are displayed in an infinite scroll.**

## Notes

Things missing from this PR:

1) Styling (ignore icons, etc.)
2) Finalized copy for empty states, error states, etc. 
3) Virtualization. Eventually I'd like to use something like React Window so that if things are still smooth if a user is scrolling through thousands of objects. (This is unlikely, as we only fetch 100 at a time).

~**NOTE: You must use dev. Use dev account 6, bucket named `jc3`.**~

^ This is no longer necessary, though I'd still recommend it since that bucket is in a state with lots of scenarios.
