### PR TITLE
Change: Firewall Interface

### DIFF
--- a/packages/linode-js-sdk/src/firewalls/types.ts
+++ b/packages/linode-js-sdk/src/firewalls/types.ts
@@ -18,7 +18,6 @@ export interface FirewallRuleType {
   protocol: 'ALL' | 'TCP' | 'UDP' | 'ICMP';
   start_port: number;
   end_port?: null | number;
-  sequence: number;
   addresses?: null | {
     ipv4?: null | string[];
     ipv6?: null | string[];

--- a/packages/manager/src/__data__/firewalls.ts
+++ b/packages/manager/src/__data__/firewalls.ts
@@ -1,4 +1,5 @@
 import { Firewall } from 'linode-js-sdk/lib/firewalls';
+import { FirewallWithSequence } from 'src/store/firewalls/firewalls.reducer';
 
 export const firewall: Firewall = {
   id: 1,
@@ -72,5 +73,72 @@ export const firewall2: Firewall = {
     }
   ]
 };
+
+const firewallWithSequence: FirewallWithSequence = {
+  ...firewall,
+  rules: [
+    {
+      inbound: [
+        {
+          protocol: 'ALL',
+          start_port: 443,
+          sequence: 1
+        }
+      ]
+    },
+    {
+      outbound: [
+        {
+          protocol: 'UDP',
+          start_port: 22,
+          addresses: {
+            ipv4: ['12.12.12.12'],
+            ipv6: ['192.168.12.12']
+          },
+          sequence: 1
+        }
+      ]
+    }
+  ]
+};
+
+const firewallWithSequence2: FirewallWithSequence = {
+  ...firewall2,
+  rules: [
+    {
+      inbound: [],
+      outbound: [
+        {
+          protocol: 'ALL',
+          start_port: 443,
+          sequence: 1
+        },
+        {
+          protocol: 'ALL',
+          start_port: 80,
+          sequence: 2
+        }
+      ]
+    },
+    {
+      inbound: [
+        {
+          protocol: 'UDP',
+          start_port: 22,
+          addresses: {
+            ipv4: ['12.12.12.12'],
+            ipv6: ['192.168.12.12']
+          },
+          sequence: 1
+        }
+      ]
+    }
+  ]
+};
+
+export const firewallsWithSequence = [
+  firewallWithSequence,
+  firewallWithSequence2
+];
 
 export const firewalls = [firewall, firewall2];

--- a/packages/manager/src/__data__/firewalls.ts
+++ b/packages/manager/src/__data__/firewalls.ts
@@ -15,8 +15,7 @@ export const firewall: Firewall = {
       inbound: [
         {
           protocol: 'ALL',
-          start_port: 443,
-          sequence: 1
+          start_port: 443
         }
       ]
     },
@@ -25,7 +24,6 @@ export const firewall: Firewall = {
         {
           protocol: 'UDP',
           start_port: 22,
-          sequence: 1,
           addresses: {
             ipv4: ['12.12.12.12'],
             ipv6: ['192.168.12.12']
@@ -51,8 +49,7 @@ export const firewall2: Firewall = {
       outbound: [
         {
           protocol: 'ALL',
-          start_port: 443,
-          sequence: 1
+          start_port: 443
         }
       ]
     },
@@ -61,7 +58,6 @@ export const firewall2: Firewall = {
         {
           protocol: 'UDP',
           start_port: 22,
-          sequence: 1,
           addresses: {
             ipv4: ['12.12.12.12'],
             ipv6: ['192.168.12.12']

--- a/packages/manager/src/__data__/firewalls.ts
+++ b/packages/manager/src/__data__/firewalls.ts
@@ -46,10 +46,15 @@ export const firewall2: Firewall = {
   },
   rules: [
     {
+      inbound: [],
       outbound: [
         {
           protocol: 'ALL',
           start_port: 443
+        },
+        {
+          protocol: 'ALL',
+          start_port: 80
         }
       ]
     },

--- a/packages/manager/src/features/Firewalls/FirewallTableRows.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallTableRows.tsx
@@ -1,4 +1,3 @@
-import { Firewall } from 'linode-js-sdk/lib/firewalls';
 import * as React from 'react';
 import { compose } from 'recompose';
 // import { makeStyles, Theme } from 'src/components/core/styles'
@@ -10,13 +9,14 @@ import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 
 import { Props as FireProps } from 'src/containers/firewalls.container';
+import { FirewallWithSequence } from 'src/store/firewalls/firewalls.reducer';
 
 // const useStyles = makeStyles((theme: Theme) => ({
 //   root: {}
 // }))
 
 interface Props extends Omit<FireProps, 'data' | 'results' | 'getFirewalls'> {
-  data: Firewall[];
+  data: FirewallWithSequence[];
 }
 
 type CombinedProps = Props;

--- a/packages/manager/src/store/firewalls/firewalls.reducer.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.ts
@@ -1,9 +1,22 @@
-import { Firewall } from 'linode-js-sdk/lib/firewalls';
+import { Firewall, FirewallRuleType } from 'linode-js-sdk/lib/firewalls';
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
 import { EntitiesAsObjectState } from '../types';
 import { getFirewalls } from './firewalls.actions';
 
-export type State = EntitiesAsObjectState<Firewall>;
+interface FirewallRuleTypeWithSequence extends FirewallRuleType {
+  sequence: number;
+}
+
+interface FirewallRuleWithSequence {
+  inbound?: FirewallRuleTypeWithSequence | null;
+  outbound?: FirewallRuleTypeWithSequence | null;
+}
+
+interface FirewallWithSequence extends Omit<Firewall, 'rules'> {
+  rules: FirewallRuleWithSequence[];
+}
+
+export type State = EntitiesAsObjectState<FirewallWithSequence>;
 
 export const defaultState: State = {
   loading: false,
@@ -21,7 +34,7 @@ const reducer = reducerWithInitialState(defaultState)
   }))
   .caseWithAction(getFirewalls.done, (state, { payload: { result } }) => ({
     ...state,
-    data: result.data.reduce((acc, eachFirewall) => {
+    data: result.data.reduce((acc, eachFirewall, index) => {
       acc[eachFirewall.id] = eachFirewall;
       return acc;
     }, {}),


### PR DESCRIPTION
## Description

API is removing the `sequence` key from the list of firewall rules. This means that _when we support drag-and-drop sorting_, we'll need to send the ENTIRE list of firewall rules back in a specific order, rather than explicitly specifying what sequence they should be ordered in.

Most object properties with the except of a few (such as `Object.keys`) will retain the order properly, but this PR serves as more of an escape hatch. Drag-and-drop sorting isn't planned for MVP, but in attempts to make this feature more future-proof, I've opted to add the `sequence` key at the time the data is stored in Redux.

## Type of Change
- Non breaking change ('update', 'change')