### PR TITLE
Add: Create Firewall Drawer

### DIFF
--- a/packages/manager/src/components/ActionMenu/ActionMenu.spec.js
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.spec.js
@@ -1,59 +1,69 @@
-const { navigateToStory, executeInAllStories } = require('../../../e2e/utils/storybook');
+const {
+  navigateToStory,
+  executeInAllStories
+} = require('../../../e2e/utils/storybook');
 
 describe('Action Menu Suite', () => {
-    const component = 'Action Menu';
-    const menuStories = [
-        'Action Menu',
-        'Action Menu with disabled menu item %26 tooltip',
-    ];
-    const actionMenu = '[data-qa-action-menu]';
-    const actionMenuItem = '[data-qa-action-menu-item]';
+  const component = 'Action Menu';
+  const menuStories = [
+    'Action Menu',
+    'Action Menu with disabled menu item %26 tooltip'
+  ];
+  const actionMenu = '[data-qa-action-menu]';
+  const actionMenuItem = '[data-qa-action-menu-item]';
 
-    it('should display action menu element', () => {
-        navigateToStory(component, menuStories, () => {
-            $(actionMenu).waitForDisplayed();
-        });
+  it('should display action menu element', () => {
+    navigateToStory(component, menuStories, () => {
+      $(actionMenu).waitForDisplayed();
     });
+  });
 
-    it('should display action menu items', () => {
-        executeInAllStories(component, menuStories, () => {
-            $(actionMenu).click();
-            $(actionMenuItem).waitForDisplayed();
-            expect($$(actionMenuItem).length)
-              .withContext(`Missing menu items`).toBeGreaterThan(1);
-            $$(actionMenuItem).forEach(i => expect(i.getTagName()).toBe('li'));
-        });
+  it('should display action menu items', () => {
+    executeInAllStories(component, menuStories, () => {
+      $(actionMenu).click();
+      $(actionMenuItem).waitForDisplayed();
+      expect($$(actionMenuItem).length)
+        .withContext(`Missing menu items`)
+        .toBeGreaterThan(1);
+      $$(actionMenuItem).forEach(i => expect(i.getTagName()).toBe('li'));
     });
+  });
 
-    it('should hide the menu items on select of an item', () => {
-        navigateToStory(component, menuStories[0]);
-        $(actionMenu).click();
-        $(actionMenuItem).waitForDisplayed();
-        $(actionMenuItem).click();
-        $(actionMenuItem).waitForExist(3000, true);
+  it('should hide the menu items on select of an item', () => {
+    navigateToStory(component, menuStories[0]);
+    $(actionMenu).click();
+    $(actionMenuItem).waitForDisplayed();
+    $(actionMenuItem).click();
+    $(actionMenuItem).waitForExist(3000, true);
+  });
 
-    });
+  it('should display tooltip menu item', () => {
+    navigateToStory(component, menuStories[1]);
 
-    it('should display tooltip menu item', () => {
-        navigateToStory(component, menuStories[1]);
+    const disabledMenuItem = '[data-qa-action-menu-item="Disabled Action"]';
+    const tooltipIcon = '[data-qa-tooltip-icon]';
+    const tooltip = '[data-qa-tooltip]';
 
-        const disabledMenuItem = '[data-qa-action-menu-item="Disabled Action"]';
-        const tooltipIcon = '[data-qa-tooltip-icon]';
-        const tooltip = '[data-qa-tooltip]';
+    $(actionMenu).waitForDisplayed();
+    $(actionMenu).click();
 
-        $(actionMenu).waitForDisplayed();
-        $(actionMenu).click();
+    $(disabledMenuItem).waitForDisplayed();
 
-        $(disabledMenuItem).waitForDisplayed();
-        $(tooltipIcon).click();
-        $(tooltip).waitForDisplayed();
-        expect($(tooltip).getText())
-          .withContext(`Incorrect tooltip text`).toBe('An explanation as to why this item is disabled');
-        expect($(disabledMenuItem).getAttribute('class'))
-          .withContext(`Class should be disabled`).toContain('disabled');
-        expect($(tooltipIcon).isDisplayed())
-          .withContext(`Tooltip icon should be displayed`).toBe(true);
-        expect($(tooltipIcon).getTagName())
-          .withContext(`Incorrect tag name`).toBe('button');
-    });
+    $(tooltipIcon).waitForDisplayed();
+    $(tooltipIcon).click();
+
+    $(tooltip).waitForDisplayed();
+    expect($(tooltip).getText())
+      .withContext(`Incorrect tooltip text`)
+      .toBe('An explanation as to why this item is disabled');
+    expect($(disabledMenuItem).getAttribute('class'))
+      .withContext(`Class should be disabled`)
+      .toContain('disabled');
+    expect($(tooltipIcon).isDisplayed())
+      .withContext(`Tooltip icon should be displayed`)
+      .toBe(true);
+    expect($(tooltipIcon).getTagName())
+      .withContext(`Incorrect tag name`)
+      .toBe('button');
+  });
 });

--- a/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
+++ b/packages/manager/src/components/AuthenticationWrapper/AuthenticationWrapper.tsx
@@ -38,6 +38,7 @@ import { requestNotifications } from 'src/store/notification/notification.reques
 import { requestProfile } from 'src/store/profile/profile.requests';
 import { requestRegions } from 'src/store/regions/regions.actions';
 import { getAllVolumes } from 'src/store/volume/volume.requests';
+import { GetAllData } from 'src/utilities/getAll';
 
 type CombinedProps = DispatchProps & StateProps & WithNodeBalancerActions;
 
@@ -142,7 +143,7 @@ interface DispatchProps {
   requestAccount: () => Promise<Account>;
   requestDomains: () => Promise<Domain[]>;
   requestImages: () => Promise<Image[]>;
-  requestLinodes: () => Promise<Linode[]>;
+  requestLinodes: () => Promise<GetAllData<Linode[]>>;
   requestNotifications: () => Promise<Notification[]>;
   requestSettings: () => Promise<AccountSettings>;
   requestTypes: () => Promise<LinodeType[]>;
@@ -160,7 +161,7 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   requestAccount: () => dispatch(requestAccount()),
   requestDomains: () => dispatch(requestDomains()),
   requestImages: () => dispatch(requestImages()),
-  requestLinodes: () => dispatch(requestLinodes()),
+  requestLinodes: () => dispatch(requestLinodes({})),
   requestNotifications: () => dispatch(requestNotifications()),
   requestSettings: () => dispatch(requestAccountSettings()),
   requestTypes: () => dispatch(requestTypes()),

--- a/packages/manager/src/components/Drawer/Drawer.tsx
+++ b/packages/manager/src/components/Drawer/Drawer.tsx
@@ -11,7 +11,7 @@ import {
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 
-interface Props extends DrawerProps {
+export interface Props extends DrawerProps {
   title: string;
   wide?: boolean;
 }

--- a/packages/manager/src/components/Drawer/index.ts
+++ b/packages/manager/src/components/Drawer/index.ts
@@ -1,2 +1,6 @@
-import Drawer from './Drawer';
+import Drawer, { Props } from './Drawer';
+
+/* tslint:disable-next-line */
+export interface DrawerProps extends Props {}
+
 export default Drawer;

--- a/packages/manager/src/components/EnhancedSelect/EnhancedSelect.spec.js
+++ b/packages/manager/src/components/EnhancedSelect/EnhancedSelect.spec.js
@@ -7,17 +7,18 @@ describe('Enhanced Select -', () => {
   const childComponents = ['Example'];
 
   beforeAll(() => {
-      navigateToStory(component, childComponents[0]);
+    navigateToStory(component, childComponents[0]);
   });
 
   describe('Basic Select -', () => {
     let basicSelect, basicSelects, options;
 
     it('should display the placeholder text in the select', () => {
+      selectLabels = $$('[data-qa-textfield-label]');
       basicSelects = $$('[data-qa-enhanced-select="Choose one fruit"]');
       let placeholderMsg = 'Choose one fruit';
 
-      expect(basicSelects[0].getText())
+      expect(selectLabels[0].getText())
         .withContext(`Select Title should be Basic Select`)
         .toContain('Basic Select');
       expect(basicSelects[0].getText())
@@ -26,7 +27,7 @@ describe('Enhanced Select -', () => {
     });
 
     it('should display options on click', () => {
-      const basicSelectInputs = basicSelects.map((s) => s.$("div"));
+      const basicSelectInputs = basicSelects.map(s => s.$('div'));
       basicSelectInputs[0].click();
       $('[data-qa-option]', constants.wait.normal).waitForDisplayed();
 
@@ -41,28 +42,30 @@ describe('Enhanced Select -', () => {
 
       options[0].click();
       options[0].waitForDisplayed(constants.wait.normal, true);
-      $(`[data-qa-enhanced-select="${optionValue}"]`, constants.wait.normal).waitForDisplayed();
+      $(
+        `[data-qa-enhanced-select="${optionValue}"]`,
+        constants.wait.normal
+      ).waitForDisplayed();
     });
   });
 
   describe('Basic Select with Error - ', () => {
     it('should display the error', () => {
       const errorMsg = "You didn't choose the correct fruit.";
-      const basicSelectWithError = $('[data-qa-enhanced-select="Choose one fruit"]');
-      const error = basicSelectWithError.$$('p').filter(p => p.getText().includes(errorMsg));
+      const errorSelectors = $$('[data-qa-textfield-error-text]');
 
-      expect(error.length)
+      expect(errorSelectors.length)
         .withContext(`Should only be one <p> with error text`)
         .toBe(1);
-      expect(error[0].isDisplayed())
+      expect(errorSelectors[0].getText())
         .withContext(`The error message should be displayed`)
-        .toBe(true);
+        .toBe(errorMsg);
     });
   });
 
   describe('Multi Select -', () => {
     let multiSelect, options, selectedOption;
-    const multiString = 'Choose some fruit'
+    const multiString = 'Choose some fruit';
     it('should display the multi select with placeholder text', () => {
       multiSelect = $(`[data-qa-multi-select="${multiString}"]`);
       expect(multiSelect.getText())
@@ -82,7 +85,10 @@ describe('Enhanced Select -', () => {
     it('should add a chip to the select on selection of an option', () => {
       selectedOption = options[0].getText();
       options[0].click();
-      $(`[data-qa-multi-option="${selectedOption}"]`, constants.wait.normal).waitForDisplayed();
+      $(
+        `[data-qa-multi-option="${selectedOption}"]`,
+        constants.wait.normal
+      ).waitForDisplayed();
     });
 
     it('should remove the chip from the select options', () => {
@@ -94,13 +100,15 @@ describe('Enhanced Select -', () => {
         .withContext(`Menu options should be reduced to 4`)
         .toBe(4);
       expect(remainingOptions)
-        .withContext(`Menu options should no longer include selected ${selectedOption}`)
+        .withContext(
+          `Menu options should no longer include selected ${selectedOption}`
+        )
         .not.toContain(selectedOption);
     });
 
     it('should remove the chip on click of the remove icon', () => {
-      $('#multi-select svg').click()
-      expect(selectedOption = options[0].getText())
+      $('#multi-select svg').click();
+      expect((selectedOption = options[0].getText()))
         .withContext(`Apple should be the first select option`)
         .toBe('Apple');
       expect(multiSelect.getText())
@@ -111,7 +119,7 @@ describe('Enhanced Select -', () => {
 
   describe('Creatable Select -', () => {
     let creatableSelect, newOption;
-    const createdText = 'Choose some timezones'
+    const createdText = 'Choose some timezones';
 
     beforeAll(() => {
       // Close any potentially open select menus
@@ -131,7 +139,10 @@ describe('Enhanced Select -', () => {
 
     it('should display the create menu option', () => {
       newOption = 'foo';
-      creatableSelect.$('..').$('input').setValue(newOption);
+      creatableSelect
+        .$('..')
+        .$('input')
+        .setValue(newOption);
       expect($(`[data-qa-option="${newOption}"]`).isDisplayed())
         .withContext(`Select option of ${newOption} should be displayed`)
         .toBe(true);
@@ -142,7 +153,10 @@ describe('Enhanced Select -', () => {
 
     it('should add a created option to the select', () => {
       $(`[data-qa-option="${newOption}"]`).click();
-      $(`[data-qa-multi-option="${newOption}"]`, constants.wait.normal).waitForDisplayed();
+      $(
+        `[data-qa-multi-option="${newOption}"]`,
+        constants.wait.normal
+      ).waitForDisplayed();
     });
 
     it('should select an already defined list option', () => {
@@ -152,14 +166,24 @@ describe('Enhanced Select -', () => {
       const optionName = optionToSelect[0].getText();
       optionToSelect[0].click();
 
-      $(`[data-qa-multi-option="${optionName}"]`).waitForDisplayed(constants.wait.normal);
+      $(`[data-qa-multi-option="${optionName}"]`).waitForDisplayed(
+        constants.wait.normal
+      );
     });
 
     it('should remove the created option on click of remove icon', () => {
-      $(`[data-qa-multi-option="${newOption}"]`).$('..').$('svg').click();
-      expect($(`[data-qa-multi-option="${newOption}"]`).waitForDisplayed(constants.wait.normal, true))
+      $(`[data-qa-multi-option="${newOption}"]`)
+        .$('..')
+        .$('svg')
+        .click();
+      expect(
+        $(`[data-qa-multi-option="${newOption}"]`).waitForDisplayed(
+          constants.wait.normal,
+          true
+        )
+      )
         .withContext(`${newOption} should not be in the select list`)
-        .toBe(true)
+        .toBe(true);
     });
   });
 });

--- a/packages/manager/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
+++ b/packages/manager/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
@@ -125,6 +125,11 @@ class Example extends React.Component<{}, State> {
       <React.Fragment>
         <Select
           label="Basic Select"
+          textFieldProps={{
+            dataAttrs: {
+              'data-qa-basic-select': true
+            }
+          }}
           value={valueSingle}
           placeholder="Choose one fruit"
           onChange={this.handleChangeSingle}

--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -1,9 +1,10 @@
 import { Linode } from 'linode-js-sdk/lib/linodes';
-import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import withLinodes from 'src/containers/withLinodes.container';
+import withLinodes, {
+  Props as LinodeProps
+} from 'src/containers/withLinodes.container';
 
 interface Props {
   linodeId: number;
@@ -13,10 +14,9 @@ interface Props {
   errorText?: string;
 }
 
-interface WithLinodesProps {
+interface WithLinodesProps
+  extends Pick<LinodeProps, 'linodesLoading' | 'linodesError'> {
   linode?: Linode;
-  linodesLoading: boolean;
-  linodesError?: APIError[];
 }
 
 type CombinedProps = Props & WithLinodesProps;

--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -3,9 +3,7 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import withLinodes, {
-  Props as LinodeProps
-} from 'src/containers/withLinodes.container';
+import withLinodes from 'src/containers/withLinodes.container';
 
 interface Props {
   linodeId: number;
@@ -18,7 +16,7 @@ interface Props {
 interface WithLinodesProps {
   linode?: Linode;
   linodesLoading: boolean;
-  linodesError?: LinodeProps['error'];
+  linodesError?: APIError[];
 }
 
 type CombinedProps = Props & WithLinodesProps;
@@ -57,7 +55,7 @@ const IPSelect: React.FC<CombinedProps> = props => {
 
   if (props.errorText) {
     errorText = props.errorText;
-  } else if (linodesError && linodesError.read) {
+  } else if (linodesError) {
     errorText = "There was an error retrieving this Linode's IP addresses.";
   }
 

--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -3,7 +3,9 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
-import withLinodes from 'src/containers/withLinodes.container';
+import withLinodes, {
+  Props as LinodeProps
+} from 'src/containers/withLinodes.container';
 
 interface Props {
   linodeId: number;
@@ -16,7 +18,7 @@ interface Props {
 interface WithLinodesProps {
   linode?: Linode;
   linodesLoading: boolean;
-  linodesError?: APIError[];
+  linodesError?: LinodeProps['error'];
 }
 
 type CombinedProps = Props & WithLinodesProps;
@@ -55,7 +57,7 @@ const IPSelect: React.FC<CombinedProps> = props => {
 
   if (props.errorText) {
     errorText = props.errorText;
-  } else if (linodesError) {
+  } else if (linodesError && linodesError.read) {
     errorText = "There was an error retrieving this Linode's IP addresses.";
   }
 

--- a/packages/manager/src/components/TagsInput/TagsInput.spec.js
+++ b/packages/manager/src/components/TagsInput/TagsInput.spec.js
@@ -8,9 +8,9 @@ describe('Tags Input Suite', () => {
   const tagInput = '#add-tags input';
   const tagOptions = '[data-qa-option]';
   const selectedTags = '[data-qa-multi-option]';
-  const inputError = '#add-tags-helper-text';
+  const inputError = '[data-qa-textfield-error-text]';
 
-  const inputValidation = (tagText) => {
+  const inputValidation = tagText => {
     $(tagInput).setValue(tagText);
     $(tagOptions).waitForDisplayed(constants.wait.normal);
     $$(tagOptions)[0].click();
@@ -18,7 +18,7 @@ describe('Tags Input Suite', () => {
     expect($(inputError).getText())
       .withContext(`Incorrect error message`)
       .toContain('Length must be 3-50 characters');
-  }
+  };
 
   beforeAll(() => {
     navigateToStory(component, childStories[0]);
@@ -31,7 +31,7 @@ describe('Tags Input Suite', () => {
     const tags = $$(tagOptions).map(tag => tag.getText());
     expect(tags)
       .withContext(`Incorrect tag names found`)
-      .toEqual(['tag1','tag2','tag3','tag4']);
+      .toEqual(['tag1', 'tag2', 'tag3', 'tag4']);
   });
 
   it('an available tag can be selected', () => {
@@ -47,19 +47,19 @@ describe('Tags Input Suite', () => {
     $(tagOptions).waitForDisplayed(constants.wait.normal);
     $$(tagOptions)[0].click();
     browser.waitUntil(() => {
-        return $$(selectedTags).length === 2;
-    },constants.wait.normal);
+      return $$(selectedTags).length === 2;
+    }, constants.wait.normal);
   });
 
   it('a single tag can be cleared by clicking the x icon on tag', () => {
     $('[data-qa-select-remove]').click();
     browser.waitUntil(() => {
-        return $$(selectedTags).length === 1;
-    },constants.wait.normal);
+      return $$(selectedTags).length === 1;
+    }, constants.wait.normal);
   });
 
   it('all tags can be cleared by clicking on the x icon to clear select', () => {
-    $('.react-select__indicators svg').click()
+    $('.react-select__indicators svg').click();
     //wait for selected tags not displayed
     $(selectedTags).waitForDisplayed(constants.wait.normal, true);
   });
@@ -73,7 +73,7 @@ describe('Tags Input Suite', () => {
     expect($(selectedTags).getText())
       .withContext(`missing created tag name`)
       .toEqual(testTag);
-    $('.react-select__indicators svg').click()
+    $('.react-select__indicators svg').click();
   });
 
   it('a tag must be between 3-50 characters', () => {
@@ -83,11 +83,12 @@ describe('Tags Input Suite', () => {
   });
 
   describe('Tags Input with api error', () => {
-
     it('an error message should be displayed when tags can not be retrieved', () => {
       navigateToStory(component, childStories[1]);
       $(selectBox).waitForDisplayed(constants.wait.normal);
-      const errorMessaage = $$('p').find(error => error.getAttribute('class').includes('error'))
+      const errorMessaage = $$('p').find(error =>
+        error.getAttribute('class').includes('error')
+      );
       expect(errorMessaage.getText())
         .withContext(`Incorrect text found`)
         .toContain('There was an error retrieving your tags.');

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -255,7 +255,6 @@ class LinodeTextField extends React.Component<CombinedProps> {
            */
           label={''}
           helperText={''}
-          // label={!!this.props.required ? `${label} (required)` : label}
           fullWidth
           /*
             let us explicitly pass an empty string to the input

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -239,9 +239,14 @@ class LinodeTextField extends React.Component<CombinedProps> {
           [classes.wrapper]: true
         })}
       >
-        <InputLabel>{maybeRequiredLabel || ''}</InputLabel>
+        <InputLabel data-qa-textfield-label>
+          {maybeRequiredLabel || ''}
+        </InputLabel>
         {helperText && helperTextPosition === 'top' && (
-          <FormHelperText className={classes.helperTextTop}>
+          <FormHelperText
+            data-qa-textfield-helper-text
+            className={classes.helperTextTop}
+          >
             {helperText}
           </FormHelperText>
         )}
@@ -330,7 +335,9 @@ class LinodeTextField extends React.Component<CombinedProps> {
         )}
         {helperText &&
           (helperTextPosition === 'bottom' || !helperTextPosition) && (
-            <FormHelperText>{helperText}</FormHelperText>
+            <FormHelperText data-qa-textfield-helper-text>
+              {helperText}
+            </FormHelperText>
           )}
       </div>
     );

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -14,18 +14,29 @@ import TextField, { TextFieldProps } from 'src/components/core/TextField';
 import HelpIcon from 'src/components/HelpIcon';
 import { convertToKebabCase } from 'src/utilities/convertToKebobCase';
 
+import FormHelperText from 'src/components/core/FormHelperText';
+import InputLabel from 'src/components/core/InputLabel';
+
 type ClassNames =
   | 'root'
   | 'helpWrapper'
   | 'helpWrapperTextField'
   | 'expand'
+  | 'errorText'
+  | 'helperTextTop'
   | 'small'
   | 'selectSmall'
+  | 'wrapper'
   | 'tiny';
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {},
+    wrapper: {
+      marginTop: theme.spacing(2)
+    },
+    root: {
+      marginTop: 0
+    },
     helpWrapper: {
       display: 'flex',
       alignItems: 'flex-end'
@@ -59,6 +70,13 @@ const styles = (theme: Theme) =>
     },
     tiny: {
       width: '3.6em'
+    },
+    errorText: {
+      color: theme.color.red
+    },
+    helperTextTop: {
+      marginBottom: theme.spacing(),
+      marginTop: theme.spacing(2)
     }
   });
 
@@ -66,6 +84,7 @@ interface BaseProps {
   errorText?: string;
   errorGroup?: string;
   affirmative?: Boolean;
+  helperTextPosition?: 'top' | 'bottom';
   tooltipText?: string;
   className?: any;
   expand?: boolean;
@@ -188,11 +207,14 @@ class LinodeTextField extends React.Component<CombinedProps> {
       small,
       tiny,
       inputProps,
+      helperText,
+      helperTextPosition,
       InputProps,
       InputLabelProps,
       SelectProps,
       value,
       dataAttrs,
+      error,
       label,
       ...textFieldProps
     } = this.props;
@@ -200,24 +222,40 @@ class LinodeTextField extends React.Component<CombinedProps> {
     let errorScrollClassName = '';
 
     if (errorText) {
-      textFieldProps.error = true;
-      textFieldProps.helperText = errorText;
       errorScrollClassName = errorGroup
         ? `error-for-scroll-${errorGroup}`
         : `error-for-scroll`;
     }
 
+    const maybeRequiredLabel = !!this.props.required
+      ? `${label} (required)`
+      : label;
+
     return (
       <div
         className={classNames({
           [classes.helpWrapper]: Boolean(tooltipText),
-          [errorScrollClassName]: !!errorText
+          [errorScrollClassName]: !!errorText,
+          [classes.wrapper]: true
         })}
       >
+        <InputLabel>{maybeRequiredLabel || ''}</InputLabel>
+        {helperText && helperTextPosition === 'top' && (
+          <FormHelperText className={classes.helperTextTop}>
+            {helperText}
+          </FormHelperText>
+        )}
         <TextField
           {...textFieldProps}
           {...dataAttrs}
-          label={!!this.props.required ? `${label} (required)` : label}
+          error={!!error || !!errorText}
+          /**
+           * set _helperText_ and _label_ to no value because we want to
+           * have the ability to put the helper text under the label at the top
+           */
+          label={''}
+          helperText={''}
+          // label={!!this.props.required ? `${label} (required)` : label}
           fullWidth
           /*
             let us explicitly pass an empty string to the input
@@ -269,7 +307,8 @@ class LinodeTextField extends React.Component<CombinedProps> {
           className={classNames(
             {
               [classes.helpWrapperTextField]: Boolean(tooltipText),
-              [classes.small]: small
+              [classes.small]: small,
+              [classes.root]: true
             },
             className
           )}
@@ -282,6 +321,15 @@ class LinodeTextField extends React.Component<CombinedProps> {
           {this.props.children}
         </TextField>
         {tooltipText && <HelpIcon text={tooltipText} />}
+        {errorText && (
+          <FormHelperText className={classes.errorText}>
+            {errorText}
+          </FormHelperText>
+        )}
+        {helperText &&
+          (helperTextPosition === 'bottom' || !helperTextPosition) && (
+            <FormHelperText>{helperText}</FormHelperText>
+          )}
       </div>
     );
   }

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -321,7 +321,10 @@ class LinodeTextField extends React.Component<CombinedProps> {
         </TextField>
         {tooltipText && <HelpIcon text={tooltipText} />}
         {errorText && (
-          <FormHelperText className={classes.errorText}>
+          <FormHelperText
+            className={classes.errorText}
+            data-qa-textfield-error-text
+          >
             {errorText}
           </FormHelperText>
         )}

--- a/packages/manager/src/components/core/Divider.ts
+++ b/packages/manager/src/components/core/Divider.ts
@@ -1,8 +1,0 @@
-import Divider, {
-  DividerProps as _DividerProps
-} from '@material-ui/core/Divider';
-
-/* tslint:disable-next-line:no-empty-interface */
-export interface DividerProps extends _DividerProps {}
-
-export default Divider;

--- a/packages/manager/src/components/core/Divider.tsx
+++ b/packages/manager/src/components/core/Divider.tsx
@@ -1,0 +1,23 @@
+import Divider, {
+  DividerProps as _DividerProps
+} from '@material-ui/core/Divider';
+import React from 'react'
+import { makeStyles, Theme } from 'src/components/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  line: {
+    /** these colors match up with the AppBar component boxShadow colors */
+    boxShadow: `inset 0 -1px 0 ${
+      theme.name === 'lightTheme' ? theme.color.border2 : theme.color.border3
+      }`
+  }
+}));
+
+const _Divider: React.FC<DividerProps> = (props) => (
+  <Divider className={useStyles().line} {...props} />
+)
+
+/* tslint:disable-next-line:no-empty-interface */
+export interface DividerProps extends _DividerProps { }
+
+export default _Divider;

--- a/packages/manager/src/containers/withLinodes.container.ts
+++ b/packages/manager/src/containers/withLinodes.container.ts
@@ -16,7 +16,9 @@ interface DispatchProps {
 export type LinodeWithMaintenance = L;
 
 /* tslint:disable-next-line */
-export type StateProps = State;
+export type StateProps = Omit<State, 'error'> & {
+  error?: APIError[];
+};
 
 type MapProps<ReduxStateProps, OwnProps> = (
   ownProps: OwnProps,
@@ -35,14 +37,22 @@ const connected = <ReduxStateProps extends {}, OwnProps extends {}>(
     DispatchProps,
     OwnProps,
     ApplicationState
-    >(
-      (state, ownProps) => {
-        const { loading, error, entities } = state.__resources.linodes;
-        if (mapAccountToProps) {
-          return mapAccountToProps(ownProps, entities, loading, path(['read'], error));
-        }
+  >(
+    (state, ownProps) => {
+      const { loading, error, entities } = state.__resources.linodes;
+      if (mapAccountToProps) {
+        return mapAccountToProps(
+          ownProps,
+          entities,
+          loading,
+          path(['read'], error)
+        );
+      }
 
-      return state.__resources.linodes;
+      return {
+        ...state.__resources.linodes,
+        error: path(['read'], state.__resources.linodes.error)
+      };
     },
     (dispatch: ThunkDispatch) => ({
       getLinodes: (params, filter) =>

--- a/packages/manager/src/containers/withLinodes.container.ts
+++ b/packages/manager/src/containers/withLinodes.container.ts
@@ -16,9 +16,13 @@ interface DispatchProps {
 export type LinodeWithMaintenance = L;
 
 /* tslint:disable-next-line */
-export type StateProps = Omit<State, 'error'> & {
-  error?: APIError[];
-};
+export interface StateProps {
+  linodesError?: APIError[];
+  linodesLoading: State['loading'];
+  linodesData: State['entities'];
+  linodesLastUpdated: State['lastUpdated'];
+  linodesResults: State['results'];
+}
 
 type MapProps<ReduxStateProps, OwnProps> = (
   ownProps: OwnProps,
@@ -39,7 +43,13 @@ const connected = <ReduxStateProps extends {}, OwnProps extends {}>(
     ApplicationState
   >(
     (state, ownProps) => {
-      const { loading, error, entities } = state.__resources.linodes;
+      const {
+        loading,
+        error,
+        entities,
+        lastUpdated,
+        results
+      } = state.__resources.linodes;
       if (mapStateToProps) {
         return mapStateToProps(
           ownProps,
@@ -50,8 +60,11 @@ const connected = <ReduxStateProps extends {}, OwnProps extends {}>(
       }
 
       return {
-        ...state.__resources.linodes,
-        error: path(['read'], state.__resources.linodes.error)
+        linodesError: path(['read'], error),
+        linodesLoading: loading,
+        linodesData: entities,
+        linodesResults: results,
+        linodesLastUpdated: lastUpdated
       };
     },
     (dispatch: ThunkDispatch) => ({

--- a/packages/manager/src/containers/withLinodes.container.ts
+++ b/packages/manager/src/containers/withLinodes.container.ts
@@ -30,7 +30,7 @@ type MapProps<ReduxStateProps, OwnProps> = (
 export type Props = DispatchProps & StateProps;
 
 const connected = <ReduxStateProps extends {}, OwnProps extends {}>(
-  mapAccountToProps?: MapProps<ReduxStateProps, OwnProps>
+  mapStateToProps?: MapProps<ReduxStateProps, OwnProps>
 ): InferableComponentEnhancerWithProps<any, any> =>
   connect<
     ReduxStateProps | StateProps,
@@ -40,8 +40,8 @@ const connected = <ReduxStateProps extends {}, OwnProps extends {}>(
   >(
     (state, ownProps) => {
       const { loading, error, entities } = state.__resources.linodes;
-      if (mapAccountToProps) {
-        return mapAccountToProps(
+      if (mapStateToProps) {
+        return mapStateToProps(
           ownProps,
           entities,
           loading,

--- a/packages/manager/src/features/Firewalls/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/AddFirewallDrawer.tsx
@@ -19,11 +19,11 @@ type CombinedProps = Props & LinodeProps;
 const AddFirewallDrawer: React.FC<CombinedProps> = props => {
   const {
     getLinodes,
-    loading: linodesLoading,
-    error: linodesError,
-    results: linodesResults,
-    entities: linodesEntities,
-    lastUpdated: linodesLastUpdated,
+    linodesLoading,
+    linodesError,
+    linodesResults,
+    linodesData,
+    linodesLastUpdated,
     ...restOfDrawerProps
   } = props;
 
@@ -49,7 +49,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
      * otherwise use the values from the react-select input value
      */
     const payloadAsArrayOfLinodeIDs = userSelectedAllLinodes(selectedLinodes)
-      ? linodesEntities.map(eachLinode => eachLinode.id)
+      ? linodesData.map(eachLinode => eachLinode.id)
       : selectedLinodes.map(eachValue => eachValue.value);
 
     return payloadAsArrayOfLinodeIDs;
@@ -109,7 +109,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
                   value: 'ALL',
                   label: 'All Linodes'
                 },
-                ...linodesEntities.map(eachLinode => ({
+                ...linodesData.map(eachLinode => ({
                   value: eachLinode.id,
                   label: eachLinode.label
                 }))

--- a/packages/manager/src/features/Firewalls/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/AddFirewallDrawer.tsx
@@ -71,6 +71,10 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
       <Select
         isLoading={linodesLoading}
         value={
+          /*
+            if the user selected _ALL_, that's the only chip
+            we want appearing in the actual text field.
+           */
           userSelectedAllLinodes(selectedLinodes)
             ? [
                 {
@@ -82,6 +86,10 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
         }
         isMulti
         options={
+          /*
+            basically, don't show any dropdown options
+            if the user has selected _ALL_
+           */
           userSelectedAllLinodes(selectedLinodes)
             ? [
                 {

--- a/packages/manager/src/features/Firewalls/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/AddFirewallDrawer.tsx
@@ -57,9 +57,15 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
 
   return (
     <Drawer {...restOfDrawerProps}>
-      <TextField label="Name" required inputRef={inputRef} />
+      <TextField
+        aria-label="Name of your new firewall"
+        label="Name"
+        required
+        inputRef={inputRef}
+      />
       <Select
         label="Rules"
+        aria-label="Select predefined rules for your firewall."
         textFieldProps={{
           required: true,
           helperText: `Add one or more predefined rules to this firewall. You can edit the
@@ -112,6 +118,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
           handleSelectLinodes(values)
         }
         placeholder="Select a Linode or type to search..."
+        aria-label="Select which Linodes to which you want to apply this new firewall"
         textFieldProps={{
           helperTextPosition: 'top',
           helperText: `Assign one or more Linodes to this firewall. You can

--- a/packages/manager/src/features/Firewalls/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/AddFirewallDrawer.tsx
@@ -75,6 +75,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
         onChange={() => null}
       />
       <Select
+        label="Linodes"
         isLoading={linodesLoading}
         value={
           /*

--- a/packages/manager/src/features/Firewalls/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/AddFirewallDrawer.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Drawer, { DrawerProps } from 'src/components/Drawer';
+import Select, { Item } from 'src/components/EnhancedSelect';
+import TextField from 'src/components/TextField';
+
+import withLinodes, {
+  Props as LinodeProps
+} from 'src/containers/withLinodes.container';
+
+/* tslint:disable-next-line */
+interface Props extends DrawerProps {}
+
+type CombinedProps = Props & LinodeProps;
+
+const AddFirewallDrawer: React.FC<CombinedProps> = props => {
+  const {
+    getLinodes,
+    loading: linodesLoading,
+    error: linodesError,
+    results: linodesResults,
+    entities: linodesEntities,
+    lastUpdated: linodesLastUpdated,
+    ...restOfDrawerProps
+  } = props;
+
+  const [selectedLinodes, handleSelectLinodes] = React.useState<
+    Item<number | string>[]
+  >([]);
+
+  const inputRef = React.useCallback(
+    node => {
+      /**
+       * focus on first textfield when drawer is opened
+       */
+      if (node && node.focus && props.open === true) {
+        node.focus();
+      }
+    },
+    [props.open]
+  );
+
+  const submitForm = () => {
+    /**
+     * if user selected _ALL_, create an array of Linode IDs for every Linode
+     * otherwise use the values from the react-select input value
+     */
+    const payloadAsArrayOfLinodeIDs = userSelectedAllLinodes(selectedLinodes)
+      ? linodesEntities.map(eachLinode => eachLinode.id)
+      : selectedLinodes.map(eachValue => eachValue.value);
+
+    return payloadAsArrayOfLinodeIDs;
+  };
+
+  return (
+    <Drawer {...restOfDrawerProps}>
+      <TextField label="Name" required inputRef={inputRef} />
+      <Select
+        label="Rules"
+        textFieldProps={{
+          required: true,
+          helperText: `Add one or more predefined rules to this firewall. You can edit the
+          default parameters for these rules after you create the firewall.`,
+          helperTextPosition: 'top'
+        }}
+        onChange={() => null}
+      />
+      <Select
+        isLoading={linodesLoading}
+        value={
+          userSelectedAllLinodes(selectedLinodes)
+            ? [
+                {
+                  value: 'ALL',
+                  label: 'All Linodes'
+                }
+              ]
+            : selectedLinodes
+        }
+        isMulti
+        options={
+          userSelectedAllLinodes(selectedLinodes)
+            ? [
+                {
+                  value: 'ALL',
+                  label: 'All Linodes'
+                }
+              ]
+            : [
+                {
+                  value: 'ALL',
+                  label: 'All Linodes'
+                },
+                ...linodesEntities.map(eachLinode => ({
+                  value: eachLinode.id,
+                  label: eachLinode.label
+                }))
+              ]
+        }
+        onChange={(values: Item<number | string>[]) =>
+          handleSelectLinodes(values)
+        }
+        placeholder="Select a Linode or type to search..."
+        textFieldProps={{
+          helperTextPosition: 'top',
+          helperText: `Assign one or more Linodes to this firewall. You can
+          add Linodes later if you want to customize your rules first.`
+        }}
+        hideSelectedOptions={true}
+      />
+      <ActionsPanel>
+        <Button
+          buttonType="primary"
+          onClick={submitForm}
+          data-qa-submit
+          loading={false}
+        >
+          Create
+        </Button>
+        <Button
+          onClick={props.onClose as any}
+          buttonType="cancel"
+          data-qa-cancel
+        >
+          Cancel
+        </Button>
+      </ActionsPanel>
+    </Drawer>
+  );
+};
+
+const userSelectedAllLinodes = (values: Item<string | number>[]) =>
+  values.some(eachValue => eachValue.value === 'ALL');
+
+export default compose<CombinedProps, Props>(
+  React.memo,
+  withLinodes()
+)(AddFirewallDrawer);

--- a/packages/manager/src/features/Firewalls/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding.tsx
@@ -12,6 +12,7 @@ import Grid from 'src/components/Grid';
 import withFirewalls, {
   Props as FireProps
 } from 'src/containers/firewalls.container';
+import AddFirewallDrawer from './AddFirewallDrawer';
 import FirewallTable from './FirewallTable';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -29,6 +30,10 @@ type CombinedProps = RouteComponentProps<{}> & FireProps;
 
 const FirewallLanding: React.FC<CombinedProps> = props => {
   const classes = useStyles();
+
+  const [addFirewallDrawerOpen, toggleAddFirewallDrawer] = React.useState<
+    boolean
+  >(false);
 
   const {
     data: firewalls,
@@ -67,9 +72,8 @@ const FirewallLanding: React.FC<CombinedProps> = props => {
           <Grid container alignItems="flex-end">
             <Grid item className="pt0">
               <AddNewLink
-                onClick={() => null}
+                onClick={() => toggleAddFirewallDrawer(true)}
                 label="Add a Firewall"
-                disabled
               />
             </Grid>
           </Grid>
@@ -82,6 +86,11 @@ const FirewallLanding: React.FC<CombinedProps> = props => {
         lastUpdated={firewallsLastUpdated}
         listOfIDsInOriginalOrder={firewallsKeys}
         results={props.results}
+      />
+      <AddFirewallDrawer
+        open={addFirewallDrawerOpen}
+        onClose={() => toggleAddFirewallDrawer(false)}
+        title="Add a Firewall"
       />
     </React.Fragment>
   );

--- a/packages/manager/src/features/Firewalls/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding.tsx
@@ -19,10 +19,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   line: {
     marginTop: theme.spacing(3),
     marginBottom: theme.spacing(3),
-    /** these colors match up with the AppBar component boxShadow colors */
-    boxShadow: `inset 0 -1px 0 ${
-      theme.name === 'lightTheme' ? theme.color.border2 : theme.color.border3
-    }`
   }
 }));
 

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -33,7 +33,9 @@ import withVolumes, {
 import withVolumesRequests, {
   VolumesRequests
 } from 'src/containers/volumesRequests.container';
-import withLinodes from 'src/containers/withLinodes.container';
+import withLinodes, {
+  LinodeWithMaintenance
+} from 'src/containers/withLinodes.container';
 import { BlockStorage } from 'src/documentation';
 import { resetEventsPolling } from 'src/events';
 import LinodePermissionsError from 'src/features/linodes/LinodesDetail/LinodePermissionsError';
@@ -137,10 +139,11 @@ const styles = (theme: Theme) =>
   });
 
 interface WithLinodesProps {
-  linodesData: Linode[];
+  linodesData: LinodeWithMaintenance[];
   linodesLoading: boolean;
   linodesError?: APIError[];
 }
+
 export interface ExtendedVolume extends Volume {
   linodeLabel?: string;
   linodeStatus?: string;
@@ -694,14 +697,11 @@ export default compose<CombinedProps, Props>(
     ...ownProps,
     eventsData: eventsData.filter(filterVolumeEvents)
   })),
-  withLinodes(
-    (ownProps: CombinedProps, linodesData, linodesLoading, linodesError) => ({
-      ...ownProps,
-      linodesData,
-      linodesLoading,
-      linodesError
-    })
-  ),
+  withLinodes((ownProps, linodesData, linodesLoading, linodesError) => ({
+    ...ownProps,
+    linodesData,
+    linodesLoading
+  })),
   withVolumes(
     (ownProps: CombinedProps, volumesData, volumesLoading, volumesError) => {
       const mappedData = volumesData.items.map(id => volumesData.itemsById[id]);

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -1,6 +1,5 @@
 import { Event } from 'linode-js-sdk/lib/account';
 import { Config, Linode } from 'linode-js-sdk/lib/linodes';
-import { APIError } from 'linode-js-sdk/lib/types';
 import { Volume } from 'linode-js-sdk/lib/volumes';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
@@ -34,7 +33,7 @@ import withVolumesRequests, {
   VolumesRequests
 } from 'src/containers/volumesRequests.container';
 import withLinodes, {
-  LinodeWithMaintenance
+  Props as WithLinodesProps
 } from 'src/containers/withLinodes.container';
 import { BlockStorage } from 'src/documentation';
 import { resetEventsPolling } from 'src/events';
@@ -137,12 +136,6 @@ const styles = (theme: Theme) =>
       minWidth: 250
     }
   });
-
-interface WithLinodesProps {
-  linodesData: LinodeWithMaintenance[];
-  linodesLoading: boolean;
-  linodesError?: APIError[];
-}
 
 export interface ExtendedVolume extends Volume {
   linodeLabel?: string;
@@ -697,11 +690,7 @@ export default compose<CombinedProps, Props>(
     ...ownProps,
     eventsData: eventsData.filter(filterVolumeEvents)
   })),
-  withLinodes((ownProps, linodesData, linodesLoading, linodesError) => ({
-    ...ownProps,
-    linodesData,
-    linodesLoading
-  })),
+  withLinodes(),
   withVolumes(
     (ownProps: CombinedProps, volumesData, volumesLoading, volumesError) => {
       const mappedData = volumesData.items.map(id => volumesData.itemsById[id]);

--- a/packages/manager/src/store/linodes/linodes.actions.ts
+++ b/packages/manager/src/store/linodes/linodes.actions.ts
@@ -1,6 +1,7 @@
 import { Notification } from 'linode-js-sdk/lib/account';
 import { CreateLinodeRequest, Linode } from 'linode-js-sdk/lib/linodes';
 import { APIError } from 'linode-js-sdk/lib/types';
+import { GetAllData } from 'src/utilities/getAll';
 import actionCreatorFactory from 'typescript-fsa';
 
 export const actionCreator = actionCreatorFactory(`@@manager/linodes`);
@@ -33,8 +34,11 @@ export type GetLinodeRequest = (params: LinodeID) => GetLinodeResponse;
 export type GetLinodeResponse = Promise<Linode>;
 
 export const getLinodesActions = actionCreator.async<
-  void,
-  Linode[],
+  {
+    params?: any;
+    filter?: any;
+  },
+  GetAllData<Linode[]>,
   APIError[]
 >('get-all');
 

--- a/packages/manager/src/store/linodes/linodes.reducer.ts
+++ b/packages/manager/src/store/linodes/linodes.reducer.ts
@@ -53,8 +53,8 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
     } = action;
     return {
       ...state,
-      entities: result,
-      results: result.map(getId),
+      entities: result.data,
+      results: result.data.map(getId),
       lastUpdated: Date.now(),
       loading: false
     };


### PR DESCRIPTION
## Description

Adds the fields and buttons for the _create firewall_ drawer

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

I also did a couple other things

1. Updated the `withLinodes` container to follow new patterns and get better typing

2. Allowed for putting the `helperText` copy at the top of a `<TextField />` because the Firewall designs have the helper copy on top. This is inconsistent with the rest of the site, though, so we might end up putting the copy on the bottom.