### PR TITLE
Fix: No error handling for 404's on kubernetes/clusters/:clusterID

### DIFF
--- a/packages/manager/config/testSetup.js
+++ b/packages/manager/config/testSetup.js
@@ -28,6 +28,8 @@ const localStorageMock = (function() {
 
 Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 
+Object.defineProperty(window, 'URL', { value: { createObjectURL: jest.fn() } });
+
 HTMLCanvasElement.prototype.getContext = () => {
   return 0;
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -196,7 +196,11 @@ export const KubernetesClusterDetail: React.FunctionComponent<
   }, []);
 
   if (clustersLoadError) {
-    return <ErrorState errorText="Unable to load cluster data." />;
+    const error = getAPIErrorOrDefault(
+      clustersLoadError,
+      'Unable to load cluster data.'
+    )[0].reason;
+    return <ErrorState errorText={error} />;
   }
 
   if (
@@ -206,6 +210,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
   ) {
     return <CircleProgress />;
   }
+
   if (cluster === null) {
     return null;
   }

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLanding.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
 import ErrorState from 'src/components/ErrorState';
-import KubernetesContainer, {
+import withKubernetes, {
   DispatchProps,
   KubernetesProps
 } from 'src/containers/kubernetes.container';
@@ -65,24 +65,6 @@ export const KubernetesLanding: React.FunctionComponent<
   );
 };
 
-const withKubernetes = KubernetesContainer(
-  (
-    ownProps,
-    clustersLoading,
-    lastUpdated,
-    clustersError,
-    clusters,
-    nodePoolsLoading
-  ) => ({
-    ...ownProps,
-    clusters,
-    clustersError,
-    clustersLoading,
-    lastUpdated,
-    nodePoolsLoading
-  })
-);
-
-const enhanced = compose<CombinedProps, {}>(withKubernetes);
+const enhanced = compose<CombinedProps, {}>(withKubernetes());
 
 export default enhanced(KubernetesLanding);

--- a/packages/manager/src/store/kubernetes/kubernetes.actions.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.actions.ts
@@ -12,10 +12,6 @@ export const requestClustersActions = actionCreator.async<
   APIError[]
 >('request');
 
-export const addOrUpdateCluster = actionCreator<KubernetesCluster>(
-  'add_or_update'
-);
-
 export const upsertCluster = actionCreator<KubernetesCluster>(`upsert`);
 
 export const setErrors = actionCreator<EntityError>('set-errors');

--- a/packages/manager/src/store/kubernetes/kubernetes.actions.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.actions.ts
@@ -37,3 +37,9 @@ export const deleteClusterActions = actionCreator.async<
   {},
   APIError[]
 >(`delete-cluster`);
+
+export const requestClusterActions = actionCreator.async<
+  ClusterID,
+  KubernetesCluster,
+  APIError[]
+>('request-cluster');

--- a/packages/manager/src/store/kubernetes/kubernetes.reducer.test.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.reducer.test.ts
@@ -1,0 +1,82 @@
+import { extendedClusters } from 'src/__data__/kubernetes';
+
+import {
+  // addOrUpdateCluster,
+  deleteClusterActions,
+  // requestClusterActions,
+  requestClustersActions
+  // updateClusterActions,
+} from './kubernetes.actions';
+import reducer, { defaultState } from './kubernetes.reducer';
+
+const mockError = [{ reason: 'an error' }];
+
+const addEntities = () =>
+  reducer(
+    defaultState,
+    requestClustersActions.done({ result: extendedClusters })
+  );
+
+describe('Kubernetes clusters reducer', () => {
+  describe('Requesting all clusters', () => {
+    it('should set loading to true when starting the request', () => {
+      const newState = reducer(defaultState, requestClustersActions.started());
+      expect(newState.loading).toBe(true);
+    });
+
+    it('should handle a successful request', () => {
+      const newState = reducer(
+        { ...defaultState, loading: true },
+        requestClustersActions.done({ result: extendedClusters })
+      );
+      expect(newState.entities).toEqual(extendedClusters);
+      expect(newState.results).toHaveLength(extendedClusters.length);
+      expect(newState.loading).toBe(false);
+      expect(newState.lastUpdated).toBeGreaterThan(0);
+    });
+
+    it('should handle a failed request', () => {
+      const newState = reducer(
+        { ...defaultState, loading: true },
+        requestClustersActions.failed({ error: mockError })
+      );
+      expect(newState.error!.read).toEqual(mockError);
+      expect(newState.loading).toBe(false);
+    });
+  });
+
+  describe('deleting a cluster', () => {
+    it('should clear errors when starting the action', () => {
+      const newState = reducer(
+        { ...defaultState, error: { delete: mockError } },
+        deleteClusterActions.started({ clusterID: 1 })
+      );
+      expect(newState.error!.delete).toBeUndefined();
+    });
+
+    it('should remove the target cluster from state', () => {
+      const withEntities = addEntities();
+      const newState = reducer(
+        withEntities,
+        deleteClusterActions.done({
+          params: { clusterID: extendedClusters[1].id },
+          result: {}
+        })
+      );
+      expect(newState.entities).not.toContain(extendedClusters[1]);
+      expect(newState.results).not.toContain(extendedClusters[1].id);
+      expect(newState.results).toHaveLength(extendedClusters.length - 1);
+    });
+
+    it('should handle a failed deletion', () => {
+      const newState = reducer(
+        defaultState,
+        deleteClusterActions.failed({
+          params: { clusterID: 1 },
+          error: mockError
+        })
+      );
+      expect(newState.error!.delete).toEqual(mockError);
+    });
+  });
+});

--- a/packages/manager/src/store/kubernetes/kubernetes.reducer.test.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.reducer.test.ts
@@ -4,7 +4,7 @@ import {
   deleteClusterActions,
   requestClusterActions,
   requestClustersActions,
-  // updateClusterActions,
+  updateClusterActions,
   upsertCluster
 } from './kubernetes.actions';
 import reducer, { defaultState } from './kubernetes.reducer';
@@ -135,6 +135,41 @@ describe('Kubernetes clusters reducer', () => {
       );
       expect(newState.loading).toBe(false);
       expect(newState.error!.read).toEqual(mockError);
+    });
+  });
+
+  describe('Update cluster actions', () => {
+    it('should initiate an update', () => {
+      const newState = reducer(
+        { ...defaultState, error: { update: mockError } },
+        updateClusterActions.started({ clusterID: 1234 })
+      );
+      expect(newState.error!.update).toBeUndefined();
+    });
+
+    it('should handle a successful update', () => {
+      const withEntities = addEntities();
+      const updatedCluster = { ...extendedClusters[1], label: 'new-label' };
+      const newState = reducer(
+        withEntities,
+        updateClusterActions.done({
+          params: { clusterID: extendedClusters[1].id },
+          result: updatedCluster
+        })
+      );
+      expect(newState.error!.update).toBeUndefined();
+      expect(newState.entities).toContain(updatedCluster);
+    });
+
+    it('should handle a failed update', () => {
+      const newState = reducer(
+        defaultState,
+        updateClusterActions.failed({
+          params: { clusterID: 1234 },
+          error: mockError
+        })
+      );
+      expect(newState.error!.update).toEqual(mockError);
     });
   });
 });

--- a/packages/manager/src/store/kubernetes/kubernetes.reducer.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.reducer.ts
@@ -58,12 +58,21 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       draft.results = entities.map(cluster => cluster.id);
     }
 
+    if (isType(action, updateClusterActions.started)) {
+      draft.error!.update = undefined;
+    }
+
     if (isType(action, updateClusterActions.done)) {
       const { result } = action.payload;
       const update = updateOrAdd(result, state.entities);
 
       draft.entities = update;
       draft.results = update.map(cluster => cluster.id);
+    }
+
+    if (isType(action, updateClusterActions.failed)) {
+      const { error } = action.payload;
+      draft.error!.update = error;
     }
 
     if (isType(action, setErrors)) {


### PR DESCRIPTION
## Description

- Update kubernetes.container and typing to use updated patterns
- Add requestClusterActions and reducer handling
- Update kubernetes.reducer to use immer
- Use API error message (rather than generic) on error state for ClusterDetail
- Add a mock to setupTests.js to clear up a console error

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

Visit the cluster detail link for a cluster that you don't own or doesn't exist. You should see a "Not found" message. The rest of the LKE section should work as before despite refactors.

We don't seem to have a pattern for handling getOne errors in Redux. I used errors.read since that's what we're doing, but open to suggestions. 