### PR TITLE
OBJ-253 Add Object Storage to list of PAT scopes

### DIFF
--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
 import { APITokenDrawer } from './APITokenDrawer';
+import { basePermNameMap, basePerms } from './utils';
 
 describe('API Token Drawer', () => {
   const component = shallow<APITokenDrawer>(
@@ -20,6 +20,8 @@ describe('API Token Drawer', () => {
       onChange={jest.fn()}
       onCreate={jest.fn()}
       onEdit={jest.fn()}
+      perms={basePerms}
+      permNameMap={basePermNameMap}
     />
   );
 

--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -214,7 +214,7 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
 
     return (
       <Table
-        aria-label="Personnal Acccess Token Permissions"
+        aria-label="Personal Access Token Permissions"
         className={classes.permsTable}
         spacingTop={24}
       >

--- a/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenDrawer.tsx
@@ -1,5 +1,6 @@
 import { APIError } from 'linode-js-sdk/lib/types';
 import * as moment from 'moment';
+import { equals } from 'ramda';
 import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
@@ -117,6 +118,8 @@ interface Props {
   label?: string;
   scopes?: string;
   expiry?: string;
+  perms: string[];
+  permNameMap: Record<string, string>;
   errors?: APIError[];
   id?: number;
   open: boolean;
@@ -139,7 +142,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 export class APITokenDrawer extends React.Component<CombinedProps, State> {
   state = {
-    scopes: scopeStringToPermTuples(this.props.scopes || ''),
+    scopes: scopeStringToPermTuples(this.props.scopes || '', this.props.perms),
     expiryTups: genExpiryTups(),
     selectAllSelectedScope: null
   };
@@ -148,11 +151,13 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
   componentWillReceiveProps(nextProps: CombinedProps) {
     if (
       /* If we are about to display a new token */
-      this.props.id !== nextProps.id
+      this.props.id !== nextProps.id ||
+      /* If we have updated perms (via feature flag) */
+      !equals(this.props.perms, nextProps.perms)
     ) {
       /* Then update our current scopes state */
       this.setState({
-        scopes: scopeStringToPermTuples(nextProps.scopes || '')
+        scopes: scopeStringToPermTuples(nextProps.scopes || '', nextProps.perms)
       });
     }
   }
@@ -195,21 +200,8 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
     return allScopesIdentical;
   };
 
-  permNameMap = {
-    account: 'Account',
-    domains: 'Domains',
-    events: 'Events',
-    images: 'Images',
-    ips: 'IPs',
-    linodes: 'Linodes',
-    longview: 'Longview',
-    nodebalancers: 'NodeBalancers',
-    stackscripts: 'StackScripts',
-    volumes: 'Volumes'
-  };
-
   renderPermsTable() {
-    const { classes, mode } = this.props;
+    const { classes, mode, permNameMap } = this.props;
     const { scopes, selectAllSelectedScope } = this.state;
 
     return (
@@ -293,17 +285,20 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
             </TableRow>
           )}
           {scopes.map(scopeTup => {
+            if (!permNameMap[scopeTup[0]]) {
+              return null;
+            }
             return (
               <TableRow
                 key={scopeTup[0]}
-                data-qa-row={this.permNameMap[scopeTup[0]]}
+                data-qa-row={permNameMap[scopeTup[0]]}
               >
                 <TableCell
                   parentColumn="Access"
                   padding="checkbox"
                   className={classes.accessCell}
                 >
-                  {this.permNameMap[scopeTup[0]]}
+                  {permNameMap[scopeTup[0]]}
                 </TableCell>
                 <TableCell
                   parentColumn="None"
@@ -450,7 +445,13 @@ export class APITokenDrawer extends React.Component<CombinedProps, State> {
               buttonType="primary"
               onClick={
                 (mode as string) === 'create'
-                  ? () => onCreate(permTuplesToScopeString(this.state.scopes))
+                  ? () =>
+                      onCreate(
+                        permTuplesToScopeString(
+                          this.state.scopes,
+                          this.props.perms
+                        )
+                      )
                   : () => onEdit()
               }
               data-qa-submit

--- a/packages/manager/src/features/Profile/APITokens/APITokenMenu.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenMenu.tsx
@@ -6,7 +6,7 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 interface Props {
   token: Token;
   type: string;
-  isAppTokenMenu: boolean;
+  isThirdPartyAccessToken: boolean;
   openViewDrawer: (token: Token) => void;
   openEditDrawer: (token: Token) => void;
   openRevokeDialog: (token: Token, type: string) => void;
@@ -17,7 +17,7 @@ type CombinedProps = Props;
 class APITokenMenu extends React.Component<CombinedProps> {
   createActions = () => {
     const {
-      isAppTokenMenu,
+      isThirdPartyAccessToken,
       openViewDrawer,
       openEditDrawer,
       openRevokeDialog,
@@ -26,7 +26,7 @@ class APITokenMenu extends React.Component<CombinedProps> {
     } = this.props;
 
     return (closeMenu: Function): Action[] => {
-      const actions = !isAppTokenMenu
+      const actions = !isThirdPartyAccessToken
         ? [
             {
               title: 'View Token Scopes',

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -9,8 +9,8 @@ import {
 } from 'linode-js-sdk/lib/profile';
 import { APIError } from 'linode-js-sdk/lib/types';
 import * as moment from 'moment';
-import { compose } from 'ramda';
 import * as React from 'react';
+import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import AddNewLink from 'src/components/AddNewLink';
 import Button from 'src/components/Button';
@@ -36,11 +36,15 @@ import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
+import withFeatureFlagConsumer, {
+  FeatureFlagConsumerProps
+} from 'src/containers/withFeatureFlagConsumer.container';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import isPast from 'src/utilities/isPast';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
 import APITokenDrawer, { DrawerMode, genExpiryTups } from './APITokenDrawer';
 import APITokenMenu from './APITokenMenu';
+import { basePermNameMap, basePerms } from './utils';
 
 type ClassNames = 'headline' | 'paper' | 'labelCell' | 'createdCell';
 
@@ -62,9 +66,11 @@ const styles = (theme: Theme) =>
   });
 
 export type APITokenType = 'OAuth Client Token' | 'Personal Access Token';
-export type APITokenTitle = 'Apps' | 'Personal Access Tokens';
+export type APITokenTitle =
+  | 'Third Party Access Tokens'
+  | 'Personal Access Tokens';
 
-interface Props extends PaginationProps<Token> {
+interface Props {
   type: APITokenType;
   title: APITokenTitle;
 }
@@ -100,7 +106,10 @@ interface State {
   token?: TokenState;
 }
 
-type CombinedProps = Props & WithStyles<ClassNames>;
+type CombinedProps = Props &
+  PaginationProps<Token> &
+  WithStyles<ClassNames> &
+  FeatureFlagConsumerProps;
 
 export const filterOutLinodeApps = (token: Token) =>
   !token.website || !/.linode.com$/.test(token.website);
@@ -471,7 +480,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
           <APITokenMenu
             token={token}
             type={type}
-            isAppTokenMenu={title === 'Apps'}
+            isThirdPartyAccessToken={title === 'Third Party Access Tokens'}
             openViewDrawer={this.openViewDrawer}
             openEditDrawer={this.openEditDrawer}
             openRevokeDialog={this.openRevokeDialog}
@@ -482,8 +491,22 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
   }
 
   render() {
-    const { classes, type, title } = this.props;
+    const { classes, flags, type, title } = this.props;
     const { form, dialog } = this.state;
+
+    // If Object Storage is enabled, add it to the list of perms.
+    // @todo: Once Object Storage is safely in GA, remove this logic.
+    const perms = flags.objectStorage
+      ? //  Scopes are returned from the API sorted alphabetically. Since we're
+        // manually inserting a scope here, I chose to sort the entire list
+        // instead of inserting 'object_storage' in the correct place according
+        // to the hard-coded basePerms array (that seemed brittle).
+        [...basePerms, 'object_storage'].sort()
+      : basePerms;
+
+    const permNameMap = flags.objectStorage
+      ? { ...basePermNameMap, object_storage: 'Object Storage' }
+      : basePermNameMap;
 
     return (
       <React.Fragment>
@@ -536,6 +559,8 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
           label={form.values.label}
           scopes={form.values.scopes}
           expiry={form.values.expiry}
+          perms={perms}
+          permNameMap={permNameMap}
           closeDrawer={this.closeDrawer}
           onChange={this.handleDrawerChange}
           onCreate={this.createToken}
@@ -645,9 +670,10 @@ const updatedRequest = (ownProps: Props, params: any, filters: any) => {
 
 const paginated = Pagey(updatedRequest);
 
-const enhanced = compose<any, any, any>(
+const enhanced = compose<CombinedProps, Props>(
   paginated,
-  styled
+  styled,
+  withFeatureFlagConsumer
 );
 
 export default enhanced(APITokenTable);

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -495,7 +495,8 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
     const { form, dialog } = this.state;
 
     // If Object Storage is enabled, add it to the list of perms.
-    // @todo: Once Object Storage is safely in GA, remove this logic.
+    // @todo: Once Object Storage is safely in GA, remove this logic and add
+    // it to the hard-coded list of scopes.
     const perms = flags.objectStorage
       ? //  Scopes are returned from the API sorted alphabetically. Since we're
         // manually inserting a scope here, I chose to sort the entire list

--- a/packages/manager/src/features/Profile/APITokens/APITokens.test.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokens.test.tsx
@@ -1,9 +1,8 @@
 import { shallow } from 'enzyme';
 import * as moment from 'moment';
 import * as React from 'react';
-
+import ldClient from 'src/__data__/ldClient';
 import { pageyProps } from 'src/__data__/pageyProps';
-
 import { APITokenTable } from './APITokenTable';
 
 describe('APITokens', () => {
@@ -35,6 +34,8 @@ describe('APITokens', () => {
         title="Personal Access Tokens"
         type="Personal Access Token"
         data={pats}
+        flags={{}}
+        ldClient={ldClient}
       />
     );
 

--- a/packages/manager/src/features/Profile/APITokens/utils.test.ts
+++ b/packages/manager/src/features/Profile/APITokens/utils.test.ts
@@ -1,9 +1,9 @@
-import { scopeStringToPermTuples } from './utils';
+import { basePerms, scopeStringToPermTuples } from './utils';
 
 describe('APIToken utils', () => {
   describe('scopeStringToPermTuples', () => {
     describe('when given `*` scopes', () => {
-      const result = scopeStringToPermTuples('*');
+      const result = scopeStringToPermTuples('*', basePerms);
       const expected = [
         ['account', 2],
         ['domains', 2],
@@ -22,7 +22,7 @@ describe('APIToken utils', () => {
     });
 
     describe('when given no scopes', () => {
-      const result = scopeStringToPermTuples('');
+      const result = scopeStringToPermTuples('', basePerms);
       const expected = [
         ['account', 0],
         ['domains', 0],
@@ -42,7 +42,7 @@ describe('APIToken utils', () => {
     });
 
     describe('when given a scope of `account:none`', () => {
-      const result = scopeStringToPermTuples('account:none');
+      const result = scopeStringToPermTuples('account:none', basePerms);
       const expected = [
         ['account', 0],
         ['domains', 0],
@@ -62,7 +62,7 @@ describe('APIToken utils', () => {
     });
 
     describe('when given a scope of `account:read_only`', () => {
-      const result = scopeStringToPermTuples('account:read_only');
+      const result = scopeStringToPermTuples('account:read_only', basePerms);
       const expected = [
         ['account', 1],
         ['domains', 0],
@@ -82,7 +82,7 @@ describe('APIToken utils', () => {
     });
 
     describe('when given a scope of `account:read_write`', () => {
-      const result = scopeStringToPermTuples('account:read_write');
+      const result = scopeStringToPermTuples('account:read_write', basePerms);
       const expected = [
         ['account', 2],
         ['domains', 0],
@@ -103,7 +103,8 @@ describe('APIToken utils', () => {
 
     describe('when given a scope of `domains:read_only,longview:read_write`', () => {
       const result = scopeStringToPermTuples(
-        'domains:read_only,longview:read_write'
+        'domains:read_only,longview:read_write',
+        basePerms
       );
       const expected = [
         ['account', 0],
@@ -128,7 +129,10 @@ describe('APIToken utils', () => {
      * but they have tokens read_write (2), so we have to set account to the higher.
      */
     describe('when given a scope of `account:none,tokens:read_write`', () => {
-      const result = scopeStringToPermTuples('account:none,tokens:read_write');
+      const result = scopeStringToPermTuples(
+        'account:none,tokens:read_write',
+        basePerms
+      );
       const expected = [
         ['account', 2],
         ['domains', 0],
@@ -152,7 +156,10 @@ describe('APIToken utils', () => {
      * but they have tokens none (0), so we have to set account to the higher.
      */
     describe('when given a scope of `account:read_write,tokens:none`', () => {
-      const result = scopeStringToPermTuples('account:read_only,tokens:none');
+      const result = scopeStringToPermTuples(
+        'account:read_only,tokens:none',
+        basePerms
+      );
       const expected = [
         ['account', 1],
         ['domains', 0],


### PR DESCRIPTION
## Description

⚠️This should be feature flagged OFF until Object Storage GA. ⚠️ 

This PR adds Object Storage to the list of scopes when creating a PAT. This issue was brought to our attention here: https://github.com/linode/linode-cli/issues/142

<img width="422" alt="Screen Shot 2019-10-22 at 5 30 00 PM" src="https://user-images.githubusercontent.com/16911484/67335376-970cb980-f4f1-11e9-8486-50fc7af5237e.png">

This required changing the APIToken utility functions to take in `perms` as an argument, since the list of scopes is no longer static. In my opinion, we should keep this pattern around even after OBJ GA, since we might need it for other kinds of scopes in the future.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

I also noticed and fixed a bug where we were allowed users to attempt to rename their Third Party Access Token. This bug was leftover from when when changed "Apps" to "Third Party Access Tokens".

## Note to Reviewers

Please test API Token creation and updating, with and without the feature flag turned on.
