### PR TITLE
OBJ-263 Confirm OBJ before adding a bucket or access key

### DIFF
--- a/packages/linode-js-sdk/src/account/types.ts
+++ b/packages/linode-js-sdk/src/account/types.ts
@@ -42,6 +42,7 @@ export interface AccountSettings {
   longview_subscription: string | null;
   network_helper: boolean;
   backups_enabled: boolean;
+  object_storage: 'active' | 'disabled' | 'suspended';
 }
 
 export interface ActivePromotion {

--- a/packages/manager/src/__data__/account.ts
+++ b/packages/manager/src/__data__/account.ts
@@ -47,5 +47,6 @@ export const accountSettings: AccountSettings = {
   backups_enabled: true,
   managed: false,
   longview_subscription: null,
-  network_helper: false
+  network_helper: false,
+  object_storage: 'active'
 };

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -1,4 +1,5 @@
 import { shallow } from 'enzyme';
+import { AccountSettings } from 'linode-js-sdk/lib/account';
 import * as React from 'react';
 import { AccessKeyDrawer, Props } from './AccessKeyDrawer';
 import { MODES } from './AccessKeyLanding';
@@ -13,7 +14,8 @@ describe('AccessKeyDrawer', () => {
     updateLabel: jest.fn(),
     isLoading: false,
     mode: 'creating' as MODES,
-    isRestrictedUser: false
+    isRestrictedUser: false,
+    object_storage: 'active' as AccountSettings['object_storage']
   };
   const wrapper = shallow<Props>(<AccessKeyDrawer {...props} />);
   it('renders without crashing', () => {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -1,7 +1,6 @@
 import { shallow } from 'enzyme';
 import { AccountSettings } from 'linode-js-sdk/lib/account';
 import * as React from 'react';
-import ldClient from 'src/__data__/ldClient';
 import { AccessKeyDrawer, Props } from './AccessKeyDrawer';
 import { MODES } from './AccessKeyLanding';
 
@@ -16,9 +15,7 @@ describe('AccessKeyDrawer', () => {
     isLoading: false,
     mode: 'creating' as MODES,
     isRestrictedUser: false,
-    object_storage: 'active' as AccountSettings['object_storage'],
-    ldClient,
-    flags: {}
+    object_storage: 'active' as AccountSettings['object_storage']
   };
   const wrapper = shallow<Props>(<AccessKeyDrawer {...props} />);
   it('renders without crashing', () => {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.test.tsx
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import { AccountSettings } from 'linode-js-sdk/lib/account';
 import * as React from 'react';
+import ldClient from 'src/__data__/ldClient';
 import { AccessKeyDrawer, Props } from './AccessKeyDrawer';
 import { MODES } from './AccessKeyLanding';
 
@@ -15,7 +16,9 @@ describe('AccessKeyDrawer', () => {
     isLoading: false,
     mode: 'creating' as MODES,
     isRestrictedUser: false,
-    object_storage: 'active' as AccountSettings['object_storage']
+    object_storage: 'active' as AccountSettings['object_storage'],
+    ldClient,
+    flags: {}
   };
   const wrapper = shallow<Props>(<AccessKeyDrawer {...props} />);
   it('renders without crashing', () => {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -7,16 +7,13 @@ import {
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
-import withFeatureFlags, {
-  FeatureFlagConsumerProps
-} from 'src/containers/withFeatureFlagConsumer.container.ts';
+import useFlags from 'src/hooks/useFlags';
 import { ApplicationState } from 'src/store';
 import EnableObjectStorageModal from '../EnableObjectStorageModal';
 import { confirmObjectStorage } from '../utilities';
@@ -36,7 +33,7 @@ interface ReduxStateProps {
   object_storage: AccountSettings['object_storage'];
 }
 
-type CombinedProps = Props & ReduxStateProps & FeatureFlagConsumerProps;
+type CombinedProps = Props & ReduxStateProps;
 
 interface FormState {
   label: string;
@@ -47,13 +44,14 @@ export const AccessKeyDrawer: React.StatelessComponent<
 > = props => {
   const {
     isRestrictedUser,
-    flags,
     open,
     onClose,
     onSubmit,
     mode,
     objectStorageKey
   } = props;
+
+  const flags = useFlags();
 
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
 
@@ -182,9 +180,4 @@ const mapStateToProps = (state: ApplicationState) => {
 
 const connected = connect(mapStateToProps);
 
-const enhanced = compose<CombinedProps, Props>(
-  connected,
-  withFeatureFlags
-);
-
-export default enhanced(AccessKeyDrawer);
+export default connected(AccessKeyDrawer);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -1,15 +1,21 @@
 import { Formik } from 'formik';
+import { AccountSettings } from 'linode-js-sdk/lib/account';
 import {
   createObjectStorageKeysSchema,
   ObjectStorageKeyRequest
 } from 'linode-js-sdk/lib/profile';
+import { pathOr } from 'ramda';
 import * as React from 'react';
+import { connect } from 'react-redux';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
+import { ApplicationState } from 'src/store';
+import EnableObjectStorageModal from '../EnableObjectStorageModal';
+import { confirmObjectStorage } from '../utilities';
 import { MODES } from './AccessKeyLanding';
 
 export interface Props {
@@ -22,7 +28,15 @@ export interface Props {
   isRestrictedUser: boolean;
 }
 
-type CombinedProps = Props;
+interface ReduxStateProps {
+  object_storage: AccountSettings['object_storage'];
+}
+
+type CombinedProps = Props & ReduxStateProps;
+
+interface FormState {
+  label: string;
+}
 
 export const AccessKeyDrawer: React.StatelessComponent<
   CombinedProps
@@ -36,96 +50,130 @@ export const AccessKeyDrawer: React.StatelessComponent<
     objectStorageKey
   } = props;
 
+  const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
+
   const title =
     mode === 'creating' ? 'Create an Access Key' : 'Edit Access Key';
 
   const initialLabelValue =
     mode === 'editing' && objectStorageKey ? objectStorageKey.label : '';
 
+  const initialValues: FormState = {
+    label: initialLabelValue
+  };
+
   return (
     <Drawer title={title} open={open} onClose={onClose}>
       <Formik
-        initialValues={{ label: initialLabelValue }}
+        initialValues={initialValues}
         validationSchema={createObjectStorageKeysSchema}
         validateOnChange={false}
         validateOnBlur={true}
         onSubmit={onSubmit}
       >
-        {({
-          values,
-          errors,
-          status,
-          handleChange,
-          handleBlur,
-          handleSubmit,
-          isSubmitting
-        }) => (
-          <>
-            {status && (
-              <Notice key={status} text={status} error data-qa-error />
-            )}
+        {formikProps => {
+          const {
+            values,
+            errors,
+            handleChange,
+            handleBlur,
+            handleSubmit,
+            isSubmitting
+          } = formikProps;
 
-            {props.isRestrictedUser && (
-              <Notice
-                error
-                important
-                text="You don't have permissions to create an Access Key. Please contact an account administrator for details."
-              />
-            )}
+          const beforeSubmit = () => {
+            confirmObjectStorage<FormState>(
+              props.object_storage,
+              formikProps,
+              () => setDialogOpen(true)
+            );
+          };
 
-            {/* Explainer copy if we're in 'creating' mode */}
-            {mode === 'creating' && (
-              <Typography>
-                Generate an Access Key for use with an{' '}
-                <a
-                  href="https://linode.com/docs/platform/object-storage/how-to-use-object-storage/#object-storage-tools"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="h-u"
-                >
-                  S3-compatible client
-                </a>
-                .
-              </Typography>
-            )}
+          return (
+            <>
+              {status && (
+                <Notice key={status} text={status} error data-qa-error />
+              )}
 
-            <form onSubmit={handleSubmit}>
-              <TextField
-                name="label"
-                label="Label"
-                data-qa-add-label
-                value={values.label}
-                error={!!errors.label}
-                errorText={errors.label}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                disabled={isRestrictedUser}
-              />
-              <ActionsPanel>
-                <Button
-                  buttonType="primary"
-                  onClick={() => handleSubmit()}
-                  loading={isSubmitting}
+              {isRestrictedUser && (
+                <Notice
+                  error
+                  important
+                  text="You don't have permissions to create an Access Key. Please contact an account administrator for details."
+                />
+              )}
+
+              {/* Explainer copy if we're in 'creating' mode */}
+              {mode === 'creating' && (
+                <Typography>
+                  Generate an Access Key for use with an{' '}
+                  <a
+                    href="https://linode.com/docs/platform/object-storage/how-to-use-object-storage/#object-storage-tools"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="h-u"
+                  >
+                    S3-compatible client
+                  </a>
+                  .
+                </Typography>
+              )}
+
+              <form onSubmit={beforeSubmit}>
+                <TextField
+                  name="label"
+                  label="Label"
+                  data-qa-add-label
+                  value={values.label}
+                  error={!!errors.label}
+                  errorText={errors.label}
+                  onChange={handleChange}
+                  onBlur={handleBlur}
                   disabled={isRestrictedUser}
-                  data-qa-submit
-                >
-                  Submit
-                </Button>
-                <Button
-                  onClick={onClose}
-                  data-qa-cancel
-                  buttonType="secondary"
-                  className="cancel"
-                >
-                  Cancel
-                </Button>
-              </ActionsPanel>
-            </form>
-          </>
-        )}
+                />
+                <ActionsPanel>
+                  <Button
+                    buttonType="primary"
+                    onClick={beforeSubmit}
+                    loading={isSubmitting}
+                    disabled={isRestrictedUser}
+                    data-qa-submit
+                  >
+                    Submit
+                  </Button>
+                  <Button
+                    onClick={onClose}
+                    data-qa-cancel
+                    buttonType="secondary"
+                    className="cancel"
+                  >
+                    Cancel
+                  </Button>
+                </ActionsPanel>
+              </form>
+              <EnableObjectStorageModal
+                open={dialogOpen}
+                onClose={() => setDialogOpen(false)}
+                handleSubmit={handleSubmit}
+              />
+            </>
+          );
+        }}
       </Formik>
     </Drawer>
   );
 };
 
-export default AccessKeyDrawer;
+const mapStateToProps = (state: ApplicationState) => {
+  return {
+    object_storage: pathOr(
+      false,
+      ['data', 'object_storage'],
+      state.__resources.accountSettings
+    )
+  };
+};
+
+const connected = connect(mapStateToProps);
+
+export default connected(AccessKeyDrawer);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -7,12 +7,16 @@ import {
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { compose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
+import withFeatureFlags, {
+  FeatureFlagConsumerProps
+} from 'src/containers/withFeatureFlagConsumer.container.ts';
 import { ApplicationState } from 'src/store';
 import EnableObjectStorageModal from '../EnableObjectStorageModal';
 import { confirmObjectStorage } from '../utilities';
@@ -32,7 +36,7 @@ interface ReduxStateProps {
   object_storage: AccountSettings['object_storage'];
 }
 
-type CombinedProps = Props & ReduxStateProps;
+type CombinedProps = Props & ReduxStateProps & FeatureFlagConsumerProps;
 
 interface FormState {
   label: string;
@@ -43,6 +47,7 @@ export const AccessKeyDrawer: React.StatelessComponent<
 > = props => {
   const {
     isRestrictedUser,
+    flags,
     open,
     onClose,
     onSubmit,
@@ -85,7 +90,8 @@ export const AccessKeyDrawer: React.StatelessComponent<
             confirmObjectStorage<FormState>(
               props.object_storage,
               formikProps,
-              () => setDialogOpen(true)
+              () => setDialogOpen(true),
+              flags.objectStorage
             );
           };
 
@@ -176,4 +182,9 @@ const mapStateToProps = (state: ApplicationState) => {
 
 const connected = connect(mapStateToProps);
 
-export default connected(AccessKeyDrawer);
+const enhanced = compose<CombinedProps, Props>(
+  connected,
+  withFeatureFlags
+);
+
+export default enhanced(AccessKeyDrawer);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -170,8 +170,8 @@ export const AccessKeyDrawer: React.StatelessComponent<
 
 const mapStateToProps = (state: ApplicationState) => {
   return {
-    object_storage: pathOr(
-      false,
+    object_storage: pathOr<AccountSettings['object_storage']>(
+      'disabled',
       ['data', 'object_storage'],
       state.__resources.accountSettings
     )

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.test.tsx
@@ -1,4 +1,5 @@
 import { shallow } from 'enzyme';
+import { AccountSettings } from 'linode-js-sdk/lib/account';
 import * as React from 'react';
 import { pageyProps } from 'src/__data__/pageyProps';
 import { AccessKeyLanding } from './AccessKeyLanding';
@@ -14,6 +15,8 @@ describe('AccessKeyLanding', () => {
       confirmationDialog: ''
     },
     isRestrictedUser: false,
+    object_storage: 'active' as AccountSettings['object_storage'],
+    updateAccountSettingsInStore: jest.fn(),
     ...pageyProps
   };
   const wrapper = shallow(<AccessKeyLanding {...props} />);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
@@ -133,6 +133,11 @@ export const AccessKeyLanding: React.StatelessComponent<
         createOrEditDrawer.close();
         displayKeysDialog.open();
 
+        // If our Redux Store says that the user doesn't have OBJ enabled,
+        // it probably means they have just enabled it with the creation
+        // of this key. In that case, update the Redux Store so that
+        // subsequently created keys don't need to go through the
+        // confirmation flow.
         if (object_storage === 'disabled') {
           updateAccountSettingsInStore({ object_storage: 'active' });
         }

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
@@ -1,4 +1,5 @@
 import { FormikBag } from 'formik';
+import { AccountSettings } from 'linode-js-sdk/lib/account';
 import {
   createObjectStorageKeys,
   getObjectStorageKeys,
@@ -6,8 +7,12 @@ import {
   revokeObjectStorageKey,
   updateObjectStorageKey
 } from 'linode-js-sdk/lib/profile';
+import { pathOr } from 'ramda';
 import * as React from 'react';
+import { connect, MapDispatchToProps } from 'react-redux';
 import { compose } from 'recompose';
+import { AnyAction } from 'redux';
+import { ThunkDispatch } from 'redux-thunk';
 import AddNewLink from 'src/components/AddNewLink';
 import {
   createStyles,
@@ -21,6 +26,8 @@ import Pagey, { PaginationProps } from 'src/components/Pagey';
 import PaginationFooter from 'src/components/PaginationFooter';
 import { useErrors } from 'src/hooks/useErrors';
 import { useOpenClose } from 'src/hooks/useOpenClose';
+import { ApplicationState } from 'src/store';
+import { updateSettingsInStore } from 'src/store/accountSettings/accountSettings.actions';
 import { getAPIErrorOrDefault, getErrorMap } from 'src/utilities/errorUtils';
 import {
   sendCreateAccessKeyEvent,
@@ -29,6 +36,7 @@ import {
 } from 'src/utilities/ga';
 import AccessKeyDisplayDialog from './AccessKeyDisplayDialog';
 import AccessKeyDrawer from './AccessKeyDrawer';
+import { MODES } from './AccessKeyLanding';
 import AccessKeyTable from './AccessKeyTable';
 import RevokeAccessKeyDialog from './RevokeAccessKeyDialog';
 
@@ -46,18 +54,33 @@ interface Props {
   isRestrictedUser: boolean;
 }
 
+export type FormikProps = FormikBag<CombinedProps, ObjectStorageKeyRequest>;
+
+interface ReduxStateProps {
+  object_storage: AccountSettings['object_storage'];
+}
+
+interface DispatchProps {
+  updateAccountSettingsInStore: (data: Partial<AccountSettings>) => void;
+}
+
 type CombinedProps = Props &
   PaginationProps<Linode.ObjectStorageKey> &
-  WithStyles<ClassNames>;
-
-export type FormikProps = FormikBag<CombinedProps, ObjectStorageKeyRequest>;
+  WithStyles<ClassNames> &
+  ReduxStateProps &
+  DispatchProps;
 
 export type MODES = 'creating' | 'editing';
 
 export const AccessKeyLanding: React.StatelessComponent<
   CombinedProps
 > = props => {
-  const { classes, ...paginationProps } = props;
+  const {
+    classes,
+    object_storage,
+    updateAccountSettingsInStore,
+    ...paginationProps
+  } = props;
 
   const [mode, setMode] = React.useState<MODES>('creating');
 
@@ -109,6 +132,10 @@ export const AccessKeyLanding: React.StatelessComponent<
 
         createOrEditDrawer.close();
         displayKeysDialog.open();
+
+        if (object_storage === 'disabled') {
+          updateAccountSettingsInStore({ object_storage: 'active' });
+        }
 
         // @analytics
         sendCreateAccessKeyEvent();
@@ -294,9 +321,34 @@ const updatedRequest = (_: CombinedProps, params: any, filters: any) =>
 
 const paginated = Pagey(updatedRequest);
 
+const mapStateToProps = (state: ApplicationState) => {
+  return {
+    object_storage: pathOr<AccountSettings['object_storage']>(
+      'disabled',
+      ['data', 'object_storage'],
+      state.__resources.accountSettings
+    )
+  };
+};
+
+const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
+  dispatch: ThunkDispatch<ApplicationState, undefined, AnyAction>
+) => {
+  return {
+    updateAccountSettingsInStore: (data: Partial<AccountSettings>) =>
+      dispatch(updateSettingsInStore(data))
+  };
+};
+
+const connected = connect(
+  mapStateToProps,
+  mapDispatchToProps
+);
+
 const enhanced = compose<CombinedProps, Props>(
   styled,
-  paginated
+  paginated,
+  connected
 );
 
 export default enhanced(AccessKeyLanding);

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
@@ -1,7 +1,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { buckets } from 'src/__data__/buckets';
-import ldClient from 'src/__data__/ldClient';
 import { CreateBucketForm, isDuplicateBucket } from './CreateBucketForm';
 
 describe('CreateBucketForm', () => {
@@ -16,8 +15,6 @@ describe('CreateBucketForm', () => {
       classes={{ root: '', textWrapper: '' }}
       isRestrictedUser={false}
       object_storage="active"
-      ldClient={ldClient}
-      flags={{}}
     />
   );
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
@@ -14,6 +14,7 @@ describe('CreateBucketForm', () => {
       bucketsLoading={false}
       classes={{ root: '', textWrapper: '' }}
       isRestrictedUser={false}
+      object_storage="active"
     />
   );
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
@@ -15,6 +15,7 @@ describe('CreateBucketForm', () => {
       classes={{ root: '', textWrapper: '' }}
       isRestrictedUser={false}
       object_storage="active"
+      updateAccountSettingsInStore={jest.fn()}
     />
   );
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.test.tsx
@@ -1,6 +1,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { buckets } from 'src/__data__/buckets';
+import ldClient from 'src/__data__/ldClient';
 import { CreateBucketForm, isDuplicateBucket } from './CreateBucketForm';
 
 describe('CreateBucketForm', () => {
@@ -15,6 +16,8 @@ describe('CreateBucketForm', () => {
       classes={{ root: '', textWrapper: '' }}
       isRestrictedUser={false}
       object_storage="active"
+      ldClient={ldClient}
+      flags={{}}
     />
   );
 

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -18,6 +18,9 @@ import bucketContainer, {
 import bucketRequestsContainer, {
   BucketsRequests
 } from 'src/containers/bucketRequests.container';
+import withFeatureFlags, {
+  FeatureFlagConsumerProps
+} from 'src/containers/withFeatureFlagConsumer.container.ts';
 // @todo: Extract ActionPanel out of Volumes
 import BucketsActionPanel from 'src/features/Volumes/VolumeDrawer/VolumesActionsPanel';
 import { CreateBucketSchema } from 'src/services/objectStorage/buckets.schema';
@@ -54,13 +57,15 @@ type CombinedProps = Props &
   BucketContainerProps &
   BucketsRequests &
   WithStyles<ClassNames> &
-  ReduxStateProps;
+  ReduxStateProps &
+  FeatureFlagConsumerProps;
 
 export const CreateBucketForm: React.StatelessComponent<
   CombinedProps
 > = props => {
   const {
     isRestrictedUser,
+    flags,
     onClose,
     onSuccess,
     createBucket,
@@ -136,7 +141,8 @@ export const CreateBucketForm: React.StatelessComponent<
           confirmObjectStorage<FormState>(
             props.object_storage,
             formikProps,
-            () => setDialogOpen(true)
+            () => setDialogOpen(true),
+            flags.objectStorage
           );
         };
 
@@ -225,7 +231,8 @@ const enhanced = compose<CombinedProps, Props>(
   styled,
   bucketRequestsContainer,
   bucketContainer,
-  connected
+  connected,
+  withFeatureFlags
 );
 
 export default enhanced(CreateBucketForm);

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -213,8 +213,8 @@ const initialValues: FormState = {
 
 const mapStateToProps = (state: ApplicationState) => {
   return {
-    object_storage: pathOr(
-      false,
+    object_storage: pathOr<AccountSettings['object_storage']>(
+      'disabled',
       ['data', 'object_storage'],
       state.__resources.accountSettings
     )

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -18,11 +18,9 @@ import bucketContainer, {
 import bucketRequestsContainer, {
   BucketsRequests
 } from 'src/containers/bucketRequests.container';
-import withFeatureFlags, {
-  FeatureFlagConsumerProps
-} from 'src/containers/withFeatureFlagConsumer.container.ts';
 // @todo: Extract ActionPanel out of Volumes
 import BucketsActionPanel from 'src/features/Volumes/VolumeDrawer/VolumesActionsPanel';
+import useFlags from 'src/hooks/useFlags';
 import { CreateBucketSchema } from 'src/services/objectStorage/buckets.schema';
 import { ApplicationState } from 'src/store';
 import {
@@ -57,20 +55,20 @@ type CombinedProps = Props &
   BucketContainerProps &
   BucketsRequests &
   WithStyles<ClassNames> &
-  ReduxStateProps &
-  FeatureFlagConsumerProps;
+  ReduxStateProps;
 
 export const CreateBucketForm: React.StatelessComponent<
   CombinedProps
 > = props => {
   const {
     isRestrictedUser,
-    flags,
     onClose,
     onSuccess,
     createBucket,
     bucketsData
   } = props;
+
+  const flags = useFlags();
 
   const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
 
@@ -231,8 +229,7 @@ const enhanced = compose<CombinedProps, Props>(
   styled,
   bucketRequestsContainer,
   bucketContainer,
-  connected,
-  withFeatureFlags
+  connected
 );
 
 export default enhanced(CreateBucketForm);

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -111,6 +111,9 @@ export const CreateBucketForm: React.StatelessComponent<
             resetForm(initialValues);
             setSubmitting(false);
             onSuccess(bucketLabel);
+
+            // If our Redux Store says that the user doesn't have OBJ enabled,
+            // it problably means they have
             if (props.object_storage === 'disabled') {
               props.updateAccountSettingsInStore({ object_storage: 'active' });
             }

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/CreateBucketForm.tsx
@@ -113,7 +113,10 @@ export const CreateBucketForm: React.StatelessComponent<
             onSuccess(bucketLabel);
 
             // If our Redux Store says that the user doesn't have OBJ enabled,
-            // it problably means they have
+            // it probably means they have just enabled it with the creation
+            // of this bucket. In that case, update the Redux Store so that
+            // subsequently created buckets don't need to go through the
+            // confirmation flow.
             if (props.object_storage === 'disabled') {
               props.updateAccountSettingsInStore({ object_storage: 'active' });
             }

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import ActionsPanel from 'src/components/ActionsPanel';
+import Button from 'src/components/Button';
+import ConfirmationDialog from 'src/components/ConfirmationDialog';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  handleSubmit: () => void;
+}
+
+const EnableObjectStorageModal: React.FC<Props> = ({
+  open,
+  onClose,
+  handleSubmit
+}) => {
+  return (
+    <ConfirmationDialog
+      open={open}
+      onClose={close}
+      title="Enable Object Storage"
+      actions={() => (
+        <ActionsPanel>
+          <Button buttonType="cancel" onClick={onClose} data-qa-cancel>
+            Cancel
+          </Button>
+          <Button
+            buttonType="secondary"
+            destructive
+            onClick={() => {
+              onClose();
+              handleSubmit();
+            }}
+          >
+            Enable
+          </Button>
+        </ActionsPanel>
+      )}
+    >
+      Do you want to enable Object Storage?
+    </ConfirmationDialog>
+  );
+};
+
+export default React.memo(EnableObjectStorageModal);

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import Typography from 'src/components/core/Typography';
+import ExternalLink from 'src/components/ExternalLink';
 
 interface Props {
   open: boolean;
@@ -18,26 +20,35 @@ const EnableObjectStorageModal: React.FC<Props> = ({
     <ConfirmationDialog
       open={open}
       onClose={close}
-      title="Enable Object Storage"
+      title="Just to confirm..."
       actions={() => (
         <ActionsPanel>
           <Button buttonType="cancel" onClick={onClose} data-qa-cancel>
             Cancel
           </Button>
           <Button
-            buttonType="secondary"
-            destructive
+            buttonType="primary"
             onClick={() => {
               onClose();
               handleSubmit();
             }}
           >
-            Enable
+            Enable Object Storage
           </Button>
         </ActionsPanel>
       )}
     >
-      Do you want to enable Object Storage?
+      <Typography variant="subtitle1">
+        Linode Object Storage has a prorated minimum monthly cost of{' '}
+        <strong>$5</strong>, which provides <strong>250 GB</strong> of storage.
+        Object Storage adds <strong>1 TB</strong> of outbound data transfer to
+        your data transfer pool.{' '}
+        <ExternalLink
+          fixedIcon
+          text="Learn more."
+          link="https://www.linode.com/docs/platform/object-storage/pricing-and-limitations/"
+        />
+      </Typography>
     </ConfirmationDialog>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/utilities.test.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.test.ts
@@ -1,5 +1,6 @@
 import {
   basename,
+  confirmObjectStorage,
   displayName,
   extendObject,
   firstSubfolder,
@@ -190,6 +191,55 @@ describe('Object Storage utilities', () => {
       expect(firstSubfolder('path/file1')).toBe('path');
       expect(firstSubfolder('path1/path2/file.txt')).toBe('path1');
       expect(firstSubfolder('file1')).toBe('file1');
+    });
+  });
+
+  describe('confirmObjectStorage', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+    const validateForm = jest.fn(() => Promise.resolve({}));
+    const setFieldTouched = jest.fn();
+    const setFieldError = jest.fn();
+    const handleSubmit = jest.fn();
+    const openConfirmationDialog = jest.fn();
+    const mockFormikProps = {
+      validateForm,
+      setFieldTouched,
+      setFieldError,
+      handleSubmit
+    } as any;
+
+    it("doesn't call the confirmation handler if the feature flag is off", async () => {
+      await confirmObjectStorage(
+        'disabled',
+        mockFormikProps,
+        openConfirmationDialog,
+        false
+      );
+      expect(openConfirmationDialog).toHaveBeenCalledTimes(0);
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it("doesn't call the confirmation handler if OBJ is active", async () => {
+      await confirmObjectStorage(
+        'active',
+        mockFormikProps,
+        openConfirmationDialog,
+        true
+      );
+      expect(openConfirmationDialog).toHaveBeenCalledTimes(0);
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+    });
+    it('calls call the confirmation handler if OBJ is disabled', async () => {
+      await confirmObjectStorage(
+        'disabled',
+        mockFormikProps,
+        openConfirmationDialog,
+        true
+      );
+      expect(openConfirmationDialog).toHaveBeenCalledTimes(1);
+      expect(handleSubmit).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -127,7 +127,7 @@ export const confirmObjectStorage = <T extends {}>(
 ) => {
   // If the user doesn't already have Object Storage enabled, we show
   // a confirmation modal before letting them create their first bucket.
-  if (featureFlag && object_storage !== 'active') {
+  if (featureFlag && object_storage === 'disabled') {
     // But first, manually validate the form.
     formikProps.validateForm().then(validationErrors => {
       if (Object.keys(validationErrors).length > 0) {

--- a/packages/manager/src/features/ObjectStorage/utilities.ts
+++ b/packages/manager/src/features/ObjectStorage/utilities.ts
@@ -122,12 +122,12 @@ export const firstSubfolder = (path: string) => path.split('/')[0];
 export const confirmObjectStorage = <T extends {}>(
   object_storage: AccountSettings['object_storage'],
   formikProps: FormikProps<T>,
-  openConfirmationDialog: () => void
+  openConfirmationDialog: () => void,
+  featureFlag = false
 ) => {
-  // @todo: feature flag?
   // If the user doesn't already have Object Storage enabled, we show
   // a confirmation modal before letting them create their first bucket.
-  if (object_storage !== 'active') {
+  if (featureFlag && object_storage !== 'active') {
     // But first, manually validate the form.
     formikProps.validateForm().then(validationErrors => {
       if (Object.keys(validationErrors).length > 0) {


### PR DESCRIPTION
## Description

**[USE DEV]**

This PR makes use of the new `object_storage` attribute on `/account/settings`. This attribute will be: `active`,  `disabled`, or `suspended`.

 If a user attempts to create a bucket or create an access key, we display a confirmation modal first (because these actions result in new charges on their account).

TODO: 

- [x] Unit tests
- [ ] Finalized copy

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Currently the new attribute works only in dev. Use Charles to change the value of `object_storage`.

Test that the Create Bucket and Create Access Forms work as expected. The form should be validated _before_ the confirmation modal appears.
