### PR TITLE
M3-3384 Force object downloads

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -233,7 +233,7 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
       });
   };
 
-  handleDownload = async (objectName: string, newTab = false) => {
+  handleDownload = async (objectName: string) => {
     const { clusterId, bucketName } = this.props.match.params;
 
     try {
@@ -241,16 +241,14 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
         clusterId,
         bucketName,
         objectName,
-        'GET'
+        'GET',
+        // Force download with content_disposition: attachment
+        { content_disposition: 'attachment' }
       );
 
       sendDownloadObjectEvent();
 
-      if (newTab) {
-        window.open(url, '_blank', 'noopener');
-      } else {
-        window.location.assign(url);
-      }
+      window.location.assign(url);
     } catch (err) {
       this.props.enqueueSnackbar('Error downloading Object', {
         variant: 'error'

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.test.tsx
@@ -33,19 +33,19 @@ describe('ObjectActionMenu', () => {
     expect(mockHandleClickDelete).toHaveBeenCalled();
   });
 
-  it('Includes a "Open" option', () => {
+  it('Includes a "Download" option', () => {
     const { queryByText } = render(
       wrapWithTheme(<ObjectActionMenu {...props} />)
     );
-    expect(queryByText('Open')).toBeInTheDocument();
+    expect(queryByText('Download')).toBeInTheDocument();
   });
 
-  it('executes the onOpen function when the "Open" option is clicked', () => {
+  it('executes the onOpen function when the "Download" option is clicked', () => {
     const { getAllByText } = render(
       wrapWithTheme(<ObjectActionMenu {...props} />)
     );
 
-    fireEvent.click(getAllByText('Open')[0]);
+    fireEvent.click(getAllByText('Download')[0]);
     expect(mockHandleClickDownload).toHaveBeenCalled();
   });
 });

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
@@ -11,7 +11,7 @@ export const ObjectActionMenu: React.FC<Props> = props => {
   const createActions = () => (closeMenu: Function): Action[] => {
     return [
       {
-        title: 'Open',
+        title: 'Download',
         onClick: (e: React.MouseEvent<HTMLElement>) => {
           const shouldOpenInNewTab = true;
           props.handleClickDownload(props.objectName, shouldOpenInNewTab);

--- a/packages/manager/src/services/objectStorage/objects.ts
+++ b/packages/manager/src/services/objectStorage/objects.ts
@@ -7,6 +7,7 @@ interface ObjectURLOptions {
   // of a request to /object-url, to inform the API which kind of file it is
   // we're trying to upload.
   content_type?: string;
+  content_disposition?: string;
 }
 
 /**

--- a/packages/manager/src/services/objectStorage/objects.ts
+++ b/packages/manager/src/services/objectStorage/objects.ts
@@ -7,7 +7,7 @@ interface ObjectURLOptions {
   // of a request to /object-url, to inform the API which kind of file it is
   // we're trying to upload.
   content_type?: string;
-  content_disposition?: string;
+  content_disposition?: 'attachment';
 }
 
 /**


### PR DESCRIPTION
## Description

This PR takes advantage of the new "content_disposition" option in the /object-url endpoint so that the resulting URL will have a `Content-Disposition` header. Set to `attachment`, this will force a browser download.

## Type of Change
- Non breaking change ('update', 'change')


## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
