### PR TITLE
M3-3277 image select bug

### DIFF
--- a/packages/manager/src/__data__/images.ts
+++ b/packages/manager/src/__data__/images.ts
@@ -333,3 +333,8 @@ export const normalizedImages = {
     expiry: null
   }
 };
+
+export const imagesByID = images.reduce((accum, thisImage) => {
+  accum[thisImage.id] = thisImage;
+  return accum;
+}, {});

--- a/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/__mocks__/Select.tsx
@@ -3,17 +3,17 @@ import * as React from 'react';
 
 const groupsToItems = (groups: any[]) => {
   if (path([0, 'value'], groups)) {
-    // This is a normal list of Item[] 
+    // This is a normal list of Item[]
     return groups;
   }
 
   // This must be an array of grouped options
   return groups.reduce((accum, thisGroup) => {
-    return [...accum, ...thisGroup.options]
-  }, [])
-}
+    return [...accum, ...thisGroup.options];
+  }, []);
+};
 
-export default ({ options, value, onChange }: any) => {
+export default ({ options, value, onChange, errorText }: any) => {
   const handleChange = (event: any) => {
     const option = _options.find(
       (thisOption: any) => thisOption.value === event.currentTarget.value
@@ -23,12 +23,15 @@ export default ({ options, value, onChange }: any) => {
 
   const _options = groupsToItems(options);
   return (
-    <select data-testid="select" value={value || ''} onChange={handleChange}>
-      {_options.map((thisOption: any) => (
-        <option key={thisOption.value || ''} value={thisOption.value || ''}>
-          {thisOption.label}
-        </option>
-      ))}
-    </select>
+    <>
+      <select data-testid="select" value={value || ''} onChange={handleChange}>
+        {_options.map((thisOption: any) => (
+          <option key={thisOption.value || ''} value={thisOption.value || ''}>
+            {thisOption.label}
+          </option>
+        ))}
+      </select>
+      <p>{errorText}</p>
+    </>
   );
 };

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -1,5 +1,6 @@
 import produce from 'immer';
 import { Image } from 'linode-js-sdk/lib/images';
+import { equals } from 'ramda';
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -12,7 +13,6 @@ import { groupBy } from 'ramda';
 
 import Select, { GroupType, Item } from 'src/components/EnhancedSelect';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
-import Notice from 'src/components/Notice';
 import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
 
 import { distroIcons } from './icons';
@@ -154,11 +154,6 @@ export const ImageSelect: React.FC<Props> = props => {
         </Typography>
         <Grid container direction="row" wrap="nowrap" spacing={4}>
           <Grid container item direction="column">
-            {error && (
-              <Grid item>
-                <Notice spacingTop={8} spacingBottom={0} error text={error} />
-              </Grid>
-            )}
             <Grid container item direction="row">
               <Grid item xs={12}>
                 <Select
@@ -171,6 +166,7 @@ export const ImageSelect: React.FC<Props> = props => {
                     selectedImageID || '',
                     options
                   )}
+                  errorText={error}
                   components={{ Option: ImageOption, SingleValue }}
                   {...reactSelectProps}
                   className={classNames}
@@ -184,4 +180,12 @@ export const ImageSelect: React.FC<Props> = props => {
   );
 };
 
-export default ImageSelect;
+const isMemo = (prevProps: Props, nextProps: Props) => {
+  return (
+    equals(prevProps.images, nextProps.images) &&
+    prevProps.selectedImageID === nextProps.selectedImageID &&
+    prevProps.error === nextProps.error &&
+    prevProps.disabled === nextProps.disabled
+  );
+};
+export default React.memo(ImageSelect, isMemo);

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -185,7 +185,7 @@ const isMemo = (prevProps: Props, nextProps: Props) => {
   return (
     equals(prevProps.images, nextProps.images) &&
     arePropsEqual<Props>(
-      ['selectedImageID', 'error', 'disabled'],
+      ['selectedImageID', 'error', 'disabled', 'handleSelectImage'],
       prevProps,
       nextProps
     )

--- a/packages/manager/src/components/ImageSelect/ImageSelect.tsx
+++ b/packages/manager/src/components/ImageSelect/ImageSelect.tsx
@@ -13,6 +13,7 @@ import { groupBy } from 'ramda';
 
 import Select, { GroupType, Item } from 'src/components/EnhancedSelect';
 import SingleValue from 'src/components/EnhancedSelect/components/SingleValue';
+import { arePropsEqual } from 'src/utilities/arePropsEqual';
 import getSelectedOptionFromGroupedOptions from 'src/utilities/getSelectedOptionFromGroupedOptions';
 
 import { distroIcons } from './icons';
@@ -183,9 +184,11 @@ export const ImageSelect: React.FC<Props> = props => {
 const isMemo = (prevProps: Props, nextProps: Props) => {
   return (
     equals(prevProps.images, nextProps.images) &&
-    prevProps.selectedImageID === nextProps.selectedImageID &&
-    prevProps.error === nextProps.error &&
-    prevProps.disabled === nextProps.disabled
+    arePropsEqual<Props>(
+      ['selectedImageID', 'error', 'disabled'],
+      prevProps,
+      nextProps
+    )
   );
 };
 export default React.memo(ImageSelect, isMemo);

--- a/packages/manager/src/containers/withImages.container.ts
+++ b/packages/manager/src/containers/withImages.container.ts
@@ -10,7 +10,7 @@ export interface WithImages {
 }
 
 export default <TInner extends {}, TOuter extends {}>(
-  mapImagesToProps: (
+  mapImagesToProps?: (
     ownProps: TOuter,
     images: Record<string, Image>,
     imagesLoading: boolean,
@@ -20,6 +20,15 @@ export default <TInner extends {}, TOuter extends {}>(
   connect((state: ApplicationState, ownProps: TOuter) => {
     const { data: images, error, loading } = state.__resources.images;
     const imageError = path<undefined | string>(['read', 0, 'reason'], error);
+
+    if (!mapImagesToProps) {
+      return {
+        ...ownProps,
+        images,
+        loading,
+        imageError
+      };
+    }
 
     return mapImagesToProps(ownProps, images, loading, imageError);
   });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
@@ -18,7 +18,7 @@ afterEach(cleanup);
 const props: CombinedProps = {
   classes: { root: '', error: '' },
   linodeId: 1234,
-  imagesData: images,
+  images,
   imagesLoading: false,
   userSSHKeys: [],
   closeSnackbar: jest.fn(),

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.test.tsx
@@ -5,7 +5,7 @@ import {
   waitForElement
 } from '@testing-library/react';
 import * as React from 'react';
-import { images } from 'src/__data__/images';
+import { imagesByID as images } from 'src/__data__/images';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { wrapWithTheme } from 'src/utilities/testHelpers';
 import { CombinedProps, RebuildFromImage } from './RebuildFromImage';
@@ -51,7 +51,9 @@ describe('RebuildFromImage', () => {
     const { getByTestId, getByText, getByPlaceholderText } = render(
       wrapWithTheme(<RebuildFromImage {...props} />)
     );
-    fireEvent.change(getByTestId('select'), { target: { value: 'linode/centos7' } });
+    fireEvent.change(getByTestId('select'), {
+      target: { value: 'linode/centos7' }
+    });
     fireEvent.change(getByPlaceholderText('Enter a password.'), {
       target: { value: 'AAbbCC1234!!' }
     });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -1,6 +1,5 @@
 import { Formik, FormikProps } from 'formik';
 import { GrantLevel } from 'linode-js-sdk/lib/account';
-import { Image } from 'linode-js-sdk/lib/images';
 import {
   rebuildLinode,
   RebuildLinodeSchema,
@@ -23,7 +22,7 @@ import {
 import Grid from 'src/components/Grid';
 import ImageSelect from 'src/components/ImageSelect';
 import Notice from 'src/components/Notice';
-import withImages from 'src/containers/withImages.container';
+import withImages, { WithImages } from 'src/containers/withImages.container';
 import { resetEventsPolling } from 'src/events';
 import userSSHKeyHoc, {
   UserSSHKeyProps
@@ -48,18 +47,12 @@ const styles = (theme: Theme) =>
     }
   });
 
-interface WithImagesProps {
-  imagesData: Record<string, Image>;
-  imagesLoading: boolean;
-  imagesError?: string;
-}
-
 interface ContextProps {
   linodeId: number;
   permissions: GrantLevel;
 }
 
-export type CombinedProps = WithImagesProps &
+export type CombinedProps = WithImages &
   WithStyles<ClassNames> &
   ContextProps &
   UserSSHKeyProps &
@@ -81,8 +74,8 @@ export const RebuildFromImage: React.StatelessComponent<
 > = props => {
   const {
     classes,
-    imagesData,
-    imagesError,
+    images,
+    imageError,
     userSSHKeys,
     sshError,
     requestKeys,
@@ -175,10 +168,8 @@ export const RebuildFromImage: React.StatelessComponent<
             {status && <Notice error>{status.generalError}</Notice>}
             <ImageSelect
               title="Select Image"
-              images={Object.keys(imagesData).map(
-                thisKey => imagesData[thisKey]
-              )}
-              error={imagesError || errors.image}
+              images={Object.keys(images).map(thisKey => images[thisKey])}
+              error={imageError || errors.image}
               selectedImageID={values.image}
               handleSelectImage={selected => setFieldValue('image', selected)}
               disabled={disabled}
@@ -241,11 +232,11 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
 
 const enhanced = compose<CombinedProps, {}>(
   linodeContext,
-  withImages((ownProps, imagesData, imagesLoading, imagesError) => ({
+  withImages((ownProps, images, imagesLoading, imageError) => ({
     ...ownProps,
-    imagesData,
+    images,
     imagesLoading,
-    imagesError
+    imageError
   })),
   userSSHKeyHoc,
   styled,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -232,12 +232,7 @@ const linodeContext = withLinodeDetailContext(({ linode }) => ({
 
 const enhanced = compose<CombinedProps, {}>(
   linodeContext,
-  withImages((ownProps, images, imagesLoading, imageError) => ({
-    ...ownProps,
-    images,
-    imagesLoading,
-    imageError
-  })),
+  withImages(),
   userSSHKeyHoc,
   styled,
   withSnackbar,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -1,7 +1,11 @@
 import { Formik, FormikProps } from 'formik';
 import { GrantLevel } from 'linode-js-sdk/lib/account';
 import { Image } from 'linode-js-sdk/lib/images';
-import { rebuildLinode, RebuildLinodeSchema, RebuildRequest } from 'linode-js-sdk/lib/linodes';
+import {
+  rebuildLinode,
+  RebuildLinodeSchema,
+  RebuildRequest
+} from 'linode-js-sdk/lib/linodes';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { isEmpty } from 'ramda';
 import * as React from 'react';
@@ -45,7 +49,7 @@ const styles = (theme: Theme) =>
   });
 
 interface WithImagesProps {
-  imagesData: Image[];
+  imagesData: Record<string, Image>;
   imagesLoading: boolean;
   imagesError?: string;
 }
@@ -171,7 +175,9 @@ export const RebuildFromImage: React.StatelessComponent<
             {status && <Notice error>{status.generalError}</Notice>}
             <ImageSelect
               title="Select Image"
-              images={imagesData}
+              images={Object.keys(imagesData).map(
+                thisKey => imagesData[thisKey]
+              )}
               error={imagesError || errors.image}
               selectedImageID={values.image}
               handleSelectImage={selected => setFieldValue('image', selected)}


### PR DESCRIPTION
## Description

to reproduce:
1) trigger a resize or other long-lived event
2) go to create from distro and open the image select
3) navigate the options with your keypad
4) Observe: the cursor is reset every time a new event is received.

Used React.memo in ImageSelect to prevent these re-renders;

Also fixed a bug that was causing the /rebuild tab to crash. This was a leftover from the imagesByID pattern update that wasn't caught previously.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

I'd love to have bugs like this caught before they go to production (as the first one did) or before they start Jenkins crashes (as the second one did). Unit tests probably won't do the trick. Open to discussion.