### PR TITLE
Fix: Security warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "devDependencies": {
     "husky": "^3.0.1",
-    "lerna": "^3.10.2"
+    "lerna": "^3.16.4"
   },
   "husky": {
     "hooks": {

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -216,7 +216,6 @@
     "inquirer": "^6.2.0",
     "jest": "^24.8.0",
     "jest-junit": "^7.0.0",
-    "lerna": "^3.4.3",
     "lint-staged": "^8.1.0",
     "madge": "^3.4.3",
     "mini-css-extract-plugin": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2808,7 +2808,7 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
-lerna@^3.10.2:
+lerna@^3.16.4:
   version "3.16.4"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-3.16.4.tgz#158cb4f478b680f46f871d5891f531f3a2cb31ec"
   integrity sha512-0HfwXIkqe72lBLZcNO9NMRfylh5Ng1l8tETgYQ260ZdHRbPuaLKE3Wqnd2YYRRkWfwPyEyZO8mZweBR+slVe1A==


### PR DESCRIPTION
## Description

Bump lerna version to resolve security vulnerability in handlebars

tbh I may have caused these vulnerabilities yesterday during release (I ran `yarn` a few times from my release clone), but in any case updating lerna seems like it took care of all 3 warnings. Will have to check after it's merged.
