### PR TITLE
M3-3095 Fix: Tooltip not showing for selection cards

### DIFF
--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -164,24 +164,11 @@ export interface Props {
   variant?: 'check' | 'info';
 }
 
-type CombinedProps = Props & WithStyles<CSSClasses>;
-
 interface WithTooltipProps {
   title?: string;
-  render: () => JSX.Element;
 }
 
-const WithTooltip: React.StatelessComponent<WithTooltipProps> = ({
-  title,
-  render
-}) =>
-  title ? (
-    <Tooltip title={title} className={'disabledInnerGrid'}>
-      {render()}
-    </Tooltip>
-  ) : (
-    render()
-  );
+type CombinedProps = Props & WithTooltipProps & WithStyles<CSSClasses>;
 
 class SelectionCard extends React.PureComponent<CombinedProps, {}> {
   handleKeyPress = (e: React.KeyboardEvent<HTMLElement>) => {
@@ -257,7 +244,7 @@ class SelectionCard extends React.PureComponent<CombinedProps, {}> {
   render() {
     const { checked, classes, disabled, onClick, tooltip } = this.props;
 
-    return (
+    const cardGrid = () => (
       <Grid
         item
         xs={12}
@@ -276,8 +263,16 @@ class SelectionCard extends React.PureComponent<CombinedProps, {}> {
         onKeyPress={this.handleKeyPress}
         data-qa-selection-card
       >
-        <WithTooltip title={tooltip} render={this.content} />
+        {this.content()}
       </Grid>
+    );
+
+    return tooltip ? (
+      <Tooltip title={tooltip} placement={'top'}>
+        {cardGrid()}
+      </Tooltip>
+    ) : (
+      cardGrid()
     );
   }
 }

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -1,4 +1,4 @@
-import { LinodeType, LinodeTypeClass } from 'linode-js-sdk/lib/linodes'
+import { LinodeType, LinodeTypeClass } from 'linode-js-sdk/lib/linodes';
 import { isEmpty, pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';


### PR DESCRIPTION
## Tooltip not showing for selection cards

This is an old regression from the last MUI update with tooltips.

Best way to test is cloning a linode and check a disabled card in the plan selection panel

## Type of Change
- Bug fix ('fix')
