### PR TITLE
Add: App-Blocking Activation Landing Page

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -51,7 +51,6 @@
     "postinstall-postinstall": "^2.0.0",
     "pretty-bytes": "^5.1.0",
     "promise": "8.0.1",
-    "promise.prototype.finally": "^3.1.0",
     "qrcode.react": "^0.8.0",
     "qs": "^6.6.0",
     "ramda": "^0.25.0",

--- a/packages/manager/src/App.test.tsx
+++ b/packages/manager/src/App.test.tsx
@@ -34,9 +34,7 @@ it('renders without crashing.', () => {
               appFrame: '',
               content: '',
               hidden: '',
-              wrapper: '',
-              grid: '',
-              switchWrapper: ''
+              wrapper: ''
             }}
             userId={123456}
             addNotificationsToLinodes={jest.fn()}

--- a/packages/manager/src/App.test.tsx
+++ b/packages/manager/src/App.test.tsx
@@ -30,12 +30,6 @@ it('renders without crashing.', () => {
               search: '',
               state: {}
             }}
-            classes={{
-              appFrame: '',
-              content: '',
-              hidden: '',
-              wrapper: ''
-            }}
             userId={123456}
             addNotificationsToLinodes={jest.fn()}
             documentation={[]}

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -58,13 +58,7 @@ import MainContent from './MainContent';
 
 shim(); // allows for .finally() usage
 
-type ClassNames =
-  | 'hidden'
-  | 'appFrame'
-  | 'content'
-  | 'wrapper'
-  | 'grid'
-  | 'switchWrapper';
+type ClassNames = 'hidden' | 'appFrame' | 'wrapper' | 'content';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -75,6 +69,15 @@ const styles = (theme: Theme) =>
       flexDirection: 'column',
       backgroundColor: theme.bg.main,
       zIndex: 1
+    },
+    wrapper: {
+      padding: theme.spacing(3),
+      transition: theme.transitions.create('opacity'),
+      [theme.breakpoints.down('sm')]: {
+        paddingTop: theme.spacing(2),
+        paddingLeft: theme.spacing(2),
+        paddingRight: theme.spacing(2)
+      }
     },
     content: {
       flex: 1,
@@ -357,11 +360,15 @@ export class App extends React.Component<CombinedProps, State> {
                 isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
                 username={this.props.username}
               />
-              <MainContent
-                accountCapabilities={accountCapabilities}
-                accountError={accountError}
-                accountLoading={accountLoading}
-              />
+              <div className={classes.wrapper} id="main-content">
+                <MainContent
+                  accountCapabilities={accountCapabilities}
+                  accountError={accountError}
+                  accountLoading={accountLoading}
+                  history={this.props.history}
+                  location={this.props.location}
+                />
+              </div>
             </main>
             <Footer />
             <WelcomeBanner

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -1,4 +1,3 @@
-import * as classnames from 'classnames';
 import {
   Account,
   AccountCapability,
@@ -8,7 +7,6 @@ import { Image } from 'linode-js-sdk/lib/images';
 import { Linode } from 'linode-js-sdk/lib/linodes';
 import { Region } from 'linode-js-sdk/lib/regions';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { shim } from 'promise.prototype.finally';
 import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -17,35 +15,18 @@ import { Action, compose } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { Subscription } from 'rxjs/Subscription';
 import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
-import {
   DocumentTitleSegment,
   withDocumentTitleProvider
 } from 'src/components/DocumentTitle';
-import SideMenu from 'src/components/SideMenu';
+
 import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
 import { events$ } from 'src/events';
-import BackupDrawer from 'src/features/Backups';
-import DomainDrawer from 'src/features/Domains/DomainDrawer';
-import Footer from 'src/features/Footer';
 import TheApplicationIsOnFire from 'src/features/TheApplicationIsOnFire';
-import ToastNotifications from 'src/features/ToastNotifications';
-import TopMenu from 'src/features/TopMenu';
-import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
+
 import { ApplicationState } from 'src/store';
 import composeState from 'src/utilities/composeState';
-import { notifications } from 'src/utilities/storage';
-import WelcomeBanner from 'src/WelcomeBanner';
-import BucketDrawer from './features/ObjectStorage/BucketLanding/BucketDrawer';
 import { MapState } from './store/types';
-import {
-  isKubernetesEnabled as _isKubernetesEnabled,
-  isObjectStorageEnabled
-} from './utilities/accountCapabilities';
+import { isKubernetesEnabled as _isKubernetesEnabled } from './utilities/accountCapabilities';
 
 import DataLoadedListener from 'src/components/DataLoadedListener';
 import { handleLoadingDone } from 'src/store/initialLoad/initialLoad.actions';
@@ -55,44 +36,6 @@ import { formatDate } from 'src/utilities/formatDate';
 import IdentifyUser from './IdentifyUser';
 
 import MainContent from './MainContent';
-
-shim(); // allows for .finally() usage
-
-type ClassNames = 'hidden' | 'appFrame' | 'wrapper' | 'content';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    appFrame: {
-      position: 'relative',
-      display: 'flex',
-      minHeight: '100vh',
-      flexDirection: 'column',
-      backgroundColor: theme.bg.main,
-      zIndex: 1
-    },
-    wrapper: {
-      padding: theme.spacing(3),
-      transition: theme.transitions.create('opacity'),
-      [theme.breakpoints.down('sm')]: {
-        paddingTop: theme.spacing(2),
-        paddingLeft: theme.spacing(2),
-        paddingRight: theme.spacing(2)
-      }
-    },
-    content: {
-      flex: 1,
-      [theme.breakpoints.up('md')]: {
-        marginLeft: theme.spacing(14) + 103 // 215
-      },
-      [theme.breakpoints.up('xl')]: {
-        marginLeft: theme.spacing(22) + 99 // 275
-      }
-    },
-    hidden: {
-      display: 'none',
-      overflow: 'hidden'
-    }
-  });
 
 interface Props {
   toggleTheme: () => void;
@@ -112,7 +55,6 @@ type CombinedProps = Props &
   DispatchProps &
   StateProps &
   RouteComponentProps &
-  WithStyles<ClassNames> &
   WithSnackbarProps;
 
 export class App extends React.Component<CombinedProps, State> {
@@ -213,34 +155,11 @@ export class App extends React.Component<CombinedProps, State> {
           );
         }
       });
-
-    if (notifications.welcome.get() === 'open') {
-      this.setState({ welcomeBanner: true });
-    }
   }
 
-  closeMenu = () => {
-    this.setState({ menuOpen: false });
-  };
-  openMenu = () => {
-    this.setState({ menuOpen: true });
-  };
-
-  toggleMenu = () => {
-    this.setState({
-      menuOpen: !this.state.menuOpen
-    });
-  };
-
-  closeWelcomeBanner = () => {
-    this.setState({ welcomeBanner: false });
-    notifications.welcome.set('closed');
-  };
-
   render() {
-    const { menuOpen, hasError } = this.state;
+    const { hasError } = this.state;
     const {
-      classes,
       toggleSpacing,
       toggleTheme,
       linodesError,
@@ -338,51 +257,18 @@ export class App extends React.Component<CombinedProps, State> {
           appIsLoaded={!this.props.appIsLoading}
         />
         <DocumentTitleSegment segment="Linode Manager" />
-        <React.Fragment>
-          <div
-            className={classnames({
-              [classes.appFrame]: true,
-              /**
-               * hidden to prevent some jankiness with the app loading before the splash screen
-               */
-              [classes.hidden]: this.props.appIsLoading
-            })}
-          >
-            <SideMenu
-              open={menuOpen}
-              closeMenu={this.closeMenu}
-              toggleTheme={toggleTheme}
-              toggleSpacing={toggleSpacing}
-            />
-            <main className={classes.content}>
-              <TopMenu
-                openSideMenu={this.openMenu}
-                isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
-                username={this.props.username}
-              />
-              <div className={classes.wrapper} id="main-content">
-                <MainContent
-                  accountCapabilities={accountCapabilities}
-                  accountError={accountError}
-                  accountLoading={accountLoading}
-                  history={this.props.history}
-                  location={this.props.location}
-                />
-              </div>
-            </main>
-            <Footer />
-            <WelcomeBanner
-              open={this.state.welcomeBanner}
-              onClose={this.closeWelcomeBanner}
-              data-qa-beta-notice
-            />
-            <ToastNotifications />
-            <DomainDrawer />
-            <VolumeDrawer />
-            <BackupDrawer />
-            {isObjectStorageEnabled(accountCapabilities) && <BucketDrawer />}
-          </div>
-        </React.Fragment>
+        <MainContent
+          accountCapabilities={accountCapabilities}
+          accountError={accountError}
+          accountLoading={accountLoading}
+          history={this.props.history}
+          location={this.props.location}
+          toggleSpacing={toggleSpacing}
+          toggleTheme={toggleTheme}
+          appIsLoading={this.props.appIsLoading}
+          isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
+          username={username}
+        />
       </React.Fragment>
     );
   }
@@ -497,11 +383,8 @@ export const connected = connect(
   mapDispatchToProps
 );
 
-export const styled = withStyles(styles);
-
 export default compose(
   connected,
-  styled,
   withDocumentTitleProvider,
   withSnackbar,
   withFeatureFlagProvider

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -12,14 +12,7 @@ import { shim } from 'promise.prototype.finally';
 import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
-import {
-  Redirect,
-  Route,
-  RouteComponentProps,
-  RouteProps,
-  Switch,
-  withRouter
-} from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { Action, compose } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { Subscription } from 'rxjs/Subscription';
@@ -29,14 +22,10 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import DefaultLoader from 'src/components/DefaultLoader';
 import {
   DocumentTitleSegment,
   withDocumentTitleProvider
 } from 'src/components/DocumentTitle';
-import Grid from 'src/components/Grid';
-import LandingLoading from 'src/components/LandingLoading';
-import NotFound from 'src/components/NotFound';
 import SideMenu from 'src/components/SideMenu';
 import withFeatureFlagProvider from 'src/containers/withFeatureFlagProvider.container';
 import { events$ } from 'src/events';
@@ -59,91 +48,15 @@ import {
 } from './utilities/accountCapabilities';
 
 import DataLoadedListener from 'src/components/DataLoadedListener';
-import ErrorState from 'src/components/ErrorState';
 import { handleLoadingDone } from 'src/store/initialLoad/initialLoad.actions';
 import { addNotificationsToLinodes } from 'src/store/linodes/linodes.actions';
 import { formatDate } from 'src/utilities/formatDate';
 
 import IdentifyUser from './IdentifyUser';
 
+import MainContent from './MainContent';
+
 shim(); // allows for .finally() usage
-
-const Account = DefaultLoader({
-  loader: () => import('src/features/Account')
-});
-
-const LinodesRoutes = DefaultLoader({
-  loader: () => import('src/features/linodes')
-  // loading: () => <div>loading...</div>
-});
-
-const Volumes = DefaultLoader({
-  loader: () => import('src/features/Volumes')
-});
-
-const Domains = DefaultLoader({
-  loader: () => import('src/features/Domains')
-});
-
-const Images = DefaultLoader({
-  loader: () => import('src/features/Images')
-});
-
-const Kubernetes = DefaultLoader({
-  loader: () => import('src/features/Kubernetes')
-});
-
-const ObjectStorage = DefaultLoader({
-  loader: () => import('src/features/ObjectStorage')
-});
-
-const Profile = DefaultLoader({
-  loader: () => import('src/features/Profile')
-});
-
-const NodeBalancers = DefaultLoader({
-  loader: () => import('src/features/NodeBalancers')
-});
-
-const StackScripts = DefaultLoader({
-  loader: () => import('src/features/StackScripts')
-});
-
-const SupportTickets = DefaultLoader({
-  loader: () => import('src/features/Support/SupportTickets')
-});
-
-const SupportTicketDetail = DefaultLoader({
-  loader: () => import('src/features/Support/SupportTicketDetail')
-});
-
-const Longview = DefaultLoader({
-  loader: () => import('src/features/Longview')
-});
-
-const Managed = DefaultLoader({
-  loader: () => import('src/features/Managed')
-});
-
-const Dashboard = DefaultLoader({
-  loader: () => import('src/features/Dashboard')
-});
-
-const Help = DefaultLoader({
-  loader: () => import('src/features/Help')
-});
-
-const SupportSearchLanding = DefaultLoader({
-  loader: () => import('src/features/Help/SupportSearchLanding')
-});
-
-const SearchLanding = DefaultLoader({
-  loader: () => import('src/features/Search')
-});
-
-const EventsLanding = DefaultLoader({
-  loader: () => import('src/features/Events/EventsLanding')
-});
 
 type ClassNames =
   | 'hidden'
@@ -172,30 +85,6 @@ const styles = (theme: Theme) =>
         marginLeft: theme.spacing(22) + 99 // 275
       }
     },
-    wrapper: {
-      padding: theme.spacing(3),
-      transition: theme.transitions.create('opacity'),
-      [theme.breakpoints.down('sm')]: {
-        paddingTop: theme.spacing(2),
-        paddingLeft: theme.spacing(2),
-        paddingRight: theme.spacing(2)
-      }
-    },
-    grid: {
-      [theme.breakpoints.up('lg')]: {
-        height: '100%'
-      }
-    },
-    switchWrapper: {
-      flex: 1,
-      maxWidth: '100%',
-      position: 'relative',
-      '&.mlMain': {
-        [theme.breakpoints.up('lg')]: {
-          maxWidth: '78.8%'
-        }
-      }
-    },
     hidden: {
       display: 'none',
       overflow: 'hidden'
@@ -205,7 +94,8 @@ const styles = (theme: Theme) =>
 interface Props {
   toggleTheme: () => void;
   toggleSpacing: () => void;
-  location: RouteProps['location'];
+  location: RouteComponentProps['location'];
+  history: RouteComponentProps['history'];
 }
 
 interface State {
@@ -403,8 +293,6 @@ export class App extends React.Component<CombinedProps, State> {
       return null;
     }
 
-    const isKubernetesEnabled = _isKubernetesEnabled(accountCapabilities);
-
     return (
       <React.Fragment>
         <a href="#main-content" className="visually-hidden">
@@ -469,58 +357,11 @@ export class App extends React.Component<CombinedProps, State> {
                 isLoggedInAsCustomer={this.props.isLoggedInAsCustomer}
                 username={this.props.username}
               />
-              <div className={classes.wrapper} id="main-content">
-                <Grid container spacing={0} className={classes.grid}>
-                  <Grid item className={classes.switchWrapper}>
-                    <Switch>
-                      <Route path="/linodes" component={LinodesRoutes} />
-                      <Route path="/volumes" component={Volumes} exact strict />
-                      <Redirect path="/volumes*" to="/volumes" />
-                      <Route path="/nodebalancers" component={NodeBalancers} />
-                      <Route path="/domains" component={Domains} />
-                      <Route path="/managed" component={Managed} />
-                      <Route exact path="/longview" component={Longview} />
-                      <Route exact strict path="/images" component={Images} />
-                      <Redirect path="/images*" to="/images" />
-                      <Route path="/stackscripts" component={StackScripts} />
-                      {getObjectStorageRoute(
-                        accountLoading,
-                        accountCapabilities,
-                        accountError
-                      )}
-                      {isKubernetesEnabled && (
-                        <Route path="/kubernetes" component={Kubernetes} />
-                      )}
-                      <Route path="/account" component={Account} />
-                      <Route
-                        exact
-                        strict
-                        path="/support/tickets"
-                        component={SupportTickets}
-                      />
-                      <Route
-                        path="/support/tickets/:ticketId"
-                        component={SupportTicketDetail}
-                        exact
-                        strict
-                      />
-                      <Route path="/profile" component={Profile} />
-                      <Route exact path="/support" component={Help} />
-                      <Route
-                        exact
-                        strict
-                        path="/support/search/"
-                        component={SupportSearchLanding}
-                      />
-                      <Route path="/dashboard" component={Dashboard} />
-                      <Route path="/search" component={SearchLanding} />
-                      <Route path="/events" component={EventsLanding} />
-                      <Redirect exact from="/" to="/dashboard" />
-                      <Route component={NotFound} />
-                    </Switch>
-                  </Grid>
-                </Grid>
-              </div>
+              <MainContent
+                accountCapabilities={accountCapabilities}
+                accountError={accountError}
+                accountLoading={accountLoading}
+              />
             </main>
             <Footer />
             <WelcomeBanner
@@ -539,35 +380,6 @@ export class App extends React.Component<CombinedProps, State> {
     );
   }
 }
-
-// Render the correct <Route /> component for Object Storage,
-// depending on whether /account is loading or has errors, and
-// whether or not the feature is enabled for this account.
-const getObjectStorageRoute = (
-  accountLoading: boolean,
-  accountCapabilities: AccountCapability[],
-  accountError?: Error | Linode.ApiFieldError[]
-) => {
-  let component;
-
-  if (accountLoading) {
-    component = () => <LandingLoading delayInMS={1000} />;
-  } else if (accountError) {
-    component = () => (
-      <ErrorState errorText="An error has occurred. Please reload and try again." />
-    );
-  } else if (isObjectStorageEnabled(accountCapabilities)) {
-    component = ObjectStorage;
-  }
-
-  // If Object Storage is not enabled for this account, return `null`,
-  // which will appear as a 404
-  if (!component) {
-    return null;
-  }
-
-  return <Route path="/object-storage" component={component} />;
-};
 
 interface DispatchProps {
   addNotificationsToLinodes: (
@@ -685,8 +497,7 @@ export default compose(
   styled,
   withDocumentTitleProvider,
   withSnackbar,
-  withFeatureFlagProvider,
-  withRouter
+  withFeatureFlagProvider
 )(App);
 
 export const hasOauthError = (

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -693,8 +693,13 @@ export const hasOauthError = (
   ...args: (Error | Linode.ApiFieldError[] | undefined)[]
 ) => {
   return args.some(eachError => {
-    return pathOr('', [0, 'reason'], eachError)
-      .toLowerCase()
-      .includes('oauth');
+    const cleanedError: string | JSX.Element = pathOr(
+      '',
+      [0, 'reason'],
+      eachError
+    );
+    return typeof cleanedError !== 'string'
+      ? false
+      : cleanedError.toLowerCase().includes('oauth');
   });
 };

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -4,7 +4,13 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { compose } from 'recompose';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import Box from 'src/components/core/Box';
+import {
+  makeStyles,
+  Theme,
+  withTheme,
+  WithTheme
+} from 'src/components/core/styles';
 
 import BackupDrawer from 'src/features/Backups';
 import DomainDrawer from 'src/features/Domains/DomainDrawer';
@@ -15,7 +21,6 @@ import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
 import WelcomeBanner from 'src/WelcomeBanner';
 import BucketDrawer from './features/ObjectStorage/BucketLanding/BucketDrawer';
 
-import AccountActivationLanding from 'src/components/AccountActivation/AccountActivationLanding';
 import DefaultLoader from 'src/components/DefaultLoader';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
@@ -26,6 +31,8 @@ import SideMenu from 'src/components/SideMenu';
 import withGlobalErrors, {
   Props as GlobalErrorProps
 } from 'src/containers/globalErrors.container';
+
+import Logo from 'src/assets/logo/logo-text.svg';
 
 import { notifications } from 'src/utilities/storage';
 import {
@@ -78,6 +85,11 @@ const useStyles = makeStyles((theme: Theme) => ({
         maxWidth: '78.8%'
       }
     }
+  },
+  logo: {
+    '& > g': {
+      fill: '#000'
+    }
   }
 }));
 
@@ -94,7 +106,7 @@ interface Props {
   isLoggedInAsCustomer: boolean;
 }
 
-type CombinedProps = Props & GlobalErrorProps;
+type CombinedProps = Props & GlobalErrorProps & WithTheme;
 
 const Account = DefaultLoader({
   loader: () => import('src/features/Account')
@@ -172,6 +184,11 @@ const EventsLanding = DefaultLoader({
   loader: () => import('src/features/Events/EventsLanding')
 });
 
+const AccountActivationLanding = DefaultLoader({
+  loader: () =>
+    import('src/components/AccountActivation/AccountActivationLanding')
+});
+
 const MainContent: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
@@ -191,23 +208,38 @@ const MainContent: React.FC<CombinedProps> = props => {
    */
   if (props.globalErrors.account_unactivated) {
     return (
-      <div style={{ margin: '5em' }}>
-        <Switch>
-          <Route
-            exact
-            strict
-            path="/support/tickets"
-            component={SupportTickets}
-          />
-          <Route
-            path="/support/tickets/:ticketId"
-            component={SupportTicketDetail}
-            exact
-            strict
-          />
-          <Route exact path="/support" component={Help} />
-          <Route component={AccountActivationLanding} />
-        </Switch>
+      <div
+        style={{
+          backgroundColor: props.theme.bg.main,
+          minHeight: '100vh'
+        }}
+      >
+        <div style={{ padding: '5em' }}>
+          <Box
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-end'
+            }}
+          >
+            <Logo width={150} height={87} className={classes.logo} />
+          </Box>
+          <Switch>
+            <Route
+              exact
+              strict
+              path="/support/tickets"
+              component={SupportTickets}
+            />
+            <Route
+              path="/support/tickets/:ticketId"
+              component={SupportTicketDetail}
+              exact
+              strict
+            />
+            <Route exact path="/support" component={Help} />
+            <Route component={AccountActivationLanding} />
+          </Switch>
+        </div>
       </div>
     );
   }
@@ -339,5 +371,6 @@ const getObjectStorageRoute = (
 
 export default compose<CombinedProps, Props>(
   React.memo,
-  withGlobalErrors()
+  withGlobalErrors(),
+  withTheme
 )(MainContent);

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -1,0 +1,221 @@
+import { AccountCapability } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
+import * as React from 'react';
+import { Redirect, Route, Switch } from 'react-router-dom';
+import { compose } from 'recompose';
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+import DefaultLoader from 'src/components/DefaultLoader';
+import ErrorState from 'src/components/ErrorState';
+import Grid from 'src/components/Grid';
+import LandingLoading from 'src/components/LandingLoading';
+import NotFound from 'src/components/NotFound';
+
+import {
+  isKubernetesEnabled as _isKubernetesEnabled,
+  isObjectStorageEnabled
+} from './utilities/accountCapabilities';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  wrapper: {
+    padding: theme.spacing(3),
+    transition: theme.transitions.create('opacity'),
+    [theme.breakpoints.down('sm')]: {
+      paddingTop: theme.spacing(2),
+      paddingLeft: theme.spacing(2),
+      paddingRight: theme.spacing(2)
+    }
+  },
+  grid: {
+    [theme.breakpoints.up('lg')]: {
+      height: '100%'
+    }
+  },
+  switchWrapper: {
+    flex: 1,
+    maxWidth: '100%',
+    position: 'relative',
+    '&.mlMain': {
+      [theme.breakpoints.up('lg')]: {
+        maxWidth: '78.8%'
+      }
+    }
+  }
+}));
+
+interface Props {
+  accountLoading: boolean;
+  accountError?: APIError[];
+  accountCapabilities: AccountCapability[];
+}
+
+type CombinedProps = Props;
+
+const Account = DefaultLoader({
+  loader: () => import('src/features/Account')
+});
+
+const LinodesRoutes = DefaultLoader({
+  loader: () => import('src/features/linodes')
+  // loading: () => <div>loading...</div>
+});
+
+const Volumes = DefaultLoader({
+  loader: () => import('src/features/Volumes')
+});
+
+const Domains = DefaultLoader({
+  loader: () => import('src/features/Domains')
+});
+
+const Images = DefaultLoader({
+  loader: () => import('src/features/Images')
+});
+
+const Kubernetes = DefaultLoader({
+  loader: () => import('src/features/Kubernetes')
+});
+
+const ObjectStorage = DefaultLoader({
+  loader: () => import('src/features/ObjectStorage')
+});
+
+const Profile = DefaultLoader({
+  loader: () => import('src/features/Profile')
+});
+
+const NodeBalancers = DefaultLoader({
+  loader: () => import('src/features/NodeBalancers')
+});
+
+const StackScripts = DefaultLoader({
+  loader: () => import('src/features/StackScripts')
+});
+
+const SupportTickets = DefaultLoader({
+  loader: () => import('src/features/Support/SupportTickets')
+});
+
+const SupportTicketDetail = DefaultLoader({
+  loader: () => import('src/features/Support/SupportTicketDetail')
+});
+
+const Longview = DefaultLoader({
+  loader: () => import('src/features/Longview')
+});
+
+const Managed = DefaultLoader({
+  loader: () => import('src/features/Managed')
+});
+
+const Dashboard = DefaultLoader({
+  loader: () => import('src/features/Dashboard')
+});
+
+const Help = DefaultLoader({
+  loader: () => import('src/features/Help')
+});
+
+const SupportSearchLanding = DefaultLoader({
+  loader: () => import('src/features/Help/SupportSearchLanding')
+});
+
+const SearchLanding = DefaultLoader({
+  loader: () => import('src/features/Search')
+});
+
+const EventsLanding = DefaultLoader({
+  loader: () => import('src/features/Events/EventsLanding')
+});
+
+const MainContent: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const isKubernetesEnabled = _isKubernetesEnabled(props.accountCapabilities);
+
+  return (
+    <div className={classes.wrapper} id="main-content">
+      <Grid container spacing={0} className={classes.grid}>
+        <Grid item className={classes.switchWrapper}>
+          <Switch>
+            <Route path="/linodes" component={LinodesRoutes} />
+            <Route path="/volumes" component={Volumes} exact strict />
+            <Redirect path="/volumes*" to="/volumes" />
+            <Route path="/nodebalancers" component={NodeBalancers} />
+            <Route path="/domains" component={Domains} />
+            <Route path="/managed" component={Managed} />
+            <Route exact path="/longview" component={Longview} />
+            <Route exact strict path="/images" component={Images} />
+            <Redirect path="/images*" to="/images" />
+            <Route path="/stackscripts" component={StackScripts} />
+            {getObjectStorageRoute(
+              props.accountLoading,
+              props.accountCapabilities,
+              props.accountError
+            )}
+            {isKubernetesEnabled && (
+              <Route path="/kubernetes" component={Kubernetes} />
+            )}
+            <Route path="/account" component={Account} />
+            <Route
+              exact
+              strict
+              path="/support/tickets"
+              component={SupportTickets}
+            />
+            <Route
+              path="/support/tickets/:ticketId"
+              component={SupportTicketDetail}
+              exact
+              strict
+            />
+            <Route path="/profile" component={Profile} />
+            <Route exact path="/support" component={Help} />
+            <Route
+              exact
+              strict
+              path="/support/search/"
+              component={SupportSearchLanding}
+            />
+            <Route path="/dashboard" component={Dashboard} />
+            <Route path="/search" component={SearchLanding} />
+            <Route path="/events" component={EventsLanding} />
+            <Redirect exact from="/" to="/dashboard" />
+            <Route component={NotFound} />
+          </Switch>
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+// Render the correct <Route /> component for Object Storage,
+// depending on whether /account is loading or has errors, and
+// whether or not the feature is enabled for this account.
+const getObjectStorageRoute = (
+  accountLoading: boolean,
+  accountCapabilities: AccountCapability[],
+  accountError?: Error | Linode.ApiFieldError[]
+) => {
+  let component;
+
+  if (accountLoading) {
+    component = () => <LandingLoading delayInMS={1000} />;
+  } else if (accountError) {
+    component = () => (
+      <ErrorState errorText="An error has occurred. Please reload and try again." />
+    );
+  } else if (isObjectStorageEnabled(accountCapabilities)) {
+    component = ObjectStorage;
+  }
+
+  // If Object Storage is not enabled for this account, return `null`,
+  // which will appear as a 404
+  if (!component) {
+    return null;
+  }
+
+  return <Route path="/object-storage" component={component} />;
+};
+
+export default compose<CombinedProps, Props>(React.memo)(MainContent);

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -5,12 +5,12 @@ import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
+import AccountActivationLanding from 'src/components/AccountActivation/AccountActivationLanding';
 import DefaultLoader from 'src/components/DefaultLoader';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import LandingLoading from 'src/components/LandingLoading';
 import NotFound from 'src/components/NotFound';
-import SupportLink from 'src/components/SupportLink';
 
 import withGlobalErrors, {
   Props as GlobalErrorProps
@@ -131,23 +131,23 @@ const MainContent: React.FC<CombinedProps> = props => {
 
   const isKubernetesEnabled = _isKubernetesEnabled(props.accountCapabilities);
 
-  if (props.globalErrors.account_unactivated) {
-    return (
-      <ErrorState
-        errorText={
-          <React.Fragment>
-            Looks like you have not activated your account yet. Please check
-            your email for activation instructions or{' '}
-            <SupportLink
-              title="Help me activate my account"
-              text="open a Support ticket for help."
-            />
-          </React.Fragment>
-        }
-      />
-    );
+  /**
+   * this is the case where the user has successfully completed signup
+   * but needs a manual review from Customer Support. In this case,
+   * the user is going to get 403 errors from almost every single endpoint.
+   *
+   * So in this case, we'll show something more user-friendly
+   */
+  if (
+    props.globalErrors.account_unactivated &&
+    !props.location.pathname.match(/support/i)
+  ) {
+    return <AccountActivationLanding />;
   }
 
+  /**
+   * otherwise just show the rest of the app.
+   */
   return (
     <Grid container spacing={0} className={classes.grid}>
       <Grid item className={classes.switchWrapper}>
@@ -232,6 +232,6 @@ const getObjectStorageRoute = (
 };
 
 export default compose<CombinedProps, Props>(
-  // React.memo,
+  React.memo,
   withGlobalErrors()
 )(MainContent);

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -90,6 +90,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& > g': {
       fill: '#000'
     }
+  },
+  activationWrapper: {
+    padding: theme.spacing(4),
+    [theme.breakpoints.up('xl')]: {
+      width: '50%',
+      margin: '0 auto'
+    }
   }
 }));
 
@@ -214,7 +221,7 @@ const MainContent: React.FC<CombinedProps> = props => {
           minHeight: '100vh'
         }}
       >
-        <div style={{ padding: '5em' }}>
+        <div className={classes.activationWrapper}>
           <Box
             style={{
               display: 'flex'

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -217,8 +217,8 @@ const MainContent: React.FC<CombinedProps> = props => {
         <div style={{ padding: '5em' }}>
           <Box
             style={{
-              display: 'flex',
-              justifyContent: 'flex-end'
+              display: 'flex'
+              // justifyContent: 'flex-end'
             }}
           >
             <Logo width={150} height={87} className={classes.logo} />

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -102,7 +102,6 @@ const Account = DefaultLoader({
 
 const LinodesRoutes = DefaultLoader({
   loader: () => import('src/features/linodes')
-  // loading: () => <div>loading...</div>
 });
 
 const Volumes = DefaultLoader({

--- a/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
@@ -1,8 +1,14 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import withGlobalErrors, { Props } from 'src/containers/globalErrors.container';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
-type CombinedProps = Props;
+interface InnerProps {
+  errors: APIError[];
+}
+
+type CombinedProps = Props & InnerProps;
 
 const AccountActivationError: React.FC<CombinedProps> = props => {
   React.useEffect(() => {
@@ -16,12 +22,12 @@ const AccountActivationError: React.FC<CombinedProps> = props => {
 
   return (
     <React.Fragment>
-      Whoops! Looks like your account hasn't been activated yet.
+      {getAPIErrorOrDefault(props.errors, 'Your account is not yet activated.')}
     </React.Fragment>
   );
 };
 
-export default compose<CombinedProps, {}>(
+export default compose<CombinedProps, InnerProps>(
   React.memo,
   withGlobalErrors()
 )(AccountActivationError);

--- a/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
@@ -22,7 +22,10 @@ const AccountActivationError: React.FC<CombinedProps> = props => {
 
   return (
     <React.Fragment>
-      {getAPIErrorOrDefault(props.errors, 'Your account is not yet activated.')}
+      {getAPIErrorOrDefault(
+        props.errors,
+        'Your account is not yet activated. Please reach out to support@linode.com for more information'
+      )}
     </React.Fragment>
   );
 };

--- a/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { compose } from 'recompose';
+import withGlobalErrors, { Props, ReduxState } from 'src/containers/globalErrors.container'
 
-// interface Props { }
-
-type CombinedProps = any;
+type CombinedProps = Props;
 
 const AccountActivationError: React.FC<CombinedProps> = props => {
+
   return (
     <React.Fragment>
       Whoops! Looks like your account hasn't been activated yet.
@@ -13,4 +13,13 @@ const AccountActivationError: React.FC<CombinedProps> = props => {
   );
 };
 
-export default compose<CombinedProps, {}>(React.memo)(AccountActivationError);
+interface S {
+  hello: ReduxState
+}
+
+export default compose<CombinedProps, {}>(
+  React.memo,
+  withGlobalErrors<S, {}>((errors => ({
+    hello: errors
+  })))
+)(AccountActivationError);

--- a/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+
+// interface Props { }
+
+type CombinedProps = any;
+
+const AccountActivationError: React.FC<CombinedProps> = props => {
+  return (
+    <React.Fragment>
+      Whoops! Looks like your account hasn't been activated yet.
+    </React.Fragment>
+  );
+};
+
+export default compose<CombinedProps, {}>(React.memo)(AccountActivationError);

--- a/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationError.tsx
@@ -1,10 +1,18 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-import withGlobalErrors, { Props, ReduxState } from 'src/containers/globalErrors.container'
+import withGlobalErrors, { Props } from 'src/containers/globalErrors.container';
 
 type CombinedProps = Props;
 
 const AccountActivationError: React.FC<CombinedProps> = props => {
+  React.useEffect(() => {
+    /** set an account_unactivated error if one hasn't already been set */
+    if (!props.globalErrors.account_unactivated) {
+      props.setErrors({
+        account_unactivated: true
+      });
+    }
+  }, [props.globalErrors]);
 
   return (
     <React.Fragment>
@@ -13,13 +21,7 @@ const AccountActivationError: React.FC<CombinedProps> = props => {
   );
 };
 
-interface S {
-  hello: ReduxState
-}
-
 export default compose<CombinedProps, {}>(
   React.memo,
-  withGlobalErrors<S, {}>((errors => ({
-    hello: errors
-  })))
+  withGlobalErrors()
 )(AccountActivationError);

--- a/packages/manager/src/components/AccountActivation/AccountActivationLanding.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationLanding.tsx
@@ -14,6 +14,10 @@ import SupportLink from 'src/components/SupportLink';
 const useStyles = makeStyles((theme: Theme) => ({
   errorHeading: {
     marginBottom: theme.spacing(2)
+  },
+  subheading: {
+    margin: '0 auto',
+    maxWidth: '60%'
   }
 }));
 
@@ -31,10 +35,10 @@ const AccountActivationLanding: React.FC<CombinedProps> = props => {
       errorText={
         <React.Fragment>
           <Typography variant="h2" className={classes.errorHeading}>
-            Thank you for completing your signup!
+            Thanks for signing up!
           </Typography>
-          <Typography>
-            Your account is currently being reviewed. You'll recieve an email
+          <Typography className={classes.subheading}>
+            Your account is currently being reviewed. You'll receive an email
             from us once our review is complete, so hang tight! If you have
             questions during this process{' '}
             <SupportLink

--- a/packages/manager/src/components/AccountActivation/AccountActivationLanding.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationLanding.tsx
@@ -1,17 +1,54 @@
+import Warning from '@material-ui/icons/CheckCircle';
 import * as React from 'react';
 import { compose } from 'recompose';
-// import { makeStyles, Theme } from 'src/components/core/styles'
+import {
+  makeStyles,
+  Theme,
+  withTheme,
+  WithTheme
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import ErrorState from 'src/components/ErrorState';
+import SupportLink from 'src/components/SupportLink';
 
-// const useStyles = makeStyles((theme: Theme) => ({
-//   root: {}
-// }))
+const useStyles = makeStyles((theme: Theme) => ({
+  errorHeading: {
+    marginBottom: theme.spacing(2)
+  }
+}));
 
-type CombinedProps = any;
+type CombinedProps = WithTheme;
 
 const AccountActivationLanding: React.FC<CombinedProps> = props => {
-  // const classes = useStyles();
+  const classes = useStyles();
 
-  return <div>hello world</div>;
+  return (
+    <ErrorState
+      CustomIcon={Warning}
+      CustomIconStyles={{
+        color: props.theme.color.blue
+      }}
+      errorText={
+        <React.Fragment>
+          <Typography variant="h2" className={classes.errorHeading}>
+            Thank you for completing your signup!
+          </Typography>
+          <Typography>
+            Your account is currently being reviewed. You'll recieve an email
+            from us once our review is complete, so hang tight! If you have
+            questions during this process{' '}
+            <SupportLink
+              title="Help me activate my account"
+              text="please open a Support ticket."
+            />
+          </Typography>
+        </React.Fragment>
+      }
+    />
+  );
 };
 
-export default compose<CombinedProps, {}>(React.memo)(AccountActivationLanding);
+export default compose<CombinedProps, {}>(
+  React.memo,
+  withTheme
+)(AccountActivationLanding);

--- a/packages/manager/src/components/AccountActivation/AccountActivationLanding.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationLanding.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+// import { makeStyles, Theme } from 'src/components/core/styles'
+
+// const useStyles = makeStyles((theme: Theme) => ({
+//   root: {}
+// }))
+
+type CombinedProps = any;
+
+const AccountActivationLanding: React.FC<CombinedProps> = props => {
+  // const classes = useStyles();
+
+  return <div>hello world</div>;
+};
+
+export default compose<CombinedProps, {}>(React.memo)(AccountActivationLanding);

--- a/packages/manager/src/components/AccountActivation/AccountActivationLanding.tsx
+++ b/packages/manager/src/components/AccountActivation/AccountActivationLanding.tsx
@@ -1,6 +1,8 @@
 import Warning from '@material-ui/icons/CheckCircle';
 import * as React from 'react';
 import { compose } from 'recompose';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
 import {
   makeStyles,
   Theme,
@@ -9,7 +11,8 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import ErrorState from 'src/components/ErrorState';
-import SupportLink from 'src/components/SupportLink';
+
+import SupportTicketDrawer from 'src/features/Support/SupportTickets/SupportTicketDrawer';
 
 const useStyles = makeStyles((theme: Theme) => ({
   errorHeading: {
@@ -18,6 +21,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   subheading: {
     margin: '0 auto',
     maxWidth: '60%'
+  },
+  cta: {
+    color: theme.color.blue,
+    cursor: 'pointer'
   }
 }));
 
@@ -25,6 +32,13 @@ type CombinedProps = WithTheme;
 
 const AccountActivationLanding: React.FC<CombinedProps> = props => {
   const classes = useStyles();
+
+  const [supportDrawerIsOpen, toggleSupportDrawer] = React.useState<boolean>(
+    false
+  );
+  const [ticketSubmitSuccess, setTicketSubmitSuccess] = React.useState<boolean>(
+    false
+  );
 
   return (
     <ErrorState
@@ -41,11 +55,38 @@ const AccountActivationLanding: React.FC<CombinedProps> = props => {
             Your account is currently being reviewed. You'll receive an email
             from us once our review is complete, so hang tight! If you have
             questions during this process{' '}
-            <SupportLink
-              title="Help me activate my account"
-              text="please open a Support ticket."
-            />
+            <span
+              onClick={() => toggleSupportDrawer(true)}
+              className={classes.cta}
+            >
+              please open a Support ticket.
+            </span>
           </Typography>
+          <SupportTicketDrawer
+            open={supportDrawerIsOpen}
+            onClose={() => toggleSupportDrawer(false)}
+            onSuccess={() => setTicketSubmitSuccess(true)}
+            keepOpenOnSuccess={true}
+            hideProductSelection
+            prefilledTitle="Help me activate my account"
+          >
+            {ticketSubmitSuccess ? (
+              <React.Fragment>
+                <Typography variant="subtitle2">
+                  Your support ticket has been submitted. We will reach out as
+                  soon as possible.
+                </Typography>
+                <ActionsPanel style={{ marginTop: 16 }}>
+                  <Button
+                    onClick={() => toggleSupportDrawer(false)}
+                    buttonType="primary"
+                  >
+                    OK
+                  </Button>
+                </ActionsPanel>
+              </React.Fragment>
+            ) : null}
+          </SupportTicketDrawer>
         </React.Fragment>
       }
     />

--- a/packages/manager/src/components/AccountActivation/index.ts
+++ b/packages/manager/src/components/AccountActivation/index.ts
@@ -1,0 +1,1 @@
+export { default as AccountActivationError } from './AccountActivationError';

--- a/packages/manager/src/components/ErrorState/ErrorState.tsx
+++ b/packages/manager/src/components/ErrorState/ErrorState.tsx
@@ -3,6 +3,7 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import {
   createStyles,
+  SvgIconProps,
   Theme,
   withStyles,
   WithStyles
@@ -14,6 +15,8 @@ interface Props {
   errorText: string | JSX.Element;
   compact?: boolean;
   cozy?: boolean;
+  CustomIcon?: React.ComponentType<SvgIconProps>;
+  CustomIconStyles?: React.CSSProperties;
 }
 
 type CSSClasses = 'root' | 'iconContainer' | 'icon' | 'compact' | 'cozy';
@@ -41,6 +44,7 @@ const styles = (theme: Theme) =>
   });
 
 const ErrorState = (props: Props & WithStyles<CSSClasses>) => {
+  const { CustomIcon } = props;
   return (
     <Grid
       container
@@ -54,15 +58,27 @@ const ErrorState = (props: Props & WithStyles<CSSClasses>) => {
     >
       <Grid item>
         <div className={props.classes.iconContainer}>
-          <ErrorOutline className={props.classes.icon} data-qa-error-icon />
+          {CustomIcon ? (
+            <CustomIcon
+              className={props.classes.icon}
+              data-qa-error-icon
+              style={props.CustomIconStyles}
+            />
+          ) : (
+            <ErrorOutline className={props.classes.icon} data-qa-error-icon />
+          )}
         </div>
-        <Typography
-          style={{ textAlign: 'center' }}
-          variant="h3"
-          data-qa-error-msg
-        >
-          {props.errorText}
-        </Typography>
+        {typeof props.errorText === 'string' ? (
+          <Typography
+            style={{ textAlign: 'center' }}
+            variant="h3"
+            data-qa-error-msg
+          >
+            {props.errorText}
+          </Typography>
+        ) : (
+          <div style={{ textAlign: 'center' }}>{props.errorText}</div>
+        )}
       </Grid>
     </Grid>
   );

--- a/packages/manager/src/components/TableRowError/TableRowError.tsx
+++ b/packages/manager/src/components/TableRowError/TableRowError.tsx
@@ -5,7 +5,7 @@ import ErrorState from 'src/components/ErrorState';
 
 export interface Props {
   colSpan: number;
-  message: string;
+  message: string | JSX.Element;
 }
 
 type CombinedProps = Props;

--- a/packages/manager/src/components/core/styles/index.ts
+++ b/packages/manager/src/components/core/styles/index.ts
@@ -2,8 +2,11 @@ import {
   WithStyles as _WithStyles,
   WithTheme as _WithTheme
 } from '@material-ui/core/styles';
-
+import { SvgIconProps as _SVGIconProps } from '@material-ui/core/SvgIcon';
 import { CSSProperties as _CSSProperties } from '@material-ui/styles';
+
+/* tslint:disable-next-line:no-empty-interface */
+export interface SvgIconProps extends _SVGIconProps {}
 
 /* tslint:disable-next-line:no-empty-interface */
 export interface WithStyles<P extends string> extends _WithStyles<P> {}

--- a/packages/manager/src/containers/globalErrors.container.ts
+++ b/packages/manager/src/containers/globalErrors.container.ts
@@ -1,0 +1,42 @@
+import { connect } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import {
+  clearErrors,
+  setErrors
+} from 'src/store/globalErrors/globalErrors.actions';
+import { State } from 'src/store/globalErrors/types';
+import { ThunkDispatch } from 'src/store/types';
+
+interface DispatchProps {
+  clearErrors: (params: State) => void;
+  setErrors: (
+    params: State
+  ) => void;
+}
+
+export interface StateProps {
+  globalErrors: State
+}
+
+/* tslint:disable-next-line */
+export interface ReduxState extends State { }
+
+export type Props = DispatchProps & StateProps
+
+export default <TInner extends {}, TOuter extends {}>(
+  mapAccountToProps?: (ownProps: TOuter, errors: State) => TInner
+) =>
+  connect<StateProps | State, DispatchProps, TOuter, ApplicationState>(
+    (state, ownProps) => {
+      if (mapAccountToProps) {
+        return mapAccountToProps(ownProps, state.globalErrors);
+      }
+      return {
+        globalErrors: state.globalErrors
+      };
+    },
+    (dispatch: ThunkDispatch) => ({
+      clearErrors: (params) => dispatch(clearErrors(params)),
+      setErrors: (params) => dispatch(setErrors(params))
+    })
+  );

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -125,9 +125,16 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
   };
 
   renderErrors = (errors: Linode.ApiFieldError[]) => {
-    let errorText = pathOr('Unable to load Linodes.', [0, 'reason'], errors);
+    let errorText: string | JSX.Element = pathOr(
+      'Unable to load Linodes.',
+      [0, 'reason'],
+      errors
+    );
 
-    if (errorText.toLowerCase() === 'this linode has been suspended') {
+    if (
+      typeof errorText === 'string' &&
+      errorText.toLowerCase() === 'this linode has been suspended'
+    ) {
       errorText = (
         <React.Fragment>
           One or more of your Linodes is suspended. Please{' '}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -2,6 +2,7 @@ import {
   NodeBalancer,
   NodeBalancerConfig
 } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { path } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -228,7 +229,7 @@ export class NodeBalancersLanding extends React.Component<
     } = this.state;
 
     if (nodeBalancersError) {
-      return <RenderError />;
+      return <RenderError errors={nodeBalancersError} />;
     }
 
     if (nodeBalancersLoading) {
@@ -423,8 +424,13 @@ const LoadingState = () => {
   return <CircleProgress />;
 };
 
-const RenderError = () => {
+const RenderError = ({ errors }: { errors: APIError[] }) => {
   return (
-    <ErrorState errorText="There was an error loading your NodeBalancers. Please try again later." />
+    <ErrorState
+      errorText={
+        errors[0].reason ||
+        'There was an error loading your NodeBalancers. Please try again later.'
+      }
+    />
   );
 };

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -422,16 +422,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
     }
 
     if (error) {
-      return (
-        <TableRowError
-          colSpan={6}
-          message={
-            error[0].reason.match(/not auth/i)
-              ? 'You do not have permission to view API Tokens.'
-              : `We were unable to load your API Tokens.`
-          }
-        />
-      );
+      return <TableRowError colSpan={6} message={error[0].reason} />;
     }
 
     const filteredData = data ? data.filter(filterOutLinodeApps) : [];

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TrustedDevicesTable.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TrustedDevicesTable.tsx
@@ -32,7 +32,7 @@ class TrustedDevicesTable extends React.PureComponent<CombinedProps, {}> {
     if (error) {
       return (
         <TableRowError
-          colSpan={4}
+          colSpan={6}
           message="There was an issue loading your trusted devices."
         />
       );

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.test.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.test.tsx
@@ -8,7 +8,13 @@ import {
 
 describe('Support Tickets Landing', () => {
   const component = shallow(
-    <SupportTicketsLanding classes={{ title: '' }} {...reactRouterProps} />
+    <SupportTicketsLanding
+      globalErrors={{}}
+      setErrors={jest.fn()}
+      clearErrors={jest.fn()}
+      classes={{ title: '' }}
+      {...reactRouterProps}
+    />
   );
 
   it('title of page should read "Customer Support"', () => {

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketsLanding.tsx
@@ -1,7 +1,8 @@
-import { SupportTicket } from "linode-js-sdk/lib/account";
-import { compose, pathOr } from 'ramda';
+import { SupportTicket } from 'linode-js-sdk/lib/account';
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { compose } from 'recompose';
 import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
 import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
@@ -22,6 +23,10 @@ import { AttachmentError } from '../SupportTicketDetail/SupportTicketDetail';
 import SupportTicketDrawer from './SupportTicketDrawer';
 import TicketList from './TicketList';
 
+import withGlobalErrors, {
+  Props as GlobalErrorProps
+} from 'src/containers/globalErrors.container';
+
 type ClassNames = 'title';
 
 const styles = (theme: Theme) =>
@@ -32,9 +37,12 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  history: any;
+  history: RouteComponentProps['history'];
 }
-type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{}>;
+type CombinedProps = Props &
+  WithStyles<ClassNames> &
+  RouteComponentProps<{}> &
+  GlobalErrorProps;
 
 interface State {
   value: number;
@@ -172,19 +180,23 @@ export class SupportTicketsLanding extends React.PureComponent<
               data-qa-breadcrumb
             />
           </Grid>
-          <Grid item>
-            <Grid container alignItems="flex-end">
-              <Grid item>
-                <Button
-                  buttonType="primary"
-                  onClick={this.openDrawer}
-                  data-qa-open-ticket-link
-                >
-                  Open New Ticket
-                </Button>
+          {this.props.globalErrors.account_unactivated ? (
+            <React.Fragment />
+          ) : (
+            <Grid item>
+              <Grid container alignItems="flex-end">
+                <Grid item>
+                  <Button
+                    buttonType="primary"
+                    onClick={this.openDrawer}
+                    data-qa-open-ticket-link
+                  >
+                    Open New Ticket
+                  </Button>
+                </Grid>
               </Grid>
             </Grid>
-          </Grid>
+          )}
         </Grid>
         {notice && <Notice success text={notice} />}
         <AppBar position="static" color="default">
@@ -213,7 +225,8 @@ export class SupportTicketsLanding extends React.PureComponent<
 
 const styled = withStyles(styles);
 
-export default compose<any, any, any>(
+export default compose<CombinedProps, Props>(
   withRouter,
-  styled
+  styled,
+  withGlobalErrors()
 )(SupportTicketsLanding);

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -1,9 +1,5 @@
 import { map as mapPromise } from 'bluebird';
-import {
-  deleteUser,
-  getUsers,
-  User
-} from 'linode-js-sdk/lib/account'
+import { deleteUser, getUsers, User } from 'linode-js-sdk/lib/account';
 import * as memoize from 'memoizee';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
@@ -319,16 +315,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
     }
 
     if (error) {
-      return (
-        <TableRowError
-          colSpan={4}
-          message={
-            error[0].reason.match(/not auth/i)
-              ? 'You do not have permission to view other users.'
-              : `Unable to load user data.`
-          }
-        />
-      );
+      return <TableRowError colSpan={4} message={error[0].reason} />;
     }
 
     if (!data || data.length === 0) {

--- a/packages/manager/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -61,7 +61,7 @@ export default compose(
         'There was an issue retrieving your Linode. Please try again later.'
       )[0].reason;
 
-      if (errorText.toLowerCase() === 'this linode has been suspended') {
+      if (typeof errorText === 'string' && errorText.toLowerCase() === 'this linode has been suspended') {
         errorText = (
           <React.Fragment>
             This Linode is suspended. Please{' '}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -174,13 +174,13 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
     };
 
     if (imagesError || linodesRequestError) {
-      let errorText = pathOr(
+      let errorText: string | JSX.Element = pathOr<string | JSX.Element>(
         'Error loading linodes',
         [0, 'reason'],
         linodesRequestError
       );
 
-      if (errorText.toLowerCase() === 'this linode has been suspended') {
+      if (typeof errorText === 'string' && errorText.toLowerCase() === 'this linode has been suspended') {
         errorText = (
           <React.Fragment>
             One or more of your Linodes is suspended. Please{' '}

--- a/packages/manager/src/index.tsx
+++ b/packages/manager/src/index.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import {
   BrowserRouter as Router,
   Route,
-  RouteProps,
+  RouteComponentProps,
   Switch
 } from 'react-router-dom';
 import { initAnalytics, initTagManager } from 'src/analytics';
@@ -65,7 +65,7 @@ const renderLish = () => (
   <LinodeThemeWrapper>{toggle => <Lish />}</LinodeThemeWrapper>
 );
 
-const renderApp = (props: RouteProps) => (
+const renderApp = (props: RouteComponentProps) => (
   <React.Fragment>
     <SplashScreen />
     <LinodeThemeWrapper>
@@ -81,6 +81,7 @@ const renderApp = (props: RouteProps) => (
             toggleTheme={toggle}
             toggleSpacing={spacing}
             location={props.location}
+            history={props.history}
           />
         </SnackBar>
       )}

--- a/packages/manager/src/services/sdk-request-interceptors.tsx
+++ b/packages/manager/src/services/sdk-request-interceptors.tsx
@@ -14,6 +14,7 @@ import { baseRequest } from 'linode-js-sdk/lib/request';
 
 import store from 'src/store';
 import { handleLogout } from 'src/store/authentication/authentication.actions';
+import { setErrors } from 'src/store/globalErrors/globalErrors.actions';
 
 import { API_ROOT, LOGIN_ROOT } from 'src/constants';
 
@@ -74,9 +75,29 @@ export const handleError = (error: AxiosError) => {
         requestedLinodeType.match(/gpu/i)
     },
     {
+      /**
+       * this component when rendered will set an account activation
+       * error in the globalErrors Redux state. The only issue here
+       * is that if a component is not rendering the actual error message
+       * that comes down, the Redux state will never be set.
+       *
+       * This means that we have 2 options
+       *
+       * 1. Dispatch the globalError Redux action somewhere in the interceptor.
+       * 2. Fix the Landing page components to display the actual error being passed.
+       */
       replacementText: <AccountActivationError />,
       condition: e =>
-        !!e.reason.match(/account must be activated/i) && status === 403
+        !!e.reason.match(/account must be activated/i) && status === 403,
+      callback: () => {
+        if (store && !store.getState().globalErrors.account_unactivated) {
+          store.dispatch(
+            setErrors({
+              account_unactivated: true
+            })
+          );
+        }
+      }
     },
     {
       replacementText: <MigrateError />,

--- a/packages/manager/src/services/sdk-request-interceptors.tsx
+++ b/packages/manager/src/services/sdk-request-interceptors.tsx
@@ -1,4 +1,5 @@
 import { AxiosError, AxiosResponse } from 'axios';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import React from 'react';
 
@@ -42,7 +43,7 @@ export const handleError = (error: AxiosError) => {
   const url = pathOr('', ['response', 'config', 'url'], error);
   const method = pathOr('', ['response', 'config', 'method'], error);
   const status: number = pathOr<number>(0, ['response', 'status'], error);
-  const errors = pathOr(
+  const errors: APIError[] = pathOr<APIError[]>(
     [{ reason: DEFAULT_ERROR_MESSAGE }],
     ['response', 'data', 'errors'],
     error

--- a/packages/manager/src/services/sdk-request-interceptors.tsx
+++ b/packages/manager/src/services/sdk-request-interceptors.tsx
@@ -86,7 +86,7 @@ export const handleError = (error: AxiosError) => {
        * 1. Dispatch the globalError Redux action somewhere in the interceptor.
        * 2. Fix the Landing page components to display the actual error being passed.
        */
-      replacementText: <AccountActivationError />,
+      replacementText: <AccountActivationError errors={errors} />,
       condition: e =>
         !!e.reason.match(/account must be activated/i) && status === 403,
       callback: () => {

--- a/packages/manager/src/services/sdk-request-interceptors.tsx
+++ b/packages/manager/src/services/sdk-request-interceptors.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { ACCESS_TOKEN, DEFAULT_ERROR_MESSAGE } from 'src/constants';
 import { interceptErrors } from 'src/utilities/interceptAPIError';
 
+import { AccountActivationError } from 'src/components/AccountActivation';
 import { GPUError } from 'src/components/GPUError';
 import { MigrateError } from 'src/components/MigrateError';
 
@@ -40,7 +41,7 @@ export const handleError = (error: AxiosError) => {
 
   const url = pathOr('', ['response', 'config', 'url'], error);
   const method = pathOr('', ['response', 'config', 'method'], error);
-  const status = pathOr(0, ['response', 'status'], error);
+  const status: number = pathOr<number>(0, ['response', 'status'], error);
   const errors = pathOr(
     [{ reason: DEFAULT_ERROR_MESSAGE }],
     ['response', 'data', 'errors'],
@@ -68,14 +69,19 @@ export const handleError = (error: AxiosError) => {
     {
       replacementText: <GPUError />,
       condition: e =>
-        e.reason.match(/verification is required/i) &&
+        !!e.reason.match(/verification is required/i) &&
         requestedLinodeType.match(/gpu/i)
+    },
+    {
+      replacementText: <AccountActivationError />,
+      condition: e =>
+        !!e.reason.match(/account must be activated/i) && status === 403
     },
     {
       replacementText: <MigrateError />,
       condition: e => {
         return (
-          e.reason.match(/migrations are currently disabled/i) &&
+          !!e.reason.match(/migrations are currently disabled/i) &&
           url.match(/migrate/i)
         );
       }

--- a/packages/manager/src/store/globalErrors/globalErrors.actions.ts
+++ b/packages/manager/src/store/globalErrors/globalErrors.actions.ts
@@ -1,0 +1,9 @@
+import { actionCreatorFactory } from 'typescript-fsa';
+import { State } from './types'
+
+export const actionCreator = actionCreatorFactory('@@manager/globalErrors');
+
+export const setErrors = actionCreator<Partial<State>>('/set');
+
+export const clearErrors = actionCreator<Partial<State> | undefined>('/clear')
+

--- a/packages/manager/src/store/globalErrors/globalErrors.reducer.ts
+++ b/packages/manager/src/store/globalErrors/globalErrors.reducer.ts
@@ -1,12 +1,9 @@
 import { Reducer } from 'redux';
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
-import {
-  clearErrors,
-  setErrors
-} from './globalErrors.actions';
-import { State } from './types'
+import { clearErrors, setErrors } from './globalErrors.actions';
+import { State } from './types';
 
-export const defaultState: State = {}
+export const defaultState: State = {};
 
 const reducer: Reducer<State> = reducerWithInitialState(defaultState)
   .case(setErrors, (state, payload) => {
@@ -16,13 +13,16 @@ const reducer: Reducer<State> = reducerWithInitialState(defaultState)
     };
   })
   .case(clearErrors, (state, payload) => {
-
-    return (payload)
+    /**
+     * if a payload exists, only clear the specified
+     * errors. If not, clear it all.
+     */
+    return payload
       ? {
-        ...state,
-        ...payload
-      }
-      : {}
+          ...state,
+          ...payload
+        }
+      : {};
   })
   .default(state => state);
 

--- a/packages/manager/src/store/globalErrors/globalErrors.reducer.ts
+++ b/packages/manager/src/store/globalErrors/globalErrors.reducer.ts
@@ -1,0 +1,29 @@
+import { Reducer } from 'redux';
+import { reducerWithInitialState } from 'typescript-fsa-reducers';
+import {
+  clearErrors,
+  setErrors
+} from './globalErrors.actions';
+import { State } from './types'
+
+export const defaultState: State = {}
+
+const reducer: Reducer<State> = reducerWithInitialState(defaultState)
+  .case(setErrors, (state, payload) => {
+    return {
+      ...state,
+      ...payload
+    };
+  })
+  .case(clearErrors, (state, payload) => {
+
+    return (payload)
+      ? {
+        ...state,
+        ...payload
+      }
+      : {}
+  })
+  .default(state => state);
+
+export default reducer;

--- a/packages/manager/src/store/globalErrors/index.ts
+++ b/packages/manager/src/store/globalErrors/index.ts
@@ -1,0 +1,3 @@
+export { default, defaultState } from './globalErrors.reducer'
+
+export { State } from './types'

--- a/packages/manager/src/store/globalErrors/types.ts
+++ b/packages/manager/src/store/globalErrors/types.ts
@@ -1,0 +1,5 @@
+interface S {
+  account_unactivated: boolean;
+}
+
+export type State = Partial<S>

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -49,6 +49,10 @@ import firewalls, {
   defaultState as defaultFirewallState,
   State as FirewallState
 } from 'src/store/firewalls/firewalls.reducer';
+import globalErrors, {
+  defaultState as defaultGlobalErrorState,
+  State as GlobalErrorState
+} from 'src/store/globalErrors'
 import images, {
   defaultState as defaultImagesState,
   State as ImagesState
@@ -203,6 +207,7 @@ export interface ApplicationState {
   preferences: PreferencesState;
   initialLoad: InitialLoadState;
   firewalls: FirewallState;
+  globalErrors: GlobalErrorState
 }
 
 const defaultState: ApplicationState = {
@@ -219,7 +224,8 @@ const defaultState: ApplicationState = {
   createLinode: linodeCreateDefaultState,
   preferences: preferencesState,
   initialLoad: initialLoadState,
-  firewalls: defaultFirewallState
+  firewalls: defaultFirewallState,
+  globalErrors: defaultGlobalErrorState
 };
 
 /**
@@ -261,7 +267,8 @@ const reducers = combineReducers<ApplicationState>({
   createLinode: linodeCreateReducer,
   preferences,
   initialLoad,
-  firewalls
+  firewalls,
+  globalErrors
 });
 
 const enhancers = compose(

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -200,6 +200,7 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
       grey4: '#8C929D',
       white: '#fff',
       black: '#222',
+      blue: primaryColors.main,
       offBlack: primaryColors.offBlack,
       boxShadow: '#ddd',
       boxShadowDark: '#aaa',

--- a/packages/manager/src/themes.ts
+++ b/packages/manager/src/themes.ts
@@ -82,6 +82,7 @@ export const dark = (options: ThemeOverrides) =>
       grey2: 'rgba(0, 0, 0, 0.2)',
       grey3: '#999',
       white: '#32363c',
+      blue: primaryColors.main,
       black: '#fff',
       offBlack: primaryColors.offBlack,
       boxShadow: '#222',

--- a/packages/manager/src/utilities/errorUtils.ts
+++ b/packages/manager/src/utilities/errorUtils.ts
@@ -61,7 +61,10 @@ export const handleUnauthorizedErrors = (
    */
   let hasUnauthorizedError = false;
   const filteredErrors = e.filter(eachError => {
-    if (eachError.reason.toLowerCase().includes('unauthorized')) {
+    if (
+      typeof eachError.reason === 'string' &&
+      eachError.reason.toLowerCase().includes('unauthorized')
+    ) {
       hasUnauthorizedError = true;
       return false;
     }

--- a/packages/manager/src/utilities/interceptAPIError.tsx
+++ b/packages/manager/src/utilities/interceptAPIError.tsx
@@ -40,6 +40,8 @@ export const interceptGPUErrors = (
 interface Intercept {
   condition: (e: APIError) => boolean;
   replacementText: JSX.Element | string;
+  /** optional callback to fire when error is matched correctly */
+  callback?: Function;
 }
 
 export const interceptErrors = (
@@ -52,6 +54,9 @@ export const interceptErrors = (
         acc = {
           reason: eachInterceptor.replacementText as string
         };
+        if (eachInterceptor.callback) {
+          eachInterceptor.callback();
+        }
       }
       return acc;
     }, thisError);

--- a/packages/manager/src/utilities/request.tsx
+++ b/packages/manager/src/utilities/request.tsx
@@ -81,7 +81,7 @@ export const handleError = (error: AxiosError) => {
        * 1. Dispatch the globalError Redux action somewhere in the interceptor.
        * 2. Fix the Landing page components to display the actual error being passed.
        */
-      replacementText: <AccountActivationError />,
+      replacementText: <AccountActivationError errors={errors} />,
       condition: e =>
         !!e.reason.match(/account must be activated/i) && status === 403,
       callback: () => {

--- a/packages/manager/src/utilities/request.tsx
+++ b/packages/manager/src/utilities/request.tsx
@@ -11,6 +11,7 @@ import { MigrateError } from 'src/components/MigrateError';
 
 import store from 'src/store';
 import { handleLogout } from 'src/store/authentication/authentication.actions';
+import { setErrors } from 'src/store/globalErrors/globalErrors.actions';
 
 const handleSuccess: <T extends AxiosResponse<any>>(
   response: T
@@ -69,9 +70,29 @@ export const handleError = (error: AxiosError) => {
         requestedLinodeType.match(/gpu/i)
     },
     {
+      /**
+       * this component when rendered will set an account activation
+       * error in the globalErrors Redux state. The only issue here
+       * is that if a component is not rendering the actual error message
+       * that comes down, the Redux state will never be set.
+       *
+       * This means that we have 2 options
+       *
+       * 1. Dispatch the globalError Redux action somewhere in the interceptor.
+       * 2. Fix the Landing page components to display the actual error being passed.
+       */
       replacementText: <AccountActivationError />,
       condition: e =>
-        !!e.reason.match(/account must be activated/i) && status === 403
+        !!e.reason.match(/account must be activated/i) && status === 403,
+      callback: () => {
+        if (store && !store.getState().globalErrors.account_unactivated) {
+          store.dispatch(
+            setErrors({
+              account_unactivated: true
+            })
+          );
+        }
+      }
     },
     {
       replacementText: <MigrateError />,

--- a/packages/manager/src/utilities/request.tsx
+++ b/packages/manager/src/utilities/request.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { ACCESS_TOKEN, DEFAULT_ERROR_MESSAGE } from 'src/constants';
 import { interceptErrors } from 'src/utilities/interceptAPIError';
 
+import { AccountActivationError } from 'src/components/AccountActivation';
 import { GPUError } from 'src/components/GPUError';
 import { MigrateError } from 'src/components/MigrateError';
 
@@ -36,7 +37,7 @@ export const handleError = (error: AxiosError) => {
 
   const url = pathOr('', ['response', 'config', 'url'], error);
   const method = pathOr('', ['response', 'config', 'method'], error);
-  const status = pathOr(0, ['response', 'status'], error);
+  const status: number = pathOr<number>(0, ['response', 'status'], error);
   const errors = pathOr(
     [{ reason: DEFAULT_ERROR_MESSAGE }],
     ['response', 'data', 'errors'],
@@ -64,14 +65,19 @@ export const handleError = (error: AxiosError) => {
     {
       replacementText: <GPUError />,
       condition: e =>
-        e.reason.match(/verification is required/i) &&
+        !!e.reason.match(/verification is required/i) &&
         requestedLinodeType.match(/gpu/i)
+    },
+    {
+      replacementText: <AccountActivationError />,
+      condition: e =>
+        !!e.reason.match(/account must be activated/i) && status === 403
     },
     {
       replacementText: <MigrateError />,
       condition: e => {
         return (
-          e.reason.match(/migrations are currently disabled/i) &&
+          !!e.reason.match(/migrations are currently disabled/i) &&
           url.match(/migrate/i)
         );
       }


### PR DESCRIPTION
## Description

Adds an activation message landing page for those who still need their account reviewed by the folks in Customer Support.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

🚨  After some UX feedback, we're going to completely render-block the app if your account is restricted. That being said, Support ticket emails still link users to cloud.linode.com/tickets/:ticketID, so those links still need to work 🚨 

So the flow roughly looks like this

1. User loads app
2. A bunch of 403 errors come back from the API informing us that this user is not activated.
3. The axios interceptor replaces that error message with a React component.

Here's where things get tricky.

This react component, when rendered, will set the activation error in Redux state only if it hasn't already been set. But the issue is that some Landing Pages (for example, the Volumes Landing) won't render the error that comes back from a `.catch` but instead static text. [See here for an example](https://github.com/linode/manager/blob/develop/packages/manager/src/features/Volumes/VolumesLanding.tsx#L732)

So because of this, we're also dispatching the action inside the Axios interceptor. IMO, this is a gross thing to do, but as far as I can tell, our hands are tied. The fix here is to get rid of all the static text errors and replace them with the API errors.

^^^ So with that in mind, the new flow becomes

1. User loads app
2. A bunch of 403 errors come down
3. Axios interceptor dispatches the `setError` action to set a global account activation error
4. `MainContent.tsx` listens to that and renders the error state.
5. `AccountActivationError.tsx` now acts as a fallback just in case the Redux state couldn't be set properly inside the Axios interceptor.