### PR TITLE
M3-3412 Improve display of status maintenance in linode row

### DIFF
--- a/packages/manager/src/components/EntityIcon/EntityIcon.tsx
+++ b/packages/manager/src/components/EntityIcon/EntityIcon.tsx
@@ -58,9 +58,7 @@ const styles = (theme: Theme) =>
     offline: {
       color: theme.color.red
     },
-    maintenance: {
-      color: theme.color.yellow
-    },
+    maintenance: {},
     loading: {
       position: 'absolute',
       top: 0,

--- a/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -19,7 +19,6 @@ const styles = (theme: Theme) =>
   createStyles({
     root: {
       '& p': {
-        marginBottom: theme.spacing(1),
         lineHeight: `20px`
       },
       '& p:last-child': {

--- a/packages/manager/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
@@ -93,7 +93,11 @@ export class BlogDashboardCard extends React.Component<CombinedProps, State> {
     }
 
     return (
-      <DashboardCard title="Blog" headerAction={this.renderAction}>
+      <DashboardCard
+        title="Blog"
+        headerAction={this.renderAction}
+        alignHeader="flex-start"
+      >
         {items.map(this.renderItem)}
       </DashboardCard>
     );

--- a/packages/manager/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/DomainsDashboardCard/DomainsDashboardCard.tsx
@@ -94,7 +94,11 @@ type CombinedProps = Props &
 class DomainsDashboardCard extends React.Component<CombinedProps, State> {
   render() {
     return (
-      <DashboardCard title="Domains" headerAction={this.renderAction}>
+      <DashboardCard
+        title="Domains"
+        headerAction={this.renderAction}
+        alignHeader="flex-start"
+      >
         <Paper>
           <Table>
             <TableBody>{this.renderContent()}</TableBody>

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -168,6 +168,7 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
             label={linode.label}
             region={linode.region}
             status={linode.status}
+            displayStatus={linode.displayStatus || ''}
             tags={linode.tags}
             mostRecentBackup={linode.mostRecentBackup || null}
             disk={linode.specs.disk}

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -84,6 +84,7 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
         title="Linodes"
         headerAction={this.renderAction}
         className={classes.root}
+        alignHeader="flex-start"
       >
         <Paper>
           <Table>

--- a/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/LinodesDashboardCard/LinodesDashboardCard.tsx
@@ -174,8 +174,9 @@ class LinodesDashboardCard extends React.Component<CombinedProps> {
             memory={linode.specs.memory}
             type={linode.type}
             image={linode.image}
-            width={70}
+            width={75}
             maintenance={linode.maintenance ? linode.maintenance.when : ''}
+            isDashboard
           />
           <Hidden xsDown>
             <TableCell className={classes.moreCol} data-qa-linode-region>

--- a/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/NodeBalancersDashboardCard/NodeBalancersDashboardCard.tsx
@@ -162,7 +162,11 @@ const NodeBalancersDashboardCard: React.FunctionComponent<
   };
 
   return (
-    <DashboardCard title="NodeBalancers" headerAction={renderAction}>
+    <DashboardCard
+      title="NodeBalancers"
+      headerAction={renderAction}
+      alignHeader="flex-start"
+    >
       <Paper>
         <Table>
           <TableBody>{renderContent()}</TableBody>

--- a/packages/manager/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/VolumesDashboardCard/VolumesDashboardCard.tsx
@@ -74,6 +74,7 @@ export const VolumesDashboardCard: React.FunctionComponent<
     <DashboardCard
       title="Volumes"
       headerAction={renderAction}
+      alignHeader="flex-start"
       data-qa-dash-volume
     >
       <Paper>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.style.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.style.ts
@@ -30,6 +30,7 @@ type ClassNames =
   | 'link'
   | 'statusProgress'
   | 'cardMaintenance'
+  | 'maintenanceNotice'
   | 'wrapHeader';
 
 export type StyleProps = WithStyles<ClassNames> & WithTheme;
@@ -187,6 +188,13 @@ const styles = (theme: Theme) =>
     cardMaintenance: {
       display: 'flex',
       alignItems: 'center'
+    },
+    maintenanceNotice: {
+      '& .noticeText': {
+        display: 'flex',
+        alignItems: 'center',
+        fontSize: '.9rem'
+      }
     }
   });
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.test.tsx
@@ -34,7 +34,8 @@ describe('LinodeRow', () => {
     cardMaintenance: '',
     wrapHeader: '',
     status: '',
-    statusHelpIcon: ''
+    statusHelpIcon: '',
+    maintenanceNotice: ''
   };
 
   const mockProps: CombinedProps = {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -216,7 +216,7 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
                       <HelpIcon
                         text={<MaintenanceText />}
                         className={classes.statusHelpIcon}
-                        tooltipPosition="right-start"
+                        tooltipPosition="top"
                       />
                     </Notice>
                   </div>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -112,15 +112,12 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
     } = this.props;
 
     const loading = linodeInTransition(status, recentEvent);
+    const dateTime = parseMaintenanceStartTime(maintenanceStartTime).split(' ');
 
     const MaintenanceText = () => {
-      const dateTime = parseMaintenanceStartTime(maintenanceStartTime).split(
-        ' '
-      );
       return (
         <>
-          Maintenance for this Linode is scheduled to begin {dateTime[0]} at{' '}
-          {dateTime[1]}. Please consult your{' '}
+          Please consult your{' '}
           <Link to="/support/tickets?type=open">support tickets</Link> for
           details.
         </>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -205,7 +205,10 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
               ) : (
                 <>
                   <div className={classes.cardMaintenance}>
-                    <Typography>Status: Maintenance Scheduled</Typography>
+                    <Typography>
+                      <strong>Maintenance Scheduled</strong> {dateTime[0]} at{' '}
+                      {dateTime[1]}
+                    </Typography>
                     <HelpIcon
                       text={<MaintenanceText />}
                       className={classes.statusHelpIcon}
@@ -304,8 +307,7 @@ export const RenderTitle: React.StatelessComponent<{
     linodeId,
     mutationAvailable,
     linodeNotifications,
-    recentEvent,
-    maintenance
+    recentEvent
   } = props;
 
   return (
@@ -314,7 +316,7 @@ export const RenderTitle: React.StatelessComponent<{
         <Grid item className={`${classes.StatusIndicatorWrapper} ${'py0'}`}>
           <EntityIcon
             variant="linode"
-            status={!maintenance ? linodeStatus : 'maintenance'}
+            status={linodeStatus}
             loading={
               recentEvent && linodeInTransition(linodeStatus, recentEvent)
             }

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -17,6 +17,7 @@ import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import HelpIcon from 'src/components/HelpIcon';
 import LinearProgress from 'src/components/LinearProgress';
+import Notice from 'src/components/Notice';
 import Tags from 'src/components/Tags';
 import {
   linodeInTransition,
@@ -205,15 +206,19 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
               ) : (
                 <>
                   <div className={classes.cardMaintenance}>
-                    <Typography>
-                      <strong>Maintenance Scheduled</strong> {dateTime[0]} at{' '}
-                      {dateTime[1]}
-                    </Typography>
-                    <HelpIcon
-                      text={<MaintenanceText />}
-                      className={classes.statusHelpIcon}
-                      tooltipPosition="right-start"
-                    />
+                    <Notice
+                      warning
+                      spacingBottom={0}
+                      className={classes.maintenanceNotice}
+                    >
+                      Maintenance Scheduled <br />
+                      {dateTime[0]} at {dateTime[1]}
+                      <HelpIcon
+                        text={<MaintenanceText />}
+                        className={classes.statusHelpIcon}
+                        tooltipPosition="right-start"
+                      />
+                    </Notice>
                   </div>
                 </>
               )}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
@@ -83,7 +83,7 @@ const styles = (theme: Theme) =>
         alignItems: 'center',
         lineHeight: 1.2,
         marginRight: -12,
-        [theme.breakpoints.down('md')]: {
+        [theme.breakpoints.down('sm')]: {
           minWidth: 200,
           justifyContent: 'flex-end'
         },

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.style.ts
@@ -70,21 +70,25 @@ const styles = (theme: Theme) =>
     },
     statusCell: {
       width: '14%',
-      textTransform: 'capitalize',
       [theme.breakpoints.down('sm')]: {
         width: '100%'
       }
     },
     statusCellMaintenance: {
+      [theme.breakpoints.up('md')]: {
+        width: '20%'
+      },
       '& .data': {
         display: 'flex',
-        width: 250,
         alignItems: 'center',
         lineHeight: 1.2,
         marginRight: -12,
+        [theme.breakpoints.down('md')]: {
+          minWidth: 200,
+          justifyContent: 'flex-end'
+        },
         [theme.breakpoints.up('md')]: {
-          width: 125,
-          marginRight: 0
+          minWidth: 200
         }
       },
       '& button': {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.test.tsx
@@ -33,6 +33,7 @@ describe('LinodeRow', () => {
     type: 'whatever',
     tags: [],
     status: 'running',
+    displayStatus: 'running',
     region: 'us-east',
     label: 'my-linode',
     ipv6: 'some.long.ipv6.address',

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -86,13 +86,12 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = props => {
   } = props;
 
   const loading = linodeInTransition(status, recentEvent);
+  const dateTime = parseMaintenanceStartTime(maintenanceStartTime).split(' ');
 
   const MaintenanceText = () => {
-    const dateTime = parseMaintenanceStartTime(maintenanceStartTime).split(' ');
     return (
       <>
-        Maintenance for this Linode is scheduled to begin {dateTime[0]} at{' '}
-        {dateTime[1]}. Please consult your{' '}
+        Please consult your{' '}
         <Link to="/support/tickets?type=open">support tickets</Link> for
         details.
       </>
@@ -157,11 +156,18 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = props => {
             )
           ) : (
             <>
-              Maintenance Scheduled
+              <div>
+                <div>
+                  <strong>Maintenance scheduled</strong>
+                </div>
+                <div>
+                  {dateTime[0]} at {dateTime[1]}
+                </div>
+              </div>
               <HelpIcon
                 text={<MaintenanceText />}
                 className={classes.statusHelpIcon}
-                tooltipPosition="right-start"
+                tooltipPosition="top"
                 interactive
               />
             </>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -40,6 +40,7 @@ interface Props {
   memory: number;
   vcpus: number;
   status: LinodeStatus;
+  displayStatus: string;
   type: null | string;
   tags: string[];
   mostRecentBackup: string | null;
@@ -69,6 +70,7 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = props => {
     label,
     region,
     status,
+    displayStatus,
     tags,
     mostRecentBackup,
     disk,
@@ -111,6 +113,7 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = props => {
       label={label}
       region={region}
       status={status}
+      displayStatus={displayStatus}
       tags={tags}
       mostRecentBackup={mostRecentBackup}
       disk={disk}
@@ -153,7 +156,7 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = props => {
             loading ? (
               'Busy'
             ) : (
-              capitalize(status)
+              capitalize(displayStatus)
             )
           ) : (
             <>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRow.tsx
@@ -24,6 +24,7 @@ import LinodeRowHeadCell from './LinodeRowHeadCell';
 import LinodeRowLoading from './LinodeRowLoading';
 
 import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
+import { capitalize } from 'src/utilities/capitalize';
 import { parseMaintenanceStartTime } from '../utils';
 
 interface Props {
@@ -152,13 +153,13 @@ export const LinodeRow: React.StatelessComponent<CombinedProps> = props => {
             loading ? (
               'Busy'
             ) : (
-              status
+              capitalize(status)
             )
           ) : (
             <>
               <div>
                 <div>
-                  <strong>Maintenance scheduled</strong>
+                  <strong>Maintenance Scheduled</strong>
                 </div>
                 <div>
                   {dateTime[0]} at {dateTime[1]}

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -13,6 +13,8 @@ import {
 import Typography from 'src/components/core/Typography';
 import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
+import HelpIcon from 'src/components/HelpIcon';
+import Notice from 'src/components/Notice';
 import TableCell from 'src/components/TableCell';
 import withImages from 'src/containers/withImages.container';
 import {
@@ -33,7 +35,10 @@ type ClassNames =
   | 'labelRow'
   | 'labelStatusWrapper'
   | 'dashboard'
-  | 'wrapHeader';
+  | 'wrapHeader'
+  | 'maintenanceContainer'
+  | 'maintenanceNotice'
+  | 'helpIcon';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -79,6 +84,23 @@ const styles = (theme: Theme) =>
     },
     wrapHeader: {
       wordBreak: 'break-all'
+    },
+    maintenanceContainer: {},
+    maintenanceNotice: {
+      paddingTop: 0,
+      paddingBottom: 0,
+      '& .noticeText': {
+        display: 'flex',
+        alignItems: 'center',
+        fontSize: '.9rem',
+        '& br': {
+          display: 'none'
+        }
+      }
+    },
+    helpIcon: {
+      paddingTop: 0,
+      paddingBottom: 0
     }
   });
 
@@ -101,6 +123,7 @@ interface Props {
   loading: boolean;
   recentEvent?: Event;
   maintenance?: string | null;
+  isDashboard?: boolean;
 }
 
 interface WithImagesProps {
@@ -128,7 +151,9 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
     recentEvent,
     displayType,
     imagesData,
-    width
+    width,
+    maintenance,
+    isDashboard
   } = props;
 
   const description = getLinodeDescription(
@@ -141,6 +166,16 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
   );
 
   const style = width ? { width: `${width}%` } : {};
+  const dateTime = maintenance && maintenance.split(' ');
+  const MaintenanceText = () => {
+    return (
+      <>
+        Please consult your{' '}
+        <Link to="/support/tickets?type=open">support tickets</Link> for
+        details.
+      </>
+    );
+  };
 
   return (
     <TableCell className={classes.root} style={style} rowSpan={loading ? 2 : 1}>
@@ -175,6 +210,24 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
             </div>
             <Typography>{description}</Typography>
           </div>
+          {maintenance && dateTime && isDashboard && (
+            <div className={classes.maintenanceContainer}>
+              <Notice
+                warning
+                spacingTop={8}
+                spacingBottom={0}
+                className={classes.maintenanceNotice}
+              >
+                Maintenance: <br />
+                {dateTime[0]} at {dateTime[1]}
+                <HelpIcon
+                  text={<MaintenanceText />}
+                  tooltipPosition="right-start"
+                  className={classes.helpIcon}
+                />
+              </Notice>
+            </div>
+          )}
         </Grid>
       </Grid>
     </TableCell>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -222,7 +222,7 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
                 {dateTime[0]} at {dateTime[1]}
                 <HelpIcon
                   text={<MaintenanceText />}
-                  tooltipPosition="right-start"
+                  tooltipPosition="top"
                   className={classes.helpIcon}
                 />
               </Notice>

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -128,8 +128,7 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
     recentEvent,
     displayType,
     imagesData,
-    width,
-    maintenance
+    width
   } = props;
 
   const description = getLinodeDescription(
@@ -149,7 +148,7 @@ const LinodeRowHeadCell: React.StatelessComponent<CombinedProps> = props => {
         <Grid item className="py0">
           <EntityIcon
             variant="linode"
-            status={!maintenance ? status : 'maintenance'}
+            status={status}
             loading={linodeInTransition(status, recentEvent)}
             marginTop={1}
           />

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeRow/LinodeRowHeadCell.tsx
@@ -116,6 +116,7 @@ interface Props {
   memory: number;
   vcpus: number;
   status: LinodeStatus;
+  displayStatus: string | null;
   type: null | string;
   tags: string[];
   mostRecentBackup: string | null;

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -321,7 +321,14 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                             </Grid>
                             <Grid item xs={12}>
                               <OrderBy
-                                data={linodesData}
+                                data={linodesData.map(e => {
+                                  return {
+                                    ...e,
+                                    status: e.maintenance
+                                      ? 'maintenance'
+                                      : e.status
+                                  };
+                                })}
                                 order={'asc'}
                                 orderBy={'label'}
                               >

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodesLanding.tsx
@@ -321,12 +321,12 @@ export class ListLinodes extends React.Component<CombinedProps, State> {
                             </Grid>
                             <Grid item xs={12}>
                               <OrderBy
-                                data={linodesData.map(e => {
+                                data={linodesData.map(linode => {
                                   return {
-                                    ...e,
-                                    status: e.maintenance
+                                    ...linode,
+                                    displayStatus: linode.maintenance
                                       ? 'maintenance'
-                                      : e.status
+                                      : linode.status
                                   };
                                 })}
                                 order={'asc'}

--- a/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListView.tsx
@@ -38,6 +38,7 @@ export const ListView: React.StatelessComponent<CombinedProps> = props => {
           label={linode.label}
           region={linode.region}
           status={linode.status}
+          displayStatus={linode.displayStatus || ''}
           tags={linode.tags}
           mostRecentBackup={linode.mostRecentBackup || null}
           disk={linode.specs.disk}

--- a/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/SortableTableHead.tsx
@@ -47,9 +47,9 @@ const SortableTableHead: React.StatelessComponent<combinedProps> = props => {
         </TableSortCell>
         <TableSortCell
           noWrap
-          label="status"
+          label="displayStatus"
           direction={order}
-          active={isActive('status')}
+          active={isActive('displayStatus')}
           handleClick={handleOrderChange}
         >
           Status

--- a/packages/manager/src/store/linodes/types.ts
+++ b/packages/manager/src/store/linodes/types.ts
@@ -6,4 +6,5 @@ export interface LinodeWithMaintenance extends L {}
 export interface LinodeWithMaintenanceAndMostRecentBackup
   extends LinodeWithMaintenance {
   mostRecentBackup?: string | null;
+  displayStatus?: string;
 }


### PR DESCRIPTION
## M3-3412 Improve display of status maintenance in linode row

We've gotten report that many users like to see the maintenance status without having to open a tooltip. The display was a bit of an issue but this POC offers a way to improve the layout. This was also added to the dashboard

In addition to this I fixed the sorting that was broken (we can now sort with maintenance statuses)

## Type of Change
- Non breaking change ('update')
