### PR TITLE
LKE-1065 Cloud Manager filters regions to only those regions that have LKE

### DIFF
--- a/packages/linode-js-sdk/src/regions/types.ts
+++ b/packages/linode-js-sdk/src/regions/types.ts
@@ -2,7 +2,8 @@ export type Capabilities =
   | 'Linodes'
   | 'NodeBalancers'
   | 'Block Storage'
-  | 'Object Storage';
+  | 'Object Storage'
+  | 'Kubernetes';
 
 export interface Region {
   id: string;

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -255,7 +255,7 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
             <SelectRegionPanel
               error={errorMap.region}
               copy={'Determine the best location for your cluster.'}
-              regions={filteredRegions || []}
+              regions={filteredRegions}
               selectedID={selectedRegion}
               handleSelection={(regionID: string) =>
                 this.setState({ selectedRegion: regionID })

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -221,8 +221,15 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
       errors
     );
 
-    const _region = regionsData
-      ? regionsData.find(thisRegion => thisRegion.id === selectedRegion)
+    // Only displaying regions that have LKE capability
+    const filteredRegions = regionsData
+      ? regionsData.filter(thisRegion =>
+          thisRegion.capabilities.includes('Kubernetes')
+        )
+      : undefined;
+
+    const _region = filteredRegions
+      ? filteredRegions.find(thisRegion => thisRegion.id === selectedRegion)
       : undefined;
 
     const regionDisplay = _region ? _region.display : undefined;
@@ -248,14 +255,14 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
             <SelectRegionPanel
               error={errorMap.region}
               copy={'Determine the best location for your cluster.'}
-              regions={regionsData || []}
+              regions={filteredRegions || []}
               selectedID={selectedRegion}
               handleSelection={(regionID: string) =>
                 this.setState({ selectedRegion: regionID })
               }
               updateFor={[
                 errorMap.region,
-                regionsData,
+                filteredRegions,
                 selectedRegion,
                 classes
               ]}

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -226,11 +226,11 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
       ? regionsData.filter(thisRegion =>
           thisRegion.capabilities.includes('Kubernetes')
         )
-      : undefined;
+      : [];
 
-    const _region = filteredRegions
-      ? filteredRegions.find(thisRegion => thisRegion.id === selectedRegion)
-      : undefined;
+    const _region = filteredRegions.find(
+      thisRegion => thisRegion.id === selectedRegion
+    );
 
     const regionDisplay = _region ? _region.display : undefined;
 


### PR DESCRIPTION
## Description

We were previously displaying all DCs as available in k8 creation, however if you tried to create a cluster in a DC without LKE capability, it would throw an error. Now we filter based on capability so users won't be able to attempt an action that will only result in error. 

## Type of Change
- Non breaking change ('change')

## Note to Reviewers

Please test (for now) using staging. 
