### PR TITLE
M3-3176 Hide active caret on mobile navigation

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -149,6 +149,11 @@ const styles = (theme: Theme) =>
           right: 0,
           top: '8%'
         }
+      },
+      [theme.breakpoints.down('sm')]: {
+        '&:before': {
+          display: 'none'
+        }
       }
     },
     sublinkPanel: {

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -20,11 +20,7 @@ const styles = (theme: Theme) =>
   createStyles({
     root: {
       flexGrow: 1,
-      width: `calc(100% + ${theme.spacing(1)}px)`,
-      backgroundColor: theme.color.white,
-      [theme.breakpoints.up('sm')]: {
-        width: `calc(100% + ${theme.spacing(2)}px)`
-      }
+      backgroundColor: theme.color.white
     },
     inner: {
       padding: theme.spacing(2),


### PR DESCRIPTION
## Hide active caret on mobile navigation

<img width="488" alt="Screen Shot 2019-08-21 at 3 29 32 PM" src="https://user-images.githubusercontent.com/205353/65052114-0d892b00-d938-11e9-9597-975e133fe695.png">


## Type of Change
- Non breaking change ('update')

