### PR TITLE
M3-3281 Fix regression with tabbed reply and code cleanup

### DIFF
--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -20,11 +20,7 @@ const styles = (theme: Theme) =>
   createStyles({
     root: {
       flexGrow: 1,
-      width: `calc(100% + ${theme.spacing(1)}px)`,
-      backgroundColor: theme.color.white,
-      [theme.breakpoints.up('sm')]: {
-        width: `calc(100% + ${theme.spacing(2)}px)`
-      }
+      backgroundColor: theme.color.white
     },
     inner: {
       padding: theme.spacing(2),

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/ReplyContainer.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/ReplyContainer.tsx
@@ -30,8 +30,7 @@ type ClassNames =
 const styles = (theme: Theme) =>
   createStyles({
     inner: {
-      padding: 0,
-      maxWidth: `calc(100% - ${theme.spacing(2)}px)`
+      padding: 0
     },
     replyContainer: {
       paddingLeft: `calc(32px + ${theme.spacing(1)}px)`,

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/ReplyContainer.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/ReplyContainer.tsx
@@ -21,7 +21,6 @@ import ReplyActions from './ReplyActions';
 import TabbedReply from './TabbedReply';
 
 type ClassNames =
-  | 'root'
   | 'replyContainer'
   | 'reference'
   | 'expPanelSummary'
@@ -30,26 +29,14 @@ type ClassNames =
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {
-      width: `calc(100% + ${theme.spacing(1)}px)`,
-      paddingLeft: theme.spacing(1),
-      paddingRight: theme.spacing(1),
-      [theme.breakpoints.up('sm')]: {
-        width: `calc(100% + ${theme.spacing(2)}px)`,
-        paddingLeft: theme.spacing(2),
-        paddingRight: theme.spacing(2)
-      }
-    },
     inner: {
       padding: 0,
-      [theme.breakpoints.up('sm')]: {
-        padding: theme.spacing(1)
-      }
+      maxWidth: `calc(100% - ${theme.spacing(2)}px)`
     },
     replyContainer: {
-      paddingLeft: 32,
+      paddingLeft: `calc(32px + ${theme.spacing(1)}px)`,
       [theme.breakpoints.up('sm')]: {
-        paddingLeft: 40
+        paddingLeft: `calc(40px + ${theme.spacing(2)}px)`
       }
     },
     expPanelSummary: {
@@ -62,7 +49,6 @@ const styles = (theme: Theme) =>
       }
     },
     reference: {
-      // backgroundColor: theme.palette.divider,
       [theme.breakpoints.up('sm')]: {
         marginTop: theme.spacing(7),
         marginRight: theme.spacing(1) / 2,
@@ -169,14 +155,16 @@ const ReplyContainer: React.FC<CombinedProps> = props => {
       {errorMap.none && (
         <Notice error spacingBottom={8} spacingTop={16} text={errorMap.none} />
       )}
-      <TabbedReply
-        error={errorMap.description}
-        handleChange={setValue}
-        innerClass={classes.inner}
-        isReply
-        value={value}
-      />
-      <Grid className={classes.root} item>
+      <Grid item>
+        <TabbedReply
+          error={errorMap.description}
+          handleChange={setValue}
+          innerClass={classes.inner}
+          isReply
+          value={value}
+        />
+      </Grid>
+      <Grid item style={{ marginTop: 8 }}>
         <ExpansionPanel
           heading="Formatting Tips"
           detailProps={{ className: classes.expPanelSummary }}
@@ -184,7 +172,7 @@ const ReplyContainer: React.FC<CombinedProps> = props => {
           <Reference isReply rootClass={classes.referenceRoot} />
         </ExpansionPanel>
       </Grid>
-      <Grid className={classes.root} item>
+      <Grid item>
         <AttachFileForm
           files={files}
           updateFiles={(filesToAttach: FileAttachment[]) =>

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TabbedReply.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TabbedReply.tsx
@@ -22,7 +22,6 @@ interface Props {
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      padding: theme.spacing(1),
       backgroundColor: 'transparent'
     }
   });


### PR DESCRIPTION
## Fix regression with tabbed reply and code cleanup

A recent change in tabbed reply introduced a regression on the create workflow page, this fixes it and cleans up the code for the support ticket tabbed reply comment field

<img width="1065" alt="Screen Shot 2019-09-17 at 11 11 57 AM" src="https://user-images.githubusercontent.com/205353/65055771-c7cf6100-d93d-11e9-989b-d8d12853cec7.png">


## Type of Change
- Bug fix ('fix')


