### PR TITLE
Add: Ability to Edit Domain Status

### DIFF
--- a/packages/linode-js-sdk/src/domains/types.ts
+++ b/packages/linode-js-sdk/src/domains/types.ts
@@ -16,7 +16,7 @@ export interface Domain {
   zonefile: ZoneFile;
 }
 
-export type DomainStatus = 'active' | 'disabled' | 'edit_mode';
+export type DomainStatus = 'active' | 'disabled' | 'edit_mode' | 'has_errors';
 
 export type DomainType = 'master' | 'slave';
 

--- a/packages/manager/src/containers/domains.container.ts
+++ b/packages/manager/src/containers/domains.container.ts
@@ -20,7 +20,7 @@ export interface StateProps {
 
 export interface DomainActionsProps {
   createDomain: (payload: CreateDomainPayload) => Promise<Domain>;
-  updateDomain: (params: UpdateDomainParams) => Promise<Domain>;
+  updateDomain: (params: UpdateDomainParams & DomainId) => Promise<Domain>;
   deleteDomain: (domainId: DomainId) => Promise<{}>;
 }
 
@@ -46,7 +46,8 @@ export default <InnerStateProps extends {}, TOuter extends {}>(
     (dispatch: ThunkDispatch) => ({
       createDomain: (payload: CreateDomainPayload) =>
         dispatch(createDomain(payload)),
-      updateDomain: (params: DomainId) => dispatch(updateDomain(params)),
+      updateDomain: (params: UpdateDomainParams & DomainId) =>
+        dispatch(updateDomain(params)),
       deleteDomain: (domainId: DomainId) => dispatch(deleteDomain(domainId))
     })
   );

--- a/packages/manager/src/features/Domains/DisableDomainDialog.tsx
+++ b/packages/manager/src/features/Domains/DisableDomainDialog.tsx
@@ -1,0 +1,100 @@
+import { Domain, UpdateDomainPayload } from 'linode-js-sdk/lib/domains';
+import { APIError } from 'linode-js-sdk/lib/types';
+import * as React from 'react';
+
+import ActionPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import Dialog from 'src/components/ConfirmationDialog';
+
+interface Props {
+  updateDomain: (
+    payload: UpdateDomainPayload & { domainId: number }
+  ) => Promise<Domain>;
+  selectedDomainID?: number;
+  selectedDomainLabel: string;
+  closeDialog: () => void;
+  open: boolean;
+  errors?: APIError[];
+}
+
+type CombinedProps = Props;
+
+const DisableDomainDialog: React.FC<CombinedProps> = props => {
+  const [isSubmitting, setSubmitting] = React.useState<boolean>(false);
+  const [errors, setErrors] = React.useState<APIError[] | undefined>(undefined);
+
+  React.useEffect(() => {
+    if (props.open) {
+      setErrors(undefined);
+    }
+  }, [props.open]);
+
+  const handleSubmit = () => {
+    if (!props.selectedDomainID) {
+      return setErrors([
+        {
+          reason: 'Something went wrong.'
+        }
+      ]);
+    }
+
+    setSubmitting(true);
+
+    props
+      .updateDomain({
+        domainId: props.selectedDomainID,
+        status: 'disabled'
+      })
+      .then(() => {
+        setSubmitting(false);
+        props.closeDialog();
+      })
+      .catch(e => {
+        setSubmitting(false);
+        setErrors(e);
+      });
+  };
+  return (
+    <Dialog
+      open={props.open}
+      title={`Disable ${props.selectedDomainLabel}?`}
+      onClose={props.closeDialog}
+      error={errors ? errors[0].reason : ''}
+      actions={
+        <Actions
+          onClose={props.closeDialog}
+          isSubmitting={isSubmitting}
+          onSubmit={handleSubmit}
+        />
+      }
+    >
+      Are you sure you want to disable this DNS zone?
+    </Dialog>
+  );
+};
+
+interface ActionsProps {
+  onClose: () => void;
+  onSubmit: () => void;
+  isSubmitting: boolean;
+}
+
+const Actions: React.FC<ActionsProps> = props => {
+  return (
+    <ActionPanel>
+      <Button onClick={props.onClose} buttonType="cancel">
+        Cancel
+      </Button>
+      <Button
+        onClick={props.onSubmit}
+        loading={props.isSubmitting}
+        destructive
+        buttonType="secondary"
+      >
+        Disable
+      </Button>
+    </ActionPanel>
+  );
+};
+
+export default React.memo(DisableDomainDialog);

--- a/packages/manager/src/features/Domains/DisableDomainDialog.tsx
+++ b/packages/manager/src/features/Domains/DisableDomainDialog.tsx
@@ -6,6 +6,8 @@ import ActionPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Dialog from 'src/components/ConfirmationDialog';
 
+import { sendDomainStatusChangeEvent } from 'src/utilities/ga';
+
 interface Props {
   updateDomain: (
     payload: UpdateDomainPayload & { domainId: number }
@@ -47,6 +49,7 @@ const DisableDomainDialog: React.FC<CombinedProps> = props => {
       })
       .then(() => {
         setSubmitting(false);
+        sendDomainStatusChangeEvent('Disable');
         props.closeDialog();
       })
       .catch(e => {

--- a/packages/manager/src/features/Domains/DomainActionMenu.test.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup } from '@testing-library/react';
+import { DomainStatus } from 'linode-js-sdk/lib/domains';
 import * as React from 'react';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
 import { DomainActionMenu } from './DomainActionMenu';
@@ -14,6 +15,8 @@ const props = {
   type: 'master' as 'master' | 'slave',
   domain: '',
   id: 1234456,
+  onDisableOrEnable: jest.fn(),
+  status: 'active' as DomainStatus,
   ...reactRouterProps
 };
 

--- a/packages/manager/src/features/Domains/DomainActionMenu.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu.tsx
@@ -1,14 +1,24 @@
+import { DomainStatus } from 'linode-js-sdk/lib/domains';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
-interface Props {
+export interface Handlers {
   onRemove: (domain: string, id: number) => void;
+  onDisableOrEnable: (
+    status: 'enable' | 'disable',
+    domain: string,
+    id: number
+  ) => void;
   onClone: (domain: string, id: number) => void;
   onEdit: (domain: string, id: number) => void;
+}
+
+interface Props extends Handlers {
   type: 'master' | 'slave';
   domain: string;
   id: number;
+  status: DomainStatus;
 }
 
 type CombinedProps = RouteComponentProps<any> & Props;
@@ -67,6 +77,18 @@ export class DomainActionMenu extends React.Component<CombinedProps> {
         title: 'Clone',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           this.handleClone();
+          closeMenu();
+          e.preventDefault();
+        }
+      },
+      {
+        title: this.props.status === 'disabled' ? 'Enable' : 'Disable',
+        onClick: (e: React.MouseEvent<HTMLElement>) => {
+          this.props.onDisableOrEnable(
+            this.props.status === 'disabled' ? 'enable' : 'disable',
+            this.props.domain,
+            this.props.id
+          );
           closeMenu();
           e.preventDefault();
         }

--- a/packages/manager/src/features/Domains/DomainActionMenu.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu.tsx
@@ -2,6 +2,7 @@ import { DomainStatus } from 'linode-js-sdk/lib/domains';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
+import { sendDomainStatusChangeEvent } from 'src/utilities/ga';
 
 export interface Handlers {
   onRemove: (domain: string, id: number) => void;
@@ -82,13 +83,22 @@ export class DomainActionMenu extends React.Component<CombinedProps> {
         }
       },
       {
-        title: this.props.status === 'disabled' ? 'Enable' : 'Disable',
+        title: this.props.status === 'active' ? 'Disable' : 'Enable',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
+          const actionToTake =
+            this.props.status === 'active' ? 'disable' : 'enable';
           this.props.onDisableOrEnable(
-            this.props.status === 'disabled' ? 'enable' : 'disable',
+            actionToTake,
             this.props.domain,
             this.props.id
           );
+          if (actionToTake === 'enable') {
+            /**
+             * disabling opens a dialog modal, so don't send the event
+             * for when the user is disabling
+             */
+            sendDomainStatusChangeEvent('Enable');
+          }
           closeMenu();
           e.preventDefault();
         }

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -1,3 +1,4 @@
+import { DomainStatus } from 'linode-js-sdk/lib/domains';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -43,7 +44,7 @@ const styles = (theme: Theme) =>
 interface Props {
   domain: string;
   id: number;
-  status: string;
+  status: DomainStatus;
   type: 'master' | 'slave';
   onRemove: (domain: string, domainId: number) => void;
   onClone: (domain: string, id: number) => void;
@@ -120,6 +121,9 @@ class DomainTableRow extends React.Component<CombinedProps> {
         <TableCell parentColumn="Type" data-qa-domain-type>
           {type}
         </TableCell>
+        <TableCell parentColumn="Status" data-qa-domain-status>
+          {humanizeDomainStatus(status)}
+        </TableCell>
         <TableCell>
           <ActionMenu
             domain={domain}
@@ -134,6 +138,21 @@ class DomainTableRow extends React.Component<CombinedProps> {
     );
   }
 }
+
+const humanizeDomainStatus = (status: DomainStatus) => {
+  switch (status) {
+    case 'active':
+      return 'Active';
+    case 'disabled':
+      return 'Disabled';
+    case 'edit_mode':
+      return 'Edit Mode';
+    case 'has_errors':
+      return 'Error';
+    default:
+      return 'Unknown';
+  }
+};
 
 const styled = withStyles(styles);
 

--- a/packages/manager/src/features/Domains/DomainTableRow.tsx
+++ b/packages/manager/src/features/Domains/DomainTableRow.tsx
@@ -12,7 +12,7 @@ import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
-import ActionMenu from './DomainActionMenu';
+import ActionMenu, { Handlers } from './DomainActionMenu';
 
 type ClassNames =
   | 'domain'
@@ -41,14 +41,11 @@ const styles = (theme: Theme) =>
     }
   });
 
-interface Props {
+interface Props extends Handlers {
   domain: string;
   id: number;
   status: DomainStatus;
   type: 'master' | 'slave';
-  onRemove: (domain: string, domainId: number) => void;
-  onClone: (domain: string, id: number) => void;
-  onEdit: (domain: string, id: number) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -127,10 +124,12 @@ class DomainTableRow extends React.Component<CombinedProps> {
         <TableCell>
           <ActionMenu
             domain={domain}
+            onDisableOrEnable={this.props.onDisableOrEnable}
             id={id}
             type={type}
             onRemove={onRemove}
             onClone={onClone}
+            status={status}
             onEdit={onEdit}
           />
         </TableCell>

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -90,24 +90,15 @@ const styles = (theme: Theme) =>
   });
 
 interface State {
-  importDrawer: {
-    open: boolean;
-    submitting: boolean;
-    errors?: APIError[];
-    domain?: string;
-    remote_nameserver?: string;
-  };
-  createDrawer: {
-    open: boolean;
-    mode: 'clone' | 'create';
-    domain?: string;
-    id?: number;
-  };
-  removeDialog: {
-    open: boolean;
-    domain?: string;
-    domainId?: number;
-  };
+  importDrawerOpen: boolean;
+  importDrawerSubmitting: false;
+  importDrawerErrors?: APIError[];
+  remote_nameserver: string;
+  createDrawerOpen: boolean;
+  createDrawerMode: 'clone' | 'create';
+  selectedDomainLabel: string;
+  selectedDomainID?: number;
+  removeDialogOpen: boolean;
 }
 
 interface Props {
@@ -125,35 +116,28 @@ export type CombinedProps = DomainProps &
 
 export class DomainsLanding extends React.Component<CombinedProps, State> {
   state: State = {
-    importDrawer: {
-      open: false,
-      submitting: false
-    },
-    createDrawer: {
-      open: false,
-      mode: 'create'
-    },
-    removeDialog: {
-      open: false
-    }
+    importDrawerOpen: false,
+    importDrawerSubmitting: false,
+    remote_nameserver: '',
+    createDrawerMode: 'create',
+    createDrawerOpen: false,
+    removeDialogOpen: false,
+    selectedDomainLabel: ''
   };
 
   static docs: Linode.Doc[] = [Domains];
 
   cancelRequest: Function;
 
-  openImportZoneDrawer = () =>
-    this.setState({ importDrawer: { ...this.state.importDrawer, open: true } });
+  openImportZoneDrawer = () => this.setState({ importDrawerOpen: true });
 
   closeImportZoneDrawer = () =>
     this.setState({
-      importDrawer: {
-        open: false,
-        submitting: false,
-        remote_nameserver: undefined,
-        domain: undefined,
-        errors: undefined
-      }
+      importDrawerOpen: false,
+      importDrawerSubmitting: false,
+      remote_nameserver: '',
+      selectedDomainLabel: '',
+      importDrawerErrors: undefined
     });
 
   handleSuccess = (domain: Domain) => {
@@ -185,12 +169,10 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
   };
 
   removeDomain = () => {
-    const {
-      removeDialog: { domainId }
-    } = this.state;
+    const { selectedDomainID } = this.state;
     const { enqueueSnackbar, deleteDomain } = this.props;
-    if (domainId) {
-      deleteDomain({ domainId })
+    if (selectedDomainID) {
+      deleteDomain({ domainId: selectedDomainID })
         .then(() => {
           this.closeRemoveDialog();
         })
@@ -211,14 +193,15 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
 
   openRemoveDialog = (domain: string, domainId: number) => {
     this.setState({
-      removeDialog: { open: true, domain, domainId }
+      removeDialogOpen: true,
+      selectedDomainLabel: domain,
+      selectedDomainID: domainId
     });
   };
 
   closeRemoveDialog = () => {
-    const { removeDialog } = this.state;
     this.setState({
-      removeDialog: { ...removeDialog, open: false }
+      removeDialogOpen: false
     });
   };
 
@@ -383,13 +366,13 @@ export class DomainsLanding extends React.Component<CombinedProps, State> {
           }}
         </PreferenceToggle>
         <DomainZoneImportDrawer
-          open={this.state.importDrawer.open}
+          open={this.state.importDrawerOpen}
           onClose={this.closeImportZoneDrawer}
           onSuccess={this.handleSuccess}
         />
         <ConfirmationDialog
-          open={this.state.removeDialog.open}
-          title={`Remove ${this.state.removeDialog.domain}`}
+          open={this.state.removeDialogOpen}
+          title={`Remove ${this.state.selectedDomainLabel}`}
           onClose={this.closeRemoveDialog}
           actions={this.getActions}
         >

--- a/packages/manager/src/features/Domains/ListDomains.tsx
+++ b/packages/manager/src/features/Domains/ListDomains.tsx
@@ -16,6 +16,7 @@ import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableSortCell from 'src/components/TableSortCell';
 import DomainTableRow from 'src/features/Domains/DomainTableRow';
+import { Handlers } from './DomainActionMenu';
 
 type ClassNames = 'root' | 'label';
 
@@ -27,14 +28,11 @@ const styles = (theme: Theme) =>
     }
   });
 
-interface Props {
+interface Props extends Handlers {
   data: Domain[];
   orderBy: string;
   order: 'asc' | 'desc';
   handleOrderChange: (orderBy: string, order?: 'asc' | 'desc') => void;
-  onRemove: (domain: string, domainId: number) => void;
-  onClone: (domain: string, id: number) => void;
-  onEdit: (domain: string, id: number) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -93,6 +91,7 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
                   onClone={props.onClone}
                   onEdit={props.onEdit}
                   onRemove={props.onRemove}
+                  onDisableOrEnable={props.onDisableOrEnable}
                 />
               </TableBody>
             </Table>
@@ -111,15 +110,12 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
   );
 };
 
-interface RenderDataProps {
+interface RenderDataProps extends Handlers {
   data: Domain[];
-  onRemove: (domain: string, domainId: number) => void;
-  onClone: (domain: string, id: number) => void;
-  onEdit: (domain: string, id: number) => void;
 }
 
 const RenderData: React.StatelessComponent<RenderDataProps> = props => {
-  const { data, onClone, onEdit, onRemove } = props;
+  const { data, onClone, onEdit, onRemove, onDisableOrEnable } = props;
 
   return (
     <>
@@ -133,6 +129,7 @@ const RenderData: React.StatelessComponent<RenderDataProps> = props => {
           onRemove={onRemove}
           type={domain.type}
           status={domain.status}
+          onDisableOrEnable={onDisableOrEnable}
         />
       ))}
     </>

--- a/packages/manager/src/features/Domains/ListDomains.tsx
+++ b/packages/manager/src/features/Domains/ListDomains.tsx
@@ -75,6 +75,15 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
                   >
                     Type
                   </TableSortCell>
+                  <TableSortCell
+                    data-qa-domain-type-header={order}
+                    active={orderBy === 'status'}
+                    label="status"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                  >
+                    Status
+                  </TableSortCell>
                   <TableCell />
                 </TableRow>
               </TableHead>

--- a/packages/manager/src/features/Domains/ListGroupedDomains.tsx
+++ b/packages/manager/src/features/Domains/ListGroupedDomains.tsx
@@ -15,6 +15,7 @@ import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import DomainTableRow from 'src/features/Domains/DomainTableRow';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
+import { Handlers } from './DomainActionMenu';
 import TableWrapper from './DomainsTableWrapper';
 
 const DEFAULT_PAGE_SIZE = 25;
@@ -62,14 +63,11 @@ const styles = (theme: Theme) =>
       }
     }
   });
-interface Props {
+interface Props extends Handlers {
   data: Domain[];
   orderBy: string;
   order: 'asc' | 'desc';
   handleOrderChange: (orderBy: string, order?: 'asc' | 'desc') => void;
-  onRemove: (domain: string, domainId: number) => void;
-  onClone: (domain: string, id: number) => void;
-  onEdit: (domain: string, id: number) => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -133,6 +131,7 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
                           onRemove={onRemove}
                           type={domain.type}
                           status={domain.status}
+                          onDisableOrEnable={props.onDisableOrEnable}
                         />
                       ))}
                       {count > DEFAULT_PAGE_SIZE && (

--- a/packages/manager/src/features/Domains/SortableTableHead.tsx
+++ b/packages/manager/src/features/Domains/SortableTableHead.tsx
@@ -50,6 +50,15 @@ const SortableTableHead: React.StatelessComponent<combinedProps> = props => {
         >
           Type
         </TableSortCell>
+        <TableSortCell
+          data-qa-domain-type-header={order}
+          active={orderBy === 'status'}
+          label="status"
+          direction={order}
+          handleClick={handleOrderChange}
+        >
+          Status
+        </TableSortCell>
         <TableCell />
       </TableRow>
     </TableHead>

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -296,3 +296,10 @@ export const sendOneClickNavigationEvent = (
     action: `From ${whichButton}`
   });
 };
+
+export const sendDomainStatusChangeEvent = (action: 'Enable' | 'Disable') => {
+  return sendEvent({
+    category: 'Domain Status Change',
+    action
+  });
+};


### PR DESCRIPTION
## Description

Gives the user the ability to either enable or disable domain status. This does not recognize the possibility of a zone being in `has_error` or `edit_mode` status. If it's in either of these statuses, the only option is to disable. You can then enable again after the zone is disabled.

Also adds status as a table column.

## Type of Change
- Non breaking change ('update', 'change')