### PR TITLE
M3-3254 Change: Use PasswordInput component for Credential drawers

### DIFF
--- a/packages/manager/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.tsx
@@ -19,6 +19,7 @@ type Props = TextFieldProps & {
   disabledReason?: string;
   hideStrengthLabel?: boolean;
   hideHelperText?: boolean;
+  hideValidation?: boolean;
 };
 
 interface State {
@@ -78,6 +79,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
       disabledReason,
       hideStrengthLabel,
       hideHelperText,
+      hideValidation,
       ...rest
     } = this.props;
 
@@ -94,12 +96,14 @@ class PasswordInput extends React.Component<CombinedProps, State> {
               required={required}
             />
           </Grid>
-          <Grid item xs={12} className={`${classes.strengthIndicator} py0`}>
-            <StrengthIndicator
-              strength={strength}
-              hideStrengthLabel={hideStrengthLabel}
-            />
-          </Grid>
+          {!hideValidation && (
+            <Grid item xs={12} className={`${classes.strengthIndicator} py0`}>
+              <StrengthIndicator
+                strength={strength}
+                hideStrengthLabel={hideStrengthLabel}
+              />
+            </Grid>
+          )}
         </Grid>
         {!hideHelperText && (
           <Typography variant="body1" className={classes.infoText}>

--- a/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/AddCredentialDrawer.tsx
@@ -5,6 +5,7 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
+import PasswordInput from 'src/components/PasswordInput';
 import TextField from 'src/components/TextField';
 import { CredentialPayload } from 'src/services/managed';
 
@@ -76,7 +77,7 @@ const CredentialDrawer: React.FC<CombinedProps> = props => {
                 onBlur={handleBlur}
               />
 
-              <TextField
+              <PasswordInput
                 name="password"
                 label="Password / Passphrase"
                 type="password"
@@ -86,6 +87,10 @@ const CredentialDrawer: React.FC<CombinedProps> = props => {
                 errorText={errors.password}
                 onChange={handleChange}
                 onBlur={handleBlur}
+                // This credential could be anything so might be counterproductive to validate strength
+                hideHelperText
+                hideValidation
+                required
               />
 
               <ActionsPanel>

--- a/packages/manager/src/features/Managed/Credentials/UpdateCredentialDrawer.tsx
+++ b/packages/manager/src/features/Managed/Credentials/UpdateCredentialDrawer.tsx
@@ -5,6 +5,7 @@ import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
+import PasswordInput from 'src/components/PasswordInput';
 import TextField from 'src/components/TextField';
 import { CredentialPayload } from 'src/services/managed';
 
@@ -143,7 +144,7 @@ const CredentialDrawer: React.FC<CombinedProps> = props => {
                 onBlur={handleBlur}
               />
 
-              <TextField
+              <PasswordInput
                 name="password"
                 label="Password / Passphrase"
                 type="password"
@@ -153,6 +154,9 @@ const CredentialDrawer: React.FC<CombinedProps> = props => {
                 errorText={errors.password}
                 onChange={handleChange}
                 onBlur={handleBlur}
+                // This credential could be anything so might be counterproductive to validate strength
+                hideHelperText
+                hideValidation
               />
 
               <ActionsPanel>


### PR DESCRIPTION
## Description

Add an eyeball to the password input when adding/editing a Credential

- Added an optional hideValidation prop to the PasswordInput,
bc for cases like credentials, the "password" field has been
defined elsewhere, and it could be any value. Validating using
standard password strength requirements doesn't seem very effective.

