### PR TITLE
M3-3509 Stackscripts breadcrumb display issue

### DIFF
--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import { makeStyles } from 'src/components/core/styles';
 import Crumbs, { CrumbOverridesProps } from './Crumbs';
@@ -24,8 +25,11 @@ const useStyles = makeStyles({
   preContainer: {
     display: 'flex',
     flexWrap: 'wrap',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     marginTop: -3
+  },
+  editablePreContainer: {
+    alignItems: 'flex-start'
   }
 });
 
@@ -51,7 +55,12 @@ export const Breadcrumb: React.FC<CombinedProps> = props => {
 
   return (
     <div className={`${classes.root} ${className}`}>
-      <div className={classes.preContainer}>
+      <div
+        className={classNames({
+          [classes.preContainer]: true,
+          [classes.editablePreContainer]: onEditHandlers !== undefined
+        })}
+      >
         <Crumbs
           pathMap={pathMap}
           onEditHandlers={onEditHandlers}

--- a/packages/manager/src/components/Breadcrumb/Crumbs.tsx
+++ b/packages/manager/src/components/Breadcrumb/Crumbs.tsx
@@ -112,7 +112,7 @@ const Crumbs: React.FC<CombinedProps> = props => {
         );
       })}
 
-      {/* 
+      {/*
         for prepending some SVG or other element before the final crumb.
         See users detail page for example
       */}
@@ -123,7 +123,7 @@ const Crumbs: React.FC<CombinedProps> = props => {
         />
       )}
 
-      {/* 
+      {/*
         the final crumb has the possibility of being a link, editable text
         or just static text
       */}
@@ -133,7 +133,7 @@ const Crumbs: React.FC<CombinedProps> = props => {
         onEditHandlers={onEditHandlers}
       />
 
-      {/* 
+      {/*
         for appending some SVG or other element after the final crumb.
         See support ticket detail as an example
       */}

--- a/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
@@ -50,7 +50,7 @@ const styles = (theme: Theme) =>
       ...theme.typography.h1
     },
     userNameSlash: {
-      color: theme.palette.text.primary,
+      color: theme.color.grey1,
       fontFamily: theme.font.normal,
       marginLeft: theme.spacing(1),
       marginRight: theme.spacing(1)

--- a/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
@@ -51,7 +51,9 @@ const styles = (theme: Theme) =>
     },
     userNameSlash: {
       color: theme.palette.text.primary,
-      fontFamily: theme.font.normal
+      fontFamily: theme.font.normal,
+      marginLeft: theme.spacing(1),
+      marginRight: theme.spacing(1)
     }
   });
 
@@ -121,7 +123,7 @@ export class StackScriptsDetail extends React.Component<CombinedProps, {}> {
           <Grid item>
             <Breadcrumb
               pathname={this.props.location.pathname}
-              labelOptions={{ prefixComponent: userNameSlash }}
+              labelOptions={{ prefixComponent: userNameSlash, noCap: true }}
               labelTitle={stackScript.label}
             />
           </Grid>


### PR DESCRIPTION
## Description

Stackscripts breadcrumb display was causing a test to break because we were capitalizing the crumb label with CSS. This adjusts that, the spacing of the 3rd slash if there are 3 crumbs, and an alignment issue I noticed on smaller screens for breadcrumb labels that weren't editable. 

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

Please take a look at Stackscripts detail page, as well as other places with 3+ crumbs (ex. User details), editable vs non-editable crumb labels, etc.
