### PR TITLE
LKE 775 Add helper text if not all nodes are accounted for

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -12,7 +12,9 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { displayPrice } from 'src/components/DisplayPrice';
+import HelpIcon from 'src/components/HelpIcon';
 import renderGuard, { RenderGuardProps } from 'src/components/RenderGuard';
+import SupportLink from 'src/components/SupportLink';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TextField from 'src/components/TextField';
@@ -103,6 +105,17 @@ export const getNodeStatus = (linodes: PoolNodeResponse[]) => {
   });
 };
 
+const tooltipText = (
+  <Typography>
+    Some of your nodes may not have been successfully created. Please open a
+    {` `}
+    <SupportLink
+      text="Support ticket."
+      title="Kubernetes Cluster nodes not created"
+    />
+  </Typography>
+);
+
 export const getStatusString = (
   count: number,
   linodes?: PoolNodeResponse[]
@@ -114,6 +127,24 @@ export const getStatusString = (
     return `${count} (0 up, ${count} down)`;
   }
   const status = getNodeStatus(linodes);
+
+  if (status.ready + status.not_ready !== count) {
+    // The API hasn't registered/created all of the nodes
+    return (
+      <>
+        <span>{`${count} (${status.ready} up, ${status.not_ready} down)`}</span>
+        <HelpIcon
+          text={tooltipText}
+          className={''}
+          tooltipPosition="right-start"
+          interactive
+          classes={''}
+        />
+      </>
+    );
+  }
+
+  // All systems normal.
   return `${count} (${status.ready} up, ${status.not_ready} down)`;
 };
 

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -124,28 +124,30 @@ export const getStatusString = (
     return '';
   }
   if (!linodes || linodes.length === 0) {
-    return `${count} (0 up, ${count} down)`;
+    return <Typography>{`${count} (0 up, ${count} down)`}</Typography>;
   }
   const status = getNodeStatus(linodes);
 
   if (status.ready + status.not_ready !== count) {
     // The API hasn't registered/created all of the nodes
     return (
-      <>
+      <Typography style={{ display: 'flex', alignItems: 'center' }}>
         <span>{`${count} (${status.ready} up, ${status.not_ready} down)`}</span>
         <HelpIcon
           text={tooltipText}
-          className={''}
           tooltipPosition="right-start"
           interactive
-          classes={''}
         />
-      </>
+      </Typography>
     );
   }
 
   // All systems normal.
-  return `${count} (${status.ready} up, ${status.not_ready} down)`;
+  return (
+    <Typography>{`${count} (${status.ready} up, ${
+      status.not_ready
+    } down)`}</Typography>
+  );
 };
 
 export const NodePoolRow: React.FunctionComponent<CombinedProps> = props => {
@@ -204,7 +206,7 @@ export const NodePoolRow: React.FunctionComponent<CombinedProps> = props => {
             }
           />
         ) : (
-          <Typography>{getStatusString(pool.count, pool.linodes)}</Typography>
+          getStatusString(pool.count, pool.linodes)
         )}
       </TableCell>
       <TableCell parentColumn="Pricing" className={classes.priceTableCell}>


### PR DESCRIPTION
## Description

Someone reported that their node status display was off (`17 (0 up, 14 down)`). It's not entirely clear what caused that case, but since those numbers are based off of different sources (`count` from the API vs. a sum of all the node pool statuses) it's possible that they'll diverge. If they're different, we can show helper text asking the user to open a support ticket.

## Note to Reviewers

You may have to mess with the logic to see the tooltip, since normal cluster creation and node pool editing don't seem to reproduce the reported issue.