### PR TITLE
[SDK] Change: Refactor Linode Types

### DIFF
--- a/packages/linode-js-sdk/src/linodes/types.ts
+++ b/packages/linode-js-sdk/src/linodes/types.ts
@@ -9,6 +9,7 @@ export interface LinodeSpecs {
   memory: number;
   vcpus: number;
   transfer: number;
+  gpus: number;
 }
 
 export interface Linode {
@@ -20,7 +21,7 @@ export interface Linode {
   image: string | null;
   group: string;
   ipv4: string[];
-  ipv6: string;
+  ipv6: string | null;
   label: string;
   type: null | string;
   status: LinodeStatus;
@@ -29,11 +30,6 @@ export interface Linode {
   specs: LinodeSpecs;
   watchdog_enabled: boolean;
   tags: string[];
-  /** Added by UI */
-  recentEvent?: Event;
-  notifications?: Notification[];
-  notification?: string;
-  mostRecentBackup: string | null;
 }
 
 export interface LinodeAlerts {
@@ -45,10 +41,13 @@ export interface LinodeAlerts {
 }
 
 export interface LinodeBackups {
-  enabled?: boolean;
+  enabled: boolean;
   schedule: LinodeBackupSchedule;
-  last_backup?: LinodeBackup;
-  snapshot?: LinodeBackup;
+}
+
+export interface BackupWithSnapAndLast extends LinodeBackups {
+  last_backup: LinodeBackup;
+  snapshot: LinodeBackup;
 }
 
 export type Window =
@@ -149,6 +148,7 @@ export type LinodeStatus =
   | 'running'
   | 'shutting_down'
   | 'rebooting'
+  | 'rebuilding'
   | 'provisioning'
   | 'deleting'
   | 'migrating'

--- a/packages/linode-js-sdk/src/linodes/types.ts
+++ b/packages/linode-js-sdk/src/linodes/types.ts
@@ -1,4 +1,3 @@
-import { Event } from '../account/types';
 import { IPAddress, IPRange } from '../networking/types';
 import { SSHKey } from '../profile/types';
 
@@ -43,11 +42,6 @@ export interface LinodeAlerts {
 export interface LinodeBackups {
   enabled: boolean;
   schedule: LinodeBackupSchedule;
-}
-
-export interface BackupWithSnapAndLast extends LinodeBackups {
-  last_backup: LinodeBackup;
-  snapshot: LinodeBackup;
 }
 
 export type Window =

--- a/packages/manager/src/__data__/linodes.ts
+++ b/packages/manager/src/__data__/linodes.ts
@@ -1,4 +1,5 @@
-import { ExtendedLinode, Linode } from 'linode-js-sdk/lib/linodes';
+import { Linode } from 'linode-js-sdk/lib/linodes';
+import { LinodeWithMaintenanceAndMostRecentBackup } from 'src/store/linodes/types';
 
 export const linode1: Linode = {
   specs: {
@@ -6,7 +7,7 @@ export const linode1: Linode = {
     memory: 1024,
     vcpus: 1,
     disk: 20480,
-    gpus: 0,
+    gpus: 0
   },
   updated: '2017-12-11T16:35:31',
   ipv4: ['97.107.143.78', '98.107.143.78', '99.107.143.78'],
@@ -44,7 +45,7 @@ export const linode2: Linode = {
     memory: 2048,
     vcpus: 1,
     disk: 30720,
-    gpus: 0,
+    gpus: 0
   },
   updated: '2018-02-22T16:11:07',
   ipv4: ['97.107.143.49'],
@@ -82,7 +83,7 @@ export const linode3: Linode = {
     memory: 2048,
     vcpus: 1,
     disk: 30720,
-    gpus: 0,
+    gpus: 0
   },
   updated: '2018-02-22T16:11:07',
   ipv4: ['97.107.143.49'],
@@ -120,7 +121,7 @@ export const linode4: Linode = {
     memory: 2048,
     vcpus: 1,
     disk: 30720,
-    gpus: 0,
+    gpus: 0
   },
   updated: '2018-02-22T16:11:07',
   ipv4: ['97.107.143.49'],
@@ -154,13 +155,17 @@ export const linode4: Linode = {
 
 export const linodes = [linode1, linode2, linode3];
 
-export const extendedLinodes: ExtendedLinode[] = [{
-  ...linode1,
-  mostRecentBackup: null
-}, {
-  ...linode2,
-  mostRecentBackup: null,
-}, {
-  ...linode3,
-  mostRecentBackup: null 
-}]
+export const extendedLinodes: LinodeWithMaintenanceAndMostRecentBackup[] = [
+  {
+    ...linode1,
+    mostRecentBackup: null
+  },
+  {
+    ...linode2,
+    mostRecentBackup: null
+  },
+  {
+    ...linode3,
+    mostRecentBackup: null
+  }
+];

--- a/packages/manager/src/__data__/linodes.ts
+++ b/packages/manager/src/__data__/linodes.ts
@@ -1,11 +1,12 @@
-import { Linode } from 'linode-js-sdk/lib/linodes';
+import { ExtendedLinode, Linode } from 'linode-js-sdk/lib/linodes';
 
 export const linode1: Linode = {
   specs: {
     transfer: 1000,
     memory: 1024,
     vcpus: 1,
-    disk: 20480
+    disk: 20480,
+    gpus: 0,
   },
   updated: '2017-12-11T16:35:31',
   ipv4: ['97.107.143.78', '98.107.143.78', '99.107.143.78'],
@@ -31,7 +32,6 @@ export const linode1: Linode = {
     },
     enabled: true
   },
-  mostRecentBackup: null,
   status: 'running',
   ipv6: '2600:3c03::f03c:91ff:fe0a:109a/64',
   watchdog_enabled: false,
@@ -43,7 +43,8 @@ export const linode2: Linode = {
     transfer: 2000,
     memory: 2048,
     vcpus: 1,
-    disk: 30720
+    disk: 30720,
+    gpus: 0,
   },
   updated: '2018-02-22T16:11:07',
   ipv4: ['97.107.143.49'],
@@ -69,7 +70,6 @@ export const linode2: Linode = {
     },
     enabled: true
   },
-  mostRecentBackup: null,
   status: 'running',
   ipv6: '2600:3c03::f03c:91ff:fe0a:0d7a/64',
   watchdog_enabled: false,
@@ -81,7 +81,8 @@ export const linode3: Linode = {
     transfer: 2000,
     memory: 2048,
     vcpus: 1,
-    disk: 30720
+    disk: 30720,
+    gpus: 0,
   },
   updated: '2018-02-22T16:11:07',
   ipv4: ['97.107.143.49'],
@@ -107,7 +108,6 @@ export const linode3: Linode = {
     },
     enabled: false
   },
-  mostRecentBackup: null,
   status: 'running',
   ipv6: '2600:3c03::f03c:91ff:fe0a:0d7a/64',
   watchdog_enabled: false,
@@ -119,7 +119,8 @@ export const linode4: Linode = {
     transfer: 2000,
     memory: 2048,
     vcpus: 1,
-    disk: 30720
+    disk: 30720,
+    gpus: 0,
   },
   updated: '2018-02-22T16:11:07',
   ipv4: ['97.107.143.49'],
@@ -145,7 +146,6 @@ export const linode4: Linode = {
     },
     enabled: false
   },
-  mostRecentBackup: null,
   status: 'running',
   ipv6: '2600:3c03::f03c:91ff:fe0a:0d7a/64',
   watchdog_enabled: false,
@@ -153,3 +153,14 @@ export const linode4: Linode = {
 };
 
 export const linodes = [linode1, linode2, linode3];
+
+export const extendedLinodes: ExtendedLinode[] = [{
+  ...linode1,
+  mostRecentBackup: null
+}, {
+  ...linode2,
+  mostRecentBackup: null,
+}, {
+  ...linode3,
+  mostRecentBackup: null 
+}]

--- a/packages/manager/src/containers/withMostRecentBackup.container.ts
+++ b/packages/manager/src/containers/withMostRecentBackup.container.ts
@@ -5,7 +5,7 @@ export default <TInner extends {}, TOuter extends {}>(
   propsSelector: (ownProps: TOuter) => number,
   mapBackupToProps: (
     ownProps: TOuter,
-    mostRecentBackup: string | null
+    mostRecentBackup?: string | null
   ) => TInner
 ) =>
   connect((state: ApplicationState, ownProps: TOuter) => {

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -29,7 +29,7 @@ import {
   isEntityEvent,
   isInProgressEvent
 } from 'src/store/events/event.helpers';
-import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
+import { LinodeWithMaintenanceAndMostRecentBackup } from 'src/store/linodes/types';
 import DashboardCard from '../DashboardCard';
 
 interface EntityEvent extends Omit<Event, 'entitiy'> {
@@ -150,7 +150,7 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
 
   renderEmpty = () => <TableRowEmptyState colSpan={3} />;
 
-  renderData = (data: LinodeWithMaintenance[]) => {
+  renderData = (data: ExtendedLinode[]) => {
     const { classes } = this.props;
 
     return data.map(linode => {
@@ -163,7 +163,7 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
             backups={linode.backups}
             id={linode.id}
             ipv4={linode.ipv4}
-            ipv6={linode.ipv6}
+            ipv6={linode.ipv6 || ''}
             label={linode.label}
             region={linode.region}
             status={linode.status}
@@ -198,8 +198,10 @@ const withTypes = connect((state: ApplicationState, ownProps) => ({
   typesData: state.__resources.types.entities
 }));
 
+type ExtendedLinode = { recentEvent: Event } & LinodeWithMaintenanceAndMostRecentBackup;
+
 interface WithUpdatingLinodesProps {
-  linodes: LinodeWithMaintenance[];
+  linodes: ExtendedLinode[];
   linodeCount: number;
   loading: boolean;
   error?: APIError[];

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -168,7 +168,7 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
             region={linode.region}
             status={linode.status}
             tags={linode.tags}
-            mostRecentBackup={linode.mostRecentBackup}
+            mostRecentBackup={linode.mostRecentBackup || null}
             disk={linode.specs.disk}
             vcpus={linode.specs.vcpus}
             memory={linode.specs.memory}
@@ -198,7 +198,9 @@ const withTypes = connect((state: ApplicationState, ownProps) => ({
   typesData: state.__resources.types.entities
 }));
 
-type ExtendedLinode = { recentEvent: Event } & LinodeWithMaintenanceAndMostRecentBackup;
+type ExtendedLinode = {
+  recentEvent: Event;
+} & LinodeWithMaintenanceAndMostRecentBackup;
 
 interface WithUpdatingLinodesProps {
   linodes: ExtendedLinode[];

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -387,6 +387,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     updateLinode({
       linodeId: linodeID,
       backups: {
+        enabled: true,
         schedule: {
           day: settingsForm.day,
           window: settingsForm.window

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/SummaryPanel.tsx
@@ -117,7 +117,7 @@ class SummaryPanel extends React.Component<CombinedProps> {
           <BackupStatus
             linodeId={linodeId}
             backupsEnabled={backupsEnabled}
-            mostRecentBackup={mostRecentBackup}
+            mostRecentBackup={mostRecentBackup || null}
           />
         </Paper>
         <Paper className={classes.summarySection}>
@@ -156,7 +156,7 @@ interface LinodeContextProps {
   linodeIpv6: any;
   linodeRegion: string;
   linodeTags: string[];
-  mostRecentBackup: string | null;
+  mostRecentBackup?: string | null;
   linodeVolumes: Volume[];
   linodeVolumesError?: APIError[];
   backupsEnabled: boolean;

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.test.tsx
@@ -17,6 +17,7 @@ const props: CombinedProps = {
   regionsLoading: false,
   openPowerActionDialog: jest.fn(),
   linodeBackups: {
+    enabled: false,
     schedule: {
       window: null,
       day: null

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -368,6 +368,9 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                                     data={linodesData.map(e => {
                                       return {
                                         ...e,
+                                        maintenance: e.maintenance || {
+                                          when: null
+                                        },
                                         linodeDescription: getLinodeDescription(
                                           e.label,
                                           e.specs.memory,

--- a/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
@@ -5,10 +5,10 @@ import { PaginationProps } from 'src/components/Paginate';
 import LinodeRow from './LinodeRow/LinodeRow';
 
 import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
-import { LinodeWithMaintenance } from 'src/store/linodes/linodes.helpers';
+import { LinodeWithMaintenanceAndMostRecentBackup } from 'src/store/linodes/types';
 
 interface Props {
-  data: LinodeWithMaintenance[];
+  data: LinodeWithMaintenanceAndMostRecentBackup[];
   images: Image[];
   showHead?: boolean;
   openDeleteDialog: (linodeID: number, linodeLabel: string) => void;
@@ -34,7 +34,7 @@ export const ListView: React.StatelessComponent<CombinedProps> = props => {
           maintenanceStartTime={
             linode.maintenance ? linode.maintenance.when : ''
           }
-          ipv6={linode.ipv6}
+          ipv6={linode.ipv6 || ''}
           label={linode.label}
           region={linode.region}
           status={linode.status}

--- a/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
@@ -39,7 +39,7 @@ export const ListView: React.StatelessComponent<CombinedProps> = props => {
           region={linode.region}
           status={linode.status}
           tags={linode.tags}
-          mostRecentBackup={linode.mostRecentBackup}
+          mostRecentBackup={linode.mostRecentBackup || null}
           disk={linode.specs.disk}
           vcpus={linode.specs.vcpus}
           memory={linode.specs.memory}

--- a/packages/manager/src/features/linodes/LinodesLanding/requestMostRecentBackupForLinode.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/requestMostRecentBackupForLinode.ts
@@ -1,9 +1,10 @@
 import { getLinodeBackups, Linode } from 'linode-js-sdk/lib/linodes';
+import { LinodeWithMaintenanceAndMostRecentBackup } from 'src/store/linodes/types';
 import { mostRecentFromResponse } from 'src/utilities/backups';
 
-const requestMostRecentBackupForLinode: (linode: Linode) => Promise<Linode> = (
+const requestMostRecentBackupForLinode: (
   linode: Linode
-) =>
+) => Promise<LinodeWithMaintenanceAndMostRecentBackup> = (linode: Linode) =>
   linode.backups.enabled === false
     ? Promise.resolve({
         ...linode,

--- a/packages/manager/src/store/linodes/linodes.helpers.test.ts
+++ b/packages/manager/src/store/linodes/linodes.helpers.test.ts
@@ -1,4 +1,4 @@
-import { Notification } from 'linode-js-sdk/lib/account'
+import { Notification } from 'linode-js-sdk/lib/account';
 import { linode1 } from 'src/__data__/linodes';
 import { addNotificationsToLinodes } from './linodes.helpers';
 
@@ -42,7 +42,8 @@ describe('Linode Redux Helpers', () => {
     addNotificationsToLinodes(maintenanceNotification(4325345345), [linode1])
   ).toEqual([
     {
-      ...linode1
+      ...linode1,
+      maintenance: null
     }
   ]);
 });

--- a/packages/manager/src/store/linodes/linodes.helpers.ts
+++ b/packages/manager/src/store/linodes/linodes.helpers.ts
@@ -19,7 +19,7 @@ export interface Maintenance {
 }
 
 export interface LinodeWithMaintenance extends Linode {
-  maintenance?: Maintenance;
+  maintenance?: Maintenance | null;
 }
 
 export const addNotificationsToLinodes = (
@@ -40,17 +40,20 @@ export const addNotificationsToLinodes = (
 
     return foundNotification
       ? {
-          ...eachLinode,
-          maintenance: {
-            /**
-             * "when" and "until" are not guaranteed to exist
-             * if we have a maintenance notification
-             */
-            when: foundNotification.when,
-            until: foundNotification.until,
-            type: foundNotification.label as Type
-          }
+        ...eachLinode,
+        maintenance: {
+          /**
+           * "when" and "until" are not guaranteed to exist
+           * if we have a maintenance notification
+           */
+          when: foundNotification.when,
+          until: foundNotification.until,
+          type: foundNotification.label as Type
         }
-      : eachLinode;
+      }
+      : {
+        ...eachLinode,
+        maintenance: null
+      };
   });
 };

--- a/packages/manager/src/store/linodes/linodes.reducer.ts
+++ b/packages/manager/src/store/linodes/linodes.reducer.ts
@@ -15,17 +15,18 @@ import {
   upsertLinode
 } from './linodes.actions';
 
-import {
-  addNotificationsToLinodes as _addNotificationsToLinodes,
-  LinodeWithMaintenance
-} from './linodes.helpers';
+import { addNotificationsToLinodes as _addNotificationsToLinodes } from './linodes.helpers';
+import { LinodeWithMaintenanceAndMostRecentBackup } from './types';
 
 const getId = <E extends HasNumericID>({ id }: E) => id;
 
 /**
  * State
  */
-export type State = EntityState<LinodeWithMaintenance, EntityError>;
+export type State = EntityState<
+  LinodeWithMaintenanceAndMostRecentBackup,
+  EntityError
+>;
 
 export const defaultState: State = {
   results: [],

--- a/packages/manager/src/store/linodes/types.ts
+++ b/packages/manager/src/store/linodes/types.ts
@@ -1,0 +1,8 @@
+import { LinodeWithMaintenance as L } from './linodes.helpers';
+
+/* tslint:disable-next-line */
+export interface LinodeWithMaintenance extends L { }
+
+export interface LinodeWithMaintenanceAndMostRecentBackup extends LinodeWithMaintenance {
+  mostRecentBackup: string | null;
+}

--- a/packages/manager/src/store/linodes/types.ts
+++ b/packages/manager/src/store/linodes/types.ts
@@ -1,8 +1,9 @@
 import { LinodeWithMaintenance as L } from './linodes.helpers';
 
 /* tslint:disable-next-line */
-export interface LinodeWithMaintenance extends L { }
+export interface LinodeWithMaintenance extends L {}
 
-export interface LinodeWithMaintenanceAndMostRecentBackup extends LinodeWithMaintenance {
-  mostRecentBackup: string | null;
+export interface LinodeWithMaintenanceAndMostRecentBackup
+  extends LinodeWithMaintenance {
+  mostRecentBackup?: string | null;
 }

--- a/packages/manager/src/store/selectors/getSearchEntities.ts
+++ b/packages/manager/src/store/selectors/getSearchEntities.ts
@@ -13,7 +13,7 @@ type State = ApplicationState['__resources'];
 
 export const getLinodeIps = (linode: Linode): string[] => {
   const { ipv4, ipv6 } = linode;
-  return ipv4.concat([ipv6]);
+  return ipv4.concat([ipv6 || '']);
 };
 
 export const getDomainIps = (domain: Domain): string[] => {


### PR DESCRIPTION
## Description

The following properties were being added to the Linode object by Cloud Manager, but not actually included in the `GET /linodes` API response:

* `mostRecentBackup`
* `notifications`
* `recentEvent`
* `notification`

To keep the SDK pure, we need to remove those typings from the base `Linode` interface.

Other changes include:

*  make `linode.ipv6` possibly `null`.
* Add `gpus` to the `Linode.specs` object

## Type of Change
- Non breaking change ('update', 'change')

## To Test

Look around the app - ensure nothing crashes