### PR TITLE
[SDK] Change: Removes Zonefile from Domain Typings

### DIFF
--- a/packages/linode-js-sdk/src/domains/types.ts
+++ b/packages/linode-js-sdk/src/domains/types.ts
@@ -13,17 +13,11 @@ export interface Domain {
   axfr_ips: string[];
   group: string;
   type: DomainType;
-  zonefile: ZoneFile;
 }
 
 export type DomainStatus = 'active' | 'disabled' | 'edit_mode' | 'has_errors';
 
 export type DomainType = 'master' | 'slave';
-
-export interface ZoneFile {
-  rendered: string;
-  status: 'current' | 'setting_up' | 'updating';
-}
 
 export type RecordType =
   | 'A'

--- a/packages/manager/src/__data__/domains.ts
+++ b/packages/manager/src/__data__/domains.ts
@@ -14,8 +14,7 @@ export const domain1: Domain = {
   retry_sec: 0,
   soa_email: 'user@host.com',
   status: 'active',
-  ttl_sec: 0,
-  zonefile: { rendered: '', status: 'current' }
+  ttl_sec: 0
 };
 
 export const domain2: Domain = {
@@ -32,8 +31,7 @@ export const domain2: Domain = {
   retry_sec: 0,
   soa_email: 'user@host.com',
   status: 'active',
-  ttl_sec: 0,
-  zonefile: { rendered: '', status: 'current' }
+  ttl_sec: 0
 };
 
 export const domain3: Domain = {
@@ -50,8 +48,7 @@ export const domain3: Domain = {
   retry_sec: 0,
   soa_email: 'user@host.com',
   status: 'active',
-  ttl_sec: 0,
-  zonefile: { rendered: '', status: 'current' }
+  ttl_sec: 0
 };
 
 export const domains = [domain1, domain2, domain3];

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -3,8 +3,7 @@ import {
   DomainRecord,
   DomainType,
   RecordType,
-  updateDomainRecord,
-  ZoneFile
+  updateDomainRecord
 } from 'linode-js-sdk/lib/domains';
 import { APIError } from 'linode-js-sdk/lib/types';
 import {
@@ -86,7 +85,6 @@ interface EditableDomainFields extends EditableSharedFields {
   retry_sec?: number;
   soa_email?: string;
   ttl_sec?: number;
-  zonefile?: ZoneFile;
 }
 
 interface State {

--- a/packages/manager/src/store/selectors/getEntitiesWithGroupsToImport.test.tsx
+++ b/packages/manager/src/store/selectors/getEntitiesWithGroupsToImport.test.tsx
@@ -68,8 +68,7 @@ describe('Entities that have groups to import', () => {
         retry_sec: 0,
         soa_email: '',
         status: 'active',
-        ttl_sec: 0,
-        zonefile: { rendered: '', status: 'current' }
+        ttl_sec: 0
       };
 
       const newState = {


### PR DESCRIPTION
## Description

`zonefile` is not a property returned from GET `/domains` so we remove it.

## Type of Change
- Non breaking change ('update', 'change')