### PR TITLE
Change: Request Firewall Devices on Mount

### DIFF
--- a/packages/linode-js-sdk/src/firewalls/firewalls.ts
+++ b/packages/linode-js-sdk/src/firewalls/firewalls.ts
@@ -7,7 +7,7 @@
 //   setXFilter
 // } from '../request';
 import { ResourcePage as Page } from '../types';
-import { Firewall } from './types';
+import { Firewall, FirewallDevice } from './types';
 
 /**
  * mocked GET firewalls
@@ -29,4 +29,20 @@ export const getFirewalls = (
   }).then((data: any) => {
     return data;
   });
+};
+
+export const getFirewallDevices = (
+  id: number,
+  mockData: FirewallDevice[]
+): Promise<Page<FirewallDevice>> => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve({
+        data: mockData,
+        page: 1,
+        pages: 1,
+        results: mockData.length
+      });
+    });
+  }).then((data: any) => data);
 };

--- a/packages/linode-js-sdk/src/firewalls/types.ts
+++ b/packages/linode-js-sdk/src/firewalls/types.ts
@@ -10,7 +10,6 @@ export interface Firewall {
   rules: FirewallRules;
   created_dt: string;
   updated_dt: string;
-  devices: FirewallDevices;
 }
 
 export interface FirewallRules {
@@ -28,6 +27,14 @@ export interface FirewallRuleType {
   };
 }
 
-export interface FirewallDevices {
-  linodes?: number[];
+export interface FirewallDeviceEntity {
+  id: number;
+  type: 'linode' | 'nodebalancer';
+  label: string;
+  url: string;
+}
+
+export interface FirewallDevice {
+  id: number;
+  entity: FirewallDeviceEntity;
 }

--- a/packages/manager/src/__data__/firewallDevices.ts
+++ b/packages/manager/src/__data__/firewallDevices.ts
@@ -1,0 +1,23 @@
+import { FirewallDevice } from 'linode-js-sdk/lib/firewalls';
+
+export const device: FirewallDevice = {
+  id: 1,
+  entity: {
+    id: 16621754,
+    url: 'v4/linode/instances/16621754',
+    type: 'linode' as any,
+    label: 'Some Linode'
+  }
+};
+
+export const device2: FirewallDevice = {
+  id: 2,
+  entity: {
+    id: 15922741,
+    url: 'v4/linode/instances/15922741',
+    type: 'linode' as any,
+    label: 'Other Linode'
+  }
+};
+
+export const devices = [device, device2];

--- a/packages/manager/src/__data__/firewalls.ts
+++ b/packages/manager/src/__data__/firewalls.ts
@@ -8,9 +8,6 @@ export const firewall: Firewall = {
   created_dt: '2019-09-11T19:44:38.526Z',
   updated_dt: '2019-09-11T19:44:38.526Z',
   tags: [],
-  devices: {
-    linodes: [16621754, 15922741]
-  },
   rules: {
     inbound: [
       {
@@ -38,9 +35,6 @@ export const firewall2: Firewall = {
   created_dt: '2019-12-11T19:44:38.526Z',
   updated_dt: '2019-12-11T19:44:38.526Z',
   tags: [],
-  devices: {
-    linodes: [15922741]
-  },
   rules: {
     inbound: [],
     outbound: [

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.test.ts
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.test.ts
@@ -1,10 +1,10 @@
 import { firewalls } from 'src/__data__/firewalls';
-import { getCountOfRules, getRuleString } from './FirewallTableRows';
+import { getCountOfRules, getRuleString } from './FirewallRow';
 
 describe('Utility functions', () => {
   it('should return correct number of inbound and outbound rules', () => {
-    expect(getCountOfRules(firewalls[0])).toEqual([1, 1]);
-    expect(getCountOfRules(firewalls[1])).toEqual([0, 2]);
+    expect(getCountOfRules(firewalls[0].rules)).toEqual([1, 1]);
+    expect(getCountOfRules(firewalls[1].rules)).toEqual([0, 2]);
   });
 
   it('should return the correct string given an array of numbers', () => {

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallRow.tsx
@@ -1,0 +1,139 @@
+import {
+  Firewall,
+  FirewallDevice,
+  getFirewallDevices as _getDevices
+} from 'linode-js-sdk/lib/firewalls';
+import { APIError } from 'linode-js-sdk/lib/types';
+import { take } from 'ramda';
+import * as React from 'react';
+import { compose } from 'recompose';
+
+import TableRow from 'src/components/core/TableRow';
+import TableCell from 'src/components/TableCell';
+
+import ActionMenu, { ActionHandlers } from './FirewallActionMenu';
+
+import { devices as mockDevices } from 'src/__data__/firewallDevices';
+
+interface Props extends ActionHandlers {
+  firewallID: number;
+  firewallLabel: string;
+  firewallStatus: Firewall['status'];
+  firewallRules: Firewall['rules'];
+}
+
+type CombinedProps = Props;
+
+const FirewallRow: React.FC<CombinedProps> = props => {
+  const {
+    firewallID,
+    firewallLabel,
+    firewallStatus,
+    firewallRules,
+    ...actionHandlers
+  } = props;
+
+  const [devicesLoading, setDevicesLoading] = React.useState<boolean>(false);
+  const [devicesError, setDevicesError] = React.useState<
+    APIError[] | undefined
+  >(undefined);
+  const [devices, setDevices] = React.useState<FirewallDevice[]>([]);
+
+  const getFirewallDevices = () => {
+    setDevicesLoading(true);
+
+    _getDevices(1, mockDevices)
+      .then(({ data }) => {
+        setDevices(data);
+        setDevicesLoading(false);
+      })
+      .catch((e: APIError[]) => {
+        setDevicesError(e);
+        setDevicesLoading(false);
+      });
+  };
+
+  React.useEffect(() => {
+    getFirewallDevices();
+  }, []);
+
+  const count = getCountOfRules(firewallRules);
+
+  return (
+    <TableRow key={`firewall-row-${firewallID}`}>
+      <TableCell>{firewallLabel}</TableCell>
+      <TableCell>{firewallStatus}</TableCell>
+      <TableCell>{getRuleString(count)}</TableCell>
+      <TableCell>
+        {getLinodesCellString(devices, devicesLoading, devicesError)}
+      </TableCell>
+      <TableCell>
+        <ActionMenu
+          firewallID={firewallID}
+          firewallLabel={firewallLabel}
+          firewallStatus={firewallStatus}
+          {...actionHandlers}
+        />
+      </TableCell>
+    </TableRow>
+  );
+};
+
+/**
+ *
+ * outputs either
+ *
+ * 1 Inbound / 2 Outbound
+ *
+ * 1 Inbound
+ *
+ * 3 Outbound
+ */
+export const getRuleString = (count: [number, number]) => {
+  const [inbound, outbound] = count;
+
+  let string = '';
+
+  if (inbound !== 0 && outbound !== 0) {
+    return `${inbound} Inbound / ${outbound} Outbound`;
+  } else if (inbound !== 0) {
+    string = `${inbound} Inbound`;
+  } else if (outbound !== 0) {
+    string += `${outbound} Outbound`;
+  }
+  return string;
+};
+
+export const getCountOfRules = (rules: Firewall['rules']): [number, number] => {
+  return [(rules.inbound || []).length, (rules.outbound || []).length];
+};
+
+const getLinodesCellString = (
+  data: FirewallDevice[],
+  loading: boolean,
+  error?: APIError[]
+): string => {
+  if (loading) {
+    return 'Loading...';
+  }
+
+  if (error) {
+    return 'Error retrieving Linodes';
+  }
+
+  if (data.length === 0) {
+    return 'None assigned';
+  }
+
+  const howManyDevicesMinusThree = data.length - 3;
+
+  const firstThreeLabels = take(3, data).map(
+    (e: FirewallDevice) => e.entity.label
+  );
+
+  return howManyDevicesMinusThree > 0
+    ? `${firstThreeLabels.join(', ')}, plus ${howManyDevicesMinusThree} more`
+    : firstThreeLabels.join(', ');
+};
+
+export default compose<CombinedProps, Props>(React.memo)(FirewallRow);

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTableRows.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTableRows.tsx
@@ -1,35 +1,23 @@
-import { Firewall } from 'linode-js-sdk/lib/firewalls';
-import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
-// import { makeStyles, Theme } from 'src/components/core/styles'
 
-import TableRow from 'src/components/core/TableRow';
-import TableCell from 'src/components/TableCell';
 import TableRowEmpty from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 
 import { Props as FireProps } from 'src/containers/firewalls.container';
-import withLinodes, {
-  Props as LinodeProps
-} from 'src/containers/withLinodes.container';
 import { FirewallWithSequence } from 'src/store/firewalls/firewalls.reducer';
-import ActionMenu, { ActionHandlers } from './FirewallActionMenu';
+import { ActionHandlers } from './FirewallActionMenu';
 
-// const useStyles = makeStyles((theme: Theme) => ({
-//   root: {}
-// }))
+import FirewallRow from './FirewallRow';
 
 interface Props extends Omit<FireProps, 'data' | 'results' | 'getFirewalls'> {
   data: FirewallWithSequence[];
 }
 
-type CombinedProps = Props & LinodeProps & ActionHandlers;
+type CombinedProps = Props & ActionHandlers;
 
 const FirewallTableRows: React.FC<CombinedProps> = props => {
-  // const classes = useStyles();
-
   const {
     data: firewalls,
     loading: firewallsLoading,
@@ -61,99 +49,21 @@ const FirewallTableRows: React.FC<CombinedProps> = props => {
   return (
     <React.Fragment>
       {firewalls.map(eachFirewall => {
-        const count = getCountOfRules(eachFirewall);
         return (
-          <TableRow key={`firewall-row-${eachFirewall.id}`}>
-            <TableCell>{eachFirewall.label}</TableCell>
-            <TableCell>{eachFirewall.status}</TableCell>
-            <TableCell>{getRuleString(count)}</TableCell>
-            <TableCell>
-              {getLinodesCellString(
-                props.linodesData,
-                props.linodesLoading && props.linodesLastUpdated === 0,
-                props.linodesError,
-                pathOr([], ['devices', 'linodes'], eachFirewall)
-              )}
-            </TableCell>
-            <TableCell>
-              <ActionMenu
-                firewallID={eachFirewall.id}
-                firewallLabel={eachFirewall.label}
-                firewallStatus={eachFirewall.status}
-                {...actionMenuHandlers}
-              />
-            </TableCell>
-          </TableRow>
+          <FirewallRow
+            key={`firewall-row-${eachFirewall.id}`}
+            firewallID={eachFirewall.id}
+            firewallLabel={eachFirewall.label}
+            firewallRules={eachFirewall.rules}
+            firewallStatus={eachFirewall.status}
+            {...actionMenuHandlers}
+          />
         );
       })}
     </React.Fragment>
   );
 };
 
-/**
- *
- * outputs either
- *
- * 1 Inbound / 2 Outbound
- *
- * 1 Inbound
- *
- * 3 Outbound
- */
-export const getRuleString = (count: [number, number]) => {
-  const [inbound, outbound] = count;
-
-  let string = '';
-
-  if (inbound !== 0 && outbound !== 0) {
-    return `${inbound} Inbound / ${outbound} Outbound`;
-  } else if (inbound !== 0) {
-    string = `${inbound} Inbound`;
-  } else if (outbound !== 0) {
-    string += `${outbound} Outbound`;
-  }
-  return string;
-};
-
-export const getCountOfRules = (firewall: Firewall): [number, number] => {
-  return [
-    (firewall.rules.inbound || []).length,
-    (firewall.rules.outbound || []).length
-  ];
-};
-
-const getLinodesCellString = (
-  data: LinodeProps['linodesData'],
-  loading: LinodeProps['linodesLoading'],
-  error: LinodeProps['linodesError'],
-  firewallLinodeIDs: number[]
-): string => {
-  if (loading) {
-    return 'Loading...';
-  }
-
-  if (error) {
-    return 'Error retrieving Linodes';
-  }
-
-  return firewallLinodeIDs
-    .reduce(
-      (acc, eachLinodeID) => {
-        const foundLinode = data.find(
-          eachLinode => eachLinode.id === eachLinodeID
-        );
-
-        if (foundLinode) {
-          acc.push(foundLinode.label);
-        }
-        return acc;
-      },
-      [] as string[]
-    )
-    .join(', ');
-};
-
-export default compose<CombinedProps, Props & ActionHandlers>(
-  withLinodes(),
-  React.memo
-)(FirewallTableRows);
+export default compose<CombinedProps, Props & ActionHandlers>(React.memo)(
+  FirewallTableRows
+);

--- a/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
+++ b/packages/manager/src/store/firewalls/firewalls.reducer.test.ts
@@ -24,8 +24,7 @@ const baseFirewall: Firewall[] = [
     label: 'zzz',
     created_dt: '2019-12-11T19:44:38.526Z',
     updated_dt: '2019-12-11T19:44:38.526Z',
-    tags: [],
-    devices: {}
+    tags: []
   }
 ];
 
@@ -76,8 +75,7 @@ describe('Cloud Firewalls Reducer', () => {
         label: 'zzz',
         created_dt: '2019-12-11T19:44:38.526Z',
         updated_dt: '2019-12-11T19:44:38.526Z',
-        tags: [],
-        devices: {}
+        tags: []
       }
     });
     expect(newState).toHaveProperty('loading', false);


### PR DESCRIPTION
## Description

Firewall devices are no longer included in the `GET /firewalls` request, so we need to make a `GET /firewalls/$id/devices` request for each firewall.

## Type of Change
- Non breaking change ('update', 'change')