### PR TITLE
OCA Add: Plesk info panel and a Tips section

### DIFF
--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -123,10 +123,10 @@ export const AppDetailDrawer: React.FunctionComponent<
             icon={LibraryBook}
           />
         )}
-        {app.additonal_info && (
+        {app.tips && (
           <TipSection
           title="Tips"
-          tips={app.additonal_info}
+          tips={app.tips}
           icon={Info}
           />
         )}

--- a/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
+++ b/packages/manager/src/features/OneClickApps/AppDetailDrawer.tsx
@@ -13,8 +13,10 @@ import { APP_ROOT } from 'src/constants';
 
 import { oneClickApps } from './FakeSpec';
 import LinkSection from './LinkSection';
+import TipSection from './TipSection';
 
 import LibraryBook from 'src/assets/icons/guides.svg';
+import Info from 'src/assets/icons/info.svg';
 import Link from 'src/assets/icons/moreInfo.svg';
 
 type ClassNames =
@@ -114,11 +116,20 @@ export const AppDetailDrawer: React.FunctionComponent<
             icon={Link}
           />
         )}
-        <LinkSection
-          title="Guides"
-          links={app.related_guides || []}
-          icon={LibraryBook}
-        />
+        {app.related_guides && (
+          <LinkSection
+            title="Guides"
+            links={app.related_guides}
+            icon={LibraryBook}
+          />
+        )}
+        {app.additonal_info && (
+          <TipSection
+          title="Tips"
+          tips={app.additonal_info}
+          icon={Info}
+          />
+        )}
       </Grid>
     </Drawer>
   );

--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -5,6 +5,7 @@ export interface OCA {
   href?: string;
   logo_url: string;
   summary: string;
+  additonal_info?: Info[];
 }
 
 export interface Doc {
@@ -12,6 +13,9 @@ export interface Doc {
   href: string;
 }
 
+export interface Info {
+  tip: string;
+}
 export const oneClickApps: OCA[] = [
   {
     name: 'Ark',
@@ -127,6 +131,22 @@ export const oneClickApps: OCA[] = [
     // href: 'https://www.ibm.com/cloud/learn/lamp-stack-explained' Not sure this is kosher.
   },
   {
+    name: 'Plesk',
+    description: `Plesk is a leading WordPress and website management platform and control panel. Plesk lets you build and manage multiple websites from a single dashboard to configure web services, email, and other applications. Plesk features hundreds of extensions, plus a complete WordPress toolkit, and can orchestrate multi-server developments. Use the Plesk One-Click App to manage websites hosted on your Linode.`,
+    summary:
+      'A secure, scalable, and versatile website management platform.',
+    additonal_info: [
+      {
+        tip: 'Please allow the script around 15 minutes to finish.',
+      },
+      {
+        tip: 'After deployment SSH into your Linode and run: "plesk login".',
+      }
+    ],
+    href: 'https://www.plesk.com/',
+    logo_url: 'assets/plesk_color.svg'
+  },
+  {
     name: 'Rust',
     description: `In Rust, you must work with or against other players
       to ensure your own survival. Players are able to steal, lie, cheat, or
@@ -167,7 +187,7 @@ export const oneClickApps: OCA[] = [
   {
     name: 'TF2',
     description: `Team Fortress 2 is a team-based multiplayer first-person shooter.
-      In TF2, you and your team choose from a number of hero classes and different game modes, 
+      In TF2, you and your team choose from a number of hero classes and different game modes,
       ensuring a unique in-game experience every match.
       Setting up a personal game server puts you in control of
       what game modes and maps you use, as well as a variety of other settings
@@ -226,11 +246,11 @@ export const oneClickApps: OCA[] = [
   },
   {
     name: 'OpenVPN',
-    description: `OpenVPN is a widely trusted, free, and open-source virtual private network 
+    description: `OpenVPN is a widely trusted, free, and open-source virtual private network
     application. OpenVPN creates network tunnels between groups of
       computers that are not on the same local network, and it uses OpenSSL
       to encrypt your traffic.`,
-    summary: `Open-source virtual private network (VPN) application. 
+    summary: `Open-source virtual private network (VPN) application.
       OpenVPN securely connects your computer to your servers,
       or to the public Internet.`,
     related_guides: [

--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -129,12 +129,14 @@ export const oneClickApps: OCA[] = [
   },
   {
     name: 'Plesk',
-    description: `Plesk is a leading WordPress and website management platform and control panel. Plesk lets you build and manage multiple websites from a single dashboard to configure web services, email, and other applications. Plesk features hundreds of extensions, plus a complete WordPress toolkit, and can orchestrate deployments. Use the Plesk One-Click App to manage websites hosted on your Linode.`,
-    summary:
-      'A secure, scalable, and versatile website management platform.',
+    description: `Plesk is a leading WordPress and website management platform and control panel. 
+      Plesk lets you build and manage multiple websites from a single dashboard to configure web services, 
+      email, and other applications. Plesk features hundreds of extensions, plus a complete WordPress toolkit, 
+      and can orchestrate multi-server deployments. Use the Plesk One-Click App to manage websites hosted on your Linode.`,
+    summary: 'A secure, scalable, and versatile website management platform.',
     tips: [
       'Please allow the script around 15 minutes to finish.',
-      'After deployment, SSH into your Linode and run: <code> plesk login</code> to generate a login link.',
+      'After deployment, SSH into your Linode and run: <code> plesk login</code> to generate a login link.'
     ],
     href: 'https://www.plesk.com/',
     logo_url: 'assets/plesk_color.svg'

--- a/packages/manager/src/features/OneClickApps/FakeSpec.ts
+++ b/packages/manager/src/features/OneClickApps/FakeSpec.ts
@@ -5,7 +5,7 @@ export interface OCA {
   href?: string;
   logo_url: string;
   summary: string;
-  additonal_info?: Info[];
+  tips?: string[];
 }
 
 export interface Doc {
@@ -13,9 +13,6 @@ export interface Doc {
   href: string;
 }
 
-export interface Info {
-  tip: string;
-}
 export const oneClickApps: OCA[] = [
   {
     name: 'Ark',
@@ -132,16 +129,12 @@ export const oneClickApps: OCA[] = [
   },
   {
     name: 'Plesk',
-    description: `Plesk is a leading WordPress and website management platform and control panel. Plesk lets you build and manage multiple websites from a single dashboard to configure web services, email, and other applications. Plesk features hundreds of extensions, plus a complete WordPress toolkit, and can orchestrate multi-server developments. Use the Plesk One-Click App to manage websites hosted on your Linode.`,
+    description: `Plesk is a leading WordPress and website management platform and control panel. Plesk lets you build and manage multiple websites from a single dashboard to configure web services, email, and other applications. Plesk features hundreds of extensions, plus a complete WordPress toolkit, and can orchestrate deployments. Use the Plesk One-Click App to manage websites hosted on your Linode.`,
     summary:
       'A secure, scalable, and versatile website management platform.',
-    additonal_info: [
-      {
-        tip: 'Please allow the script around 15 minutes to finish.',
-      },
-      {
-        tip: 'After deployment SSH into your Linode and run: "plesk login".',
-      }
+    tips: [
+      'Please allow the script around 15 minutes to finish.',
+      'After deployment, SSH into your Linode and run: <code> plesk login</code> to generate a login link.',
     ],
     href: 'https://www.plesk.com/',
     logo_url: 'assets/plesk_color.svg'

--- a/packages/manager/src/features/OneClickApps/TipSection.tsx
+++ b/packages/manager/src/features/OneClickApps/TipSection.tsx
@@ -8,6 +8,8 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import { sanitizeHTML } from 'src/utilities/sanitize-html'
+
 
 type ClassNames = 'root' | 'icon' | 'tip' | 'title';
 
@@ -34,14 +36,10 @@ const styles = (theme: Theme) =>
     }
   });
 
-interface Info {
-  tip: string
-}
-
 interface Props {
   icon: any;
   title: string;
-  tips: Info[];
+  tips: string[];
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -67,10 +65,14 @@ export const TipSection: React.FunctionComponent<CombinedProps> = props => {
         </Grid>
       </Grid>
       <Grid container item className={classes.tip}>
-        {tips.map((additional_info, idx) => (
+        {tips.map((tip, idx) => (
           <Grid item key={`${title}-tip-item-${idx}`}>
             <Typography className={classes.title}>
-             {additional_info.tip}
+              <div
+                  dangerouslySetInnerHTML={{
+                    __html: sanitizeHTML(tip)
+                  }}
+              />
             </Typography>
           </Grid>
         ))}

--- a/packages/manager/src/features/OneClickApps/TipSection.tsx
+++ b/packages/manager/src/features/OneClickApps/TipSection.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+
+import Grid from 'src/components/core/Grid';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+
+type ClassNames = 'root' | 'icon' | 'tip' | 'title';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      marginTop: theme.spacing(4)
+    },
+    icon: {
+      width: 24,
+      position: 'relative',
+      top: 2,
+      marginRight: 8,
+      color: theme.color.headline
+    },
+    tip: {
+      marginLeft: 32,
+      fontSize: '1em',
+      lineHeight: 2
+    },
+    title: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1)
+    }
+  });
+
+interface Info {
+  tip: string
+}
+
+interface Props {
+  icon: any;
+  title: string;
+  tips: Info[];
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+export const TipSection: React.FunctionComponent<CombinedProps> = props => {
+  const { classes, icon, tips, title } = props;
+  const Icon = icon;
+
+  return (
+    <Grid container item className={classes.root}>
+      <Grid
+        container
+        item
+        direction="row"
+        justify="flex-start"
+        alignItems="center"
+      >
+        <Grid item>
+          <Icon className={classes.icon} />
+        </Grid>
+        <Grid item>
+          <Typography variant="h3">{title}</Typography>
+        </Grid>
+      </Grid>
+      <Grid container item className={classes.tip}>
+        {tips.map((additional_info, idx) => (
+          <Grid item key={`${title}-tip-item-${idx}`}>
+            <Typography className={classes.title}>
+             {additional_info.tip}
+            </Typography>
+          </Grid>
+        ))}
+      </Grid>
+    </Grid>
+  );
+};
+
+const styled = withStyles(styles);
+
+export default styled(TipSection);


### PR DESCRIPTION
## Description

This adds the info panel for the Plesk OCA. It also adds a **Tips** section, which will hopefully allow us to move any simple configurations directly to manager, as opposed to redirecting users to external resources. (The whole panel should probably be reworked a little to include markdown)

Also, **Guides** will no longer display if there are no guides in the `FakeSpec`

## Type of Change
- Non breaking change ('update', 'change')

<img width="530" alt="Screen Shot 2019-09-27 at 12 28 48 PM" src="https://user-images.githubusercontent.com/7669934/65786693-2efec980-e125-11e9-99e1-31aa6ba178f2.png">

