### PR TITLE
LKE-987 Hide the ability to tag clusters in Cloud Manager

### DIFF
--- a/packages/linode-js-sdk/src/kubernetes/kubernetes.schema.ts
+++ b/packages/linode-js-sdk/src/kubernetes/kubernetes.schema.ts
@@ -22,7 +22,6 @@ export const createKubeClusterSchema = object().shape({
   label: clusterLabelSchema,
   region: string().required('Region is required.'),
   version: string().required('Kubernetes version is required.'),
-  tags: array().of(string()),
   node_pools: array()
     .of(nodePoolSchema)
     .min(1, 'Please add at least one node pool.')

--- a/packages/linode-js-sdk/src/kubernetes/types.ts
+++ b/packages/linode-js-sdk/src/kubernetes/types.ts
@@ -1,7 +1,6 @@
 export interface KubernetesCluster {
   created: string;
   region: string;
-  tags: string[];
   status: string; // @todo enum this
   label: string;
   version: string;
@@ -38,5 +37,4 @@ export interface CreateKubeClusterPayload {
   region?: string; // Will be caught by Yup if undefined
   node_pools: PoolNodeRequest[];
   version?: string; // Will be caught by Yup if undefined
-  tags: string[];
 }

--- a/packages/manager/src/__data__/kubernetes.ts
+++ b/packages/manager/src/__data__/kubernetes.ts
@@ -3,7 +3,6 @@ import { pool1 } from 'src/__data__/nodePools';
 
 export const clusters: KubernetesCluster[] = [
   {
-    tags: ['spam', 'eggs'],
     region: 'us-central',
     label: 'cluster-1',
     created: '2019-04-29 18:02:17',
@@ -12,7 +11,6 @@ export const clusters: KubernetesCluster[] = [
     version: '1.13.5'
   },
   {
-    tags: ['spam', 'eggs'],
     region: 'us-central',
     label: 'cluster-2',
     created: '2019-04-29 18:02:17',

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -24,7 +24,6 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ErrorState from 'src/components/ErrorState';
 import Notice from 'src/components/Notice';
 import SelectRegionPanel from 'src/components/SelectRegionPanel';
-import TagsInput from 'src/components/TagsInput';
 import TextField from 'src/components/TextField';
 import { dcDisplayNames } from 'src/constants';
 import regionsContainer from 'src/containers/regions.container';
@@ -33,7 +32,6 @@ import { WithRegionsProps } from 'src/features/linodes/LinodesCreate/types';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 import { getAll } from 'src/utilities/getAll';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import { getTagsAsStrings } from 'src/utilities/tagUtils';
 
 import KubeCheckoutBar from '.././KubeCheckoutBar';
 import { getMonthlyPrice } from '.././kubeUtils';
@@ -65,7 +63,6 @@ interface State {
   numberOfLinodes: number;
   nodePools: PoolNodeWithPrice[];
   label?: string;
-  tags: Item<string>[];
   version?: Item<string>;
   errors?: APIError[];
   submitting: boolean;
@@ -92,7 +89,6 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
     numberOfLinodes: 1,
     nodePools: [],
     label: undefined,
-    tags: [],
     version: undefined,
     errors: undefined,
     submitting: false,
@@ -121,7 +117,7 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
   }
 
   createCluster = () => {
-    const { selectedRegion, nodePools, label, tags, version } = this.state;
+    const { selectedRegion, nodePools, label, version } = this.state;
     const {
       history: { push }
     } = this.props;
@@ -144,8 +140,7 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
       region: selectedRegion,
       node_pools,
       label,
-      version: _version,
-      tags: getTagsAsStrings(tags)
+      version: _version
     };
 
     createKubernetesCluster(payload)
@@ -199,10 +194,6 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
     this.setState({ label: newLabel ? newLabel : undefined });
   };
 
-  updateTags = (newTags: Item<string>[]) => {
-    this.setState({ tags: newTags });
-  };
-
   render() {
     const {
       classes,
@@ -220,14 +211,13 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
       selectedType,
       numberOfLinodes,
       nodePools,
-      tags,
       submitting,
       version,
       versionOptions
     } = this.state;
 
     const errorMap = getErrorMap(
-      ['region', 'node_pools', 'label', 'tags', 'version', 'versionLoad'],
+      ['region', 'node_pools', 'label', 'version', 'versionLoad'],
       errors
     );
 
@@ -327,11 +317,6 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
                     this.setState({ version: selected })
                   }
                   isClearable={false}
-                />
-                <TagsInput
-                  value={tags}
-                  onChange={this.updateTags}
-                  tagError={errorMap.tags}
                 />
               </div>
             </Paper>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -9,17 +9,14 @@ import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
 import Grid from 'src/components/core/Grid';
-import Paper from 'src/components/core/Paper';
 import {
   createStyles,
   Theme,
   WithStyles,
   withStyles
 } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
-import TagsPanel from 'src/components/TagsPanel';
 import KubeContainer, {
   DispatchProps
 } from 'src/containers/kubernetes.container';
@@ -43,13 +40,11 @@ type ClassNames =
   | 'section'
   | 'panelItem'
   | 'button'
-  | 'tagSectionInner'
   | 'deleteSection'
   | 'titleGridWrapper'
   | 'tagHeading'
   | 'sectionMain'
-  | 'sectionSideBar'
-  | 'tagSection';
+  | 'sectionSideBar';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -80,11 +75,6 @@ const styles = (theme: Theme) =>
         }
       }
     },
-    tagSectionInner: {
-      padding: `${theme.spacing(2) + 3}px ${theme.spacing(3)}px ${theme.spacing(
-        1
-      ) - 1}px`
-    },
     deleteSection: {
       [theme.breakpoints.up('md')]: {
         marginLeft: theme.spacing(3)
@@ -105,11 +95,6 @@ const styles = (theme: Theme) =>
       [theme.breakpoints.up('md')]: {
         order: 2,
         display: 'inline-block'
-      }
-    },
-    tagSection: {
-      [theme.breakpoints.down('sm')]: {
-        order: 3
       }
     }
   });
@@ -153,8 +138,6 @@ export const KubernetesClusterDetail: React.FunctionComponent<
     undefined
   );
   const [count, setCount] = React.useState<number>(1);
-  /** For adding tags */
-  const [tags, updateTags] = React.useState<string[]>([]);
   /** Form submission */
   const [submitting, setSubmitting] = React.useState<boolean>(false);
   const [generalError, setErrors] = React.useState<APIError[] | undefined>(
@@ -405,15 +388,6 @@ export const KubernetesClusterDetail: React.FunctionComponent<
     setConfirmation(true);
   };
 
-  const handleUpdateTags = (newTags: string[]) => {
-    return props
-      .updateCluster({ clusterID: cluster.id, tags: newTags })
-      .then(response => {
-        updateTags(newTags);
-        return response;
-      });
-  };
-
   const handleLabelChange = async (newLabel: string) => {
     props.updateCluster({ clusterID: cluster.id, label: newLabel });
     return cluster.label;
@@ -464,20 +438,6 @@ export const KubernetesClusterDetail: React.FunctionComponent<
           </Grid>
           <Grid item xs={12} className={classes.section}>
             <KubeSummaryPanel cluster={cluster} />
-          </Grid>
-          <Grid item xs={12} className={classes.tagSection}>
-            <Paper className={classes.tagSectionInner}>
-              <Typography
-                variant="h2"
-                className={classes.tagHeading}
-                data-qa-title
-              >
-                Cluster Tags
-              </Typography>
-              <div>
-                <TagsPanel tags={tags} updateTags={handleUpdateTags} />
-              </div>
-            </Paper>
           </Grid>
         </Grid>
         <Grid


### PR DESCRIPTION
## Description

Removing references to tags within the LKE flow, as the ability to edit tags for clusters will not be implemented for beta.

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

Please verify that there are no regressions to the LKE create flow + details page. 
cc @asauber