### PR TITLE
M3-3427 LV: CPU Gauge 

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.test.tsx
@@ -1,0 +1,57 @@
+import { CPU } from '../../request.types';
+import { normalizeValue, sumCPUUsage } from './CPU';
+
+describe('CPU Gauge', () => {
+  describe('sumCPUUSage', () => {
+    const cpuData: Record<string, CPU> = {
+      cpu0: {
+        user: [{ x: 0, y: 1 }],
+        system: [{ x: 0, y: 2 }],
+        wait: [{ x: 0, y: 3 }]
+      }
+    };
+    it('sums CPU usage given data', () => {
+      expect(sumCPUUsage(cpuData)).toBe(6);
+    });
+    it('works with multiple CPUs', () => {
+      const data = {
+        ...cpuData,
+        cpu1: {
+          user: [{ x: 0, y: 1 }],
+          system: [{ x: 0, y: 2 }],
+          wait: [{ x: 0, y: 3 }]
+        }
+      };
+      expect(sumCPUUsage(data)).toBe(12);
+    });
+    it('returns 0 if data is malformed', () => {
+      expect(sumCPUUsage({})).toBe(0);
+      expect(sumCPUUsage({ cpu0: {} as any })).toBe(0);
+      expect(sumCPUUsage({ cpu0: { user: undefined } as any })).toBe(0);
+      expect(sumCPUUsage({ cpu0: { user: null } as any })).toBe(0);
+      expect(
+        sumCPUUsage({ cpu0: { user: [], system: null, wait: 1 } as any })
+      ).toBe(0);
+    });
+  });
+
+  describe('normalizeValue utility', () => {
+    it('should clamp the value between 0 and 100', () => {
+      expect(normalizeValue(-1, 1)).toBe(0);
+      expect(normalizeValue(0, 1)).toBe(0);
+      expect(normalizeValue(50, 1)).toBe(50);
+      expect(normalizeValue(100, 1)).toBe(100);
+      expect(normalizeValue(101, 1)).toBe(100);
+    });
+    it('rounds the result', () => {
+      expect(normalizeValue(49.99, 1)).toBe(50);
+      expect(normalizeValue(99.01, 1)).toBe(99);
+    });
+    it('should clamp max based on number of cores', () => {
+      expect(normalizeValue(150, 1)).toBe(100);
+      expect(normalizeValue(150, 2)).toBe(150);
+      expect(normalizeValue(-50, 1)).toBe(0);
+      expect(normalizeValue(-50, 2)).toBe(0);
+    });
+  });
+});

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -1,22 +1,70 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+import { clamp, path, pathOr } from 'ramda';
 import * as React from 'react';
-
 import Typography from 'src/components/core/Typography';
 import GaugePercent from 'src/components/GaugePercent';
+import { pluralize } from 'src/utilities/pluralize';
+import requestStats from '../../request';
+import { CPU } from '../../request.types';
 import { baseGaugeProps } from './common';
 
-const LongviewGauge: React.FC = () => {
+interface Props {
+  clientAPIKey: string;
+  lastUpdated: number;
+}
+
+const LongviewGauge: React.FC<Props> = props => {
+  const { clientAPIKey, lastUpdated } = props;
+
+  const [loading, setLoading] = React.useState<boolean>(true);
+  const [error, setError] = React.useState<APIError | undefined>();
+
+  const [usedCPU, setUsedCPU] = React.useState<number>(0);
+  const [numCores, setNumCores] = React.useState<number>(1);
+
+  React.useEffect(() => {
+    requestStats(clientAPIKey, 'getLatestValue', ['cpu', 'sysinfo'])
+      .then(data => {
+        setLoading(false);
+        setError(undefined);
+
+        const cores = path<number>(['SysInfo', 'cpu', 'cores'], data);
+
+        // If we don't have the number of cores, we can't determine the value.
+        if (!cores) {
+          return;
+        }
+
+        setNumCores(cores);
+
+        const used = sumCPUUsage(data.CPU);
+        const normalizedUsed = normalizeValue(used, cores);
+        setUsedCPU(normalizedUsed);
+      })
+      .catch(_ => {
+        setError({
+          reason: 'Error' // @todo: Error message?
+        });
+        setLoading(false);
+      });
+  }, [lastUpdated]);
+
   return (
     <GaugePercent
       {...baseGaugeProps}
-      max={100}
-      value={25}
-      innerText="300%"
+      // The MAX depends on the number of CPU cores. Default to 1 if cores
+      // doesn't exist or is 0.
+      max={100 * numCores || 1}
+      value={usedCPU}
+      innerText={innerText(usedCPU, loading, error)}
       subTitle={
         <>
           <Typography>
             <strong>CPU</strong>
           </Typography>
-          <Typography>4 Cores</Typography>
+          {!error && !loading && (
+            <Typography>{pluralize('Core', 'Cores', numCores)}</Typography>
+          )}
         </>
       }
     />
@@ -24,3 +72,38 @@ const LongviewGauge: React.FC = () => {
 };
 
 export default LongviewGauge;
+
+// UTILITIES
+export const sumCPUUsage = (CPUData: Record<string, CPU> = {}) => {
+  let sum = 0;
+  Object.keys(CPUData).forEach(key => {
+    const cpu = CPUData[key];
+    Object.keys(cpu).forEach(entry => {
+      const val = pathOr(0, [entry, 0, 'y'], cpu);
+      sum += val;
+    });
+  });
+  return sum;
+};
+
+export const normalizeValue = (value: number, numCores: number) => {
+  const clamped = clamp(0, 100 * numCores)(value);
+  const rounded = Math.round(clamped);
+  return rounded;
+};
+
+export const innerText = (
+  value: number,
+  loading: boolean,
+  error?: APIError
+) => {
+  if (error) {
+    return error.reason;
+  }
+
+  if (loading) {
+    return 'Loading...';
+  }
+
+  return `${value}%`;
+};

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -67,7 +67,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
     <TableRow className={classes.root} rowLink={`longview/clients/${clientID}`}>
       <TableCell>{`${clientLabel} - ${lastUpdated}`}</TableCell>
       <TableCell>
-        <CPUGauge />
+        <CPUGauge clientAPIKey={clientAPIKey} lastUpdated={lastUpdated} />
       </TableCell>
       <TableCell>
         <RAMGauge />

--- a/packages/manager/src/features/Longview/request.ts
+++ b/packages/manager/src/features/Longview/request.ts
@@ -78,6 +78,11 @@ interface Get {
     action: 'getLatestValue',
     field: ('load' | 'sysinfo')[]
   ): Promise<LongviewLoad & LongviewSystemInfo>;
+  (
+    token: string,
+    action: 'getLatestValue',
+    field: ('cpu' | 'sysinfo')[]
+  ): Promise<LongviewCPU & LongviewSystemInfo>;
   (token: string, action: LongviewAction, field?: LongviewFieldName[]): Promise<
     Partial<AllData>
   >;

--- a/packages/manager/src/features/Longview/request.types.ts
+++ b/packages/manager/src/features/Longview/request.types.ts
@@ -25,7 +25,7 @@ interface Disk {
 }
 /*
   each key will be the name of the disk
-  
+
   So if I have 1 ext disk and 1 swap, the keys might be:
 
   {
@@ -57,15 +57,15 @@ export interface LongviewMemory {
   };
 }
 
-interface CPU {
+export interface CPU {
   user: Stat[];
   wait: Stat[];
   system: Stat[];
 }
 
 /*
-  each key will be cpu${number} 
-  
+  each key will be cpu${number}
+
   So if I have 2 CPUs, the keys will be:
 
   {


### PR DESCRIPTION
## Description

The CPU gauge is now functional. 

<img width="179" alt="Screen Shot 2019-10-16 at 5 03 57 PM" src="https://user-images.githubusercontent.com/16911484/66958780-f58bf080-f036-11e9-97d3-226eb80edc11.png">

## Type of Change
- Non breaking change ('update', 'change')



## Note to Reviewers

**TO TEST:**
- There are new unit tests for the utility functions. 
- To test in the app, you'll ideally want to try multiple LV clients with Linodes that have different number of cores. .
