### PR TITLE
M3-3341 Firefox styles for chip and tags

### DIFF
--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -65,7 +65,8 @@ const styles = (theme: Theme) =>
       width: '13%'
     },
     radioCell: {
-      width: '5%'
+      width: '5%',
+      height: 55
     }
   });
 

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -480,8 +480,11 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
         label: {
           paddingLeft: 4,
           paddingRight: 4,
-          position: 'relative',
-          top: -1
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          height: 'inherit'
         },
         deleteIcon: {
           padding: 2,


### PR DESCRIPTION
## Description

This work adds a height to table row for Resize so all rows will be a consistent size as well as adjustments to chip label styles to accommodate for Firefox.

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

Please view in multiple browsers and places where the chip component is used in such as tags panel on linode detail, the beta tag on OCA create flow, and the 'current plan' chip on resize.
