### PR TITLE
M3-3157 Fix: Config memory size limit not displayed

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -485,7 +485,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
             <TextField
               type="number"
               label="Memory Limit Allotment (in MB)"
-              // value={memory_limit}
+              value={memory_limit}
               min={0}
               max={maxMemory}
               onChange={this.handleMemoryLimitChange}


### PR DESCRIPTION
## Description

A line of code passing the memory_limit to its text field had been commented out.
As a result, opening a config for editing didn't display the value, leading
users to think that their edits had not been saved.

No idea why this line was commented out in the first place; must have been a reason
but I hope it's no longer valid.

