### PR TITLE
Change: Upgrade ChartJS

### DIFF
--- a/packages/manager/patches/chart.js+2.7.3.patch
+++ b/packages/manager/patches/chart.js+2.7.3.patch
@@ -12,7 +12,7 @@ index 2496a48..b96ccf5 100644
  
  			for (i = 0, ilen = ticks.length; i < ilen; ++i) {
 -				labels.push(this.tickFormatFunction(moment(ticks[i].value), i, ticks));
-+				if (offset) {
++				if (offset === 0 || offset) {
 +					labels.push(this.tickFormatFunction(moment(moment(ticks[i].value).utc()).utcOffset(offset), i, ticks));
 +				} else {
 +					labels.push(this.tickFormatFunction(moment(ticks[i].value), i, ticks));


### PR DESCRIPTION
## Description

Upgrades ChartJS to fix issue with tooltips not respecting the time offset.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## To Test

`yarn clean && yarn up` <---- important

In develop, set your timezone to GMT, look at your graphs and notice the tooltip datetime doesn't match up wit the X-Axis

And then try it again in this branch.