### PR TITLE
Updates for breaking API OBJ changes

### DIFF
--- a/packages/manager/src/__data__/buckets.ts
+++ b/packages/manager/src/__data__/buckets.ts
@@ -1,19 +1,13 @@
 export const buckets: Linode.Bucket[] = [
   {
     label: 'test-bucket-001',
-    objects: 3,
     created: '2019-02-20 18:46:15.516813',
-    region: 'us-east',
-    size: 812412288,
     hostname: 'test-bucket-001.alpha.linodeobjects.com',
     cluster: 'a-cluster'
   },
   {
     label: 'test-bucket-002',
-    objects: 24,
     created: '2019-02-24 18:46:15.516813',
-    region: 'us-east',
-    size: 1223156288,
     hostname: 'test-bucket-002.alpha.linodeobjects.com',
     cluster: 'a-cluster'
   }

--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -87,6 +87,8 @@ export const ZONES: Record<string, ZoneName> = {
 };
 
 export const dcDisplayNames = {
+  // us-east-1 is for backwards-compatibility
+  'us-east-1': 'Newark, NJ',
   'us-east-1a': 'Newark, NJ',
   'us-south-1a': 'Dallas, TX',
   'us-west-1a': 'Fremont, CA',

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu.tsx
@@ -3,8 +3,6 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 export interface Props {
   onRemove: () => void;
-  bucketLabel: string;
-  cluster: string;
 }
 
 export const BucketActionMenu: React.StatelessComponent<Props> = props => {

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.test.tsx
@@ -11,7 +11,7 @@ describe('ObjectStorageLanding', () => {
       bucketsLoading={false}
       openBucketDrawer={jest.fn()}
       closeBucketDrawer={jest.fn()}
-      classes={{ root: '', confirmationCopy: '' }}
+      classes={{ copy: '' }}
       deleteBucket={jest.fn()}
     />
   );

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -29,7 +29,6 @@ import bucketRequestsContainer, {
 import useOpenClose from 'src/hooks/useOpenClose';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import { sendDeleteBucketEvent } from 'src/utilities/ga';
-import { readableBytes } from 'src/utilities/unitConversions';
 import BucketTable from './BucketTable';
 
 type ClassNames = 'root' | 'confirmationCopy';
@@ -82,9 +81,7 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
     setIsLoading(true);
 
     const { cluster, label } = bucketToRemove;
-    // Passing in `force: 1` as a param to delete ALL items within
-    // the bucket before deleting the bucket itself.
-    deleteBucket({ cluster, label, params: { force: 1 } })
+    deleteBucket({ cluster, label })
       .then(() => {
         removeBucketConfirmationDialog.close();
         setIsLoading(false);
@@ -127,23 +124,9 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
 
   const deleteBucketConfirmationMessage = bucketToRemove ? (
     <React.Fragment>
-      {bucketToRemove.size > 0 ? (
-        <Typography>
-          This bucket contains{' '}
-          <strong>
-            {bucketToRemove.objects}{' '}
-            {bucketToRemove.objects === 1 ? 'object' : 'objects'}
-          </strong>{' '}
-          totalling{' '}
-          <strong>{readableBytes(bucketToRemove.size).formatted}</strong> that
-          will be deleted along with the bucket. Deleting a bucket is permanent
-          and can't be undone.
-        </Typography>
-      ) : (
-        <Typography>
-          Deleting a bucket is permanent and can't be undone.
-        </Typography>
-      )}
+      <Typography>
+        Deleting a bucket is permanent and can't be undone.
+      </Typography>
       <Typography className={classes.confirmationCopy}>
         To confirm deletion, type the name of the bucket ({bucketToRemove.label}
         ) in the field below:

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -28,15 +28,17 @@ import bucketRequestsContainer, {
 } from 'src/containers/bucketRequests.container';
 import useOpenClose from 'src/hooks/useOpenClose';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
-import { sendDeleteBucketEvent } from 'src/utilities/ga';
+import {
+  sendDeleteBucketEvent,
+  sendDeleteBucketFailedEvent
+} from 'src/utilities/ga';
 import BucketTable from './BucketTable';
 
-type ClassNames = 'root' | 'confirmationCopy';
+type ClassNames = 'copy';
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {},
-    confirmationCopy: {
+    copy: {
       marginTop: theme.spacing(1)
     }
   });
@@ -90,6 +92,9 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
         sendDeleteBucketEvent(cluster);
       })
       .catch(e => {
+        // @analytics
+        sendDeleteBucketFailedEvent(cluster);
+
         setIsLoading(false);
         const errorText = getErrorStringOrDefault(e, 'Error removing bucket.');
         setError(errorText);
@@ -127,7 +132,19 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
       <Typography>
         Deleting a bucket is permanent and can't be undone.
       </Typography>
-      <Typography className={classes.confirmationCopy}>
+      <Typography className={classes.copy}>
+        A bucket must be empty before deleting it. Please delete all objects, or
+        use{' '}
+        <a
+          href="https://www.linode.com/docs/platform/object-storage/how-to-use-object-storage/#object-storage-tools"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          another tool
+        </a>{' '}
+        to force deletion.
+      </Typography>
+      <Typography className={classes.copy}>
         To confirm deletion, type the name of the bucket ({bucketToRemove.label}
         ) in the field below:
       </Typography>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.test.tsx
@@ -24,12 +24,6 @@ describe('BucketTable', () => {
   it('renders a "Name" column', () => {
     expect(innerComponent.find('[data-qa-name]')).toHaveLength(1);
   });
-  it('renders an "Objects" column', () => {
-    expect(innerComponent.find('[data-qa-objects]')).toHaveLength(1);
-  });
-  it('renders a "Size" column', () => {
-    expect(innerComponent.find('[data-qa-size]')).toHaveLength(1);
-  });
   it('renders a "Region" column', () => {
     expect(innerComponent.find('[data-qa-region]')).toHaveLength(1);
   });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTable.tsx
@@ -73,24 +73,6 @@ export const BucketTable: React.StatelessComponent<CombinedProps> = props => {
                     Name
                   </TableSortCell>
                   <TableSortCell
-                    active={orderBy === 'objects'}
-                    label="objects"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    data-qa-objects
-                  >
-                    Objects
-                  </TableSortCell>
-                  <TableSortCell
-                    active={orderBy === 'size'}
-                    label="size"
-                    direction={order}
-                    handleClick={handleOrderChange}
-                    data-qa-size
-                  >
-                    Size
-                  </TableSortCell>
-                  <TableSortCell
                     active={orderBy === 'region'}
                     label="region"
                     direction={order}

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.test.tsx
@@ -13,12 +13,9 @@ describe('BucketTableRow', () => {
         bucketRow: ''
       }}
       label="test-bucket-001"
-      size={812412288}
       created="2019-02-24 18:46:15.516813"
-      objects={24}
       hostname="test-bucket-001.alpha.linodeobjects.com"
-      region="us-east"
-      cluster="a-cluster"
+      cluster="us-east"
       onRemove={mockOnRemove}
     />
   );
@@ -45,16 +42,7 @@ describe('BucketTableRow', () => {
     ).toBe('test-bucket-001.alpha.linodeobjects.com');
   });
 
-  it('should render the size in a human-readable manner', () => {
-    expect(
-      wrapper
-        .find('[data-qa-size]')
-        .childAt(0)
-        .text()
-    ).toBe('775 MB');
-  });
-
-  it('should render the region in a human-readable manner', () => {
+  it('should render the cluster/region in a human-readable manner', () => {
     expect(
       wrapper
         .find('[data-qa-region]')
@@ -69,38 +57,10 @@ describe('BucketTableRow', () => {
     );
   });
 
-  it('should render an Action Menu with label and cluster', () => {
+  it('should render an Action Menu', () => {
     const actionMenuProps = wrapper
       .find('[data-qa-action-menu]')
       .props() as ActionMenuProps;
-    expect(actionMenuProps.bucketLabel).toBe('test-bucket-001');
-    expect(actionMenuProps.cluster).toBe('a-cluster');
     expect(actionMenuProps.onRemove).toBe(mockOnRemove);
-  });
-
-  it('should correctly pluralize the number of objects in the bucket', () => {
-    wrapper.setProps({ objects: 0 });
-    expect(
-      wrapper
-        .find('[data-qa-num-objects]')
-        .childAt(0)
-        .text()
-    ).toBe('0 objects');
-
-    wrapper.setProps({ objects: 1 });
-    expect(
-      wrapper
-        .find('[data-qa-num-objects]')
-        .childAt(0)
-        .text()
-    ).toBe('1 object');
-
-    wrapper.setProps({ objects: 24 });
-    expect(
-      wrapper
-        .find('[data-qa-num-objects]')
-        .childAt(0)
-        .text()
-    ).toBe('24 objects');
   });
 });

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -12,7 +12,6 @@ import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import { formatRegion } from 'src/utilities/formatRegion';
-import { readableBytes } from 'src/utilities/unitConversions';
 import BucketActionMenu from './BucketActionMenu';
 
 type ClassNames = 'bucketNameWrapper' | 'bucketRow';
@@ -39,17 +38,7 @@ type CombinedProps = BucketTableRowProps & WithStyles<ClassNames>;
 export const BucketTableRow: React.StatelessComponent<
   CombinedProps
 > = props => {
-  const {
-    classes,
-    label,
-    region,
-    size,
-    objects,
-    cluster,
-    hostname,
-    created,
-    onRemove
-  } = props;
+  const { classes, label, cluster, hostname, created, onRemove } = props;
 
   return (
     <TableRow
@@ -75,23 +64,9 @@ export const BucketTableRow: React.StatelessComponent<
           </Grid>
         </Grid>
       </TableCell>
-      <TableCell parentColumn="Objects">
-        <Grid>
-          <Typography variant="body2" data-qa-num-objects>
-            {`${objects} ${objects === 1 ? 'object' : 'objects'}`}
-          </Typography>
-        </Grid>
-      </TableCell>
-      <TableCell parentColumn="Size">
-        <Grid>
-          <Typography variant="body1" data-qa-size>
-            {readableBytes(size).formatted}
-          </Typography>
-        </Grid>
-      </TableCell>
       <TableCell parentColumn="Region">
         <Typography variant="body2" data-qa-region>
-          {formatRegion(region)}
+          {formatRegion(cluster)}
         </Typography>
       </TableCell>
       <TableCell parentColumn="Created">
@@ -102,12 +77,7 @@ export const BucketTableRow: React.StatelessComponent<
         />
       </TableCell>
       <TableCell>
-        <BucketActionMenu
-          onRemove={onRemove}
-          bucketLabel={label}
-          cluster={cluster}
-          data-qa-action-menu
-        />
+        <BucketActionMenu onRemove={onRemove} data-qa-action-menu />
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/services/objectStorage/buckets.ts
+++ b/packages/manager/src/services/objectStorage/buckets.ts
@@ -18,7 +18,6 @@ export interface BucketRequestPayload {
 export interface DeleteBucketRequestPayload {
   cluster: string;
   label: string;
-  params?: { force: number };
 }
 
 /**
@@ -54,19 +53,11 @@ export const createBucket = (data: BucketRequestPayload) =>
  *
  * Removes a Bucket from your account.
  *
- * NOTE: By default, attempting to delete a non-empty bucket
- * will result in an error. Passing `force: 1` as a param will
- * delete every item in the bucket, then delete the bucket itself.
- *
+ * NOTE: Attempting to delete a non-empty bucket will result in an error.
  */
-export const deleteBucket = ({
-  cluster,
-  label,
-  params
-}: DeleteBucketRequestPayload) =>
+export const deleteBucket = ({ cluster, label }: DeleteBucketRequestPayload) =>
   Request<Linode.Bucket>(
     setURL(`${BETA_API_ROOT}/object-storage/buckets/${cluster}/${label}`),
-    setParams(params),
     setMethod('DELETE')
   );
 

--- a/packages/manager/src/store/bucket/bucket.reducer.ts
+++ b/packages/manager/src/store/bucket/bucket.reducer.ts
@@ -81,8 +81,9 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       ...state,
       data: state.data.filter(
         bucket =>
-          // Buckets don't have IDs, so we look at the region and label to remove the deleted bucket from state
-          bucket.label !== params.label && bucket.region !== params.cluster
+          // Buckets don't have IDs, so we look at the cluster and label to
+          // remove the deleted bucket from state
+          !(bucket.label === params.label && bucket.cluster === params.cluster)
       )
     };
   }

--- a/packages/manager/src/types/ObjectStorage.ts
+++ b/packages/manager/src/types/ObjectStorage.ts
@@ -8,10 +8,7 @@ namespace Linode {
 
   export interface Bucket {
     label: string;
-    objects: number;
     created: string;
-    size: number;
-    region: string;
     cluster: string;
     hostname: string;
   }

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -221,6 +221,14 @@ export const sendDeleteBucketEvent = (eventLabel: string) => {
   });
 };
 
+export const sendDeleteBucketFailedEvent = (eventLabel: string) => {
+  sendEvent({
+    category: 'Object Storage',
+    action: 'Delete Bucket Failed',
+    label: eventLabel
+  });
+};
+
 // AccessKeyLanding.tsx
 export const sendCreateAccessKeyEvent = () => {
   sendEvent({


### PR DESCRIPTION
## Description

API is removing:

- bucket.region
- bucket.size
- bucket.objects
- The ability to force delete buckets (so we can no longer delete non-empty buckets)

Because of this, we need to:

- Remove "Size" column from Buckets Landing
- Remove "Objects" column from Buckets Landing
- Change deletion confirmation text so that we don't reference the objects and size

We should also probably add some helper text before attempting to delete a bucket, letting the user know the bucket needs to be empty first, but I'm waiting to hear from Jay about this. The API _does_ return a helpful message, so at least there's that.

## Type of Change
- Breaking change ('break', 'deprecate')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

In Charles, remove `region`, `size`, and `objects` from the response of `/object-storage/buckets`. Everything should still work correctly. Create buckets, delete them, etc.