### PR TITLE
Use safer check for the Managed dashboard card error state

### DIFF
--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedDashboardCard.tsx
@@ -89,7 +89,7 @@ const Content: React.FC<StateProps> = props => {
    * Don't show error state if we've successfully retrieved
    * monitor data but then a subsequent poll fails
    */
-  if (error && monitors.length === 0) {
+  if (error && updated === 0) {
     const errorString = getAPIErrorOrDefault(
       error,
       'Error loading your Managed service information.'


### PR DESCRIPTION
## Description

The previous logic assumed that all Managed users would have monitors on their account, which obviously is not a safe assumption. 


## Note to Reviewers

Load the dashboard, then (without reloading) block requests to /managed. Also for completeness you can try the other way around, load the page with /managed blocked then unblock it.