### PR TITLE
[For release] Fix bug with table updates

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -34,7 +34,12 @@ import { getQueryParam } from 'src/utilities/queryParams';
 import { truncateMiddle } from 'src/utilities/truncate';
 import ObjectUploader from '../ObjectUploader';
 import { deleteObject } from '../requests';
-import { displayName, ExtendedObject, extendObject } from '../utilities';
+import {
+  displayName,
+  ExtendedObject,
+  extendObject,
+  getElementToAddToTable
+} from '../utilities';
 import BucketBreadcrumb from './BucketBreadcrumb';
 import ObjectTableContent from './ObjectTableContent';
 
@@ -308,15 +313,15 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
   };
 
   addOneFile = (objectName: string, sizeInBytes: number) => {
+    const prefix = getQueryParam(this.props.location.search, 'prefix');
+
     const object: Linode.Object = {
-      name: objectName,
+      name: prefix + objectName,
       etag: '',
       owner: '',
       last_modified: new Date().toISOString(),
       size: sizeInBytes
     };
-
-    const prefix = getQueryParam(this.props.location.search, 'prefix');
 
     const extendedObject = extendObject(object, prefix, true);
 
@@ -324,7 +329,9 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
 
     // If the file already exists in `data` (i.e. if the file is being
     // overwritten), move it from its current location to the front.
-    const idx = updatedFiles.findIndex(file => file.name === objectName);
+    const idx = updatedFiles.findIndex(
+      file => file.name === prefix + objectName
+    );
     if (idx > -1) {
       updatedFiles.splice(idx, 1);
       updatedFiles.unshift(extendedObject);
@@ -337,19 +344,21 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
   };
 
   addOneFolder = (objectName: string) => {
+    const prefix = getQueryParam(this.props.location.search, 'prefix');
+
     const folder: Linode.Object = {
-      name: objectName,
+      name: prefix + objectName + '/',
       etag: null,
       owner: null,
       last_modified: null,
       size: null
     };
 
-    const prefix = getQueryParam(this.props.location.search, 'prefix');
-
     const extendedFolder = extendObject(folder, prefix, true);
 
-    const idx = this.state.data.findIndex(object => object.name === objectName);
+    const idx = this.state.data.findIndex(
+      object => object.name === prefix + objectName + '/'
+    );
     // If the folder isn't already in `data`, add it to the front.
     if (idx === -1) {
       this.setState({ data: [extendedFolder, ...this.state.data] });
@@ -360,6 +369,18 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
     this.setState({
       deleteObjectDialogOpen: false
     });
+  };
+
+  maybeAddObjectToTable = (path: string, sizeInBytes: number) => {
+    const prefix = getQueryParam(this.props.location.search, 'prefix');
+    const action = getElementToAddToTable(prefix, path);
+    if (action) {
+      if (action.type === 'FILE') {
+        this.addOneFile(action.name, sizeInBytes);
+      } else {
+        this.addOneFolder(action.name);
+      }
+    }
   };
 
   render() {
@@ -414,8 +435,7 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
               clusterId={clusterId}
               bucketName={bucketName}
               prefix={prefix}
-              addOneFile={this.addOneFile}
-              addOneFolder={this.addOneFolder}
+              maybeAddObjectToTable={this.maybeAddObjectToTable}
             />
           </Grid>
           <Grid item xs={12} lg={8} className={classes.tableContainer}>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -38,7 +38,7 @@ import {
   displayName,
   ExtendedObject,
   extendObject,
-  getElementToAddToTable
+  tableUpdateAction
 } from '../utilities';
 import BucketBreadcrumb from './BucketBreadcrumb';
 import ObjectTableContent from './ObjectTableContent';
@@ -312,6 +312,18 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
     }
   };
 
+  maybeAddObjectToTable = (path: string, sizeInBytes: number) => {
+    const prefix = getQueryParam(this.props.location.search, 'prefix');
+    const action = tableUpdateAction(prefix, path);
+    if (action) {
+      if (action.type === 'FILE') {
+        this.addOneFile(action.name, sizeInBytes);
+      } else {
+        this.addOneFolder(action.name);
+      }
+    }
+  };
+
   addOneFile = (objectName: string, sizeInBytes: number) => {
     const prefix = getQueryParam(this.props.location.search, 'prefix');
 
@@ -369,18 +381,6 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
     this.setState({
       deleteObjectDialogOpen: false
     });
-  };
-
-  maybeAddObjectToTable = (path: string, sizeInBytes: number) => {
-    const prefix = getQueryParam(this.props.location.search, 'prefix');
-    const action = getElementToAddToTable(prefix, path);
-    if (action) {
-      if (action.type === 'FILE') {
-        this.addOneFile(action.name, sizeInBytes);
-      } else {
-        this.addOneFolder(action.name);
-      }
-    }
   };
 
   render() {

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -141,14 +141,13 @@ interface Props {
   clusterId: string;
   bucketName: string;
   prefix: string;
-  addOneFile: (fileName: string, sizeInBytes: number) => void;
-  addOneFolder: (folderName: string) => void;
+  maybeAddObjectToTable: (path: string, sizeInBytes: number) => void;
 }
 
 type CombinedProps = Props & WithSnackbarProps;
 
 const ObjectUploader: React.FC<CombinedProps> = props => {
-  const { clusterId, bucketName, prefix, addOneFile, addOneFolder } = props;
+  const { clusterId, bucketName, prefix } = props;
 
   const classes = useStyles();
 
@@ -241,17 +240,7 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
       const onUploadProgress = onUploadProgressFactory(dispatch, path);
 
       const handleSuccess = () => {
-        if (isInFolder) {
-          // Determine if the path is a nested folder (2+ levels deep). If so,
-          // add a folder to the object table.
-          const pathAsArray = path.split('/');
-          if (pathAsArray.length <= 3) {
-            const folderName = pathAsArray[1] || '';
-            addOneFolder(fileUpload.prefix + folderName + '/');
-          }
-        } else {
-          addOneFile(fullObjectName, file.size);
-        }
+        props.maybeAddObjectToTable(fullObjectName, file.size);
 
         dispatch({
           type: 'UPDATE_FILES',

--- a/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectUploader/ObjectUploader.tsx
@@ -240,6 +240,9 @@ const ObjectUploader: React.FC<CombinedProps> = props => {
       const onUploadProgress = onUploadProgressFactory(dispatch, path);
 
       const handleSuccess = () => {
+        // We may want to add the object to the table, depending on the prefix
+        // the user is currently viewing. Do this in the parent, which has the
+        // current prefix in scope.
         props.maybeAddObjectToTable(fullObjectName, file.size);
 
         dispatch({

--- a/packages/manager/src/features/ObjectStorage/utilities.test.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.test.ts
@@ -2,6 +2,9 @@ import {
   basename,
   displayName,
   extendObject,
+  firstSubfolder,
+  getElementToAddToTable,
+  isFile,
   isFolder,
   prefixArrayToString
 } from './utilities';
@@ -124,6 +127,71 @@ describe('Object Storage utilities', () => {
     });
     it('ignores trailing slashes', () => {
       expect(displayName('hello/world.jpg')).toBe('world.jpg');
+    });
+  });
+
+  describe('getElementToAddToTable', () => {
+    it('should return files', () => {
+      expect(getElementToAddToTable('', 'file.txt')).toEqual({
+        type: 'FILE',
+        name: 'file.txt'
+      });
+      expect(getElementToAddToTable('hello/', 'hello/file.txt')).toEqual({
+        type: 'FILE',
+        name: 'file.txt'
+      });
+      expect(
+        getElementToAddToTable('hello/world/', 'hello/world/file.txt')
+      ).toEqual({
+        type: 'FILE',
+        name: 'file.txt'
+      });
+    });
+
+    it('should return folders', () => {
+      expect(getElementToAddToTable('', 'hello/file.txt')).toEqual({
+        type: 'FOLDER',
+        name: 'hello'
+      });
+      expect(getElementToAddToTable('hello/', 'hello/world/file.txt')).toEqual({
+        type: 'FOLDER',
+        name: 'world'
+      });
+      expect(
+        getElementToAddToTable('hello/world/', 'hello/world/path/file.txt')
+      ).toEqual({
+        type: 'FOLDER',
+        name: 'path'
+      });
+    });
+
+    it('returns null if the prefix does not match', () => {
+      expect(getElementToAddToTable('another/path', 'hello/file.txt')).toBe(
+        null
+      );
+      expect(getElementToAddToTable('some/', 'hello/file.txt')).toBe(null);
+      expect(
+        getElementToAddToTable('some/another/path', 'another/path/file.txt')
+      ).toBe(null);
+    });
+  });
+
+  describe('isFile', () => {
+    it('should return true for folders', () => {
+      expect(isFile('file.txt')).toBe(true);
+      expect(isFile('file')).toBe(true);
+      expect(isFile('file')).toBe(true);
+      expect(isFile('folder/file')).toBe(false);
+      expect(isFile('folder/file.txt')).toBe(false);
+      expect(isFile('folder/path/file.txt')).toBe(false);
+    });
+  });
+
+  describe('firstSubfolder', () => {
+    it('should return the first subfolder in a given path', () => {
+      expect(firstSubfolder('path/file1')).toBe('path');
+      expect(firstSubfolder('path1/path2/file.txt')).toBe('path1');
+      expect(firstSubfolder('file1')).toBe('file1');
     });
   });
 });

--- a/packages/manager/src/features/ObjectStorage/utilities.test.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.test.ts
@@ -3,10 +3,10 @@ import {
   displayName,
   extendObject,
   firstSubfolder,
-  getElementToAddToTable,
   isFile,
   isFolder,
-  prefixArrayToString
+  prefixArrayToString,
+  tableUpdateAction
 } from './utilities';
 
 const folder: Linode.Object = {
@@ -132,33 +132,33 @@ describe('Object Storage utilities', () => {
 
   describe('getElementToAddToTable', () => {
     it('should return files', () => {
-      expect(getElementToAddToTable('', 'file.txt')).toEqual({
+      expect(tableUpdateAction('', 'file.txt')).toEqual({
         type: 'FILE',
         name: 'file.txt'
       });
-      expect(getElementToAddToTable('hello/', 'hello/file.txt')).toEqual({
+      expect(tableUpdateAction('hello/', 'hello/file.txt')).toEqual({
         type: 'FILE',
         name: 'file.txt'
       });
-      expect(
-        getElementToAddToTable('hello/world/', 'hello/world/file.txt')
-      ).toEqual({
-        type: 'FILE',
-        name: 'file.txt'
-      });
+      expect(tableUpdateAction('hello/world/', 'hello/world/file.txt')).toEqual(
+        {
+          type: 'FILE',
+          name: 'file.txt'
+        }
+      );
     });
 
     it('should return folders', () => {
-      expect(getElementToAddToTable('', 'hello/file.txt')).toEqual({
+      expect(tableUpdateAction('', 'hello/file.txt')).toEqual({
         type: 'FOLDER',
         name: 'hello'
       });
-      expect(getElementToAddToTable('hello/', 'hello/world/file.txt')).toEqual({
+      expect(tableUpdateAction('hello/', 'hello/world/file.txt')).toEqual({
         type: 'FOLDER',
         name: 'world'
       });
       expect(
-        getElementToAddToTable('hello/world/', 'hello/world/path/file.txt')
+        tableUpdateAction('hello/world/', 'hello/world/path/file.txt')
       ).toEqual({
         type: 'FOLDER',
         name: 'path'
@@ -166,18 +166,16 @@ describe('Object Storage utilities', () => {
     });
 
     it('returns null if the prefix does not match', () => {
-      expect(getElementToAddToTable('another/path', 'hello/file.txt')).toBe(
-        null
-      );
-      expect(getElementToAddToTable('some/', 'hello/file.txt')).toBe(null);
+      expect(tableUpdateAction('another/path', 'hello/file.txt')).toBe(null);
+      expect(tableUpdateAction('some/', 'hello/file.txt')).toBe(null);
       expect(
-        getElementToAddToTable('some/another/path', 'another/path/file.txt')
+        tableUpdateAction('some/another/path', 'another/path/file.txt')
       ).toBe(null);
     });
   });
 
   describe('isFile', () => {
-    it('should return true for folders', () => {
+    it('should return true for files and false for folders', () => {
       expect(isFile('file.txt')).toBe(true);
       expect(isFile('file')).toBe(true);
       expect(isFile('file')).toBe(true);

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -89,3 +89,25 @@ export const displayName = (objectName: string) => {
     ? basename(objectName.substr(0, objectName.length - 1))
     : basename(objectName);
 };
+
+export const getElementToAddToTable = (
+  currentPrefix: string,
+  objectName: string
+) => {
+  if (objectName.startsWith(currentPrefix) || currentPrefix === '') {
+    // If the prefix matches the beginning of the objectName, we "subtract" it
+    // from the objectName, and make decisions based on that.
+    const delta = objectName.slice(currentPrefix.length);
+
+    if (isFile(delta)) {
+      return { type: 'FILE', name: delta };
+    } else {
+      return { type: 'FOLDER', name: firstSubfolder(delta) };
+    }
+  }
+  return null;
+};
+
+export const isFile = (path: string) => path.split('/').length < 2;
+
+export const firstSubfolder = (path: string) => path.split('/')[0];

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -90,13 +90,18 @@ export const displayName = (objectName: string) => {
     : basename(objectName);
 };
 
-export const getElementToAddToTable = (
+// Given a prefix and an object name, determine table update action to take once
+// the upload is successful.
+export const tableUpdateAction = (
   currentPrefix: string,
   objectName: string
-) => {
+): null | { type: 'FILE' | 'FOLDER'; name: string } => {
   if (objectName.startsWith(currentPrefix) || currentPrefix === '') {
     // If the prefix matches the beginning of the objectName, we "subtract" it
     // from the objectName, and make decisions based on that.
+
+    // Example: if the current prefix is 'my-folder/' and the objectName is
+    // 'my-folder/my-file.txt', we just need to look at 'my-file.txt'.
     const delta = objectName.slice(currentPrefix.length);
 
     if (isFile(delta)) {


### PR DESCRIPTION
## Description

This PR fixes a bug where successfully uploaded objects might not appear in the correct place in the Object Table once the upload was successful.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

## Note to Reviewers

**To test:**

Look at the new unit tests to see how the helper functions should behave.

While object uploads are in progress, navigate to different directories in your bucket. The newly uploaded objects should only appear if they belong in a directory you're currently viewing.

Try uploaded whole folders, duplicates, etc. Compare with a tool like CyberDuck to make sure the uploads ended up in the correct place. Refresh the page, download, delete files, etc.
