### PR TITLE
M3-3360 fixing MX priority field

### DIFF
--- a/packages/linode-js-sdk/src/domains/records.schema.ts
+++ b/packages/linode-js-sdk/src/domains/records.schema.ts
@@ -5,7 +5,7 @@ const recordBaseSchema = object().shape({
   target: string(),
   priority: number()
     .min(0, 'Priority must be between 0 and 255.')
-    .max(255, 'Priority must be between 1 and 255.'),
+    .max(255, 'Priority must be between 0 and 255.'),
   weight: number(),
   port: number(),
   service: string().nullable(true),

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -32,7 +32,6 @@ import {
   DomainActionsProps,
   withDomainActions
 } from 'src/store/domains/domains.container';
-import defaultNumeric from 'src/utilities/defaultNumeric';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
@@ -198,10 +197,6 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
   );
 
   NumberField = ({ label, field }: NumberFieldProps) => {
-    const defaultValue: number = DomainRecordDrawer.defaultFieldsState(
-      this.props
-    )[field];
-
     return (
       <TextField
         label={label}
@@ -210,9 +205,9 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
           DomainRecordDrawer.errorFields,
           this.state.errors
         )(field)}
-        value={defaultTo(defaultValue, this.state.fields[field])}
+        value={this.state.fields[field]}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-          this.updateField(field)(defaultNumeric(defaultValue, e.target.value))
+          this.updateField(field)(+e.target.value)
         }
         data-qa-target={label}
       />


### PR DESCRIPTION
## Description

Adjusted the MX and SRV record fields to accept values between 0-255.
Modified error message to display 'Priority must be between 0 and 255.'
The API is limiting this value between 0-255

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --file folder/"spec name"`

## Note to Reviewers

To test this you will need to create a domain record 
Go to the details of the domain record
MX drawer test:
1. Add an MX record 
2. Set a mail server 
3. Set preference to 256
4. Select Save
5. Error will be displayed 'Priority must be between 0 and 255.'
6. Enter a value of 0 and save

SRV record test:
1. Add an SRV record 
2. Set a service and target value
3. Set priority to 256
4. Select Save
5. Error will be displayed 'Priority must be between 0 and 255.'
6. Enter a value of 0 and save


