### PR TITLE
M3-3343 Fix overflow-x in select drop downs on compact mode

### DIFF
--- a/packages/manager/src/components/EnhancedSelect/Select.styles.ts
+++ b/packages/manager/src/components/EnhancedSelect/Select.styles.ts
@@ -73,7 +73,7 @@ export const styles = (theme: Theme) =>
         zIndex: 100
       },
       '& .react-select__group': {
-        width: 'calc(100% + 4px)',
+        width: `calc(100% + ${theme.spacing(1) / 2}px)`,
         '&:last-child': {
           paddingBottom: 0
         }


### PR DESCRIPTION
## Fix overflow-x in select drop downs on compact mode

<img width="573" alt="Screen Shot 2019-09-24 at 8 44 29 AM" src="https://user-images.githubusercontent.com/205353/65542671-96c2d380-dedd-11e9-93a7-0ef82a2bcde0.png">
