### PR TITLE
OBJ-242 [OBJ] Primary Nav and Restricted Users

### DIFF
--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -4,7 +4,6 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { compose } from 'recompose';
-import Logo from 'src/assets/logo/logo-text.svg';
 import Box from 'src/components/core/Box';
 import {
   makeStyles,
@@ -12,26 +11,32 @@ import {
   withTheme,
   WithTheme
 } from 'src/components/core/styles';
-import DefaultLoader from 'src/components/DefaultLoader';
-import ErrorState from 'src/components/ErrorState';
-import Grid from 'src/components/Grid';
-import LandingLoading from 'src/components/LandingLoading';
-import NotFound from 'src/components/NotFound';
-import SideMenu from 'src/components/SideMenu';
-import withGlobalErrors, {
-  Props as GlobalErrorProps
-} from 'src/containers/globalErrors.container';
-import withFeatureFlags, {
-  FeatureFlagConsumerProps
-} from 'src/containers/withFeatureFlagConsumer.container.ts';
+
 import BackupDrawer from 'src/features/Backups';
 import DomainDrawer from 'src/features/Domains/DomainDrawer';
 import Footer from 'src/features/Footer';
 import ToastNotifications from 'src/features/ToastNotifications';
 import TopMenu from 'src/features/TopMenu';
 import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
-import { notifications } from 'src/utilities/storage';
 import WelcomeBanner from 'src/WelcomeBanner';
+
+import DefaultLoader from 'src/components/DefaultLoader';
+import ErrorState from 'src/components/ErrorState';
+import Grid from 'src/components/Grid';
+import LandingLoading from 'src/components/LandingLoading';
+import NotFound from 'src/components/NotFound';
+import SideMenu from 'src/components/SideMenu';
+
+import withGlobalErrors, {
+  Props as GlobalErrorProps
+} from 'src/containers/globalErrors.container';
+import withFeatureFlags, {
+  FeatureFlagConsumerProps
+} from 'src/containers/withFeatureFlagConsumer.container.ts';
+
+import Logo from 'src/assets/logo/logo-text.svg';
+
+import { notifications } from 'src/utilities/storage';
 import {
   isKubernetesEnabled as _isKubernetesEnabled,
   isObjectStorageEnabled

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -4,6 +4,7 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { compose } from 'recompose';
+import Logo from 'src/assets/logo/logo-text.svg';
 import Box from 'src/components/core/Box';
 import {
   makeStyles,
@@ -11,33 +12,26 @@ import {
   withTheme,
   WithTheme
 } from 'src/components/core/styles';
-
-import BackupDrawer from 'src/features/Backups';
-import DomainDrawer from 'src/features/Domains/DomainDrawer';
-import Footer from 'src/features/Footer';
-import ToastNotifications from 'src/features/ToastNotifications';
-import TopMenu from 'src/features/TopMenu';
-import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
-import WelcomeBanner from 'src/WelcomeBanner';
-import BucketDrawer from './features/ObjectStorage/BucketLanding/BucketDrawer';
-
 import DefaultLoader from 'src/components/DefaultLoader';
 import ErrorState from 'src/components/ErrorState';
 import Grid from 'src/components/Grid';
 import LandingLoading from 'src/components/LandingLoading';
 import NotFound from 'src/components/NotFound';
 import SideMenu from 'src/components/SideMenu';
-
 import withGlobalErrors, {
   Props as GlobalErrorProps
 } from 'src/containers/globalErrors.container';
 import withFeatureFlags, {
   FeatureFlagConsumerProps
 } from 'src/containers/withFeatureFlagConsumer.container.ts';
-
-import Logo from 'src/assets/logo/logo-text.svg';
-
+import BackupDrawer from 'src/features/Backups';
+import DomainDrawer from 'src/features/Domains/DomainDrawer';
+import Footer from 'src/features/Footer';
+import ToastNotifications from 'src/features/ToastNotifications';
+import TopMenu from 'src/features/TopMenu';
+import VolumeDrawer from 'src/features/Volumes/VolumeDrawer';
 import { notifications } from 'src/utilities/storage';
+import WelcomeBanner from 'src/WelcomeBanner';
 import {
   isKubernetesEnabled as _isKubernetesEnabled,
   isObjectStorageEnabled
@@ -303,7 +297,8 @@ const MainContent: React.FC<CombinedProps> = props => {
                 {getObjectStorageRoute(
                   props.accountLoading,
                   props.accountCapabilities,
-                  props.accountError
+                  props.accountError,
+                  Boolean(props.flags.objectStorage)
                 )}
                 {isKubernetesEnabled && (
                   <Route path="/kubernetes" component={Kubernetes} />
@@ -355,7 +350,6 @@ const MainContent: React.FC<CombinedProps> = props => {
       <DomainDrawer />
       <VolumeDrawer />
       <BackupDrawer />
-      {isObjectStorageEnabled(props.accountCapabilities) && <BucketDrawer />}
     </div>
   );
 };
@@ -366,11 +360,15 @@ const MainContent: React.FC<CombinedProps> = props => {
 const getObjectStorageRoute = (
   accountLoading: boolean,
   accountCapabilities: AccountCapability[],
-  accountError?: Error | APIError[]
+  accountError?: Error | APIError[],
+  featureFlag?: boolean
 ) => {
   let component;
-
-  if (accountLoading) {
+  // If the feature flag is on, we want to see Object Storage regardless of
+  // the state of account.
+  if (featureFlag) {
+    component = ObjectStorage;
+  } else if (accountLoading) {
     component = () => <LandingLoading delayInMS={1000} />;
   } else if (accountError) {
     component = () => (

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -325,7 +325,9 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
 
     return [
       {
-        conditionToAdd: () => isObjectStorageEnabled(accountCapabilities),
+        conditionToAdd: () =>
+          isObjectStorageEnabled(accountCapabilities) ||
+          Boolean(flags.objectStorage),
         insertAfter: 'Volumes',
         link: {
           display: 'Object Storage',

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -12,7 +12,8 @@ describe('AccessKeyDrawer', () => {
     label: 'test-label',
     updateLabel: jest.fn(),
     isLoading: false,
-    mode: 'creating' as MODES
+    mode: 'creating' as MODES,
+    isRestrictedUser: false
   };
   const wrapper = shallow<Props>(<AccessKeyDrawer {...props} />);
   it('renders without crashing', () => {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -19,6 +19,7 @@ export interface Props {
   mode: MODES;
   // If the mode is 'editing', we should have an ObjectStorageKey to edit
   objectStorageKey?: Linode.ObjectStorageKey;
+  isRestrictedUser: boolean;
 }
 
 type CombinedProps = Props;
@@ -26,7 +27,14 @@ type CombinedProps = Props;
 export const AccessKeyDrawer: React.StatelessComponent<
   CombinedProps
 > = props => {
-  const { open, onClose, onSubmit, mode, objectStorageKey } = props;
+  const {
+    isRestrictedUser,
+    open,
+    onClose,
+    onSubmit,
+    mode,
+    objectStorageKey
+  } = props;
 
   const title =
     mode === 'creating' ? 'Create an Access Key' : 'Edit Access Key';
@@ -57,6 +65,14 @@ export const AccessKeyDrawer: React.StatelessComponent<
               <Notice key={status} text={status} error data-qa-error />
             )}
 
+            {props.isRestrictedUser && (
+              <Notice
+                error
+                important
+                text="You don't have permissions to create an Access Key. Please contact an account administrator for details."
+              />
+            )}
+
             {/* Explainer copy if we're in 'creating' mode */}
             {mode === 'creating' && (
               <Typography>
@@ -83,12 +99,14 @@ export const AccessKeyDrawer: React.StatelessComponent<
                 errorText={errors.label}
                 onChange={handleChange}
                 onBlur={handleBlur}
+                disabled={isRestrictedUser}
               />
               <ActionsPanel>
                 <Button
                   buttonType="primary"
                   onClick={() => handleSubmit()}
                   loading={isSubmitting}
+                  disabled={isRestrictedUser}
                   data-qa-submit
                 >
                   Submit

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.test.tsx
@@ -13,6 +13,7 @@ describe('AccessKeyLanding', () => {
       createdCell: '',
       confirmationDialog: ''
     },
+    isRestrictedUser: false,
     ...pageyProps
   };
   const wrapper = shallow(<AccessKeyLanding {...props} />);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
@@ -42,13 +42,21 @@ const styles = (theme: Theme) =>
     }
   });
 
-type Props = PaginationProps<Linode.ObjectStorageKey> & WithStyles<ClassNames>;
+interface Props {
+  isRestrictedUser: boolean;
+}
 
-export type FormikProps = FormikBag<Props, ObjectStorageKeyRequest>;
+type CombinedProps = Props &
+  PaginationProps<Linode.ObjectStorageKey> &
+  WithStyles<ClassNames>;
+
+export type FormikProps = FormikBag<CombinedProps, ObjectStorageKeyRequest>;
 
 export type MODES = 'creating' | 'editing';
 
-export const AccessKeyLanding: React.StatelessComponent<Props> = props => {
+export const AccessKeyLanding: React.StatelessComponent<
+  CombinedProps
+> = props => {
   const { classes, ...paginationProps } = props;
 
   const [mode, setMode] = React.useState<MODES>('creating');
@@ -259,6 +267,7 @@ export const AccessKeyLanding: React.StatelessComponent<Props> = props => {
         onSubmit={mode === 'creating' ? handleCreateKey : handleEditKey}
         mode={mode}
         objectStorageKey={keyToEdit ? keyToEdit : undefined}
+        isRestrictedUser={props.isRestrictedUser}
       />
 
       <AccessKeyDisplayDialog
@@ -280,12 +289,12 @@ export const AccessKeyLanding: React.StatelessComponent<Props> = props => {
 
 const styled = withStyles(styles);
 
-const updatedRequest = (_: Props, params: any, filters: any) =>
+const updatedRequest = (_: CombinedProps, params: any, filters: any) =>
   getObjectStorageKeys(params, filters);
 
 const paginated = Pagey(updatedRequest);
 
-const enhanced = compose<Props, {}>(
+const enhanced = compose<CombinedProps, Props>(
   styled,
   paginated
 );

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.test.tsx
@@ -19,6 +19,7 @@ describe('ObjectStorageKeyTable', () => {
         }}
         openDrawerForEditing={jest.fn()}
         openRevokeDialog={jest.fn()}
+        isRestrictedUser={false}
         {...pageyProps}
       />
     );

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
@@ -46,6 +46,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
+  isRestrictedUser: boolean;
   openRevokeDialog: (objectStorageKey: Linode.ObjectStorageKey) => void;
   openDrawerForEditing: (objectStorageKey: Linode.ObjectStorageKey) => void;
 }
@@ -62,11 +63,16 @@ export const AccessKeyTable: React.StatelessComponent<
     data,
     loading,
     error,
+    isRestrictedUser,
     openRevokeDialog,
     openDrawerForEditing
   } = props;
 
   const renderContent = () => {
+    if (isRestrictedUser) {
+      return <TableRowEmptyState colSpan={6} />;
+    }
+
     if (loading) {
       return <TableRowLoading colSpan={6} />;
     }

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDrawer.test.tsx
@@ -8,6 +8,7 @@ describe('BucketDrawer', () => {
       isOpen={true}
       openBucketDrawer={jest.fn()}
       closeBucketDrawer={jest.fn()}
+      isRestrictedUser={false}
     />
   );
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketDrawer.tsx
@@ -7,14 +7,19 @@ import bucketDrawerContainer, {
 } from 'src/containers/bucketDrawer.container';
 import CreateBucketForm from './CreateBucketForm';
 
-type CombinedProps = StateProps & DispatchProps;
+interface Props {
+  isRestrictedUser: boolean;
+}
+
+type CombinedProps = Props & StateProps & DispatchProps;
 
 export const BucketDrawer: React.StatelessComponent<CombinedProps> = props => {
-  const { isOpen, closeBucketDrawer } = props;
+  const { isOpen, isRestrictedUser, closeBucketDrawer } = props;
 
   return (
     <Drawer onClose={closeBucketDrawer} open={isOpen} title="Create a Bucket">
       <CreateBucketForm
+        isRestrictedUser={isRestrictedUser}
         onClose={closeBucketDrawer}
         onSuccess={() => closeBucketDrawer()}
       />
@@ -22,5 +27,5 @@ export const BucketDrawer: React.StatelessComponent<CombinedProps> = props => {
   );
 };
 
-const enhanced = compose<CombinedProps, {}>(bucketDrawerContainer);
+const enhanced = compose<CombinedProps, Props>(bucketDrawerContainer);
 export default enhanced(BucketDrawer);

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.test.tsx
@@ -13,6 +13,7 @@ describe('ObjectStorageLanding', () => {
       closeBucketDrawer={jest.fn()}
       classes={{ copy: '' }}
       deleteBucket={jest.fn()}
+      isRestrictedUser={false}
     />
   );
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -43,7 +43,12 @@ const styles = (theme: Theme) =>
     }
   });
 
-type CombinedProps = StateProps &
+interface Props {
+  isRestrictedUser: boolean;
+}
+
+type CombinedProps = Props &
+  StateProps &
   DispatchProps &
   WithStyles<ClassNames> &
   BucketsRequests;
@@ -54,6 +59,7 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
     bucketsData,
     bucketsLoading,
     bucketsError,
+    isRestrictedUser,
     openBucketDrawer
   } = props;
 
@@ -150,6 +156,10 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
       </Typography>
     </React.Fragment>
   ) : null;
+
+  if (isRestrictedUser) {
+    return <RenderEmpty onClick={openBucketDrawer} data-qa-empty-state />;
+  }
 
   if (bucketsLoading) {
     return <RenderLoading data-qa-loading-state />;
@@ -258,7 +268,7 @@ const EmptyCopy = () => (
 
 const styled = withStyles(styles);
 
-const enhanced = compose<CombinedProps, {}>(
+const enhanced = compose<CombinedProps, Props>(
   styled,
   bucketContainer,
   bucketRequestsContainer,

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
@@ -11,6 +11,7 @@ interface Props {
   onChange: (value: string) => void;
   onBlur: (e: any) => void;
   error?: string;
+  disabled?: boolean;
 }
 
 type CombinedProps = Props & StateProps;
@@ -21,7 +22,8 @@ export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
     onChange,
     onBlur,
     clustersData,
-    clustersError
+    clustersError,
+    disabled
   } = props;
 
   const options: Item<string>[] = clustersData.map(eachCluster => ({
@@ -57,6 +59,7 @@ export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
       isClearable={false}
       errorText={errorText}
       defaultValue={options.length === 1 && options[0]}
+      disabled={disabled}
     />
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
@@ -13,6 +13,7 @@ describe('CreateBucketForm', () => {
       bucketsData={[]}
       bucketsLoading={false}
       classes={{ root: '', textWrapper: '' }}
+      isRestrictedUser={false}
     />
   );
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -158,6 +158,7 @@ export const CreateBucketForm: React.StatelessComponent<
                 resetForm();
                 onClose();
               }}
+              disabled={props.isRestrictedUser}
             />
           </Form>
         );

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -35,6 +35,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
+  isRestrictedUser: boolean;
   onClose: () => void;
   onSuccess: (bucketLabel: string) => void;
 }
@@ -47,7 +48,13 @@ type CombinedProps = Props &
 export const CreateBucketForm: React.StatelessComponent<
   CombinedProps
 > = props => {
-  const { onClose, onSuccess, createBucket, bucketsData } = props;
+  const {
+    isRestrictedUser,
+    onClose,
+    onSuccess,
+    createBucket,
+    bucketsData
+  } = props;
 
   return (
     <Formik
@@ -116,7 +123,14 @@ export const CreateBucketForm: React.StatelessComponent<
           <Form>
             {/* `status` holds generalError messages */}
             {status && <Notice error>{status.generalError}</Notice>}
-
+            {props.isRestrictedUser && (
+              <Notice
+                error
+                important
+                text="You don't have permissions to create a Bucket. Please contact an account administrator for details."
+                data-qa-permissions-notice
+              />
+            )}
             <TextField
               data-qa-cluster-label
               label="Label"
@@ -125,6 +139,7 @@ export const CreateBucketForm: React.StatelessComponent<
               onBlur={handleBlur}
               onChange={handleChange}
               value={values.label}
+              disabled={props.isRestrictedUser}
             />
 
             <ClusterSelect
@@ -133,8 +148,8 @@ export const CreateBucketForm: React.StatelessComponent<
               onBlur={handleBlur}
               onChange={value => setFieldValue('cluster', value)}
               selectedCluster={values.cluster}
+              disabled={isRestrictedUser}
             />
-
             <BucketsActionPanel
               data-qa-bucket-actions-panel
               isSubmitting={isSubmitting}

--- a/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/ObjectStorageLanding.tsx
@@ -85,7 +85,7 @@ export const ObjectStorageLanding: React.FunctionComponent<
         /** We choose to do nothing, relying on the Redux error state. */
       });
     }
-  }, []);
+  }, [props.isRestrictedUser]);
 
   const url = props.match.url;
   const matches = (p: string) => {


### PR DESCRIPTION
## Description

This PR accomplishes two things:

1. Show "Object Storage" in Primary Nav for all users (behind `object-storage` feature flag).
2. Display Object Storage feature to restricted users.

Previously we were looking at `account.capabilities` to determine whether to show Object Storage in Primary Nav. This works for account owners, but in order show Object Storage to restricted users, we need to include it in the Primary Nav by default (since we don't have access to `/account` for restricted users). This will currently be hidden behind the `object-storage` feature flag.

Restricted users currently can't use Object Storage. This PR makes it so that restricted users can see everything within the feature, with notices explaining they need to contact an account admin (following the pattern we have elsewhere in the app).

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Please test all combinations (with unrestricted as well as restricted users):

1. User enrolled in beta, flag off
2. User enrolled in beta, flag on
3. User not enrolled in beta, flag off
4. User not enrolled in beta, flag on
