### PR TITLE
LV: Add <GaugePercent /> components on Landing

### DIFF
--- a/packages/manager/src/components/GaugePercent/GaugePercent.tsx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.tsx
@@ -26,7 +26,7 @@ const useStyles = (options: Options) =>
       top: `calc((${options.height}px / 2))`,
       width: options.width,
       textAlign: 'center',
-      fontSize: options.fontSize || `${theme.spacing(2.5)}px `,
+      fontSize: options.fontSize || `${theme.spacing(2)}px `,
       color: theme.palette.text.primary
     },
     subTitle: {

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+import Typography from 'src/components/core/Typography';
+import GaugePercent from 'src/components/GaugePercent';
+import { baseGaugeProps } from './common';
+
+const LongviewGauge: React.FC = () => {
+  return (
+    <GaugePercent
+      {...baseGaugeProps}
+      max={100}
+      value={25}
+      innerText="300%"
+      subTitle={
+        <>
+          <Typography>
+            <strong>CPU</strong>
+          </Typography>
+          <Typography>4 Cores</Typography>
+        </>
+      }
+    />
+  );
+};
+
+export default LongviewGauge;

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import Typography from 'src/components/core/Typography';
+import GaugePercent from 'src/components/GaugePercent';
+import { baseGaugeProps } from './common';
+
+const LoadGauge: React.FC = () => {
+  return (
+    <GaugePercent
+      {...baseGaugeProps}
+      max={100}
+      value={70}
+      filledInColor="#FADB50"
+      innerText="0.75"
+      subTitle={
+        <>
+          <Typography>
+            <strong>Load</strong>
+          </Typography>
+          <Typography>0% Overallocated</Typography>
+        </>
+      }
+    />
+  );
+};
+
+export default LoadGauge;

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import Typography from 'src/components/core/Typography';
+import GaugePercent from 'src/components/GaugePercent';
+import { baseGaugeProps } from './common';
+
+const NetworkGauge: React.FC = () => {
+  return (
+    <GaugePercent
+      {...baseGaugeProps}
+      max={100}
+      value={35}
+      filledInColor="#4FAD62"
+      innerText="250 Mb/s"
+      subTitle={
+        <>
+          <Typography>
+            <strong>Network</strong>
+          </Typography>
+          <Typography>1 GB/s</Typography>
+        </>
+      }
+    />
+  );
+};
+
+export default NetworkGauge;

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import Typography from 'src/components/core/Typography';
+import GaugePercent from 'src/components/GaugePercent';
+import { baseGaugeProps } from './common';
+
+const RAMGauge: React.FC = () => {
+  return (
+    <GaugePercent
+      {...baseGaugeProps}
+      max={100}
+      value={50}
+      filledInColor="#D38ADB"
+      innerText="2 GB"
+      subTitle={
+        <>
+          <Typography>
+            <strong>RAM</strong>
+          </Typography>
+          <Typography>4 GB</Typography>
+        </>
+      }
+    />
+  );
+};
+
+export default RAMGauge;

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import Typography from 'src/components/core/Typography';
+import GaugePercent from 'src/components/GaugePercent';
+import { baseGaugeProps } from './common';
+
+const StorageGauge: React.FC = () => {
+  return (
+    <GaugePercent
+      {...baseGaugeProps}
+      max={100}
+      value={80}
+      filledInColor="#D38ADB"
+      innerText="36.41 GB"
+      subTitle={
+        <>
+          <Typography>
+            <strong>Storage</strong>
+          </Typography>
+          <Typography>38.33 GB</Typography>
+        </>
+      }
+    />
+  );
+};
+
+export default StorageGauge;

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
@@ -10,7 +10,7 @@ const StorageGauge: React.FC = () => {
       {...baseGaugeProps}
       max={100}
       value={80}
-      filledInColor="#D38ADB"
+      filledInColor="#F4AC3D"
       innerText="36.41 GB"
       subTitle={
         <>

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Swap.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Swap.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+import Typography from 'src/components/core/Typography';
+import GaugePercent from 'src/components/GaugePercent';
+import { baseGaugeProps } from './common';
+
+const SwapGauge: React.FC = () => {
+  return (
+    <GaugePercent
+      {...baseGaugeProps}
+      max={100}
+      value={25}
+      filledInColor="#DC4138"
+      innerText="128 MB"
+      subTitle={
+        <>
+          <Typography>
+            <strong>Swap</strong>
+          </Typography>
+          <Typography>512 MB</Typography>
+        </>
+      }
+    />
+  );
+};
+
+export default SwapGauge;

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/common.ts
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/common.ts
@@ -1,0 +1,4 @@
+export const baseGaugeProps = {
+  height: 125,
+  width: 125
+};

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -1,11 +1,26 @@
 import * as React from 'react';
 import { compose } from 'recompose';
 
+import { makeStyles, Theme } from 'src/components/core/styles';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
+import CPUGauge from './Gauges/CPU';
 import ActionMenu, { ActionHandlers } from './LongviewActionMenu';
 
 import { getLastUpdated } from '../request';
+import LoadGauge from './Gauges/Load';
+import NetworkGauge from './Gauges/Network';
+import RAMGauge from './Gauges/RAM';
+import StorageGauge from './Gauges/Storage';
+import SwapGauge from './Gauges/Swap';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    '& td': {
+      height: 192
+    }
+  }
+}));
 
 interface Props extends ActionHandlers {
   clientID: number;
@@ -16,6 +31,8 @@ interface Props extends ActionHandlers {
 type CombinedProps = Props;
 
 const LongviewClientRow: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
   let requestInterval: NodeJS.Timeout;
 
   const { clientID, clientLabel, clientAPIKey, ...actionHandlers } = props;
@@ -47,8 +64,26 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
   });
 
   return (
-    <TableRow rowLink={`longview/clients/${clientID}`}>
+    <TableRow className={classes.root} rowLink={`longview/clients/${clientID}`}>
       <TableCell>{`${clientLabel} - ${lastUpdated}`}</TableCell>
+      <TableCell>
+        <CPUGauge />
+      </TableCell>
+      <TableCell>
+        <RAMGauge />
+      </TableCell>
+      <TableCell>
+        <SwapGauge />
+      </TableCell>
+      <TableCell>
+        <LoadGauge />
+      </TableCell>
+      <TableCell>
+        <NetworkGauge />
+      </TableCell>
+      <TableCell>
+        <StorageGauge />
+      </TableCell>
       <TableCell>
         <ActionMenu
           longviewClientID={clientID}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewTable.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewTable.tsx
@@ -67,6 +67,13 @@ const LongviewTable: React.FC<CombinedProps> = props => {
                         >
                           Client
                         </TableSortCell>
+                        {/* @todo: Make these sortable (by what, though?) */}
+                        <TableCell>CPU</TableCell>
+                        <TableCell>RAM</TableCell>
+                        <TableCell>Swap</TableCell>
+                        <TableCell>Load</TableCell>
+                        <TableCell>Network</TableCell>
+                        <TableCell>Storage</TableCell>
                         <TableCell />
                       </TableRow>
                     </TableHead>


### PR DESCRIPTION
## Description

This PR adds `<GaugePercent />` components with dummy data. 

Each of these components will get their own data and manage loading, error states, etc.

I thought about making _one_ `<LongviewGauge />` component that takes a `getData` prop to do its data fetching/manipulation.... but I think it makes since to start with the super verbose version. If we want to eventually combine components, we can do it later.

**NOTE:** Mobile styling doesn't exist yet. Not sure if this has been decided on.

<img width="1274" alt="Screen Shot 2019-10-15 at 5 26 23 PM" src="https://user-images.githubusercontent.com/16911484/66871098-ee9aaa80-ef70-11e9-8ad2-646a8c74839c.png">
