### PR TITLE
Add Managed stats SDK method and types

### DIFF
--- a/packages/linode-js-sdk/src/managed/managed.ts
+++ b/packages/linode-js-sdk/src/managed/managed.ts
@@ -26,7 +26,7 @@ import {
   ManagedServicePayload,
   ManagedSSHPubKey,
   ManagedSSHSetting,
-  ManagedStatsResponse,
+  ManagedStats,
   UpdateCredentialPayload,
   UpdatePasswordPayload
 } from './types';
@@ -297,7 +297,7 @@ export const getManagedIssues = () =>
  * Returns usage data for all of the Linodes on a Managed customer's account.
  */
 export const getManagedStats = () =>
-  Request<ManagedStatsResponse>(
+  Request<ManagedStats>(
     setMethod('GET'),
     setURL(`${API_ROOT}/managed/stats`)
-  ).then(response => response.data.data);
+  ).then(response => response.data);

--- a/packages/linode-js-sdk/src/managed/managed.ts
+++ b/packages/linode-js-sdk/src/managed/managed.ts
@@ -26,6 +26,7 @@ import {
   ManagedServicePayload,
   ManagedSSHPubKey,
   ManagedSSHSetting,
+  ManagedStatsResponse,
   UpdateCredentialPayload,
   UpdatePasswordPayload
 } from './types';
@@ -289,3 +290,14 @@ export const getManagedIssues = () =>
     setMethod('GET'),
     setURL(`${API_ROOT}/managed/issues`)
   ).then(response => response.data);
+
+/**
+ * getManagedStats
+ *
+ * Returns usage data for all of the Linodes on a Managed customer's account.
+ */
+export const getManagedData = () =>
+  Request<ManagedStatsResponse>(
+    setMethod('GET'),
+    setURL(`${API_ROOT}/managed/stats`)
+  ).then(response => response.data.data);

--- a/packages/linode-js-sdk/src/managed/managed.ts
+++ b/packages/linode-js-sdk/src/managed/managed.ts
@@ -296,7 +296,7 @@ export const getManagedIssues = () =>
  *
  * Returns usage data for all of the Linodes on a Managed customer's account.
  */
-export const getManagedData = () =>
+export const getManagedStats = () =>
   Request<ManagedStatsResponse>(
     setMethod('GET'),
     setURL(`${API_ROOT}/managed/stats`)

--- a/packages/linode-js-sdk/src/managed/types.ts
+++ b/packages/linode-js-sdk/src/managed/types.ts
@@ -103,3 +103,19 @@ export interface IssueEntity {
   type: 'ticket'; // I don't make the rules I'm just describing them
   url: string;
 }
+
+export interface DataSeries {
+  x: number;
+  y: number;
+}
+export interface ManagedStats {
+  disk: DataSeries[];
+  cpu: DataSeries;
+  net_in: DataSeries;
+  net_out: DataSeries;
+  swap: DataSeries;
+}
+
+export interface ManagedStatsResponse {
+  data: ManagedStats;
+}

--- a/packages/linode-js-sdk/src/managed/types.ts
+++ b/packages/linode-js-sdk/src/managed/types.ts
@@ -110,10 +110,10 @@ export interface DataSeries {
 }
 export interface ManagedStats {
   disk: DataSeries[];
-  cpu: DataSeries;
-  net_in: DataSeries;
-  net_out: DataSeries;
-  swap: DataSeries;
+  cpu: DataSeries[];
+  net_in: DataSeries[];
+  net_out: DataSeries[];
+  swap: DataSeries[];
 }
 
 export interface ManagedStatsResponse {

--- a/packages/linode-js-sdk/src/managed/types.ts
+++ b/packages/linode-js-sdk/src/managed/types.ts
@@ -115,7 +115,3 @@ export interface ManagedStats {
   net_out: DataSeries[];
   swap: DataSeries[];
 }
-
-export interface ManagedStatsResponse {
-  data: ManagedStats;
-}

--- a/packages/linode-js-sdk/src/managed/types.ts
+++ b/packages/linode-js-sdk/src/managed/types.ts
@@ -108,10 +108,14 @@ export interface DataSeries {
   x: number;
   y: number;
 }
-export interface ManagedStats {
+
+export interface ManagedStatsData {
   disk: DataSeries[];
   cpu: DataSeries[];
   net_in: DataSeries[];
   net_out: DataSeries[];
   swap: DataSeries[];
+}
+export interface ManagedStats {
+  data: ManagedStatsData;
 }


### PR DESCRIPTION
## Description

Uses the secret Managed/stats endpoint to retrieve summary data for a Managed user's account.

## Type of Change
- Non breaking change ('update', 'change')

## Notes

There isn't documentation for this endpoint yet, so I'm basing this shape off of:

`curlp managed/stats | jq 'keys'`
`curlp managed/stats | jq '.data | keys'`

....and some console logging.