### PR TITLE
LKE 938: Fix cell height when not in Cluster edit mode

### DIFF
--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -235,13 +235,14 @@ class LinodeTextField extends React.Component<CombinedProps> {
       <div
         className={classNames({
           [classes.helpWrapper]: Boolean(tooltipText),
-          [errorScrollClassName]: !!errorText,
-          [classes.wrapper]: true
+          [errorScrollClassName]: !!errorText
         })}
       >
-        <InputLabel data-qa-textfield-label>
-          {maybeRequiredLabel || ''}
-        </InputLabel>
+        {maybeRequiredLabel && (
+          <InputLabel data-qa-textfield-label className={classes.wrapper}>
+            {maybeRequiredLabel || ''}
+          </InputLabel>
+        )}
         {helperText && helperTextPosition === 'top' && (
           <FormHelperText
             data-qa-textfield-helper-text

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -337,6 +337,10 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: e =>
       `A node on NodeBalancer ${e.entity!.label} has been created.`
   },
+  nodebalancer_node_delete: {
+    notification: e =>
+      `A node on NodeBalancer ${e.entity!.label} has been deleted.`
+  },
   nodebalancer_node_update: {
     notification: e =>
       `A node on NodeBalancer ${e.entity!.label} has been updated.`

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -37,7 +37,6 @@ type ClassNames =
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {},
     link: {
       color: `${theme.palette.primary.main} !important` as any
     },
@@ -75,7 +74,8 @@ const styles = (theme: Theme) =>
       width: '20%'
     },
     regularCell: {
-      width: '25%'
+      width: '25%',
+      height: 70
     }
   });
 


### PR DESCRIPTION
## Description

- Keep the cell height consistent between modes in the edit Node Pools table
- Adjusted TextField styling (a margin was pushing the field down even when a label wasn't specified)
- Added handling for nodebalancer_node_delete events, which apparently exist.

## Type of Change
- Non breaking change ('update', 'change')
