### PR TITLE
Fix: Paypal Sandbox configuration

### DIFF
--- a/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -49,7 +49,6 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
 import TextField from 'src/components/TextField';
-import { isProduction } from 'src/constants';
 import AccountContainer, {
   DispatchProps as AccountDispatchProps
 } from 'src/containers/account.container';
@@ -154,18 +153,13 @@ const client = {
 };
 
 const paypalSrcQueryParams = `&disable-funding=card,credit&currency=USD&commit=false&intent=capture`;
+const env = process.env.REACT_APP_PAYPAL_ID ? 'sandbox' : 'production';
 
 const paypalScriptSrc = () => {
-  return isProduction
-    ? `https://www.paypal.com/sdk/js?client-id=${
-        client.production
-      }${paypalSrcQueryParams}`
-    : `https://www.paypal.com/sdk/js?client-id=${
-        client.sandbox
-      }${paypalSrcQueryParams}`;
+  return `https://www.paypal.com/sdk/js?client-id=${
+    client[env]
+  }${paypalSrcQueryParams}`;
 };
-
-const env = process.env.NODE_ENV === 'development' ? 'sandbox' : 'production';
 
 export const getDefaultPayment = (balance: number | false): string => {
   if (!balance) {


### PR DESCRIPTION
## Description

When running in non-production environments, the paypal source was erroneously set to production. Added an env var to be added to `.env` as `REACT_APP_PAYPAL_ID` that, when set, will use the paypal sandbox environment. 

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn && yarn start`
2. `yarn selenium`
3. `yarn e2e --spec=COMMA_SEPARATED_LIST_OF_SPECS_HERE --browser=headlessChrome`

## Note to Reviewers

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
