### PR TITLE
Change: Deprecate Linode.ApiFieldError

### DIFF
--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -362,7 +362,7 @@ import { Observable } from 'rxjs/Observable';
 Our application has to work with different types of errors: JavaScript `Error` objects, `AxiosErrors`, and field errors
 from the Linode API. To simplify working with these and maintain consistency, we have created several helper methods in `src/utilities/errorUtils`.
 
-# API Error arrays
+#### API Error arrays
 
 In most cases, we want components to work with an array of Linode API errors. These have the shape:
 

--- a/CODE_CONVENTIONS.md
+++ b/CODE_CONVENTIONS.md
@@ -362,9 +362,9 @@ import { Observable } from 'rxjs/Observable';
 Our application has to work with different types of errors: JavaScript `Error` objects, `AxiosErrors`, and field errors
 from the Linode API. To simplify working with these and maintain consistency, we have created several helper methods in `src/utilities/errorUtils`.
 
-#### ApiFieldError arrays
+# API Error arrays
 
-In most cases, we want components to work with an array of Linode API field errors. These have the shape:
+In most cases, we want components to work with an array of Linode API errors. These have the shape:
 
 `{ field: 'field-name', reason: 'why this error occurred' }`
 
@@ -449,12 +449,13 @@ If your data is being sourced from Redux state, it's safe to assume that the dat
 The first step in paginating things from Redux is to source the data
 
 ```js
+import { APIError } from 'linode-js-sdk/lib/types'
 import { Volume } from 'linode-js-sdk/lib/volumes'
 import { connect } from 'react-redux'
 
 interface ReduxStateProps {
   loading: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   data: Volume[];
 }
 

--- a/packages/linode-js-sdk/src/request.ts
+++ b/packages/linode-js-sdk/src/request.ts
@@ -117,7 +117,7 @@ export const requestGenerator = <T>(...fns: Function[]): AxiosPromise<T> => {
   const config = reduceRequestConfig(...fns);
   if (config.validationErrors) {
     return Promise.reject(
-      config.validationErrors // All failed requests, client or server errors, should be Linode.ApiFieldError[]
+      config.validationErrors // All failed requests, client or server errors, should be APIError[]
     );
   }
 
@@ -203,7 +203,7 @@ const createError = (message: string, response: AxiosResponse) => {
 
 /**
  *
- * Helper method to easily generate APIFieldError[] for a number of fields and a general error.
+ * Helper method to easily generate APIError[] for a number of fields and a general error.
  */
 export const mockAPIFieldErrors = (fields: string[]): APIError[] => {
   return fields.reduce(

--- a/packages/manager/src/App.test.tsx
+++ b/packages/manager/src/App.test.tsx
@@ -1,4 +1,5 @@
 import { shallow } from 'enzyme';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { Provider } from 'react-redux';
 import { StaticRouter } from 'react-router-dom';
@@ -53,7 +54,7 @@ it('renders without crashing.', () => {
   expect(component.find('App')).toHaveLength(1);
 });
 
-const errors: (Linode.ApiFieldError[] | Error)[] = [
+const errors: (APIError[] | Error)[] = [
   [
     {
       reason: 'invalid OAuTh token'

--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -6,6 +6,7 @@ import {
 import { Image } from 'linode-js-sdk/lib/images';
 import { Linode } from 'linode-js-sdk/lib/linodes';
 import { Region } from 'linode-js-sdk/lib/regions';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { path, pathOr } from 'ramda';
 import * as React from 'react';
@@ -313,20 +314,20 @@ interface StateProps {
   bucketsLoading: boolean;
   accountLoading: boolean;
   accountSettingsLoading: boolean;
-  accountSettingsError?: Linode.ApiFieldError[];
+  accountSettingsError?: APIError[];
   nodeBalancersLoading: boolean;
-  linodesError?: Linode.ApiFieldError[];
-  volumesError?: Linode.ApiFieldError[];
-  nodeBalancersError?: Linode.ApiFieldError[];
-  domainsError?: Linode.ApiFieldError[];
-  imagesError?: Linode.ApiFieldError[];
-  bucketsError?: Linode.ApiFieldError[];
-  profileError?: Linode.ApiFieldError[];
-  accountError?: Linode.ApiFieldError[];
-  settingsError?: Linode.ApiFieldError[];
-  notificationsError?: Linode.ApiFieldError[];
-  typesError?: Linode.ApiFieldError[];
-  regionsError?: Linode.ApiFieldError[];
+  linodesError?: APIError[];
+  volumesError?: APIError[];
+  nodeBalancersError?: APIError[];
+  domainsError?: APIError[];
+  imagesError?: APIError[];
+  bucketsError?: APIError[];
+  profileError?: APIError[];
+  accountError?: APIError[];
+  settingsError?: APIError[];
+  notificationsError?: APIError[];
+  typesError?: APIError[];
+  regionsError?: APIError[];
   appIsLoading: boolean;
 }
 
@@ -390,9 +391,7 @@ export default compose(
   withFeatureFlagProvider
 )(App);
 
-export const hasOauthError = (
-  ...args: (Error | Linode.ApiFieldError[] | undefined)[]
-) => {
+export const hasOauthError = (...args: (Error | APIError[] | undefined)[]) => {
   return args.some(eachError => {
     const cleanedError: string | JSX.Element = pathOr(
       '',

--- a/packages/manager/src/IdentifyUser.tsx
+++ b/packages/manager/src/IdentifyUser.tsx
@@ -1,10 +1,11 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as md5 from 'md5';
 import * as React from 'react';
 import { useLDClient } from 'src/containers/withFeatureFlagProvider.container';
 
 interface Props {
   accountCountry?: string;
-  accountError?: Linode.ApiFieldError[];
+  accountError?: APIError[];
   userID?: number;
   username?: string;
   taxID?: string;

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -366,7 +366,7 @@ const MainContent: React.FC<CombinedProps> = props => {
 const getObjectStorageRoute = (
   accountLoading: boolean,
   accountCapabilities: AccountCapability[],
-  accountError?: Error | Linode.ApiFieldError[]
+  accountError?: Error | APIError[]
 ) => {
   let component;
 

--- a/packages/manager/src/components/IPSelect/IPSelect.tsx
+++ b/packages/manager/src/components/IPSelect/IPSelect.tsx
@@ -1,4 +1,5 @@
 import { Linode } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
@@ -15,7 +16,7 @@ interface Props {
 interface WithLinodesProps {
   linode?: Linode;
   linodesLoading: boolean;
-  linodesError?: Linode.ApiFieldError[];
+  linodesError?: APIError[];
 }
 
 type CombinedProps = Props & WithLinodesProps;

--- a/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -37,7 +38,7 @@ interface Props {
   maintenanceEnd?: string | null;
   userTimezone?: string;
   userTimezoneLoading: boolean;
-  userTimezoneError?: Linode.ApiFieldError[];
+  userTimezoneError?: APIError[];
   type?: 'migration' | 'reboot';
 }
 

--- a/packages/manager/src/components/Pagey/Pagey.ts
+++ b/packages/manager/src/components/Pagey/Pagey.ts
@@ -1,4 +1,4 @@
-import { ResourcePage } from 'linode-js-sdk/lib/types'
+import { APIError, ResourcePage } from 'linode-js-sdk/lib/types';
 import { clone } from 'ramda';
 import * as React from 'react';
 import { storage } from 'src/utilities/storage';
@@ -33,7 +33,7 @@ export type OrderBy = undefined | string;
 
 interface State<T = {}> {
   count: number;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   loading: boolean;
   isSorting?: boolean;
   page: number;

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -1,4 +1,5 @@
 import { getTags } from 'linode-js-sdk/lib/tags';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { concat } from 'ramda';
 import * as React from 'react';
 import Select, {
@@ -14,7 +15,7 @@ export interface Tag {
 
 export interface State {
   accountTags: Item[];
-  errors: Linode.ApiFieldError[];
+  errors: APIError[];
 }
 
 export interface Props {

--- a/packages/manager/src/containers/bucket.container.ts
+++ b/packages/manager/src/containers/bucket.container.ts
@@ -1,10 +1,11 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { connect, MapStateToProps } from 'react-redux';
 import { ApplicationState } from 'src/store';
 
 export interface StateProps {
   bucketsData: Linode.Bucket[];
   bucketsLoading: boolean;
-  bucketsError?: Error | Linode.ApiFieldError[];
+  bucketsError?: Error | APIError[];
 }
 
 const mapStateToProps: MapStateToProps<

--- a/packages/manager/src/containers/clusters.container.ts
+++ b/packages/manager/src/containers/clusters.container.ts
@@ -1,9 +1,10 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 
 export interface StateProps {
   clustersData: Linode.Cluster[];
-  clustersError?: Linode.ApiFieldError[];
+  clustersError?: APIError[];
   clustersLoading: boolean;
 }
 

--- a/packages/manager/src/containers/nodebalancerConfigs.container.ts
+++ b/packages/manager/src/containers/nodebalancerConfigs.container.ts
@@ -1,11 +1,12 @@
 import { NodeBalancerConfig } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { connect, MapStateToProps } from 'react-redux';
 import { ApplicationState } from 'src/store';
 
 export interface StateProps {
   configs: NodeBalancerConfig[];
   configsLoading: boolean;
-  configsError?: Error | Linode.ApiFieldError[];
+  configsError?: Error | APIError[];
 }
 
 const mapStateToProps: MapStateToProps<

--- a/packages/manager/src/containers/regions.container.ts
+++ b/packages/manager/src/containers/regions.container.ts
@@ -1,10 +1,11 @@
 import { Region } from 'linode-js-sdk/lib/regions';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 
 export interface DefaultProps {
   regionsData: Region[];
-  regionsError?: Linode.ApiFieldError[];
+  regionsError?: APIError[];
   regionsLoading: boolean;
   regionsLastUpdated: number;
 }
@@ -23,7 +24,7 @@ const defaultMap: (p: InjectedProps) => DefaultProps = ({
 
 interface InjectedProps {
   data: Region[];
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   loading: boolean;
   lastUpdated: number;
 }

--- a/packages/manager/src/containers/types.container.ts
+++ b/packages/manager/src/containers/types.container.ts
@@ -1,4 +1,5 @@
 import { LinodeType } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, filter, map, pathOr } from 'ramda';
 import { connect } from 'react-redux';
 
@@ -9,7 +10,7 @@ import { ApplicationState } from 'src/store';
 export interface WithTypesProps {
   typesData?: ExtendedType[];
   typesLoading: boolean;
-  typesError?: Linode.ApiFieldError[];
+  typesError?: APIError[];
 }
 
 export default connect((state: ApplicationState, ownProps) => ({

--- a/packages/manager/src/containers/withLinodes.container.ts
+++ b/packages/manager/src/containers/withLinodes.container.ts
@@ -1,4 +1,5 @@
 import { Linode } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { path } from 'ramda';
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
@@ -7,7 +8,7 @@ type MapProps<TOuter, TInner> = (
   ownProps: TOuter,
   linodes: Linode[],
   loading: boolean,
-  error?: Linode.ApiFieldError[]
+  error?: APIError[]
 ) => TInner;
 
 export default <TInner extends {}, TOuter extends {}>(

--- a/packages/manager/src/containers/withNodeBalancers.container.ts
+++ b/packages/manager/src/containers/withNodeBalancers.container.ts
@@ -1,4 +1,5 @@
 import { NodeBalancer } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 
@@ -6,7 +7,7 @@ type MapProps<TOuter, TInner> = (
   ownProps: TOuter,
   nodeBalancers: NodeBalancer[],
   loading: boolean,
-  error?: Linode.ApiFieldError[]
+  error?: APIError[]
 ) => TInner;
 
 export default <TInner extends {}, TOuter extends {}>(

--- a/packages/manager/src/features/Account/GlobalSettings.tsx
+++ b/packages/manager/src/features/Account/GlobalSettings.tsx
@@ -1,5 +1,6 @@
 import { AccountSettings } from 'linode-js-sdk/lib/account';
 import { Linode } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { isEmpty, path, pathOr } from 'ramda';
 import * as React from 'react';
@@ -34,7 +35,7 @@ interface StateProps {
   backups_enabled: boolean;
   error?: Error;
   linodesWithoutBackups: Linode[];
-  updateError?: Linode.ApiFieldError[];
+  updateError?: APIError[];
   networkHelperEnabled: boolean;
   entitiesWithGroupsToImport: GroupedEntitiesForImport;
   isManaged: boolean;
@@ -71,7 +72,7 @@ class GlobalSettings extends React.Component<CombinedProps, {}> {
     return updateAccount({ network_helper: !networkHelperEnabled });
   };
 
-  displayError = (errors: Linode.ApiFieldError[] | undefined) => {
+  displayError = (errors: APIError[] | undefined) => {
     if (!errors) {
       return;
     }

--- a/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -25,7 +25,8 @@ import {
   executePaypalPayment,
   makePayment,
   stagePaypalPayment
-} from 'linode-js-sdk/lib/account'
+} from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import scriptLoader from 'react-async-script-loader';
@@ -106,7 +107,7 @@ interface State {
   type: 'CREDIT_CARD' | 'PAYPAL';
   isSubmittingCreditCardPayment: boolean;
   successMessage?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   usd: string;
   cvv?: string;
   paymentID: string;
@@ -157,11 +158,11 @@ const paypalSrcQueryParams = `&disable-funding=card,credit&currency=USD&commit=f
 const paypalScriptSrc = () => {
   return isProduction
     ? `https://www.paypal.com/sdk/js?client-id=${
-    client.production
-    }${paypalSrcQueryParams}`
+        client.production
+      }${paypalSrcQueryParams}`
     : `https://www.paypal.com/sdk/js?client-id=${
-    client.sandbox
-    }${paypalSrcQueryParams}`;
+        client.sandbox
+      }${paypalSrcQueryParams}`;
 };
 
 const env = process.env.NODE_ENV === 'development' ? 'sandbox' : 'production';
@@ -331,7 +332,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
           paypalDialogOpen: false,
           successMessage: `Payment for $${
             this.state.usd
-            } successfully submitted`
+          } successfully submitted`
         });
       })
       .catch(errorResponse => {
@@ -578,10 +579,10 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
             </div>
           </React.Fragment>
         ) : (
-            <Button buttonType="primary" onClick={this.openCreditCardDialog}>
-              Submit Payment
+          <Button buttonType="primary" onClick={this.openCreditCardDialog}>
+            Submit Payment
           </Button>
-          )}
+        )}
         <Button buttonType="cancel" onClick={this.resetForm}>
           Cancel
         </Button>

--- a/packages/manager/src/features/Billing/BillingPanels/PromotionsPanel/PromotionsPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/PromotionsPanel/PromotionsPanel.tsx
@@ -1,4 +1,5 @@
-import { ActivePromotion } from 'linode-js-sdk/lib/account'
+import { ActivePromotion } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -20,7 +21,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface StateProps {
   accountLoading: boolean;
-  accountError?: Linode.ApiFieldError[];
+  accountError?: APIError[];
   accountUpdated: number;
   promotions: ActivePromotion[];
 }

--- a/packages/manager/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/RecentInvoicesPanel/RecentInvoicesPanel.tsx
@@ -1,4 +1,5 @@
-import { Account, getInvoices, Invoice } from 'linode-js-sdk/lib/account'
+import { Account, getInvoices, Invoice } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -94,8 +95,8 @@ class RecentInvoicesPanel extends React.Component<CombinedProps, State> {
         <RecentInvoiceRow key={index} invoice={eachInvoice} account={account} />
       ))
     ) : (
-        <TableRowEmptyState colSpan={4} />
-      );
+      <TableRowEmptyState colSpan={4} />
+    );
   };
 
   handleExpansion = (e: any, expanded: boolean) => {
@@ -109,7 +110,7 @@ class RecentInvoicesPanel extends React.Component<CombinedProps, State> {
 interface ReduxState {
   account?: Account;
   accountLoading: boolean;
-  accountError?: Linode.ApiFieldError[] | Error;
+  accountError?: APIError[] | Error;
 }
 
 interface StateProps extends ReduxState {

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/CancelAccountDialog.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/CancelAccountDialog.tsx
@@ -1,4 +1,5 @@
-import { cancelAccount } from 'linode-js-sdk/lib/account'
+import { cancelAccount } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -26,9 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 const CancelAccountDialog: React.FC<CombinedProps> = props => {
   const [isCancelling, setCancelling] = React.useState<boolean>(false);
-  const [errors, setErrors] = React.useState<
-    Linode.ApiFieldError[] | undefined
-  >(undefined);
+  const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
   const [comments, setComments] = React.useState<string>('');
   const [inputtedUsername, setUsername] = React.useState<string>('');
   const [canSubmit, setCanSubmit] = React.useState<boolean>(false);
@@ -85,7 +84,7 @@ const CancelAccountDialog: React.FC<CombinedProps> = props => {
         /** shoot the user off to survey monkey to answer some questions */
         props.history.push(`/cancel?link=${response.survey_link}`);
       })
-      .catch((e: Linode.ApiFieldError[]) => {
+      .catch((e: APIError[]) => {
         setCancelling(false);
         setErrors(e);
       });

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
@@ -1,4 +1,5 @@
-import { Account } from 'linode-js-sdk/lib/account'
+import { Account } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
@@ -14,13 +15,13 @@ import BillingInfo from './PanelCards/BillingInformation';
 import ContactInfo from './PanelCards/ContactInformation';
 
 interface AccountContextProps {
-  accountError?: Linode.ApiFieldError[];
+  accountError?: APIError[];
   lastUpdated: number;
   account?: Account;
   accountLoading: boolean;
 }
 
-interface Props extends Pick<RouteComponentProps, 'history'> { }
+interface Props extends Pick<RouteComponentProps, 'history'> {}
 
 export type CombinedProps = AccountContextProps & Profile & Props;
 
@@ -87,7 +88,7 @@ export class SummaryPanel extends React.Component<CombinedProps, {}> {
 
 interface Profile {
   profileLoading: boolean;
-  profileError?: Linode.ApiFieldError[];
+  profileError?: APIError[];
   username?: string;
   isRestricted: boolean;
 }

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -1,5 +1,6 @@
 import countryData from 'country-region-data';
 import { Account } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { defaultTo, lensPath, set } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -136,7 +137,7 @@ class UpdateContactInformationPanel extends React.Component<
 
   renderLoading = () => null;
 
-  renderErrors = (e: Linode.ApiFieldError[]) => null;
+  renderErrors = (e: APIError[]) => null;
 
   renderForm = (account: Account) => {
     const { classes, accountError } = this.props;

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
@@ -1,4 +1,5 @@
-import { Account, saveCreditCard } from 'linode-js-sdk/lib/account'
+import { Account, saveCreditCard } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, range, take, takeLast } from 'ramda';
 import * as React from 'react';
 import NumberFormat from 'react-number-format';
@@ -64,7 +65,7 @@ const styles = (theme: Theme) =>
 
 interface AccountContextProps {
   accountLoading: boolean;
-  accountErrors: Linode.ApiFieldError[];
+  accountErrors: APIError[];
   expiry: string;
   last_four: string;
   updateAccount: (update: (a: Account) => Account) => void;
@@ -73,7 +74,7 @@ interface AccountContextProps {
 
 interface State {
   submitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   success?: boolean;
   card_number: string;
   expiry_month: number;

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceDetail.tsx
@@ -6,6 +6,7 @@ import {
   Invoice,
   InvoiceItem
 } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
@@ -63,7 +64,7 @@ interface State {
   invoice?: Invoice;
   items?: InvoiceItem[];
   loading: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   pdfGenerationError?: any;
 }
 

--- a/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
+++ b/packages/manager/src/features/Billing/InvoiceDetail/InvoiceTable.tsx
@@ -1,4 +1,5 @@
 import { InvoiceItem } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
@@ -15,7 +16,7 @@ import PaginationFooter from 'src/components/PaginationFooter';
 
 interface Props {
   loading: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   items?: InvoiceItem[];
 }
 
@@ -130,7 +131,7 @@ const RenderLoading: React.StatelessComponent<{}> = () => {
 };
 
 const RenderErrors: React.StatelessComponent<{
-  errors: Linode.ApiFieldError[];
+  errors: APIError[];
 }> = props => {
   return (
     <TableRowError colSpan={8} message="Unable to retrieve invoice items." />
@@ -143,7 +144,7 @@ const RenderEmpty: React.StatelessComponent<{}> = () => {
 
 const MaybeRenderContent: React.StatelessComponent<{
   loading: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   items?: any[];
 }> = props => {
   const { loading, errors, items } = props;

--- a/packages/manager/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
@@ -1,5 +1,6 @@
 import Axios from 'axios';
 import { decode } from 'he';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, map, pathOr, take } from 'ramda';
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
@@ -43,7 +44,7 @@ export interface BlogItem {
 interface State {
   items: BlogItem[];
   loading: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 type CombinedProps = WithStyles<ClassNames>;

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { Notification } from 'linode-js-sdk/lib/account';
 import { Linode } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -57,7 +58,7 @@ interface StateProps {
   notifications: Notification[];
   userTimezone: string;
   userTimezoneLoading: boolean;
-  userTimezoneError?: Linode.ApiFieldError[];
+  userTimezoneError?: APIError[];
   someLinodesHaveScheduledMaintenance: boolean;
 }
 

--- a/packages/manager/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -1,5 +1,6 @@
 import { Entity, Event } from 'linode-js-sdk/lib/account';
 import { Domain } from 'linode-js-sdk/lib/domains';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, prop, sortBy, take } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -73,7 +74,7 @@ const styles = (theme: Theme) =>
 
 interface State {
   loading: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   data?: Domain[];
   results?: number;
 }
@@ -145,7 +146,7 @@ class DomainsDashboardCard extends React.Component<CombinedProps, State> {
     return <TableRowLoading colSpan={2} />;
   };
 
-  renderErrors = (errors: Linode.ApiFieldError[]) => (
+  renderErrors = (errors: APIError[]) => (
     <TableRowError colSpan={3} message={`Unable to load domains.`} />
   );
 
@@ -210,7 +211,7 @@ interface WithUpdatingDomainsProps {
   domains: Domain[];
   domainCount: number;
   loading: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 const withUpdatingDomains = connect(

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -1,5 +1,6 @@
 import { Entity, Event } from 'linode-js-sdk/lib/account';
 import { Linode, LinodeType } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, path, pathOr, prop, sortBy, take } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -124,7 +125,7 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
     return <TableRowLoading colSpan={3} />;
   };
 
-  renderErrors = (errors: Linode.ApiFieldError[]) => {
+  renderErrors = (errors: APIError[]) => {
     let errorText: string | JSX.Element = pathOr(
       'Unable to load Linodes.',
       [0, 'reason'],
@@ -201,7 +202,7 @@ interface WithUpdatingLinodesProps {
   linodes: LinodeWithMaintenance[];
   linodeCount: number;
   loading: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 const withUpdatingLinodes = connect((state: ApplicationState, ownProps: {}) => {

--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedDashboardCard.tsx
@@ -1,4 +1,5 @@
 import { ManagedServiceMonitor } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -29,7 +30,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface StateProps {
   monitors: ManagedServiceMonitor[];
   loading: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   updated: number;
 }
 

--- a/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -1,4 +1,5 @@
 import { NodeBalancer } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { take } from 'ramda';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
@@ -75,7 +76,7 @@ const styles = (theme: Theme) =>
 interface NodeBalancerProps {
   nodeBalancersData: NodeBalancer[];
   nodeBalancersLoading: boolean;
-  nodeBalancersError?: Linode.ApiFieldError[];
+  nodeBalancersError?: APIError[];
 }
 
 type CombinedProps = NodeBalancerProps & WithStyles<ClassNames>;
@@ -121,7 +122,7 @@ const NodeBalancersDashboardCard: React.FunctionComponent<
     return <TableRowLoading colSpan={2} />;
   };
 
-  const renderErrors = (errors: Linode.ApiFieldError[]) => (
+  const renderErrors = (errors: APIError[]) => (
     <TableRowError colSpan={2} message={`Unable to load NodeBalancers.`} />
   );
 

--- a/packages/manager/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/TransferDashboardCard/TransferDashboardCard.tsx
@@ -1,4 +1,5 @@
 import { getNetworkUtilization } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import BarPercent from 'src/components/BarPercent';
 import CircleProgress from 'src/components/CircleProgress';
@@ -58,7 +59,7 @@ const styles = (theme: Theme) =>
 
 interface State {
   loading: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   used?: number;
   quota?: number;
 }
@@ -145,7 +146,7 @@ class TransferDashboardCard extends React.Component<CombinedProps, State> {
     );
   }
 
-  renderErrorState = (e: Linode.ApiFieldError[]) => null;
+  renderErrorState = (e: APIError[]) => null;
 
   renderLoadingState = () => (
     <DashboardCard>

--- a/packages/manager/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { Volume } from 'linode-js-sdk/lib/volumes';
 import { take } from 'ramda';
 import * as React from 'react';
@@ -16,7 +17,7 @@ import VolumeDashboardRow from './VolumeDashboardRow';
 
 interface VolumeProps {
   volumesLoading: boolean;
-  volumesError?: Linode.ApiFieldError[];
+  volumesError?: APIError[];
   volumesData: Volume[];
 }
 
@@ -63,7 +64,7 @@ export const VolumesDashboardCard: React.FunctionComponent<
     return <TableRowLoading colSpan={3} />;
   };
 
-  const renderErrors = (errors: Linode.ApiFieldError[]) => (
+  const renderErrors = (errors: APIError[]) => (
     <TableRowError colSpan={3} message={`Unable to load Volumes.`} />
   );
 

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -5,6 +5,7 @@ import {
 } from 'linode-js-sdk/lib/domains';
 import { Linode } from 'linode-js-sdk/lib/linodes';
 import { NodeBalancer } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { Lens, lensPath, over, path, pathOr, set, view } from 'ramda';
 import * as React from 'react';
@@ -76,7 +77,7 @@ interface State {
   soaEmail: string;
   cloneName: string;
   tags: Tag[];
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   submitting: boolean;
   master_ips: string[];
   masterIPsCount: number;
@@ -612,7 +613,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               .then(() => {
                 return this.redirectToLandingOrDetail(type, domainData.id);
               })
-              .catch((e: Linode.ApiFieldError[]) => {
+              .catch((e: APIError[]) => {
                 reportException(
                   `Default DNS Records couldn't be created from Linode: ${
                     e[0].reason
@@ -641,7 +642,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               .then(() => {
                 return this.redirectToLandingOrDetail(type, domainData.id);
               })
-              .catch((e: Linode.ApiFieldError[]) => {
+              .catch((e: APIError[]) => {
                 reportException(
                   `Default DNS Records couldn't be created from NodeBalancer: ${
                     e[0].reason

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -6,6 +6,7 @@ import {
   updateDomainRecord,
   ZoneFile
 } from 'linode-js-sdk/lib/domains';
+import { APIError } from 'linode-js-sdk/lib/types';
 import {
   cond,
   defaultTo,
@@ -91,7 +92,7 @@ interface EditableDomainFields extends EditableSharedFields {
 
 interface State {
   submitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   fields: EditableRecordFields | EditableDomainFields;
 }
 

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -5,6 +5,7 @@ import {
   DomainType,
   RecordType
 } from 'linode-js-sdk/lib/domains';
+import { APIError } from 'linode-js-sdk/lib/types';
 import {
   compose,
   equals,
@@ -93,7 +94,7 @@ interface Props {
 interface ConfirmationState {
   open: boolean;
   submitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   recordId?: number;
 }
 

--- a/packages/manager/src/features/Domains/DomainZoneImportDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainZoneImportDrawer.tsx
@@ -1,4 +1,5 @@
 import { Domain, importZone } from 'linode-js-sdk/lib/domains';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -16,7 +17,7 @@ interface Props {
 
 interface State {
   submitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   domain?: string;
   remote_nameserver?: string;
 }

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -1,4 +1,5 @@
 import { Domain } from 'linode-js-sdk/lib/domains';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { pathOr } from 'ramda';
 import * as React from 'react';
@@ -92,7 +93,7 @@ interface State {
   importDrawer: {
     open: boolean;
     submitting: boolean;
-    errors?: Linode.ApiFieldError[];
+    errors?: APIError[];
     domain?: string;
     remote_nameserver?: string;
   };

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -1,5 +1,6 @@
 import { createImage, updateImage } from 'linode-js-sdk/lib/images';
 import { Disk, getLinodeDisks } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, equals } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -60,7 +61,7 @@ export interface Props {
 interface State {
   disks: Disk[];
   notice?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 type CombinedProps = Props & WithStyles<ClassNames> & RouteComponentProps<{}>;

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -1,4 +1,5 @@
 import { deleteImage, Image } from 'linode-js-sdk/lib/images';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -415,7 +416,7 @@ class ImagesLanding extends React.Component<CombinedProps, State> {
     );
   }
 
-  renderError = (_: Linode.ApiFieldError[]) => {
+  renderError = (_: APIError[]) => {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="Images" />
@@ -478,7 +479,7 @@ const EmptyCopy = () => (
 interface WithPrivateImages {
   imagesData: Record<string, Image>;
   imagesLoading: boolean;
-  imagesError?: Linode.ApiFieldError[];
+  imagesError?: APIError[];
 }
 
 const withPrivateImages = connect(

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -4,6 +4,7 @@ import {
   KubernetesVersion,
   PoolNodeRequest
 } from 'linode-js-sdk/lib/kubernetes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pick, remove, update } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -66,7 +67,7 @@ interface State {
   label?: string;
   tags: Item<string>[];
   version?: Item<string>;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   submitting: boolean;
   versionOptions: Item<string>[];
 }

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -1,4 +1,5 @@
 import * as Bluebird from 'bluebird';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { contains, equals, path, pathOr, remove, update } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -115,8 +116,8 @@ const styles = (theme: Theme) =>
 interface KubernetesContainerProps {
   cluster: ExtendedCluster | null;
   clustersLoading: boolean;
-  clustersLoadError?: Linode.ApiFieldError[];
-  clusterDeleteError?: Linode.ApiFieldError[];
+  clustersLoadError?: APIError[];
+  clusterDeleteError?: APIError[];
   lastUpdated: number;
   nodePoolsLoading: boolean;
 }
@@ -156,9 +157,9 @@ export const KubernetesClusterDetail: React.FunctionComponent<
   const [tags, updateTags] = React.useState<string[]>([]);
   /** Form submission */
   const [submitting, setSubmitting] = React.useState<boolean>(false);
-  const [generalError, setErrors] = React.useState<
-    Linode.ApiFieldError[] | undefined
-  >(undefined);
+  const [generalError, setErrors] = React.useState<APIError[] | undefined>(
+    undefined
+  );
   const [success, setSuccess] = React.useState<boolean>(false);
   /** Deletion confirmation modal */
   const [confirmationOpen, setConfirmation] = React.useState<boolean>(false);
@@ -219,10 +220,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
    * state for actions that succeeded (so that e.g. a pending pool that has been added no longer has the
    * "pending pool" styles).
    */
-  const handleError = (
-    pool: PoolNodeWithPrice,
-    error: Linode.ApiFieldError[]
-  ) => {
+  const handleError = (pool: PoolNodeWithPrice, error: APIError[]) => {
     const poolIdx = pools.findIndex(thisPool => thisPool.id === pool.id);
     updatePool(poolIdx, { ...pool, _error: error });
     return Promise.reject(error);

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 
@@ -87,7 +88,7 @@ interface Props {
   editing: boolean;
   submittingForm: boolean;
   submissionSuccess: boolean;
-  submissionError?: Linode.ApiFieldError[];
+  submissionError?: APIError[];
   pools: PoolNodeWithPrice[];
   poolsForEdit: PoolNodeWithPrice[];
   types: ExtendedType[];

--- a/packages/manager/src/features/Kubernetes/types.ts
+++ b/packages/manager/src/features/Kubernetes/types.ts
@@ -2,12 +2,13 @@ import {
   KubernetesCluster,
   PoolNodeResponse
 } from 'linode-js-sdk/lib/kubernetes';
+import { APIError } from 'linode-js-sdk/lib/types';
 
 export interface PoolNodeWithPrice extends ExtendedPoolNode {
   totalMonthlyPrice: number;
   queuedForDeletion?: boolean;
   queuedForAddition?: boolean;
-  _error?: Linode.ApiFieldError[];
+  _error?: APIError[];
 }
 
 export interface ExtendedPoolNode {

--- a/packages/manager/src/features/LinodeConfigSelectionDrawer/LinodeConfigSelectionDrawer.tsx
+++ b/packages/manager/src/features/LinodeConfigSelectionDrawer/LinodeConfigSelectionDrawer.tsx
@@ -1,4 +1,5 @@
 import { Config } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -17,7 +18,7 @@ interface Props {
   isOpen: boolean;
   selectedConfigID?: number;
   loading: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 type CombinedProps = Props;

--- a/packages/manager/src/features/Managed/Contacts/Contacts.tsx
+++ b/packages/manager/src/features/Managed/Contacts/Contacts.tsx
@@ -1,4 +1,5 @@
 import { deleteContact, ManagedContact } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import AddNewLink from 'src/components/AddNewLink';
@@ -46,7 +47,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   contacts: ManagedContact[];
   loading: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   lastUpdated: number;
   transformData: (fn: (contacts: ManagedContact[]) => void) => void;
   update: () => void;

--- a/packages/manager/src/features/Managed/Contacts/ContactsTableContent.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsTableContent.tsx
@@ -1,4 +1,5 @@
 import { ManagedContact } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { equals } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -16,7 +17,7 @@ interface Props {
   updateOrAdd: (contact: ManagedContact) => void;
   openDrawer: (linodeId: number) => void;
   openDialog: (contactId: number) => void;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 export type CombinedProps = Props;

--- a/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
@@ -7,6 +7,7 @@ import {
   updateCredential,
   updatePassword
 } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import AddNewLink from 'src/components/AddNewLink';
@@ -44,7 +45,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   credentials: ManagedCredential[];
   loading: boolean;
   update: () => void;
@@ -92,7 +93,7 @@ export const CredentialList: React.FC<CombinedProps> = props => {
   };
 
   const _handleError = (
-    e: Linode.ApiFieldError[],
+    e: APIError[],
     setSubmitting: any,
     setErrors: any,
     setStatus: any,

--- a/packages/manager/src/features/Managed/Credentials/CredentialTableContent.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialTableContent.tsx
@@ -1,4 +1,5 @@
 import { ManagedCredential } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 
 import TableRowEmpty from 'src/components/TableRowEmptyState';
@@ -11,7 +12,7 @@ interface Props {
   loading: boolean;
   openDialog: (id: number, label: string) => void;
   openForEdit: (id: number) => void;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 export type CombinedProps = Props;

--- a/packages/manager/src/features/Managed/Monitors/HistoryDrawer.tsx
+++ b/packages/manager/src/features/Managed/Monitors/HistoryDrawer.tsx
@@ -1,4 +1,5 @@
 import { ManagedIssue } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -11,7 +12,7 @@ import IssueCalendar from './IssueCalendar';
 
 interface Props {
   open: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   loading: boolean;
   monitorLabel: string;
   issues: ExtendedIssue[];
@@ -39,7 +40,7 @@ export const HistoryDrawer: React.FC<Props> = props => {
 const renderDrawerContent = (
   issues: ManagedIssue[],
   loading: boolean,
-  error?: Linode.ApiFieldError[]
+  error?: APIError[]
 ) => {
   if (loading) {
     return <CircleProgress />;

--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
@@ -1,4 +1,5 @@
 import { MonitorStatus } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -34,7 +35,7 @@ export class MonitorActionMenu extends React.Component<CombinedProps, {}> {
       status
     } = this.props;
 
-    const handleError = (message: string, error: Linode.ApiFieldError[]) => {
+    const handleError = (message: string, error: APIError[]) => {
       const errMessage = getAPIErrorOrDefault(error, message);
       enqueueSnackbar(errMessage[0].reason, { variant: 'error' });
     };

--- a/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTable.tsx
@@ -4,6 +4,7 @@ import {
   ManagedServiceMonitor,
   ManagedServicePayload
 } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -54,7 +55,7 @@ interface Props {
   credentials: ManagedCredential[];
   groups: string[];
   loading: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 export type Modes = 'create' | 'edit';
@@ -148,7 +149,7 @@ export const MonitorTable: React.FC<CombinedProps> = props => {
       handleDrawerClose();
     };
 
-    const _error = (e: Linode.ApiFieldError[]) => {
+    const _error = (e: APIError[]) => {
       const defaultMessage = `Unable to ${
         drawerMode === 'create' ? 'create' : 'update'
       } this Monitor. Please try again later.`;

--- a/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
@@ -1,4 +1,5 @@
 import { ManagedServiceMonitor } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 
 import TableRowEmpty from 'src/components/TableRowEmptyState';
@@ -15,7 +16,7 @@ interface Props {
   openDialog: (id: number, label: string) => void;
   openHistoryDrawer: (id: number, label: string) => void;
   openMonitorDrawer: (id: number, mode: string) => void;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 export type CombinedProps = Props;

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
@@ -2,6 +2,7 @@ import {
   ManagedLinodeSetting,
   updateLinodeSettings
 } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -20,7 +21,7 @@ export type CombinedProps = Props & WithSnackbarProps;
 export const SSHAccessActionMenu: React.FC<CombinedProps> = props => {
   const { linodeId, isEnabled, updateOne, openDrawer, enqueueSnackbar } = props;
 
-  const handleError = (message: string, error: Linode.ApiFieldError[]) => {
+  const handleError = (message: string, error: APIError[]) => {
     const errMessage = getAPIErrorOrDefault(error, message);
     enqueueSnackbar(errMessage[0].reason, { variant: 'error' });
   };

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTableContent.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTableContent.tsx
@@ -1,4 +1,5 @@
 import { ManagedLinodeSetting } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import TableRowEmpty from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
@@ -12,7 +13,7 @@ interface Props {
   lastUpdated: number;
   updateOne: (linodeSetting: ManagedLinodeSetting) => void;
   openDrawer: (linodeId: number) => void;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 export type CombinedProps = Props;

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -1,4 +1,5 @@
 import { NodeBalancerConfigNodeFields } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
@@ -115,7 +116,7 @@ const styled = withStyles(styles);
 
 interface Props {
   nodeBalancerRegion?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   nodeMessage?: string;
   configIdx?: number;
 

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import {
   append,
   clone,
@@ -91,11 +92,11 @@ interface NodeBalancerFieldsState {
 interface State {
   submitting: boolean;
   nodeBalancerFields: NodeBalancerFieldsState;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   deleteConfigConfirmDialog: {
     open: boolean;
     submitting: boolean;
-    errors?: Linode.ApiFieldError[];
+    errors?: APIError[];
     idxToDelete?: number;
   };
 }
@@ -256,7 +257,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     this.setState((compose as any)(...setFns));
   };
 
-  setNodeErrors = (errors: Linode.ApiFieldError[]) => {
+  setNodeErrors = (errors: APIError[]) => {
     /* Map the objects with this shape
         {
           path: ['configs', 2, 'nodes', 0, 'errors'],
@@ -320,7 +321,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
       .catch(errorResponse => {
         const errors = getAPIErrorOrDefault(errorResponse);
         this.setNodeErrors(
-          errors.map((e: Linode.ApiFieldError) => ({
+          errors.map((e: APIError) => ({
             ...e,
             ...(e.field && { field: e.field.replace(/(\[|\]\.)/g, '_') })
           }))
@@ -370,7 +371,7 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
     /* remove the errors related to that config */
     if (this.state.errors) {
       this.setState({
-        errors: this.state.errors!.filter((error: Linode.ApiFieldError) => {
+        errors: this.state.errors!.filter((error: APIError) => {
           const t = new RegExp(`configs_${idxToDelete}_`);
           return error.field && !t.test(error.field);
         })
@@ -729,7 +730,7 @@ export interface FieldAndPath {
   path: any[];
 }
 
-export const fieldErrorsToNodePathErrors = (errors: Linode.ApiFieldError[]) => {
+export const fieldErrorsToNodePathErrors = (errors: APIError[]) => {
   /**
    * Potentials;
    *  JOI error config_0_nodes_0_address
@@ -745,7 +746,7 @@ export const fieldErrorsToNodePathErrors = (errors: Linode.ApiFieldError[]) => {
         }
       }
   */
-  return errors.reduce((acc: any, error: Linode.ApiFieldError) => {
+  return errors.reduce((acc: any, error: APIError) => {
     const errorFields = pathOr('', ['field'], error).split('|');
     const pathErrors: FieldAndPath[] = errorFields.map((field: string) =>
       getPathAndFieldFromFieldString(field)
@@ -773,7 +774,7 @@ export const fieldErrorsToNodePathErrors = (errors: Linode.ApiFieldError[]) => {
 interface WithRegions {
   regionsData: ExtendedRegion[];
   regionsLoading: boolean;
-  regionsError: Linode.ApiFieldError[];
+  regionsError: APIError[];
 }
 
 interface StateProps {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerDetail.tsx
@@ -2,6 +2,7 @@ import {
   getNodeBalancer,
   getNodeBalancerConfigs
 } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { any, last, pathOr } from 'ramda';
 import * as React from 'react';
@@ -67,7 +68,7 @@ type RouteProps = RouteComponentProps<{ nodeBalancerId?: string }>;
 
 interface State {
   nodeBalancer?: ExtendedNodeBalancer;
-  ApiError: Linode.ApiFieldError[] | undefined;
+  ApiError: APIError[] | undefined;
   labelInput?: string;
 }
 

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { clamp, compose, defaultTo } from 'ramda';
 import * as React from 'react';
 import { compose as composeC } from 'recompose';
@@ -54,7 +55,7 @@ interface Props {
 
 interface State {
   isSubmitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   success?: string;
   fields: FieldsState;
 }

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerCreationErrors.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerCreationErrors.tsx
@@ -2,6 +2,7 @@ import {
   NodeBalancerConfig,
   NodeBalancerConfigNode
 } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import List from 'src/components/core/List';
 import ListItem from 'src/components/core/ListItem';
@@ -9,7 +10,7 @@ import ListItemText from 'src/components/core/ListItemText';
 import Notice from 'src/components/Notice';
 
 interface ErrorResponse {
-  errors: Linode.ApiFieldError[];
+  errors: APIError[];
 }
 
 interface ConfigErrorResponse extends ErrorResponse {
@@ -53,7 +54,7 @@ const NodeBalancerCreationError: React.StatelessComponent<
 
 export default NodeBalancerCreationError;
 
-const maybeListReason = (errors?: Linode.ApiFieldError[]) => {
+const maybeListReason = (errors?: APIError[]) => {
   if (!errors || errors.length === 0) {
     return null;
   }

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerSelect.tsx
@@ -1,4 +1,5 @@
 import { NodeBalancer } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import EnhancedSelect, { Item } from 'src/components/EnhancedSelect/Select';
@@ -10,7 +11,7 @@ import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 interface WithNodeBalancersProps {
   nodeBalancersData: NodeBalancer[];
   nodeBalancersLoading: boolean;
-  nodeBalancersError?: Linode.ApiFieldError[];
+  nodeBalancersError?: APIError[];
 }
 
 interface Props {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -39,6 +39,7 @@ import {
   WithNodeBalancerActions
 } from 'src/store/nodeBalancer/nodeBalancer.containers';
 import { nodeBalancersWithConfigs } from 'src/store/nodeBalancer/nodeBalancer.selectors';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendGroupByTagEnabledEvent } from 'src/utilities/ga';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import ListGroupedNodeBalancers from './ListGroupedNodeBalancers';
@@ -186,21 +187,15 @@ export class NodeBalancersLanding extends React.Component<
         });
       })
       .catch(err => {
-        const apiError = path<APIError[]>(['response', 'data', 'error'], err);
-
         return this.setState(
           {
             deleteConfirmDialog: {
               ...this.state.deleteConfirmDialog,
               submitting: false,
-              errors: apiError
-                ? apiError
-                : [
-                    {
-                      field: 'none',
-                      reason: 'Unable to complete your request at this time.'
-                    }
-                  ]
+              errors: getAPIErrorOrDefault(
+                err,
+                'There was an error deleting this NodeBalancer.'
+              )
             }
           },
           () => {

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLanding.tsx
@@ -97,7 +97,7 @@ const styles = (theme: Theme) =>
 interface DeleteConfirmDialogState {
   open: boolean;
   submitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 interface State {
@@ -186,10 +186,7 @@ export class NodeBalancersLanding extends React.Component<
         });
       })
       .catch(err => {
-        const apiError = path<Linode.ApiFieldError[]>(
-          ['response', 'data', 'error'],
-          err
-        );
+        const apiError = path<APIError[]>(['response', 'data', 'error'], err);
 
         return this.setState(
           {
@@ -388,7 +385,7 @@ interface NodeBalancerWithConfigs extends NodeBalancer {
 interface WithNodeBalancers {
   nodeBalancersCount: number;
   nodeBalancersData: NodeBalancerWithConfigs[];
-  nodeBalancersError?: Linode.ApiFieldError[];
+  nodeBalancersError?: APIError[];
   nodeBalancersLoading: boolean;
 }
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/RevokeAccessKeyDialog.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/RevokeAccessKeyDialog.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -10,7 +11,7 @@ interface RevokeKeysDialogProps {
   isLoading: boolean;
   handleClose: () => void;
   handleSubmit: () => void;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 export const RevokeAccessKeyDialog: React.StatelessComponent<

--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as moment from 'moment';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -116,7 +117,7 @@ interface Props {
   label?: string;
   scopes?: string;
   expiry?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   id?: number;
   open: boolean;
   mode: string;

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -7,6 +7,7 @@ import {
   Token,
   updatePersonalAccessToken
 } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as moment from 'moment';
 import { compose } from 'ramda';
 import * as React from 'react';
@@ -71,7 +72,7 @@ interface Props extends PaginationProps<Token> {
 interface FormState {
   mode: DrawerMode;
   open: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   id?: number;
   values: {
     scopes?: string;
@@ -84,7 +85,7 @@ interface DialogState {
   open: boolean;
   id?: number;
   label?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   type: string;
 }
 

--- a/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/AuthenticationSettings.tsx
@@ -1,4 +1,5 @@
 import { Profile } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { lensPath, path, pathOr, set } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -117,7 +118,7 @@ interface StateProps {
   ipWhitelisting: boolean;
   twoFactor?: boolean;
   username?: string;
-  profileUpdateError?: Linode.ApiFieldError[];
+  profileUpdateError?: APIError[];
 }
 
 const mapStateToProps: MapState<StateProps, {}> = state => {
@@ -128,7 +129,7 @@ const mapStateToProps: MapState<StateProps, {}> = state => {
     ipWhitelisting: pathOr(false, ['data', 'ip_whitelist_enabled'], profile),
     twoFactor: path(['data', 'two_factor_auth'], profile),
     username: path(['data', 'username'], profile),
-    profileUpdateError: path<Linode.ApiFieldError[]>(['update'], profile.error)
+    profileUpdateError: path<APIError[]>(['update'], profile.error)
   };
 };
 

--- a/packages/manager/src/features/Profile/AuthenticationSettings/SecuritySettings.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/SecuritySettings.tsx
@@ -1,4 +1,5 @@
 import { Profile } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import FormControl from 'src/components/core/FormControl';
 import FormControlLabel from 'src/components/core/FormControlLabel';
@@ -32,7 +33,7 @@ const styles = (theme: Theme) =>
 interface Props {
   onSuccess: () => void;
   updateProfile: (v: Partial<Profile>) => Promise<Profile>;
-  updateProfileError?: Linode.ApiFieldError[];
+  updateProfileError?: APIError[];
   ipWhitelistingEnabled: boolean;
 }
 

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TrustedDevicesTable.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TrustedDevicesTable.tsx
@@ -1,4 +1,5 @@
 import { TrustedDevice } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import TableCell from 'src/components/TableCell';
@@ -9,7 +10,7 @@ import TableRowLoading from 'src/components/TableRowLoading';
 
 interface Props {
   loading: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   data?: TrustedDevice[];
   setDevice: (deviceId: number) => void;
   toggleDialog: () => void;

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/EnableTwoFactorForm.tsx
@@ -1,4 +1,5 @@
 import { confirmTwoFactor } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import CircleProgress from 'src/components/CircleProgress';
 import Divider from 'src/components/core/Divider';
@@ -36,7 +37,7 @@ interface Props {
 }
 
 interface State {
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   submitting: boolean;
   token: string;
 }
@@ -96,7 +97,7 @@ export class EnableTwoFactorForm extends React.Component<CombinedProps, State> {
           'Could not confirm code.',
           'tfa_code'
         );
-        APIErrors = APIErrors.filter((err: Linode.ApiFieldError) => {
+        APIErrors = APIErrors.filter((err: APIError) => {
           // Filter potentially confusing API error
           return (
             err.reason !==

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/TwoFactor.tsx
@@ -1,5 +1,6 @@
 import SettingsBackupRestore from '@material-ui/icons/SettingsBackupRestore';
 import { getTFAToken, Profile } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { path } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -83,7 +84,7 @@ interface ConfirmDisable {
 
 interface State {
   disableDialog: ConfirmDisable;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   loading: boolean;
   secret: string;
   showQRCode: boolean;

--- a/packages/manager/src/features/Profile/DisplaySettings/EmailChangeForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/EmailChangeForm.tsx
@@ -1,4 +1,5 @@
 import { Profile } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { lensPath, set } from 'ramda';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -33,11 +34,11 @@ interface Props {
   username: string;
   email: string;
   updateProfile: (v: Partial<Profile>) => Promise<Profile>;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 interface State {
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   success?: string;
   submitting: boolean;
   updatedEmail: string;

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -1,4 +1,5 @@
-import { Profile } from "linode-js-sdk/lib/profile";
+import { Profile } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { lensPath, pathOr, set } from 'ramda';
 import * as React from 'react';
 import timezones from 'src/assets/timezones/timezones';
@@ -36,7 +37,7 @@ interface Props {
   timezone: string;
   loggedInAsCustomer: boolean;
   updateProfile: (v: Partial<Profile>) => Promise<Profile>;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 interface State {
@@ -44,7 +45,7 @@ interface State {
   inputValue: string;
   submitting: boolean;
   success?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 interface Timezone {

--- a/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
@@ -1,4 +1,5 @@
-import { Profile } from "linode-js-sdk/lib/profile";
+import { Profile } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { dec, lensPath, path, remove, set } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -82,7 +83,7 @@ const styles = (theme: Theme) =>
 
 interface State {
   submitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   success?: string;
   lishAuthMethod: Pick<Profile, 'lish_auth_method'>;
   authorizedKeys: string[];
@@ -257,9 +258,8 @@ class LishSettings extends React.Component<CombinedProps, State> {
       });
   };
 
-  onListAuthMethodChange = (
-    e: Item<Pick<Profile, 'lish_auth_method'>>
-  ) => this.setState({ lishAuthMethod: e.value });
+  onListAuthMethodChange = (e: Item<Pick<Profile, 'lish_auth_method'>>) =>
+    this.setState({ lishAuthMethod: e.value });
 
   onPublicKeyChange = (idx: number) => (
     e: React.ChangeEvent<HTMLInputElement>

--- a/packages/manager/src/features/Profile/OAuthClients/Modals.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/Modals.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 
@@ -12,7 +13,7 @@ interface Props {
   secretID?: string;
   secret: string;
   label: string;
-  modalErrors?: Linode.ApiFieldError[];
+  modalErrors?: APIError[];
   secretModalOpen: boolean;
   deleteModalOpen: boolean;
   secretSuccessOpen: boolean;

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -4,8 +4,9 @@ import {
   getOAuthClients,
   OAuthClient,
   resetOAuthClientSecret,
-  updateOAuthClient,
-} from "linode-js-sdk/lib/account";
+  updateOAuthClient
+} from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import AddNewLink from 'src/components/AddNewLink';
@@ -59,10 +60,10 @@ interface State {
   isPublic: boolean;
   redirectUri: string;
   deleteModalOpen: boolean;
-  modalErrors?: Linode.ApiFieldError[];
+  modalErrors?: APIError[];
   drawerOpen: boolean;
   drawerIsInEditMode: boolean;
-  drawerErrors?: Linode.ApiFieldError[];
+  drawerErrors?: APIError[];
   isResetting: boolean;
   isDeleting: boolean;
   drawerLoading: boolean;
@@ -161,7 +162,7 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
         this.props.onDelete();
         this.setState({ deleteModalOpen: false, isDeleting: false });
       })
-      .catch((e: Linode.ApiFieldError[]) =>
+      .catch((e: APIError[]) =>
         this.setState({ modalErrors: e, isDeleting: false })
       );
   };
@@ -194,7 +195,7 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
           isResetting: false
         });
       })
-      .catch((e: Linode.ApiFieldError[]) => {
+      .catch((e: APIError[]) => {
         this.setState({ modalErrors: e, isResetting: false });
       });
   };

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthFormDrawer.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -15,7 +16,7 @@ interface Props {
   label?: string;
   redirect_uri?: string;
   public: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   edit?: boolean;
   onClose: () => void;
   onSubmit: () => void;

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeyCreationDrawer.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeyCreationDrawer.tsx
@@ -1,4 +1,5 @@
 import { createSSHKey } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -16,7 +17,7 @@ interface Props {
 
 interface State {
   submitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   label: string;
   sshKey: string;
 }
@@ -106,7 +107,7 @@ export class SSHKeyCreationDrawer extends React.PureComponent<
   onSubmit = () => {
     const { label, sshKey } = this.state;
 
-    const errors: Linode.ApiFieldError[] = [];
+    const errors: APIError[] = [];
 
     if (label === '') {
       errors.push({ field: 'label', reason: 'Label cannot be blank.' });

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeys.tsx
@@ -1,4 +1,5 @@
 import { getSSHKeys, SSHKey } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as moment from 'moment-timezone';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -143,7 +144,7 @@ export class SSHKeys extends React.Component<CombinedProps, State> {
     return <TableRowEmptyState colSpan={4} />;
   };
 
-  static renderError = (error: Linode.ApiFieldError[]) => {
+  static renderError = (error: APIError[]) => {
     return (
       <TableRowError
         colSpan={4}

--- a/packages/manager/src/features/StackScripts/LandingPanel/Table/StackScriptTable.tsx
+++ b/packages/manager/src/features/StackScripts/LandingPanel/Table/StackScriptTable.tsx
@@ -1,4 +1,5 @@
 import { StackScript } from 'linode-js-sdk/lib/stackscripts';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 
 import TableBody from 'src/components/core/TableBody';
@@ -11,7 +12,7 @@ import StackScriptTableRows from './TableRows';
 interface Props {
   type: 'linode' | 'own' | 'community';
   count: number;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   loading: boolean;
   page: number;
   pageSize: number;

--- a/packages/manager/src/features/StackScripts/LandingPanel/Table/TableRows/TableRows.tsx
+++ b/packages/manager/src/features/StackScripts/LandingPanel/Table/TableRows/TableRows.tsx
@@ -1,5 +1,6 @@
 import { Grant } from 'linode-js-sdk/lib/account';
 import { StackScript } from 'linode-js-sdk/lib/stackscripts';
+import { APIError } from 'linode-js-sdk/lib/types';
 import {
   compose as ramdaCompose,
   isEmpty,
@@ -32,7 +33,7 @@ import LabelCell from '../LabelCell';
 interface StackScriptData {
   stackScripts?: StackScript[];
   loading: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 interface Props {

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -1,6 +1,7 @@
 import { Grant } from 'linode-js-sdk/lib/account';
 import { Image } from 'linode-js-sdk/lib/images';
 import { StackScript } from 'linode-js-sdk/lib/stackscripts';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -59,8 +60,8 @@ export interface State {
   currentFilter: any; // @TODO type correctly
   currentSearchFilter: any;
   isSorting: boolean;
-  error?: Linode.ApiFieldError[];
-  fieldError: Linode.ApiFieldError | undefined;
+  error?: APIError[];
+  fieldError: APIError | undefined;
   isSearching: boolean;
   didSearch: boolean;
   successMessage: string;

--- a/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptCreate/StackScriptCreate.tsx
@@ -1,5 +1,6 @@
 import { Image } from 'linode-js-sdk/lib/images';
 import { createStackScript, StackScript } from 'linode-js-sdk/lib/stackscripts';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { path } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -59,7 +60,7 @@ interface State {
   script: string;
   revisionNote: string;
   isSubmitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   dialogOpen: boolean;
 }
 
@@ -341,7 +342,7 @@ const styled = withStyles(styles);
 interface WithImagesProps {
   imagesData: Record<string, Image>;
   imagesLoading: boolean;
-  imagesError?: Linode.ApiFieldError[];
+  imagesError?: APIError[];
 }
 
 const enhanced = compose<CombinedProps, {}>(

--- a/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptForm/StackScriptForm.tsx
@@ -1,4 +1,5 @@
 import { Image } from 'linode-js-sdk/lib/images';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -122,7 +123,7 @@ interface Props {
   revision: TextFieldHandler;
   description: TextFieldHandler;
   script: TextFieldHandler;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   onSubmit: () => void;
   onCancel: () => void;
   onSelectChange: (image: Item<string>[]) => void;

--- a/packages/manager/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -5,6 +5,7 @@ import {
   StackScript,
   updateStackScript
 } from 'linode-js-sdk/lib/stackscripts';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -70,7 +71,7 @@ interface State {
   script: string;
   revisionNote: string;
   isSubmitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   dialogOpen: boolean;
 }
 
@@ -430,7 +431,7 @@ const reloaded = reloadableWithRouter<
 interface WithImagesProps {
   imagesData: Record<string, Image>;
   imagesLoading: boolean;
-  imagesError?: Linode.ApiFieldError[];
+  imagesError?: APIError[];
 }
 const enhanced = compose<CombinedProps, {}>(
   setDocs(StackScriptUpdate.docs),

--- a/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsLanding.tsx
@@ -1,4 +1,5 @@
 import { Image } from 'linode-js-sdk/lib/images';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
@@ -101,7 +102,7 @@ const styled = withStyles(styles);
 interface WithImagesProps {
   imagesData: Record<string, Image>;
   imagesLoading: boolean;
-  imagesError?: Linode.ApiFieldError[];
+  imagesError?: APIError[];
 }
 
 export default compose<CombinedProps, {}>(

--- a/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
+++ b/packages/manager/src/features/StackScripts/UserDefinedFieldsPanel/UserDefinedFieldsPanel.tsx
@@ -1,4 +1,5 @@
 import { UserDefinedField } from 'linode-js-sdk/lib/stackscripts';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Paper from 'src/components/core/Paper';
@@ -43,7 +44,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   userDefinedFields?: UserDefinedField[];
   handleChange: (key: string, value: any) => void;
   udf_data: any;
@@ -180,7 +181,7 @@ class UserDefinedFieldsPanel extends React.PureComponent<CombinedProps> {
   }
 }
 
-const getError = (field: UserDefinedField, errors?: Linode.ApiFieldError[]) => {
+const getError = (field: UserDefinedField, errors?: APIError[]) => {
   if (!errors) {
     return;
   }

--- a/packages/manager/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/SupportTicketDetail.tsx
@@ -2,6 +2,7 @@ import * as Bluebird from 'bluebird';
 import * as classNames from 'classnames';
 import { SupportReply, SupportTicket } from 'linode-js-sdk/lib/account';
 import { getTicket, getTicketReplies } from 'linode-js-sdk/lib/support';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, isEmpty, path, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -114,7 +115,7 @@ export interface AttachmentError {
 
 interface State {
   loading: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   attachmentErrors: AttachmentError[];
   replies?: SupportReply[];
   ticket?: SupportTicket;

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/ReplyContainer.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/ReplyContainer.tsx
@@ -1,5 +1,6 @@
 import { SupportReply } from 'linode-js-sdk/lib/account';
 import { createReply, uploadAttachment } from 'linode-js-sdk/lib/support';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { lensPath, set } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -73,9 +74,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 const ReplyContainer: React.FC<CombinedProps> = props => {
   const { classes, onSuccess, reloadAttachments, ...rest } = props;
 
-  const [errors, setErrors] = React.useState<
-    Linode.ApiFieldError[] | undefined
-  >(undefined);
+  const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
   const [value, setValue] = React.useState<string>('');
   const [isSubmitting, setSubmitting] = React.useState<boolean>(false);
   const [files, setFiles] = React.useState<FileAttachment[]>([]);

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -5,6 +5,7 @@ import {
   createSupportTicket,
   uploadAttachment
 } from 'linode-js-sdk/lib/support';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { getVolumes } from 'linode-js-sdk/lib/volumes';
 import { compose, lensPath, set } from 'ramda';
 import * as React from 'react';
@@ -105,7 +106,7 @@ export interface State {
   loading: boolean;
   submitting: boolean;
   ticket: Ticket;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   files: FileAttachment[];
 }
 
@@ -192,7 +193,7 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
     this.setState({ data: entityItems, loading: false });
   };
 
-  handleCatch = (errors: Linode.ApiFieldError[]) => {
+  handleCatch = (errors: APIError[]) => {
     this.setState({
       errors,
       loading: false

--- a/packages/manager/src/features/Support/index.ts
+++ b/packages/manager/src/features/Support/index.ts
@@ -1,3 +1,5 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+
 export interface FileAttachment {
   name: string;
   file: File;
@@ -6,5 +8,5 @@ export interface FileAttachment {
   /* Used to ensure that the file doesn't get uploaded again */
   uploaded: boolean;
   /* Each file needs to keep track of its own errors because each request hits the same endpoint */
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }

--- a/packages/manager/src/features/Users/CreateUserDrawer.tsx
+++ b/packages/manager/src/features/Users/CreateUserDrawer.tsx
@@ -1,4 +1,5 @@
-import { createUser, User } from "linode-js-sdk/lib/account";
+import { createUser, User } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -21,7 +22,7 @@ interface State {
   username: string;
   email: string;
   restricted: boolean;
-  errors: Linode.ApiFieldError[];
+  errors: APIError[];
   submitting: boolean;
 }
 

--- a/packages/manager/src/features/Users/UserDetail.tsx
+++ b/packages/manager/src/features/Users/UserDetail.tsx
@@ -1,5 +1,6 @@
 import { getUser, updateUser } from 'linode-js-sdk/lib/account';
 import { updateProfile } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { clone, compose, path as pathRamda } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -84,10 +85,10 @@ interface State {
   email: string;
   restricted?: boolean;
   accountSaving: boolean;
-  accountErrors?: Linode.ApiFieldError[];
+  accountErrors?: APIError[];
   accountSuccess?: boolean;
   profileSaving: boolean;
-  profileErrors?: Linode.ApiFieldError[];
+  profileErrors?: APIError[];
   profileSuccess?: boolean;
 }
 

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -7,6 +7,7 @@ import {
   updateGrants,
   updateUser
 } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, flatten, lensPath, omit, set } from 'ramda';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -131,7 +132,7 @@ interface State {
   grants?: Grants;
   originalGrants?: Grants /* used to implement cancel functionality */;
   restricted?: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   success?: Success;
   /* null needs to be a string here because it's a Select value */
   setAllPerm: 'null' | 'read_only' | 'read_write';

--- a/packages/manager/src/features/Users/UserProfile.tsx
+++ b/packages/manager/src/features/Users/UserProfile.tsx
@@ -1,4 +1,5 @@
 import { deleteUser } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { path } from 'ramda';
 import * as React from 'react';
@@ -75,11 +76,11 @@ interface Props {
   saveAccount: () => void;
   accountSaving: boolean;
   accountSuccess: boolean;
-  accountErrors?: Linode.ApiFieldError[];
+  accountErrors?: APIError[];
   saveProfile: () => void;
   profileSaving: boolean;
   profileSuccess: boolean;
-  profileErrors?: Linode.ApiFieldError[];
+  profileErrors?: APIError[];
   originalUsername?: string;
 }
 

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -1,5 +1,6 @@
 import { map as mapPromise } from 'bluebird';
 import { deleteUser, getUsers, User } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as memoize from 'memoizee';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
@@ -307,7 +308,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
 
   renderTableContent = (
     loading: boolean,
-    error?: Linode.ApiFieldError[],
+    error?: APIError[],
     data?: User[]
   ) => {
     if (loading) {

--- a/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -1,5 +1,6 @@
 import { Grant } from 'linode-js-sdk/lib/account';
 import { getLinodeConfigs } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -37,7 +38,7 @@ interface State {
   configs: string[][];
   selectedLinode: number | null;
   selectedConfig?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 interface LinodesProps {

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -2,6 +2,7 @@
  * @todo Display the volume configuration information on success.
  */
 import { Form, Formik } from 'formik';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { CreateVolumeSchema } from 'linode-js-sdk/lib/volumes';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -219,7 +220,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
                 touched.tags
                   ? errors.tags
                     ? getErrorStringOrDefault(
-                        errors.tags as Linode.ApiFieldError[],
+                        errors.tags as APIError[],
                         'Unable to tag volume.'
                       )
                     : undefined

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForm.tsx
@@ -1,5 +1,6 @@
 import { Form, Formik } from 'formik';
 import { Region } from 'linode-js-sdk/lib/regions';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { CreateVolumeSchema } from 'linode-js-sdk/lib/volumes';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -239,7 +240,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
                 touched.tags
                   ? errors.tags
                     ? getErrorStringOrDefault(
-                        errors.tags as Linode.ApiFieldError[],
+                        errors.tags as APIError[],
                         'Unable to tag Volume.'
                       )
                     : undefined

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -1,5 +1,6 @@
 import { Event } from 'linode-js-sdk/lib/account';
 import { Config, Linode } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { Volume } from 'linode-js-sdk/lib/volumes';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
@@ -138,7 +139,7 @@ const styles = (theme: Theme) =>
 interface WithLinodesProps {
   linodesData: Linode[];
   linodesLoading: boolean;
-  linodesError?: Linode.ApiFieldError[];
+  linodesError?: APIError[];
 }
 export interface ExtendedVolume extends Volume {
   linodeLabel?: string;

--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -7,6 +7,7 @@ import {
   Linode,
   LinodeStatus
 } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { intersection, pathOr } from 'ramda';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -86,7 +87,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface WithLinodesProps {
   linodesData: Linode[];
   linodesLoading: boolean;
-  linodesError?: Linode.ApiFieldError[];
+  linodesError?: APIError[];
 }
 
 type CombinedProps = RouteComponentProps<{}> &
@@ -204,7 +205,7 @@ export const CloneLanding: React.FC<CombinedProps> = props => {
     return dispatch({ type: 'setSubmitting', value });
   };
 
-  const setErrors = (errors?: Linode.ApiFieldError[]) => {
+  const setErrors = (errors?: APIError[]) => {
     return dispatch({ type: 'setErrors', errors });
   };
 

--- a/packages/manager/src/features/linodes/CloneLanding/utilities.ts
+++ b/packages/manager/src/features/linodes/CloneLanding/utilities.ts
@@ -1,5 +1,6 @@
 import produce from 'immer';
 import { Config, Disk } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as moment from 'moment';
 import { append, compose, flatten, keys, map, pickBy, uniqBy } from 'ramda';
 
@@ -12,7 +13,7 @@ export interface CloneLandingState {
   diskSelection: DiskSelection;
   selectedLinodeId: number | null;
   isSubmitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 // Allows for easy toggling of a selected config.
@@ -32,7 +33,7 @@ export type CloneLandingAction =
   | { type: 'toggleDisk'; id: number }
   | { type: 'setSelectedLinodeId'; id: number }
   | { type: 'setSubmitting'; value: boolean }
-  | { type: 'setErrors'; errors?: Linode.ApiFieldError[] }
+  | { type: 'setErrors'; errors?: APIError[] }
   | { type: 'clearAll' }
   | {
       type: 'syncConfigsDisks';

--- a/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -1,4 +1,5 @@
 import { Linode } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { groupBy } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -15,7 +16,7 @@ import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 interface WithLinodesProps {
   linodesData: Linode[];
   linodesLoading: boolean;
-  linodesError?: Linode.ApiFieldError[];
+  linodesError?: APIError[];
 }
 
 type Override = keyof Linode | ((linode: Linode) => any);

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -5,6 +5,7 @@ import {
   Linode
 } from 'linode-js-sdk/lib/linodes';
 import { StackScript, UserDefinedField } from 'linode-js-sdk/lib/stackscripts';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { pathOr } from 'ramda';
 import * as React from 'react';
@@ -84,7 +85,7 @@ interface State {
   password: string;
   udfs?: any[];
   tags?: Tag[];
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   formIsSubmitting: boolean;
   appInstances?: StackScript[];
   appInstancesLoading: boolean;

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateSubTabs.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateSubTabs.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { parse } from 'querystring';
 import * as React from 'react';
 import AppBar from 'src/components/core/AppBar';
@@ -45,7 +46,7 @@ export interface Tab {
 }
 
 interface Props {
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   history: any;
   reset: () => void;
   tabs: Tab[];

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/formUtilities.test.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/formUtilities.test.ts
@@ -1,8 +1,9 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { filterUDFErrors } from './formUtilities';
 
 describe('Linode Create Utilities', () => {
   it('should filter out all errors except UDF errors', () => {
-    const mockErrors: Linode.ApiFieldError[] = [
+    const mockErrors: APIError[] = [
       {
         field: 'label',
         reason: 'label is required'

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/formUtilities.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/formUtilities.ts
@@ -1,3 +1,5 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+
 /**
  * filter out all the API errors that aren't UDF errors from our error state.
  * To do this, we compare the keys from the error state to our "errorResources"
@@ -5,7 +7,7 @@
  */
 export const filterUDFErrors = (
   errorResources: Record<string, string>,
-  errors?: Linode.ApiFieldError[]
+  errors?: APIError[]
 ) => {
   if (typeof errorResources !== 'object') {
     throw Error('errorResources must be an object.');

--- a/packages/manager/src/features/linodes/LinodesCreate/types.ts
+++ b/packages/manager/src/features/linodes/LinodesCreate/types.ts
@@ -1,6 +1,7 @@
 import { Image } from 'linode-js-sdk/lib/images';
 import { CreateLinodeRequest, Linode } from 'linode-js-sdk/lib/linodes';
 import { StackScript, UserDefinedField } from 'linode-js-sdk/lib/stackscripts';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { ExtendedRegion } from 'src/components/EnhancedSelect/variants/RegionSelect';
 import { Tag } from 'src/components/TagsInput';
 import { State as userSSHKeysProps } from 'src/features/linodes/userSSHKeyHoc';
@@ -47,19 +48,19 @@ export interface WithImagesProps {
 export interface WithLinodesProps {
   linodesData?: Linode[];
   linodesLoading: boolean;
-  linodesError?: Linode.ApiFieldError[];
+  linodesError?: APIError[];
 }
 
 export interface WithRegionsProps {
   regionsData?: ExtendedRegion[];
   regionsLoading: boolean;
-  regionsError?: Linode.ApiFieldError[];
+  regionsError?: APIError[];
 }
 
 export interface WithTypesProps {
   typesData?: ExtendedType[];
   typesLoading: boolean;
-  typesError?: Linode.ApiFieldError[];
+  typesError?: APIError[];
 }
 
 /**
@@ -93,7 +94,7 @@ export type HandleSubmit = (
  * the _create from image_ flow to function
  */
 export interface BaseFormStateAndHandlers {
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   formIsSubmitting: boolean;
   handleSubmitForm: HandleSubmit;
   selectedImageID?: string;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -1,4 +1,5 @@
 import { Config, linodeReboot } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -214,7 +215,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
           errorResponse,
           `Error booting ${label}`
         );
-        errors.map((error: Linode.ApiFieldError) => {
+        errors.map((error: APIError) => {
           this.props.enqueueSnackbar(error.reason, {
             variant: 'error'
           });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskDrawer.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import { UserSSHKeyObject } from 'src/components/AccessPanel';
@@ -47,7 +48,7 @@ interface EditableFields {
 interface Props extends EditableFields {
   mode: 'create' | 'rename' | 'resize';
   open: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   maximumSize: number;
   submitting: boolean;
   onClose: () => void;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -1,4 +1,5 @@
 import { Disk } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -91,7 +92,7 @@ type Filesystem = 'raw' | 'swap' | 'ext3' | 'ext4' | 'initrd' | '_none_';
 interface ConfirmDeleteState {
   open: boolean;
   submitting: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   id?: number;
   label?: string;
 }
@@ -100,7 +101,7 @@ interface DrawerState {
   open: boolean;
   submitting: boolean;
   mode: 'create' | 'rename' | 'resize';
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   diskId?: number;
   maximumSize: number;
   fields: {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -12,6 +12,7 @@ import {
   takeSnapshot,
   Window
 } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as moment from 'moment-timezone';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { path, pathOr, sortBy } from 'ramda';
@@ -153,12 +154,12 @@ interface State {
   backups: LinodeBackupsResponse;
   snapshotForm: {
     label: string;
-    errors?: Linode.ApiFieldError[];
+    errors?: APIError[];
   };
   settingsForm: {
     window: Window;
     day: Day;
-    errors?: Linode.ApiFieldError[];
+    errors?: APIError[];
   };
   restoreDrawer: {
     open: boolean;
@@ -310,11 +311,10 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
         sendBackupsEnabledEvent('From Backups tab');
       })
       .catch(errorResponse => {
-        getAPIErrorOrDefault(errorResponse).forEach(
-          (err: Linode.ApiFieldError) =>
-            enqueueSnackbar(err.reason, {
-              variant: 'error'
-            })
+        getAPIErrorOrDefault(errorResponse).forEach((err: APIError) =>
+          enqueueSnackbar(err.reason, {
+            variant: 'error'
+          })
         );
         this.setState({ enabling: false });
       });
@@ -340,7 +340,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
           'There was an error disabling backups'
         )
           /**  @todo move this error to the actual modal */
-          .forEach((err: Linode.ApiFieldError) =>
+          .forEach((err: APIError) =>
             enqueueSnackbar(err.reason, {
               variant: 'error'
             })

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -1,5 +1,6 @@
 import { getLinodes, restoreBackup } from 'linode-js-sdk/lib/linodes';
 import { Profile } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -32,7 +33,7 @@ interface State {
   linodes: string[][];
   overwrite: boolean;
   selectedLinode?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 type CombinedProps = Props & {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/CreateIPv4Drawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/CreateIPv4Drawer.tsx
@@ -1,4 +1,5 @@
 import { allocateIPAddress } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -19,7 +20,7 @@ interface Props {
 
 interface State {
   forPublic: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 type CombinedProps = Props;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
@@ -1,4 +1,5 @@
 import { updateIP } from 'linode-js-sdk/lib/networking';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -21,7 +22,7 @@ interface State {
   rdns?: string | null;
   address?: string;
   loading: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   delayText: string | null;
 }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -1,5 +1,6 @@
 import { getLinodes, Linode } from 'linode-js-sdk/lib/linodes';
 import { shareAddresses } from 'linode-js-sdk/lib/networking';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { clone, flatten, pathOr, uniq } from 'ramda';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
@@ -92,7 +93,7 @@ interface State {
   loading: boolean;
   submitting: boolean;
   successMessage?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -1,5 +1,6 @@
 import { getLinodes } from 'linode-js-sdk/lib/linodes';
 import { assignAddresses } from 'linode-js-sdk/lib/networking';
+import { APIError } from 'linode-js-sdk/lib/types';
 import {
   both,
   compose,
@@ -105,7 +106,7 @@ interface State {
   successMessage?: string;
   ips: IPRowState;
   linodes: { id: number; label: string; ips: string[] }[];
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 type Mode = 'none' | 'swap' | 'move';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -5,6 +5,7 @@ import {
   RebuildLinodeFromStackScriptSchema
 } from 'linode-js-sdk/lib/linodes';
 import { UserDefinedField } from 'linode-js-sdk/lib/stackscripts';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { isEmpty } from 'ramda';
 import * as React from 'react';
@@ -126,9 +127,9 @@ export const RebuildFromStackScript: React.StatelessComponent<
   // In this component, most errors are handled by Formik. This is not
   // possible with UDFs, since they are dynamic. Their errors need to
   // be handled separately.
-  const [udfErrors, setUdfErrors] = React.useState<
-    Linode.ApiFieldError[] | undefined
-  >(undefined);
+  const [udfErrors, setUdfErrors] = React.useState<APIError[] | undefined>(
+    undefined
+  );
 
   const [isDialogOpen, setIsDialogOpen] = React.useState<boolean>(false);
 
@@ -162,8 +163,8 @@ export const RebuildFromStackScript: React.StatelessComponent<
         history.push(`/linodes/${linodeId}/summary`);
       })
       .catch(errorResponse => {
-        const APIError = getAPIErrorOrDefault(errorResponse);
-        setUdfErrors(getUDFErrors(APIError));
+        const APIErrors = getAPIErrorOrDefault(errorResponse);
+        setUdfErrors(getUDFErrors(APIErrors));
 
         const defaultMessage = `There was an issue rebuilding your Linode.`;
         const mapErrorToStatus = (generalError: string) =>
@@ -183,7 +184,7 @@ export const RebuildFromStackScript: React.StatelessComponent<
   // to be validated separately. This functions checks if we've got values
   // for all REQUIRED UDFs, and sets errors appropriately.
   const validateUdfs = () => {
-    const maybeErrors: Linode.ApiFieldError[] = [];
+    const maybeErrors: APIError[] = [];
 
     // Walk through the defined UDFs
     ss.user_defined_fields.forEach(eachUdf => {
@@ -384,7 +385,7 @@ export default enhanced(RebuildFromStackScript);
 // Helpers
 // =============================================================================
 
-const getUDFErrors = (errors: Linode.ApiFieldError[] | undefined) => {
+const getUDFErrors = (errors: APIError[] | undefined) => {
   const fixedErrorFields = ['stackscript_id', 'root_pass', 'image', 'none'];
 
   return errors

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -1,5 +1,6 @@
 import { GrantLevel } from 'linode-js-sdk/lib/account';
 import { Config, rescueLinode } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { assoc, clamp, pathOr } from 'ramda';
 import * as React from 'react';
@@ -62,7 +63,7 @@ interface ContextProps {
 }
 
 interface StateProps {
-  diskError?: Linode.ApiFieldError[];
+  diskError?: APIError[];
 }
 
 interface VolumesProps {
@@ -72,7 +73,7 @@ interface VolumesProps {
 
 interface State {
   rescueDevices: DevicesAsStrings;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   devices: {
     disks: ExtendedDisk[];
     volumes: ExtendedVolume[];
@@ -153,7 +154,7 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
         getAPIErrorOrDefault(
           errorResponse,
           'There was an issue rescuing your Linode.'
-        ).forEach((err: Linode.ApiFieldError) =>
+        ).forEach((err: APIError) =>
           enqueueSnackbar(err.reason, {
             variant: 'error'
           })

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -5,6 +5,7 @@ import {
   LinodeType,
   resizeLinode
 } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
@@ -99,7 +100,7 @@ interface LinodeContextProps {
 interface State {
   selectedId: string;
   isLoading: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
   autoDiskResize: boolean;
 }
 
@@ -187,7 +188,7 @@ export class LinodeResize extends React.Component<CombinedProps, State> {
         getAPIErrorOrDefault(
           errorResponse,
           'There was an issue resizing your Linode.'
-        ).forEach((err: Linode.ApiFieldError) =>
+        ).forEach((err: APIError) =>
           enqueueSnackbar(err.reason, {
             variant: 'error'
           })

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigDrawer.tsx
@@ -4,6 +4,7 @@
  * it from there and make the (thunk) request to get the latest/greatest information.
  */
 import { Disk, getLinodeKernels, Kernel } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { Volume } from 'linode-js-sdk/lib/volumes';
 import { pathOr } from 'ramda';
 import * as React from 'react';
@@ -102,7 +103,7 @@ interface State {
     config: boolean;
   };
   kernels: Kernel[];
-  errors?: Error | Linode.ApiFieldError[];
+  errors?: Error | APIError[];
   fields: EditableFields;
 }
 
@@ -222,10 +223,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     );
   }
 
-  renderContent = (
-    errors: Error | Linode.ApiFieldError[] = [],
-    loading: boolean
-  ) => {
+  renderContent = (errors: Error | APIError[] = [], loading: boolean) => {
     if (errors instanceof Error) {
       return this.renderErrorState();
     }
@@ -243,7 +241,7 @@ class LinodeConfigDrawer extends React.Component<CombinedProps, State> {
     <ErrorState errorText="Unable to load configurations." />
   );
 
-  renderForm = (errors?: Linode.ApiFieldError[]) => {
+  renderForm = (errors?: APIError[]) => {
     const { onClose, maxMemory, classes, readOnly } = this.props;
 
     const {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsAlertsPanel.tsx
@@ -1,5 +1,6 @@
 import { GrantLevel } from 'linode-js-sdk/lib/account';
 import { LinodeAlerts } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, lensPath, set } from 'ramda';
 import * as React from 'react';
 import { compose as rCompose } from 'recompose';
@@ -32,7 +33,7 @@ interface State {
   incoming: AlertState;
   outbound: AlertState;
   transfer: AlertState;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 interface AlertState {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { lensPath, set } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -23,7 +24,7 @@ interface Props {
 
 interface State {
   open: boolean;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 type CombinedProps = Props &
@@ -47,7 +48,7 @@ class LinodeSettingsDeletePanel extends React.Component<CombinedProps, State> {
         resetEventsPolling();
         this.props.history.push('/linodes');
       })
-      .catch((error: Linode.ApiFieldError[]) => {
+      .catch((error: APIError[]) => {
         this.setState(set(lensPath(['errors']), error), () => {
           scrollErrorIntoView();
         });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsLabelPanel.tsx
@@ -1,4 +1,5 @@
 import { GrantLevel } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { lensPath, pathOr, set } from 'ramda';
 import * as React from 'react';
 import { compose as recompose } from 'recompose';
@@ -21,7 +22,7 @@ interface State {
   updatedValue: string;
   submitting: boolean;
   success?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 type CombinedProps = ContextProps;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsPasswordPanel.tsx
@@ -4,6 +4,7 @@ import {
   Disk,
   getLinodeDisks
 } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, lensPath, set } from 'ramda';
 import * as React from 'react';
 import { compose as recompose } from 'recompose';
@@ -35,7 +36,7 @@ interface State {
   diskId?: number;
 
   success?: string;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 type CombinedProps = Props & ContextProps;
@@ -66,7 +67,7 @@ class LinodeSettingsPasswordPanel extends React.Component<
       compose(
         set(lensPath(['submitting']), true),
         set(lensPath(['success']), undefined),
-        set(lensPath(['errors']), undefined) as () => Linode.ApiFieldError[]
+        set(lensPath(['errors']), undefined) as () => APIError[]
       )
     );
 
@@ -80,7 +81,7 @@ class LinodeSettingsPasswordPanel extends React.Component<
           )
         );
       })
-      .catch((errors: Linode.ApiFieldError[]) => {
+      .catch((errors: APIError[]) => {
         this.setState(
           compose(
             set(lensPath(['errors']), errors),

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -6,6 +6,7 @@ import {
   LinodeType,
   Stats
 } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { Volume } from 'linode-js-sdk/lib/volumes';
 import * as moment from 'moment';
 import { map, pathOr } from 'ramda';
@@ -149,7 +150,7 @@ interface LinodeContextProps {
   linodeId: number;
   linodeData: Linode;
   linodeVolumes: Volume[];
-  linodeVolumesError?: Linode.ApiFieldError[];
+  linodeVolumesError?: APIError[];
 }
 
 interface WithImagesProps {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -1,4 +1,5 @@
 import { Image } from 'linode-js-sdk/lib/images';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { Volume } from 'linode-js-sdk/lib/volumes';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -157,7 +158,7 @@ interface LinodeContextProps {
   linodeTags: string[];
   mostRecentBackup: string | null;
   linodeVolumes: Volume[];
-  linodeVolumesError?: Linode.ApiFieldError[];
+  linodeVolumesError?: APIError[];
   backupsEnabled: boolean;
   readOnly: boolean;
 }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { last } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -86,7 +87,7 @@ const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
         resetEditableLabel();
       })
       .catch(err => {
-        const errors: Linode.ApiFieldError[] = getAPIErrorOrDefault(
+        const errors: APIError[] = getAPIErrorOrDefault(
           err,
           'An error occurred while updating label',
           'label'

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -1,5 +1,6 @@
 import { Notification } from 'linode-js-sdk/lib/account';
 import { LinodeStatus } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { path } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -89,7 +90,7 @@ interface ContextProps {
 
 interface ProfileProps {
   userTimezoneLoading: boolean;
-  userTimezoneError?: Linode.ApiFieldError[];
+  userTimezoneError?: APIError[];
   userTimezone?: string;
 }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/maybeRenderError.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/maybeRenderError.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { path } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -8,12 +9,12 @@ import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 interface OuterProps {
-  configsError?: Linode.ApiFieldError[];
-  typesError?: Linode.ApiFieldError[];
+  configsError?: APIError[];
+  typesError?: APIError[];
 }
 
 interface InnerProps {
-  error?: Linode.ApiFieldError[] | Error;
+  error?: APIError[] | Error;
 }
 
 const collectErrors: MapState<InnerProps, OuterProps> = (
@@ -55,13 +56,16 @@ export default compose(
   branch(
     ({ error }) => Boolean(error),
     /** error is not the only prop, but it's the only one we care about */
-    renderComponent((props: { error: Linode.ApiFieldError[] }) => {
+    renderComponent((props: { error: APIError[] }) => {
       let errorText: string | JSX.Element = getAPIErrorOrDefault(
         props.error,
         'There was an issue retrieving your Linode. Please try again later.'
       )[0].reason;
 
-      if (typeof errorText === 'string' && errorText.toLowerCase() === 'this linode has been suspended') {
+      if (
+        typeof errorText === 'string' &&
+        errorText.toLowerCase() === 'this linode has been suspended'
+      ) {
         errorText = (
           <React.Fragment>
             This Linode is suspended. Please{' '}

--- a/packages/manager/src/features/linodes/LinodesDetail/types.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/types.ts
@@ -1,5 +1,6 @@
 import { Event, GrantLevel } from 'linode-js-sdk/lib/account';
 import { Config, Disk, LinodeType } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { Volume } from 'linode-js-sdk/lib/volumes';
 import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
 
@@ -9,7 +10,7 @@ export interface ExtendedLinode extends LinodeWithMaintenance {
   _events: Event[];
   _notifications: Notification[];
   _volumes: Volume[];
-  _volumesError: Linode.ApiFieldError[];
+  _volumesError: APIError[];
   _type?: null | LinodeType;
   _permissions: GrantLevel;
 }

--- a/packages/manager/src/features/linodes/LinodesLanding/DeleteDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DeleteDialog.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 
@@ -18,9 +19,7 @@ type CombinedProps = Props;
 
 const DeleteLinodeDialog: React.FC<CombinedProps> = props => {
   const [isDeleting, setDeleting] = React.useState<boolean>(false);
-  const [errors, setErrors] = React.useState<
-    Linode.ApiFieldError[] | undefined
-  >(undefined);
+  const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
 
   React.useEffect(() => {
     if (props.open) {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -3,6 +3,7 @@ import {
   getLinodeConfigs,
   LinodeBackups
 } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { stringify } from 'qs';
 import { pathOr } from 'ramda';
 import * as React from 'react';
@@ -57,7 +58,7 @@ export type CombinedProps = Props &
 interface State {
   configs: Config[];
   hasMadeConfigsRequest: boolean;
-  configsError?: Linode.ApiFieldError[];
+  configsError?: APIError[];
 }
 
 export class LinodeActionMenu extends React.Component<CombinedProps, State> {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -1,4 +1,5 @@
 import { Config } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as moment from 'moment-timezone';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { parse, stringify } from 'qs';
@@ -180,7 +181,10 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
         linodesRequestError
       );
 
-      if (typeof errorText === 'string' && errorText.toLowerCase() === 'this linode has been suspended') {
+      if (
+        typeof errorText === 'string' &&
+        errorText.toLowerCase() === 'this linode has been suspended'
+      ) {
         errorText = (
           <React.Fragment>
             One or more of your Linodes is suspended. Please{' '}
@@ -446,11 +450,11 @@ interface StateProps {
   managed: boolean;
   linodesCount: number;
   linodesData: LinodeWithMaintenance[];
-  linodesRequestError?: Linode.ApiFieldError[];
+  linodesRequestError?: APIError[];
   linodesRequestLoading: boolean;
   userTimezone: string;
   userTimezoneLoading: boolean;
-  userTimezoneError?: Linode.ApiFieldError[];
+  userTimezoneError?: APIError[];
   someLinodesHaveScheduledMaintenance: boolean;
 }
 
@@ -475,7 +479,7 @@ const mapStateToProps: MapState<StateProps, {}> = (state, ownProps) => {
     linodesRequestError: path(['error', 'read'], state.__resources.linodes),
     userTimezone: pathOr('', ['data', 'timezone'], state.__resources.profile),
     userTimezoneLoading: state.__resources.profile.loading,
-    userTimezoneError: path<Linode.ApiFieldError[]>(
+    userTimezoneError: path<APIError[]>(
       ['read'],
       state.__resources.profile.error
     )
@@ -504,7 +508,7 @@ const updateParams = <T extends any>(params: string, updater: (s: T) => T) => {
 
 interface WithImagesProps {
   imagesLoading: boolean;
-  imagesError?: Linode.ApiFieldError[];
+  imagesError?: APIError[];
 }
 
 export const enhanced = compose<CombinedProps, {}>(

--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
@@ -4,6 +4,7 @@ import {
   linodeReboot,
   linodeShutdown
 } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 
@@ -31,9 +32,7 @@ type CombinedProps = Props;
 
 const PowerActionsDialogOrDrawer: React.FC<CombinedProps> = props => {
   const [isTakingAction, setTakingAction] = React.useState<boolean>(false);
-  const [errors, setErrors] = React.useState<
-    Linode.ApiFieldError[] | undefined
-  >(undefined);
+  const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
   const [selectedConfigID, selectConfigID] = React.useState<number | undefined>(
     undefined
   );

--- a/packages/manager/src/hooks/useAPIRequest.ts
+++ b/packages/manager/src/hooks/useAPIRequest.ts
@@ -8,7 +8,7 @@ interface UseAPIRequest<T> {
   lastUpdated: number;
   update: () => void;
   transformData: (fn: (data: T) => void) => void;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 // @todo: write a README for this hook.

--- a/packages/manager/src/hooks/useDialog.ts
+++ b/packages/manager/src/hooks/useDialog.ts
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 
 export interface DialogState {
@@ -70,7 +71,7 @@ export const useDialog = <T>(
         handleSuccess();
         return response;
       })
-      .catch((e: Linode.ApiFieldError[]) => {
+      .catch((e: APIError[]) => {
         /**
          * This sets the error to whatever the API returns.
          * Consumers can use the exposed handleError method

--- a/packages/manager/src/hooks/useErrors.ts
+++ b/packages/manager/src/hooks/useErrors.ts
@@ -1,12 +1,13 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 
 export const useErrors = (): [
-  Linode.ApiFieldError[],
-  React.Dispatch<React.SetStateAction<Linode.ApiFieldError[]>>,
+  APIError[],
+  React.Dispatch<React.SetStateAction<APIError[]>>,
   () => void
 ] => {
-  const [errors, setErrors] = React.useState<Linode.ApiFieldError[]>([]);
+  const [errors, setErrors] = React.useState<APIError[]>([]);
 
   // If there are errors, scroll them into view
   React.useEffect(() => {

--- a/packages/manager/src/hooks/useOpenClose.ts
+++ b/packages/manager/src/hooks/useOpenClose.ts
@@ -1,8 +1,9 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 
 interface OpenCloseState {
   open: boolean;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
 }
 
 export interface OpenClose {

--- a/packages/manager/src/requestableContext.tsx
+++ b/packages/manager/src/requestableContext.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 
 import { getDisplayName } from 'src/utilities';
@@ -8,7 +9,7 @@ export interface Requestable<T> {
   request: (...args: any[]) => Promise<any>;
   update: (f: (t: T) => T) => void;
   data?: T;
-  errors?: Linode.ApiFieldError[];
+  errors?: APIError[];
 }
 
 /* tslint:disable */

--- a/packages/manager/src/services/index.ts
+++ b/packages/manager/src/services/index.ts
@@ -1,4 +1,5 @@
 import Axios, { AxiosError, AxiosPromise, AxiosResponse } from 'axios';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { compose, isEmpty, isNil, lensPath, not, omit, set, when } from 'ramda';
 import { ObjectSchema, ValidationError } from 'yup';
 
@@ -66,7 +67,7 @@ export const setData = <T>(
       set(
         L.validationErrors,
         convertYupToLinodeErrors(error)
-      ) as () => Linode.ApiFieldError[]
+      ) as () => APIError[]
     );
   }
 };
@@ -77,7 +78,7 @@ export const setData = <T>(
  */
 const convertYupToLinodeErrors = (
   validationError: ValidationError
-): Linode.ApiFieldError[] => {
+): APIError[] => {
   const { inner } = validationError;
 
   /** If aggregate errors */
@@ -95,7 +96,7 @@ const convertYupToLinodeErrors = (
 const mapYupToLinodeAPIError = ({
   message,
   path
-}: ValidationError): Linode.ApiFieldError => ({
+}: ValidationError): APIError => ({
   reason: message,
   ...(path && { field: path })
 });
@@ -112,7 +113,7 @@ export default <T>(...fns: Function[]): AxiosPromise<T> => {
   const config = reduceRequestConfig(...fns);
   if (config.validationErrors) {
     return Promise.reject(
-      config.validationErrors // All failed requests, client or server errors, should be Linode.ApiFieldError[]
+      config.validationErrors // All failed requests, client or server errors, should be APIError[]
     );
   }
 
@@ -200,9 +201,7 @@ const createError = (message: string, response: AxiosResponse) => {
  *
  * Helper method to easily generate APIFieldError[] for a number of fields and a general error.
  */
-export const mockAPIFieldErrors = (
-  fields: string[]
-): Linode.ApiFieldError[] => {
+export const mockAPIFieldErrors = (fields: string[]): APIError[] => {
   return fields.reduce(
     (result, field) => [...result, { field, reason: `${field} is incorrect.` }],
     [{ reason: 'A general error has occurred.' }]

--- a/packages/manager/src/store/account/account.actions.ts
+++ b/packages/manager/src/store/account/account.actions.ts
@@ -1,4 +1,5 @@
-import { Account } from 'linode-js-sdk/lib/account'
+import { Account } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 
 /**
@@ -10,11 +11,11 @@ export const profileRequest = actionCreator('request');
 
 export const profileRequestSuccess = actionCreator<Account>('success');
 
-export const profileRequestFail = actionCreator<Linode.ApiFieldError[]>('fail');
+export const profileRequestFail = actionCreator<APIError[]>('fail');
 
 export type UpdateAccountParams = Partial<Account>;
 export const updateAccountActions = actionCreator.async<
   UpdateAccountParams,
   Account,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);

--- a/packages/manager/src/store/backupDrawer/index.ts
+++ b/packages/manager/src/store/backupDrawer/index.ts
@@ -1,5 +1,6 @@
 import * as Bluebird from 'bluebird';
 import { enableBackups, Linode } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { isEmpty, pathOr } from 'ramda';
 import { Reducer } from 'redux';
 import { updateAccountSettings } from 'src/store/accountSettings/accountSettings.requests';
@@ -22,7 +23,7 @@ export interface State {
   autoEnroll: boolean;
   autoEnrollError?: string;
   enrolling: boolean;
-  error?: Error | Linode.ApiFieldError[];
+  error?: Error | APIError[];
   data?: Linode[];
 }
 

--- a/packages/manager/src/store/bucket/bucket.actions.ts
+++ b/packages/manager/src/store/bucket/bucket.actions.ts
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import {
   BucketRequestPayload,
   DeleteBucketRequestPayload
@@ -9,17 +10,17 @@ export const actionCreator = actionCreatorFactory('@@manager/buckets');
 export const createBucketActions = actionCreator.async<
   BucketRequestPayload,
   Linode.Bucket,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`create`);
 
 export const getAllBucketsActions = actionCreator.async<
   void,
   Linode.Bucket[],
-  Linode.ApiFieldError[]
+  APIError[]
 >('get-all');
 
 export const deleteBucketActions = actionCreator.async<
   DeleteBucketRequestPayload,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >('delete');

--- a/packages/manager/src/store/bucket/bucket.requests.ts
+++ b/packages/manager/src/store/bucket/bucket.requests.ts
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import {
   BucketRequestPayload,
   createBucket as _createBucket,
@@ -21,7 +22,7 @@ export type CreateBucketRequest = BucketRequestPayload;
 export const createBucket = createRequestThunk<
   CreateBucketRequest,
   Linode.Bucket,
-  Linode.ApiFieldError[]
+  APIError[]
 >(createBucketActions, data => _createBucket(data));
 
 /*
@@ -43,5 +44,5 @@ export type DeleteBucketRequest = DeleteBucketRequestPayload;
 export const deleteBucket = createRequestThunk<
   DeleteBucketRequestPayload,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(deleteBucketActions, data => _deleteBucket(data));

--- a/packages/manager/src/store/clusters/clusters.actions.ts
+++ b/packages/manager/src/store/clusters/clusters.actions.ts
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { getClusters } from 'src/services/objectStorage/clusters';
 import { actionCreatorFactory } from 'typescript-fsa';
 import { ThunkActionCreator } from '../types';
@@ -7,7 +8,7 @@ const actionCreator = actionCreatorFactory(`@@manager/clusters`);
 export const clustersRequestActions = actionCreator.async<
   void,
   Linode.Cluster[],
-  Linode.ApiFieldError[]
+  APIError[]
 >(`request`);
 
 export const requestClusters: ThunkActionCreator<

--- a/packages/manager/src/store/domains/domains.actions.ts
+++ b/packages/manager/src/store/domains/domains.actions.ts
@@ -5,6 +5,7 @@ import {
   getDomains,
   UpdateDomainPayload
 } from 'linode-js-sdk/lib/domains';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { Dispatch } from 'redux';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
@@ -29,7 +30,7 @@ export const getDomainsSuccess = actionCreator<{
   results: number;
 }>('success');
 
-export const getDomainsFailure = actionCreator<Linode.ApiFieldError[]>('fail');
+export const getDomainsFailure = actionCreator<APIError[]>('fail');
 
 export const upsertDomain = actionCreator<Domain>('upsert');
 
@@ -38,17 +39,17 @@ export const deleteDomain = actionCreator<number>('delete');
 export const createDomainActions = actionCreator.async<
   CreateDomainPayload,
   Domain,
-  Linode.ApiFieldError[]
+  APIError[]
 >('create');
 export const updateDomainActions = actionCreator.async<
   UpdateDomainParams,
   Domain,
-  Linode.ApiFieldError[]
+  APIError[]
 >('update');
 export const deleteDomainActions = actionCreator.async<
   DomainId,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >('delete');
 
 /**

--- a/packages/manager/src/store/domains/domains.requests.ts
+++ b/packages/manager/src/store/domains/domains.requests.ts
@@ -5,6 +5,7 @@ import {
   Domain,
   updateDomain as _updateDomain
 } from 'linode-js-sdk/lib/domains';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { createRequestThunk } from '../store.helpers';
 import {
   createDomainActions,
@@ -17,19 +18,18 @@ import {
 export const createDomain = createRequestThunk<
   CreateDomainPayload,
   Domain,
-  Linode.ApiFieldError[]
+  APIError[]
 >(createDomainActions, payload => _createDomain(payload));
 
-export const deleteDomain = createRequestThunk<
-  DomainId,
-  {},
-  Linode.ApiFieldError[]
->(deleteDomainActions, ({ domainId }) => _deleteDomain(domainId));
+export const deleteDomain = createRequestThunk<DomainId, {}, APIError[]>(
+  deleteDomainActions,
+  ({ domainId }) => _deleteDomain(domainId)
+);
 
 export const updateDomain = createRequestThunk<
   UpdateDomainParams,
   Domain,
-  Linode.ApiFieldError[]
+  APIError[]
 >(updateDomainActions, ({ domainId, ...payload }) =>
   _updateDomain(domainId, payload)
 );

--- a/packages/manager/src/store/image/image.actions.ts
+++ b/packages/manager/src/store/image/image.actions.ts
@@ -1,5 +1,5 @@
 import { Image } from 'linode-js-sdk/lib/images';
-
+import { APIError } from 'linode-js-sdk/lib/types';
 import actionCreatorFactory from 'typescript-fsa';
 
 export const actionCreator = actionCreatorFactory(`@@manager/images`);
@@ -10,7 +10,7 @@ export const getImagesSuccess = actionCreator<Linode.ResourcePage<Image>>(
   `success`
 );
 
-export const getImagesFailure = actionCreator<Linode.ApiFieldError[]>(`fail`);
+export const getImagesFailure = actionCreator<APIError[]>(`fail`);
 
 export const removeImage = actionCreator<number | string>(`remove`);
 

--- a/packages/manager/src/store/kubernetes/kubernetes.actions.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.actions.ts
@@ -1,4 +1,5 @@
 import { KubernetesCluster } from 'linode-js-sdk/lib/kubernetes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import actionCreatorFactory from 'typescript-fsa';
 
 import { EntityError } from 'src/store/types';
@@ -8,7 +9,7 @@ export const actionCreator = actionCreatorFactory(`@@manager/kubernetes`);
 export const requestClustersActions = actionCreator.async<
   void,
   KubernetesCluster[],
-  Linode.ApiFieldError[]
+  APIError[]
 >('request');
 
 export const addOrUpdateCluster = actionCreator<KubernetesCluster>(
@@ -27,12 +28,12 @@ export type UpdateClusterParams = ClusterID & Partial<KubernetesCluster>;
 export const updateClusterActions = actionCreator.async<
   UpdateClusterParams,
   KubernetesCluster,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);
 
 export type DeleteClusterParams = ClusterID;
 export const deleteClusterActions = actionCreator.async<
   DeleteClusterParams,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(`delete-cluster`);

--- a/packages/manager/src/store/kubernetes/nodePools.actions.ts
+++ b/packages/manager/src/store/kubernetes/nodePools.actions.ts
@@ -2,6 +2,7 @@ import {
   KubeNodePoolResponse,
   PoolNodeRequest
 } from 'linode-js-sdk/lib/kubernetes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import actionCreatorFactory from 'typescript-fsa';
 
 import { EntityError } from 'src/store/types';
@@ -17,7 +18,7 @@ export const actionCreator = actionCreatorFactory(
 export const requestNodePoolsActions = actionCreator.async<
   void,
   ExtendedNodePool[],
-  Linode.ApiFieldError[]
+  APIError[]
 >('request');
 
 export const addOrUpdateNodePool = actionCreator<KubeNodePoolResponse>(
@@ -40,26 +41,26 @@ export type CreateNodePoolParams = ClusterID & PoolNodeRequest;
 export const createNodePoolActions = actionCreator.async<
   CreateNodePoolParams,
   ExtendedNodePool,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`create-node-pool`);
 
 export type UpdateNodePoolParams = ClusterID & NodePoolID & PoolNodeRequest;
 export const updateNodePoolActions = actionCreator.async<
   UpdateNodePoolParams,
   ExtendedNodePool,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update-node-pool`);
 
 export type DeleteClusterParams = ClusterID;
 export const deleteClusterActions = actionCreator.async<
   DeleteClusterParams,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(`delete-cluster`);
 
 export type DeleteNodePoolParams = ClusterID & NodePoolID;
 export const deleteNodePoolActions = actionCreator.async<
   DeleteNodePoolParams,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(`delete-node-pool`);

--- a/packages/manager/src/store/linodeType/linodeType.actions.ts
+++ b/packages/manager/src/store/linodeType/linodeType.actions.ts
@@ -1,4 +1,5 @@
 import { LinodeType } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import actionCreatorFactory from 'typescript-fsa';
 
 const actionCreator = actionCreatorFactory(`@@manager/types`);
@@ -6,5 +7,5 @@ const actionCreator = actionCreatorFactory(`@@manager/types`);
 export const getLinodeTypesActions = actionCreator.async<
   void,
   LinodeType[],
-  Linode.ApiFieldError[]
+  APIError[]
 >(`request`);

--- a/packages/manager/src/store/linodeType/linodeType.containers.ts
+++ b/packages/manager/src/store/linodeType/linodeType.containers.ts
@@ -1,11 +1,12 @@
 import { LinodeType } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { connect } from 'react-redux';
 import { ApplicationState } from '..';
 import { State } from './linodeType.reducer';
 
 export interface WithTypes {
   types: LinodeType[];
-  typesError: Linode.ApiFieldError[];
+  typesError: APIError[];
   typesLastUpdated: number;
   typesLoading: boolean;
 }

--- a/packages/manager/src/store/linodes/config/config.actions.ts
+++ b/packages/manager/src/store/linodes/config/config.actions.ts
@@ -1,4 +1,5 @@
 import { LinodeConfigCreationData } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 import { Entity } from './config.types';
 
@@ -28,7 +29,7 @@ export type GetLinodeConfigsRequest = (
 export const getLinodeConfigsActions = actionCreator.async<
   GetLinodeConfigsParams,
   Entity[],
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get-page`);
 
 /** Get Linode Configs (all) */
@@ -43,7 +44,7 @@ export type GetAllLinodeConfigsRequest = (
 export const getAllLinodeConfigsActions = actionCreator.async<
   GetAllLinodeConfigsParams,
   Entity[],
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get-all`);
 
 /** Get Linode Config */
@@ -58,7 +59,7 @@ export type GetLinodeConfigRequest = (
 export const getLinodeConfigActions = actionCreator.async<
   GetLinodeConfigParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get`);
 
 /** Create Linode Config */
@@ -73,7 +74,7 @@ export type CreateLinodeConfigRequest = (
 export const createLinodeConfigActions = actionCreator.async<
   CreateLinodeConfigParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`create`);
 
 /** Update Linode Config */
@@ -89,7 +90,7 @@ export type UpdateLinodeConfigRequest = (
 export const updateLinodeConfigActions = actionCreator.async<
   UpdateLinodeConfigParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);
 
 /** Delete Linode Config */
@@ -104,5 +105,5 @@ export type DeleteLinodeConfigRequest = (
 export const deleteLinodeConfigActions = actionCreator.async<
   DeleteLinodeConfigParams,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(`delete`);

--- a/packages/manager/src/store/linodes/disk/disk.actions.ts
+++ b/packages/manager/src/store/linodes/disk/disk.actions.ts
@@ -1,4 +1,5 @@
 import { LinodeDiskCreationData } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 import { Entity } from './disk.types';
 
@@ -30,7 +31,7 @@ export type GetLinodeDisksRequest = (
 export const getLinodeDisksActions = actionCreator.async<
   GetLinodeDisksParams,
   Entity[],
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get-page`);
 
 /** Get Linode Disks (all) */
@@ -45,7 +46,7 @@ export type GetAllLinodeDisksRequest = (
 export const getAllLinodeDisksActions = actionCreator.async<
   GetAllLinodeDisksParams,
   Entity[],
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get-all`);
 
 /** Get Linode Disk */
@@ -60,7 +61,7 @@ export type GetLinodeDiskRequest = (
 export const getLinodeDiskActions = actionCreator.async<
   GetLinodeDiskParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get`);
 
 /** Create Linode Disk */
@@ -75,7 +76,7 @@ export type CreateLinodeDiskRequest = (
 export const createLinodeDiskActions = actionCreator.async<
   CreateLinodeDiskParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`create`);
 
 /** Update Linode Disk */
@@ -91,7 +92,7 @@ export type UpdateLinodeDiskRequest = (
 export const updateLinodeDiskActions = actionCreator.async<
   UpdateLinodeDiskParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);
 
 /** Delete Linode Disk */
@@ -106,7 +107,7 @@ export type DeleteLinodeDiskRequest = (
 export const deleteLinodeDiskActions = actionCreator.async<
   DeleteLinodeDiskParams,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(`delete`);
 
 /** Resize Linode Disk */
@@ -121,5 +122,5 @@ export type ResizeLinodeDiskRequest = (
 export const resizeLinodeDiskActions = actionCreator.async<
   ResizeLinodeDiskParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`resize`);

--- a/packages/manager/src/store/linodes/linodes.actions.ts
+++ b/packages/manager/src/store/linodes/linodes.actions.ts
@@ -1,5 +1,6 @@
 import { Notification } from 'linode-js-sdk/lib/account';
 import { CreateLinodeRequest, Linode } from 'linode-js-sdk/lib/linodes';
+import { APIError } from 'linode-js-sdk/lib/types';
 import actionCreatorFactory from 'typescript-fsa';
 
 export const actionCreator = actionCreatorFactory(`@@manager/linodes`);
@@ -34,39 +35,39 @@ export type GetLinodeResponse = Promise<Linode>;
 export const getLinodesActions = actionCreator.async<
   void,
   Linode[],
-  Linode.ApiFieldError[]
+  APIError[]
 >('get-all');
 
 export const getLinodeActions = actionCreator.async<
   LinodeID,
   Linode,
-  Linode.ApiFieldError[]
+  APIError[]
 >('get-one');
 
 export type CreateLinodeParams = CreateLinodeRequest;
 export const createLinodeActions = actionCreator.async<
   CreateLinodeParams,
   Linode,
-  Linode.ApiFieldError[]
+  APIError[]
 >('create');
 
 export type UpdateLinodeParams = Partial<Linode> & LinodeID;
 export const updateLinodeActions = actionCreator.async<
   UpdateLinodeParams,
   Linode,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);
 
 export type DeleteLinodeParams = LinodeID;
 export const deleteLinodeActions = actionCreator.async<
   DeleteLinodeParams,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >('delete');
 
 export type RebootLinodeParams = LinodeID & { configId?: number };
 export const rebootLinodeActions = actionCreator.async<
   RebootLinodeParams,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >('reboot');

--- a/packages/manager/src/store/managed/issues.actions.ts
+++ b/packages/manager/src/store/managed/issues.actions.ts
@@ -1,4 +1,5 @@
 import { ManagedIssue } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import actionCreatorFactory from 'typescript-fsa';
 
 export const actionCreator = actionCreatorFactory(`@@manager/managed`);
@@ -11,5 +12,5 @@ export interface ExtendedIssue extends ManagedIssue {
 export const requestManagedIssuesActions = actionCreator.async<
   void,
   ExtendedIssue[],
-  Linode.ApiFieldError[]
+  APIError[]
 >('request-issues');

--- a/packages/manager/src/store/managed/managed.actions.ts
+++ b/packages/manager/src/store/managed/managed.actions.ts
@@ -2,6 +2,7 @@ import {
   ManagedServiceMonitor,
   ManagedServicePayload
 } from 'linode-js-sdk/lib/managed';
+import { APIError } from 'linode-js-sdk/lib/types';
 import actionCreatorFactory from 'typescript-fsa';
 
 export const actionCreator = actionCreatorFactory(`@@manager/managed`);
@@ -13,36 +14,36 @@ export interface MonitorPayload {
 export const requestServicesActions = actionCreator.async<
   void,
   ManagedServiceMonitor[],
-  Linode.ApiFieldError[]
+  APIError[]
 >('request');
 
 export const disableServiceMonitorActions = actionCreator.async<
   MonitorPayload,
   ManagedServiceMonitor,
-  Linode.ApiFieldError[]
+  APIError[]
 >('disable');
 
 export const createServiceMonitorActions = actionCreator.async<
   ManagedServicePayload,
   ManagedServiceMonitor,
-  Linode.ApiFieldError[]
+  APIError[]
 >('create');
 
 export type UpdateServicePayload = MonitorPayload & ManagedServicePayload;
 export const updateServiceMonitorActions = actionCreator.async<
   UpdateServicePayload,
   ManagedServiceMonitor,
-  Linode.ApiFieldError[]
+  APIError[]
 >('update');
 
 export const enableServiceMonitorActions = actionCreator.async<
   MonitorPayload,
   ManagedServiceMonitor,
-  Linode.ApiFieldError[]
+  APIError[]
 >('enable');
 
 export const deleteServiceMonitorActions = actionCreator.async<
   MonitorPayload,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >('delete');

--- a/packages/manager/src/store/nodeBalancer/nodeBalancer.actions.ts
+++ b/packages/manager/src/store/nodeBalancer/nodeBalancer.actions.ts
@@ -2,6 +2,7 @@ import {
   CreateNodeBalancerPayload,
   NodeBalancer
 } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 
 const actionCreator = actionCreatorFactory(`@@manager/nodeBalancer`);
@@ -15,7 +16,7 @@ type Entity = NodeBalancer;
 export const getAllNodeBalancersActions = actionCreator.async<
   void,
   NodeBalancer[],
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get-all`);
 
 export type CreateNodeBalancerParams = CreateNodeBalancerPayload;
@@ -23,7 +24,7 @@ export type CreateNodeBalancerParams = CreateNodeBalancerPayload;
 export const createNodeBalancersActions = actionCreator.async<
   CreateNodeBalancerParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`create`);
 
 /** We require the ID in the action, if we just did Partial<NB> that makes id number | undefined */
@@ -32,7 +33,7 @@ export type UpdateNodeBalancerParams = BalancerParams & Partial<Entity>;
 export const updateNodeBalancersActions = actionCreator.async<
   UpdateNodeBalancerParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);
 
 export type DeleteNodeBalancerParams = BalancerParams;
@@ -40,7 +41,7 @@ export type DeleteNodeBalancerParams = BalancerParams;
 export const deleteNodeBalancerActions = actionCreator.async<
   DeleteNodeBalancerParams,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(`delete`);
 
 export type GetNodeBalancerWithConfigsParams = BalancerParams;
@@ -48,5 +49,5 @@ export type GetNodeBalancerWithConfigsParams = BalancerParams;
 export const getNodeBalancerWithConfigsActions = actionCreator.async<
   GetNodeBalancerWithConfigsParams,
   NodeBalancer,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get`);

--- a/packages/manager/src/store/nodeBalancerConfig/configNode.actions.ts
+++ b/packages/manager/src/store/nodeBalancerConfig/configNode.actions.ts
@@ -3,6 +3,7 @@ import {
   NodeBalancerConfigNode,
   UpdateNodeBalancerConfigNode
 } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 import { BalancerParams } from '../nodeBalancer/nodeBalancer.actions';
 
@@ -20,7 +21,7 @@ export type GetAllConfigNodesParams = ConfigParams;
 export const requestNodeBalancerConfigNodesActions = actionCreator.async<
   GetAllConfigNodesParams,
   NodeBalancerConfigNode[],
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get-all`);
 
 export type CreateNodeBalancerConfigNodeParams = ConfigParams &
@@ -28,7 +29,7 @@ export type CreateNodeBalancerConfigNodeParams = ConfigParams &
 export const createNodeBalancerConfigNodeActions = actionCreator.async<
   CreateNodeBalancerConfigNodeParams,
   NodeBalancerConfigNode,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`create`);
 
 export type UpdateNodeBalancerConfigNodeParams = NodeParams &
@@ -36,14 +37,14 @@ export type UpdateNodeBalancerConfigNodeParams = NodeParams &
 export const updateNodeBalancerConfigNodeActions = actionCreator.async<
   UpdateNodeBalancerConfigNodeParams,
   NodeBalancerConfigNode,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);
 
 export type DeleteNodeBalancerConfigNodeParams = NodeParams;
 export const deleteNodeBalancerConfigNodeActions = actionCreator.async<
   DeleteNodeBalancerConfigNodeParams,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(`delete`);
 
 export const removeNodeBalancerConfigNodes = actionCreator<number[]>(

--- a/packages/manager/src/store/nodeBalancerConfig/nodeBalancerConfig.actions.ts
+++ b/packages/manager/src/store/nodeBalancerConfig/nodeBalancerConfig.actions.ts
@@ -3,6 +3,7 @@ import {
   NodeBalancerConfig,
   UpdateNodeBalancerConfig
 } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 import { BalancerParams } from '../nodeBalancer/nodeBalancer.actions';
 
@@ -18,7 +19,7 @@ export type GetAllNodeBalancerConfigsParams = BalancerParams;
 export const getAllNodeBalancerConfigsActions = actionCreator.async<
   GetAllNodeBalancerConfigsParams,
   Entity[],
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get-all`);
 
 export type CreateNodeBalancerConfigParams = BalancerParams &
@@ -26,7 +27,7 @@ export type CreateNodeBalancerConfigParams = BalancerParams &
 export const createNodeBalancerConfigActions = actionCreator.async<
   CreateNodeBalancerConfigParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`create`);
 
 export type UpdateNodeBalancerConfigParams = ConfigParams &
@@ -34,14 +35,14 @@ export type UpdateNodeBalancerConfigParams = ConfigParams &
 export const updateNodeBalancerConfigActions = actionCreator.async<
   UpdateNodeBalancerConfigParams,
   Entity,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);
 
 export type DeleteNodeBalancerConfigParams = ConfigParams;
 export const deleteNodeBalancerConfigActions = actionCreator.async<
   DeleteNodeBalancerConfigParams,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(`delete`);
 
 export const removeNodeBalancerConfigs = actionCreator<number[]>(`remove-many`);

--- a/packages/manager/src/store/notification/notification.actions.ts
+++ b/packages/manager/src/store/notification/notification.actions.ts
@@ -1,8 +1,9 @@
-import { Notification } from 'linode-js-sdk/lib/account'
+import { Notification } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 
 export interface Action {
   type: string;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   data?: any;
 }
 
@@ -17,7 +18,7 @@ export const UPDATE = '@manager/notifications/UPDATE';
 // ACTION CREATORS
 export const startRequest: ActionCreator = () => ({ type: LOAD });
 
-export const handleError: ActionCreator = (error: Linode.ApiFieldError[]) => ({
+export const handleError: ActionCreator = (error: APIError[]) => ({
   type: ERROR,
   error
 });

--- a/packages/manager/src/store/notification/notification.containers.ts
+++ b/packages/manager/src/store/notification/notification.containers.ts
@@ -1,4 +1,5 @@
 import { Notification } from 'linode-js-sdk/lib/account';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { connect } from 'react-redux';
 import { ApplicationState } from '..';
 import { ThunkActionCreator } from '../types';
@@ -15,7 +16,7 @@ const actions: Actions = {
 
 export interface WithNotifications {
   notifications: Notification[];
-  notificationsError: Linode.ApiFieldError[];
+  notificationsError: APIError[];
   notificationsLastUpdated: number;
   notificationsLoading: boolean;
 }

--- a/packages/manager/src/store/preferences/preferences.actions.ts
+++ b/packages/manager/src/store/preferences/preferences.actions.ts
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 
 const actionCreator = actionCreatorFactory(`@@manager/preferences`);
@@ -5,11 +6,11 @@ const actionCreator = actionCreatorFactory(`@@manager/preferences`);
 export const handleGetPreferences = actionCreator.async<
   void,
   Record<string, any>,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get`);
 
 export const handleUpdatePreferences = actionCreator.async<
   Record<string, any>,
   Record<string, any>,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);

--- a/packages/manager/src/store/profile/profile.actions.ts
+++ b/packages/manager/src/store/profile/profile.actions.ts
@@ -1,16 +1,15 @@
-import { Profile } from 'linode-js-sdk/lib/profile'
+import { Profile } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 
 const actionCreator = actionCreatorFactory(`@@manager/profile`);
 
-export const getProfileActions = actionCreator.async<
-  void,
-  Profile,
-  Linode.ApiFieldError[]
->(`request`);
+export const getProfileActions = actionCreator.async<void, Profile, APIError[]>(
+  `request`
+);
 
 export const handleUpdateProfile = actionCreator.async<
   Partial<Profile>,
   Partial<Profile>,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);

--- a/packages/manager/src/store/profile/profile.reducer.ts
+++ b/packages/manager/src/store/profile/profile.reducer.ts
@@ -1,4 +1,5 @@
 import { Profile } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { Reducer } from 'redux';
 import { isType } from 'typescript-fsa';
 import { EntityError, RequestableData } from '../types';
@@ -8,7 +9,7 @@ export type State = RequestableData<Profile, EntityError>;
 
 interface Action<T> {
   type: string;
-  error?: Linode.ApiFieldError[];
+  error?: APIError[];
   payload?: T;
 }
 

--- a/packages/manager/src/store/profile/profile.requests.ts
+++ b/packages/manager/src/store/profile/profile.requests.ts
@@ -4,6 +4,7 @@ import {
   Profile,
   updateProfile as _updateProfile
 } from 'linode-js-sdk/lib/profile';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import { Action } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -95,8 +96,8 @@ const handleUpdateSuccess = (
 
 const handleUpdateFailure = (
   payload: Partial<Profile>,
-  error: Linode.ApiFieldError[],
-  failed: ActionCreator<Failure<Partial<Profile>, Linode.ApiFieldError[]>>,
+  error: APIError[],
+  failed: ActionCreator<Failure<Partial<Profile>, APIError[]>>,
   dispatch: ThunkDispatch<ApplicationState, undefined, Action<any>>
 ) => {
   dispatch(

--- a/packages/manager/src/store/regions/regions.actions.ts
+++ b/packages/manager/src/store/regions/regions.actions.ts
@@ -1,4 +1,5 @@
 import { getRegions, Region } from 'linode-js-sdk/lib/regions';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { actionCreatorFactory } from 'typescript-fsa';
 import { createRequestThunk } from '../store.helpers';
 
@@ -7,7 +8,7 @@ const actionCreator = actionCreatorFactory(`@@manager/regions`);
 export const regionsRequestActions = actionCreator.async<
   void,
   Region[],
-  Linode.ApiFieldError[]
+  APIError[]
 >(`request`);
 
 export const requestRegions = createRequestThunk(regionsRequestActions, () =>

--- a/packages/manager/src/store/selectors/entitiesLoading.ts
+++ b/packages/manager/src/store/selectors/entitiesLoading.ts
@@ -1,6 +1,7 @@
 import { Domain } from 'linode-js-sdk/lib/domains';
 import { Linode, LinodeType } from 'linode-js-sdk/lib/linodes';
 import { NodeBalancer } from 'linode-js-sdk/lib/nodebalancers';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { Volume } from 'linode-js-sdk/lib/volumes';
 import { createSelector } from 'reselect';
 import { ApplicationState } from 'src/store';
@@ -10,7 +11,7 @@ import { State as ImageState } from 'src/store/image/image.reducer';
 
 type State = ApplicationState['__resources'];
 
-interface Resource<T, E = Linode.ApiFieldError[]> {
+interface Resource<T, E = APIError[]> {
   results: string[] | number[];
   entities: T;
   loading: boolean;

--- a/packages/manager/src/store/store.helpers.ts
+++ b/packages/manager/src/store/store.helpers.ts
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { assoc, omit } from 'ramda';
 import {
   Entity,
@@ -34,14 +35,14 @@ export const onGetAllSuccess = <E extends Entity, S>(
     )
   });
 
-export const onError = <S = {}, E = Linode.ApiFieldError[] | undefined>(
+export const onError = <S = {}, E = APIError[] | undefined>(
   error: E,
   state: S
 ) => Object.assign({}, state, { error, loading: false });
 
 export const createDefaultState = <
   E extends Entity,
-  O = Linode.ApiFieldError[] | undefined
+  O = APIError[] | undefined
 >(
   override: Partial<MappedEntityState<E, O>> = {}
 ): MappedEntityState<E, O> => ({
@@ -53,30 +54,21 @@ export const createDefaultState = <
   ...override
 });
 
-export const onDeleteSuccess = <
-  E extends Entity,
-  O = Linode.ApiFieldError[] | undefined
->(
+export const onDeleteSuccess = <E extends Entity, O = APIError[] | undefined>(
   id: string | number,
   state: MappedEntityState<E, O>
 ): MappedEntityState<E, O> => {
   return removeMany([String(id)], state);
 };
 
-export const onCreateOrUpdate = <
-  E extends Entity,
-  O = Linode.ApiFieldError[] | undefined
->(
+export const onCreateOrUpdate = <E extends Entity, O = APIError[] | undefined>(
   entity: E,
   state: MappedEntityState<E, O>
 ): MappedEntityState<E, O> => {
   return addMany([entity], state);
 };
 
-export const removeMany = <
-  E extends Entity,
-  O = Linode.ApiFieldError[] | undefined
->(
+export const removeMany = <E extends Entity, O = APIError[] | undefined>(
   list: string[],
   state: MappedEntityState<E, O>
 ): MappedEntityState<E, O> => {
@@ -89,10 +81,7 @@ export const removeMany = <
   };
 };
 
-export const addMany = <
-  E extends Entity,
-  O = Linode.ApiFieldError[] | undefined
->(
+export const addMany = <E extends Entity, O = APIError[] | undefined>(
   list: E[],
   state: MappedEntityState<E, O>
 ): MappedEntityState<E, O> => {

--- a/packages/manager/src/store/volume/volume.actions.ts
+++ b/packages/manager/src/store/volume/volume.actions.ts
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import {
   AttachVolumePayload,
   CloneVolumePayload,
@@ -22,44 +23,44 @@ export const actionCreator = actionCreatorFactory('@@manager/volumes');
 export const createVolumeActions = actionCreator.async<
   VolumeRequestPayload,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`create`);
 export const getOneVolumeActions = actionCreator.async<
   VolumeId,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`get-one`);
 export const updateVolumeActions = actionCreator.async<
   UpdateVolumeParams,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`update`);
 export const deleteVolumeActions = actionCreator.async<
   VolumeId,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(`delete`);
 
 export const attachVolumeActions = actionCreator.async<
   AttachVolumeParams,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`attach`);
 export const detachVolumeActions = actionCreator.async<
   VolumeId,
   {},
-  Linode.ApiFieldError[]
+  APIError[]
 >(`detach`);
 
 export const cloneVolumeActions = actionCreator.async<
   CloneVolumeParams,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`clone`);
 export const resizeVolumeActions = actionCreator.async<
   ResizeVolumeParams,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(`resize`);
 
 // We want to provide the option NOT to set { loading: true } when requesting all Volumes.
@@ -71,5 +72,5 @@ export interface GetAllVolumesOptions {
 export const getAllVolumesActions = actionCreator.async<
   GetAllVolumesOptions | void,
   Volume[],
-  Linode.ApiFieldError[]
+  APIError[]
 >('get-all');

--- a/packages/manager/src/store/volume/volume.requests.ts
+++ b/packages/manager/src/store/volume/volume.requests.ts
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import {
   attachVolume as _attachVolume,
   cloneVolume as _cloneVolume,
@@ -37,7 +38,7 @@ export type CreateVolumeRequest = _VolumeRequestPayload;
 export const createVolume = createRequestThunk<
   CreateVolumeRequest,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(createVolumeActions, data => _createVolume(data));
 
 /*
@@ -46,7 +47,7 @@ export const createVolume = createRequestThunk<
 export const updateVolume = createRequestThunk<
   UpdateVolumeParams,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(updateVolumeActions, ({ volumeId, ...data }) =>
   _updateVolume(volumeId, data)
 );
@@ -54,11 +55,10 @@ export const updateVolume = createRequestThunk<
 /*
  * Delete Volume
  */
-export const deleteVolume = createRequestThunk<
-  VolumeId,
-  {},
-  Linode.ApiFieldError[]
->(deleteVolumeActions, ({ volumeId }) => _deleteVolume(volumeId));
+export const deleteVolume = createRequestThunk<VolumeId, {}, APIError[]>(
+  deleteVolumeActions,
+  ({ volumeId }) => _deleteVolume(volumeId)
+);
 
 /*
  * Attach Volume
@@ -66,7 +66,7 @@ export const deleteVolume = createRequestThunk<
 export const attachVolume = createRequestThunk<
   AttachVolumeParams,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(attachVolumeActions, ({ volumeId, ...data }) =>
   _attachVolume(volumeId, data)
 );
@@ -74,11 +74,10 @@ export const attachVolume = createRequestThunk<
 /*
  * Detach Volume
  */
-export const detachVolume = createRequestThunk<
-  VolumeId,
-  {},
-  Linode.ApiFieldError[]
->(detachVolumeActions, ({ volumeId }) => _detachVolume(volumeId));
+export const detachVolume = createRequestThunk<VolumeId, {}, APIError[]>(
+  detachVolumeActions,
+  ({ volumeId }) => _detachVolume(volumeId)
+);
 
 /*
  * Resize Volume
@@ -86,7 +85,7 @@ export const detachVolume = createRequestThunk<
 export const resizeVolume = createRequestThunk<
   ResizeVolumeParams,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(resizeVolumeActions, ({ volumeId, ...payload }) =>
   _resizeVolume(volumeId, payload)
 );
@@ -94,11 +93,10 @@ export const resizeVolume = createRequestThunk<
 /*
  * Get One Volume
  */
-export const getOneVolume = createRequestThunk<
-  VolumeId,
-  Volume,
-  Linode.ApiFieldError[]
->(getOneVolumeActions, ({ volumeId }) => _getVolume(volumeId));
+export const getOneVolume = createRequestThunk<VolumeId, Volume, APIError[]>(
+  getOneVolumeActions,
+  ({ volumeId }) => _getVolume(volumeId)
+);
 
 /*
  * Clone Volume
@@ -106,7 +104,7 @@ export const getOneVolume = createRequestThunk<
 export const cloneVolume = createRequestThunk<
   CloneVolumeParams,
   Volume,
-  Linode.ApiFieldError[]
+  APIError[]
 >(cloneVolumeActions, ({ volumeId, ...payload }) =>
   _cloneVolume(volumeId, payload)
 );

--- a/packages/manager/src/types/index.ts
+++ b/packages/manager/src/types/index.ts
@@ -34,11 +34,6 @@ namespace Linode {
     hourly: number;
   }
 
-  export interface ApiFieldError {
-    field?: string;
-    reason: string;
-  }
-
   export interface PaginationOptions {
     page?: number;
     page_size?: number;

--- a/packages/manager/src/utilities/errorUtils.ts
+++ b/packages/manager/src/utilities/errorUtils.ts
@@ -18,7 +18,7 @@ import { reportException } from 'src/exceptionReporting';
  *
  * fetchData()
  *  .then()
- *  .catch((e: Linode.ApiFieldError[]) => getAPIErrorOrDefault(e, 'There was an error', 'label'))
+ *  .catch((e: APIError[]) => getAPIErrorOrDefault(e, 'There was an error', 'label'))
  *
  * @param { AxiosError } - Error response from some API request
  * @param { string } - Default error message on the "reason" key
@@ -30,10 +30,10 @@ import { reportException } from 'src/exceptionReporting';
  *
  */
 export const getAPIErrorOrDefault = (
-  errorResponse: Linode.ApiFieldError[],
+  errorResponse: APIError[],
   defaultError: string = DEFAULT_ERROR_MESSAGE,
   field?: string
-): Linode.ApiFieldError[] => {
+): APIError[] => {
   const _defaultError = field
     ? [{ reason: defaultError, field }]
     : [{ reason: defaultError }];
@@ -41,7 +41,7 @@ export const getAPIErrorOrDefault = (
   return isDefaultError(errorResponse) ? _defaultError : errorResponse;
 };
 
-const isDefaultError = (errorResponse: Linode.ApiFieldError[]) => {
+const isDefaultError = (errorResponse: APIError[]) => {
   return (
     errorResponse &&
     errorResponse.length === 1 &&
@@ -88,16 +88,16 @@ export const handleUnauthorizedErrors = (
    */
   return hasUnauthorizedError
     ? [
-      {
-        reason: unauthedMessage
-      },
-      ...filteredErrors
-    ]
+        {
+          reason: unauthedMessage
+        },
+        ...filteredErrors
+      ]
     : filteredErrors;
 };
 
 export const getErrorStringOrDefault = (
-  errors: Linode.ApiFieldError[] | string,
+  errors: APIError[] | string,
   defaultError: string = 'An unexpected error occurred.'
 ): string => {
   if (typeof errors === 'string') {
@@ -131,7 +131,7 @@ export const getErrorStringOrDefault = (
  */
 export const getErrorMap = (
   fields: string[] = [],
-  errors?: Linode.ApiFieldError[]
+  errors?: APIError[]
 ): Record<string, string | undefined> => {
   if (!errors) {
     return {};

--- a/packages/manager/src/utilities/formikErrorUtils.ts
+++ b/packages/manager/src/utilities/formikErrorUtils.ts
@@ -1,9 +1,10 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { getAPIErrorOrDefault } from './errorUtils';
 import isNilOrEmpty from './isNilOrEmpty';
 
 export const handleFieldErrors = (
   callback: Function,
-  fieldErrors: Linode.ApiFieldError[] = []
+  fieldErrors: APIError[] = []
 ) => {
   const mappedFieldErrors = fieldErrors.reduce(
     (result, { field, reason }) =>
@@ -18,7 +19,7 @@ export const handleFieldErrors = (
 
 export const handleGeneralErrors = (
   callback: Function,
-  apiErrors: Linode.ApiFieldError[],
+  apiErrors: APIError[],
   defaultMessage: string = 'An error has occurred.'
 ) => {
   if (!apiErrors) {

--- a/packages/manager/src/utilities/getAPIErrorFor.ts
+++ b/packages/manager/src/utilities/getAPIErrorFor.ts
@@ -1,6 +1,8 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+
 export default (
   errorMap: { [index: string]: string },
-  arr: Linode.ApiFieldError[] = []
+  arr: APIError[] = []
 ) => (field: string): undefined | string => {
   let err;
 

--- a/packages/manager/src/utilities/interceptAPIError.tsx
+++ b/packages/manager/src/utilities/interceptAPIError.tsx
@@ -19,7 +19,7 @@ export const interceptGPUErrors = (
    * pre-filled support ticket). Checking the text of the error
    * and the type string of the plan is the best we can do.
    *
-   * Passing JSX to an APIFieldError.reason doesn't seem to break anything,
+   * Passing JSX to an APIError.reason doesn't seem to break anything,
    * but if we do this anywhere else we'll have to update the typings.
    */
   return errors.map(thisError => {

--- a/packages/manager/src/utilities/request.tsx
+++ b/packages/manager/src/utilities/request.tsx
@@ -105,7 +105,7 @@ export const handleError = (error: AxiosError) => {
     }
   ]);
 
-  // Downstream components should only have to handle ApiFieldErrors, not AxiosErrors.
+  // Downstream components should only have to handle APIError, not AxiosErrors.
   return Promise.reject(interceptedErrors);
 };
 


### PR DESCRIPTION
## Description

I'm sorry 😭 . This is the last monster I promise.

Deprecates `Linode.ApiFieldError` in favor of `import { APIError } from 'linode-js-sdk/lib/types'`

## Type of Change
- Breaking change ('break', 'deprecate')