### PR TITLE
OBJ-247 Simultaneous file uploads

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -421,7 +421,11 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
           <Grid item xs={12} lg={8} className={classes.tableContainer}>
             <>
               <Paper className={classes.objectTable}>
-                <Table removeLabelonMobile aria-label="List of Bucket Objects">
+                <Table
+                  removeLabelonMobile
+                  aria-label="List of Bucket Objects"
+                  isResponsive={false}
+                >
                   <TableHead>
                     <TableRow>
                       <TableCell className={classes.nameColumn}>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -362,22 +362,6 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
     });
   };
 
-  updateInPlace() {
-    const { bucketName, clusterId } = this.props.match.params;
-    const prefix = getQueryParam(this.props.location.search, 'prefix');
-
-    // @todo: If there are exactly 100 objects already, what do we do? Set a marker?
-    getObjectList(clusterId, bucketName, { delimiter, prefix, page_size }).then(
-      response => {
-        // Replace the old data with the new data.
-        this.setState({
-          data: response.data.map(object => extendObject(object, prefix))
-        });
-      }
-    );
-    // @todo: Do we need to catch this?
-  }
-
   render() {
     const { classes } = this.props;
     const {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -307,6 +307,55 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
     }
   };
 
+  addOneFile = (objectName: string, sizeInBytes: number) => {
+    const object: Linode.Object = {
+      name: objectName,
+      etag: '',
+      owner: '',
+      last_modified: new Date().toISOString(),
+      size: sizeInBytes
+    };
+
+    const prefix = getQueryParam(this.props.location.search, 'prefix');
+
+    const extendedObject = extendObject(object, prefix, true);
+
+    const updatedFiles = [...this.state.data];
+
+    // If the file already exists in `data` (i.e. if the file is being
+    // overwritten), move it from its current location to the front.
+    const idx = updatedFiles.findIndex(file => file.name === objectName);
+    if (idx > -1) {
+      updatedFiles.splice(idx, 1);
+      updatedFiles.unshift(extendedObject);
+      this.setState({ data: updatedFiles });
+    } else {
+      this.setState({
+        data: [extendedObject, ...this.state.data]
+      });
+    }
+  };
+
+  addOneFolder = (objectName: string) => {
+    const folder: Linode.Object = {
+      name: objectName,
+      etag: null,
+      owner: null,
+      last_modified: null,
+      size: null
+    };
+
+    const prefix = getQueryParam(this.props.location.search, 'prefix');
+
+    const extendedFolder = extendObject(folder, prefix, true);
+
+    const idx = this.state.data.findIndex(object => object.name === objectName);
+    // If the folder isn't already in `data`, add it to the front.
+    if (idx === -1) {
+      this.setState({ data: [extendedFolder, ...this.state.data] });
+    }
+  };
+
   closeDeleteObjectDialog = () => {
     this.setState({
       deleteObjectDialogOpen: false
@@ -354,7 +403,7 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
       <>
         <Box display="flex" flexDirection="row" justifyContent="space-between">
           <Breadcrumb
-            // The actual pathname doesn't match what we want in the Breadcrumb,
+            // The actual pathname doesn't match what we want` in the Breadcrumb,
             // so we create a custom one.
             pathname={`/object-storage/${bucketName}`}
             crumbOverrides={[
@@ -381,7 +430,8 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
               clusterId={clusterId}
               bucketName={bucketName}
               prefix={prefix}
-              update={() => this.updateInPlace()}
+              addOneFile={this.addOneFile}
+              addOneFolder={this.addOneFolder}
             />
           </Grid>
           <Grid item xs={12} lg={8} className={classes.tableContainer}>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -439,7 +439,7 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
                       loading={loading}
                       error={generalError}
                       prefix={prefix}
-                      handleDownload={this.handleDownload}
+                      handleClickDownload={this.handleDownload}
                       handleClickDelete={this.handleClickDelete}
                     />
                   </TableBody>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
@@ -11,6 +11,9 @@ import TableRow from 'src/components/TableRow';
 // import { generateObjectUrl } from '../utilities';
 
 const useStyles = makeStyles((theme: Theme) => ({
+  manuallyCreated: {
+    backgroundColor: theme.bg.lightBlue
+  },
   folderNameWrapper: {
     display: 'flex',
     flexFlow: 'row nowrap',
@@ -24,10 +27,11 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   folderName: string;
   displayName: string;
+  manuallyCreated: boolean;
 }
 
 const FolderTableRow: React.FC<Props> = props => {
-  const { folderName, displayName } = props;
+  const { folderName, displayName, manuallyCreated } = props;
 
   const history = useHistory();
 
@@ -38,7 +42,11 @@ const FolderTableRow: React.FC<Props> = props => {
   };
 
   return (
-    <TableRow key={folderName} rowLink={handleClick}>
+    <TableRow
+      className={manuallyCreated ? classes.manuallyCreated : ''}
+      key={folderName}
+      rowLink={handleClick}
+    >
       <TableCell parentColumn="Object">
         <Grid container wrap="nowrap" alignItems="center">
           <Grid item className={classes.iconWrapper}>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
@@ -13,7 +13,7 @@ import TableRow from 'src/components/TableRow';
 const useStyles = makeStyles((theme: Theme) => ({
   manuallyCreated: {
     '&:before': {
-      backgroundColor: theme.palette.status.warningDark
+      backgroundColor: theme.bg.lightBlue
     }
   },
   folderNameWrapper: {

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/FolderTableRow.tsx
@@ -12,7 +12,9 @@ import TableRow from 'src/components/TableRow';
 
 const useStyles = makeStyles((theme: Theme) => ({
   manuallyCreated: {
-    backgroundColor: theme.bg.lightBlue
+    '&:before': {
+      backgroundColor: theme.palette.status.warningDark
+    }
   },
   folderNameWrapper: {
     display: 'flex',

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.test.tsx
@@ -10,7 +10,8 @@ const mockHandleClickDownload = jest.fn();
 
 const props: Props = {
   handleClickDownload: mockHandleClickDownload,
-  handleClickDelete: mockHandleClickDelete
+  handleClickDelete: mockHandleClickDelete,
+  objectName: 'my-object'
 };
 
 afterEach(cleanup);

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 export interface Props {
+  objectName: string;
   handleClickDownload: (newTab: boolean) => void;
-  handleClickDelete: () => void;
+  handleClickDelete: (objectName: string) => void;
 }
 
 export const ObjectActionMenu: React.FC<Props> = props => {
@@ -21,7 +22,7 @@ export const ObjectActionMenu: React.FC<Props> = props => {
       {
         title: 'Delete',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
-          props.handleClickDelete();
+          props.handleClickDelete(props.objectName);
           closeMenu();
           e.preventDefault();
         }

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
@@ -3,7 +3,7 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 export interface Props {
   objectName: string;
-  handleClickDownload: (newTab: boolean) => void;
+  handleClickDownload: (objectName: string, newTab: boolean) => void;
   handleClickDelete: (objectName: string) => void;
 }
 
@@ -14,7 +14,7 @@ export const ObjectActionMenu: React.FC<Props> = props => {
         title: 'Open',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           const shouldOpenInNewTab = true;
-          props.handleClickDownload(shouldOpenInNewTab);
+          props.handleClickDownload(props.objectName, shouldOpenInNewTab);
           closeMenu();
           e.preventDefault();
         }

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -14,7 +14,7 @@ interface Props {
   loading: boolean;
   error?: APIError[];
   prefix: string;
-  handleDownload: (objectName: string, newTab: boolean) => void;
+  handleClickDownload: (objectName: string, newTab: boolean) => void;
   handleClickDelete: (objectName: string) => void;
 }
 
@@ -24,7 +24,7 @@ const ObjectTableContent: React.FC<Props> = props => {
     loading,
     error,
     prefix,
-    handleDownload,
+    handleClickDownload,
     handleClickDelete
   } = props;
 
@@ -101,10 +101,8 @@ const ObjectTableContent: React.FC<Props> = props => {
              */
             objectSize={object.size || 0}
             objectLastModified={object.last_modified || ''}
-            handleClickDownload={(newTab: boolean) =>
-              handleDownload(object.name, newTab)
-            }
             manuallyCreated={object._manuallyCreated}
+            handleClickDownload={handleClickDownload}
             handleClickDelete={handleClickDelete}
           />
         );

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -91,7 +91,8 @@ const ObjectTableContent: React.FC<Props> = props => {
         return (
           <ObjectTableRow
             key={object.name}
-            objectName={truncateMiddle(object._displayName, maxNameWidth)}
+            displayName={truncateMiddle(object._displayName, maxNameWidth)}
+            fullName={object.name}
             /**
              * In reality, if there's no `size` or `last_modified`, we're
              * probably dealing with a folder and will have already returned

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableContent.tsx
@@ -83,6 +83,7 @@ const ObjectTableContent: React.FC<Props> = props => {
               key={object.name}
               folderName={object.name}
               displayName={truncateEnd(object._displayName, maxNameWidth)}
+              manuallyCreated={object._manuallyCreated}
             />
           );
         }
@@ -102,7 +103,8 @@ const ObjectTableContent: React.FC<Props> = props => {
             handleClickDownload={(newTab: boolean) =>
               handleDownload(object.name, newTab)
             }
-            handleClickDelete={() => handleClickDelete(object.name)}
+            manuallyCreated={object._manuallyCreated}
+            handleClickDelete={handleClickDelete}
           />
         );
       })}

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Box from 'src/components/core/Box';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import EntityIcon from 'src/components/EntityIcon';
@@ -9,12 +10,27 @@ import TableRow from 'src/components/TableRow';
 import { readableBytes } from 'src/utilities/unitConversions';
 import ObjectActionMenu from './ObjectActionMenu';
 
+const useStyles = makeStyles((theme: Theme) => ({
+  manuallyCreated: {
+    backgroundColor: theme.bg.lightBlue
+  },
+  folderNameWrapper: {
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center'
+  },
+  iconWrapper: {
+    margin: '2px 0'
+  }
+}));
+
 interface Props {
   objectName: string;
   objectSize: number;
   objectLastModified: string;
   handleClickDownload: (newTab: boolean) => void;
-  handleClickDelete: () => void;
+  handleClickDelete: (objectName: string) => void;
+  manuallyCreated: boolean;
 }
 
 const ObjectTableRow: React.FC<Props> = props => {
@@ -23,11 +39,14 @@ const ObjectTableRow: React.FC<Props> = props => {
     objectSize,
     objectLastModified,
     handleClickDownload,
-    handleClickDelete
+    handleClickDelete,
+    manuallyCreated
   } = props;
 
+  const classes = useStyles();
+
   return (
-    <TableRow>
+    <TableRow className={manuallyCreated ? classes.manuallyCreated : ''}>
       <TableCell parentColumn="Object">
         <Grid container wrap="nowrap" alignItems="center">
           <Grid item className="py0">
@@ -52,6 +71,7 @@ const ObjectTableRow: React.FC<Props> = props => {
         <ObjectActionMenu
           handleClickDownload={handleClickDownload}
           handleClickDelete={handleClickDelete}
+          objectName={objectName}
         />
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
@@ -25,7 +25,8 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
-  objectName: string;
+  displayName: string;
+  fullName: string;
   objectSize: number;
   objectLastModified: string;
   handleClickDownload: (newTab: boolean) => void;
@@ -35,7 +36,8 @@ interface Props {
 
 const ObjectTableRow: React.FC<Props> = props => {
   const {
-    objectName,
+    displayName,
+    fullName,
     objectSize,
     objectLastModified,
     handleClickDownload,
@@ -55,7 +57,7 @@ const ObjectTableRow: React.FC<Props> = props => {
           <Grid item>
             <Box display="flex" alignItems="center">
               <Typography>
-                <strong>{objectName}</strong>
+                <strong>{displayName}</strong>
               </Typography>
             </Box>
           </Grid>
@@ -71,7 +73,7 @@ const ObjectTableRow: React.FC<Props> = props => {
         <ObjectActionMenu
           handleClickDownload={handleClickDownload}
           handleClickDelete={handleClickDelete}
-          objectName={objectName}
+          objectName={fullName}
         />
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
@@ -13,7 +13,7 @@ import ObjectActionMenu from './ObjectActionMenu';
 const useStyles = makeStyles((theme: Theme) => ({
   manuallyCreated: {
     '&:before': {
-      backgroundColor: theme.palette.status.warningDark
+      backgroundColor: theme.bg.lightBlue
     }
   },
   folderNameWrapper: {
@@ -23,6 +23,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   iconWrapper: {
     margin: '2px 0'
+  },
+  manuallyCreatedIcon: {
+    '& g': {
+      fill: theme.bg.lightBlue
+    }
   }
 }));
 
@@ -51,10 +56,14 @@ const ObjectTableRow: React.FC<Props> = props => {
 
   return (
     <TableRow className={manuallyCreated ? classes.manuallyCreated : ''}>
-      <TableCell parentColumn="Object">
+      <TableCell>
         <Grid container wrap="nowrap" alignItems="center">
           <Grid item className="py0">
-            <EntityIcon variant="object" size={20} />
+            <EntityIcon
+              variant="object"
+              size={20}
+              className={manuallyCreated ? classes.manuallyCreatedIcon : ''}
+            />
           </Grid>
           <Grid item>
             <Box display="flex" alignItems="center">
@@ -65,10 +74,8 @@ const ObjectTableRow: React.FC<Props> = props => {
           </Grid>
         </Grid>
       </TableCell>
-      <TableCell parentColumn="Size" noWrap>
-        {readableBytes(objectSize).formatted}
-      </TableCell>
-      <TableCell parentColumn="Last Modified" noWrap>
+      <TableCell noWrap>{readableBytes(objectSize).formatted}</TableCell>
+      <TableCell noWrap>
         <DateTimeDisplay value={objectLastModified} humanizeCutoff="never" />
       </TableCell>
       <TableCell>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
@@ -12,7 +12,9 @@ import ObjectActionMenu from './ObjectActionMenu';
 
 const useStyles = makeStyles((theme: Theme) => ({
   manuallyCreated: {
-    backgroundColor: theme.bg.lightBlue
+    '&:before': {
+      backgroundColor: theme.palette.status.warningDark
+    }
   },
   folderNameWrapper: {
     display: 'flex',

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectTableRow.tsx
@@ -31,7 +31,7 @@ interface Props {
   fullName: string;
   objectSize: number;
   objectLastModified: string;
-  handleClickDownload: (newTab: boolean) => void;
+  handleClickDownload: (objectName: string, newTab: boolean) => void;
   handleClickDelete: (objectName: string) => void;
   manuallyCreated: boolean;
 }

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
@@ -1,4 +1,3 @@
-import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import CautionIcon from 'src/assets/icons/caution.svg';
 import FileUploadIcon from 'src/assets/icons/fileUpload.svg';
@@ -13,6 +12,7 @@ import { readableBytes } from 'src/utilities/unitConversions';
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     display: 'flex',
+    flexShrink: 0,
     alignItems: 'center',
     position: 'relative',
     height: theme.spacing(5.25),
@@ -76,7 +76,7 @@ interface Props {
   name: string;
   sizeInBytes: number;
   percentCompleted: number;
-  error?: APIError;
+  error?: string;
 }
 
 const FileUpload: React.FC<Props> = props => {
@@ -118,7 +118,7 @@ const FileUpload: React.FC<Props> = props => {
         <>
           <CautionIcon width={22} height={22} className={classes.iconRight} />
           <Typography variant="body2" className={classes.errorText}>
-            {props.error.reason}
+            {props.error}
           </Typography>
         </>
       ) : (
@@ -131,4 +131,4 @@ const FileUpload: React.FC<Props> = props => {
     </div>
   );
 };
-export default FileUpload;
+export default React.memo(FileUpload);

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
@@ -10,6 +10,7 @@ import LinearProgress from 'src/components/core/LinearProgress';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
+import { truncateMiddle } from 'src/utilities/truncate';
 import { readableBytes } from 'src/utilities/unitConversions';
 import { ObjectUploaderAction } from './reducer';
 
@@ -105,8 +106,8 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface Props {
-  name: string;
-  fullObjectName: string;
+  displayName: string;
+  fileName: string;
   sizeInBytes: number;
   percentCompleted: number;
   overwriteNotice: boolean;
@@ -121,17 +122,17 @@ const FileUpload: React.FC<Props> = props => {
   const confirmOverwrite = () =>
     props.dispatch({
       type: 'CONFIRM_OVERWRITE',
-      fileName: props.fullObjectName
+      fileName: props.fileName
     });
 
   const cancelOverwrite = () =>
     props.dispatch({
       type: 'CANCEL_OVERWRITE',
-      fileName: props.fullObjectName
+      fileName: props.fileName
     });
 
   return (
-    <div className={classes.root} key={props.name}>
+    <div className={classes.root} key={props.displayName}>
       <LinearProgress
         variant="determinate"
         value={props.percentCompleted}
@@ -162,7 +163,7 @@ const FileUpload: React.FC<Props> = props => {
           [classes.error]: props.error
         })}
       >
-        {props.name}
+        {props.displayName}
       </Typography>
 
       <Typography
@@ -206,7 +207,8 @@ const FileUpload: React.FC<Props> = props => {
       {props.overwriteNotice && (
         <div className={classes.overwriteNotice}>
           <Typography variant="body1">
-            {props.name} already exists. Are you sure you want to overwrite it?
+            {truncateMiddle(props.fileName)} already exists. Are you sure you
+            want to overwrite it?
           </Typography>
           <div className={classes.actions}>
             <Button

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
@@ -5,11 +5,13 @@ import FileUploadIcon from 'src/assets/icons/fileUpload.svg';
 import FileUploadComplete from 'src/assets/icons/fileUploadComplete.svg';
 import UploadCaution from 'src/assets/icons/uploadCaution.svg';
 import UploadPending from 'src/assets/icons/uploadPending.svg';
+import Button from 'src/components/Button';
 import LinearProgress from 'src/components/core/LinearProgress';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import { readableBytes } from 'src/utilities/unitConversions';
+import { ObjectUploaderAction } from './reducer';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -81,18 +83,52 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& g': {
       stroke: theme.color.red
     }
+  },
+  overwriteNotice: {
+    position: 'absolute',
+    bottom: theme.spacing(-13),
+    padding: theme.spacing(1),
+    display: 'flex',
+    flexDirection: 'column',
+    alignContent: 'center'
+  },
+  actions: {
+    marginTop: theme.spacing(2),
+    display: 'flex',
+    justifyContent: 'center',
+    '& button': {
+      padding: theme.spacing(1.25),
+      marginLeft: theme.spacing(1.25),
+      marginRight: theme.spacing(1.25)
+    }
   }
 }));
 
 interface Props {
   name: string;
+  fullObjectName: string;
   sizeInBytes: number;
   percentCompleted: number;
+  overwriteNotice: boolean;
+  dispatch: React.Dispatch<ObjectUploaderAction>;
   error?: string;
+  url?: string;
 }
 
 const FileUpload: React.FC<Props> = props => {
   const classes = useStyles();
+
+  const confirmOverwrite = () =>
+    props.dispatch({
+      type: 'CONFIRM_OVERWRITE',
+      fileName: props.fullObjectName
+    });
+
+  const cancelOverwrite = () =>
+    props.dispatch({
+      type: 'CANCEL_OVERWRITE',
+      fileName: props.fullObjectName
+    });
 
   return (
     <div className={classes.root} key={props.name}>
@@ -106,7 +142,7 @@ const FileUpload: React.FC<Props> = props => {
         className={classes.progressBar}
       />
 
-      {props.error ? (
+      {props.error || props.overwriteNotice ? (
         <UploadCaution
           width={28}
           height={28}
@@ -145,11 +181,17 @@ const FileUpload: React.FC<Props> = props => {
           height={22}
           className={classes.iconRight}
         />
-      ) : props.error ? (
+      ) : props.error || props.overwriteNotice ? (
         <>
           <Tooltip title={props.error} placement="left-start">
             <span className={classes.tooltip}>
-              <CautionIcon width={22} height={22} className={classes.error} />
+              <CautionIcon
+                width={22}
+                height={22}
+                className={classNames({
+                  [classes.error]: props.error
+                })}
+              />
             </span>
           </Tooltip>
         </>
@@ -159,6 +201,30 @@ const FileUpload: React.FC<Props> = props => {
           height={22}
           className={`${classes.iconRight} ${classes.rotate}`}
         />
+      )}
+
+      {props.overwriteNotice && (
+        <div className={classes.overwriteNotice}>
+          <Typography variant="body1">
+            {props.name} already exists. Are you sure you want to overwrite it?
+          </Typography>
+          <div className={classes.actions}>
+            <Button
+              buttonType="secondary"
+              superCompact
+              onClick={cancelOverwrite}
+            >
+              Cancel
+            </Button>
+            <Button
+              buttonType="primary"
+              superCompact
+              onClick={confirmOverwrite}
+            >
+              Overwrite
+            </Button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
@@ -83,7 +83,7 @@ const FileUpload: React.FC<Props> = props => {
   const classes = useStyles();
 
   return (
-    <div className={classes.root}>
+    <div className={classes.root} key={props.name}>
       <LinearProgress
         variant="determinate"
         value={props.percentCompleted}

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import CautionIcon from 'src/assets/icons/caution.svg';
 import FileUploadIcon from 'src/assets/icons/fileUpload.svg';
@@ -6,6 +7,7 @@ import UploadCaution from 'src/assets/icons/uploadCaution.svg';
 import UploadPending from 'src/assets/icons/uploadPending.svg';
 import LinearProgress from 'src/components/core/LinearProgress';
 import { makeStyles, Theme } from 'src/components/core/styles';
+import Tooltip from 'src/components/core/Tooltip';
 import Typography from 'src/components/core/Typography';
 import { readableBytes } from 'src/utilities/unitConversions';
 
@@ -56,10 +58,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   errorText: {
     position: 'absolute',
-    right: 0,
-    bottom: `-${theme.spacing(3)}px`,
-    left: 0,
-    textAlign: 'center',
+    textDecoration: 'underline',
+    cursor: 'pointer',
+    right: theme.spacing(1),
     color: theme.color.red
   },
   '@keyframes rotate': {
@@ -68,6 +69,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     to: {
       transform: 'rotate(0deg)'
+    }
+  },
+  tooltip: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1.25)
+  },
+  error: {
+    color: theme.color.red,
+    '& g': {
+      stroke: theme.color.red
     }
   }
 }));
@@ -95,16 +107,35 @@ const FileUpload: React.FC<Props> = props => {
       />
 
       {props.error ? (
-        <UploadCaution width={28} height={28} className={classes.iconLeft} />
+        <UploadCaution
+          width={28}
+          height={28}
+          className={classNames({
+            [classes.iconLeft]: true,
+            [classes.error]: props.error
+          })}
+        />
       ) : (
         <FileUploadIcon width={28} height={28} className={classes.iconLeft} />
       )}
 
-      <Typography variant="body1" className={classes.fileName}>
+      <Typography
+        variant="body1"
+        className={classNames({
+          [classes.fileName]: true,
+          [classes.error]: props.error
+        })}
+      >
         {props.name}
       </Typography>
 
-      <Typography variant="body1" className={classes.fileSize}>
+      <Typography
+        variant="body1"
+        className={classNames({
+          [classes.fileSize]: true,
+          [classes.error]: props.error
+        })}
+      >
         {readableBytes(props.sizeInBytes).formatted}
       </Typography>
 
@@ -116,10 +147,11 @@ const FileUpload: React.FC<Props> = props => {
         />
       ) : props.error ? (
         <>
-          <CautionIcon width={22} height={22} className={classes.iconRight} />
-          <Typography variant="body2" className={classes.errorText}>
-            {props.error}
-          </Typography>
+          <Tooltip title={props.error} placement="left-start">
+            <span className={classes.tooltip}>
+              <CautionIcon width={22} height={22} className={classes.error} />
+            </span>
+          </Tooltip>
         </>
       ) : (
         <UploadPending

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
@@ -102,6 +102,9 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginLeft: theme.spacing(1.25),
       marginRight: theme.spacing(1.25)
     }
+  },
+  errorState: {
+    cursor: 'pointer'
   }
 }));
 
@@ -119,9 +122,9 @@ interface Props {
 const FileUpload: React.FC<Props> = props => {
   const classes = useStyles();
 
-  const confirmOverwrite = () =>
+  const resumeUpload = () =>
     props.dispatch({
-      type: 'CONFIRM_OVERWRITE',
+      type: 'RESUME_UPLOAD',
       fileName: props.fileName
     });
 
@@ -131,8 +134,21 @@ const FileUpload: React.FC<Props> = props => {
       fileName: props.fileName
     });
 
-  return (
-    <div className={classes.root} key={props.displayName}>
+  const handleClickRow = () => {
+    if (props.error) {
+      resumeUpload();
+    }
+  };
+
+  const Content = (
+    <div
+      className={classNames({
+        [classes.root]: true,
+        [classes.errorState]: props.error
+      })}
+      key={props.displayName}
+      onClick={handleClickRow}
+    >
       <LinearProgress
         variant="determinate"
         value={props.percentCompleted}
@@ -184,17 +200,15 @@ const FileUpload: React.FC<Props> = props => {
         />
       ) : props.error || props.overwriteNotice ? (
         <>
-          <Tooltip title={props.error} placement="left-start">
-            <span className={classes.tooltip}>
-              <CautionIcon
-                width={22}
-                height={22}
-                className={classNames({
-                  [classes.error]: props.error
-                })}
-              />
-            </span>
-          </Tooltip>
+          <span className={classes.tooltip}>
+            <CautionIcon
+              width={22}
+              height={22}
+              className={classNames({
+                [classes.error]: props.error
+              })}
+            />
+          </span>
         </>
       ) : (
         <UploadPending
@@ -218,17 +232,23 @@ const FileUpload: React.FC<Props> = props => {
             >
               Cancel
             </Button>
-            <Button
-              buttonType="primary"
-              superCompact
-              onClick={confirmOverwrite}
-            >
+            <Button buttonType="primary" superCompact onClick={resumeUpload}>
               Overwrite
             </Button>
           </div>
         </div>
       )}
     </div>
+  );
+
+  const TooltipTitle = <div>Error uploading object. Click to retry.</div>;
+
+  return props.error ? (
+    <Tooltip title={TooltipTitle} placement="bottom">
+      {Content}
+    </Tooltip>
+  ) : (
+    Content
   );
 };
 export default React.memo(FileUpload);

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/FileUpload.tsx
@@ -16,17 +16,20 @@ import { ObjectUploaderAction } from './reducer';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    display: 'flex',
-    flexShrink: 0,
-    alignItems: 'center',
     position: 'relative',
-    height: theme.spacing(5.25),
     marginTop: theme.spacing(0.5),
-    marginBottom: theme.spacing(0.5)
+    marginBottom: theme.spacing(0.5),
+    '&:last-child ': {
+      '&$overwriteNotice': {
+        borderBottom: 0,
+        paddingBottom: theme.spacing(1)
+      }
+    }
   },
   progressBar: {
     height: theme.spacing(5.25),
     position: 'absolute',
+    zIndex: 1,
     width: '100%',
     backgroundColor: theme.bg.main,
     borderRadius: 4
@@ -34,24 +37,34 @@ const useStyles = makeStyles((theme: Theme) => ({
   barColorPrimary: {
     backgroundColor: theme.bg.lightBlue
   },
-  fileName: {
-    position: 'absolute',
-    left: 28 + theme.spacing(2)
+  container: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    position: 'relative',
+    zIndex: 2,
+    padding: theme.spacing(1)
   },
+  leftWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    marginRight: theme.spacing(1)
+  },
+  rightWrapper: {
+    display: 'flex',
+    alignItems: 'center'
+  },
+  fileName: {},
   fileSize: {
-    position: 'absolute',
-    right: 28 + theme.spacing(2)
+    marginRight: theme.spacing(1)
   },
   iconLeft: {
-    position: 'absolute',
-    left: theme.spacing(1),
+    marginRight: theme.spacing(1),
     '& g': {
       stroke: theme.color.offBlack
     }
   },
   iconRight: {
-    position: 'absolute',
-    right: theme.spacing(1),
     '& g': {
       stroke: theme.color.offBlack
     }
@@ -60,7 +73,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     animation: '$rotate 2s linear infinite'
   },
   errorText: {
-    position: 'absolute',
     textDecoration: 'underline',
     cursor: 'pointer',
     right: theme.spacing(1),
@@ -74,11 +86,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       transform: 'rotate(0deg)'
     }
   },
-  tooltip: {
-    position: 'absolute',
-    right: theme.spacing(1),
-    top: theme.spacing(1.25)
-  },
+  tooltip: {},
   error: {
     color: theme.color.red,
     '& g': {
@@ -86,12 +94,14 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   overwriteNotice: {
-    position: 'absolute',
-    bottom: theme.spacing(-13),
+    position: 'relative',
+    zIndex: 10,
     padding: theme.spacing(1),
+    paddingBottom: theme.spacing(2),
     display: 'flex',
     flexDirection: 'column',
-    alignContent: 'center'
+    alignContent: 'center',
+    borderBottom: `1px solid ${theme.color.grey2}`
   },
   actions: {
     marginTop: theme.spacing(2),
@@ -158,78 +168,81 @@ const FileUpload: React.FC<Props> = props => {
         }}
         className={classes.progressBar}
       />
-
-      {props.error || props.overwriteNotice ? (
-        <UploadCaution
-          width={28}
-          height={28}
-          className={classNames({
-            [classes.iconLeft]: true,
-            [classes.error]: props.error
-          })}
-        />
-      ) : (
-        <FileUploadIcon width={28} height={28} className={classes.iconLeft} />
-      )}
-
-      <Typography
-        variant="body1"
-        className={classNames({
-          [classes.fileName]: true,
-          [classes.error]: props.error
-        })}
-      >
-        {props.displayName}
-      </Typography>
-
-      <Typography
-        variant="body1"
-        className={classNames({
-          [classes.fileSize]: true,
-          [classes.error]: props.error
-        })}
-      >
-        {readableBytes(props.sizeInBytes).formatted}
-      </Typography>
-
-      {props.percentCompleted === 100 ? (
-        <FileUploadComplete
-          width={22}
-          height={22}
-          className={classes.iconRight}
-        />
-      ) : props.error || props.overwriteNotice ? (
-        <>
-          <span className={classes.tooltip}>
-            <CautionIcon
-              width={22}
-              height={22}
+      <div className={classes.container}>
+        <div className={classes.leftWrapper}>
+          {props.error || props.overwriteNotice ? (
+            <UploadCaution
+              width={28}
+              height={28}
               className={classNames({
+                [classes.iconLeft]: true,
                 [classes.error]: props.error
               })}
             />
-          </span>
-        </>
-      ) : (
-        <UploadPending
-          width={22}
-          height={22}
-          className={`${classes.iconRight} ${classes.rotate}`}
-        />
-      )}
+          ) : (
+            <FileUploadIcon
+              width={28}
+              height={28}
+              className={classes.iconLeft}
+            />
+          )}
+
+          <Typography
+            variant="body1"
+            className={classNames({
+              [classes.fileName]: true,
+              [classes.error]: props.error
+            })}
+          >
+            {props.displayName}
+          </Typography>
+        </div>
+        <div className={classes.rightWrapper}>
+          <Typography
+            variant="body1"
+            className={classNames({
+              [classes.fileSize]: true,
+              [classes.error]: props.error
+            })}
+          >
+            {readableBytes(props.sizeInBytes).formatted}
+          </Typography>
+          {props.percentCompleted === 100 ? (
+            <FileUploadComplete
+              width={22}
+              height={22}
+              className={classes.iconRight}
+            />
+          ) : props.error || props.overwriteNotice ? (
+            <>
+              <span className={classes.tooltip}>
+                <CautionIcon
+                  width={22}
+                  height={22}
+                  className={classNames({
+                    [classes.error]: props.error
+                  })}
+                />
+              </span>
+            </>
+          ) : (
+            <UploadPending
+              width={22}
+              height={22}
+              className={`${classes.iconRight} ${classes.rotate}`}
+            />
+          )}
+        </div>
+      </div>
 
       {props.overwriteNotice && (
         <div className={classes.overwriteNotice}>
           <Typography variant="body1">
-            {truncateMiddle(props.fileName)} already exists. Are you sure you
-            want to overwrite it?
+            <b>{truncateMiddle(props.fileName)}</b> already exists. Are you sure
+            you want to overwrite it?
           </Typography>
           <div className={classes.actions}>
-            <Button
-              buttonType="secondary"
-              superCompact
-              onClick={cancelOverwrite}
-            >
+            <Button buttonType="cancel" superCompact onClick={cancelOverwrite}>
               Cancel
             </Button>
             <Button buttonType="primary" superCompact onClick={resumeUpload}>

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -34,6 +34,16 @@ const useStyles = makeStyles((theme: Theme) => ({
       marginLeft: theme.spacing(4)
     }
   },
+  rootActive: {
+    [theme.breakpoints.down('md')]: {
+      paddingBottom: 60,
+      position: 'relative'
+    },
+    [theme.breakpoints.up('lg')]: {
+      minHeight: 200,
+      height: `calc(100vh - (220px + ${theme.spacing(20)}px))`
+    }
+  },
   dropzone: {
     display: 'flex',
     flexDirection: 'row',
@@ -91,6 +101,21 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
     [theme.breakpoints.up('lg')]: {
       padding: `${theme.spacing(4)}px ${theme.spacing(8)}px`
+    }
+  },
+  UploadZoneActiveButton: {
+    position: 'absolute',
+    zIndex: 10,
+    backgroundColor: theme.palette.divider,
+    bottom: -70,
+    left: theme.spacing(2),
+    width: `calc(100% - ${theme.spacing(4)}px)`,
+    padding: 0,
+    '& $uploadButton': {
+      marginTop: 0
+    },
+    [theme.breakpoints.down('md')]: {
+      bottom: 0
     }
   },
   fileUploads: {
@@ -274,8 +299,6 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
   // These max widths and breakpoints are based on trial-and-error.
   const truncationMaxWidth = width < 1920 ? 20 : 30;
 
-  console.log(state.files);
-
   const {
     getInputProps,
     getRootProps,
@@ -301,8 +324,15 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
     [isDragActive, isDragAccept, isDragReject]
   );
 
+  const UploadZoneActive = state.files.length !== 0;
+
   return (
-    <div className={classes.root}>
+    <div
+      className={classNames({
+        [classes.root]: true,
+        [classes.rootActive]: UploadZoneActive
+      })}
+    >
       <div {...getRootProps({ className: `${classes.dropzone} ${className}` })}>
         <input {...getInputProps()} />
 
@@ -330,23 +360,32 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
           })}
         </div>
 
-        {state.files.length === 0 && (
-          <div className={classes.dropzoneContent}>
+        <div
+          className={classNames({
+            [classes.dropzoneContent]: true,
+            [classes.UploadZoneActiveButton]: UploadZoneActive
+          })}
+        >
+          {!UploadZoneActive && (
             <Hidden xsDown>
               <CloudUpload />
             </Hidden>
+          )}
+          {!UploadZoneActive && (
             <Typography variant="subtitle2" className={classes.copy}>
               You can browse your device to upload files or drop them here.
             </Typography>
-            <Button
-              buttonType="primary"
-              onClick={open}
-              className={classes.uploadButton}
-            >
-              Browse Files
-            </Button>
-          </div>
-        )}
+          )}
+          <Button
+            buttonType="primary"
+            onClick={open}
+            className={classNames({
+              [classes.uploadButton]: true
+            })}
+          >
+            Browse Files
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -174,17 +174,17 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
     });
   };
 
-  const queuedUploads = React.useMemo(() => {
-    return state.files.filter(upload => upload.status === 'QUEUED');
-  }, [state.numQueued]);
-
   const nextBatch = React.useMemo(() => {
     if (state.numQueued === 0 || state.numInProgress >= MAX_PARALLEL_UPLOADS) {
       return [];
     }
 
+    const queuedUploads = state.files.filter(
+      upload => upload.status === 'QUEUED'
+    );
+
     return queuedUploads.slice(0, MAX_PARALLEL_UPLOADS - state.numInProgress);
-  }, [state.numQueued, state.numInProgress, queuedUploads]);
+  }, [state.numQueued, state.numInProgress]);
 
   // When `nextBatch` changes, upload the files.
   React.useEffect(() => {
@@ -249,7 +249,7 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
         <input {...getInputProps()} />
 
         <div className={classes.fileUploads}>
-          {state.files.slice(0, MAX_NUM_UPLOADS).map((upload, idx) => {
+          {state.files.map((upload, idx) => {
             return (
               <FileUpload
                 key={idx}

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -48,6 +48,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     backgroundColor: 'transparent',
     outline: 'none',
     height: '100%',
+    minHeight: 200,
     transition: theme.transitions.create(['border-color', 'background-color']),
     overflow: 'auto'
   },
@@ -56,7 +57,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     margin: '0 auto',
     [theme.breakpoints.up('lg')]: {
       marginTop: theme.spacing(4),
-      marginBottom: theme.spacing(10)
+      marginBottom: theme.spacing(2)
     }
   },
   active: {
@@ -89,7 +90,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       padding: theme.spacing(2)
     },
     [theme.breakpoints.up('lg')]: {
-      padding: theme.spacing(8)
+      padding: `${theme.spacing(4)}px ${theme.spacing(8)}px`
     }
   },
   fileUploads: {

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -179,15 +179,16 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
 
   // This function will be called when dropped files that are over the max size.
   const onDropRejected = (files: File[]) => {
-    files.forEach(file => {
-      props.enqueueSnackbar(
-        `Max file size (${
-          readableBytes(MAX_FILE_SIZE_IN_BYTES).formatted
-        }) exceeded for file: ${file.name}`,
-        {
-          variant: 'error'
-        }
-      );
+    let errorMessage = `Max file size (${
+      readableBytes(MAX_FILE_SIZE_IN_BYTES).formatted
+    }) exceeded`;
+
+    if (files.length > 1) {
+      errorMessage += ' for some files';
+    }
+
+    props.enqueueSnackbar(errorMessage, {
+      variant: 'error'
     });
   };
 

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -199,12 +199,15 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
       // support it. Using the path, we can upload directories. Fallback on the
       // name if the browser doesn't support it.
       const path = (file as any).path || file.name;
-      const fullObjectName = prefix + path;
+      const isFolder = path.startsWith('/');
+
+      // Folders start with '/', which we need to drop.
+      const fullObjectName = prefix + (isFolder ? path.substring(1) : path);
 
       const updateTable = () => {
         const match = path.match(/\/(.+\/)/);
         if (match) {
-          addOneFolder(match[1]);
+          addOneFolder(prefix + match[1]);
         } else {
           addOneFile(fullObjectName, fileUpload.file.size);
         }
@@ -234,7 +237,7 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
           if (exists) {
             dispatch({
               type: 'NOTIFY_FILE_EXISTS',
-              fileName: fullObjectName,
+              fileName: file.name,
               url
             });
             return;
@@ -305,15 +308,14 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
         <div className={classes.fileUploads}>
           {state.files.map((upload, idx) => {
             const path = (upload.file as any).path || upload.file.name;
-            const fullObjectName = prefix + path;
             return (
               <FileUpload
                 key={idx}
-                name={truncateMiddle(
+                displayName={truncateMiddle(
                   upload.file.name || '',
                   truncationMaxWidth
                 )}
-                fullObjectName={fullObjectName}
+                fileName={path}
                 sizeInBytes={upload.file.size || 0}
                 percentCompleted={upload.percentComplete || 0}
                 overwriteNotice={upload.status === 'OVERWRITE_NOTICE'}

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -338,7 +338,7 @@ const getURLAndUploadObject = (
         }
       });
     })
-    .catch(err => {
+    .catch(_ => {
       dispatch({
         type: 'UPDATE_FILES',
         filesToUpdate: [file.name],
@@ -346,6 +346,5 @@ const getURLAndUploadObject = (
           status: 'ERROR'
         }
       });
-      return Promise.reject();
     });
 };

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.test.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.test.ts
@@ -10,8 +10,7 @@ describe('reducer', () => {
     numInProgress: 0,
     numFinished: 0,
     numCancelled: 0,
-    numErrors: 0,
-    allUploadsFinished: false
+    numErrors: 0
   };
 
   const file1: File = {

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.test.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.test.ts
@@ -31,7 +31,8 @@ describe('reducer', () => {
   it('enqueues new files and updates the count', () => {
     const newState = reducer(baseState, {
       type: 'ENQUEUE',
-      files: [file1, file2]
+      files: [file1, file2],
+      prefix: ''
     });
     expect(newState.files).toHaveLength(2);
     expect(newState.numQueued).toBe(2);
@@ -44,13 +45,15 @@ describe('reducer', () => {
         {
           file: file1,
           percentComplete: 0,
-          status: 'IN_PROGRESS'
+          status: 'IN_PROGRESS',
+          prefix: ''
         }
       ]
     };
     const newState = reducer(initialState, {
       type: 'ENQUEUE',
-      files: [file1]
+      files: [file1],
+      prefix: ''
     });
 
     expect(newState.files[0].status).toBe('IN_PROGRESS');
@@ -63,13 +66,15 @@ describe('reducer', () => {
         {
           file: file1,
           percentComplete: 0,
-          status: 'FINISHED'
+          status: 'FINISHED',
+          prefix: ''
         }
       ]
     };
     const newState = reducer(initialState, {
       type: 'ENQUEUE',
-      files: [file1]
+      files: [file1],
+      prefix: ''
     });
 
     expect(newState.files[0].status).toBe('QUEUED');
@@ -79,7 +84,9 @@ describe('reducer', () => {
     const newState = reducer(
       {
         ...baseState,
-        files: [{ status: 'QUEUED', percentComplete: 0, file: file1 }]
+        files: [
+          { status: 'QUEUED', percentComplete: 0, file: file1, prefix: '' }
+        ]
       },
       {
         type: 'UPDATE_FILES',

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.test.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.test.ts
@@ -1,0 +1,102 @@
+import {
+  curriedObjectUploaderReducer as reducer,
+  ObjectUploaderState
+} from './reducer';
+
+describe('reducer', () => {
+  const baseState: ObjectUploaderState = {
+    files: [],
+    numQueued: 0,
+    numInProgress: 0,
+    numFinished: 0,
+    numCancelled: 0,
+    numErrors: 0,
+    allUploadsFinished: false
+  };
+
+  const file1: File = {
+    name: 'my-file1',
+    lastModified: 0,
+    size: 0,
+    type: '',
+    slice: jest.fn()
+  };
+  const file2: File = {
+    name: 'my-file2',
+    lastModified: 0,
+    size: 0,
+    type: '',
+    slice: jest.fn()
+  };
+
+  it('enqueues new files and updates the count', () => {
+    const newState = reducer(baseState, {
+      type: 'ENQUEUE',
+      files: [file1, file2]
+    });
+    expect(newState.files).toHaveLength(2);
+    expect(newState.numQueued).toBe(2);
+  });
+
+  it('does not update files that are in progress', () => {
+    const initialState: ObjectUploaderState = {
+      ...baseState,
+      files: [
+        {
+          file: file1,
+          percentComplete: 0,
+          status: 'IN_PROGRESS'
+        }
+      ]
+    };
+    const newState = reducer(initialState, {
+      type: 'ENQUEUE',
+      files: [file1]
+    });
+
+    expect(newState.files[0].status).toBe('IN_PROGRESS');
+  });
+
+  it('update files that are finished', () => {
+    const initialState: ObjectUploaderState = {
+      ...baseState,
+      files: [
+        {
+          file: file1,
+          percentComplete: 0,
+          status: 'FINISHED'
+        }
+      ]
+    };
+    const newState = reducer(initialState, {
+      type: 'ENQUEUE',
+      files: [file1]
+    });
+
+    expect(newState.files[0].status).toBe('QUEUED');
+  });
+
+  it('updates files with given params and updates the count', () => {
+    const newState = reducer(
+      {
+        ...baseState,
+        files: [{ status: 'QUEUED', percentComplete: 0, file: file1 }]
+      },
+      {
+        type: 'UPDATE_FILES',
+        filesToUpdate: [file1.name],
+        data: { status: 'IN_PROGRESS' }
+      }
+    );
+    expect(newState.files[0].status).toBe('IN_PROGRESS');
+    expect(newState.files[0].percentComplete).toBe(0);
+    expect(newState.numInProgress).toBe(1);
+  });
+
+  it('updates allUploads finished on batch finish', () => {
+    const newState = reducer(baseState, {
+      type: 'FINISH_BATCH'
+    });
+    expect(newState.allUploadsFinished).toBe(true);
+  });
+});

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.test.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.test.ts
@@ -92,11 +92,4 @@ describe('reducer', () => {
     expect(newState.files[0].percentComplete).toBe(0);
     expect(newState.numInProgress).toBe(1);
   });
-
-  it('updates allUploads finished on batch finish', () => {
-    const newState = reducer(baseState, {
-      type: 'FINISH_BATCH'
-    });
-    expect(newState.allUploadsFinished).toBe(true);
-  });
 });

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -119,9 +119,10 @@ const cloneLandingReducer = (
       break;
 
     case 'CONFIRM_OVERWRITE':
-      foundFile = draft.files.find(
-        fileUpload => fileUpload.file.name === action.fileName
-      );
+      foundFile = draft.files.find(fileUpload => {
+        const path = (fileUpload.file as any).path || fileUpload.file.name;
+        return path === action.fileName;
+      });
       if (foundFile) {
         foundFile.status = 'QUEUED';
       }
@@ -130,7 +131,8 @@ const cloneLandingReducer = (
 
     case 'CANCEL_OVERWRITE':
       const idx = draft.files.findIndex(fileUpload => {
-        return fileUpload.file.name === action.fileName;
+        const path = (fileUpload.file as any).path || fileUpload.file.name;
+        return path === action.fileName;
       });
       if (idx > -1) {
         draft.files.splice(idx, 1);

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -28,8 +28,7 @@ export type ObjectUploaderAction =
       type: 'UPDATE_FILES';
       filesToUpdate: string[];
       data: Partial<ExtendedFile>;
-    }
-  | { type: 'FINISH_BATCH' };
+    };
 
 const cloneLandingReducer = (
   draft: ObjectUploaderState,
@@ -97,15 +96,7 @@ const cloneLandingReducer = (
           }
         }
       });
-
       break;
-
-    // Update the count. If there are no in-progress uploads, flag as finished.
-    case 'FINISH_BATCH':
-      updateCount(draft);
-      if (draft.numInProgress === 0) {
-        draft.allUploadsFinished = true;
-      }
   }
 };
 

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -4,10 +4,6 @@ export const MAX_NUM_UPLOADS = 100;
 export const MAX_PARALLEL_UPLOADS = 6;
 export const MAX_FILE_SIZE_IN_BYTES = 5 * 1024 * 1024 * 1024;
 
-/**
- * TYPES
- */
-
 type FileStatus = 'QUEUED' | 'IN_PROGRESS' | 'FINISHED' | 'CANCELLED' | 'ERROR';
 
 export interface ExtendedFile {

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -1,0 +1,132 @@
+import produce from 'immer';
+
+/**
+ * TYPES
+ */
+
+type FileStatus = 'QUEUED' | 'IN_PROGRESS' | 'FINISHED' | 'CANCELLED' | 'ERROR';
+
+export interface ExtendedFile {
+  status: FileStatus;
+  percentComplete: number;
+  file: File;
+}
+
+export interface ObjectUploaderState {
+  files: ExtendedFile[];
+  numQueued: number;
+  numInProgress: number;
+  numFinished: number;
+  numCancelled: number;
+  numErrors: number;
+  allUploadsFinished: boolean;
+}
+
+export type ObjectUploaderAction =
+  | { type: 'ENQUEUE'; files: File[] }
+  | { type: 'SET_IN_PROGRESS'; files: ExtendedFile[] }
+  | { type: 'UPDATE_FILE'; data: { fileName: string } & Partial<ExtendedFile> }
+  | { type: 'FINISH_BATCH' };
+
+const cloneLandingReducer = (
+  draft: ObjectUploaderState,
+  action: ObjectUploaderAction
+) => {
+  switch (action.type) {
+    case 'ENQUEUE':
+      // Filter out files that are already queued or in progress
+      const filteredFiles = action.files.filter(file => {
+        const foundFile = draft.files.find(
+          upload => upload.file.name === file.name
+        );
+        return (
+          !foundFile ||
+          (foundFile.status !== 'IN_PROGRESS' && foundFile.status !== 'QUEUED')
+        );
+      });
+
+      const extendedFiles: ExtendedFile[] = filteredFiles.map(file => ({
+        status: 'QUEUED',
+        percentComplete: 0,
+        file
+      }));
+      draft.files = [...extendedFiles, ...draft.files];
+      updateCount(draft);
+      draft.allUploadsFinished = false;
+      break;
+
+    case 'SET_IN_PROGRESS':
+      action.files.forEach(file => {
+        // I was getting a shadowed-variable-name error here (???)
+        // tslint:disable-next-line
+        const idx = draft.files.findIndex(
+          prevUpload => prevUpload.file.name === file.file.name
+        );
+        if (idx > -1) {
+          draft.files[idx].status = 'IN_PROGRESS';
+        }
+      });
+      updateCount(draft);
+      break;
+
+    case 'UPDATE_FILE':
+      const idx = draft.files.findIndex(
+        prevUpload => prevUpload.file.name === action.data.fileName
+      );
+      if (idx > -1) {
+        draft.files[idx] = { ...draft.files[idx], ...action.data };
+
+        // If the status has been changed, we need to update the count.
+        if (action.data.status) {
+          updateCount(draft);
+        }
+      }
+      break;
+
+    case 'FINISH_BATCH':
+      updateCount(draft);
+      if (draft.numInProgress === 0) {
+        draft.allUploadsFinished = true;
+      }
+  }
+};
+
+export const curriedObjectUploaderReducer = produce(cloneLandingReducer);
+
+export const defaultState: ObjectUploaderState = {
+  files: [],
+  numQueued: 0,
+  numInProgress: 0,
+  numFinished: 0,
+  numCancelled: 0,
+  numErrors: 0,
+  allUploadsFinished: false
+};
+
+const updateCount = (draft: ObjectUploaderState) => {
+  let numQueued = 0;
+  let numInProgress = 0;
+  let numFinished = 0;
+  let numCancelled = 0;
+  let numErrors = 0;
+
+  draft.files.forEach(file => {
+    if (file.status === 'QUEUED') {
+      numQueued++;
+    } else if (file.status === 'IN_PROGRESS') {
+      numInProgress++;
+    } else if (file.status === 'FINISHED') {
+      numFinished++;
+    } else if (file.status === 'CANCELLED') {
+      numCancelled++;
+    } else if (file.status === 'ERROR') {
+      numErrors++;
+    }
+  });
+
+  draft.numQueued = numQueued;
+  draft.numInProgress = numInProgress;
+  draft.numFinished = numFinished;
+  draft.numCancelled = numCancelled;
+  draft.numErrors = numErrors;
+};

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -148,9 +148,3 @@ const updateCount = (draft: ObjectUploaderState) => {
   draft.numCancelled = numCancelled;
   draft.numErrors = numErrors;
 };
-
-export const extendFile = (file: File): ExtendedFile => ({
-  status: 'QUEUED',
-  percentComplete: 0,
-  file
-});

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -37,8 +37,9 @@ export type ObjectUploaderAction =
       data: Partial<ExtendedFile>;
     }
   | { type: 'NOTIFY_FILE_EXISTS'; fileName: string; url: string }
-  | { type: 'CONFIRM_OVERWRITE'; fileName: string }
-  | { type: 'CANCEL_OVERWRITE'; fileName: string };
+  | { type: 'CANCEL_OVERWRITE'; fileName: string }
+  | { type: 'TRY_AGAIN'; fileName: string }
+  | { type: 'RESUME_UPLOAD'; fileName: string };
 
 const cloneLandingReducer = (
   draft: ObjectUploaderState,
@@ -118,7 +119,7 @@ const cloneLandingReducer = (
       }
       break;
 
-    case 'CONFIRM_OVERWRITE':
+    case 'RESUME_UPLOAD':
       foundFile = draft.files.find(fileUpload => {
         const path = (fileUpload.file as any).path || fileUpload.file.name;
         return path === action.fileName;

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -1,7 +1,7 @@
 import produce from 'immer';
 
-export const MAX_NUM_UPLOADS = 100;
-export const MAX_PARALLEL_UPLOADS = 25;
+export const MAX_NUM_UPLOADS = 250;
+export const MAX_PARALLEL_UPLOADS = 6;
 export const MAX_FILE_SIZE_IN_BYTES = 5 * 1024 * 1024 * 1024;
 
 type FileStatus =

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -1,7 +1,7 @@
 import produce from 'immer';
 
 export const MAX_NUM_UPLOADS = 100;
-export const MAX_PARALLEL_UPLOADS = 6;
+export const MAX_PARALLEL_UPLOADS = 25;
 export const MAX_FILE_SIZE_IN_BYTES = 5 * 1024 * 1024 * 1024;
 
 type FileStatus = 'QUEUED' | 'IN_PROGRESS' | 'FINISHED' | 'CANCELLED' | 'ERROR';

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -16,6 +16,7 @@ export interface ExtendedFile {
   status: FileStatus;
   percentComplete: number;
   file: File;
+  prefix: string;
   url?: string;
 }
 
@@ -29,7 +30,7 @@ export interface ObjectUploaderState {
 }
 
 export type ObjectUploaderAction =
-  | { type: 'ENQUEUE'; files: File[] }
+  | { type: 'ENQUEUE'; files: File[]; prefix: string }
   | {
       type: 'UPDATE_FILES';
       filesToUpdate: string[];
@@ -70,7 +71,8 @@ const cloneLandingReducer = (
             draft.files.unshift({
               status: 'QUEUED',
               percentComplete: 0,
-              file
+              file,
+              prefix: action.prefix
             });
           }
         }
@@ -79,7 +81,8 @@ const cloneLandingReducer = (
       const extendedFiles: ExtendedFile[] = newFiles.map(file => ({
         status: 'QUEUED',
         percentComplete: 0,
-        file
+        file,
+        prefix: action.prefix
       }));
 
       draft.files = [...extendedFiles, ...draft.files];

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/reducer.ts
@@ -1,5 +1,9 @@
 import produce from 'immer';
 
+export const MAX_NUM_UPLOADS = 100;
+export const MAX_PARALLEL_UPLOADS = 6;
+export const MAX_FILE_SIZE_IN_BYTES = 5 * 1024 * 1024 * 1024;
+
 /**
  * TYPES
  */
@@ -24,8 +28,11 @@ export interface ObjectUploaderState {
 
 export type ObjectUploaderAction =
   | { type: 'ENQUEUE'; files: File[] }
-  | { type: 'SET_IN_PROGRESS'; files: ExtendedFile[] }
-  | { type: 'UPDATE_FILE'; data: { fileName: string } & Partial<ExtendedFile> }
+  | {
+      type: 'UPDATE_FILES';
+      filesToUpdate: string[];
+      data: Partial<ExtendedFile>;
+    }
   | { type: 'FINISH_BATCH' };
 
 const cloneLandingReducer = (
@@ -33,56 +40,71 @@ const cloneLandingReducer = (
   action: ObjectUploaderAction
 ) => {
   switch (action.type) {
+    // Add files to the queue
     case 'ENQUEUE':
-      // Filter out files that are already queued or in progress
-      const filteredFiles = action.files.filter(file => {
-        const foundFile = draft.files.find(
+      const newFiles: File[] = [];
+      action.files.forEach(file => {
+        // See if we're already tracking the file.
+        const foundFileIdx = draft.files.findIndex(
           upload => upload.file.name === file.name
         );
-        return (
-          !foundFile ||
-          (foundFile.status !== 'IN_PROGRESS' && foundFile.status !== 'QUEUED')
-        );
+
+        // If we aren't already tracking it, add it to the list of new files.
+        if (foundFileIdx === -1) {
+          newFiles.push(file);
+        } else {
+          // If we already have the file, and its status is FINISHED, CANCELLED,
+          // or ERROR, we re-queue the same file. We remove the file from the
+          // original list and add it to the top, so we can be sure to see it.
+          const foundFileStatus = draft.files[foundFileIdx].status;
+          if (
+            foundFileStatus === 'FINISHED' ||
+            foundFileStatus === 'CANCELLED' ||
+            foundFileStatus === 'ERROR'
+          ) {
+            draft.files.splice(foundFileIdx, 1);
+            draft.files.unshift({
+              status: 'QUEUED',
+              percentComplete: 0,
+              file
+            });
+          }
+        }
       });
 
-      const extendedFiles: ExtendedFile[] = filteredFiles.map(file => ({
+      const extendedFiles: ExtendedFile[] = newFiles.map(file => ({
         status: 'QUEUED',
         percentComplete: 0,
         file
       }));
+
       draft.files = [...extendedFiles, ...draft.files];
       updateCount(draft);
       draft.allUploadsFinished = false;
       break;
 
-    case 'SET_IN_PROGRESS':
-      action.files.forEach(file => {
-        // I was getting a shadowed-variable-name error here (???)
-        // tslint:disable-next-line
-        const idx = draft.files.findIndex(
-          prevUpload => prevUpload.file.name === file.file.name
+    // Update files given a list of filenames and attributes to update.
+    case 'UPDATE_FILES':
+      action.filesToUpdate.forEach(filename => {
+        const existingFile = draft.files.find(
+          prevUpload => prevUpload.file.name === filename
         );
-        if (idx > -1) {
-          draft.files[idx].status = 'IN_PROGRESS';
+
+        if (existingFile) {
+          Object.keys(action.data).forEach(key => {
+            existingFile[key] = action.data[key];
+          });
+
+          // If the status has been changed, we need to update the count.
+          if (action.data.status) {
+            updateCount(draft);
+          }
         }
       });
-      updateCount(draft);
+
       break;
 
-    case 'UPDATE_FILE':
-      const idx = draft.files.findIndex(
-        prevUpload => prevUpload.file.name === action.data.fileName
-      );
-      if (idx > -1) {
-        draft.files[idx] = { ...draft.files[idx], ...action.data };
-
-        // If the status has been changed, we need to update the count.
-        if (action.data.status) {
-          updateCount(draft);
-        }
-      }
-      break;
-
+    // Update the count. If there are no in-progress uploads, flag as finished.
     case 'FINISH_BATCH':
       updateCount(draft);
       if (draft.numInProgress === 0) {
@@ -130,3 +152,9 @@ const updateCount = (draft: ObjectUploaderState) => {
   draft.numCancelled = numCancelled;
   draft.numErrors = numErrors;
 };
+
+export const extendFile = (file: File): ExtendedFile => ({
+  status: 'QUEUED',
+  percentComplete: 0,
+  file
+});

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -41,11 +41,13 @@ export interface ExtendedObject extends Linode.Object {
   _isFolder: boolean;
   _displayName: string;
   _shouldDisplayObject: boolean;
+  _manuallyCreated: boolean;
 }
 
 export const extendObject = (
   object: Linode.Object,
-  prefix: string
+  prefix: string,
+  manuallyCreated = false
 ): ExtendedObject => {
   const _isFolder = isFolder(object);
 
@@ -63,7 +65,8 @@ export const extendObject = (
     // If we're in a folder called "my-folder", we don't want to show the object
     // called "my-folder/". We can look at the prefix to make this decision,
     // since it will also be "my-folder/".
-    _shouldDisplayObject: object.name !== prefix
+    _shouldDisplayObject: object.name !== prefix,
+    _manuallyCreated: manuallyCreated
   };
 };
 

--- a/packages/manager/src/hooks/usePrevious.ts
+++ b/packages/manager/src/hooks/usePrevious.ts
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react';
+
+/** This hook is from the React docs:
+ * https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+ */
+
+export const usePrevious = <T>(value: T) => {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};

--- a/packages/manager/src/types/ObjectStorage.ts
+++ b/packages/manager/src/types/ObjectStorage.ts
@@ -30,6 +30,7 @@ namespace Linode {
   }
 
   export interface ObjectURL {
+    exists: boolean;
     url: string;
   }
 

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -318,3 +318,11 @@ export const sendDownloadObjectEvent = () => {
     action: 'Download Object'
   });
 };
+
+export const sendObjectsQueuedForUploadEvent = (numObjects: number) => {
+  sendEvent({
+    category: 'Object Storage',
+    action: 'Objects queued for upload',
+    label: `${numObjects} objects`
+  });
+};


### PR DESCRIPTION
## Description

This PR makes it possible to upload multiple files at once.

It's possible to drop up to 100 files at a time,  but the uploads are batched, with a max of 25 parallel uploads at a time (feedback appreciated on these numbers).

Since the DOM is being updated rather frequently, there are many performance considerations that have gone into this. This informed the shape of the data structures used in the reducer, as well as which values are memoized. Feedback is greatly appreciated in this regard.

Here's how this component works:

1. Files are dropped in the upload area (e.g. `file1` and `file2`).
2. The `onDrop()` function is called. An action is dispatched, which sets the status of these files to `QUEUED`.
3. Because the number of queued files has changed, the memoized value `nextBatch` is calculated. It is now `[file1, file2]`.
4. Because `nextBatch` has changed, the `useEffect()` which uploads the files is run. Once the files are uploaded, an action is dispatched which sets the progress to `FINISHED`.
5. Since the number of in-progress events has changed, the memoized value `nextBatch` is calculated again. Since there are no more files to upload, it is now `[]`.
6. Because `nextBatch` has changed, the `useEffect()` which uploads the files is run again. Since `nextBatch` is `[]`, this function returns early.


## Notes
 **Two followup PRs coming:**

- ~Improved error state (with "Retry" functionality)~ Working on this now, will add it to this PR.
- ~When a file is successfully uploaded, we'll add it to the the object table manually.~ Included in this PR.