### PR TITLE
M3-3138 Refactor Volume Creation Workflow

### DIFF
--- a/packages/manager/e2e/constants.js
+++ b/packages/manager/e2e/constants.js
@@ -17,7 +17,8 @@ exports.constants = {
     dashboard: '/',
     create: {
       linode: '/linodes/create',
-      nodebalancer: '/nodebalancers/create'
+      nodebalancer: '/nodebalancers/create',
+      volume: 'volumes/create'
     },
     linodes: '/linodes',
     volumes: '/volumes',

--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -291,7 +291,7 @@ const MainContent: React.FC<CombinedProps> = props => {
             <Grid item className={classes.switchWrapper}>
               <Switch>
                 <Route path="/linodes" component={LinodesRoutes} />
-                <Route path="/volumes" component={Volumes} exact strict />
+                <Route path="/volumes" component={Volumes} />
                 <Redirect path="/volumes*" to="/volumes" />
                 <Route path="/nodebalancers" component={NodeBalancers} />
                 <Route path="/domains" component={Domains} />

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -157,8 +157,9 @@ class CheckoutBar extends React.Component<CombinedProps> {
             disabled={disabled}
             onClick={onDeploy}
             data-qa-deploy-linode
+            loading={isMakingRequest}
           >
-            {!isMakingRequest ? 'Create' : 'Creating...'}
+            Create
           </Button>
         </div>
       </div>

--- a/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
+++ b/packages/manager/src/components/CheckoutBar/CheckoutBar.tsx
@@ -128,6 +128,7 @@ class CheckoutBar extends React.Component<CombinedProps> {
               )}
               {details && (
                 <Typography
+                  component="span"
                   data-qa-details={details}
                   className={classes.detail}
                 >

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -25,6 +25,7 @@ export interface Props {
   value: Item[];
   onChange: (selected: Item[]) => void;
   disabled?: boolean;
+  menuPlacement?: 'bottom' | 'top' | 'auto' | undefined;
 }
 
 class TagsInput extends React.Component<Props, State> {
@@ -80,7 +81,15 @@ class TagsInput extends React.Component<Props, State> {
   };
 
   render() {
-    const { tagError, onChange, value, name, label, disabled } = this.props;
+    const {
+      tagError,
+      onChange,
+      value,
+      name,
+      label,
+      disabled,
+      menuPlacement
+    } = this.props;
     const { accountTags, errors } = this.state;
 
     const hasErrorFor = getAPIErrorFor({ label: 'label' }, errors);
@@ -103,6 +112,7 @@ class TagsInput extends React.Component<Props, State> {
         createNew={this.createTag}
         noOptionsMessage={this.getEmptyMessage}
         disabled={disabled}
+        menuPlacement={menuPlacement}
       />
     );
   }

--- a/packages/manager/src/components/Toggle/Toggle.tsx
+++ b/packages/manager/src/components/Toggle/Toggle.tsx
@@ -1,4 +1,3 @@
-import * as classNames from 'classnames';
 import * as React from 'react';
 import ToggleOff from 'src/assets/icons/toggleOff.svg';
 import ToggleOn from 'src/assets/icons/toggleOn.svg';
@@ -32,16 +31,9 @@ type CombinedProps = Props & SwitchProps & WithStyles<CSSClasses>;
 const LinodeSwitchControl: React.StatelessComponent<CombinedProps> = props => {
   const { classes, tooltipText, ...rest } = props;
 
-  const classnames = classNames({
-    [classes.root]: true,
-    [classes.checked]: Boolean(props.checked),
-    [classes.disabled]: props.disabled === true
-  });
-
   return (
     <React.Fragment>
       <Switch
-        className={classnames}
         icon={<ToggleOff />}
         checkedIcon={<ToggleOn />}
         data-qa-toggle={props.checked}

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -23,7 +23,6 @@ import {
 } from 'src/components/core/styles';
 import { openForCreating as openDomainDrawerForCreating } from 'src/store/domainDrawer';
 import { MapState } from 'src/store/types';
-import { openForCreating as openVolumeDrawerForCreating } from 'src/store/volumeDrawer';
 import { isKubernetesEnabled } from 'src/utilities/accountCapabilities';
 import AddNewMenuItem, { MenuItems } from './AddNewMenuItem';
 
@@ -82,7 +81,7 @@ const styles = (theme: Theme) =>
   });
 
 interface Props {
-  openVolumeDrawerForCreating: typeof openVolumeDrawerForCreating;
+  // openVolumeDrawerForCreating: typeof openVolumeDrawerForCreating;
   openDomainDrawerForCreating: typeof openDomainDrawerForCreating;
 }
 
@@ -256,10 +255,7 @@ const mapStateToProps: MapState<StateProps, CombinedProps> = (
 };
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) =>
-  bindActionCreators(
-    { openDomainDrawerForCreating, openVolumeDrawerForCreating },
-    dispatch
-  );
+  bindActionCreators({ openDomainDrawerForCreating }, dispatch);
 
 const connected = connect(
   mapStateToProps,

--- a/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
+++ b/packages/manager/src/features/TopMenu/AddNewMenu/AddNewMenu.tsx
@@ -119,10 +119,11 @@ class AddNewMenu extends React.Component<CombinedProps, State> {
       {
         title: 'Volume',
         onClick: e => {
-          this.props.openVolumeDrawerForCreating('Created from Add New Menu');
+          // this.props.openVolumeDrawerForCreating('Created from Add New Menu');
           this.handleClose();
           e.preventDefault();
         },
+        linkTo: '/volumes/create',
         body: `Block Storage service allows you to attach additional storage to your Linode`,
         ItemIcon: VolumeIcon
       },

--- a/packages/manager/src/features/Volumes/ListGroupedVolumes.tsx
+++ b/packages/manager/src/features/Volumes/ListGroupedVolumes.tsx
@@ -72,7 +72,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
+const ListGroupedDomains: React.FC<CombinedProps> = props => {
   const {
     data,
     order,

--- a/packages/manager/src/features/Volumes/ListVolumes.tsx
+++ b/packages/manager/src/features/Volumes/ListVolumes.tsx
@@ -18,7 +18,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const ListVolumes: React.StatelessComponent<CombinedProps> = props => {
+const ListVolumes: React.FC<CombinedProps> = props => {
   const { orderBy, order, handleOrderChange, data, renderProps } = props;
   return (
     <Paginate data={data} pageSize={25}>

--- a/packages/manager/src/features/Volumes/RenderVolumeData.tsx
+++ b/packages/manager/src/features/Volumes/RenderVolumeData.tsx
@@ -32,7 +32,7 @@ export interface RenderVolumeDataProps {
   handleDelete: (volumeId: number, volumeLabel: string) => void;
 }
 
-const RenderData: React.StatelessComponent<
+const RenderData: React.FC<
   { data: Volume[] } & RenderVolumeDataProps
 > = props => {
   const {

--- a/packages/manager/src/features/Volumes/SortableVolumesTableHeader.tsx
+++ b/packages/manager/src/features/Volumes/SortableVolumesTableHeader.tsx
@@ -42,7 +42,7 @@ const styles = (theme: Theme) =>
       }
     },
     regionCol: {
-      width: '20%',
+      width: '10%',
       minWidth: 75
     },
     labelCol: {
@@ -59,7 +59,7 @@ const styles = (theme: Theme) =>
       minWidth: 75
     },
     pathCol: {
-      width: '25%',
+      width: '30%',
       minWidth: 100
     }
   });

--- a/packages/manager/src/features/Volumes/SortableVolumesTableHeader.tsx
+++ b/packages/manager/src/features/Volumes/SortableVolumesTableHeader.tsx
@@ -72,7 +72,7 @@ type CombinedProps = WithStyles<ClassNames> &
   SortableVolumesTableHeaderProps &
   Omit<OrderByProps, 'data'>;
 
-const SortableTableHeader: React.StatelessComponent<CombinedProps> = props => {
+const SortableTableHeader: React.FC<CombinedProps> = props => {
   const {
     classes,
     order,

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -4,7 +4,7 @@ import { APIError } from 'linode-js-sdk/lib/types';
 import { CreateVolumeSchema } from 'linode-js-sdk/lib/volumes';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import CheckoutBar from 'src/components/CheckoutBar';
 import FormHelperText from 'src/components/core/FormHelperText';
@@ -76,6 +76,7 @@ const styles = (theme: Theme) =>
 
 interface Props {
   regions: Region[];
+  history: RouteComponentProps['history'];
   onSuccess: (
     volumeLabel: string,
     volumePath: string,
@@ -84,12 +85,11 @@ interface Props {
 }
 
 type CombinedProps = Props &
-  RouteComponentProps &
   VolumesRequests &
   WithStyles<ClassNames> &
   StateProps;
 
-const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
+const CreateVolumeForm: React.FC<CombinedProps> = props => {
   const { onSuccess, classes, createVolume, disabled, origin, history } = props;
   return (
     <Formik
@@ -332,6 +332,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
     />
   );
 };
+
 interface FormState {
   label: string;
   size: number;
@@ -365,7 +366,6 @@ const connected = connect(mapStateToProps);
 const styled = withStyles(styles);
 
 const enhanced = compose<CombinedProps, Props>(
-  withRouter,
   withVolumesRequests,
   connected,
   styled

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -162,7 +162,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
             ? errors.linodeId
             : undefined;
 
-        const { region, linodeId, tags, configId } = values;
+        const { region, linodeId, tags } = values;
         const displaySections = [];
         if (region) {
           displaySections.push({
@@ -189,12 +189,12 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
             details: tags.map((tag, i) => <Tag key={i} label={tag.label} />)
           });
         }
-        if (linodeId !== -1 && configId !== -1) {
-          displaySections.push({
-            title: 'Config',
-            details: 'how do i grab this??'
-          });
-        }
+        // if (linodeId !== -1 && configId !== -1) {
+        //   displaySections.push({
+        //     title: 'Config',
+        //     details: 'how do i grab this??'
+        //   });
+        // }
 
         return (
           <Form className={classes.form}>

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -56,8 +56,13 @@ const styles = (theme: Theme) =>
       padding: theme.spacing(3)
     },
     sidebar: {
+      [theme.breakpoints.down('sm')]: {
+        marginTop: `0 !important`
+      },
       '& > div': {
-        padding: `${theme.spacing(1)}px 0`
+        [theme.breakpoints.up('md')]: {
+          padding: `${theme.spacing(1)}px 0`
+        }
       }
     },
     copy: {
@@ -141,7 +146,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
           handleBlur,
           handleChange,
           handleSubmit,
-          // isSubmitting,
+          isSubmitting,
           setFieldValue,
           status,
           values,
@@ -286,6 +291,7 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
                   onDeploy={handleSubmit}
                   calculatedPrice={values.size / 10}
                   disabled={values.configId === -9999 || disabled}
+                  isMakingRequest={isSubmitting}
                 />
               </Grid>
             </Grid>

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -24,7 +24,7 @@ import {
   isRestrictedUser
 } from 'src/features/Profile/permissionsHelpers';
 import { MapState } from 'src/store/types';
-import { Origin as VolumeDrawerOrigin } from 'src/store/volumeDrawer';
+import { Origin as VolumeDrawerOrigin } from 'src/store/volumeForm';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import {
   handleFieldErrors,
@@ -33,13 +33,13 @@ import {
 import { sendCreateVolumeEvent } from 'src/utilities/ga';
 import isNilOrEmpty from 'src/utilities/isNilOrEmpty';
 import maybeCastToNumber from 'src/utilities/maybeCastToNumber';
-import ConfigSelect from './ConfigSelect';
-import LabelField from './LabelField';
-import LinodeSelect from './LinodeSelect';
-import NoticePanel from './NoticePanel';
-import PricePanel from './PricePanel';
-import SizeField from './SizeField';
-import VolumesActionsPanel from './VolumesActionsPanel';
+import ConfigSelect from '../VolumeDrawer/ConfigSelect';
+import LabelField from '../VolumeDrawer/LabelField';
+import LinodeSelect from '../VolumeDrawer/LinodeSelect';
+import NoticePanel from '../VolumeDrawer/NoticePanel';
+import PricePanel from '../VolumeDrawer/PricePanel';
+import SizeField from '../VolumeDrawer/SizeField';
+import VolumesActionsPanel from '../VolumeDrawer/VolumesActionsPanel';
 
 import RegionSelect from 'src/components/EnhancedSelect/variants/RegionSelect';
 import { dcDisplayNames } from 'src/constants';
@@ -49,12 +49,13 @@ type ClassNames = 'copy';
 const styles = (theme: Theme) =>
   createStyles({
     copy: {
-      marginTop: theme.spacing(1)
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(2)
     }
   });
 
 interface Props {
-  onClose: () => void;
+  // onClose: () => void;
   regions: Region[];
   onSuccess: (
     volumeLabel: string,
@@ -69,7 +70,7 @@ type CombinedProps = Props &
   StateProps;
 
 const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
-  const { onClose, onSuccess, classes, createVolume, disabled, origin } = props;
+  const { onSuccess, classes, createVolume, disabled, origin } = props;
   return (
     <Formik
       initialValues={initialValues}
@@ -271,7 +272,6 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
               onSubmit={handleSubmit}
               onCancel={() => {
                 resetForm();
-                onClose();
               }}
             />
           </Form>

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -189,12 +189,6 @@ const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
             details: tags.map((tag, i) => <Tag key={i} label={tag.label} />)
           });
         }
-        // if (linodeId !== -1 && configId !== -1) {
-        //   displaySections.push({
-        //     title: 'Config',
-        //     details: 'how do i grab this??'
-        //   });
-        // }
 
         return (
           <Form className={classes.form}>

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -302,6 +302,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
                     disabled={disabled}
                     onChange={selected => setFieldValue('tags', selected)}
                     value={values.tags}
+                    menuPlacement="top"
                   />
 
                   <ConfigSelect

--- a/packages/manager/src/features/Volumes/VolumeCreate/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/VolumeCreate.tsx
@@ -4,8 +4,8 @@ import { pathOr } from 'ramda';
 import React from 'react';
 import { connect, MapDispatchToProps } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
+import BreadCrumb from 'src/components/Breadcrumb';
 import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import { isRestrictedUser } from 'src/features/Profile/permissionsHelpers';
@@ -16,7 +16,11 @@ import CreateVolumeForm from './CreateVolumeForm';
 const useStyles = makeStyles((theme: Theme) => ({
   root: {},
   main: {
-    marginTop: theme.spacing(2)
+    marginTop: theme.spacing(1)
+  },
+  title: {
+    marginTop: 3,
+    marginBottom: theme.spacing(1)
   }
 }));
 
@@ -68,10 +72,12 @@ const VolumeCreate: React.FC<CombinedProps> = props => {
   return (
     <>
       <DocumentTitleSegment segment="Create a Volume" />
-      <Grid item className="mlMain">
-        <Typography variant="h1" data-qa-create-nodebalancer-header>
-          Create a Volume
-        </Typography>
+      <Grid item>
+        <BreadCrumb
+          pathname={props.location.pathname}
+          labelTitle="Create"
+          className={classes.title}
+        />
         <div className={classes.main}>
           <CreateVolumeForm
             onSuccess={actions.openForConfig}

--- a/packages/manager/src/features/Volumes/VolumeCreate/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/VolumeCreate.tsx
@@ -67,7 +67,7 @@ type CombinedProps = StateProps & RouteComponentProps<{}> & DispatchProps;
 
 const VolumeCreate: React.FC<CombinedProps> = props => {
   const classes = useStyles();
-  const { actions, regions } = props;
+  const { actions, regions, history } = props;
 
   return (
     <>
@@ -82,6 +82,7 @@ const VolumeCreate: React.FC<CombinedProps> = props => {
           <CreateVolumeForm
             onSuccess={actions.openForConfig}
             regions={regions}
+            history={history}
           />
         </div>
       </Grid>

--- a/packages/manager/src/features/Volumes/VolumeCreate/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/VolumeCreate.tsx
@@ -1,15 +1,135 @@
+import { Grant } from 'linode-js-sdk/lib/account';
+import { Region } from 'linode-js-sdk/lib/regions';
+import { pathOr } from 'ramda';
 import React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { compose as recompose } from 'recompose';
+import { connect, MapDispatchToProps } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import Grid from 'src/components/Grid';
+import { isRestrictedUser } from 'src/features/Profile/permissionsHelpers';
+import { MapState } from 'src/store/types';
+import { openForConfig, viewResizeInstructions } from 'src/store/volumeForm';
+import CreateVolumeForm from './CreateVolumeForm';
 
-interface Props {}
-
-type CombinedProps = Props & RouteComponentProps<{}>;
-
-class VolumeCreate extends React.Component<CombinedProps> {
-  render() {
-    return <p>Create a Volume</p>;
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {},
+  main: {
+    marginTop: theme.spacing(2)
   }
+}));
+
+interface StateProps {
+  mode: string;
+  volumeId?: number;
+  volumeLabel?: string;
+  volumeRegion?: string;
+  volumeSize?: number;
+  volumeTags?: string[];
+  volumePath?: string;
+  linodeId?: number;
+  linodeLabel?: string;
+  linodeRegion?: string;
+  message?: string;
+  readOnly?: boolean;
+  regions: Region[];
 }
 
-export default recompose<CombinedProps, {}>(withRouter)(VolumeCreate);
+interface DispatchProps {
+  actions: {
+    openForConfig: (
+      volumeLabel: string,
+      volumePath: string,
+      message?: string
+    ) => void;
+    openForResizeInstructions: (volumeLabel: string, message?: string) => void;
+  };
+}
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({
+  actions: {
+    openForConfig: (
+      volumeLabel: string,
+      volumePath: string,
+      message?: string
+    ) => dispatch(openForConfig(volumeLabel, volumePath, message)),
+    openForResizeInstructions: (volumeLabel: string, message?: string) =>
+      dispatch(viewResizeInstructions({ volumeLabel, message }))
+  }
+});
+
+type CombinedProps = StateProps & RouteComponentProps<{}> & DispatchProps;
+
+const VolumeCreate: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+  const { actions, regions } = props;
+
+  return (
+    <>
+      <DocumentTitleSegment segment="Create a Volume" />
+      <Grid item className="mlMain">
+        <Typography variant="h1" data-qa-create-nodebalancer-header>
+          Create a Volume
+        </Typography>
+        <div className={classes.main}>
+          <CreateVolumeForm
+            onSuccess={actions.openForConfig}
+            regions={regions}
+          />
+        </div>
+      </Grid>
+    </>
+  );
+};
+
+const mapStateToProps: MapState<StateProps, {}> = state => {
+  const {
+    linodeId,
+    linodeLabel,
+    linodeRegion,
+    mode,
+    volumeId,
+    volumeLabel,
+    volumeRegion,
+    volumeSize,
+    volumeTags,
+    volumePath,
+    message
+  } = state.volumeDrawer;
+
+  const volumesPermissions = pathOr(
+    [],
+    ['__resources', 'profile', 'data', 'grants', 'volume'],
+    state
+  );
+  const volumePermissions = volumesPermissions.find(
+    (v: Grant) => v.id === volumeId
+  );
+
+  return {
+    regions: state.__resources.regions.entities,
+    linodeId,
+    linodeLabel,
+    linodeRegion,
+    mode,
+    volumeId,
+    volumeLabel,
+    volumeRegion,
+    volumeSize,
+    volumeTags,
+    volumePath,
+    message,
+    readOnly:
+      isRestrictedUser(state) &&
+      volumePermissions &&
+      volumePermissions.permissions === 'read_only'
+  };
+};
+
+const connected = connect(
+  mapStateToProps,
+  mapDispatchToProps
+);
+
+export default connected(VolumeCreate);

--- a/packages/manager/src/features/Volumes/VolumeCreate/VolumeCreate.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/VolumeCreate.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { compose as recompose } from 'recompose';
+
+interface Props {}
+
+type CombinedProps = Props & RouteComponentProps<{}>;
+
+class VolumeCreate extends React.Component<CombinedProps> {
+  render() {
+    return <p>Create a Volume</p>;
+  }
+}
+
+export default recompose<CombinedProps, {}>(withRouter)(VolumeCreate);

--- a/packages/manager/src/features/Volumes/VolumeCreate/index.ts
+++ b/packages/manager/src/features/Volumes/VolumeCreate/index.ts
@@ -1,0 +1,2 @@
+import VolumeCreate from './VolumeCreate';
+export default VolumeCreate;

--- a/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
@@ -44,9 +44,7 @@ const validationScheme = object({
 
 const initialValues = { volume_id: -1, config_id: -1 };
 
-const AttachVolumeToLinodeForm: React.StatelessComponent<
-  CombinedProps
-> = props => {
+const AttachVolumeToLinodeForm: React.FC<CombinedProps> = props => {
   const {
     actions,
     onClose,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
@@ -10,7 +10,7 @@ import withVolumesRequests, {
 } from 'src/containers/volumesRequests.container';
 import { resetEventsPolling } from 'src/events';
 import { MapState } from 'src/store/types';
-import { openForCreating } from 'src/store/volumeDrawer';
+import { openForCreating } from 'src/store/volumeForm';
 import {
   handleFieldErrors,
   handleGeneralErrors

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CloneVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CloneVolumeForm.tsx
@@ -30,7 +30,7 @@ const validationScheme = CloneVolumeSchema;
 
 const initialValues = { label: '' };
 
-const CloneVolumeForm: React.StatelessComponent<CombinedProps> = props => {
+const CloneVolumeForm: React.FC<CombinedProps> = props => {
   const {
     onClose,
     volumeId,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -28,7 +28,7 @@ import { MapState } from 'src/store/types';
 import {
   openForAttaching,
   Origin as VolumeDrawerOrigin
-} from 'src/store/volumeDrawer';
+} from 'src/store/volumeForm';
 import { getErrorStringOrDefault } from 'src/utilities/errorUtils';
 import {
   handleFieldErrors,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -72,7 +72,7 @@ type CombinedProps = Props &
   DispatchProps &
   WithStyles<ClassNames>;
 
-const CreateVolumeForm: React.StatelessComponent<CombinedProps> = props => {
+const CreateVolumeForm: React.FC<CombinedProps> = props => {
   const {
     onClose,
     onSuccess,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/EditVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/EditVolumeForm.tsx
@@ -33,7 +33,7 @@ interface FormState {
   tags: Tag[];
 }
 
-const RenameVolumeForm: React.StatelessComponent<CombinedProps> = props => {
+const RenameVolumeForm: React.FC<CombinedProps> = props => {
   const {
     volumeId,
     volumeLabel,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/LabelField.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/LabelField.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const LabelField: React.StatelessComponent<CombinedProps> = ({
+const LabelField: React.FC<CombinedProps> = ({
   error,
   onBlur,
   onChange,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ModeSelection.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ModeSelection.tsx
@@ -29,7 +29,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const DrawerModeSelection: React.StatelessComponent<CombinedProps> = ({
+const DrawerModeSelection: React.FC<CombinedProps> = ({
   mode,
   onChange,
   classes

--- a/packages/manager/src/features/Volumes/VolumeDrawer/NoticePanel.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/NoticePanel.tsx
@@ -17,13 +17,18 @@ const NoticePanel: React.StatelessComponent<CombinedProps> = ({
   return (
     <>
       {success && (
-        <Notice success important={important}>
+        <Notice
+          success
+          important={important}
+          spacingBottom={24}
+          spacingTop={16}
+        >
           {success}
         </Notice>
       )}
 
       {error && (
-        <Notice error important={important}>
+        <Notice error important={important} spacingBottom={24} spacingTop={16}>
           {error}
         </Notice>
       )}

--- a/packages/manager/src/features/Volumes/VolumeDrawer/NoticePanel.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/NoticePanel.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const NoticePanel: React.StatelessComponent<CombinedProps> = ({
+const NoticePanel: React.FC<CombinedProps> = ({
   success,
   error,
   important

--- a/packages/manager/src/features/Volumes/VolumeDrawer/PricePanel.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/PricePanel.tsx
@@ -35,7 +35,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const PricePanel: React.StatelessComponent<CombinedProps> = ({
+const PricePanel: React.FC<CombinedProps> = ({
   currentSize,
   value,
   classes

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumeForm.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 type CombinedProps = Props & VolumesRequests;
 
-const ResizeVolumeForm: React.StatelessComponent<CombinedProps> = props => {
+const ResizeVolumeForm: React.FC<CombinedProps> = props => {
   const {
     volumeId,
     volumeSize,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumesInstruction.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumesInstruction.tsx
@@ -32,9 +32,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ResizeVolumeInstructions: React.StatelessComponent<
-  CombinedProps
-> = props => {
+const ResizeVolumeInstructions: React.FC<CombinedProps> = props => {
   const { classes, message, onClose, volumeLabel } = props;
 
   return (

--- a/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/SizeField.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const SizeField: React.StatelessComponent<CombinedProps> = ({
+const SizeField: React.FC<CombinedProps> = ({
   error,
   onBlur,
   onChange,

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
@@ -33,7 +33,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const VolumeConfigDrawer: React.StatelessComponent<CombinedProps> = props => {
+const VolumeConfigDrawer: React.FC<CombinedProps> = props => {
   const { classes, message, onClose } = props;
 
   return (

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
@@ -222,9 +222,6 @@ const titleFromState = (state: ApplicationState['volumeDrawer']) => {
   const { mode, volumeLabel, linodeLabel } = state;
 
   switch (mode) {
-    case modes.CREATING:
-      return `Create a Volume`;
-
     case modes.CREATING_FOR_LINODE:
       return `Create a volume for ${linodeLabel}`;
 

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeDrawer.tsx
@@ -11,11 +11,10 @@ import {
   close,
   openForConfig,
   viewResizeInstructions
-} from 'src/store/volumeDrawer';
+} from 'src/store/volumeForm';
 import AttachVolumeToLinodeForm from './AttachVolumeToLinodeForm';
 import CloneVolumeForm from './CloneVolumeForm';
 import CreateVolumeForLinodeForm from './CreateVolumeForLinodeForm';
-import CreateVolumeForm from './CreateVolumeForm';
 import EditVolumeForm from './EditVolumeForm';
 import { modes } from './modes';
 import ResizeVolumeForm from './ResizeVolumeForm';
@@ -46,13 +45,6 @@ class VolumeDrawer extends React.PureComponent<CombinedProps> {
 
     return (
       <Drawer open={isOpen} title={drawerTitle} onClose={actions.closeDrawer}>
-        {mode === modes.CREATING && (
-          <CreateVolumeForm
-            onClose={actions.closeDrawer}
-            onSuccess={actions.openForConfig}
-            regions={this.props.regions}
-          />
-        )}
         {mode === modes.EDITING &&
           volumeId !== undefined &&
           volumeLabel !== undefined &&

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumesActionsPanel.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumesActionsPanel.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 type CombinedProps = Props;
 
-const VolumesActionsPanel: React.StatelessComponent<CombinedProps> = ({
+const VolumesActionsPanel: React.FC<CombinedProps> = ({
   onSubmit,
   isSubmitting,
   onCancel,
@@ -32,7 +32,7 @@ const VolumesActionsPanel: React.StatelessComponent<CombinedProps> = ({
       )}
       {onCancel && (
         <Button onClick={onCancel} buttonType="cancel" data-qa-cancel>
-          Reset Form
+          Cancel
         </Button>
       )}
     </ActionsPanel>

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumesActionsPanel.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumesActionsPanel.tsx
@@ -32,7 +32,7 @@ const VolumesActionsPanel: React.StatelessComponent<CombinedProps> = ({
       )}
       {onCancel && (
         <Button onClick={onCancel} buttonType="cancel" data-qa-cancel>
-          Cancel
+          Reset Form
         </Button>
       )}
     </ActionsPanel>

--- a/packages/manager/src/features/Volumes/VolumeDrawer/modes.ts
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/modes.ts
@@ -3,7 +3,6 @@ export const modes = {
   CLONING: 'cloning',
   CLOSED: 'closed',
   CREATING_FOR_LINODE: 'creating_for_linode',
-  CREATING: 'creating',
   EDITING: 'editing',
   RESIZING: 'resizing',
   VIEW_RESIZE_INSTRUCTIONS: 'viewing_resize_instructions',

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -125,9 +125,7 @@ const progressFromEvent = (e?: Event) => {
   return undefined;
 };
 
-export const VolumeTableRow: React.StatelessComponent<
-  CombinedProps
-> = props => {
+export const VolumeTableRow: React.FC<CombinedProps> = props => {
   const {
     classes,
     isUpdating,

--- a/packages/manager/src/features/Volumes/VolumeTableWrapper.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableWrapper.tsx
@@ -29,7 +29,7 @@ type CombinedProps = Omit<OrderByProps, 'data'> &
   VolumeTableWrapperProps &
   WithStyles<ClassNames>;
 
-const DomainsTableWrapper: React.StatelessComponent<CombinedProps> = props => {
+const DomainsTableWrapper: React.FC<CombinedProps> = props => {
   const {
     order,
     orderBy,

--- a/packages/manager/src/features/Volumes/Volumes.tsx
+++ b/packages/manager/src/features/Volumes/Volumes.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import {
+  Route,
+  RouteComponentProps,
+  Switch,
+  withRouter
+} from 'react-router-dom';
+
+import DefaultLoader from '../../../src/components/DefaultLoader';
+
+const VolumesLanding = DefaultLoader({
+  loader: () => import('./VolumesLanding')
+});
+
+const VolumeCreate = DefaultLoader({
+  loader: () => import('./VolumeCreate/VolumeCreate')
+});
+
+type Props = RouteComponentProps<{}>;
+
+class Volumes extends React.Component<Props> {
+  render() {
+    const {
+      match: { path }
+    } = this.props;
+
+    return (
+      <Switch>
+        <Route component={VolumesLanding} path={path} exact />
+        <Route component={VolumeCreate} path={`${path}/create`} exact />
+      </Switch>
+    );
+  }
+}
+
+export default withRouter(Volumes);

--- a/packages/manager/src/features/Volumes/Volumes.tsx
+++ b/packages/manager/src/features/Volumes/Volumes.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Redirect,
   Route,
   RouteComponentProps,
   Switch,
@@ -26,8 +27,9 @@ class Volumes extends React.Component<Props> {
 
     return (
       <Switch>
-        <Route component={VolumesLanding} path={path} exact />
-        <Route component={VolumeCreate} path={`${path}/create`} exact />
+        <Route component={VolumesLanding} path={path} exact strict />
+        <Route component={VolumeCreate} path={`${path}/create`} exact strict />
+        <Redirect to={path} />
       </Switch>
     );
   }

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -46,7 +46,7 @@ import {
   openForEdit,
   openForResize,
   Origin as VolumeDrawerOrigin
-} from 'src/store/volumeDrawer';
+} from 'src/store/volumeForm';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { sendGroupByTagEnabledEvent } from 'src/utilities/ga';
 import DestructiveVolumeDialog from './DestructiveVolumeDialog';

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -78,10 +78,13 @@ type ClassNames =
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {},
+    root: {
+      paddingBottom: 0
+    },
     tagGroup: {
       flexDirection: 'row-reverse',
-      marginBottom: theme.spacing(1)
+      position: 'relative',
+      top: -(theme.spacing(1) + 1)
     },
     titleWrapper: {
       flex: 1
@@ -343,7 +346,7 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                   container
                   justify="space-between"
                   alignItems={removeBreadCrumb ? 'center' : 'flex-end'}
-                  style={{ paddingBottom: 0 }}
+                  className={classes.root}
                 >
                   <Grid item className={classes.titleWrapper}>
                     {removeBreadCrumb ? (
@@ -375,8 +378,10 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                     <Grid container alignItems="flex-end">
                       <Grid item className="pt0">
                         <AddNewLink
-                          onClick={this.openCreateVolumeDrawer}
-                          label="Add a Volume"
+                          onClick={e => {
+                            this.props.history.push('/volumes/create');
+                          }}
+                          label="Create a Volume"
                         />
                       </Grid>
                     </Grid>
@@ -684,7 +689,6 @@ const filterVolumeEvents = (event: Event): boolean => {
 export default compose<CombinedProps, Props>(
   connected,
   documented,
-  styled,
   withVolumesRequests,
   _withEvents((ownProps: CombinedProps, eventsData) => ({
     ...ownProps,
@@ -714,7 +718,8 @@ export default compose<CombinedProps, Props>(
     }
   ),
   withRegions(),
-  withSnackbar
+  withSnackbar,
+  styled
 )(VolumesLanding);
 
 const RenderError = () => {

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -153,6 +153,7 @@ interface Props {
   recentEvent?: Event;
   readOnly?: boolean;
   removeBreadCrumb?: boolean;
+  fromLinodes?: boolean;
 }
 
 //
@@ -303,7 +304,8 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
       volumesLoading,
       mappedVolumesDataWithLinodes,
       readOnly,
-      removeBreadCrumb
+      removeBreadCrumb,
+      fromLinodes
     } = this.props;
 
     if (volumesLoading) {
@@ -378,9 +380,13 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
                     <Grid container alignItems="flex-end">
                       <Grid item className="pt0">
                         <AddNewLink
-                          onClick={e => {
-                            this.props.history.push('/volumes/create');
-                          }}
+                          onClick={
+                            fromLinodes
+                              ? this.openCreateVolumeDrawer
+                              : () => {
+                                  this.props.history.push('/volumes/create');
+                                }
+                          }
                           label="Create a Volume"
                         />
                       </Grid>

--- a/packages/manager/src/features/Volumes/index.tsx
+++ b/packages/manager/src/features/Volumes/index.tsx
@@ -1,2 +1,2 @@
-import VolumesLanding from './VolumesLanding';
-export default VolumesLanding;
+import Volumes from './Volumes';
+export default Volumes;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailNavigation.tsx
@@ -138,6 +138,7 @@ const LinodesDetailNavigation: React.StatelessComponent<
               linodeRegion={linodeRegion}
               linodeConfigs={linodeConfigs}
               readOnly={readOnly}
+              fromLinodes
               removeBreadCrumb
               {...routeProps}
             />

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -130,7 +130,7 @@ import volumes, {
 import volumeDrawer, {
   defaultState as volumeDrawerDefaultState,
   State as VolumeDrawerState
-} from 'src/store/volumeDrawer';
+} from 'src/store/volumeForm';
 import initialLoad, {
   defaultState as initialLoadState,
   State as InitialLoadState

--- a/packages/manager/src/store/volumeForm/index.ts
+++ b/packages/manager/src/store/volumeForm/index.ts
@@ -204,7 +204,7 @@ type ActionTypes =
 
 const getMode = (action: AnyAction) => action.meta && action.meta.mode;
 
-export const volumeDrawer: Reducer<State> = (
+export const volumeForm: Reducer<State> = (
   state = defaultState,
   action: ActionTypes
 ) => {
@@ -311,4 +311,4 @@ export const volumeDrawer: Reducer<State> = (
   }
 };
 
-export default volumeDrawer;
+export default volumeForm;


### PR DESCRIPTION
## Refactor Volume Creation Workflow

The goal of this PR is to extract the creation workflow from the drawer to be consistent with other creation workflows (domains should be next). I used the same pattern (checkout sidebar) as other entities BUT this code is old and we need to use redux, esp in order to bring config management (this item is currently missing from the checkout sidebar). 

## Type of Change
- Non breaking change ('update')


