### PR TITLE
update Managed placeholder/confirmation text to match Classic

### DIFF
--- a/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
+++ b/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
@@ -74,7 +74,7 @@ const ManagedPlaceholder: React.FC<CombinedProps> = props => {
         title="Linode Managed"
         copy={`Let us worry about your infrastructure, so you can get back to worrying about your business. 
            Linode Managed helps keep your systems up and running with our team of Linode experts responding to monitoring events, so you can sleep well.
-           Linode Managed includes 24/7 monitoring and incident responses, backups and Longview Pro. +$100/month per Linode.`}
+           Linode Managed includes 24/7 monitoring and incident responses, backups, and Longview Pro. +$100/month per Linode.`}
         buttonProps={[
           {
             onClick: () => setOpen(true),

--- a/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
+++ b/packages/manager/src/features/Managed/EnableManagedPlaceholder.tsx
@@ -72,9 +72,9 @@ const ManagedPlaceholder: React.FC<CombinedProps> = props => {
       <Placeholder
         icon={ManagedIcon}
         title="Linode Managed"
-        copy={
-          'Experience true peace of mind and let the experts at Linode manage your servers.'
-        }
+        copy={`Let us worry about your infrastructure, so you can get back to worrying about your business. 
+           Linode Managed helps keep your systems up and running with our team of Linode experts responding to monitoring events, so you can sleep well.
+           Linode Managed includes 24/7 monitoring and incident responses, backups and Longview Pro. +$100/month per Linode.`}
         buttonProps={[
           {
             onClick: () => setOpen(true),
@@ -101,12 +101,12 @@ const ManagedPlaceholder: React.FC<CombinedProps> = props => {
         actions={actions}
       >
         <Typography>
-          Linode Managed is billed at{' '}
+          Linode Managed costs an additional{' '}
           <strong>$100 per month per Linode.</strong> {` `}
           You currently have{` `}
           <strong>{pluralize('Linode', 'Linodes', props.linodeCount)}</strong>,
-          so Managed will cost{' '}
-          <strong>${`${props.linodeCount * 100}/month`}</strong>.
+          so Managed will increase your projected monthly bill by{' '}
+          <strong>${`${props.linodeCount * 100}`}</strong>.
         </Typography>
       </ConfirmationDialog>
     </>


### PR DESCRIPTION
## Description

As per review feedback, change Managed placeholder text to exactly match Classic. There may be a further update from Marketing at some point, but for now it's always safe to stick with Classic.
