### PR TITLE
Fix: Gauge Last Updated Logic

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -10,7 +10,7 @@ import { baseGaugeProps } from './common';
 
 interface Props {
   clientAPIKey: string;
-  lastUpdated: number;
+  lastUpdated?: number;
 }
 
 const LongviewGauge: React.FC<Props> = props => {

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -8,7 +8,7 @@ import { baseGaugeProps } from './common';
 import requestStats from '../../request';
 
 interface Props {
-  lastUpdated: number;
+  lastUpdated?: number;
   token: string;
 }
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -1,3 +1,4 @@
+import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 
@@ -38,12 +39,20 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
 
   const { clientID, clientLabel, clientAPIKey, ...actionHandlers } = props;
 
-  const [lastUpdated, setLastUpdated] = React.useState<number>(0);
+  /* 
+   lastUpdated _might_ come back from the endpoint as 0, so it's important
+   that we differentiate between _0_ and _undefined_
+   */
+  const [lastUpdated, setLastUpdated] = React.useState<number | undefined>();
 
   const requestAndSetLastUpdated = () => {
     return getLastUpdated(clientAPIKey)
       .then(response => {
-        if (response.updated > lastUpdated) {
+        /* 
+          only update _lastUpdated_ state if it hasn't already been set
+          or the API response is in a time past what's already been set.
+        */
+        if (!lastUpdated || pathOr(0, ['updated'], response) > lastUpdated) {
           setLastUpdated(response.updated);
         }
       })
@@ -68,7 +77,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
     <TableRow className={classes.root} rowLink={`longview/clients/${clientID}`}>
       <TableCell>{`${clientLabel}`}</TableCell>
       <TableCell>
-        <CPUGauge clientAPIKey={clientAPIKey} lastUpdated={lastUpdated} />
+        <CPUGauge clientAPIKey={clientAPIKey} lastUpdated={lastUpdated || 0} />
       </TableCell>
       <TableCell>
         <RAMGauge />
@@ -77,7 +86,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
         <SwapGauge />
       </TableCell>
       <TableCell>
-        <LoadGauge lastUpdated={lastUpdated} token={clientAPIKey} />
+        <LoadGauge lastUpdated={lastUpdated || 0} token={clientAPIKey} />
       </TableCell>
       <TableCell>
         <NetworkGauge />

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -77,7 +77,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
     <TableRow className={classes.root} rowLink={`longview/clients/${clientID}`}>
       <TableCell>{`${clientLabel}`}</TableCell>
       <TableCell>
-        <CPUGauge clientAPIKey={clientAPIKey} lastUpdated={lastUpdated || 0} />
+        <CPUGauge clientAPIKey={clientAPIKey} lastUpdated={lastUpdated} />
       </TableCell>
       <TableCell>
         <RAMGauge />
@@ -86,7 +86,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
         <SwapGauge />
       </TableCell>
       <TableCell>
-        <LoadGauge lastUpdated={lastUpdated || 0} token={clientAPIKey} />
+        <LoadGauge lastUpdated={lastUpdated} token={clientAPIKey} />
       </TableCell>
       <TableCell>
         <NetworkGauge />


### PR DESCRIPTION
## Description

Last Updated State in the Longview Row component was only being set if it differed after the API request finished. But because API will return a `lastUpdated` of `0` if the Longview has no client installed, then we need to differentiate between `undefined` and `0` on the client.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')