### PR TITLE
M3-3473 Styling regression on Important Error notices

### DIFF
--- a/packages/manager/src/components/Notice/Notice.tsx
+++ b/packages/manager/src/components/Notice/Notice.tsx
@@ -46,6 +46,7 @@ const styles = (theme: Theme) => {
     },
     root: {
       marginBottom: theme.spacing(2),
+      position: 'relative',
       padding: '4px 16px',
       maxWidth: '100%',
       display: 'flex',
@@ -64,7 +65,7 @@ const styles = (theme: Theme) => {
     icon: {
       color: 'white',
       position: 'absolute',
-      left: theme.spacing(1) + 7
+      left: -25 // This value must be static regardless of theme selection
     },
     closeIcon: {
       paddingLeft: theme.spacing(1)


### PR DESCRIPTION
## Description

The Important Error notice styling was off in the Volumes creation drawer for restricted users (likely that this issue was happening elsewhere as well). I think eventually combining the icon + border into one element may be a future improvement that would help make the styling a little more predictable, but this should suffice in the short-term.

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

Please view a variety of important notices in both regular and compact theme views:
• Volumes creation drawer (for users restricted from creating volumes)
• Maintenance banner on dashboard
• Stories for `Notice`
