### PR TITLE
Add: Longview Memory Gauge

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:docker": "lerna run build --stream --scope linode-js-sdk && yarn start:all",
     "start:all": "lerna run start --parallel -- --color",
     "clean": "rm -rf node_modules && lerna clean --yes",
-    "test": "lerna run test --stream --scope linode-manager -- --color",
+    "test": "lerna run test --stream --scope linode-manager -- --color --detectOpenHandles",
     "selenium": "lerna run selenium --stream --scope linode-manager -- --color",
     "storybook": "lerna run storybook --stream --scope linode-manager",
     "storybook:e2e": "lerna run storybook:e2e --stream --scope linode-manager -- --color",

--- a/packages/manager/src/__data__/longview.ts
+++ b/packages/manager/src/__data__/longview.ts
@@ -1,5 +1,6 @@
 import {
   LongviewLoad,
+  LongviewMemory,
   LongviewSystemInfo
 } from 'src/features/Longview/request.types';
 
@@ -27,5 +28,50 @@ export const systemInfo: LongviewSystemInfo = {
       type: 'Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz'
     },
     hostname: 'localhost'
+  }
+};
+
+export const memory: LongviewMemory = {
+  Memory: {
+    real: {
+      used: [
+        {
+          y: 5000,
+          x: 500
+        }
+      ],
+      cache: [
+        {
+          y: 100,
+          x: 100
+        }
+      ],
+      buffers: [
+        {
+          y: 100,
+          x: 100
+        }
+      ],
+      free: [
+        {
+          y: 2000000,
+          x: 200
+        }
+      ]
+    },
+    swap: {
+      free: [
+        {
+          y: 100,
+          x: 100
+        }
+      ],
+      used: [
+        {
+          y: 2000000,
+          x: 100
+        }
+      ]
+    }
   }
 };

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -57,7 +57,7 @@ const LongviewGauge: React.FC<Props> = props => {
       // The MAX depends on the number of CPU cores. Default to 1 if cores
       // doesn't exist or is 0.
       max={typeof numCores === 'undefined' ? 1 : 100 * numCores}
-      value={typeof usedCPU === 'undefined' ? 1 : usedCPU}
+      value={typeof usedCPU === 'undefined' ? 0 : usedCPU}
       innerText={innerText(usedCPU || 0, loading, error)}
       subTitle={
         <>

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -19,8 +19,8 @@ const LongviewGauge: React.FC<Props> = props => {
   const [loading, setLoading] = React.useState<boolean>(true);
   const [error, setError] = React.useState<APIError | undefined>();
 
-  const [usedCPU, setUsedCPU] = React.useState<number>(0);
-  const [numCores, setNumCores] = React.useState<number>(1);
+  const [usedCPU, setUsedCPU] = React.useState<number | undefined>();
+  const [numCores, setNumCores] = React.useState<number | undefined>();
 
   React.useEffect(() => {
     requestStats(clientAPIKey, 'getLatestValue', ['cpu', 'sysinfo'])
@@ -56,16 +56,16 @@ const LongviewGauge: React.FC<Props> = props => {
       {...baseGaugeProps}
       // The MAX depends on the number of CPU cores. Default to 1 if cores
       // doesn't exist or is 0.
-      max={100 * numCores || 1}
-      value={usedCPU || 100}
-      innerText={innerText(usedCPU, loading, error)}
+      max={typeof numCores === 'undefined' ? 1 : 100 * numCores}
+      value={typeof usedCPU === 'undefined' ? 1 : usedCPU}
+      innerText={innerText(usedCPU || 0, loading, error)}
       subTitle={
         <>
           <Typography>
             <strong>CPU</strong>
           </Typography>
           {!error && !loading && (
-            <Typography>{pluralize('Core', 'Cores', numCores)}</Typography>
+            <Typography>{pluralize('Core', 'Cores', numCores || 0)}</Typography>
           )}
         </>
       }

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -96,7 +96,7 @@ const LoadGauge: React.FC<Props> = props => {
     <GaugePercent
       {...baseGaugeProps}
       max={typeof amountOfCores === 'undefined' ? 1 : amountOfCores}
-      value={typeof load === 'undefined' ? 1 : load}
+      value={typeof load === 'undefined' ? 0 : load}
       filledInColor="#FADB50"
       {...generateCopy()}
     />

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -13,19 +13,17 @@ interface Props {
 }
 
 const LoadGauge: React.FC<Props> = props => {
-  const [load, setLoad] = React.useState<number | undefined>(undefined);
-  const [amountOfCores, setCores] = React.useState<number | undefined>(
-    undefined
-  );
+  const [load, setLoad] = React.useState<number | undefined>();
+  const [amountOfCores, setCores] = React.useState<number | undefined>();
   const [loading, setLoading] = React.useState<boolean>(true);
-  const [error, setError] = React.useState<APIError | undefined>(undefined);
+  const [error, setError] = React.useState<APIError | undefined>();
 
   React.useEffect(() => {
     let mounted = true;
     requestStats(props.token, 'getLatestValue', ['sysinfo', 'load'])
       .then(response => {
         if (mounted) {
-          setLoad(response.Load[0].y);
+          setLoad(pathOr(0, ['Load', 0, 'y'], response));
           setCores(pathOr(0, ['cpu', 'cores'], response.SysInfo));
           setError(undefined);
 
@@ -97,8 +95,8 @@ const LoadGauge: React.FC<Props> = props => {
   return (
     <GaugePercent
       {...baseGaugeProps}
-      max={amountOfCores || 1}
-      value={load || 1}
+      max={typeof amountOfCores === 'undefined' ? 1 : amountOfCores}
+      value={typeof load === 'undefined' ? 1 : load}
       filledInColor="#FADB50"
       {...generateCopy()}
     />

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, waitForElement } from '@testing-library/react';
+import MockAdapter from 'axios-mock-adapter';
+import * as React from 'react';
+import { memory as mockMemory } from 'src/__data__/longview';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import { baseRequest } from '../../request';
+import RAM, { generateTotalMemory, generateUsedMemory } from './RAM';
+
+const mockApi = new MockAdapter(baseRequest);
+
+afterEach(cleanup);
+
+describe('Utility Functions', () => {
+  it('should generate used memory correctly', () => {
+    expect(generateUsedMemory(400, 100, 100)).toBe(200);
+    expect(generateUsedMemory(0, 100, 100)).toBe(0);
+    expect(generateUsedMemory(1000, 100, 100)).toBe(800);
+  });
+
+  it('should generate total memory correctly', () => {
+    expect(generateTotalMemory(100, 400)).toBe(500);
+    expect(generateTotalMemory(500, 400)).toBe(900);
+    expect(generateTotalMemory(100, 900)).toBe(1000);
+  });
+});
+
+describe('Longview RAM Gauge UI', () => {
+  it('should render a loading state initially', () => {
+    const { getByText } = renderWithTheme(<RAM lastUpdated={0} token="" />);
+
+    expect(getByText(/Loading/)).toBeInTheDocument();
+  });
+
+  it('should render an error state on 400 responses', async done => {
+    const { getByText } = renderWithTheme(<RAM lastUpdated={0} token="" />);
+
+    mockApi.onPost().reply(400, [
+      {
+        /** everything inside is the response from the Longview API */
+        NOTIFICATIONS: [],
+        DATA: {
+          ...mockMemory
+        }
+      }
+    ]);
+
+    const resolvedDiv = await waitForElement(() => getByText(/Error/));
+
+    expect(resolvedDiv).toHaveTextContent(/Error/);
+    done();
+  });
+
+  it('should render a data state on 200 responses', async done => {
+    const { getByTestId } = renderWithTheme(<RAM lastUpdated={0} token="" />);
+
+    mockApi.onPost().reply(200, [
+      {
+        /** everything inside is the response from the Longview API */
+        NOTIFICATIONS: [],
+        DATA: {
+          ...mockMemory
+        }
+      }
+    ]);
+
+    const innerText = await waitForElement(() =>
+      getByTestId('gauge-innertext')
+    );
+    const subtext = await waitForElement(() => getByTestId('gauge-subtext'));
+    done();
+
+    expect(innerText).toHaveTextContent('4.69 MB');
+    expect(subtext).toHaveTextContent('1.91 GB');
+  });
+});

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -1,27 +1,155 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+import { pathOr } from 'ramda';
 import * as React from 'react';
-
 import Typography from 'src/components/core/Typography';
 import GaugePercent from 'src/components/GaugePercent';
+import requestStats from '../../request';
 import { baseGaugeProps } from './common';
 
-const RAMGauge: React.FC = () => {
-  return (
-    <GaugePercent
-      {...baseGaugeProps}
-      max={100}
-      value={50}
-      filledInColor="#D38ADB"
-      innerText="2 GB"
-      subTitle={
-        <>
+import { readableBytes } from 'src/utilities/unitConversions';
+
+interface Props {
+  lastUpdated: number;
+  token: string;
+}
+
+const RAMGauge: React.FC<Props> = props => {
+  const [memory, setMemory] = React.useState<number | undefined>();
+  const [totalMemory, setTotalMemory] = React.useState<number | undefined>();
+  const [loading, setLoading] = React.useState<boolean>(true);
+  const [error, setError] = React.useState<APIError | undefined>();
+
+  let mounted = true;
+
+  React.useEffect(() => {
+    requestStats(props.token, 'getLatestValue', ['memory'])
+      .then(response => {
+        /**
+         * The likelihood of any of these paths being undefined is a big
+         * unknown, so we learn towards safety.
+         */
+        const free = pathOr(0, ['Memory', 'real', 'free', 0, 'y'], response);
+        const used = pathOr(0, ['Memory', 'real', 'used', 0, 'y'], response);
+        const buffers = pathOr(
+          0,
+          ['Memory', 'real', 'buffers', 0, 'y'],
+          response
+        );
+        const cache = pathOr(0, ['Memory', 'real', 'cache', 0, 'y'], response);
+
+        if (mounted) {
+          setError(undefined);
+          /**
+           * All units come back in KB. We will do our converting in the render methods
+           */
+          setMemory(generateUsedMemory(used, buffers, cache, free));
+          setTotalMemory(generateTotalMemory(used, free));
+          if (!!loading) {
+            setLoading(false);
+          }
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          if (!memory) {
+            setError({
+              reason: 'Error'
+            });
+          }
+
+          if (!!loading) {
+            setLoading(false);
+          }
+        }
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [props.lastUpdated]);
+
+  const generateText = (): {
+    innerText: string;
+    subTitle: string | JSX.Element;
+  } => {
+    if (loading) {
+      return {
+        innerText: 'Loading',
+        subTitle: (
           <Typography>
             <strong>RAM</strong>
           </Typography>
-          <Typography>4 GB</Typography>
-        </>
+        )
+      };
+    }
+
+    if (error) {
+      return {
+        innerText: 'Error',
+        subTitle: (
+          <Typography>
+            <strong>RAM</strong>
+          </Typography>
+        )
+      };
+    }
+
+    /** first convert memory from KB to bytes */
+    const usedMemoryToBytes = (memory || 0) * 1024;
+    const howManyBytesInGB = 1073741824;
+
+    const convertedUsedMemory = readableBytes(
+      /** convert KB to bytes */
+      usedMemoryToBytes,
+      {
+        unit: usedMemoryToBytes > howManyBytesInGB ? 'GB' : 'MB'
       }
+    );
+
+    const convertedTotalMemory = readableBytes(
+      /** convert KB to bytes */
+      (totalMemory || 0) * 1024,
+      {
+        unit: 'GB'
+      }
+    );
+
+    return {
+      innerText: `${convertedUsedMemory.value} ${convertedUsedMemory.unit}`,
+      subTitle: (
+        <React.Fragment>
+          <Typography>
+            <strong>RAM</strong>
+          </Typography>
+          <Typography>{`${convertedTotalMemory.value} GB`}</Typography>
+        </React.Fragment>
+      )
+    };
+  };
+
+  return (
+    <GaugePercent
+      {...baseGaugeProps}
+      max={totalMemory || 1}
+      value={memory || 1}
+      filledInColor="#D38ADB"
+      {...generateText()}
     />
   );
 };
+
+const generateUsedMemory = (
+  used: number,
+  buffers: number,
+  cache: number,
+  free: number
+) => {
+  /**
+   * calculation comes from original implementation of Longview.JS
+   */
+  return used - (buffers + cache);
+};
+
+const generateTotalMemory = (used: number, free: number) => used + free;
 
 export default RAMGauge;

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -42,7 +42,7 @@ const RAMGauge: React.FC<Props> = props => {
           /**
            * All units come back in KB. We will do our converting in the render methods
            */
-          setMemory(generateUsedMemory(used, buffers, cache, free));
+          setMemory(generateUsedMemory(used, buffers, cache));
           setTotalMemory(generateTotalMemory(used, free));
           if (!!loading) {
             setLoading(false);
@@ -138,18 +138,18 @@ const RAMGauge: React.FC<Props> = props => {
   );
 };
 
-const generateUsedMemory = (
+export const generateUsedMemory = (
   used: number,
   buffers: number,
-  cache: number,
-  free: number
+  cache: number
 ) => {
   /**
    * calculation comes from original implementation of Longview.JS
    */
-  return used - (buffers + cache);
+  const result = used - (buffers + cache);
+  return result < 0 ? 0 : result;
 };
 
-const generateTotalMemory = (used: number, free: number) => used + free;
+export const generateTotalMemory = (used: number, free: number) => used + free;
 
 export default RAMGauge;

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -9,7 +9,7 @@ import { baseGaugeProps } from './common';
 import { readableBytes } from 'src/utilities/unitConversions';
 
 interface Props {
-  lastUpdated: number;
+  lastUpdated?: number;
   token: string;
 }
 

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -1,5 +1,5 @@
 import { APIError } from 'linode-js-sdk/lib/types';
-import { pathOr } from 'ramda';
+import { path } from 'ramda';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
 import GaugePercent from 'src/components/GaugePercent';
@@ -28,22 +28,34 @@ const RAMGauge: React.FC<Props> = props => {
          * The likelihood of any of these paths being undefined is a big
          * unknown, so we learn towards safety.
          */
-        const free = pathOr(0, ['Memory', 'real', 'free', 0, 'y'], response);
-        const used = pathOr(0, ['Memory', 'real', 'used', 0, 'y'], response);
-        const buffers = pathOr(
-          0,
+        const free = path<number | undefined>(
+          ['Memory', 'real', 'free', 0, 'y'],
+          response
+        );
+        const used = path<number | undefined>(
+          ['Memory', 'real', 'used', 0, 'y'],
+          response
+        );
+        const buffers = path<number | undefined>(
           ['Memory', 'real', 'buffers', 0, 'y'],
           response
         );
-        const cache = pathOr(0, ['Memory', 'real', 'cache', 0, 'y'], response);
+        const cache = path<number | undefined>(
+          ['Memory', 'real', 'cache', 0, 'y'],
+          response
+        );
 
         if (mounted) {
           setError(undefined);
           /**
            * All units come back in KB. We will do our converting in the render methods
+           * Only set state if these values are not undefined because the render method
+           * has custom handling for if the values are undefined.
            */
-          setMemory(generateUsedMemory(used, buffers, cache));
-          setTotalMemory(generateTotalMemory(used, free));
+          if (!!free && !!used && !!cache && !!buffers) {
+            setMemory(generateUsedMemory(used, buffers, cache));
+            setTotalMemory(generateTotalMemory(used, free));
+          }
           if (!!loading) {
             setLoading(false);
           }
@@ -130,8 +142,8 @@ const RAMGauge: React.FC<Props> = props => {
   return (
     <GaugePercent
       {...baseGaugeProps}
-      max={totalMemory || 1}
-      value={memory || 1}
+      max={typeof totalMemory === 'undefined' ? 1 : totalMemory}
+      value={typeof memory === 'undefined' ? 0 : memory}
       filledInColor="#D38ADB"
       {...generateText()}
     />

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -14,6 +14,9 @@ interface Props {
 }
 
 const RAMGauge: React.FC<Props> = props => {
+  const [dataHasResolvedAtLeastOnce, setDataResolved] = React.useState<boolean>(
+    false
+  );
   const [memory, setMemory] = React.useState<number | undefined>();
   const [totalMemory, setTotalMemory] = React.useState<number | undefined>();
   const [loading, setLoading] = React.useState<boolean>(true);
@@ -59,11 +62,14 @@ const RAMGauge: React.FC<Props> = props => {
           if (!!loading) {
             setLoading(false);
           }
+          if (!dataHasResolvedAtLeastOnce) {
+            setDataResolved(true);
+          }
         }
       })
       .catch(() => {
         if (mounted) {
-          if (!memory) {
+          if (!dataHasResolvedAtLeastOnce) {
             setError({
               reason: 'Error'
             });

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -80,13 +80,13 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
         <CPUGauge clientAPIKey={clientAPIKey} lastUpdated={lastUpdated} />
       </TableCell>
       <TableCell>
-        <RAMGauge />
+        <RAMGauge token={clientAPIKey} lastUpdated={lastUpdated} />
       </TableCell>
       <TableCell>
         <SwapGauge />
       </TableCell>
       <TableCell>
-        <LoadGauge lastUpdated={lastUpdated} token={clientAPIKey} />
+        <LoadGauge token={clientAPIKey} lastUpdated={lastUpdated} />
       </TableCell>
       <TableCell>
         <NetworkGauge />

--- a/packages/manager/src/features/Longview/request.ts
+++ b/packages/manager/src/features/Longview/request.ts
@@ -72,19 +72,22 @@ type AllData = LongviewCPU &
  * the return type will be Promise<LongviewCPU>
  */
 interface Get {
-  (token: string, action: 'lastUpdated'): Promise<LastUpdated>;
+  (token: string, action: 'lastUpdated'): Promise<Partial<LastUpdated>>;
   (
     token: string,
     action: 'getLatestValue',
     field: ('load' | 'sysinfo')[]
-  ): Promise<LongviewLoad & LongviewSystemInfo>;
+  ): Promise<Partial<LongviewLoad & LongviewSystemInfo>>;
   (
     token: string,
     action: 'getLatestValue',
     field: ('cpu' | 'sysinfo')[]
-  ): Promise<LongviewCPU & LongviewSystemInfo>;
+  ): Promise<Partial<LongviewCPU & LongviewSystemInfo>>;
   (token: string, action: LongviewAction, field?: LongviewFieldName[]): Promise<
     Partial<AllData>
+  >;
+  (token: string, action: 'getLatestValue', field: 'memory'[]): Promise<
+    Partial<LongviewMemory>
   >;
 }
 


### PR DESCRIPTION
🚨  This code got a little muddy. I think in follow up PR, I'm going to add logic to the Gauge to say

`if (value === 0 && max === 0) { max = 1 }`

so that we end up with a full grey bar if the stat is actually sitting at 0. [See this commit in the next upcoming PR](https://github.com/linode/manager/pull/5619/commits/969046ebfe509caa86abd5acec9606b32cdd461f) 🚨 

## Description

Adds Longview Memory Gauge

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

I tried deleting my swap disk and seeing the dataset that is returned from the Longview API. It appears that if you don't have a certain disk, the response will still return the same keys but just have a value of `0`.

I also initialized all values as `undefined` so that `value || 1` logic isn't applied when a value is actually `0`.