### PR TITLE
M3-2042 & M3-3296: Nodebalancer create- label wrapping issue & Dashboard FF mobile issue

### DIFF
--- a/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -57,7 +57,11 @@ const styles = (theme: Theme) =>
       paddingRight: '4px !important'
     },
     description: {
-      paddingTop: theme.spacing(1) / 2
+      paddingTop: theme.spacing(1) / 2,
+      [theme.breakpoints.down('sm')]: {
+        // Firefox only
+        overflowWrap: 'anywhere'
+      }
     },
     labelCol: {
       width: '70%'

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -73,12 +73,12 @@ const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
       }}
       labelOverride={linode => {
         return (
-          <span>
+          <div>
             <strong>
               {linode.ipv4.find(eachIP => eachIP.match(privateIPRegex))}
             </strong>
-            {` ${linode.label}`}
-          </span>
+            <div style={{ display: 'block' }}>{` ${linode.label}`}</div>
+          </div>
         );
       }}
       filterCondition={linode => {

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -2,9 +2,25 @@ import { Linode } from 'linode-js-sdk/lib/linodes';
 import * as React from 'react';
 import { compose } from 'recompose';
 
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+
 import { Props as TextFieldProps } from 'src/components/TextField';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
 import { privateIPRegex } from 'src/utilities/ipUtils';
+
+type ClassNames = 'labelOuter';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    labelOuter: {
+      display: 'block'
+    }
+  });
 
 interface Props {
   selectedRegion?: string;
@@ -16,12 +32,13 @@ interface Props {
   textfieldProps: TextFieldProps;
 }
 
-type CombinedProps = Props;
+type CombinedProps = WithStyles<ClassNames> & Props;
 
 const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
   const [selectedLinode, setSelectedLinode] = React.useState<number | null>(
     null
   );
+  const { classes } = props;
 
   const handleChange = (linode: Linode) => {
     setSelectedLinode(linode.id);
@@ -77,7 +94,7 @@ const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
             <strong>
               {linode.ipv4.find(eachIP => eachIP.match(privateIPRegex))}
             </strong>
-            <div style={{ display: 'block' }}>{` ${linode.label}`}</div>
+            <div className={classes.labelOuter}>{` ${linode.label}`}</div>
           </div>
         );
       }}
@@ -96,4 +113,9 @@ const ConfigNodeIPSelect: React.FC<CombinedProps> = props => {
   );
 };
 
-export default compose<CombinedProps, Props>(React.memo)(ConfigNodeIPSelect);
+const styled = withStyles(styles);
+
+export default compose<CombinedProps, Props>(
+  React.memo,
+  styled
+)(ConfigNodeIPSelect);

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -942,26 +942,27 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                   disabled={disabled}
                                 />
                               </Grid>
-
-                              <Grid item xs={6} sm={4} lg={2}>
-                                <Typography
-                                  variant="h3"
-                                  data-qa-active-checks-header
-                                  className={classes.statusHeader}
-                                >
-                                  Status
-                                  <div>
-                                    <Chip
-                                      className={`
+                              {node.status && (
+                                <Grid item xs={6} sm={4} lg={2}>
+                                  <Typography
+                                    variant="h3"
+                                    data-qa-active-checks-header
+                                    className={classes.statusHeader}
+                                  >
+                                    Status
+                                    <div>
+                                      <Chip
+                                        className={`
                                           ${classes.statusChip}
                                           ${classes[`chip-${node.status}`]}
                                         `}
-                                      label={node.status}
-                                      component="div"
-                                    />
-                                  </div>
-                                </Typography>
-                              </Grid>
+                                        label={node.status}
+                                        component="div"
+                                      />
+                                    </div>
+                                  </Typography>
+                                </Grid>
+                              )}
                             </Grid>
                           </Grid>
                           <Grid item xs={12}>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -375,7 +375,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
     });
 
     return (
-      <Grid item xs={12} md={4}>
+      <Grid item xs={12} md={6}>
         <Grid container>
           <Grid
             updateFor={[classes]} // never update after initial render

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -56,6 +56,10 @@ const styles = (theme: Theme) =>
       },
       [theme.breakpoints.down('xs')]: {
         marginTop: 0
+      },
+      '& .remove': {
+        margin: 0,
+        padding: theme.spacing(2.5)
       }
     },
     suggestionsParent: {
@@ -97,7 +101,8 @@ const styles = (theme: Theme) =>
     },
     statusHeader: {
       fontSize: '.9rem',
-      color: theme.color.label
+      color: theme.color.label,
+      marginTop: theme.spacing(2) - 4
     },
     statusChip: {
       marginTop: theme.spacing(1),
@@ -108,7 +113,7 @@ const styles = (theme: Theme) =>
       }
     },
     passiveChecks: {
-      marginTop: theme.spacing(1)
+      marginTop: theme.spacing(2.5)
     }
   });
 
@@ -937,27 +942,26 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                   disabled={disabled}
                                 />
                               </Grid>
-                              {node.status && (
-                                <Grid item xs={6} sm={4} lg={2}>
-                                  <Typography
-                                    variant="h3"
-                                    data-qa-active-checks-header
-                                    className={classes.statusHeader}
-                                  >
-                                    Status
-                                    <div>
-                                      <Chip
-                                        className={`
+
+                              <Grid item xs={6} sm={4} lg={2}>
+                                <Typography
+                                  variant="h3"
+                                  data-qa-active-checks-header
+                                  className={classes.statusHeader}
+                                >
+                                  Status
+                                  <div>
+                                    <Chip
+                                      className={`
                                           ${classes.statusChip}
                                           ${classes[`chip-${node.status}`]}
                                         `}
-                                        label={node.status}
-                                        component="div"
-                                      />
-                                    </div>
-                                  </Typography>
-                                </Grid>
-                              )}
+                                      label={node.status}
+                                      component="div"
+                                    />
+                                  </div>
+                                </Typography>
+                              </Grid>
                             </Grid>
                           </Grid>
                           <Grid item xs={12}>

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -705,6 +705,7 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
       },
       MuiFormHelperText: {
         root: {
+          maxWidth: 415,
           fontSize: '0.875rem',
           '&$error': {
             color: '#ca0813'


### PR DESCRIPTION
## Description

This PR addresses 2 separate issues; please see tickets for more details.

• On Nodebalancer create workflow under 'Backend Nodes' selection, if the linode label was a bit longer it was wrapping weirdly. Now the label is display blocked on its own line.

• The other issue was occurring on Firefox mobile screen sizes. On dashboard, Nodebalancer links were pushing the table and not wrapping as expected. 

## Type of Change
- Non breaking change ('update')