### PR TITLE
Change: Update Typings for Thunk Action Creators

### DIFF
--- a/packages/linode-js-sdk/src/firewalls/firewalls.ts
+++ b/packages/linode-js-sdk/src/firewalls/firewalls.ts
@@ -15,7 +15,7 @@ import { Firewall } from './types';
 export const getFirewalls = (
   mockData: Firewall[],
   params: any = {},
-  filters: any = {}
+  filter: any = {}
 ): Promise<Page<Firewall>> => {
   return new Promise((resolve, reject) => {
     setTimeout(() => {

--- a/packages/linode-js-sdk/src/kubernetes/kubernetes.ts
+++ b/packages/linode-js-sdk/src/kubernetes/kubernetes.ts
@@ -33,7 +33,7 @@ export const getKubernetesClusters = (params?: any, filters?: any) =>
  *
  * Return details about a single Kubernetes cluster
  */
-export const getKubernetesCluster = (clusterID: string) =>
+export const getKubernetesCluster = (clusterID: number) =>
   Request<KubernetesCluster>(
     setMethod('GET'),
     setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}`)

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -175,7 +175,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   requestProfile: () => dispatch(requestProfile()),
   requestBuckets: () => dispatch(getAllBuckets()),
   requestClusters: () => dispatch(requestClusters()),
-  requestFirewalls: () => dispatch(getAllFirewalls())
+  requestFirewalls: () => dispatch(getAllFirewalls({}))
 });
 
 const connected = connect(

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -175,7 +175,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   requestProfile: () => dispatch(requestProfile()),
   requestBuckets: () => dispatch(getAllBuckets()),
   requestClusters: () => dispatch(requestClusters()),
-  requestFirewalls: () => dispatch(getAllFirewalls({}))
+  requestFirewalls: () => dispatch(getAllFirewalls())
 });
 
 const connected = connect(

--- a/packages/manager/src/containers/firewalls.container.ts
+++ b/packages/manager/src/containers/firewalls.container.ts
@@ -1,0 +1,43 @@
+import { Firewall } from 'linode-js-sdk/lib/firewalls';
+import { connect } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import { State } from 'src/store/firewalls/firewalls.reducer';
+import { getAllFirewalls as _getFirewalls } from 'src/store/firewalls/firewalls.requests';
+import { ThunkDispatch } from 'src/store/types';
+import { GetAllData } from 'src/utilities/getAll';
+
+interface DispatchProps {
+  getFirewalls: (params: any, filters: any) => Promise<GetAllData<Firewall[]>>;
+}
+
+/* tslint:disable-next-line */
+export type StateProps = State;
+
+export type Props = DispatchProps & StateProps;
+
+const connected = <ReduxStateProps extends {}, OwnProps extends {}>(
+  mapAccountToProps?: (
+    ownProps: OwnProps,
+    state: StateProps
+  ) => ReduxStateProps & Partial<StateProps>
+) =>
+  connect<
+    ReduxStateProps | StateProps,
+    DispatchProps,
+    OwnProps,
+    ApplicationState
+  >(
+    (state, ownProps) => {
+      if (mapAccountToProps) {
+        return mapAccountToProps(ownProps, state.firewalls);
+      }
+
+      return state.firewalls;
+    },
+    (dispatch: ThunkDispatch) => ({
+      getFirewalls: (params, filters) =>
+        dispatch(_getFirewalls(params, filters))
+    })
+  );
+
+export default connected;

--- a/packages/manager/src/containers/firewalls.container.ts
+++ b/packages/manager/src/containers/firewalls.container.ts
@@ -35,8 +35,8 @@ const connected = <ReduxStateProps extends {}, OwnProps extends {}>(
       return state.firewalls;
     },
     (dispatch: ThunkDispatch) => ({
-      getFirewalls: (params, filters) =>
-        dispatch(_getFirewalls(params, filters))
+      getFirewalls: (params, filter) =>
+        dispatch(_getFirewalls({ params, filter }))
     })
   );
 

--- a/packages/manager/src/features/Firewalls/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding.tsx
@@ -3,18 +3,29 @@ import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
+import withFirewalls, {
+  Props as FireProps
+} from 'src/containers/firewalls.container';
+
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     color: 'blue'
   }
 }));
 
-type CombinedProps = RouteComponentProps<{}>;
+type CombinedProps = RouteComponentProps<{}> & FireProps;
 
 const FirewallLanding: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
+  React.useEffect(() => {
+    props.getFirewalls('hello', 'world');
+  }, []);
+
   return <div className={classes.root}>hello world</div>;
 };
 
-export default compose<CombinedProps, {}>(React.memo)(FirewallLanding);
+export default compose<CombinedProps, {}>(
+  React.memo,
+  withFirewalls<{}, CombinedProps>()
+)(FirewallLanding);

--- a/packages/manager/src/features/Firewalls/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding.tsx
@@ -19,7 +19,7 @@ const FirewallLanding: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
   React.useEffect(() => {
-    props.getFirewalls('hello', 'world');
+    props.getFirewalls({ hello: 'hello' }, { world: 'world' });
   }, []);
 
   return <div className={classes.root}>hello world</div>;

--- a/packages/manager/src/layouts/Logout.tsx
+++ b/packages/manager/src/layouts/Logout.tsx
@@ -38,7 +38,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
 ) => {
   return {
     dispatchLogout: (client_id: string, token: string) =>
-      dispatch(handleLogout(client_id, token))
+      dispatch(handleLogout({ client_id, token }))
   };
 };
 

--- a/packages/manager/src/store/authentication/authentication.requests.ts
+++ b/packages/manager/src/store/authentication/authentication.requests.ts
@@ -10,10 +10,13 @@ import { handleLogout as _handleLogout } from './authentication.actions';
  * @param { string } token - the auth token used to make HTTP requests
  *
  */
-export const handleLogout: ThunkActionCreator<Promise<Success>> = (
-  client_id: string,
-  token: string
-) => dispatch => {
+export const handleLogout: ThunkActionCreator<
+  Promise<Success>,
+  {
+    client_id: string;
+    token: string;
+  }
+> = ({ client_id, token }) => dispatch => {
   return revokeToken(client_id, token)
     .then(response => {
       dispatch(_handleLogout());

--- a/packages/manager/src/store/bucket/bucket.actions.ts
+++ b/packages/manager/src/store/bucket/bucket.actions.ts
@@ -13,7 +13,7 @@ export const createBucketActions = actionCreator.async<
 >(`create`);
 
 export const getAllBucketsActions = actionCreator.async<
-  {},
+  void,
   Linode.Bucket[],
   Linode.ApiFieldError[]
 >('get-all');

--- a/packages/manager/src/store/domains/domains.actions.ts
+++ b/packages/manager/src/store/domains/domains.actions.ts
@@ -74,7 +74,7 @@ export const requestDomains: ThunkActionCreator<Promise<Domain[]>> = () => (
     });
 };
 
-type RequestDomainForStoreThunk = ThunkActionCreator<void>;
+type RequestDomainForStoreThunk = ThunkActionCreator<void, number>;
 export const requestDomainForStore: RequestDomainForStoreThunk = id => (
   dispatch,
   getState

--- a/packages/manager/src/store/firewalls/firewalls.actions.ts
+++ b/packages/manager/src/store/firewalls/firewalls.actions.ts
@@ -1,5 +1,6 @@
 import { Firewall } from 'linode-js-sdk/lib/firewalls';
 import { APIError } from 'linode-js-sdk/lib/types';
+import { GetAllData } from 'src/utilities/getAll';
 
 import actionCreatorFactory from 'typescript-fsa';
 
@@ -7,6 +8,6 @@ export const actionCreator = actionCreatorFactory(`@@manager/firewalls`);
 
 export const getFirewalls = actionCreator.async<
   void,
-  Omit<Linode.ResourcePage<Firewall>, 'page' | 'pages'>,
+  GetAllData<Firewall[]>,
   APIError[]
 >(`success`);

--- a/packages/manager/src/store/firewalls/firewalls.actions.ts
+++ b/packages/manager/src/store/firewalls/firewalls.actions.ts
@@ -7,7 +7,10 @@ import actionCreatorFactory from 'typescript-fsa';
 export const actionCreator = actionCreatorFactory(`@@manager/firewalls`);
 
 export const getFirewalls = actionCreator.async<
-  void,
+  {
+    params?: any;
+    filter?: any;
+  },
   GetAllData<Firewall[]>,
   APIError[]
 >(`success`);

--- a/packages/manager/src/store/firewalls/firewalls.actions.ts
+++ b/packages/manager/src/store/firewalls/firewalls.actions.ts
@@ -10,7 +10,7 @@ export const getFirewalls = actionCreator.async<
   {
     params?: any;
     filter?: any;
-  },
+  } | void,
   GetAllData<Firewall[]>,
   APIError[]
 >(`success`);

--- a/packages/manager/src/store/firewalls/firewalls.requests.ts
+++ b/packages/manager/src/store/firewalls/firewalls.requests.ts
@@ -1,15 +1,20 @@
 import { Firewall, getFirewalls } from 'linode-js-sdk/lib/firewalls';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { firewalls as mockFirewalls } from 'src/__data__/firewalls';
-import { getAll } from 'src/utilities/getAll';
+import { getAll, GetAllData } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import { getFirewalls as _getFirewallsAction } from './firewalls.actions';
 
-const getAllFirewallsRequest = () =>
-  getAll<Firewall>((params, filters) =>
-    getFirewalls(mockFirewalls, params, filters)
-  )();
+const getAllFirewallsRequest = (payload: { params?: any; filter?: any }) =>
+  getAll<Firewall>((passedParams, passedFilter) =>
+    getFirewalls(mockFirewalls, passedParams, passedFilter)
+  )(payload.params, payload.filter);
 
-export const getAllFirewalls = createRequestThunk(
-  _getFirewallsAction,
-  getAllFirewallsRequest
-);
+export const getAllFirewalls = createRequestThunk<
+  {
+    params?: any;
+    filter?: any;
+  },
+  GetAllData<Firewall[]>,
+  APIError[]
+>(_getFirewallsAction, getAllFirewallsRequest);

--- a/packages/manager/src/store/firewalls/firewalls.requests.ts
+++ b/packages/manager/src/store/firewalls/firewalls.requests.ts
@@ -1,7 +1,6 @@
 import { Firewall, getFirewalls } from 'linode-js-sdk/lib/firewalls';
-import { APIError } from 'linode-js-sdk/lib/types';
 import { firewalls as mockFirewalls } from 'src/__data__/firewalls';
-import { getAll, GetAllData } from 'src/utilities/getAll';
+import { getAll } from 'src/utilities/getAll';
 import { createRequestThunk } from '../store.helpers';
 import { getFirewalls as _getFirewallsAction } from './firewalls.actions';
 
@@ -10,12 +9,7 @@ const getAllFirewallsRequest = (payload: { params?: any; filter?: any }) =>
     getFirewalls(mockFirewalls, passedParams, passedFilter)
   )(payload.params, payload.filter);
 
-export const getAllFirewalls = createRequestThunk<
-  | {
-      params?: any;
-      filter?: any;
-    }
-  | undefined,
-  GetAllData<Firewall[]>,
-  APIError[]
->(_getFirewallsAction, getAllFirewallsRequest);
+export const getAllFirewalls = createRequestThunk(
+  _getFirewallsAction,
+  getAllFirewallsRequest
+);

--- a/packages/manager/src/store/firewalls/firewalls.requests.ts
+++ b/packages/manager/src/store/firewalls/firewalls.requests.ts
@@ -11,10 +11,11 @@ const getAllFirewallsRequest = (payload: { params?: any; filter?: any }) =>
   )(payload.params, payload.filter);
 
 export const getAllFirewalls = createRequestThunk<
-  {
-    params?: any;
-    filter?: any;
-  },
+  | {
+      params?: any;
+      filter?: any;
+    }
+  | undefined,
   GetAllData<Firewall[]>,
   APIError[]
 >(_getFirewallsAction, getAllFirewallsRequest);

--- a/packages/manager/src/store/kubernetes/kubernetes.requests.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.requests.ts
@@ -44,7 +44,7 @@ export const requestKubernetesClusters: ThunkActionCreator<
     });
 };
 
-type RequestClusterForStoreThunk = ThunkActionCreator<void>;
+type RequestClusterForStoreThunk = ThunkActionCreator<void, number>;
 export const requestClusterForStore: RequestClusterForStoreThunk = clusterID => dispatch => {
   getKubernetesCluster(clusterID).then(cluster => {
     dispatch(requestNodePoolsForCluster({ clusterID }));

--- a/packages/manager/src/store/kubernetes/nodePools.requests.ts
+++ b/packages/manager/src/store/kubernetes/nodePools.requests.ts
@@ -38,7 +38,8 @@ const extendNodePool = (clusterID: number, nodePool: KubeNodePoolResponse) => ({
 });
 
 export const requestNodePoolsForCluster: ThunkActionCreator<
-  Promise<KubeNodePoolResponse[]>
+  Promise<KubeNodePoolResponse[]>,
+  { clusterID: number }
 > = ({ clusterID }) => dispatch => {
   dispatch(requestNodePoolsActions.started());
 
@@ -60,7 +61,10 @@ export const requestNodePoolsForCluster: ThunkActionCreator<
     });
 };
 
-type RequestNodePoolForStoreThunk = ThunkActionCreator<void>;
+type RequestNodePoolForStoreThunk = ThunkActionCreator<
+  void,
+  { clusterID: number; nodePoolID: number }
+>;
 export const requestNodePoolForStore: RequestNodePoolForStoreThunk = ({
   clusterID,
   nodePoolID

--- a/packages/manager/src/store/linodes/config/config.requests.ts
+++ b/packages/manager/src/store/linodes/config/config.requests.ts
@@ -62,9 +62,10 @@ export const deleteLinodeConfig = createRequestThunk(
   ({ linodeId, configId }) => _deleteLinodeConfig(linodeId, configId)
 );
 
-export const getAllLinodeConfigs: ThunkActionCreator<Promise<Entity[]>> = (
-  params: GetAllLinodeConfigsParams
-) => async dispatch => {
+export const getAllLinodeConfigs: ThunkActionCreator<
+  Promise<Entity[]>,
+  GetAllLinodeConfigsParams
+> = params => async dispatch => {
   const { linodeId } = params;
   const { started, done, failed } = getAllLinodeConfigsActions;
   dispatch(started(params));

--- a/packages/manager/src/store/linodes/disk/disk.requests.ts
+++ b/packages/manager/src/store/linodes/disk/disk.requests.ts
@@ -62,9 +62,10 @@ export const deleteLinodeDisk = createRequestThunk(
   ({ linodeId, diskId }) => _deleteLinodeDisk(linodeId, diskId)
 );
 
-export const getAllLinodeDisks: ThunkActionCreator<Promise<Entity[]>> = (
-  params: GetAllLinodeDisksParams
-) => async dispatch => {
+export const getAllLinodeDisks: ThunkActionCreator<
+  Promise<Entity[]>,
+  GetAllLinodeDisksParams
+> = params => async dispatch => {
   const { linodeId } = params;
   const { started, done, failed } = getAllLinodeDisksActions;
   dispatch(started(params));

--- a/packages/manager/src/store/linodes/linode.requests.ts
+++ b/packages/manager/src/store/linodes/linode.requests.ts
@@ -73,7 +73,7 @@ export const requestLinodes: ThunkActionCreator<
 const getBackupsForLinodes = ({ data }: { data: Linode[] }) =>
   Bluebird.map(data, requestMostRecentBackupForLinode);
 
-type RequestLinodeForStoreThunk = ThunkActionCreator<void>;
+type RequestLinodeForStoreThunk = ThunkActionCreator<void, number>;
 export const requestLinodeForStore: RequestLinodeForStoreThunk = id => (
   dispatch,
   getState

--- a/packages/manager/src/store/nodeBalancer/nodeBalancer.requests.ts
+++ b/packages/manager/src/store/nodeBalancer/nodeBalancer.requests.ts
@@ -37,9 +37,10 @@ export const getAllNodeBalancers = createRequestThunk(
  * include the newly created configs or nodes. In order to keep the state updated, we manually
  * request the configs after successful creation.
  */
-export const createNodeBalancer: ThunkActionCreator<Promise<NodeBalancer>> = (
-  params: CreateNodeBalancerParams
-) => dispatch => {
+export const createNodeBalancer: ThunkActionCreator<
+  Promise<NodeBalancer>,
+  CreateNodeBalancerParams
+> = params => dispatch => {
   const { started, done, failed } = createNodeBalancersActions;
 
   dispatch(started(params));
@@ -59,9 +60,10 @@ export const createNodeBalancer: ThunkActionCreator<Promise<NodeBalancer>> = (
     });
 };
 
-export const deleteNodeBalancer: ThunkActionCreator<Promise<{}>> = (params: {
-  nodeBalancerId: number;
-}) => dispatch => {
+export const deleteNodeBalancer: ThunkActionCreator<
+  Promise<{}>,
+  { nodeBalancerId: number }
+> = params => dispatch => {
   const { nodeBalancerId } = params;
   const { started, done, failed } = deleteNodeBalancerActions;
 
@@ -111,8 +113,9 @@ export const getAllNodeBalancersWithConfigs: ThunkActionCreator<
 };
 
 export const getNodeBalancerWithConfigs: ThunkActionCreator<
-  Promise<NodeBalancer>
-> = (params: GetNodeBalancerWithConfigsParams) => async dispatch => {
+  Promise<NodeBalancer>,
+  GetNodeBalancerWithConfigsParams
+> = params => async dispatch => {
   const { nodeBalancerId } = params;
   const { started, done, failed } = getNodeBalancerWithConfigsActions;
 

--- a/packages/manager/src/store/nodeBalancerConfig/nodeBalancerConfig.requests.ts
+++ b/packages/manager/src/store/nodeBalancerConfig/nodeBalancerConfig.requests.ts
@@ -39,11 +39,9 @@ export const updateNodeBalancerConfig = createRequestThunk(
 );
 
 export const deleteNodeBalancerConfig: ThunkActionCreator<
-  Promise<{}>
-> = (params: { nodeBalancerConfigId: number; nodeBalancerId: number }) => (
-  dispatch,
-  getStore
-) => {
+  Promise<{}>,
+  { nodeBalancerConfigId: number; nodeBalancerId: number }
+> = params => (dispatch, getStore) => {
   const { nodeBalancerConfigId, nodeBalancerId } = params;
   const { started, done, failed } = deleteNodeBalancerConfigActions;
 
@@ -67,9 +65,10 @@ export const deleteNodeBalancerConfig: ThunkActionCreator<
  * An orphaned config is one which exists in the STORE but not in the API.
  * A new config is one which exists in the API but not in the STORE.
  */
-export const updateNodeBalancerConfigs: ThunkActionCreator<void> = (
-  nodeBalancerId: number
-) => (dispatch, getStore) => {
+export const updateNodeBalancerConfigs: ThunkActionCreator<
+  void,
+  number
+> = nodeBalancerId => (dispatch, getStore) => {
   const {
     nodeBalancerConfigs: { itemsById: nodeBalancerConfigs }
   } = getStore().__resources;

--- a/packages/manager/src/store/notification/notification.requests.ts
+++ b/packages/manager/src/store/notification/notification.requests.ts
@@ -7,7 +7,8 @@ import {
 } from './notification.actions';
 
 export const requestNotifications: ThunkActionCreator<
-  Promise<Notification[]>
+  Promise<Notification[]>,
+  void
 > = () => dispatch => {
   dispatch(startRequest());
   return getNotifications()

--- a/packages/manager/src/store/preferences/preferences.requests.ts
+++ b/packages/manager/src/store/preferences/preferences.requests.ts
@@ -35,8 +35,9 @@ export const getUserPreferences: ThunkActionCreator<
 };
 
 export const updateUserPreferences: ThunkActionCreator<
-  Promise<Record<string, any>>
-> = (payload: Record<string, any>) => dispatch => {
+  Promise<Record<string, any>>,
+  Record<string, any>
+> = payload => dispatch => {
   const { started, done, failed } = handleUpdatePreferences;
 
   dispatch(

--- a/packages/manager/src/store/profile/profile.requests.ts
+++ b/packages/manager/src/store/profile/profile.requests.ts
@@ -62,9 +62,10 @@ export const requestProfile: ThunkActionCreator<Promise<Profile>> = () => (
 /**
  * @todo this doesn't let you update grants
  */
-export const updateProfile: ThunkActionCreator<Promise<Partial<Profile>>> = (
-  payload: Partial<Profile>
-) => dispatch => {
+export const updateProfile: ThunkActionCreator<
+  Promise<Partial<Profile>>,
+  Partial<Profile>
+> = payload => dispatch => {
   const { done, failed } = handleUpdateProfile;
 
   /**

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -125,23 +125,30 @@ export const getAddRemoved = <E extends Entity>(
   return [added, removed];
 };
 
+/**
+ * Create overload for createRequestThunk so that the param argument
+ * can either be typed as Req[] or Req. In the case of Req[], we need
+ * to spread the props to the request
+ */
+
 /* tslint:disable-next-line */
 function createRequestThunk<Req extends any, Res, Err>(
   actions: AsyncActionCreators<Req, Res, Err>,
   request: (params: Req) => Promise<Res>
 ): ThunkActionCreator<Promise<Res>, Req>;
 /* tslint:disable-next-line */
-function createRequestThunk<Req extends any, Res, Err>(
+function createRequestThunk<Req extends any[], Res, Err>(
   actions: AsyncActionCreators<Req[], Res, Err>,
   request: (...params: Req[]) => Promise<Res>
 ): ThunkActionCreator<Promise<Res>, Req> {
-  return (...params: any[]) => async dispatch => {
+  return (...params: Req[]) => async dispatch => {
     const { started, done, failed } = actions;
 
     dispatch(started(params));
 
     try {
       const result = await request(...params);
+
       const doneAction = done({ result, params });
 
       dispatch(doneAction);

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -125,7 +125,7 @@ export const getAddRemoved = <E extends Entity>(
   return [added, removed];
 };
 
-const createRequestThunk = <Req extends any, Res, Err>(
+export const createRequestThunk = <Req extends any, Res, Err>(
   actions: AsyncActionCreators<Req, Res, Err>,
   request: (params: Req) => Promise<Res>
 ): ThunkActionCreator<Promise<Res>, Req> => {
@@ -136,21 +136,16 @@ const createRequestThunk = <Req extends any, Res, Err>(
 
     try {
       const result = await request(params);
-
       const doneAction = done({ result, params });
-
       dispatch(doneAction);
       return result;
     } catch (error) {
       const failAction = failed({ error, params });
-
       dispatch(failAction);
       return Promise.reject(error);
     }
   };
 };
-
-export { createRequestThunk };
 
 export const updateInPlace = <E extends Entity>(
   id: number | string,

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -125,27 +125,37 @@ export const getAddRemoved = <E extends Entity>(
   return [added, removed];
 };
 
-export const createRequestThunk = <Req extends any, Res, Err>(
+/* tslint:disable-next-line */
+function createRequestThunk<Req extends any, Res, Err>(
   actions: AsyncActionCreators<Req, Res, Err>,
   request: (params: Req) => Promise<Res>
-): ThunkActionCreator<Promise<Res>, Req> => (params: Req) => async dispatch => {
-  const { started, done, failed } = actions;
+): ThunkActionCreator<Promise<Res>, Req>;
+/* tslint:disable-next-line */
+function createRequestThunk<Req extends any, Res, Err>(
+  actions: AsyncActionCreators<Req[], Res, Err>,
+  request: (...params: Req[]) => Promise<Res>
+): ThunkActionCreator<Promise<Res>, Req> {
+  return (...params: any[]) => async dispatch => {
+    const { started, done, failed } = actions;
 
-  dispatch(started(params));
+    dispatch(started(params));
 
-  try {
-    const result = await request(params);
-    const doneAction = done({ result, params });
+    try {
+      const result = await request(...params);
+      const doneAction = done({ result, params });
 
-    dispatch(doneAction);
-    return result;
-  } catch (error) {
-    const failAction = failed({ error, params });
+      dispatch(doneAction);
+      return result;
+    } catch (error) {
+      const failAction = failed({ error, params });
 
-    dispatch(failAction);
-    return Promise.reject(error);
-  }
-};
+      dispatch(failAction);
+      return Promise.reject(error);
+    }
+  };
+}
+
+export { createRequestThunk };
 
 export const updateInPlace = <E extends Entity>(
   id: number | string,

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -125,23 +125,11 @@ export const getAddRemoved = <E extends Entity>(
   return [added, removed];
 };
 
-/**
- * Create overload for createRequestThunk so that the param argument
- * can either be typed as Req[] or Req. In the case of Req[], we need
- * to spread the props to the request
- */
-
-/* tslint:disable-next-line */
-function createRequestThunk<Req extends any, Res, Err>(
+const createRequestThunk = <Req extends any, Res, Err>(
   actions: AsyncActionCreators<Req, Res, Err>,
   request: (params: Req) => Promise<Res>
-): ThunkActionCreator<Promise<Res>, Req>;
-/* tslint:disable-next-line */
-function createRequestThunk<Req extends any[], Res, Err>(
-  actions: AsyncActionCreators<Req[], Res, Err>,
-  request: (params: Req[]) => Promise<Res>
-): ThunkActionCreator<Promise<Res>, Req[]> {
-  return (params: Req[]) => async dispatch => {
+): ThunkActionCreator<Promise<Res>, Req> => {
+  return (params: Req) => async dispatch => {
     const { started, done, failed } = actions;
 
     dispatch(started(params));
@@ -160,7 +148,7 @@ function createRequestThunk<Req extends any[], Res, Err>(
       return Promise.reject(error);
     }
   };
-}
+};
 
 export { createRequestThunk };
 

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -139,15 +139,15 @@ function createRequestThunk<Req extends any, Res, Err>(
 /* tslint:disable-next-line */
 function createRequestThunk<Req extends any[], Res, Err>(
   actions: AsyncActionCreators<Req[], Res, Err>,
-  request: (...params: Req[]) => Promise<Res>
-): ThunkActionCreator<Promise<Res>, Req> {
-  return (...params: Req[]) => async dispatch => {
+  request: (params: Req[]) => Promise<Res>
+): ThunkActionCreator<Promise<Res>, Req[]> {
+  return (params: Req[]) => async dispatch => {
     const { started, done, failed } = actions;
 
     dispatch(started(params));
 
     try {
-      const result = await request(...params);
+      const result = await request(params);
 
       const doneAction = done({ result, params });
 

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -125,10 +125,10 @@ export const getAddRemoved = <E extends Entity>(
   return [added, removed];
 };
 
-export const createRequestThunk = <Req, Res, Err>(
+export const createRequestThunk = <Req extends any, Res, Err>(
   actions: AsyncActionCreators<Req, Res, Err>,
   request: (params: Req) => Promise<Res>
-): ThunkActionCreator<Promise<Res>> => (params: Req) => async dispatch => {
+): ThunkActionCreator<Promise<Res>, Req> => (params: Req) => async dispatch => {
   const { started, done, failed } = actions;
 
   dispatch(started(params));

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -34,11 +34,20 @@ export interface EntityError {
  * }
  *
  */
-export type ReduxActionCreator<A, Params extends any> = (
-  ...args: Params[]
-) => A;
 
-export type ThunkActionCreator<T, Params = any> = ReduxActionCreator<
+export type ParamType<F> = F extends (args: infer A) => any
+  ? A extends undefined | null
+    ? [any?]
+    : [A]
+  : [any?];
+
+// export type ReduxActionCreator<A, Params> = Params extends null | undefined
+//   ? (...args: any[]) => A
+//   : (args: Params) => A;
+
+export type R<A, Params> = (...args: ParamType<(args: Params) => A>) => A;
+
+export type ThunkActionCreator<T, Params = undefined> = R<
   ThunkResult<T>,
   Params
 >;

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -36,11 +36,11 @@ export interface EntityError {
  */
 export type ParamType<F> = F extends (args: infer A) => any
   ? A extends undefined | null
-    ? [any?]
-    : [A]
-  : [any?];
+    ? void
+    : A
+  : void;
 
-export type R<A, Params> = (...args: ParamType<(args: Params) => A>) => A;
+export type R<A, Params> = (args: ParamType<(args: Params) => A>) => A;
 
 export type ThunkActionCreator<T, Params = undefined> = R<
   ThunkResult<T>,

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -1,9 +1,6 @@
 import { Entity as EventEntity, Event } from 'linode-js-sdk/lib/account';
 import { APIError } from 'linode-js-sdk/lib/types';
-import {
-  ActionCreator,
-  MapStateToProps as _MapStateToProps
-} from 'react-redux';
+import { MapStateToProps as _MapStateToProps } from 'react-redux';
 import { Action, Dispatch } from 'redux';
 import { ThunkAction, ThunkDispatch as _ThunkDispatch } from 'redux-thunk';
 import { ApplicationState } from 'src/store';
@@ -26,7 +23,25 @@ export interface EntityError {
   update?: APIError[];
 }
 
-export type ThunkActionCreator<T> = ActionCreator<ThunkResult<T>>;
+/**
+ * the native Redux Action Creator doesn't let us pass typed
+ * arguments for the parameters section
+ *
+ * original ReduxActionCreator:
+ *
+ * export interface ReduxActionCreator<A> {
+ *  (...args: any[]): A;
+ * }
+ *
+ */
+export type ReduxActionCreator<A, Params extends any> = (
+  ...args: Params[]
+) => A;
+
+export type ThunkActionCreator<T, Params = any> = ReduxActionCreator<
+  ThunkResult<T>,
+  Params
+>;
 
 export type ThunkDispatch = _ThunkDispatch<ApplicationState, undefined, Action>;
 

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -23,29 +23,9 @@ export interface EntityError {
   update?: APIError[];
 }
 
-/**
- * the native Redux Action Creator doesn't let us pass typed
- * arguments for the parameters section
- *
- * original ReduxActionCreator:
- *
- * export interface ReduxActionCreator<A> {
- *  (...args: any[]): A;
- * }
- *
- */
-export type ParamType<F> = F extends (args: infer A) => any
-  ? A extends undefined | null
-    ? void
-    : A
-  : void;
-
-export type R<A, Params> = (args: ParamType<(args: Params) => A>) => A;
-
-export type ThunkActionCreator<T, Params = undefined> = R<
-  ThunkResult<T>,
-  Params
->;
+export type ThunkActionCreator<ReturnType, Params = void> = (
+  args: Params
+) => ThunkResult<ReturnType>;
 
 export type ThunkDispatch = _ThunkDispatch<ApplicationState, undefined, Action>;
 

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -34,16 +34,11 @@ export interface EntityError {
  * }
  *
  */
-
 export type ParamType<F> = F extends (args: infer A) => any
   ? A extends undefined | null
     ? [any?]
     : [A]
   : [any?];
-
-// export type ReduxActionCreator<A, Params> = Params extends null | undefined
-//   ? (...args: any[]) => A
-//   : (args: Params) => A;
 
 export type R<A, Params> = (...args: ParamType<(args: Params) => A>) => A;
 

--- a/packages/manager/src/store/volume/volume.actions.ts
+++ b/packages/manager/src/store/volume/volume.actions.ts
@@ -69,7 +69,7 @@ export interface GetAllVolumesOptions {
   setLoading?: boolean;
 }
 export const getAllVolumesActions = actionCreator.async<
-  GetAllVolumesOptions | undefined,
+  GetAllVolumesOptions | void,
   Volume[],
   Linode.ApiFieldError[]
 >('get-all');

--- a/packages/manager/src/store/volume/volume.actions.ts
+++ b/packages/manager/src/store/volume/volume.actions.ts
@@ -69,7 +69,7 @@ export interface GetAllVolumesOptions {
   setLoading?: boolean;
 }
 export const getAllVolumesActions = actionCreator.async<
-  GetAllVolumesOptions,
+  GetAllVolumesOptions | undefined,
   Volume[],
   Linode.ApiFieldError[]
 >('get-all');

--- a/packages/manager/src/store/volume/volume.events.ts
+++ b/packages/manager/src/store/volume/volume.events.ts
@@ -1,4 +1,4 @@
-import { EventStatus } from 'linode-js-sdk/lib/account'
+import { EventStatus } from 'linode-js-sdk/lib/account';
 import { Dispatch } from 'redux';
 import { EventHandler } from 'src/store/types';
 import { deleteVolumeActions } from './volume.actions';
@@ -45,10 +45,7 @@ const handleVolumeUpdate = (
   }
 };
 
-const handleVolumeClone = (
-  dispatch: Dispatch<any>,
-  status: EventStatus
-) => {
+const handleVolumeClone = (dispatch: Dispatch<any>, status: EventStatus) => {
   switch (status) {
     case 'failed':
     case 'finished':
@@ -58,7 +55,7 @@ const handleVolumeClone = (
       // We can't just get the cloned volume, since the entity on volume_clone events is the PARENT
       // (so we don't know the correct volumeId to GET). Therefore, we need to get ALL volumes,
       // but we don't want to see a loading state – we want this to happen in the "background".
-      dispatch(getAllVolumes({ shouldSetLoading: false }));
+      dispatch(getAllVolumes({ setLoading: false }));
 
     default:
       return;

--- a/packages/manager/src/store/volume/volume.reducer.ts
+++ b/packages/manager/src/store/volume/volume.reducer.ts
@@ -97,11 +97,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
    * Get All Volumes
    **/
   if (isType(action, getAllVolumesActions.started)) {
-    const shouldSetLoading = pathOr(
-      true,
-      ['payload', 'shouldSetLoading'],
-      action
-    );
+    const shouldSetLoading = pathOr(true, ['payload', 'setLoading'], action);
     if (shouldSetLoading) {
       return onStart<MappedEntityState<Volume, EntityError>>(state);
     }


### PR DESCRIPTION
## Description

Adds better typing, so we can type the parameters that are getting passed to action creators through `createRequestThunk`

### Before (`args?: any` yuck 😢)

![Screen Shot 2019-09-19 at 12 38 55 PM](https://user-images.githubusercontent.com/7387001/65263361-7dcfb200-dada-11e9-9fb9-699d6c24818d.png)

### After (properly typed parameters 😎 )

![Screen Shot 2019-09-19 at 12 38 27 PM](https://user-images.githubusercontent.com/7387001/65263371-82946600-dada-11e9-98da-15e82fb44bd0.png)

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

I recommend hovering over multiple places where `dispatch(someAction())` is happening to make sure the param typings are correct.

If types weren't explicitly passed in the actual action creator type arguments, then it will remain a `any?` but otherwise should be typed correctly.