### PR TITLE
OBJ-257 Update Documentation Links

### DIFF
--- a/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/BucketDetail.tsx
@@ -419,8 +419,7 @@ export class BucketDetail extends React.Component<CombinedProps, {}> {
             ]}
             labelOptions={{ noCap: true }}
           />
-          {/* @todo: What should this link be? */}
-          <DocumentationButton href="https://www.linode.com/docs/platform/object-storage/how-to-use-object-storage/" />
+          <DocumentationButton href="https://www.linode.com/docs/platform/object-storage/" />
         </Box>
         <Divider className={classes.divider} />
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -133,8 +133,15 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
         Deleting a bucket is permanent and can't be undone.
       </Typography>
       <Typography className={classes.copy}>
-        A bucket must be empty before deleting it. Please delete all objects, or
-        use{' '}
+        A bucket must be empty before deleting it. Please{' '}
+        <a
+          href="https://www.linode.com/docs/platform/object-storage/lifecycle-policies/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          delete all objects
+        </a>
+        , or use{' '}
         <a
           href="https://www.linode.com/docs/platform/object-storage/how-to-use-object-storage/#object-storage-tools"
           target="_blank"
@@ -244,7 +251,7 @@ const EmptyCopy = () => (
     <Typography variant="subtitle1">Need help getting started?</Typography>
     <Typography variant="subtitle1">
       <a
-        href="https://linode.com/docs/platform/object-storage/how-to-use-object-storage/"
+        href="https://linode.com/docs/platform/object-storage"
         target="_blank"
         rel="noopener noreferrer"
         className="h-u"

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -92,13 +92,7 @@ export const ObjectStorageLanding: React.FunctionComponent<
           labelTitle="Object Storage"
           removeCrumbX={1}
         />
-        <DocumentationButton
-          href={
-            props.location.pathname.match(/access/i)
-              ? 'https://www.linode.com/docs/platform/object-storage/how-to-use-object-storage/#object-storage-key-pair'
-              : 'https://www.linode.com/docs/platform/object-storage/how-to-use-object-storage/'
-          }
-        />
+        <DocumentationButton href="https://www.linode.com/docs/platform/object-storage/" />
       </Box>
       <AppBar position="static" color="default">
         <Tabs


### PR DESCRIPTION
## Description

This PR updates several documentation links in Object Storage, since some new guides have been published. New links can be found in the following places:

- Bucket Landing Page
- Documentation Button (top-right, on all pages)
- Delete Bucket modal.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Prod test account 1 doesn't have any buckets, so you can easily see the landing page. To see the Delete modal, add a bucket (but don't upload any objects) click "Delete" in the action menu on the Buckets Landing.
