### PR TITLE
M3-3216 Allow deletion of disks on active Linodes

### DIFF
--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -91,10 +91,12 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
           );
         }
 
-        if (event.action === 'disk_delete' && ['finished', 'notification'].includes(event.status)) {
+        if (event.action === 'disk_delete' && event.status === 'failed') {
           const label = pathOr(false, ['entity', 'label'], event);
           return enqueueSnackbar(
-            `Unable to delete disk${label ? ` on ${label}` : ''}. Is it attached to a configuration profile that is in use?`,
+            `Unable to delete disk${
+              label ? ` on ${label}` : ''
+            }. Is it attached to a configuration profile that is in use?`,
             { variant: 'error' }
           );
         }

--- a/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
+++ b/packages/manager/src/features/ToastNotifications/ToastNotifications.tsx
@@ -1,4 +1,5 @@
 import { withSnackbar, WithSnackbarProps } from 'notistack';
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import 'rxjs/add/operator/bufferTime';
 import 'rxjs/add/operator/filter';
@@ -86,6 +87,14 @@ class ToastNotifications extends React.PureComponent<WithSnackbarProps, {}> {
           return enqueueSnackbar(
             `There was an error attaching volume ${event.entity &&
               event.entity.label}.`,
+            { variant: 'error' }
+          );
+        }
+
+        if (event.action === 'disk_delete' && ['finished', 'notification'].includes(event.status)) {
+          const label = pathOr(false, ['entity', 'label'], event);
+          return enqueueSnackbar(
+            `Unable to delete disk${label ? ` on ${label}` : ''}. Is it attached to a configuration profile that is in use?`,
             { variant: 'error' }
           );
         }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
@@ -79,7 +79,7 @@ class DiskActionMenu extends React.Component<CombinedProps> {
           this.props.onDelete();
           closeMenu();
         },
-        ...disabledProps
+        ...(readOnly ? disabledProps : {})
       }
     ];
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -177,10 +177,10 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
 
   componentDidUpdate(prevProps: CombinedProps) {
     if (
-      prevProps.diskDeleteError &&
+      this.props.diskDeleteError &&
       prevProps.diskDeleteError !== this.props.diskDeleteError
     ) {
-      this.props.enqueueSnackbar(prevProps.diskDeleteError[0].reason, {
+      this.props.enqueueSnackbar(this.props.diskDeleteError[0].reason, {
         variant: 'error'
       });
     }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -1,8 +1,6 @@
 import { Disk } from 'linode-js-sdk/lib/linodes';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
-import { path } from 'ramda';
 import * as React from 'react';
-import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
@@ -37,7 +35,6 @@ import {
 import userSSHKeyHoc, {
   UserSSHKeyProps
 } from 'src/features/linodes/userSSHKeyHoc';
-import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import LinodeDiskActionMenu from './LinodeDiskActionMenu';
@@ -131,7 +128,6 @@ interface State {
 type CombinedProps = UserSSHKeyProps &
   LinodeContextProps &
   WithStyles<ClassNames> &
-  StateProps &
   WithSnackbarProps;
 
 const defaultDrawerState: DrawerState = {
@@ -173,17 +169,6 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
       imagizeDrawer: defaultImagizeDrawerState,
       confirmDelete: defaultConfirmDeleteState
     };
-  }
-
-  componentDidUpdate(prevProps: CombinedProps) {
-    if (
-      this.props.diskDeleteError &&
-      prevProps.diskDeleteError !== this.props.diskDeleteError
-    ) {
-      this.props.enqueueSnackbar(this.props.diskDeleteError[0].reason, {
-        variant: 'error'
-      });
-    }
   }
 
   errorState = (
@@ -721,25 +706,8 @@ const linodeContext = withLinodeDetailContext(
   })
 );
 
-interface StateProps {
-  diskDeleteError?: Linode.ApiFieldError[];
-}
-
-const mapStateToProps: MapState<StateProps, CombinedProps> = state => ({
-  diskDeleteError: path(
-    ['__resources', 'linodeDisks', 'error', 'delete'],
-    state
-  )
-});
-
-const connected = connect(
-  mapStateToProps,
-  undefined
-);
-
 const enhanced = compose<CombinedProps, {}>(
   styled,
-  connected,
   linodeContext,
   userSSHKeyHoc,
   withSnackbar

--- a/packages/manager/src/store/linodes/disk/disk.actions.ts
+++ b/packages/manager/src/store/linodes/disk/disk.actions.ts
@@ -123,7 +123,3 @@ export const resizeLinodeDiskActions = actionCreator.async<
   Entity,
   Linode.ApiFieldError[]
 >(`resize`);
-
-export const handleDiskDeleteFailureEvent = actionCreator<void>(
-  'delete-failure'
-);

--- a/packages/manager/src/store/linodes/disk/disk.actions.ts
+++ b/packages/manager/src/store/linodes/disk/disk.actions.ts
@@ -123,3 +123,7 @@ export const resizeLinodeDiskActions = actionCreator.async<
   Entity,
   Linode.ApiFieldError[]
 >(`resize`);
+
+export const handleDiskDeleteFailureEvent = actionCreator<void>(
+  'delete-failure'
+);

--- a/packages/manager/src/store/linodes/disk/disk.reducer.ts
+++ b/packages/manager/src/store/linodes/disk/disk.reducer.ts
@@ -18,6 +18,7 @@ import {
   getAllLinodeDisksActions,
   getLinodeDiskActions,
   getLinodeDisksActions,
+  handleDiskDeleteFailureEvent,
   updateLinodeDiskActions
 } from './disk.actions';
 import { Entity } from './disk.types';
@@ -98,6 +99,20 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     return onError<MappedEntityState<Entity, EntityError>, EntityError>(
       {
         read: error
+      },
+      state
+    );
+  }
+
+  if (isType(action, handleDiskDeleteFailureEvent)) {
+    return onError<MappedEntityState<Entity, EntityError>, EntityError>(
+      {
+        delete: [
+          {
+            reason:
+              'Unable to delete disk. Is it attached to a configuration profile that is in use?'
+          }
+        ]
       },
       state
     );

--- a/packages/manager/src/store/linodes/disk/disk.reducer.ts
+++ b/packages/manager/src/store/linodes/disk/disk.reducer.ts
@@ -70,6 +70,15 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     return onCreateOrUpdate(result, state);
   }
 
+  if (isType(action, deleteLinodeDiskActions.started)) {
+    return onError<MappedEntityState<Entity, EntityError>, EntityError>(
+      {
+        delete: undefined
+      },
+      state
+    );
+  }
+
   if (isType(action, deleteLinodeDiskActions.done)) {
     const {
       params: { diskId: DiskId }

--- a/packages/manager/src/store/linodes/disk/disk.reducer.ts
+++ b/packages/manager/src/store/linodes/disk/disk.reducer.ts
@@ -18,7 +18,6 @@ import {
   getAllLinodeDisksActions,
   getLinodeDiskActions,
   getLinodeDisksActions,
-  handleDiskDeleteFailureEvent,
   updateLinodeDiskActions
 } from './disk.actions';
 import { Entity } from './disk.types';
@@ -108,20 +107,6 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     return onError<MappedEntityState<Entity, EntityError>, EntityError>(
       {
         read: error
-      },
-      state
-    );
-  }
-
-  if (isType(action, handleDiskDeleteFailureEvent)) {
-    return onError<MappedEntityState<Entity, EntityError>, EntityError>(
-      {
-        delete: [
-          {
-            reason:
-              'Unable to delete disk. Is it attached to a configuration profile that is in use?'
-          }
-        ]
       },
       state
     );

--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -3,7 +3,6 @@ import * as moment from 'moment';
 import { Dispatch } from 'redux';
 import { ApplicationState } from 'src/store';
 import { getAllLinodeConfigs } from 'src/store/linodes/config/config.requests';
-import { handleDiskDeleteFailureEvent } from 'src/store/linodes/disk/disk.actions';
 import { getAllLinodeDisks } from 'src/store/linodes/disk/disk.requests';
 import { requestLinodeForStore } from 'src/store/linodes/linode.requests';
 import { EventHandler } from 'src/store/types';
@@ -56,10 +55,7 @@ const linodeEventsHandler: EventHandler = (event, dispatch, getState) => {
          * If a disk deletion fails (most likely because it is attached to
          * a configuration profile that is in use on a running Linode)
          * the disk menu needs to be refreshed to return the disk to it.
-         * We also need to set error.delete for any listening components to
-         * handle.
          */
-        dispatch(handleDiskDeleteFailureEvent());
         dispatch(getAllLinodeDisks({ linodeId: id }));
       }
 


### PR DESCRIPTION
## Description

We had previously been doing a client side check to disallow deleting
a disk on a Linode that is running. However, this is too restrictive;
deleting a disk is possible as long as the disk is not in use
(that is, it's not associated with the config profile that booted
the Linode).

It turns out that proper validation here is impossible, so we're going
to allow deletions on any disk, and rely on the error event to let users
know that it failed. This involves creating a new Redux action to
update the linodeDisks.error.delete error field, and adding logic
in linode.events to trigger this action as well as refresh disk state.

We also send a toast notification if the user is still on the disks menu
when this happens.

## Note

I'm not thrilled about this UX. We could try something more complicated like forcing the pending disk to remain in the display until we get a success or failure event, but I thought that was too complicated. Feedback or suggestions welcome.

In addition, the ticket only specified deleting disks, but we use the same validation for disk resizing. If the pattern works, I can do a follow-up to allow resizing on a powered-on Linode as well.
