### PR TITLE
Fix: Send undefined rather than empty string when creating a Linode withou…

### DIFF
--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -36,7 +36,7 @@ interface Props {
   selectedImageID?: string;
   images: Image[];
   error?: string;
-  variant?: Variant; // @todo no one uses "all", either use or remove
+  variant?: Variant;
   disabled?: boolean;
   handleSelectImage: (selection?: string) => void;
   classNames?: string;
@@ -140,7 +140,7 @@ export const ImageSelect: React.FC<Props> = props => {
 
   const onChange = (selection: ImageItem | null) => {
     if (selection === null) {
-      return handleSelectImage('');
+      return handleSelectImage(undefined);
     }
 
     return handleSelectImage(selection.value);


### PR DESCRIPTION
Fix: Send undefined rather than empty string when creating a Linode without an image.

## Notes

Try to clear the image select and submit the form. It should work without error and create an empty Linode.

One new oddity is that you can go to My Images and do the same thing, which...sort of makes sense but might not be what we want.