### PR TITLE
Change: Deprecate Linode.ResourcePage

### DIFF
--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -72,7 +72,7 @@ interface Props {
 
 interface State {
   actions?: Action[];
-  anchorEl?: Linode.TodoAny;
+  anchorEl?: any;
 }
 
 type CombinedProps = Props & WithStyles<CSSClasses>;
@@ -83,7 +83,7 @@ export class ActionMenu extends React.Component<CombinedProps, State> {
     anchorEl: undefined
   };
 
-  generateActions(createActions: Linode.TodoAny) {
+  generateActions(createActions: any) {
     this.setState({
       actions: createActions(this.handleClose)
     });

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -1,4 +1,5 @@
 import { Event, getEvents } from 'linode-js-sdk/lib/account';
+import { ResourcePage } from 'linode-js-sdk/lib/types';
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import { compose as rCompose, concat, uniq } from 'ramda';
 import * as React from 'react';
@@ -211,7 +212,7 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
       });
   };
 
-  const handleEventsRequestSuccess = (response: Linode.ResourcePage<Event>) => {
+  const handleEventsRequestSuccess = (response: ResourcePage<Event>) => {
     setCurrentPage(currentPage + 1);
     setLoadMoreEvents(true);
     /** append our events to component state */

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -9,7 +9,7 @@ import {
   NodeBalancerConfigNodeFields,
   updateNodeBalancerConfigNode
 } from 'linode-js-sdk/lib/nodebalancers';
-import { APIError } from 'linode-js-sdk/lib/types';
+import { APIError, ResourcePage } from 'linode-js-sdk/lib/types';
 import {
   append,
   clone,
@@ -93,7 +93,7 @@ type RouteProps = RouteComponentProps<MatchProps>;
 
 interface PreloadedProps {
   configs: PromiseLoaderResponse<
-    Linode.ResourcePage<NodeBalancerConfigFieldsWithStatus>
+    ResourcePage<NodeBalancerConfigFieldsWithStatus>
   >;
 }
 

--- a/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
+++ b/packages/manager/src/features/StackScripts/SelectStackScriptPanel/SelectStackScriptPanel.tsx
@@ -6,6 +6,7 @@ import {
   StackScript,
   UserDefinedField
 } from 'linode-js-sdk/lib/stackscripts';
+import { ResourcePage } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -104,7 +105,7 @@ interface Props extends RenderGuardProps {
     params?: any,
     filter?: any,
     stackScriptGrants?: Grant[]
-  ) => Promise<Linode.ResourcePage<any>>;
+  ) => Promise<ResourcePage<any>>;
   category: string;
   header: string;
 }

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -1,7 +1,7 @@
 import { Grant } from 'linode-js-sdk/lib/account';
 import { Image } from 'linode-js-sdk/lib/images';
 import { StackScript } from 'linode-js-sdk/lib/stackscripts';
-import { APIError } from 'linode-js-sdk/lib/types';
+import { APIError, ResourcePage } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -144,7 +144,7 @@ const withStackScriptBase = (isSelecting: boolean) => (
         filter,
         stackScriptGrants
       )
-        .then((response: Linode.ResourcePage<StackScript>) => {
+        .then((response: ResourcePage<StackScript>) => {
           if (!this.mounted) {
             return;
           }

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptPanelContent.tsx
@@ -4,6 +4,7 @@ import {
   StackScript,
   updateStackScript
 } from 'linode-js-sdk/lib/stackscripts';
+import { ResourcePage } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import StackScriptBase, {
@@ -39,7 +40,7 @@ interface Props {
     username: string,
     params?: any,
     filter?: any
-  ) => Promise<Linode.ResourcePage<StackScript>>;
+  ) => Promise<ResourcePage<StackScript>>;
   category: string;
 }
 

--- a/packages/manager/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptUpdate/StackScriptUpdate.tsx
@@ -218,7 +218,7 @@ export class StackScriptUpdate extends React.Component<CombinedProps, State> {
           successMessage: `${updatedStackScript.label} successfully updated`
         });
       })
-      .catch((error: Linode.TodoAny) => {
+      .catch((error: APIError[]) => {
         if (!this.mounted) {
           return;
         }

--- a/packages/manager/src/features/StackScripts/stackScriptUtils.ts
+++ b/packages/manager/src/features/StackScripts/stackScriptUtils.ts
@@ -4,10 +4,11 @@ import {
   getStackScripts,
   StackScript
 } from 'linode-js-sdk/lib/stackscripts';
+import { ResourcePage } from 'linode-js-sdk/lib/types';
 
 export type StackScriptCategory = 'account' | 'community';
 
-export const emptyResult: Linode.ResourcePage<StackScript> = {
+export const emptyResult: ResourcePage<StackScript> = {
   data: [],
   page: 1,
   pages: 1,

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -5,7 +5,7 @@ import {
   createSupportTicket,
   uploadAttachment
 } from 'linode-js-sdk/lib/support';
-import { APIError } from 'linode-js-sdk/lib/types';
+import { APIError, ResourcePage } from 'linode-js-sdk/lib/types';
 import { getVolumes } from 'linode-js-sdk/lib/volumes';
 import { compose, lensPath, set } from 'ramda';
 import * as React from 'react';
@@ -182,7 +182,7 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
     }
   }
 
-  handleThen = (response: Linode.ResourcePage<any>) => {
+  handleThen = (response: ResourcePage<any>) => {
     const type = this.state.ticket.entity_type;
     const entityItems = response.data.map(entity => {
       return type === 'domain_id'

--- a/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/TabbedContent/FromStackScriptContent.tsx
@@ -1,6 +1,7 @@
 import { Grant } from 'linode-js-sdk/lib/account';
 import { Image } from 'linode-js-sdk/lib/images';
 import { StackScript, UserDefinedField } from 'linode-js-sdk/lib/stackscripts';
+import { ResourcePage } from 'linode-js-sdk/lib/types';
 import { assocPath, pathOr } from 'ramda';
 import * as React from 'react';
 import { Sticky, StickyProps } from 'react-sticky';
@@ -70,7 +71,7 @@ interface Props {
     params?: any,
     filter?: any,
     stackScriptGrants?: Grant[]
-  ) => Promise<Linode.ResourcePage<StackScript>>;
+  ) => Promise<ResourcePage<StackScript>>;
   header: string;
   category: 'community' | 'account';
 }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -241,7 +241,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           ? `${testYear}-0${testMonth}-01`
           : `${testYear}-${testMonth}-01`;
     } while (moment(formattedTestDate).diff(creationFirstOfMonth) >= 0);
-    (this.rangeSelectOptions as any) = options.map(option => {
+    this.rangeSelectOptions = options.map(option => {
       return { label: option[1], value: option[0] };
     });
   }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -241,7 +241,7 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
           ? `${testYear}-0${testMonth}-01`
           : `${testYear}-${testMonth}-01`;
     } while (moment(formattedTestDate).diff(creationFirstOfMonth) >= 0);
-    (this.rangeSelectOptions as Linode.TodoAny) = options.map(option => {
+    (this.rangeSelectOptions as any) = options.map(option => {
       return { label: option[1], value: option[0] };
     });
   }

--- a/packages/manager/src/hooks/useAPIRequest.ts
+++ b/packages/manager/src/hooks/useAPIRequest.ts
@@ -37,7 +37,7 @@ interface UseAPIRequest<T> {
  * Get Linodes:
  *
  * We'd like to resolve `response.data` from the request, so we can deal with Linode[]
- * instead of Linode.ResourcePage<Linode>.
+ * instead of ResourcePage<Linode>.
  *
  * ```typescript
  * const { data, loading, lastUpdated, error } = useAPIData<Linode[]>(

--- a/packages/manager/src/layouts/OAuth.test.tsx
+++ b/packages/manager/src/layouts/OAuth.test.tsx
@@ -4,9 +4,7 @@ import { parseQueryParams } from 'src/utilities/queryParams';
 describe('layouts/OAuth', () => {
   describe('parseQueryParams', () => {
     it('parses query params of the expected format', () => {
-      const res = parseQueryParams(
-        'entity=key&color=bronze&weight=20%20grams'
-      ) as Linode.TodoAny;
+      const res = parseQueryParams('entity=key&color=bronze&weight=20%20grams');
       expect(res.entity).toBe('key');
       expect(res.color).toBe('bronze');
       expect(res.weight).toBe('20 grams');
@@ -21,8 +19,8 @@ describe('layouts/OAuth', () => {
       const res = parseQueryParams(
         'access_token=123456&return=https://localhost:3000/oauth/callback?returnTo=/asdf'
       );
-      expect((res as Linode.TodoAny).access_token).toBe('123456');
-      expect((res as Linode.TodoAny).return).toBe(
+      expect(res.access_token).toBe('123456');
+      expect(res.return).toBe(
         'https://localhost:3000/oauth/callback?returnTo=/asdf'
       );
     });

--- a/packages/manager/src/services/objectStorage/buckets.ts
+++ b/packages/manager/src/services/objectStorage/buckets.ts
@@ -1,3 +1,4 @@
+import { ResourcePage } from 'linode-js-sdk/lib/types';
 import { BETA_API_ROOT } from 'src/constants';
 import Request, {
   setData,
@@ -8,7 +9,7 @@ import Request, {
 } from '../index';
 import { CreateBucketSchema } from './buckets.schema';
 
-type Page<T> = Linode.ResourcePage<T>;
+type Page<T> = ResourcePage<T>;
 
 export interface BucketRequestPayload {
   label: string;

--- a/packages/manager/src/services/objectStorage/clusters.ts
+++ b/packages/manager/src/services/objectStorage/clusters.ts
@@ -1,7 +1,8 @@
+import { ResourcePage } from 'linode-js-sdk/lib/types';
 import { BETA_API_ROOT } from 'src/constants';
 import Request, { setMethod, setParams, setURL, setXFilter } from '../index';
 
-type Page<T> = Linode.ResourcePage<T>;
+type Page<T> = ResourcePage<T>;
 
 /**
  * getClusters

--- a/packages/manager/src/store/image/image.actions.ts
+++ b/packages/manager/src/store/image/image.actions.ts
@@ -1,14 +1,12 @@
 import { Image } from 'linode-js-sdk/lib/images';
-import { APIError } from 'linode-js-sdk/lib/types';
+import { APIError, ResourcePage } from 'linode-js-sdk/lib/types';
 import actionCreatorFactory from 'typescript-fsa';
 
 export const actionCreator = actionCreatorFactory(`@@manager/images`);
 
 export const getImagesRequest = actionCreator(`request`);
 
-export const getImagesSuccess = actionCreator<Linode.ResourcePage<Image>>(
-  `success`
-);
+export const getImagesSuccess = actionCreator<ResourcePage<Image>>(`success`);
 
 export const getImagesFailure = actionCreator<APIError[]>(`fail`);
 

--- a/packages/manager/src/store/image/image.requests.ts
+++ b/packages/manager/src/store/image/image.requests.ts
@@ -1,4 +1,5 @@
 import { getImages, Image } from 'linode-js-sdk/lib/images';
+import { ResourcePage } from 'linode-js-sdk/lib/types';
 import { ThunkActionCreator } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
@@ -15,7 +16,7 @@ export const requestImages: ThunkActionCreator<
         getImagesSuccess({
           data,
           results
-        } as Linode.ResourcePage<Image>)
+        } as ResourcePage<Image>)
       );
       return data;
     })

--- a/packages/manager/src/types/index.ts
+++ b/packages/manager/src/types/index.ts
@@ -7,35 +7,3 @@ declare module '*.svg';
 declare module '*.png';
 
 declare module 'react-csv';
-
-namespace Linode {
-  export type TodoAny = any;
-
-  export type NullableString = string | null;
-
-  export type Hypervisor = 'kvm' | 'zen';
-
-  export interface ResourcePage<T> {
-    data: T[];
-    page: number;
-    pages: number;
-    results: number;
-  }
-
-  export interface LinodeSpecs {
-    disk: number;
-    memory: number;
-    vcpus: number;
-    transfer: number;
-  }
-
-  export interface PriceObject {
-    monthly: number;
-    hourly: number;
-  }
-
-  export interface PaginationOptions {
-    page?: number;
-    page_size?: number;
-  }
-}


### PR DESCRIPTION
## Description

Deprecates `Linode.ResourcePage` along with some other leftover namespace items.

`Linode.TodoAny` was supposed to be a marker to let the devs know to go back and re-type it later, but realistically nobody is going to actually do that.

## Type of Change
- Breaking change ('break', 'deprecate')