### PR TITLE
M3-3340 Fix: duplicate ID for react-select

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -96,6 +96,7 @@ export interface BaseSelectProps
   hideLabel?: boolean;
   errorGroup?: string;
   guidance?: string | React.ReactNode;
+  inputId?: any;
 }
 
 interface CreatableProps extends CreatableSelectProps<any> {}
@@ -133,6 +134,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
       hideLabel,
       errorGroup,
       onFocus,
+      inputId,
       ...restOfProps
     } = this.props;
 
@@ -177,6 +179,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
           but we're using the MUI select element so any props that
           can be passed to the MUI TextField element can be passed here
          */
+        inputId={inputId}
         textFieldProps={{
           ...textFieldProps,
           label,

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -184,7 +184,7 @@ class SearchBar extends React.Component<CombinedProps, State> {
         >
           <Search className={classes.icon} data-qa-search-icon />
           <EnhancedSelect
-            id="search-bar"
+            inputId="search-bar"
             blurInputOnSelect
             options={finalOptions}
             onChange={this.onSelect}


### PR DESCRIPTION
## Fix duplicate ID for react-select

console warning: `Found 2 elements with non-unique id #react-select-2-input:`

at /linodes/create

## Type of Change
- Bug fix ('fix')
