### PR TITLE
M3-3453 Update domainsDrawer reducer to use similar pattern as volumesDrawer reducer

### DIFF
--- a/packages/manager/src/store/domainDrawer/index.test.ts
+++ b/packages/manager/src/store/domainDrawer/index.test.ts
@@ -15,7 +15,7 @@ describe('domainDrawer reducer', () => {
   });
 
   it('should be OPEN when opening for cloning', () => {
-    const newState = reducer(defaultState, openForCloning());
+    const newState = reducer(defaultState, openForCloning('my-domain', 1234));
     expect(newState).toHaveProperty('open', true);
     expect(newState.mode).toBe(CLONING);
   });

--- a/packages/manager/src/store/domainDrawer/index.test.ts
+++ b/packages/manager/src/store/domainDrawer/index.test.ts
@@ -9,7 +9,10 @@ import reducer, {
 
 describe('domainDrawer reducer', () => {
   it('should be OPEN when opening for creating', () => {
-    const newState = reducer(defaultState, openForCreating());
+    const newState = reducer(
+      defaultState,
+      openForCreating('Created from Add New Menu')
+    );
     expect(newState).toHaveProperty('open', true);
     expect(newState.mode).toBe(CREATING);
   });

--- a/packages/manager/src/store/domainDrawer/index.ts
+++ b/packages/manager/src/store/domainDrawer/index.ts
@@ -1,5 +1,5 @@
-import { Action } from 'redux';
-import actionCreatorFactory from 'typescript-fsa';
+import { Action, Reducer } from 'redux';
+import actionCreatorFactory, { isType } from 'typescript-fsa';
 
 export interface State {
   open: boolean;
@@ -21,7 +21,6 @@ export const RESET = '@manager/domains/RESET';
 
 interface Creating extends Action {
   type: typeof CREATING;
-  origin: Origin;
 }
 interface Cloning extends Action {
   type: typeof CLONING;
@@ -62,7 +61,7 @@ interface CreateDomainPayload {
 }
 
 const createDomain = actionCreator<CreateDomainPayload>(`CREAT_DOMAIN`, {
-  type: CREATING
+  mode: CREATING
 });
 
 export const openForEditing = (domain: string, id: number): Editing => ({
@@ -85,11 +84,19 @@ export const defaultState: State = {
 
 type ActionTypes = Creating | Editing | Cloning | Close | Reset;
 
-export default (state: State = defaultState, action: ActionTypes) => {
-  switch (action.type) {
-    case CREATING:
-      return { mode: CREATING, open: true, origin: action.origin };
+export const domainDrawer: Reducer<State> = (
+  state = defaultState,
+  action: ActionTypes
+) => {
+  if (isType(action, createDomain)) {
+    return {
+      ...state,
+      open: true,
+      origin: action.payload.origin
+    };
+  }
 
+  switch (action.type) {
     case EDITING:
       return {
         open: true,
@@ -116,3 +123,5 @@ export default (state: State = defaultState, action: ActionTypes) => {
       return state;
   }
 };
+
+export default domainDrawer;

--- a/packages/manager/src/store/domainDrawer/index.ts
+++ b/packages/manager/src/store/domainDrawer/index.ts
@@ -60,7 +60,7 @@ interface CreateDomainPayload {
   origin: Origin;
 }
 
-const createDomain = actionCreator<CreateDomainPayload>(`CREAT_DOMAIN`, {
+const createDomain = actionCreator<CreateDomainPayload>(`CREATE_DOMAIN`, {
   mode: CREATING
 });
 

--- a/packages/manager/src/store/domainDrawer/index.ts
+++ b/packages/manager/src/store/domainDrawer/index.ts
@@ -9,15 +9,15 @@ export interface State {
   origin?: Origin;
 }
 
-const actionCreator = actionCreatorFactory(`@@manager/domains`);
+const actionCreator = actionCreatorFactory(`@@manager/domainDrawer`);
 
 // ACTIONS
-export const OPEN = '@manager/domains/OPEN';
-export const CLOSE = '@manager/domains/CLOSE';
-export const CREATING = '@manager/domains/CREATING';
-export const EDITING = '@manager/domains/EDITING';
-export const CLONING = '@manager/domains/CLONING';
-export const RESET = '@manager/domains/RESET';
+export const OPEN = '@manager/domainDrawer/OPEN';
+export const CLOSE = '@manager/domainDrawer/CLOSE';
+export const CREATING = '@manager/domainDrawer/CREATING';
+export const EDITING = '@manager/domainDrawer/EDITING';
+export const CLONING = '@manager/domainDrawer/CLONING';
+export const RESET = '@manager/domainDrawer/RESET';
 
 interface Creating extends Action {
   type: typeof CREATING;

--- a/packages/manager/src/store/domainDrawer/index.ts
+++ b/packages/manager/src/store/domainDrawer/index.ts
@@ -1,12 +1,5 @@
 import { Action } from 'redux';
-
-// ACTIONS
-export const OPEN = '@manager/domains/OPEN';
-export const CLOSE = '@manager/domains/CLOSE';
-export const CREATING = '@manager/domains/CREATING';
-export const EDITING = '@manager/domains/EDITING';
-export const CLONING = '@manager/domains/CLONING';
-export const RESET = '@manager/domains/RESET';
+import actionCreatorFactory from 'typescript-fsa';
 
 export interface State {
   open: boolean;
@@ -15,6 +8,16 @@ export interface State {
   domain?: string;
   origin?: Origin;
 }
+
+const actionCreator = actionCreatorFactory(`@@manager/domains`);
+
+// ACTIONS
+export const OPEN = '@manager/domains/OPEN';
+export const CLOSE = '@manager/domains/CLOSE';
+export const CREATING = '@manager/domains/CREATING';
+export const EDITING = '@manager/domains/EDITING';
+export const CLONING = '@manager/domains/CLONING';
+export const RESET = '@manager/domains/RESET';
 
 interface Creating extends Action {
   type: typeof CREATING;
@@ -36,39 +39,43 @@ interface Close extends Action {
   type: typeof CLOSE;
 }
 
+export const closeDrawer = (): Close => ({
+  type: CLOSE
+});
+
 interface Reset extends Action {
   type: typeof RESET;
 }
 
-type ActionCreator = (...args: any[]) => Action;
+export const resetDrawer = (): Reset => ({
+  type: RESET
+});
 
 export type Origin =
   | 'Created from Add New Menu'
   | 'Created from Domain Landing';
 
-// ACTION CREATORS
-export const openForCreating: ActionCreator = (origin: Origin): Creating => ({
-  type: CREATING,
-  origin
+export const openForCreating = (origin: Origin) => createDomain({ origin });
+
+interface CreateDomainPayload {
+  origin: Origin;
+}
+
+const createDomain = actionCreator<CreateDomainPayload>(`CREAT_DOMAIN`, {
+  type: CREATING
 });
-export const openForEditing: ActionCreator = (
-  domain: string,
-  id: number
-): Editing => ({
+
+export const openForEditing = (domain: string, id: number): Editing => ({
   type: EDITING,
   domain,
   id
 });
-export const openForCloning: ActionCreator = (
-  domain: string,
-  id: number
-): Cloning => ({
+
+export const openForCloning = (domain: string, id: number): Cloning => ({
   type: CLONING,
   domain,
   id
 });
-export const closeDrawer: ActionCreator = (): Close => ({ type: CLOSE });
-export const resetDrawer: ActionCreator = (): Reset => ({ type: RESET });
 
 // DEFAULT STATE
 export const defaultState: State = {


### PR DESCRIPTION
## Description

domainsDrawer was using an old `actionCreator` function that wasn't type-safe or consistent with the pattern of volumesDrawer. This updates domainsDrawer to utilize `actionCreatorFactory` instead of the old function.

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

Please make sure there aren't any regressions to the domains drawer and that the `Create Domain` analytics are working as expected.