### PR TITLE
OBJ: Use API response for pagination

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -199,8 +199,6 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
       page_size
     })
       .then(response => {
-        // If there are less results than the page size we requested, we know
-        // we've reached the end of the bucket (or folder).
         const allObjectsFetched = !response.is_truncated;
 
         // @todo @tdt: Extract this data-manipulation logic out of this

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -100,6 +100,7 @@ interface State {
   data: ExtendedObject[];
   loading: boolean;
   allObjectsFetched: boolean;
+  nextMarker: string | null;
   deleteObjectDialogOpen: boolean;
   deleteObjectLoading: boolean;
   deleteObjectError?: string;
@@ -113,6 +114,7 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
     data: [],
     loading: false,
     allObjectsFetched: false,
+    nextMarker: null,
     deleteObjectDialogOpen: false,
     deleteObjectLoading: false,
     generalError: undefined,
@@ -124,7 +126,6 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
     const prefix = getQueryParam(this.props.location.search, 'prefix');
 
     this.setState({
-      allObjectsFetched: false,
       loading: true,
       generalError: undefined,
       nextPageError: undefined,
@@ -135,20 +136,19 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
       .then(response => {
         // If there are less results than the page size we requested, we know
         // we've reached the end of the bucket (or folder).
-        const allObjectsFetched =
-          response.data.length < page_size ? true : false;
+        const allObjectsFetched = !response.is_truncated;
 
         // @todo @tdt: Extract this data-manipulation logic out of this
         // component and test.
         const extendedData = response.data.map(object =>
           extendObject(object, prefix)
         );
-        const sortedData = sortBy(prop('name'))(extendedData);
 
         this.setState({
           loading: false,
-          data: sortedData,
-          allObjectsFetched
+          data: extendedData,
+          allObjectsFetched,
+          nextMarker: response.next_marker
         });
       })
       .catch(err => {
@@ -173,9 +173,11 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
   }
 
   getNextPage = () => {
-    const { data } = this.state;
-    const tail = data[data.length - 1];
-    if (!tail) {
+    const { nextMarker } = this.state;
+
+    // If we don't have a nextMarker, there isn't another page to get.
+    // This probably won't happen.
+    if (!nextMarker) {
       return;
     }
 
@@ -193,14 +195,13 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
       // `marker` is used for Object Storage pagination. It is the name of
       // the last file of the current set. Specifying a marker will get you
       // the next page of objects after the marker.
-      marker: tail.name,
+      marker: nextMarker,
       page_size
     })
       .then(response => {
         // If there are less results than the page size we requested, we know
         // we've reached the end of the bucket (or folder).
-        const allObjectsFetched =
-          response.data.length < page_size ? true : false;
+        const allObjectsFetched = !response.is_truncated;
 
         // @todo @tdt: Extract this data-manipulation logic out of this
         // component and test.
@@ -212,7 +213,8 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
         this.setState({
           loading: false,
           data: [...this.state.data, ...sortedData],
-          allObjectsFetched
+          allObjectsFetched,
+          nextMarker: response.next_marker
         });
       })
       .catch(err => {
@@ -380,8 +382,8 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
                   </TableBody>
                 </Table>
                 {/* We shouldn't allow infinite scrolling if we're still loading,
-              if we've gotten all objects in the bucket (or folder), or if there
-              are errors. */}
+                if we've gotten all objects in the bucket (or folder), or if there
+                are errors. */}
                 {!loading &&
                   !allObjectsFetched &&
                   !generalError &&
@@ -404,8 +406,7 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
                 </Typography>
               )}
 
-              {/* Only display this message if there were more than 100 objects. */}
-              {allObjectsFetched && numOfDisplayedObjects > 100 && (
+              {allObjectsFetched && numOfDisplayedObjects >= 100 && (
                 <Typography variant="subtitle2" className={classes.footer}>
                   Showing all {numOfDisplayedObjects} items
                 </Typography>

--- a/packages/manager/src/services/objectStorage/buckets.ts
+++ b/packages/manager/src/services/objectStorage/buckets.ts
@@ -76,6 +76,12 @@ export interface ObjectListParams {
   prefix?: string;
   page_size?: number;
 }
+
+export interface ObjectListResponse {
+  data: Linode.Object[];
+  next_marker: string | null;
+  is_truncated: boolean;
+}
 /**
  * Returns a list of Objects in a given Bucket.
  */
@@ -84,7 +90,7 @@ export const getObjectList = (
   bucketName: string,
   params?: ObjectListParams
 ) =>
-  Request<{ data: Linode.Object[] }>(
+  Request<ObjectListResponse>(
     setMethod('GET'),
     setParams(params),
     setURL(


### PR DESCRIPTION
## Description

Recall that we were doing two hacks to help with OBJ pagination:

- Sorting the object list and using the name of the last file as a marker to get the next page.
- Assuming we've gotten all objects if the number of objects returned is less than the number we requested.

The API is now returning `next_marker` and `is_truncated` on the `/object-list` response. This means we can remove these hacks.

## Type of Chang
- Non breaking change ('update', 'change')

## Note to Reviewers

Look through buckets with many files to test. Feel free to use prod account 9, bucket name jc2 to see Cloud source code.
