### PR TITLE
M3-3369 Make CVV required on Update Credit Card Panel

### DIFF
--- a/packages/linode-js-sdk/src/account/account.schema.ts
+++ b/packages/linode-js-sdk/src/account/account.schema.ts
@@ -61,7 +61,8 @@ export const CreditCardSchema = object({
   expiry_month: number()
     .required('Expiration month is required.')
     .min(1, 'Expiration month must be a number from 1 to 12.')
-    .max(12, 'Expiration month must be a number from 1 to 12.')
+    .max(12, 'Expiration month must be a number from 1 to 12.'),
+  cvv: string().required('CVV code is required.')
 });
 
 export const CreateUserSchema = object({

--- a/packages/linode-js-sdk/src/account/account.schema.ts
+++ b/packages/linode-js-sdk/src/account/account.schema.ts
@@ -62,7 +62,10 @@ export const CreditCardSchema = object({
     .required('Expiration month is required.')
     .min(1, 'Expiration month must be a number from 1 to 12.')
     .max(12, 'Expiration month must be a number from 1 to 12.'),
-  cvv: string().required('CVV code is required.')
+  cvv: string()
+    .required('CVV code is required.')
+    .min(3, 'CVV code must be between 3 and 4 characters.')
+    .max(4, 'CVV code must be between 3 and 4 characters.')
 });
 
 export const CreateUserSchema = object({

--- a/packages/linode-js-sdk/src/account/types.ts
+++ b/packages/linode-js-sdk/src/account/types.ts
@@ -58,7 +58,7 @@ export interface ActivePromotion {
 interface CreditCard {
   expiry: string;
   last_four: string;
-  cvv?: string;
+  cvv: string;
 }
 
 export interface Invoice {

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateCreditCardPanel/UpdateCreditCardPanel.tsx
@@ -69,7 +69,7 @@ interface AccountContextProps {
   expiry: string;
   last_four: string;
   updateAccount: (update: (a: Account) => Account) => void;
-  cvv?: string;
+  cvv: string;
 }
 
 interface State {
@@ -186,7 +186,8 @@ class UpdateCreditCardPanel extends React.Component<CombinedProps, State> {
       {
         card_number: 'card number',
         expiry_month: 'expiration month',
-        expiry_year: 'expiration year'
+        expiry_year: 'expiration year',
+        cvv: 'cvv code'
       },
       errors
     );
@@ -283,6 +284,7 @@ class UpdateCreditCardPanel extends React.Component<CombinedProps, State> {
 
                 <Grid item className={classes.fullWidthMobile}>
                   <TextField
+                    required
                     label="CVV"
                     value={this.state.cvv}
                     onChange={this.handleCVVChange}


### PR DESCRIPTION
## Description

Making the CVV code required on the Update Credit Card panel under /account/billing. 

## Type of Change
- Non breaking change ('change')
