### PR TITLE
OCA Add: feature flags

### DIFF
--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -5,10 +5,7 @@ interface TaxBanner {
   date: string;
 }
 
-interface OneClickApp {
-  id: number;
-  label: string;
-}
+type OneClickApp = Record<string, string>;
 
 interface Flags {
   managed: boolean;
@@ -18,7 +15,7 @@ interface Flags {
   oneClickLocation: 'sidenav' | 'createmenu';
   lkeHideButtons: boolean;
   firewalls: boolean;
-  oneClickApps: OneClickApp[];
+  oneClickApps: OneClickApp;
 }
 
 /**

--- a/packages/manager/src/featureFlags.ts
+++ b/packages/manager/src/featureFlags.ts
@@ -5,6 +5,11 @@ interface TaxBanner {
   date: string;
 }
 
+interface OneClickApp {
+  id: number;
+  label: string;
+}
+
 interface Flags {
   managed: boolean;
   objectStorage: boolean;
@@ -13,6 +18,7 @@ interface Flags {
   oneClickLocation: 'sidenav' | 'createmenu';
   lkeHideButtons: boolean;
   firewalls: boolean;
+  oneClickApps: OneClickApp[];
 }
 
 /**

--- a/packages/manager/src/features/StackScripts/stackScriptUtils.ts
+++ b/packages/manager/src/features/StackScripts/stackScriptUtils.ts
@@ -14,6 +14,70 @@ export const emptyResult: Linode.ResourcePage<StackScript> = {
   results: 0
 };
 
+/**
+ * We need a way to make sure that newly added SS that meet
+ * our filtering criteria don't automatically end up being
+ * shown to the user before we've updated Cloud to support them.
+ */
+export const baseApps = [
+  {
+    id: 401699,
+    label: 'Ark - Latest One-Click'
+  },
+  {
+    id: 401704,
+    label: 'TF2 - Latest One-Click'
+  },
+  {
+    id: 401705,
+    label: 'Terraria - Latest One-Click'
+  },
+  {
+    id: 401703,
+    label: 'Rust - Latest One-Click'
+  },
+  {
+    id: 401700,
+    label: 'CS:GO - Latest One-Click'
+  },
+  {
+    id: 401702,
+    label: 'MERN One-Click'
+  },
+  {
+    id: 401698,
+    label: 'Drupal - Latest One-Click'
+  },
+  {
+    id: 401707,
+    label: 'GitLab - Latest One-Click'
+  },
+  {
+    id: 401708,
+    label: 'WooCommerce - Latest One-Click'
+  },
+  {
+    id: 401706,
+    label: 'WireGuard - Latest One-Click'
+  },
+  {
+    id: 401709,
+    label: 'Minecraft - Latest One-Click'
+  },
+  {
+    id: 401701,
+    label: 'LAMP One-Click'
+  },
+  {
+    id: 401719,
+    label: 'OpenVPN - Latest One-Click'
+  },
+  {
+    id: 401697,
+    label: 'WordPress - Latest One-Click'
+  }
+];
+
 const oneClickFilter = [
   {
     '+and': [

--- a/packages/manager/src/features/StackScripts/stackScriptUtils.ts
+++ b/packages/manager/src/features/StackScripts/stackScriptUtils.ts
@@ -19,64 +19,22 @@ export const emptyResult: Linode.ResourcePage<StackScript> = {
  * our filtering criteria don't automatically end up being
  * shown to the user before we've updated Cloud to support them.
  */
-export const baseApps = [
-  {
-    id: 401699,
-    label: 'Ark - Latest One-Click'
-  },
-  {
-    id: 401704,
-    label: 'TF2 - Latest One-Click'
-  },
-  {
-    id: 401705,
-    label: 'Terraria - Latest One-Click'
-  },
-  {
-    id: 401703,
-    label: 'Rust - Latest One-Click'
-  },
-  {
-    id: 401700,
-    label: 'CS:GO - Latest One-Click'
-  },
-  {
-    id: 401702,
-    label: 'MERN One-Click'
-  },
-  {
-    id: 401698,
-    label: 'Drupal - Latest One-Click'
-  },
-  {
-    id: 401707,
-    label: 'GitLab - Latest One-Click'
-  },
-  {
-    id: 401708,
-    label: 'WooCommerce - Latest One-Click'
-  },
-  {
-    id: 401706,
-    label: 'WireGuard - Latest One-Click'
-  },
-  {
-    id: 401709,
-    label: 'Minecraft - Latest One-Click'
-  },
-  {
-    id: 401701,
-    label: 'LAMP One-Click'
-  },
-  {
-    id: 401719,
-    label: 'OpenVPN - Latest One-Click'
-  },
-  {
-    id: 401697,
-    label: 'WordPress - Latest One-Click'
-  }
-];
+export const baseApps = {
+  '401699': 'Ark - Latest One-Click',
+  '401704': 'TF2 - Latest One-Click',
+  '401705': 'Terraria - Latest One-Click',
+  '401703': 'Rust - Latest One-Click',
+  '401700': 'CS:GO - Latest One-Click',
+  '401702': 'MERN One-Click',
+  '401698': 'Drupal - Latest One-Click',
+  '401707': 'GitLab - Latest One-Click',
+  '401708': 'WooCommerce - Latest One-Click',
+  '401706': 'WireGuard - Latest One-Click',
+  '401709': 'Minecraft - Latest One-Click',
+  '401701': 'LAMP One-Click',
+  '401719': 'OpenVPN - Latest One-Click',
+  '401697': 'WordPress - Latest One-Click'
+};
 
 const oneClickFilter = [
   {

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -170,7 +170,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
     const params = getParamsFromUrl(this.props.location.search);
     // Allowed apps include the base set of original apps + anything LD tells us to show
     const newApps = this.props.flags.oneClickApps || [];
-    const allowedApps = [...baseApps, ...newApps].map(i => i.id);
+    const allowedApps = Object.keys({ ...baseApps, ...newApps });
     if (params && params !== {}) {
       this.setState({
         // This set is for creating from a Backup
@@ -191,7 +191,8 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       .then(response =>
         response.data.filter(script => {
           return (
-            !script.label.match(/helpers/i) && allowedApps.includes(script.id)
+            !script.label.match(/helpers/i) &&
+            allowedApps.includes(String(script.id))
           );
         })
       )

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -169,9 +169,8 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
   componentDidMount() {
     const params = getParamsFromUrl(this.props.location.search);
     // Allowed apps include the base set of original apps + anything LD tells us to show
-    const allowedApps = [...baseApps, ...this.props.flags.oneClickApps].map(
-      i => i.id
-    );
+    const newApps = this.props.flags.oneClickApps || [];
+    const allowedApps = [...baseApps, ...newApps].map(i => i.id);
     if (params && params !== {}) {
       this.setState({
         // This set is for creating from a Backup
@@ -192,7 +191,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
       .then(response =>
         response.data.filter(script => {
           return (
-            !script.label.match(/helpers/i) && !allowedApps.includes(script.id)
+            !script.label.match(/helpers/i) && allowedApps.includes(script.id)
           );
         })
       )


### PR DESCRIPTION
## Description

We need a way to prevent new One-click StackScripts from being shown as options to the user before we have a chance to provide app details and logo icons for the new app. 

This PR attempts to use feature flags. Basically, we start with a hard-coded list of OCAs in `stackScriptHelpers.ts`. Any apps returned from the LD `oneClickApps` flag are appended to this list, and then the GET /stackscripts response is filtered to only include apps in the combined list.

I chose to hard-code the "basic" apps within Cloud bc LD doesn't seem to provide a way to extend flag variations, so there's no way to say "show this user the basic apps PLUS these two", each new variant would have to be a full list.


## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

To test, delete the ARK entry in the baseApps variable in stackScriptUtils, then toggle the OCA flag. You should see the app reappear in the list (you have to reload the page, since we only make this request on page load).

(NB This is more hard-coding, not less, and is not a scalable or sustainable solution.)