### PR TITLE
M3-3411 Change dashboard feed links

### DIFF
--- a/packages/manager/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
@@ -65,7 +65,7 @@ export class BlogDashboardCard extends React.Component<CombinedProps, State> {
     this.mounted = true;
 
     req
-      .get(`https://blog.linode.com/feed/`, { responseType: 'text' })
+      .get(`https://linode.com/blog/feed/`, { responseType: 'text' })
       .then(({ data }) => parseXMLStringPromise(data))
       .then(processXMLData)
       .then(
@@ -128,7 +128,7 @@ export class BlogDashboardCard extends React.Component<CombinedProps, State> {
   renderAction = () => (
     <ViewAllLink
       text="Read More"
-      link={'https://blog.linode.com/'}
+      link={'https://linode.com/blog/'}
       data-qa-read-more
       external
     />


### PR DESCRIPTION
## M3-3411 Change dashboard feed links

The Blog RSS feed url needed to be updated to linode.com/blog/feed, where the XML is located.

## Type of Change
- Non breaking change ('update')