### PR TITLE
M3-3011 show booted config

### DIFF
--- a/packages/linode-js-sdk/src/account/types.ts
+++ b/packages/linode-js-sdk/src/account/types.ts
@@ -190,6 +190,7 @@ export type EventAction =
   | 'domain_record_delete'
   | 'image_update'
   | 'image_delete'
+  | 'lassie_reboot'
   | 'linode_addip'
   | 'linode_boot'
   | 'linode_clone'

--- a/packages/linode-js-sdk/src/account/types.ts
+++ b/packages/linode-js-sdk/src/account/types.ts
@@ -257,6 +257,7 @@ export interface Event {
   status: EventStatus;
   time_remaining: null | number;
   username: string;
+  secondary_entity?: Entity;
   _initial?: boolean;
 }
 /**

--- a/packages/linode-js-sdk/src/account/types.ts
+++ b/packages/linode-js-sdk/src/account/types.ts
@@ -257,7 +257,7 @@ export interface Event {
   status: EventStatus;
   time_remaining: null | number;
   username: string;
-  secondary_entity?: Entity;
+  secondary_entity: Entity | null;
   _initial?: boolean;
 }
 /**

--- a/packages/manager/src/__data__/events.ts
+++ b/packages/manager/src/__data__/events.ts
@@ -1,4 +1,4 @@
-import { Event } from 'linode-js-sdk/lib/account'
+import { Event } from 'linode-js-sdk/lib/account';
 import { ExtendedEvent } from 'src/store/events/event.helpers';
 
 export const events: Event[] = [
@@ -439,7 +439,7 @@ export const events: Event[] = [
     time_remaining: 0,
     seen: true,
     created: '2018-12-02T20:21:11',
-    action: 'linode_shutdown',
+    action: 'lassie_reboot',
     read: false,
     percent_complete: 100,
     username: 'test',

--- a/packages/manager/src/__data__/events.ts
+++ b/packages/manager/src/__data__/events.ts
@@ -10,6 +10,7 @@ export const events: Event[] = [
     action: 'linode_reboot',
     read: false,
     percent_complete: 100,
+    secondary_entity: null,
     username: 'test',
     rate: null,
     entity: {
@@ -23,6 +24,7 @@ export const events: Event[] = [
   {
     id: 18029767,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-03T22:38:16',
     action: 'linode_reboot',
@@ -41,6 +43,7 @@ export const events: Event[] = [
   {
     id: 18029572,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-03T22:34:09',
     action: 'linode_reboot',
@@ -59,6 +62,7 @@ export const events: Event[] = [
   {
     id: 18022171,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-03T19:59:53',
     action: 'linode_shutdown',
@@ -77,6 +81,7 @@ export const events: Event[] = [
   {
     id: 18022021,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-03T19:54:28',
     action: 'linode_boot',
@@ -95,6 +100,7 @@ export const events: Event[] = [
   {
     id: 18021942,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-03T19:53:26',
     action: 'linode_reboot',
@@ -113,6 +119,7 @@ export const events: Event[] = [
   {
     id: 17957943,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T23:15:45',
     action: 'linode_shutdown',
@@ -131,6 +138,7 @@ export const events: Event[] = [
   {
     id: 17957944,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T23:15:45',
     action: 'linode_delete',
@@ -149,6 +157,7 @@ export const events: Event[] = [
   {
     id: 17957718,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T23:08:38',
     action: 'linode_shutdown',
@@ -167,6 +176,7 @@ export const events: Event[] = [
   {
     id: 17957108,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T22:55:43',
     action: 'linode_boot',
@@ -185,6 +195,7 @@ export const events: Event[] = [
   {
     id: 17956743,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T22:48:37',
     action: 'linode_shutdown',
@@ -203,6 +214,7 @@ export const events: Event[] = [
   {
     id: 17956360,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T22:38:36',
     action: 'linode_boot',
@@ -221,6 +233,7 @@ export const events: Event[] = [
   {
     id: 17955994,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T22:31:24',
     action: 'linode_shutdown',
@@ -239,6 +252,7 @@ export const events: Event[] = [
   {
     id: 17955841,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T22:29:02',
     action: 'linode_boot',
@@ -264,6 +278,7 @@ export const events: Event[] = [
     percent_complete: 100,
     username: 'test',
     rate: null,
+    secondary_entity: null,
     entity: {
       id: 11440645,
       label: 'linode11440645',
@@ -282,6 +297,7 @@ export const events: Event[] = [
     percent_complete: 100,
     username: 'test',
     rate: null,
+    secondary_entity: null,
     entity: {
       id: 11440645,
       label: 'linode11440645',
@@ -296,6 +312,7 @@ export const events: Event[] = [
     seen: true,
     created: '2018-12-02T22:21:51',
     action: 'linode_shutdown',
+    secondary_entity: null,
     read: false,
     percent_complete: 100,
     username: 'test',
@@ -312,6 +329,7 @@ export const events: Event[] = [
     id: 17955613,
     time_remaining: 0,
     seen: true,
+    secondary_entity: null,
     created: '2018-12-02T22:20:43',
     action: 'linode_boot',
     read: false,
@@ -330,6 +348,7 @@ export const events: Event[] = [
     id: 17955464,
     time_remaining: 0,
     seen: true,
+    secondary_entity: null,
     created: '2018-12-02T22:19:10',
     action: 'linode_shutdown',
     read: false,
@@ -348,6 +367,7 @@ export const events: Event[] = [
     id: 17954738,
     time_remaining: 0,
     seen: true,
+    secondary_entity: null,
     created: '2018-12-02T22:03:38',
     action: 'linode_boot',
     read: false,
@@ -366,6 +386,7 @@ export const events: Event[] = [
     id: 17951319,
     time_remaining: 0,
     seen: true,
+    secondary_entity: null,
     created: '2018-12-02T20:45:52',
     action: 'linode_shutdown',
     read: false,
@@ -384,6 +405,7 @@ export const events: Event[] = [
     id: 17951106,
     time_remaining: 0,
     seen: true,
+    secondary_entity: null,
     created: '2018-12-02T20:39:36',
     action: 'linode_boot',
     read: false,
@@ -402,6 +424,7 @@ export const events: Event[] = [
     id: 17950945,
     time_remaining: 0,
     seen: true,
+    secondary_entity: null,
     created: '2018-12-02T20:35:54',
     action: 'linode_shutdown',
     read: false,
@@ -420,6 +443,7 @@ export const events: Event[] = [
     id: 17950407,
     time_remaining: 0,
     seen: true,
+    secondary_entity: null,
     created: '2018-12-02T20:23:43',
     action: 'linode_boot',
     read: false,
@@ -438,6 +462,7 @@ export const events: Event[] = [
     id: 17950183,
     time_remaining: 0,
     seen: true,
+    secondary_entity: null,
     created: '2018-12-02T20:21:11',
     action: 'lassie_reboot',
     read: false,
@@ -458,6 +483,7 @@ export const uniqueEvents: Event[] = [
   {
     id: 1231234,
     time_remaining: 50,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T20:23:43',
     action: 'linode_boot',
@@ -476,6 +502,7 @@ export const uniqueEvents: Event[] = [
   {
     id: 17950407,
     time_remaining: 0,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T20:23:43',
     action: 'linode_boot',
@@ -496,6 +523,7 @@ export const uniqueEvents: Event[] = [
 export const reduxEvent: ExtendedEvent = {
   _initial: false,
   id: 123551234,
+  secondary_entity: null,
   time_remaining: 50,
   seen: true,
   created: '2018-12-02T20:23:43',

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -136,19 +136,21 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   linode_boot: {
     scheduled: e =>
-      `Linode ${e.entity!.label}: ${
+      `Linode ${e.entity!.label} is scheduled to boot with config ${
         e.secondary_entity!.label
-      } is scheduled to boot.`,
+      }.`,
     started: e =>
-      `Linode ${e.entity!.label}: ${
+      `Linode ${e.entity!.label} is being booted with config${
         e.secondary_entity!.label
-      } is being booted.`,
+      }.`,
     failed: e =>
-      `Linode ${e.entity!.label}: ${
+      `Linode ${e.entity!.label} could not be booted with config ${
         e.secondary_entity!.label
-      } could not be booted.`,
+      }.`,
     finished: e =>
-      `Linode ${e.entity!.label}: ${e.secondary_entity!.label} has been booted.`
+      `Linode ${e.entity!.label} has been booted with config ${
+        e.secondary_entity!.label
+      }.`
   },
   lassie_reboot: {
     scheduled: e =>
@@ -249,21 +251,21 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   linode_reboot: {
     scheduled: e =>
-      `Linode ${e.entity!.label}: ${
+      `Linode ${e.entity!.label} is scheduled for a reboot with config ${
         e.secondary_entity!.label
-      } is scheduled for a reboot.`,
+      }.`,
     started: e =>
-      `Linode ${e.entity!.label}: ${
+      `Linode ${e.entity!.label} is being rebooted with config ${
         e.secondary_entity!.label
-      } is being rebooted.`,
+      }.`,
     failed: e =>
-      `Linode ${e.entity!.label}: ${
+      `Linode ${e.entity!.label} could not be rebooted with config ${
         e.secondary_entity!.label
-      } could not be rebooted.`,
+      }.`,
     finished: e =>
-      `Linode ${e.entity!.label}: ${
+      `Linode ${e.entity!.label} has been rebooted with config ${
         e.secondary_entity!.label
-      } has been rebooted.`
+      }.`
   },
   linode_rebuild: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled for rebuild.`,

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -140,7 +140,7 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
         e.secondary_entity!.label
       }.`,
     started: e =>
-      `Linode ${e.entity!.label} is being booted with config${
+      `Linode ${e.entity!.label} is being booted with config ${
         e.secondary_entity!.label
       }.`,
     failed: e =>

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -140,7 +140,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
         e.secondary_entity!.label
       } is scheduled to boot.`,
     started: e =>
-      `Linode ${e.entity!.label}: ${e.secondary_entity!.label} is booting.`,
+      `Linode ${e.entity!.label}: ${
+        e.secondary_entity!.label
+      } is being booted.`,
     failed: e =>
       `Linode ${e.entity!.label}: ${
         e.secondary_entity!.label
@@ -172,7 +174,7 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
         e.entity!.label
       } is scheduled to reboot (Host initiated restart).`,
     started: e =>
-      `Linode ${e.entity!.label} is booting (Host initiated restart).`,
+      `Linode ${e.entity!.label} is being booted (Host initiated restart).`,
     failed: e =>
       `Linode ${e.entity!.label} could not be booted (Host initiated restart).`,
     finished: e =>
@@ -184,7 +186,8 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   lish_boot: {
     scheduled: e =>
       `Linode ${e.entity!.label} is scheduled to boot (Lish initiated boot).`,
-    started: e => `Linode ${e.entity!.label} is booting (Lish initiated boot).`,
+    started: e =>
+      `Linode ${e.entity!.label} is being booted (Lish initiated boot).`,
     failed: e =>
       `Linode ${e.entity!.label} could not be booted (Lish initiated boot).`,
     finished: e => `Linode ${e.entity!.label} has booted (Lish initiated boot).`
@@ -250,7 +253,9 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
         e.secondary_entity!.label
       } is scheduled for a reboot.`,
     started: e =>
-      `Linode ${e.entity!.label}: ${e.secondary_entity!.label} is rebooting.`,
+      `Linode ${e.entity!.label}: ${
+        e.secondary_entity!.label
+      } is being rebooted.`,
     failed: e =>
       `Linode ${e.entity!.label}: ${
         e.secondary_entity!.label

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -135,10 +135,18 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: e => `An IP has been added to ${e.entity!.label}.`
   },
   linode_boot: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled to boot.`,
-    started: e => `Linode ${e.entity!.label} is booting.`,
-    failed: e => `Linode ${e.entity!.label} could not be booted.`,
-    finished: e => `Linode ${e.entity!.label} has been booted.`
+    scheduled: e =>
+      `Linode ${e.entity!.label}: ${
+        e.secondary_entity!.label
+      } is scheduled to boot.`,
+    started: e =>
+      `Linode ${e.entity!.label}: ${e.secondary_entity!.label} is booting.`,
+    failed: e =>
+      `Linode ${e.entity!.label}: ${
+        e.secondary_entity!.label
+      } could not be booted.`,
+    finished: e =>
+      `Linode ${e.entity!.label}: ${e.secondary_entity!.label} has been booted.`
   },
   lassie_reboot: {
     scheduled: e =>
@@ -237,10 +245,20 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     notification: e => `Linode ${e.entity!.label} is being upgraded.`
   },
   linode_reboot: {
-    scheduled: e => `Linode ${e.entity!.label} is scheduled for a reboot.`,
-    started: e => `Linode ${e.entity!.label} is rebooting.`,
-    failed: e => `Linode ${e.entity!.label} could not be rebooted.`,
-    finished: e => `Linode ${e.entity!.label} has been rebooted.`
+    scheduled: e =>
+      `Linode ${e.entity!.label}: ${
+        e.secondary_entity!.label
+      } is scheduled for a reboot.`,
+    started: e =>
+      `Linode ${e.entity!.label}: ${e.secondary_entity!.label} is rebooting.`,
+    failed: e =>
+      `Linode ${e.entity!.label}: ${
+        e.secondary_entity!.label
+      } could not be rebooted.`,
+    finished: e =>
+      `Linode ${e.entity!.label}: ${
+        e.secondary_entity!.label
+      } has been rebooted.`
   },
   linode_rebuild: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled for rebuild.`,

--- a/packages/manager/src/features/Events/Event.helpers.test.ts
+++ b/packages/manager/src/features/Events/Event.helpers.test.ts
@@ -1,6 +1,9 @@
+import { EventAction } from 'linode-js-sdk/lib/account';
 import { reduxEvent, uniqueEvents } from 'src/__data__/events';
 import {
   filterUniqueEvents,
+  formatEventWithUsername,
+  maybeRemoveTrailingPeriod,
   percentCompleteHasUpdated,
   shouldUpdateEvents
 } from './Event.helpers';
@@ -88,5 +91,45 @@ describe('Utility Functions', () => {
         }
       )
     ).toBeFalsy();
+  });
+
+  describe('formatEventWithUsername utility', () => {
+    it('it should return a message for an event without a username unchanged', () => {
+      const message = 'a message';
+      expect(
+        formatEventWithUsername('linode_boot' as EventAction, null, message)
+      ).toEqual(message);
+    });
+
+    it('should append the username to a normal event', () => {
+      const message = 'a message';
+      expect(
+        formatEventWithUsername(
+          'linode_boot' as EventAction,
+          'test-user-001',
+          message
+        )
+      ).toEqual('a message by test-user-001.');
+    });
+
+    it('should append the username to a normal event', () => {
+      const message = 'a message';
+      expect(
+        formatEventWithUsername(
+          'lassie_reboot' as EventAction,
+          'test-user-001',
+          message
+        )
+      ).toEqual(message);
+    });
+  });
+
+  describe('maybeRemoveTrailingPeriod', () => {
+    it('should remove trailing periods', () => {
+      expect(maybeRemoveTrailingPeriod('hello world.')).toBe('hello world');
+      expect(maybeRemoveTrailingPeriod('hello wor..ld')).toBe('hello wor..ld');
+      expect(maybeRemoveTrailingPeriod('hello world')).toBe('hello world');
+      expect(maybeRemoveTrailingPeriod('hello. world')).toBe('hello. world');
+    });
   });
 });

--- a/packages/manager/src/features/Events/Event.helpers.ts
+++ b/packages/manager/src/features/Events/Event.helpers.ts
@@ -1,4 +1,4 @@
-import { Event } from 'linode-js-sdk/lib/account';
+import { Event, EventAction } from 'linode-js-sdk/lib/account';
 import { equals } from 'ramda';
 
 /**
@@ -69,4 +69,26 @@ export const shouldUpdateEvents = (prevProps: Payload, nextProps: Payload) => {
         nextProps.inProgressEvents
       ))
   );
+};
+
+export const maybeRemoveTrailingPeriod = (string: string) => {
+  const lastChar = string[string.length - 1];
+  if (lastChar === '.') {
+    return string.substr(0, string.length - 1);
+  }
+  return string;
+};
+
+export const formatEventWithUsername = (
+  action: EventAction,
+  username: string | null,
+  message: string
+) => {
+  return username && action !== 'lassie_reboot'
+    ? /**
+       * The event message for Lassie events already includes "by the Lassie Watchdog service",
+       * so we don't want to add "by Linode" after that.
+       */
+      `${maybeRemoveTrailingPeriod(message)} by ${username}.`
+    : message;
 };

--- a/packages/manager/src/features/Events/EventRow.test.tsx
+++ b/packages/manager/src/features/Events/EventRow.test.tsx
@@ -1,9 +1,10 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { maybeRemoveTrailingPeriod, Row, RowProps } from './EventRow';
+import { Row, RowProps } from './EventRow';
 
 const message = 'this is a message.';
 const props: RowProps = {
+  action: 'linode_boot',
   message,
   type: 'linode',
   created: '2018-01-01',
@@ -55,14 +56,5 @@ describe('EventRow component', () => {
     expect(row.find(`[data-qa-event-message]`).text()).toBe(
       'this is a message by marty.'
     );
-  });
-});
-
-describe('utilities', () => {
-  it('should remove trailing periods', () => {
-    expect(maybeRemoveTrailingPeriod('hello world.')).toBe('hello world');
-    expect(maybeRemoveTrailingPeriod('hello wor..ld')).toBe('hello wor..ld');
-    expect(maybeRemoveTrailingPeriod('hello world')).toBe('hello world');
-    expect(maybeRemoveTrailingPeriod('hello. world')).toBe('hello. world');
   });
 });

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -1,4 +1,4 @@
-import { Event } from 'linode-js-sdk/lib/account';
+import { Event, EventAction } from 'linode-js-sdk/lib/account';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -20,6 +20,8 @@ import eventMessageGenerator from 'src/eventMessageGenerator';
 
 import { getEntityByIDFromStore } from 'src/utilities/getEntityByIDFromStore';
 import getEventsActionLink from 'src/utilities/getEventsActionLink';
+
+import { formatEventWithUsername } from './Event.helpers';
 
 type ClassNames = 'root' | 'message';
 
@@ -63,6 +65,7 @@ export const EventRow: React.StatelessComponent<CombinedProps> = props => {
     type,
     entityId,
     username: event.username,
+    action: event.action,
     classes
   };
 
@@ -75,12 +78,14 @@ export interface RowProps extends WithStyles<ClassNames> {
   linkTarget?: (e: React.MouseEvent<HTMLElement>) => void;
   type: 'linode' | 'domain' | 'nodebalancer' | 'stackscript' | 'volume';
   status?: string;
+  action: EventAction;
   created: string;
   username: string | null;
 }
 
 export const Row: React.StatelessComponent<RowProps> = props => {
   const {
+    action,
     classes,
     entityId,
     linkTarget,
@@ -121,9 +126,7 @@ export const Row: React.StatelessComponent<RowProps> = props => {
           data-qa-event-message
           variant="body1"
         >
-          {username
-            ? `${maybeRemoveTrailingPeriod(message)} by ${username}.`
-            : message}
+          {formatEventWithUsername(action, username, message)}
         </Typography>
       </TableCell>
       <TableCell parentColumn={'Time'} data-qa-event-created-cell compact>
@@ -142,11 +145,3 @@ const enhanced = compose<CombinedProps, Props & RenderGuardProps>(
 );
 
 export default enhanced(EventRow);
-
-export const maybeRemoveTrailingPeriod = (string: string) => {
-  const lastChar = string[string.length - 1];
-  if (lastChar === '.') {
-    return string.substr(0, string.length - 1);
-  }
-  return string;
-};

--- a/packages/manager/src/features/Events/EventsLanding.test.ts
+++ b/packages/manager/src/features/Events/EventsLanding.test.ts
@@ -6,6 +6,7 @@ const someEvent: Event[] = [
   {
     id: 1234,
     time_remaining: 50,
+    secondary_entity: null,
     seen: true,
     created: '2018-12-02T20:23:43',
     action: 'linode_boot',

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -10,7 +10,7 @@ import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import Grid from 'src/components/Grid';
 import eventMessageGenerator from 'src/eventMessageGenerator';
-import { maybeRemoveTrailingPeriod } from 'src/features/Events/EventRow';
+import { formatEventWithUsername } from 'src/features/Events/Event.helpers';
 
 type ClassNames = 'root';
 
@@ -50,9 +50,7 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
     >
       <Grid item>
         <Typography>
-          {event.username
-            ? `${maybeRemoveTrailingPeriod(message)} by ${event.username}.`
-            : message}
+          {formatEventWithUsername(event.action, event.username, message)}
         </Typography>
       </Grid>
       <Grid item>

--- a/packages/manager/src/features/linodes/transitions.test.ts
+++ b/packages/manager/src/features/linodes/transitions.test.ts
@@ -6,6 +6,7 @@ describe('transitionText helper', () => {
       transitionText('loading', {
         id: 123,
         action: 'linode_snapshot',
+        secondary_entity: null,
         created: '2012-12-12',
         entity: null,
         percent_complete: null,
@@ -28,6 +29,7 @@ describe('transitionText helper', () => {
       transitionText('optimus', {
         id: 123,
         action: 'linode_addip',
+        secondary_entity: null,
         created: '2012-12-12',
         entity: null,
         percent_complete: null,

--- a/packages/manager/src/store/events/event.helpers.test.ts
+++ b/packages/manager/src/store/events/event.helpers.test.ts
@@ -98,6 +98,7 @@ describe('event.helpers', () => {
         {
           id: 17957944,
           time_remaining: 0,
+          secondary_entity: null,
           seen: true,
           created: '2018-12-02T23:15:45',
           action: 'linode_delete',
@@ -116,6 +117,7 @@ describe('event.helpers', () => {
         {
           id: 17957108,
           time_remaining: 0,
+          secondary_entity: null,
           seen: true,
           created: '2018-12-02T22:55:43',
           action: 'linode_boot',
@@ -137,6 +139,7 @@ describe('event.helpers', () => {
         {
           id: 17957944,
           time_remaining: 0,
+          secondary_entity: null,
           seen: true,
           created: '2018-12-02T23:15:45',
           action: 'linode_delete',
@@ -156,6 +159,7 @@ describe('event.helpers', () => {
         {
           id: 17957108,
           time_remaining: 0,
+          secondary_entity: null,
           seen: true,
           created: '2018-12-02T22:55:43',
           action: 'linode_boot',
@@ -185,6 +189,7 @@ describe('event.helpers', () => {
         {
           id: 17957944,
           time_remaining: 0,
+          secondary_entity: null,
           seen: true,
           created: '2018-12-02T23:15:45',
           action: 'linode_delete',
@@ -198,6 +203,7 @@ describe('event.helpers', () => {
         {
           id: 17957718,
           time_remaining: 0,
+          secondary_entity: null,
           seen: true,
           created: '2018-12-02T23:08:38',
           action: 'linode_shutdown',
@@ -211,6 +217,7 @@ describe('event.helpers', () => {
         {
           id: 17957108,
           time_remaining: 0,
+          secondary_entity: null,
           seen: true,
           created: '2018-12-02T22:55:43',
           action: 'linode_boot',
@@ -226,6 +233,7 @@ describe('event.helpers', () => {
         {
           id: 17957718,
           time_remaining: 0,
+          secondary_entity: null,
           seen: true,
           created: '2018-12-02T23:08:38',
           action: 'linode_shutdown',
@@ -246,6 +254,7 @@ describe('event.helpers', () => {
           seen: true,
           created: '2018-12-02T23:15:45',
           action: 'linode_delete',
+          secondary_entity: null,
           read: false,
           percent_complete: 100,
           username: 'test',
@@ -259,6 +268,7 @@ describe('event.helpers', () => {
           seen: true,
           created: '2018-12-02T23:08:38',
           action: 'linode_shutdown',
+          secondary_entity: null,
           read: false,
           percent_complete: 70,
           username: 'test',
@@ -269,6 +279,7 @@ describe('event.helpers', () => {
         {
           id: 17957108,
           time_remaining: 0,
+          secondary_entity: null,
           seen: true,
           created: '2018-12-02T22:55:43',
           action: 'linode_boot',

--- a/packages/manager/src/store/events/event.reducer.test.ts
+++ b/packages/manager/src/store/events/event.reducer.test.ts
@@ -19,6 +19,7 @@ describe('events.reducer', () => {
           {
             id: 18029572,
             time_remaining: 0,
+            secondary_entity: null,
             seen: true,
             created: '2018-12-03T22:34:09',
             action: 'linode_reboot',
@@ -37,6 +38,7 @@ describe('events.reducer', () => {
           {
             id: 18022171,
             time_remaining: 0,
+            secondary_entity: null,
             seen: false,
             created: '2018-12-03T19:59:53',
             action: 'linode_shutdown',


### PR DESCRIPTION
## Description

Update eventMessageGenerator to show which config is associated with `linode_boot` and `linode_reboot` events. The exact syntax is up for debate (other options include "Linode my-linode has been booted with my-config by prod-test-004), please weigh in.

There's a ton of other stuff we can do in this file now that we have secondary entities, but afaict the other boot events e.g. `lassie_reboot` don't have them (I'm asking the API team for confirmation).

I also cleaned up some of the messaging, we were getting things like "Linode my-linode has been booted by the Lassie watchdog service by Linode" and "Linode my-linode is booting by Linode".

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

Boot and reboot things with different config profiles.