### PR TITLE
TDT: redux refactors

### DIFF
--- a/packages/manager/src/store/regions/regions.actions.ts
+++ b/packages/manager/src/store/regions/regions.actions.ts
@@ -1,6 +1,6 @@
 import { getRegions, Region } from 'linode-js-sdk/lib/regions';
 import { actionCreatorFactory } from 'typescript-fsa';
-import { ThunkActionCreator } from '../types';
+import { createRequestThunk } from '../store.helpers';
 
 const actionCreator = actionCreatorFactory(`@@manager/regions`);
 
@@ -10,22 +10,6 @@ export const regionsRequestActions = actionCreator.async<
   Linode.ApiFieldError[]
 >(`request`);
 
-export const requestRegions: ThunkActionCreator<
-  Promise<Region[]>
-> = () => dispatch => {
-  dispatch(regionsRequestActions.started());
-
-  return getRegions()
-    .then(({ data }) => {
-      dispatch(
-        regionsRequestActions.done({
-          result: data
-        })
-      );
-      return data;
-    })
-    .catch(error => {
-      dispatch(regionsRequestActions.failed({ error }));
-      return error;
-    });
-};
+export const requestRegions = createRequestThunk(regionsRequestActions, () =>
+  getRegions().then(response => response.data)
+);

--- a/packages/manager/src/store/regions/regions.reducer.test.ts
+++ b/packages/manager/src/store/regions/regions.reducer.test.ts
@@ -1,0 +1,31 @@
+import { regions } from 'src/__data__/regionsData';
+import { regionsRequestActions } from './regions.actions';
+import reducer, { defaultState } from './regions.reducer';
+
+const mockError = [{ reason: 'No reason' }];
+
+describe('Images reducer', () => {
+  it('should handle an initialized request correctly', () => {
+    const newState = reducer(defaultState, regionsRequestActions.started);
+    expect(newState.loading).toBe(true);
+  });
+
+  it('should handle a successful request', () => {
+    const newState = reducer(
+      { ...defaultState, loading: true },
+      regionsRequestActions.done({ result: regions })
+    );
+    expect(newState.entities).toEqual(regions);
+    expect(newState.results).toHaveLength(regions.length);
+    expect(newState.loading).toBe(false);
+  });
+
+  it('should handle a failed request', () => {
+    const newState = reducer(
+      { ...defaultState, loading: true },
+      regionsRequestActions.failed({ error: mockError })
+    );
+    expect(newState.loading).toBe(false);
+    expect(newState.error).toEqual(mockError);
+  });
+});

--- a/packages/manager/src/store/regions/regions.reducer.test.ts
+++ b/packages/manager/src/store/regions/regions.reducer.test.ts
@@ -4,7 +4,7 @@ import reducer, { defaultState } from './regions.reducer';
 
 const mockError = [{ reason: 'No reason' }];
 
-describe('Images reducer', () => {
+describe('Regions reducer', () => {
   it('should handle an initialized request correctly', () => {
     const newState = reducer(defaultState, regionsRequestActions.started);
     expect(newState.loading).toBe(true);

--- a/packages/manager/src/store/regions/regions.reducer.ts
+++ b/packages/manager/src/store/regions/regions.reducer.ts
@@ -1,3 +1,4 @@
+import produce from 'immer';
 import { Region } from 'linode-js-sdk/lib/regions';
 import { Reducer } from 'redux';
 import { EntityState } from 'src/store/types';
@@ -25,23 +26,23 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     if (isType(action, regionsRequestActions.started)) {
       draft.loading = true;
     }
-  
+
     if (isType(action, regionsRequestActions.done)) {
       const { result } = action.payload;
-  
+
       draft.loading = false;
       draft.lastUpdated = Date.now();
       draft.entities = result;
       draft.results = result.map(r => r.id);
     }
-  
+
     if (isType(action, regionsRequestActions.failed)) {
       const { error } = action.payload;
-  
+
       draft.loading = false;
       draft.error = error;
     }
-  })
+  });
 };
 
 export default reducer;

--- a/packages/manager/src/store/regions/regions.reducer.ts
+++ b/packages/manager/src/store/regions/regions.reducer.ts
@@ -21,36 +21,27 @@ export const defaultState: State = {
  * Reducer
  */
 const reducer: Reducer<State> = (state = defaultState, action) => {
-  if (isType(action, regionsRequestActions.started)) {
-    return {
-      ...state,
-      loading: true
-    };
-  }
-
-  if (isType(action, regionsRequestActions.done)) {
-    const { result } = action.payload;
-
-    return {
-      ...state,
-      loading: false,
-      lastUpdated: Date.now(),
-      entities: result,
-      results: result.map(r => r.id)
-    };
-  }
-
-  if (isType(action, regionsRequestActions.failed)) {
-    const { error } = action.payload;
-
-    return {
-      ...state,
-      loading: false,
-      error
-    };
-  }
-
-  return state;
+  return produce(state, draft => {
+    if (isType(action, regionsRequestActions.started)) {
+      draft.loading = true;
+    }
+  
+    if (isType(action, regionsRequestActions.done)) {
+      const { result } = action.payload;
+  
+      draft.loading = false;
+      draft.lastUpdated = Date.now();
+      draft.entities = result;
+      draft.results = result.map(r => r.id);
+    }
+  
+    if (isType(action, regionsRequestActions.failed)) {
+      const { error } = action.payload;
+  
+      draft.loading = false;
+      draft.error = error;
+    }
+  })
 };
 
 export default reducer;


### PR DESCRIPTION
## Description

Trying to unify our Redux patterns, so they're less confusing for new devs.

At the same time trying to keep these PRs relatively small, so this only updates:

- regions
- images

## Notes

There's a discussion to be had about whether to enforce EntityError state for all Redux entities (for consistency and so you don't have to look up what an entity's error state will look like). OTOH, since we don't update, create, or delete regions through redux, it's kind of wasteful.