### PR TITLE
M3-3174 Implement over limit quota visuals on Linode detail summary and dashboard

### DIFF
--- a/packages/manager/src/components/BarPercent/BarPercent.test.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent.test.tsx
@@ -8,7 +8,8 @@ const componentLoading = shallow(
       root: '',
       primaryColor: '',
       loadingText: '',
-      rounded: ''
+      rounded: '',
+      overLimit: ''
     }}
     value={20}
     max={100}

--- a/packages/manager/src/components/BarPercent/BarPercent.tsx
+++ b/packages/manager/src/components/BarPercent/BarPercent.tsx
@@ -9,7 +9,12 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 
-type ClassNames = 'root' | 'primaryColor' | 'loadingText' | 'rounded';
+type ClassNames =
+  | 'root'
+  | 'primaryColor'
+  | 'overLimit'
+  | 'loadingText'
+  | 'rounded';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -19,6 +24,11 @@ const styles = (theme: Theme) =>
     },
     primaryColor: {
       backgroundColor: theme.color.green
+    },
+    overLimit: {
+      '& > div': {
+        backgroundColor: theme.palette.status.warningDark
+      }
     },
     rounded: {
       borderRadius: theme.shape.borderRadius
@@ -36,6 +46,7 @@ interface Props {
   loadingText?: string;
   className?: string;
   rounded?: boolean;
+  overLimit?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -49,7 +60,8 @@ export class BarPercent extends React.PureComponent<CombinedProps, {}> {
       max,
       isFetchingValue,
       loadingText,
-      rounded
+      rounded,
+      overLimit
     } = this.props;
     return (
       <div className={className}>
@@ -66,7 +78,8 @@ export class BarPercent extends React.PureComponent<CombinedProps, {}> {
             barColorPrimary: classes.primaryColor
           }}
           className={classNames({
-            [classes.rounded]: rounded
+            [classes.rounded]: rounded,
+            [classes.overLimit]: overLimit
           })}
         />
       </div>

--- a/packages/manager/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -127,7 +127,7 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
                 </Grid>
                 <Grid item>
                   <Typography>
-                    {quota > used ? (
+                    {quota >= used ? (
                       <span>{quota - used} GB Available</span>
                     ) : (
                       <span className={classes.overLimit}>

--- a/packages/manager/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -19,7 +19,8 @@ export type ClassNames =
   | 'grid'
   | 'poolUsageProgress'
   | 'initialLoader'
-  | 'title';
+  | 'title'
+  | 'overLimit';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -48,6 +49,10 @@ const styles = (theme: Theme) =>
     },
     title: {
       paddingBottom: theme.spacing(2)
+    },
+    overLimit: {
+      color: theme.palette.status.warningDark,
+      fontFamily: theme.font.bold
     }
   });
 
@@ -79,7 +84,7 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { errors, loading, used, quota } = this.state;
+    const { errors, loading, quota, used } = this.state;
     const { classes } = this.props;
 
     if (loading) {
@@ -95,7 +100,7 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
       return null;
     }
 
-    const poolUsagePct = (used / quota) * 100;
+    const poolUsagePct = used < quota ? (used / quota) * 100 : 100;
 
     return (
       <DashboardCard className={classes.card}>
@@ -114,13 +119,23 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
                 value={Math.ceil(poolUsagePct)}
                 className={classes.poolUsageProgress}
                 rounded
+                overLimit={quota < used}
               />
               <Grid container justify="space-between">
                 <Grid item style={{ marginRight: 10 }}>
                   <Typography>{used} GB Used</Typography>
                 </Grid>
                 <Grid item>
-                  <Typography>{quota - used} GB Available</Typography>
+                  <Typography>
+                    {quota > used ? (
+                      <span>{quota - used} GB Available</span>
+                    ) : (
+                      <span className={classes.overLimit}>
+                        {(quota - used).toString().replace(/\-/, '')} GB Over
+                        Quota
+                      </span>
+                    )}
+                  </Typography>
                 </Grid>
               </Grid>
             </Grid>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivitySummary.tsx
@@ -27,7 +27,8 @@ const styles = (theme: Theme) =>
   createStyles({
     root: {},
     header: {
-      marginBottom: theme.spacing(2)
+      marginTop: theme.spacing(3),
+      marginBottom: theme.spacing(1)
     },
     viewMore: {
       position: 'relative',

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
@@ -60,18 +60,20 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
 
     const usedInGb = used / 1024 / 1024 / 1024;
 
-    const usagePercent = 100 - ((total - usedInGb) * 100) / total;
+    const totalInBytes = total * 1024 * 1024 * 1024;
+
+    const usagePercent =
+      totalInBytes > used ? 100 - ((total - usedInGb) * 100) / total : 100;
 
     const readableUsed = readableBytes(used, {
       maxUnit: 'GB',
       round: { MB: 0, GB: 1 }
     });
 
-    const totalInBytes = total * 1024 * 1024 * 1024;
     const readableFree = readableBytes(totalInBytes - used, {
       maxUnit: 'GB',
       round: { MB: 0, GB: 1 },
-      handleNegatives: false
+      handleNegatives: true
     });
 
     if (loading) {
@@ -126,6 +128,7 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
             value={Math.ceil(usagePercent)}
             className={classes.poolUsageProgress}
             rounded
+            overLimit={totalInBytes < used}
           />
           <Grid container justify="space-between">
             <Grid item style={{ marginRight: 10 }}>
@@ -134,7 +137,16 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
               </Typography>
             </Grid>
             <Grid item>
-              <Typography>{readableFree.formatted} Available</Typography>
+              <Typography>
+                {totalInBytes > used ? (
+                  <span>{readableFree.formatted} Available</span>
+                ) : (
+                  <span className={classes.overLimit}>
+                    {readableFree.formatted.toString().replace(/\-/, '')} Over
+                    Quota
+                  </span>
+                )}
+              </Typography>
             </Grid>
           </Grid>
         </Grid>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeNetSummary.tsx
@@ -138,7 +138,7 @@ class LinodeNetSummary extends React.Component<CombinedProps, StateProps> {
             </Grid>
             <Grid item>
               <Typography>
-                {totalInBytes > used ? (
+                {totalInBytes >= used ? (
                   <span>{readableFree.formatted} Available</span>
                 ) : (
                   <span className={classes.overLimit}>


### PR DESCRIPTION
##  Implement over limit quota visuals on Linode detail summary and dashboard

<img width="1810" alt="Screen Shot 2019-08-14 at 9 31 01 AM" src="https://user-images.githubusercontent.com/205353/64567736-e6729e00-d326-11e9-846c-8f7283207257.png">

## Type of Change
- Non breaking change ('update', 'change')