### PR TITLE
M3-692 Add: Redux boilerplate for Managed issues & issue drawer

### DIFF
--- a/packages/manager/src/containers/managedIssues.container.ts
+++ b/packages/manager/src/containers/managedIssues.container.ts
@@ -23,7 +23,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
 });
 
 export default <TInner extends {}, TOuter extends {}>(
-  mapManagedIssuesToProps: (
+  mapManagedIssuesToProps?: (
     ownProps: TOuter,
     issuesLoading: boolean,
     lastUpdated: number,
@@ -38,13 +38,17 @@ export default <TInner extends {}, TOuter extends {}>(
       const issuesError = state.__resources.managedIssues.error;
       const lastUpdated = state.__resources.managedIssues.lastUpdated;
 
-      return mapManagedIssuesToProps(
-        ownProps,
-        issuesLoading,
-        lastUpdated,
-        issues,
-        issuesError
-      );
+      if (mapManagedIssuesToProps) {
+        return mapManagedIssuesToProps(
+          ownProps,
+          issuesLoading,
+          lastUpdated,
+          issues,
+          issuesError
+        );
+      }
+
+      return { ...ownProps, issuesLoading, lastUpdated, issues, issuesError };
     },
     mapDispatchToProps
   );

--- a/packages/manager/src/containers/managedIssues.container.ts
+++ b/packages/manager/src/containers/managedIssues.container.ts
@@ -1,0 +1,50 @@
+import { connect, MapDispatchToProps } from 'react-redux';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { ApplicationState } from 'src/store';
+import { requestManagedIssues as _requestManagedIssues } from 'src/store/managed/issues.requests';
+import { EntityError } from 'src/store/types';
+
+export interface ManagedIssuesProps {
+  issues: Linode.ManagedIssue[];
+  issuesLoading: boolean;
+  issuesError: EntityError;
+  lastUpdated: number;
+}
+
+export interface DispatchProps {
+  requestManagedIssues: () => Promise<any>;
+}
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
+  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
+) => ({
+  requestManagedIssues: () => dispatch(_requestManagedIssues())
+});
+
+export default <TInner extends {}, TOuter extends {}>(
+  mapManagedIssuesToProps: (
+    ownProps: TOuter,
+    issuesLoading: boolean,
+    lastUpdated: number,
+    issues: Linode.ManagedIssue[],
+    issuesError?: EntityError
+  ) => TInner
+) =>
+  connect(
+    (state: ApplicationState, ownProps: TOuter) => {
+      const issues = state.__resources.managedIssues.entities;
+      const issuesLoading = state.__resources.managedIssues.loading;
+      const issuesError = state.__resources.managedIssues.error;
+      const lastUpdated = state.__resources.managedIssues.lastUpdated;
+
+      return mapManagedIssuesToProps(
+        ownProps,
+        issuesLoading,
+        lastUpdated,
+        issues,
+        issuesError
+      );
+    },
+    mapDispatchToProps
+  );

--- a/packages/manager/src/containers/managedServices.container.ts
+++ b/packages/manager/src/containers/managedServices.container.ts
@@ -42,11 +42,12 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
     dispatch(_deleteServiceMonitor({ monitorID })),
   enableServiceMonitor: (monitorID: number) =>
     dispatch(_enableServiceMonitor({ monitorID })),
-  updateServiceMonitor: (params: UpdateServicePayload) => dispatch(_updateServiceMonitor(params))
+  updateServiceMonitor: (params: UpdateServicePayload) =>
+    dispatch(_updateServiceMonitor(params))
 });
 
 export default <TInner extends {}, TOuter extends {}>(
-  mapManagedServicesToProps: (
+  mapManagedServicesToProps?: (
     ownProps: TOuter,
     managedLoading: boolean,
     lastUpdated: number,
@@ -61,13 +62,23 @@ export default <TInner extends {}, TOuter extends {}>(
       const managedError = state.__resources.managed.error;
       const lastUpdated = state.__resources.managed.lastUpdated;
 
-      return mapManagedServicesToProps(
-        ownProps,
-        managedLoading,
-        lastUpdated,
+      if (mapManagedServicesToProps) {
+        return mapManagedServicesToProps(
+          ownProps,
+          managedLoading,
+          lastUpdated,
+          monitors,
+          managedError
+        );
+      }
+
+      return {
+        ...ownProps,
         monitors,
-        managedError
-      );
+        managedLoading,
+        managedError,
+        lastUpdated
+      };
     },
     mapDispatchToProps
   );

--- a/packages/manager/src/features/Managed/Monitors/HistoryDrawer.tsx
+++ b/packages/manager/src/features/Managed/Monitors/HistoryDrawer.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import Drawer from 'src/components/Drawer';
+
+interface Props {
+  open: boolean;
+  error?: Linode.ApiFieldError[];
+  loading: boolean;
+  monitorLabel: string;
+  issues: any[];
+  onClose: () => void;
+}
+
+export const HistoryDrawer: React.FC<Props> = props => {
+  const { error, issues, loading, monitorLabel, onClose, open } = props;
+  return (
+    <Drawer
+      title={`Issue History: ${monitorLabel}`}
+      open={open}
+      onClose={onClose}
+    >
+      {renderDrawerContent(issues, loading, error)}
+    </Drawer>
+  );
+};
+
+const renderDrawerContent = (
+  issues: Linode.ManagedIssue[],
+  loading: boolean,
+  error?: Linode.ApiFieldError[]
+) => {
+  if (loading) {
+    return <div>Loading!</div>;
+  }
+
+  if (error) {
+    return <div>Error!</div>;
+  }
+
+  if (issues.length === 0) {
+    return <div>Empty</div>;
+  }
+
+  return issues.map((i, idx) => <div key={idx}>{i.id}</div>);
+};
+
+export default HistoryDrawer;

--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.test.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.test.tsx
@@ -17,7 +17,8 @@ const props: CombinedProps = {
   label: 'this-monitor',
   openDialog: jest.fn(),
   monitorID: 1,
-  openDrawer: jest.fn(),
+  openMonitorDrawer: jest.fn(),
+  openHistoryDrawer: jest.fn(),
   updateServiceMonitor: jest.fn(),
   createServiceMonitor: jest.fn(),
   requestManagedServices: jest.fn(),
@@ -34,7 +35,7 @@ describe('Volume action menu', () => {
     const { queryByText } = render(
       wrapWithTheme(<ActionMenu {...props} status={'disabled'} />)
     );
-    includesActions(['Delete'], queryByText);
+    includesActions(['Edit', 'View Issue History', 'Delete'], queryByText);
   });
 
   it('should include Enable if the monitor is disabled', () => {

--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
@@ -13,7 +13,8 @@ interface Props {
   status: Linode.MonitorStatus;
   label: string;
   openDialog: (id: number, label: string) => void;
-  openDrawer: (id: number, mode: string) => void;
+  openMonitorDrawer: (id: number, mode: string) => void;
+  openHistoryDrawer: () => void;
 }
 
 export type CombinedProps = Props & DispatchProps & WithSnackbarProps;
@@ -27,7 +28,8 @@ export class MonitorActionMenu extends React.Component<CombinedProps, {}> {
       label,
       monitorID,
       openDialog,
-      openDrawer,
+      openHistoryDrawer,
+      openMonitorDrawer,
       status
     } = this.props;
 
@@ -70,12 +72,19 @@ export class MonitorActionMenu extends React.Component<CombinedProps, {}> {
               }
             },
         {
-          title: 'Edit',
+          title: 'View Issue History',
           onClick: () => {
-            openDrawer(monitorID, 'edit');
+            openHistoryDrawer();
             closeMenu();
           }
-        },    
+        },
+        {
+          title: 'Edit',
+          onClick: () => {
+            openMonitorDrawer(monitorID, 'edit');
+            closeMenu();
+          }
+        },
         {
           title: 'Delete',
           onClick: () => {

--- a/packages/manager/src/features/Managed/Monitors/MonitorRow.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorRow.tsx
@@ -45,13 +45,20 @@ const styles = (theme: Theme) =>
 interface Props {
   monitor: Linode.ManagedServiceMonitor;
   openDialog: (id: number, label: string) => void;
-  openDrawer: (id: number, mode: string) => void;
+  openMonitorDrawer: (id: number, mode: string) => void;
+  openHistoryDrawer: () => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 export const monitorRow: React.FunctionComponent<CombinedProps> = props => {
-  const { classes, monitor, openDialog, openDrawer } = props;
+  const {
+    classes,
+    monitor,
+    openDialog,
+    openHistoryDrawer,
+    openMonitorDrawer
+  } = props;
   const Icon = statusIconMap[monitor.status];
   return (
     <TableRow
@@ -89,7 +96,8 @@ export const monitorRow: React.FunctionComponent<CombinedProps> = props => {
           status={monitor.status}
           monitorID={monitor.id}
           openDialog={openDialog}
-          openDrawer={openDrawer}
+          openMonitorDrawer={openMonitorDrawer}
+          openHistoryDrawer={openHistoryDrawer}
           label={monitor.label}
         />
       </TableCell>

--- a/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
@@ -90,20 +90,26 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
     handleError
   } = useDialog<number>(deleteServiceMonitor);
 
-  const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
+  const [historyDrawerOpen, setHistoryDrawerOpen] = React.useState<boolean>(
+    false
+  );
+
+  const [monitorDrawerOpen, setMonitorDrawerOpen] = React.useState<boolean>(
+    false
+  );
   const [drawerMode, setDrawerMode] = React.useState<Modes>('create');
   const [editID, setEditID] = React.useState<number>(0);
 
   const handleDrawerClose = () => {
     setEditID(0);
     setDrawerMode('create');
-    setDrawerOpen(false);
+    setMonitorDrawerOpen(false);
   };
 
   const handleDrawerOpen = (id: number, mode: Modes) => {
     setEditID(id);
     setDrawerMode(mode);
-    setDrawerOpen(true);
+    setMonitorDrawerOpen(true);
   };
 
   const handleDelete = () => {
@@ -177,7 +183,7 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
           <Grid container alignItems="flex-end">
             <Grid item className="pt0">
               <AddNewLink
-                onClick={() => setDrawerOpen(true)}
+                onClick={() => setMonitorDrawerOpen(true)}
                 label="Add a Monitor"
               />
             </Grid>
@@ -237,7 +243,8 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
                         loading={loading}
                         error={error}
                         openDialog={openDialog}
-                        openDrawer={handleDrawerOpen}
+                        openMonitorDrawer={handleDrawerOpen}
+                        openHistoryDrawer={() => setHistoryDrawerOpen(true)}
                       />
                     </TableBody>
                   </Table>
@@ -264,7 +271,7 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
         loading={dialog.isLoading}
       />
       <MonitorDrawer
-        open={drawerOpen}
+        open={monitorDrawerOpen}
         onClose={handleDrawerClose}
         onSubmit={submitMonitorForm}
         mode={drawerMode}
@@ -273,8 +280,8 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
         credentials={credentials}
       />
       <HistoryDrawer
-        open={true}
-        onClose={() => null}
+        open={historyDrawerOpen}
+        onClose={() => setHistoryDrawerOpen(false)}
         monitorLabel="My-monitor"
         issues={issues}
         loading={issuesLoading && lastUpdated === 0}
@@ -287,16 +294,8 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
 const styled = withStyles(styles);
 const enhanced = compose<CombinedProps, Props>(
   styled,
-  withManagedIssues(
-    (ownProps, issuesLoading, lastUpdated, issues, issuesError) => ({
-      ...ownProps,
-      issuesLoading,
-      lastUpdated,
-      issues,
-      issuesError
-    })
-  ),
-  withManagedServices(() => ({})),
+  withManagedIssues(),
+  withManagedServices(),
   withSnackbar
 );
 export default enhanced(MonitorTable);

--- a/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
@@ -22,6 +22,9 @@ import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableSortCell from 'src/components/TableSortCell';
+import withManagedIssues, {
+  ManagedIssuesProps
+} from 'src/containers/managedIssues.container';
 import withManagedServices, {
   DispatchProps
 } from 'src/containers/managedServices.container';
@@ -34,6 +37,7 @@ import {
 } from 'src/utilities/formikErrorUtils';
 
 import MonitorDrawer from '../MonitorDrawer';
+import HistoryDrawer from './HistoryDrawer';
 import MonitorTableContent from './MonitorTableContent';
 
 type ClassNames = 'labelHeader';
@@ -59,6 +63,7 @@ export type FormikProps = FormikBag<CombinedProps, ManagedServicePayload>;
 export type CombinedProps = Props &
   WithStyles<ClassNames> &
   DispatchProps &
+  ManagedIssuesProps &
   WithSnackbarProps;
 
 export const MonitorTable: React.FC<CombinedProps> = props => {
@@ -70,7 +75,11 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
     loading,
     monitors,
     groups,
-    credentials
+    credentials,
+    issues,
+    issuesError,
+    issuesLoading,
+    lastUpdated
   } = props;
 
   const {
@@ -263,6 +272,14 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
         groups={groups}
         credentials={credentials}
       />
+      <HistoryDrawer
+        open={true}
+        onClose={() => null}
+        monitorLabel="My-monitor"
+        issues={issues}
+        loading={issuesLoading && lastUpdated === 0}
+        error={issuesError.read}
+      />
     </>
   );
 };
@@ -270,6 +287,15 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
 const styled = withStyles(styles);
 const enhanced = compose<CombinedProps, Props>(
   styled,
+  withManagedIssues(
+    (ownProps, issuesLoading, lastUpdated, issues, issuesError) => ({
+      ...ownProps,
+      issuesLoading,
+      lastUpdated,
+      issues,
+      issuesError
+    })
+  ),
   withManagedServices(() => ({})),
   withSnackbar
 );

--- a/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
@@ -9,14 +9,22 @@ interface Props {
   monitors: Linode.ManagedServiceMonitor[];
   loading: boolean;
   openDialog: (id: number, label: string) => void;
-  openDrawer: (id: number, mode: string) => void;
+  openHistoryDrawer: () => void;
+  openMonitorDrawer: (id: number, mode: string) => void;
   error?: Linode.ApiFieldError[];
 }
 
 export type CombinedProps = Props;
 
 export const MonitorTableContent: React.FC<CombinedProps> = props => {
-  const { error, loading, monitors, openDialog, openDrawer } = props;
+  const {
+    error,
+    loading,
+    monitors,
+    openDialog,
+    openHistoryDrawer,
+    openMonitorDrawer
+  } = props;
   if (loading) {
     return <TableRowLoading colSpan={12} />;
   }
@@ -41,7 +49,8 @@ export const MonitorTableContent: React.FC<CombinedProps> = props => {
           key={`service-monitor-row-${idx}`}
           monitor={monitor}
           openDialog={openDialog}
-          openDrawer={openDrawer}
+          openMonitorDrawer={openMonitorDrawer}
+          openHistoryDrawer={openHistoryDrawer}
         />
       ))}
     </>

--- a/packages/manager/src/features/Managed/Monitors/Monitors.tsx
+++ b/packages/manager/src/features/Managed/Monitors/Monitors.tsx
@@ -1,7 +1,9 @@
 import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
-
+import withManagedIssues, {
+  DispatchProps as IssuesDispatchProps
+} from 'src/containers/managedIssues.container';
 import withManagedServices, {
   DispatchProps,
   ManagedProps
@@ -15,7 +17,7 @@ interface Props {
   errorFromProps?: APIError[];
 }
 
-type CombinedProps = Props & ManagedProps & DispatchProps;
+type CombinedProps = Props & ManagedProps & DispatchProps & IssuesDispatchProps;
 
 export const Monitors: React.FC<CombinedProps> = props => {
   const {
@@ -27,10 +29,12 @@ export const Monitors: React.FC<CombinedProps> = props => {
     managedError,
     managedLoading,
     monitors,
+    requestManagedIssues,
     requestManagedServices
   } = props;
 
   React.useEffect(() => {
+    requestManagedIssues().catch(_ => null); // Errors handled in Redux state
     requestManagedServices().catch(_ => null); // Errors handled in Redux state
   }, [requestManagedServices]);
 
@@ -46,6 +50,7 @@ export const Monitors: React.FC<CombinedProps> = props => {
 };
 
 const enhanced = compose<CombinedProps, Props>(
+  withManagedIssues(() => ({})),
   withManagedServices(
     (ownProps, managedLoading, lastUpdated, monitors, managedError) => ({
       ...ownProps,

--- a/packages/manager/src/services/managed/managed.ts
+++ b/packages/manager/src/services/managed/managed.ts
@@ -298,3 +298,14 @@ export const deleteContact = (contactId: number) =>
     setMethod('DELETE'),
     setURL(`${API_ROOT}/managed/contacts/${contactId}`)
   ).then(response => response.data);
+
+/**
+ * getManagedIssues
+ *
+ * Returns a paginated list of Issues on a Managed customer's account.
+ */
+export const getManagedIssues = () =>
+  Request<Page<Linode.ManagedIssue>>(
+    setMethod('GET'),
+    setURL(`${API_ROOT}/managed/issues`)
+  ).then(response => response.data);

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -78,6 +78,10 @@ import types, {
   defaultState as defaultTypesState,
   State as TypesState
 } from 'src/store/linodeType/linodeType.reducer';
+import managedIssues, {
+  defaultState as defaultManagedIssuesState,
+  State as ManagedIssuesState
+} from 'src/store/managed/issues.reducer';
 import managed, {
   defaultState as defaultManagedState,
   State as ManagedState
@@ -147,6 +151,7 @@ const __resourcesDefaultState = {
   images: defaultImagesState,
   kubernetes: defaultKubernetesState,
   managed: defaultManagedState,
+  managedIssues: defaultManagedIssuesState,
   nodePools: defaultNodePoolsState,
   linodes: defaultLinodesState,
   linodeConfigs: defaultLinodeConfigsState,
@@ -169,6 +174,7 @@ export interface ResourcesState {
   images: ImagesState;
   kubernetes: KubernetesState;
   managed: ManagedState;
+  managedIssues: ManagedIssuesState;
   nodePools: KubeNodePoolsState;
   linodes: LinodesState;
   linodeConfigs: LinodeConfigsState;
@@ -230,6 +236,7 @@ const __resources = combineReducers({
   linodeConfigs,
   linodeDisks,
   managed,
+  managedIssues,
   nodeBalancers,
   nodeBalancerConfigs,
   notifications,

--- a/packages/manager/src/store/managed/issues.actions.ts
+++ b/packages/manager/src/store/managed/issues.actions.ts
@@ -1,0 +1,9 @@
+import actionCreatorFactory from 'typescript-fsa';
+
+export const actionCreator = actionCreatorFactory(`@@manager/managed`);
+
+export const requestManagedIssuesActions = actionCreator.async<
+  void,
+  Linode.ManagedIssue[],
+  Linode.ApiFieldError[]
+>('request-issues');

--- a/packages/manager/src/store/managed/issues.reducer.ts
+++ b/packages/manager/src/store/managed/issues.reducer.ts
@@ -1,0 +1,50 @@
+import produce from 'immer';
+import { Reducer } from 'redux';
+import { isType } from 'typescript-fsa';
+
+import { EntityError, EntityState } from 'src/store/types';
+import { requestManagedIssuesActions } from './issues.actions';
+
+/**
+ * State
+ */
+
+export type State = EntityState<Linode.ManagedIssue, EntityError>;
+
+export const defaultState: State = {
+  results: [],
+  entities: [],
+  loading: false,
+  lastUpdated: 0,
+  error: {}
+};
+
+/**
+ * Reducer
+ */
+const reducer: Reducer<State> = (state = defaultState, action) => {
+  return produce(state, draft => {
+    if (isType(action, requestManagedIssuesActions.started)) {
+      draft.loading = true;
+      draft.error!.read = undefined;
+    }
+
+    if (isType(action, requestManagedIssuesActions.done)) {
+      const { result } = action.payload;
+      draft.loading = false;
+      draft.entities = result;
+      draft.results = result.map(i => i.id);
+      draft.lastUpdated = Date.now();
+    }
+
+    if (isType(action, requestManagedIssuesActions.failed)) {
+      const { error } = action.payload;
+      draft.loading = false;
+      draft.error!.read = error;
+    }
+
+    return draft;
+  });
+};
+
+export default reducer;

--- a/packages/manager/src/store/managed/issues.requests.ts
+++ b/packages/manager/src/store/managed/issues.requests.ts
@@ -1,0 +1,12 @@
+import { getManagedIssues } from 'src/services/managed';
+import { getAll } from 'src/utilities/getAll';
+import { createRequestThunk } from '../store.helpers';
+import { requestManagedIssuesActions } from './issues.actions';
+
+const _getAllIssues = getAll(getManagedIssues);
+const getAllIssues = () => _getAllIssues().then(({ data }) => data);
+
+export const requestManagedIssues = createRequestThunk(
+  requestManagedIssuesActions,
+  getAllIssues
+);

--- a/packages/manager/src/store/managed/managed.requests.ts
+++ b/packages/manager/src/store/managed/managed.requests.ts
@@ -6,7 +6,7 @@ import {
   enableServiceMonitor as _enable,
   getServices,
   ManagedServicePayload,
-  updateServiceMonitor as _update,
+  updateServiceMonitor as _update
 } from 'src/services/managed';
 import { getAll } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
@@ -17,7 +17,7 @@ import {
   enableServiceMonitorActions,
   MonitorPayload,
   requestServicesActions,
-  updateServiceMonitorActions,
+  updateServiceMonitorActions
 } from './managed.actions';
 
 const _getAll = getAll(getServices);
@@ -25,7 +25,8 @@ const _getAll = getAll(getServices);
 const deleteService = (params: MonitorPayload) => _delete(params.monitorID);
 const disableService = (params: MonitorPayload) => _disable(params.monitorID);
 const enableService = (params: MonitorPayload) => _enable(params.monitorID);
-const updateService = (params: MonitorPayload & ManagedServicePayload) => _update(params.monitorID, omit(['monitorID'], params));
+const updateService = (params: MonitorPayload & ManagedServicePayload) =>
+  _update(params.monitorID, omit(['monitorID'], params));
 
 const getAllServices = () => _getAll().then(({ data }) => data);
 
@@ -47,7 +48,7 @@ export const createServiceMonitor = createRequestThunk(
 export const updateServiceMonitor = createRequestThunk(
   updateServiceMonitorActions,
   updateService
-)
+);
 
 export const deleteServiceMonitor = createRequestThunk(
   deleteServiceMonitorActions,

--- a/packages/manager/src/types/Managed.ts
+++ b/packages/manager/src/types/Managed.ts
@@ -8,7 +8,7 @@ namespace Linode {
     service_type: ServiceType;
     timeout: number;
     region: string | null;
-    credentials: ManagedCredential[]; // @todo
+    credentials: ManagedCredential[];
     address: string;
     body: string;
     notes: string;
@@ -54,5 +54,20 @@ namespace Linode {
 
   export interface ManagedSSHPubKey {
     ssh_key: string;
+  }
+
+  export interface ManagedIssue {
+    id: number;
+    services: number[];
+    created: string;
+    entity: any;
+  }
+
+  // This is much like a support ticket but it's a special case so here's a special type:
+  export interface IssueEntity {
+    id: number;
+    label: string;
+    type: 'ticket'; // I don't make the rules I'm just describing them
+    url: string;
   }
 }


### PR DESCRIPTION
## Description

Add services method, actions, requests, and reducer for Managed issues. Chose to use Redux for these because:

- It looks like they will be a major part of our upcoming Managed dashboard widget
- There will be some logic for iterating over the list of issues and fetching the corresponding support ticket for each to determine its status. Best to put this in one place.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

There is a dummy drawer at /managed/monitors that is always open and will display the ids of returned issues. (prod-test-004 has a single issue available).