### PR TITLE
Add: Types and helper methods for working with the Longview API

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -30,6 +30,8 @@ export const ALGOLIA_SEARCH_KEY =
 export const LAUNCH_DARKLY_API_KEY =
   process.env.REACT_APP_LAUNCH_DARKLY_ID || '';
 
+export const LONGVIEW_ROOT = 'https://longview.linode.com/fetch';
+
 /** optional variables */
 export const SENTRY_URL = process.env.REACT_APP_SENTRY_URL;
 export const LOGIN_SESSION_LIFETIME_MS = 45 * 60 * 1000;

--- a/packages/manager/src/features/Longview/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding.tsx
@@ -23,7 +23,8 @@ export class LongviewLanding extends React.Component<{}, {}> {
    * Only for testing the LV API. Will be deleted pre-merge.
    */
   componentDidMount() {
-    getValues(DUMMY_KEY, ['Uptime', 'SysInfo.client', 'Load'])
+    const _getValues = getValues(DUMMY_KEY);
+    _getValues(['uptime'])
       .then(response => console.log(response))
       .catch(e => console.log('error!', e));
   }

--- a/packages/manager/src/features/Longview/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding.tsx
@@ -5,6 +5,10 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Placeholder from 'src/components/Placeholder';
 import { MonitoringYourServer } from 'src/documentation';
 
+import { getValues } from './longviewRequests';
+
+const DUMMY_KEY = 'AFD0FFEF-9706-D7DF-C1AAAC956F40E301';
+
 export class LongviewLanding extends React.Component<{}, {}> {
   static docs: Linode.Doc[] = [
     {
@@ -14,6 +18,15 @@ export class LongviewLanding extends React.Component<{}, {}> {
     },
     MonitoringYourServer
   ];
+
+  /**
+   * Only for testing the LV API. Will be deleted pre-merge.
+   */
+  componentDidMount() {
+    getValues(DUMMY_KEY, ['Uptime', 'SysInfo.client', 'Load'])
+      .then(response => console.log(response))
+      .catch(e => console.log('error!', e));
+  }
 
   render() {
     return (

--- a/packages/manager/src/features/Longview/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding.tsx
@@ -5,10 +5,6 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Placeholder from 'src/components/Placeholder';
 import { MonitoringYourServer } from 'src/documentation';
 
-import { getValues } from './longviewRequests';
-
-const DUMMY_KEY = 'AFD0FFEF-9706-D7DF-C1AAAC956F40E301';
-
 export class LongviewLanding extends React.Component<{}, {}> {
   static docs: Linode.Doc[] = [
     {
@@ -18,16 +14,6 @@ export class LongviewLanding extends React.Component<{}, {}> {
     },
     MonitoringYourServer
   ];
-
-  /**
-   * Only for testing the LV API. Will be deleted pre-merge.
-   */
-  componentDidMount() {
-    const _getValues = getValues(DUMMY_KEY);
-    _getValues(['uptime'])
-      .then(response => console.log(response))
-      .catch(e => console.log('error!', e));
-  }
 
   render() {
     return (

--- a/packages/manager/src/features/Longview/longviewRequests.ts
+++ b/packages/manager/src/features/Longview/longviewRequests.ts
@@ -94,13 +94,6 @@ export const handleLongviewResponse = (
      * and what code/severity checking we should be doing
      * to make sure we only reject with errors.
      */
-    // const errors = [];
-    // let i = 0;
-    // for (i; i < notifications.length; i++) {
-    //   errors.push({
-    //     reason: notifications[i].TEXT
-    //   });
-    // }
     const errors = notifications.map((thisNotification: LongviewError) => ({
       reason: pathOr('Error accessing Longview API', ['TEXT'], thisNotification)
     }));

--- a/packages/manager/src/features/Longview/longviewRequests.ts
+++ b/packages/manager/src/features/Longview/longviewRequests.ts
@@ -1,4 +1,5 @@
 import Axios, { AxiosResponse } from 'axios';
+import { pathOr } from 'ramda';
 import { LONGVIEW_ROOT } from 'src/constants';
 
 /**
@@ -43,9 +44,17 @@ import { LONGVIEW_ROOT } from 'src/constants';
  * So the errors will be available at response.data[0].NOTIFICATIONS.
  */
 
+export type LongviewAction =
+  | 'batch'
+  | 'getTopProcesses'
+  | 'getLatestValue'
+  | 'getValue'
+  | 'getValues'
+  | 'lastUpdated';
+
 export interface LongviewResponse {
   VERSION: number;
-  ACTION: string;
+  ACTION: LongviewAction;
   DATA: any;
   NOTIFICATIONS: LongviewError[];
 }
@@ -83,7 +92,7 @@ export const handleLongviewResponse = (
     //   });
     // }
     const errors = notifications.map((thisNotification: LongviewError) => ({
-      reason: thisNotification.TEXT
+      reason: pathOr('Error accessing Longview API', ['TEXT'], thisNotification)
     }));
     return Promise.reject(errors);
   } else {
@@ -95,7 +104,11 @@ export const getLastUpdated = (token: string) => {
   return get(token, 'getLatestValue');
 };
 
-export const get = (token: string, action: string, fields?: string[]) => {
+export const get = (
+  token: string,
+  action: LongviewAction,
+  fields?: string[]
+) => {
   const request = baseRequest();
   const data = new FormData();
   data.set('api_key', token);


### PR DESCRIPTION
## Description

Plenty more to do here but I wanted to get feedback before going much further. I'm hoping to get some tests for these, but mocking the setup through Axios has been tricky.

New content is in features/longview/longviewRequests.ts.

If you log in as prod user 004 and go to /longview, a few demo requests will be made and logged to the console.
