### PR TITLE
Add: Longview Load Gauge

### DIFF
--- a/packages/manager/src/components/GaugePercent/GaugePercent.tsx
+++ b/packages/manager/src/components/GaugePercent/GaugePercent.tsx
@@ -48,7 +48,7 @@ interface Props {
   max: number;
   innerText?: string;
   innerTextFontSize?: number;
-  subTitle?: string | JSX.Element;
+  subTitle?: string | JSX.Element | null;
 }
 
 type CombinedProps = Props & WithTheme;
@@ -61,6 +61,12 @@ const GaugePercent: React.FC<CombinedProps> = props => {
     height,
     fontSize: props.innerTextFontSize
   })();
+
+  /**
+   * if the value exceeds the maximum (e.g Longview Load), just make the max 0
+   * so the value takes up 100% of the gauge
+   */
+  const finalMax = props.max - props.value < 0 ? 0 : props.max - props.value;
 
   return (
     <React.Fragment>
@@ -80,7 +86,7 @@ const GaugePercent: React.FC<CombinedProps> = props => {
                   props.nonFilledInColor || props.theme.color.grey2
                 ],
                 /** so basically, index 0 is the filled in, index 1 is the full graph percentage */
-                data: [props.value, props.max - props.value],
+                data: [props.value, finalMax],
                 backgroundColor: [
                   props.filledInColor || props.theme.color.blue,
                   props.nonFilledInColor || props.theme.color.grey2

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -25,6 +25,7 @@ const LoadGauge: React.FC<Props> = props => {
       .then(response => {
         setLoad(response.Load[0].y);
         setCores(pathOr(0, ['cpu', 'cores'], response.SysInfo));
+        setError(undefined);
 
         if (!!loading) {
           setLoading(false);

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -1,27 +1,100 @@
-import * as React from 'react';
-
+import { APIError } from 'linode-js-sdk/lib/types';
+import { pathOr } from 'ramda';
+import React from 'react';
 import Typography from 'src/components/core/Typography';
 import GaugePercent from 'src/components/GaugePercent';
 import { baseGaugeProps } from './common';
 
-const LoadGauge: React.FC = () => {
-  return (
-    <GaugePercent
-      {...baseGaugeProps}
-      max={100}
-      value={70}
-      filledInColor="#FADB50"
-      innerText="0.75"
-      subTitle={
-        <>
+import requestStats from '../../request';
+
+interface Props {
+  lastUpdated: number;
+  token: string;
+}
+
+const LoadGauge: React.FC<Props> = props => {
+  const [load, setLoad] = React.useState<number | undefined>(undefined);
+  const [amountOfCores, setCores] = React.useState<number | undefined>(
+    undefined
+  );
+  const [loading, setLoading] = React.useState<boolean>(true);
+  const [error, setError] = React.useState<APIError | undefined>(undefined);
+
+  React.useEffect(() => {
+    requestStats(props.token, 'getLatestValue', ['sysinfo', 'load'])
+      .then(response => {
+        setLoad(response.Load[0].y);
+        setCores(pathOr(1, ['cpu', 'cores'], response.SysInfo));
+
+        if (!!loading) {
+          setLoading(false);
+        }
+      })
+      .catch(e => {
+        if (!load) {
+          setError({
+            reason: 'Error'
+          });
+        }
+      });
+  }, [props.lastUpdated]);
+
+  const generateCopy = (): {
+    innerText: string;
+    subTitle: JSX.Element | null;
+  } => {
+    if (error) {
+      return {
+        innerText: error.reason,
+        subTitle: null
+      };
+    }
+
+    if (loading) {
+      return {
+        innerText: 'Loading...',
+        subTitle: null
+      };
+    }
+
+    return {
+      innerText: `${(load || 0).toFixed(2)}`,
+      subTitle: (
+        <React.Fragment>
           <Typography>
             <strong>Load</strong>
           </Typography>
-          <Typography>0% Overallocated</Typography>
-        </>
-      }
+          <Typography>
+            {`${getOverallocationPercent(
+              amountOfCores || 0,
+              load || 0
+            )}% Overallocated`}
+          </Typography>
+        </React.Fragment>
+      )
+    };
+  };
+
+  return (
+    <GaugePercent
+      {...baseGaugeProps}
+      max={amountOfCores || 1}
+      value={load || 1}
+      filledInColor="#FADB50"
+      {...generateCopy()}
     />
   );
+};
+
+const getOverallocationPercent = (amountOfCores: number, load: number) => {
+  /** we have a negative number meaning we're overallocated */
+  const allocation = amountOfCores - load;
+  if (allocation < 0) {
+    /** turn into a positive number as a percent */
+    return Math.round(allocation * 100 * -1);
+  }
+
+  return 0;
 };
 
 export default LoadGauge;

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -24,17 +24,21 @@ const LoadGauge: React.FC<Props> = props => {
     requestStats(props.token, 'getLatestValue', ['sysinfo', 'load'])
       .then(response => {
         setLoad(response.Load[0].y);
-        setCores(pathOr(1, ['cpu', 'cores'], response.SysInfo));
+        setCores(pathOr(0, ['cpu', 'cores'], response.SysInfo));
 
         if (!!loading) {
           setLoading(false);
         }
       })
-      .catch(e => {
+      .catch(() => {
         if (!load) {
           setError({
             reason: 'Error'
           });
+        }
+
+        if (!!loading) {
+          setLoading(false);
         }
       });
   }, [props.lastUpdated]);
@@ -46,14 +50,22 @@ const LoadGauge: React.FC<Props> = props => {
     if (error) {
       return {
         innerText: error.reason,
-        subTitle: null
+        subTitle: (
+          <Typography>
+            <strong>Load</strong>
+          </Typography>
+        )
       };
     }
 
     if (loading) {
       return {
         innerText: 'Loading...',
-        subTitle: null
+        subTitle: (
+          <Typography>
+            <strong>Load</strong>
+          </Typography>
+        )
       };
     }
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -17,7 +17,8 @@ import SwapGauge from './Gauges/Swap';
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     '& td': {
-      height: 192
+      height: 192,
+      paddingBottom: theme.spacing(4)
     }
   }
 }));
@@ -65,7 +66,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
 
   return (
     <TableRow className={classes.root} rowLink={`longview/clients/${clientID}`}>
-      <TableCell>{`${clientLabel} - ${lastUpdated}`}</TableCell>
+      <TableCell>{`${clientLabel}`}</TableCell>
       <TableCell>
         <CPUGauge clientAPIKey={clientAPIKey} lastUpdated={lastUpdated} />
       </TableCell>
@@ -76,7 +77,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
         <SwapGauge />
       </TableCell>
       <TableCell>
-        <LoadGauge />
+        <LoadGauge lastUpdated={lastUpdated} token={clientAPIKey} />
       </TableCell>
       <TableCell>
         <NetworkGauge />

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewTableRows.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewTableRows.tsx
@@ -35,7 +35,7 @@ const LongviewTableRows: React.FC<CombinedProps> = props => {
   } = props;
 
   if (longviewClientsLoading && longviewClientsLastUpdated === 0) {
-    return <TableRowLoading colSpan={3} />;
+    return <TableRowLoading colSpan={9} />;
   }
 
   /**
@@ -44,7 +44,7 @@ const LongviewTableRows: React.FC<CombinedProps> = props => {
   if (longviewClientsError.read && longviewClientsLastUpdated === 0) {
     return (
       <TableRowError
-        colSpan={3}
+        colSpan={9}
         message={longviewClientsError.read[0].reason}
       />
     );
@@ -53,7 +53,7 @@ const LongviewTableRows: React.FC<CombinedProps> = props => {
   if (longviewClientsLastUpdated !== 0 && longviewClientsResults === 0) {
     return (
       <TableRowEmpty
-        colSpan={3}
+        colSpan={9}
         message="You do not have any Longview Clients"
       />
     );

--- a/packages/manager/src/hooks/usePrevious.ts
+++ b/packages/manager/src/hooks/usePrevious.ts
@@ -11,3 +11,5 @@ export const usePrevious = <T>(value: T) => {
   });
   return ref.current;
 };
+
+export default usePrevious;


### PR DESCRIPTION
## Description

Adds logic to the Longview Load gauge.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Load of 1 === 100% CPU utilized.


![Screen Shot 2019-10-16 at 1 53 11 PM](https://user-images.githubusercontent.com/7387001/66945456-13e4f280-f01d-11e9-8a61-4de66b747655.png)
![Screen Shot 2019-10-16 at 12 09 13 PM](https://user-images.githubusercontent.com/7387001/66945457-13e4f280-f01d-11e9-8acb-3f7519a69c09.png)
