### PR TITLE
Change: Sets Error On Gauges

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -16,6 +16,9 @@ interface Props {
 const LongviewGauge: React.FC<Props> = props => {
   const { clientAPIKey, lastUpdated } = props;
 
+  const [dataHasResolvedAtLeastOnce, setDataResolved] = React.useState<boolean>(
+    false
+  );
   const [loading, setLoading] = React.useState<boolean>(true);
   const [error, setError] = React.useState<APIError | undefined>();
 
@@ -35,6 +38,10 @@ const LongviewGauge: React.FC<Props> = props => {
           return;
         }
 
+        if (!dataHasResolvedAtLeastOnce) {
+          setDataResolved(true);
+        }
+
         setNumCores(cores);
 
         const used = sumCPUUsage(data.CPU);
@@ -42,7 +49,7 @@ const LongviewGauge: React.FC<Props> = props => {
         setUsedCPU(normalizedUsed);
       })
       .catch(_ => {
-        if (!usedCPU) {
+        if (!dataHasResolvedAtLeastOnce) {
           setError({
             reason: 'Error' // @todo: Error message?
           });

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -13,6 +13,9 @@ interface Props {
 }
 
 const LoadGauge: React.FC<Props> = props => {
+  const [dataHasResolvedAtLeastOnce, setDataResolved] = React.useState<boolean>(
+    false
+  );
   const [load, setLoad] = React.useState<number>(0);
   const [amountOfCores, setCores] = React.useState<number>(0);
   const [loading, setLoading] = React.useState<boolean>(true);
@@ -30,10 +33,13 @@ const LoadGauge: React.FC<Props> = props => {
           if (!!loading) {
             setLoading(false);
           }
+          if (!dataHasResolvedAtLeastOnce) {
+            setDataResolved(true);
+          }
         }
       })
       .catch(() => {
-        if (!load && mounted) {
+        if (!dataHasResolvedAtLeastOnce && mounted) {
           setError({
             reason: 'Error'
           });


### PR DESCRIPTION
## Description

Opts to set errors on gauges if that data hasn't resolved at least once. We choose not to do checking on the actual value of the gauge because `0` is a valid value and `0` evaluates to `false`, so we need to set errors only if we don't already have data.

## Type of Change
- Non breaking change ('update', 'change')

## To Test

Ensure your Longview client successfully recovers from an error -> data state.

Ensure your Longview client does not error out if it's already been supplied with data at least once.

