### PR TITLE
Me-3430 [LV]:  Storage Gauge

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.test.tsx
@@ -1,0 +1,60 @@
+import { Disk } from '../../request.types';
+import { sumStorage } from './Storage';
+
+describe('Storage Gauge', () => {
+  describe('sumStorage', () => {
+    const storageData: Record<string, Disk> = {
+      '/dev/sda': {
+        fs: {
+          free: [{ x: 0, y: 1 }],
+          total: [{ x: 0, y: 2 }],
+          ifree: [],
+          itotal: [],
+          path: '/'
+        },
+        isswap: 0,
+        childof: 0,
+        children: 0,
+        dm: 0,
+        mounted: 1
+      }
+    };
+    it('returns `free` and `total` for one disk', () => {
+      expect(sumStorage(storageData).free).toBe(1);
+      expect(sumStorage(storageData).total).toBe(2);
+    });
+    it('sums `free` and `total` for multiple disks', () => {
+      const data = {
+        ...storageData,
+        '/dev/sda2': {
+          fs: {
+            free: [{ x: 0, y: 100 }],
+            total: [{ x: 0, y: 200 }],
+            ifree: [],
+            itotal: [],
+            path: '/'
+          },
+          isswap: 0,
+          childof: 0,
+          children: 0,
+          dm: 0,
+          mounted: 1
+        }
+      };
+      expect(sumStorage(data).free).toBe(101);
+      expect(sumStorage(data).total).toBe(202);
+    });
+    it('returns 0 if data is malformed', () => {
+      const emptyData = { free: 0, total: 0 };
+      expect(sumStorage({})).toEqual(emptyData);
+      expect(sumStorage({ '/dev/sda': {} as any })).toEqual(emptyData);
+      expect(sumStorage({ '/dev/sda': { fs: undefined } as any })).toEqual(
+        emptyData
+      );
+      expect(sumStorage({ '/dev/sda': { fs: null } as any })).toEqual(
+        emptyData
+      );
+      expect(sumStorage({ '/dev/sda': { fs: [] } as any })).toEqual(emptyData);
+    });
+  });
+});

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
@@ -1,23 +1,64 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+import { pathOr } from 'ramda';
 import * as React from 'react';
-
 import Typography from 'src/components/core/Typography';
 import GaugePercent from 'src/components/GaugePercent';
+import { readableBytes } from 'src/utilities/unitConversions';
+import requestStats from '../../request';
+import { Disk } from '../../request.types';
 import { baseGaugeProps } from './common';
 
-const StorageGauge: React.FC = () => {
+interface Props {
+  clientAPIKey: string;
+  lastUpdated: number;
+}
+
+const StorageGauge: React.FC<Props> = props => {
+  const { clientAPIKey, lastUpdated } = props;
+
+  const [loading, setLoading] = React.useState<boolean>(true);
+  const [error, setError] = React.useState<APIError | undefined>();
+
+  const [storage, setStorage] = React.useState<Storage | undefined>();
+
+  React.useEffect(() => {
+    requestStats(clientAPIKey, 'getLatestValue', ['disk'])
+      .then(data => {
+        setLoading(false);
+        setError(undefined);
+        setStorage(sumStorage(data.Disk));
+      })
+      .catch(_ => {
+        if (!storage) {
+          setError({
+            reason: 'Error' // @todo: Error message?
+          });
+          setLoading(false);
+        }
+      });
+  }, [lastUpdated]);
+
+  const usedStorage = storage ? storage.total - storage.free : 100;
+
   return (
     <GaugePercent
       {...baseGaugeProps}
-      max={100}
-      value={80}
+      max={storage ? storage.total : 100}
+      value={usedStorage}
+      innerText={innerText(
+        readableBytes(usedStorage).formatted,
+        loading,
+        error
+      )}
       filledInColor="#F4AC3D"
-      innerText="36.41 GB"
       subTitle={
         <>
           <Typography>
             <strong>Storage</strong>
           </Typography>
-          <Typography>38.33 GB</Typography>
+          {!error && !loading && storage && (
+            <Typography>{readableBytes(storage.total).formatted}</Typography>
+          )}
         </>
       }
     />
@@ -25,3 +66,36 @@ const StorageGauge: React.FC = () => {
 };
 
 export default StorageGauge;
+
+// UTILITIES
+interface Storage {
+  free: number;
+  total: number;
+}
+
+export const sumStorage = (DiskData: Record<string, Disk> = {}): Storage => {
+  let free = 0;
+  let total = 0;
+  Object.keys(DiskData).forEach(key => {
+    const disk = DiskData[key];
+    free += pathOr(0, ['fs', 'free', 0, 'y'], disk);
+    total += pathOr(0, ['fs', 'total', 0, 'y'], disk);
+  });
+  return { free, total };
+};
+
+export const innerText = (
+  value: string,
+  loading: boolean,
+  error?: APIError
+) => {
+  if (error) {
+    return error.reason;
+  }
+
+  if (loading) {
+    return 'Loading...';
+  }
+
+  return value;
+};

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -92,7 +92,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
         <NetworkGauge />
       </TableCell>
       <TableCell>
-        <StorageGauge />
+        <StorageGauge clientAPIKey={clientAPIKey} lastUpdated={lastUpdated} />
       </TableCell>
       <TableCell>
         <ActionMenu

--- a/packages/manager/src/features/Longview/request.ts
+++ b/packages/manager/src/features/Longview/request.ts
@@ -126,9 +126,7 @@ export type LongviewFieldName =
   | 'load'
   | 'sysinfo'
   | 'network'
-  | 'disk'
-  | 'diskFsFree'
-  | 'diskFsTotal';
+  | 'disk';
 
 export const fieldNames: Record<LongviewFieldName, string> = {
   cpu: 'CPU.*',
@@ -137,8 +135,6 @@ export const fieldNames: Record<LongviewFieldName, string> = {
   load: 'Load.*',
   network: 'Network.*',
   disk: 'Disk.*',
-  diskFsFree: 'Disk.*.fs.free',
-  diskFsTotal: 'Disk.*.fs.total',
   sysinfo: 'SysInfo.*'
 };
 

--- a/packages/manager/src/features/Longview/request.ts
+++ b/packages/manager/src/features/Longview/request.ts
@@ -83,6 +83,9 @@ interface Get {
     action: 'getLatestValue',
     field: ('cpu' | 'sysinfo')[]
   ): Promise<Partial<LongviewCPU & LongviewSystemInfo>>;
+  (token: string, action: 'getLatestValue', field: ('disk')[]): Promise<
+    Partial<LongviewDisk>
+  >;
   (token: string, action: LongviewAction, field?: LongviewFieldName[]): Promise<
     Partial<AllData>
   >;
@@ -123,7 +126,9 @@ export type LongviewFieldName =
   | 'load'
   | 'sysinfo'
   | 'network'
-  | 'disk';
+  | 'disk'
+  | 'diskFsFree'
+  | 'diskFsTotal';
 
 export const fieldNames: Record<LongviewFieldName, string> = {
   cpu: 'CPU.*',
@@ -132,6 +137,8 @@ export const fieldNames: Record<LongviewFieldName, string> = {
   load: 'Load.*',
   network: 'Network.*',
   disk: 'Disk.*',
+  diskFsFree: 'Disk.*.fs.free',
+  diskFsTotal: 'Disk.*.fs.total',
   sysinfo: 'SysInfo.*'
 };
 

--- a/packages/manager/src/features/Longview/request.types.ts
+++ b/packages/manager/src/features/Longview/request.types.ts
@@ -11,7 +11,7 @@ interface FS {
   path: string;
 }
 
-interface Disk {
+export interface Disk {
   dm: number;
   children: number;
   mounted: number;


### PR DESCRIPTION
## Description

This PR includes the storage gauge for the Longview overview page. Follows the same pattern as the CPU gauge.

<img width="229" alt="Screen Shot 2019-10-21 at 5 21 15 PM" src="https://user-images.githubusercontent.com/16911484/67244196-33b65500-f427-11e9-8e74-b0b6570f224a.png">

New utility function with unit tests to sum storage.

## Type of Change
- Non breaking change ('update', 'change'

