### PR TITLE
M3-2436 Change: Sort support tickets by order created

### DIFF
--- a/packages/manager/src/features/Support/SupportTickets/ticketUtils.ts
+++ b/packages/manager/src/features/Support/SupportTickets/ticketUtils.ts
@@ -39,7 +39,7 @@ export const getTicketsPage = (
   ticketStatus: 'open' | 'closed' | 'all'
 ) => {
   const status = getStatusFilter(ticketStatus);
-  const ordering = { '+order_by': 'updated', '+order': 'desc' };
+  const ordering = { '+order_by': 'opened', '+order': 'desc' };
   const filter = { ...status, ...ordering, ...filters };
   return getTickets(params, filter).then(response => response.data);
 };


### PR DESCRIPTION
## Description

One-word change to sort support tickets by date opened (instead of updated). There was a bug in the API that prevented this ordering from being honored, but it has been fixed and will go out in the next release.
