### PR TITLE
M3-3228 Add warning when user creates a new snapshot

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
@@ -27,10 +27,6 @@ interface Props {
   error?: string;
   onClose: () => void;
   onSnapshot: () => void;
-  // onDelete: () => void;
-  // volumeLabel: string;
-  // linodeLabel: string;
-  // poweredOff: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
@@ -22,7 +22,6 @@ const styles = (theme: Theme) =>
 
 interface Props {
   open: boolean;
-  loading: boolean;
   error?: string;
   onClose: () => void;
   onSnapshot: () => void;
@@ -30,7 +29,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
+class DestructiveSnapshotDialog extends React.PureComponent<CombinedProps, {}> {
   renderActions = () => {
     return (
       <ActionsPanel style={{ padding: 0 }}>
@@ -69,4 +68,4 @@ class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
   }
 }
 
-export default withStyles(styles)(DestructiveVolumeDialog);
+export default withStyles(styles)(DestructiveSnapshotDialog);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import {
+  createStyles,
+  Theme,
+  withStyles,
+  WithStyles
+} from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import Notice from 'src/components/Notice';
+
+type ClassNames = 'warningCopy';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    warningCopy: {
+      color: theme.color.red,
+      marginBottom: theme.spacing(2)
+    }
+  });
+
+interface Props {
+  open: boolean;
+  mode: 'snapshot';
+  error?: string;
+  onClose: () => void;
+  onSnapshot: () => void;
+  // onDelete: () => void;
+  // volumeLabel: string;
+  // linodeLabel: string;
+  // poweredOff: boolean;
+}
+
+type CombinedProps = Props & WithStyles<ClassNames>;
+
+class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
+  renderActions = () => {
+    const method = {
+      snapshot: this.props.onSnapshot
+    }[this.props.mode];
+
+    return (
+      <ActionsPanel style={{ padding: 0 }}>
+        <Button buttonType="cancel" onClick={this.props.onClose} data-qa-cancel>
+          Cancel
+        </Button>
+        <Button
+          buttonType="secondary"
+          destructive
+          onClick={method}
+          data-qa-confirm
+        >
+          {'Take Snapshot'}
+        </Button>
+      </ActionsPanel>
+    );
+  };
+
+  render() {
+    const { error } = this.props;
+    const title = 'Take a snapshot?';
+
+    return (
+      <ConfirmationDialog
+        open={this.props.open}
+        title={`${title}`}
+        onClose={this.props.onClose}
+        actions={this.renderActions}
+      >
+        {error && <Notice error text={error} />}
+
+        <Typography>
+          Taking a snapshot will back up your Linode in its current state,
+          over-writing your previous snapshot. Are you sure?
+        </Typography>
+      </ConfirmationDialog>
+    );
+  }
+}
+
+export default withStyles(styles)(DestructiveVolumeDialog);

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
@@ -9,7 +9,6 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Notice from 'src/components/Notice';
 
 type ClassNames = 'warningCopy';
 
@@ -23,7 +22,7 @@ const styles = (theme: Theme) =>
 
 interface Props {
   open: boolean;
-  mode: 'snapshot';
+  loading: boolean;
   error?: string;
   onClose: () => void;
   onSnapshot: () => void;
@@ -33,10 +32,6 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
   renderActions = () => {
-    const method = {
-      snapshot: this.props.onSnapshot
-    }[this.props.mode];
-
     return (
       <ActionsPanel style={{ padding: 0 }}>
         <Button buttonType="cancel" onClick={this.props.onClose} data-qa-cancel>
@@ -45,7 +40,7 @@ class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
         <Button
           buttonType="secondary"
           destructive
-          onClick={method}
+          onClick={this.props.onSnapshot}
           data-qa-confirm
         >
           {'Take Snapshot'}
@@ -55,7 +50,6 @@ class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
   };
 
   render() {
-    const { error } = this.props;
     const title = 'Take a snapshot?';
 
     return (
@@ -64,9 +58,8 @@ class DestructiveVolumeDialog extends React.PureComponent<CombinedProps, {}> {
         title={`${title}`}
         onClose={this.props.onClose}
         actions={this.renderActions}
+        error={this.props.error}
       >
-        {error && <Notice error text={error} />}
-
         <Typography>
           Taking a snapshot will back up your Linode in its current state,
           over-writing your previous snapshot. Are you sure?

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/DestructiveSnapshotDialog.tsx
@@ -23,6 +23,7 @@ const styles = (theme: Theme) =>
 interface Props {
   open: boolean;
   error?: string;
+  loading: boolean;
   onClose: () => void;
   onSnapshot: () => void;
 }
@@ -41,6 +42,7 @@ class DestructiveSnapshotDialog extends React.PureComponent<CombinedProps, {}> {
           destructive
           onClick={this.props.onSnapshot}
           data-qa-confirm
+          loading={this.props.loading}
         >
           {'Take Snapshot'}
         </Button>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -168,11 +168,9 @@ interface State {
     backupCreated: string;
     backupID?: number;
   };
-  destructiveDialog: {
-    open: boolean;
-    mode: 'snapshot';
-    error?: string;
-  };
+  dialogOpen: boolean;
+  dialogError?: string;
+  dialogLoading: boolean;
   cancelBackupsAlertOpen: boolean;
   enabling: boolean;
 }
@@ -223,10 +221,9 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
       open: false,
       backupCreated: ''
     },
-    destructiveDialog: {
-      open: false,
-      mode: 'snapshot'
-    },
+    dialogOpen: false,
+    dialogError: undefined,
+    dialogLoading: false,
     cancelBackupsAlertOpen: false,
     enabling: false
   };
@@ -386,23 +383,21 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
               'There was an error taking a snapshot'
             )
           },
-          destructiveDialog: {
-            ...this.state.destructiveDialog,
-            error: getAPIErrorOrDefault(
-              errorResponse,
-              'There was an error taking a snapshot'
-            )[0].reason
-          }
+          dialogOpen: this.state.dialogOpen,
+          dialogError: getAPIErrorOrDefault(
+            errorResponse,
+            'There was an error taking a snapshot'
+          )[0].reason,
+          dialogLoading: this.state.dialogLoading
         });
       });
   };
 
   closeDestructiveDialog = () => {
     this.setState({
-      destructiveDialog: {
-        ...this.state.destructiveDialog,
-        open: false
-      }
+      dialogOpen: false,
+      dialogError: undefined,
+      dialogLoading: false
     });
   };
 
@@ -479,11 +474,9 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
 
   handleSnapshotDialogDisplay = () => {
     this.setState({
-      destructiveDialog: {
-        open: true,
-        mode: 'snapshot',
-        error: undefined
-      }
+      dialogOpen: true,
+      dialogError: undefined,
+      dialogLoading: false
     });
   };
 
@@ -655,9 +648,9 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
           </FormControl>
         </Paper>
         <DestructiveSnapshotDialog
-          open={this.state.destructiveDialog.open}
-          error={this.state.destructiveDialog.error}
-          mode={this.state.destructiveDialog.mode}
+          open={this.state.dialogOpen}
+          error={this.state.dialogError}
+          loading={this.state.dialogLoading}
           onClose={this.closeDestructiveDialog}
           onSnapshot={this.takeSnapshot}
         />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -363,6 +363,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
   takeSnapshot = () => {
     const { linodeID, enqueueSnackbar } = this.props;
     const { snapshotForm } = this.state;
+    this.setState({ loading: true });
     takeSnapshot(linodeID, snapshotForm.label)
       .then(() => {
         enqueueSnackbar('A snapshot is being taken', {
@@ -370,7 +371,8 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
         });
         this.closeDestructiveDialog();
         this.setState({
-          snapshotForm: { label: '', errors: undefined }
+          snapshotForm: { label: '', errors: undefined },
+          loading: false
         });
         resetEventsPolling();
       })
@@ -384,6 +386,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
             )
           },
           dialogOpen: this.state.dialogOpen,
+          loading: false,
           dialogError: getAPIErrorOrDefault(
             errorResponse,
             'There was an error taking a snapshot'
@@ -649,6 +652,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
           error={this.state.dialogError}
           onClose={this.closeDestructiveDialog}
           onSnapshot={this.takeSnapshot}
+          loading={this.state.loading}
         />
       </React.Fragment>
     );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -170,7 +170,7 @@ interface State {
   };
   dialogOpen: boolean;
   dialogError?: string;
-  dialogLoading: boolean;
+  loading: boolean;
   cancelBackupsAlertOpen: boolean;
   enabling: boolean;
 }
@@ -223,7 +223,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     },
     dialogOpen: false,
     dialogError: undefined,
-    dialogLoading: false,
+    loading: false,
     cancelBackupsAlertOpen: false,
     enabling: false
   };
@@ -387,8 +387,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
           dialogError: getAPIErrorOrDefault(
             errorResponse,
             'There was an error taking a snapshot'
-          )[0].reason,
-          dialogLoading: this.state.dialogLoading
+          )[0].reason
         });
       });
   };
@@ -396,8 +395,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
   closeDestructiveDialog = () => {
     this.setState({
       dialogOpen: false,
-      dialogError: undefined,
-      dialogLoading: false
+      dialogError: undefined
     });
   };
 
@@ -475,8 +473,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
   handleSnapshotDialogDisplay = () => {
     this.setState({
       dialogOpen: true,
-      dialogError: undefined,
-      dialogLoading: false
+      dialogError: undefined
     });
   };
 
@@ -650,7 +647,6 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
         <DestructiveSnapshotDialog
           open={this.state.dialogOpen}
           error={this.state.dialogError}
-          loading={this.state.dialogLoading}
           onClose={this.closeDestructiveDialog}
           onSnapshot={this.takeSnapshot}
         />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -387,7 +387,11 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
             )
           },
           destructiveDialog: {
-            ...this.state.destructiveDialog
+            ...this.state.destructiveDialog,
+            error: getAPIErrorOrDefault(
+              errorResponse,
+              'There was an error taking a snapshot'
+            )[0].reason
           }
         });
       });


### PR DESCRIPTION
## Description

For manual snapshots, we will now present a dialog to allow the user to confirm/cancel that they want to proceed with the new snapshot and inform them they will lose their previous snapshot. 

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

Please test creating various snapshots and verifying errors (one way is to try creating a snapshot while one is already in progress)

Also, does this make sense as a dialog? The requested copy from classic seems to fit our dialog pattern, but maybe a warning notice is all that is needed. Let me know what you think!