### PR TITLE
OBJ-225 Don't allow duplicate bucket names

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -154,7 +154,8 @@ export const dcDisplayCountry = {
 };
 
 export const objectStorageClusterDisplay: Record<Linode.ClusterID, string> = {
-  'us-east-1': 'Newark, NJ'
+  'us-east-1': 'Newark, NJ',
+  'us-east': 'Newark, NJ'
 };
 
 export type ContinentKey = 'NA' | 'EU' | 'AS';

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.test.tsx
@@ -23,7 +23,7 @@ describe('ClusterSelect', () => {
   it('should pass down error messages to <Select />', () => {
     wrapper.setProps({ clustersError: 'error' });
     expect(wrapper.find('WithStyles(Select)').prop('errorText')).toBe(
-      'Error loading Clusters'
+      'Error loading Regions'
     );
 
     wrapper.setProps({ error: 'Field Error', clustersError: undefined });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
@@ -39,7 +39,7 @@ export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
 
   // Error could be: 1. General Clusters error, 2. Field error, 3. Nothing
   const errorText = clustersError
-    ? 'Error loading Clusters'
+    ? 'Error loading Regions'
     : error
     ? error
     : undefined;
@@ -48,9 +48,9 @@ export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
     <Select
       data-qa-select-cluster
       name="cluster"
-      label="Cluster"
+      label="Region"
       options={options}
-      placeholder="All Clusters"
+      placeholder="All Regions"
       onChange={(item: Item<string>) => onChange(item.value)}
       onBlur={onBlur}
       isSearchable={false}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { CreateBucketForm } from './CreateBucketForm';
+import { buckets } from 'src/__data__/buckets';
+import { CreateBucketForm, isDuplicateBucket } from './CreateBucketForm';
 
 describe('CreateBucketForm', () => {
   const wrapper = shallow(
@@ -9,6 +10,8 @@ describe('CreateBucketForm', () => {
       onSuccess={jest.fn()}
       createBucket={jest.fn()}
       deleteBucket={jest.fn()}
+      bucketsData={[]}
+      bucketsLoading={false}
       classes={{ root: '', textWrapper: '' }}
     />
   );
@@ -22,5 +25,28 @@ describe('CreateBucketForm', () => {
       label: '',
       cluster: ''
     });
+  });
+});
+
+describe('isDuplicateBucket helper function', () => {
+  it('returns `true` if the label and cluster match a bucket in the data', () => {
+    const result = isDuplicateBucket(buckets, 'test-bucket-001', 'a-cluster');
+    expect(result).toBe(true);
+  });
+  it('returns `false` if only the label matches', () => {
+    const result = isDuplicateBucket(
+      buckets,
+      'test-bucket-001',
+      'other-cluster'
+    );
+    expect(result).toBe(false);
+  });
+  it('returns `false` if only the cluster matches', () => {
+    const result = isDuplicateBucket(buckets, 'other-bucket', 'a-cluster');
+    expect(result).toBe(false);
+  });
+  it('returns `false` if neither label or cluster matches', () => {
+    const result = isDuplicateBucket(buckets, 'other-bucket', 'other-cluster');
+    expect(result).toBe(false);
   });
 });

--- a/packages/manager/src/types/ObjectStorage.ts
+++ b/packages/manager/src/types/ObjectStorage.ts
@@ -33,5 +33,5 @@ namespace Linode {
   }
 
   // Enum containing IDs for each Cluster
-  export type ClusterID = 'us-east-1';
+  export type ClusterID = 'us-east-1' | 'us-east';
 }


### PR DESCRIPTION
## Description

The API returns a `200` when creating a new bucket with the _same name of a bucket you already own in the same cluster._

We can prevent the user from doing this by looking at the buckets they already own. 

Also in this PR:

- Support for `us-east` cluster
- Display "Region" instead of "Cluster" in the Add Bucket drawer.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

**To test:**

- Run the new unit tests: `yarn run test packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx`
- Create buckets with names of buckets you _do not_ own (happy path)
- Try to create buckets with names of buckets that you already own.
- Try to create buckets with names of buckets that you _do not_ own, but other people do (e.g. `test`, `jc1`).