### PR TITLE
M3 editable table cell

### DIFF
--- a/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
@@ -123,6 +123,7 @@ interface Props {
   onInputChange: (text: string) => void;
   text: string;
   errorText?: string;
+  editable?: boolean;
   typeVariant: EditableTextVariant;
   className?: string;
   inputText: string;
@@ -137,6 +138,7 @@ type FinalProps = PassThroughProps;
 export const EditableInput: React.FC<FinalProps> = props => {
   const {
     errorText,
+    editable,
     onEdit,
     openForEdit,
     cancelEdit,
@@ -214,24 +216,25 @@ export const EditableInput: React.FC<FinalProps> = props => {
             })
           }}
           autoFocus={true}
+          editable
         />
         {!loading && (
           <>
-          <Button
-            className={`${classes.button} ${classes.saveButton}`}
-            onClick={() => onEdit()}
-            data-qa-save-edit
-          >
-            <Check className={`${classes.icon} ${classes.save}`} />
-          </Button>
-          <Button
-            className={classes.button}
-            onClick={cancelEdit}
-            data-qa-cancel-edit
-          >
-            <Close className={`${classes.icon} ${classes.close}`} />
-          </Button>
-        </>
+            <Button
+              className={`${classes.button} ${classes.saveButton}`}
+              onClick={() => onEdit()}
+              data-qa-save-edit
+            >
+              <Check className={`${classes.icon} ${classes.save}`} />
+            </Button>
+            <Button
+              className={classes.button}
+              onClick={cancelEdit}
+              data-qa-cancel-edit
+            >
+              <Close className={`${classes.icon} ${classes.close}`} />
+            </Button>
+          </>
         )}
       </div>
     </ClickAwayListener>

--- a/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
@@ -22,7 +22,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   root: {
     padding: '5px 8px',
     display: 'inline-block',
-    border: '1px solid transparent',
     transition: theme.transitions.create(['opacity']),
     wordBreak: 'break-all',
     textDecoration: 'inherit',
@@ -32,11 +31,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: 'flex',
     justifyContent: 'flex-start',
     alignItems: 'center',
-    maxHeight: 48,
     position: 'relative'
   },
   initial: {
-    border: '1px solid transparent',
     '&:hover, &:focus': {
       '& $editIcon': {
         opacity: 1
@@ -70,9 +67,11 @@ const useStyles = makeStyles((theme: Theme) => ({
     }
   },
   button: {
-    minWidth: 'auto',
-    minHeight: 48,
     padding: 0,
+    height: 24,
+    width: 24,
+    minWidth: 'auto',
+    minHeight: 'auto',
     marginTop: 0,
     background: 'transparent !important'
   },
@@ -82,6 +81,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     '&:hover, &:focus': {
       color: theme.palette.primary.light
     }
+  },
+  saveButton: {
+    marginLeft: 8,
+    marginRight: 8
   },
   save: {
     fontSize: 26
@@ -100,6 +103,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     ...theme.typography.h1
   },
   editIcon: {
+    position: 'absolute',
+    right: 0,
     [theme.breakpoints.up('sm')]: {
       opacity: 0,
       '&:focus': {
@@ -208,7 +213,7 @@ export const EditableInput: React.FC<FinalProps> = props => {
           autoFocus={true}
         />
         <Button
-          className={classes.button}
+          className={`${classes.button} ${classes.saveButton}`}
           onClick={() => onEdit()}
           data-qa-save-edit
         >

--- a/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
@@ -8,7 +8,7 @@ import ClickAwayListener from 'src/components/core/ClickAwayListener';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import { TextFieldProps } from 'src/components/core/TextField';
 import Typography from 'src/components/core/Typography';
-import TextField from '../TextField';
+import TextField from 'src/components/TextField';
 
 const useStyles = makeStyles((theme: Theme) => ({
   '@keyframes fadeIn': {
@@ -106,11 +106,6 @@ const useStyles = makeStyles((theme: Theme) => ({
         opacity: 1
       }
     }
-  },
-  underlineOnHover: {
-    '&:hover, &:focus': {
-      textDecoration: 'underline !important'
-    }
   }
 }));
 
@@ -123,7 +118,6 @@ interface Props {
   onInputChange: (text: string) => void;
   text: string;
   errorText?: string;
-  labelLink?: string;
   typeVariant: EditableTextVariant;
   className?: string;
   inputText: string;
@@ -136,7 +130,6 @@ type FinalProps = PassThroughProps;
 
 export const EditableInput: React.FC<FinalProps> = props => {
   const {
-    labelLink,
     errorText,
     onEdit,
     openForEdit,

--- a/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
@@ -1,0 +1,285 @@
+import Check from '@material-ui/icons/Check';
+import Close from '@material-ui/icons/Close';
+import Edit from '@material-ui/icons/Edit';
+import * as classnames from 'classnames';
+import * as React from 'react';
+import Button from 'src/components/Button';
+import ClickAwayListener from 'src/components/core/ClickAwayListener';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import { TextFieldProps } from 'src/components/core/TextField';
+import Typography from 'src/components/core/Typography';
+import TextField from '../TextField';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  '@keyframes fadeIn': {
+    from: {
+      opacity: 0
+    },
+    to: {
+      opacity: 1
+    }
+  },
+  root: {
+    padding: '5px 8px',
+    display: 'inline-block',
+    border: '1px solid transparent',
+    transition: theme.transitions.create(['opacity']),
+    wordBreak: 'break-all',
+    textDecoration: 'inherit',
+    lineHeight: 1
+  },
+  container: {
+    display: 'flex',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    maxHeight: 48,
+    position: 'relative'
+  },
+  initial: {
+    border: '1px solid transparent',
+    '&:hover, &:focus': {
+      '& $editIcon': {
+        opacity: 1
+      },
+      '& $icon': {
+        color: theme.color.grey1,
+        '&:hover': {
+          color: theme.color.black
+        }
+      }
+    }
+  },
+  edit: {
+    fontSize: 22,
+    border: '1px solid transparent'
+  },
+  textField: {
+    opacity: 0,
+    animation: '$fadeIn .3s ease-in-out forwards',
+    margin: 0
+  },
+  inputRoot: {
+    maxWidth: 170,
+    borderColor: `${theme.palette.primary.main} !important`,
+    backgroundColor: 'transparent',
+    boxShadow: 'none',
+    minHeight: 40,
+    [theme.breakpoints.up('md')]: {
+      maxWidth: 415,
+      width: '100%'
+    }
+  },
+  button: {
+    minWidth: 'auto',
+    minHeight: 48,
+    padding: 0,
+    marginTop: 0,
+    background: 'transparent !important'
+  },
+  icon: {
+    margin: '0 10px',
+    color: theme.palette.text.primary,
+    '&:hover, &:focus': {
+      color: theme.palette.primary.light
+    }
+  },
+  save: {
+    fontSize: 26
+  },
+  close: {
+    fontSize: 26
+  },
+  input: {
+    padding: '5px 8px',
+    ...theme.typography.body1
+  },
+  headline: {
+    ...theme.typography.h1
+  },
+  title: {
+    ...theme.typography.h1
+  },
+  editIcon: {
+    [theme.breakpoints.up('sm')]: {
+      opacity: 0,
+      '&:focus': {
+        opacity: 1
+      }
+    }
+  },
+  underlineOnHover: {
+    '&:hover, &:focus': {
+      textDecoration: 'underline !important'
+    }
+  }
+}));
+
+export type EditableTextVariant = 'h1' | 'h2' | 'table-cell';
+
+interface Props {
+  onEdit: () => Promise<any>;
+  onCancel: () => void;
+  openForEdit: () => void;
+  cancelEdit: () => void;
+  onInputChange: (text: string) => void;
+  text: string;
+  errorText?: string;
+  labelLink?: string;
+  typeVariant: EditableTextVariant;
+  className?: string;
+  inputText: string;
+  isEditing: boolean;
+}
+
+type PassThroughProps = Props & TextFieldProps;
+
+type FinalProps = PassThroughProps;
+
+export const EditableInput: React.FC<FinalProps> = props => {
+  // componentDidUpdate(prevProps: FinalProps, prevState: State) {
+  //   const { text } = this.props;
+  //   const { text: prevText } = prevProps;
+  //   if (text !== prevText) {
+  //     this.setState({
+  //       isEditing: false,
+  //       text
+  //     });
+  //   }
+  // // }
+
+  // const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   this.setState({ text: e.target.value });
+  // };
+
+  // const openEdit = () => {
+  //   this.setState({ isEditing: true });
+  // };
+
+  // const finishEditing = () => {
+  //   const { text } = this.state;
+  //   /**
+  //    * if the entered text is different from the original text
+  //    * provided, run the update callback
+  //    *
+  //    * only exit editing mode if promise resolved
+  //    */
+  //   if (text !== this.props.text) {
+  //     this.props
+  //       .onEdit(text)
+  //       .then(() => {
+  //         this.setState({ isEditing: false });
+  //       })
+  //       .catch(e => e);
+  //   } else {
+  //     /** otherwise, we've just submitted the form with no value change */
+  //     this.setState({ isEditing: false });
+  //   }
+  // };
+
+  // cancelEditing = () => {
+  //   /** cancel editing and invoke callback function and revert text to original */
+  //   this.setState({ isEditing: false, text: this.props.text }, () => {
+  //     this.props.onCancel();
+  //   });
+  // };
+
+  // /** confirm or cancel edits if the enter or escape keys are pressed, respectively */
+  // handleKeyPress = (e: React.KeyboardEvent) => {
+  //   if (e.key === 'Enter') {
+  //     this.finishEditing();
+  //   }
+  //   if (e.key === 'Escape' || e.key === 'Esc') {
+  //     this.cancelEditing();
+  //   }
+  // };
+
+  const {
+    labelLink,
+    errorText,
+    onEdit,
+    onCancel,
+    openForEdit,
+    cancelEdit,
+    onInputChange,
+    text,
+    typeVariant,
+    className,
+    isEditing,
+    inputText,
+    ...rest
+  } = props;
+
+  const classes = useStyles();
+
+  const labelText = (
+    <Typography
+      className={className ? className : classes.root}
+      variant={typeVariant === 'table-cell' ? 'body1' : 'h1'}
+      data-qa-editable-text
+    >
+      <strong>{text}</strong>
+    </Typography>
+  );
+
+  return !isEditing && !errorText ? (
+    <div
+      className={`${classes.container} ${classes.initial} ${className}`}
+      data-testid={'editable-text'}
+    >
+      <React.Fragment>
+        {labelText}
+        {/** pencil icon */}
+        <Button
+          className={`${classes.button} ${classes.editIcon}`}
+          onClick={openForEdit}
+          data-qa-edit-button
+          aria-label={`Edit ${labelText}`}
+        >
+          <Edit className={`${classes.icon} ${classes.edit}`} />
+        </Button>
+      </React.Fragment>
+    </div>
+  ) : (
+    <ClickAwayListener onClickAway={cancelEdit} mouseEvent="onMouseDown">
+      <div
+        className={`${classes.container} ${classes.edit} ${className}`}
+        data-qa-edit-field
+      >
+        <TextField
+          {...rest}
+          className={classes.textField}
+          type="text"
+          onChange={(e: any) => onInputChange(e.target.value)}
+          onKeyDown={() => null}
+          value={text}
+          errorText={errorText}
+          InputProps={{ className: classes.inputRoot }}
+          inputProps={{
+            className: classnames({
+              [classes.headline]: typeVariant === 'h1',
+              [classes.title]: typeVariant === 'h2',
+              [classes.input]: true
+            })
+          }}
+          autoFocus={true}
+        />
+        <Button
+          className={classes.button}
+          onClick={() => onEdit()}
+          data-qa-save-edit
+        >
+          <Check className={`${classes.icon} ${classes.save}`} />
+        </Button>
+        <Button
+          className={classes.button}
+          onClick={cancelEdit}
+          data-qa-cancel-edit
+        >
+          <Close className={`${classes.icon} ${classes.close}`} />
+        </Button>
+      </div>
+    </ClickAwayListener>
+  );
+};
+
+export default EditableInput;

--- a/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
@@ -127,6 +127,7 @@ interface Props {
   className?: string;
   inputText: string;
   isEditing: boolean;
+  loading: boolean;
 }
 
 type PassThroughProps = Props & TextFieldProps;
@@ -145,6 +146,7 @@ export const EditableInput: React.FC<FinalProps> = props => {
     className,
     isEditing,
     inputText,
+    loading,
     ...rest
   } = props;
 
@@ -196,6 +198,7 @@ export const EditableInput: React.FC<FinalProps> = props => {
       >
         <TextField
           {...rest}
+          loading={loading}
           className={classes.textField}
           type="text"
           onChange={(e: any) => onInputChange(e.target.value)}
@@ -212,20 +215,24 @@ export const EditableInput: React.FC<FinalProps> = props => {
           }}
           autoFocus={true}
         />
-        <Button
-          className={`${classes.button} ${classes.saveButton}`}
-          onClick={() => onEdit()}
-          data-qa-save-edit
-        >
-          <Check className={`${classes.icon} ${classes.save}`} />
-        </Button>
-        <Button
-          className={classes.button}
-          onClick={cancelEdit}
-          data-qa-cancel-edit
-        >
-          <Close className={`${classes.icon} ${classes.close}`} />
-        </Button>
+        {!loading && (
+          <>
+          <Button
+            className={`${classes.button} ${classes.saveButton}`}
+            onClick={() => onEdit()}
+            data-qa-save-edit
+          >
+            <Check className={`${classes.icon} ${classes.save}`} />
+          </Button>
+          <Button
+            className={classes.button}
+            onClick={cancelEdit}
+            data-qa-cancel-edit
+          >
+            <Close className={`${classes.icon} ${classes.close}`} />
+          </Button>
+        </>
+        )}
       </div>
     </ClickAwayListener>
   );

--- a/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
@@ -117,7 +117,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export type EditableTextVariant = 'h1' | 'h2' | 'table-cell';
 
 interface Props {
-  onEdit: () => Promise<any>;
+  onEdit: () => void;
   onCancel: () => void;
   openForEdit: () => void;
   cancelEdit: () => void;
@@ -251,7 +251,7 @@ export const EditableInput: React.FC<FinalProps> = props => {
           type="text"
           onChange={(e: any) => onInputChange(e.target.value)}
           onKeyDown={() => null}
-          value={text}
+          value={inputText}
           errorText={errorText}
           InputProps={{ className: classes.inputRoot }}
           inputProps={{

--- a/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableInput.tsx
@@ -118,7 +118,6 @@ export type EditableTextVariant = 'h1' | 'h2' | 'table-cell';
 
 interface Props {
   onEdit: () => void;
-  onCancel: () => void;
   openForEdit: () => void;
   cancelEdit: () => void;
   onInputChange: (text: string) => void;
@@ -136,68 +135,10 @@ type PassThroughProps = Props & TextFieldProps;
 type FinalProps = PassThroughProps;
 
 export const EditableInput: React.FC<FinalProps> = props => {
-  // componentDidUpdate(prevProps: FinalProps, prevState: State) {
-  //   const { text } = this.props;
-  //   const { text: prevText } = prevProps;
-  //   if (text !== prevText) {
-  //     this.setState({
-  //       isEditing: false,
-  //       text
-  //     });
-  //   }
-  // // }
-
-  // const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   this.setState({ text: e.target.value });
-  // };
-
-  // const openEdit = () => {
-  //   this.setState({ isEditing: true });
-  // };
-
-  // const finishEditing = () => {
-  //   const { text } = this.state;
-  //   /**
-  //    * if the entered text is different from the original text
-  //    * provided, run the update callback
-  //    *
-  //    * only exit editing mode if promise resolved
-  //    */
-  //   if (text !== this.props.text) {
-  //     this.props
-  //       .onEdit(text)
-  //       .then(() => {
-  //         this.setState({ isEditing: false });
-  //       })
-  //       .catch(e => e);
-  //   } else {
-  //     /** otherwise, we've just submitted the form with no value change */
-  //     this.setState({ isEditing: false });
-  //   }
-  // };
-
-  // cancelEditing = () => {
-  //   /** cancel editing and invoke callback function and revert text to original */
-  //   this.setState({ isEditing: false, text: this.props.text }, () => {
-  //     this.props.onCancel();
-  //   });
-  // };
-
-  // /** confirm or cancel edits if the enter or escape keys are pressed, respectively */
-  // handleKeyPress = (e: React.KeyboardEvent) => {
-  //   if (e.key === 'Enter') {
-  //     this.finishEditing();
-  //   }
-  //   if (e.key === 'Escape' || e.key === 'Esc') {
-  //     this.cancelEditing();
-  //   }
-  // };
-
   const {
     labelLink,
     errorText,
     onEdit,
-    onCancel,
     openForEdit,
     cancelEdit,
     onInputChange,
@@ -208,6 +149,16 @@ export const EditableInput: React.FC<FinalProps> = props => {
     inputText,
     ...rest
   } = props;
+
+  /** confirm or cancel edits if the enter or escape keys are pressed, respectively */
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      onEdit();
+    }
+    if (e.key === 'Escape' || e.key === 'Esc') {
+      cancelEdit();
+    }
+  };
 
   const classes = useStyles();
 
@@ -250,7 +201,7 @@ export const EditableInput: React.FC<FinalProps> = props => {
           className={classes.textField}
           type="text"
           onChange={(e: any) => onInputChange(e.target.value)}
-          onKeyDown={() => null}
+          onKeyDown={handleKeyPress}
           value={inputText}
           errorText={errorText}
           InputProps={{ className: classes.inputRoot }}

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
@@ -12,9 +12,16 @@ import EditableTableRowLabel from './EditableTableRowLabel';
 storiesOf('EditableTableRowLabel', module)
   .add('default', () => {
     const [text, setText] = React.useState<string>('sample text');
+    const [loading, setLoading] = React.useState<boolean>(false);
 
     const onEdit = (s: string) => {
-      return Promise.resolve(s).then(response => setText(response));
+      return new Promise((resolve, reject) => {
+        setLoading(true);
+        setTimeout(() => {
+          setLoading(false);
+          resolve(setText(s));
+        }, 3000);
+      });
     };
 
     return (
@@ -33,6 +40,7 @@ storiesOf('EditableTableRowLabel', module)
               iconVariant="linode"
               subText="Waiting for data..."
               onEdit={onEdit}
+              loading={loading}
             />
             <TableCell>Table Value</TableCell>
             <TableCell>2 days ago</TableCell>
@@ -42,11 +50,18 @@ storiesOf('EditableTableRowLabel', module)
     );
   })
   .add('with error', () => {
-    const [text, setText] = React.useState<string>('sample text');
+    const [loading, setLoading] = React.useState<boolean>(false);
 
     const onEdit = (s: string) => {
-      return Promise.reject('an error').then(response => setText(response));
+      return new Promise((resolve, reject) => {
+        setLoading(true);
+        setTimeout(() => {
+          setLoading(false);
+          reject();
+        }, 3000);
+      });
     };
+
 
     return (
       <Table>
@@ -60,10 +75,11 @@ storiesOf('EditableTableRowLabel', module)
         <TableBody>
           <TableRow>
             <EditableTableRowLabel
-              text={text}
+              text={"demo text"}
               iconVariant="linode"
               subText="Waiting for data..."
               onEdit={onEdit}
+              loading={loading}
             />
             <TableCell>Table Value</TableCell>
             <TableCell>2 days ago</TableCell>

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
@@ -20,7 +20,11 @@ storiesOf('EditableTableRowLabel', module).add('default', () => (
     </TableHead>
     <TableBody>
       <TableRow>
-        <EditableTableRowLabel text="sample text" />
+        <EditableTableRowLabel
+          text="sample text"
+          iconVariant="linode"
+          subText="Waiting for data..."
+        />
         <TableCell>Table Value</TableCell>
         <TableCell>2 days ago</TableCell>
       </TableRow>

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
@@ -9,25 +9,35 @@ import TableCell from 'src/components/TableCell';
 
 import EditableTableRowLabel from './EditableTableRowLabel';
 
-storiesOf('EditableTableRowLabel', module).add('default', () => (
-  <Table aria-label="List of Your Images">
-    <TableHead>
-      <TableRow>
-        <TableCell>Label</TableCell>
-        <TableCell>Value</TableCell>
-        <TableCell>Created</TableCell>
-      </TableRow>
-    </TableHead>
-    <TableBody>
-      <TableRow>
-        <EditableTableRowLabel
-          text="sample text"
-          iconVariant="linode"
-          subText="Waiting for data..."
-        />
-        <TableCell>Table Value</TableCell>
-        <TableCell>2 days ago</TableCell>
-      </TableRow>
-    </TableBody>
-  </Table>
-));
+
+
+storiesOf('EditableTableRowLabel', module).add('default', () => {
+  const [text, setText] = React.useState<string>('sample text');
+
+  const onEdit = (s: string) => {
+    return Promise.resolve(s).then((response => setText(response)));
+  }
+  
+  return (
+    <Table aria-label="List of Your Images">
+      <TableHead>
+        <TableRow>
+          <TableCell>Label</TableCell>
+          <TableCell>Value</TableCell>
+          <TableCell>Created</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <TableRow>
+          <EditableTableRowLabel
+            text={text}
+            iconVariant="linode"
+            subText="Waiting for data..."
+            onEdit={onEdit}
+          />
+          <TableCell>Table Value</TableCell>
+          <TableCell>2 days ago</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+)});

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
@@ -1,0 +1,29 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/core/TableRow';
+import Table from 'src/components/Table';
+import TableCell from 'src/components/TableCell';
+
+import EditableTableRowLabel from './EditableTableRowLabel';
+
+storiesOf('EditableTableRowLabel', module).add('default', () => (
+  <Table aria-label="List of Your Images">
+    <TableHead>
+      <TableRow>
+        <TableCell>Label</TableCell>
+        <TableCell>Value</TableCell>
+        <TableCell>Created</TableCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      <TableRow>
+        <EditableTableRowLabel text="sample text" />
+        <TableCell>Table Value</TableCell>
+        <TableCell>2 days ago</TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>
+));

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
@@ -57,11 +57,10 @@ storiesOf('EditableTableRowLabel', module)
         setLoading(true);
         setTimeout(() => {
           setLoading(false);
-          reject();
+          reject('An error occurred!');
         }, 3000);
       });
     };
-
 
     return (
       <Table>
@@ -75,7 +74,7 @@ storiesOf('EditableTableRowLabel', module)
         <TableBody>
           <TableRow>
             <EditableTableRowLabel
-              text={"demo text"}
+              text={'demo text'}
               iconVariant="linode"
               subText="Waiting for data..."
               onEdit={onEdit}

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.stories.tsx
@@ -9,35 +9,66 @@ import TableCell from 'src/components/TableCell';
 
 import EditableTableRowLabel from './EditableTableRowLabel';
 
+storiesOf('EditableTableRowLabel', module)
+  .add('default', () => {
+    const [text, setText] = React.useState<string>('sample text');
 
+    const onEdit = (s: string) => {
+      return Promise.resolve(s).then(response => setText(response));
+    };
 
-storiesOf('EditableTableRowLabel', module).add('default', () => {
-  const [text, setText] = React.useState<string>('sample text');
+    return (
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Label</TableCell>
+            <TableCell>Value</TableCell>
+            <TableCell>Created</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <EditableTableRowLabel
+              text={text}
+              iconVariant="linode"
+              subText="Waiting for data..."
+              onEdit={onEdit}
+            />
+            <TableCell>Table Value</TableCell>
+            <TableCell>2 days ago</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+  })
+  .add('with error', () => {
+    const [text, setText] = React.useState<string>('sample text');
 
-  const onEdit = (s: string) => {
-    return Promise.resolve(s).then((response => setText(response)));
-  }
-  
-  return (
-    <Table aria-label="List of Your Images">
-      <TableHead>
-        <TableRow>
-          <TableCell>Label</TableCell>
-          <TableCell>Value</TableCell>
-          <TableCell>Created</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        <TableRow>
-          <EditableTableRowLabel
-            text={text}
-            iconVariant="linode"
-            subText="Waiting for data..."
-            onEdit={onEdit}
-          />
-          <TableCell>Table Value</TableCell>
-          <TableCell>2 days ago</TableCell>
-        </TableRow>
-      </TableBody>
-    </Table>
-)});
+    const onEdit = (s: string) => {
+      return Promise.reject('an error').then(response => setText(response));
+    };
+
+    return (
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Label</TableCell>
+            <TableCell>Value</TableCell>
+            <TableCell>Created</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <EditableTableRowLabel
+              text={text}
+              iconVariant="linode"
+              subText="Waiting for data..."
+              onEdit={onEdit}
+            />
+            <TableCell>Table Value</TableCell>
+            <TableCell>2 days ago</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+  });

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
@@ -30,9 +30,13 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
   const classes = useStyles();
 
   const onSubmit = () => {
-    onEdit(inputText)
-      .then(() => toggleEditing(false))
-  }
+    if (inputText !== text) {
+      onEdit(inputText).then(() => toggleEditing(false));
+    } else {
+      toggleEditing(false);
+    }
+  };
+
   return (
     <TableCell style={{ width: width || '30%' }}>
       <Grid
@@ -58,7 +62,6 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
           <Grid item className="py0 px0">
             <EditableInput
               onEdit={onSubmit}
-              onCancel={() => toggleEditing(false)}
               openForEdit={() => toggleEditing(true)}
               cancelEdit={() => toggleEditing(false)}
               onInputChange={(t: string) => setInputText(t)}

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
@@ -24,11 +24,12 @@ interface Props {
   onEdit: (s: string) => Promise<any>;
   width?: string;
   iconVariant: Variant;
+  loading: boolean;
   subText?: string;
 }
 
 export const EditableTableRowLabel: React.FC<Props> = props => {
-  const { iconVariant, subText, text, width, onEdit } = props;
+  const { iconVariant, loading, subText, text, width, onEdit } = props;
   const [isEditing, toggleEditing] = React.useState<boolean>(false);
   const [inputText, setInputText] = React.useState<string>(text);
   const [error, setError] = React.useState<string | undefined>();
@@ -81,6 +82,7 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
           <Grid item className="py0 px0">
             <EditableInput
               errorText={error}
+              loading={loading}
               onEdit={onSubmit}
               openForEdit={handleOpen}
               cancelEdit={handleClose}

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
@@ -8,10 +8,11 @@ import EditableInput from './EditableInput';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    padding: theme.spacing(2)
+    minHeight: 40
   },
   smallInput: {
-    height: '1em'
+    position: 'relative',
+    paddingRight: 20
   },
   subText: {
     fontSize: '0.8em'
@@ -55,16 +56,17 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
   };
 
   return (
-    <TableCell className={classes.root} style={{ width: width || '30%' }}>
+    <TableCell style={{ width: width || '30%' }}>
       <Grid
         container
         direction="row"
         wrap="nowrap"
         alignItems="center"
         justify="flex-start"
+        className={`${classes.root} m0`}
       >
         {!isEditing && (
-          <Grid item xs={1}>
+          <Grid item xs={1} className="py0">
             <EntityIcon variant={iconVariant} />
           </Grid>
         )}
@@ -74,6 +76,7 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
           direction="column"
           alignItems="flex-start"
           justify="center"
+          className="py0"
         >
           <Grid item className="py0 px0">
             <EditableInput

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
@@ -55,7 +55,7 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
   };
 
   return (
-    <TableCell  style={{ width: width || '30%', padding: '12px'}}>
+    <TableCell className={classes.root} style={{ width: width || '30%' }}>
       <Grid
         container
         direction="row"
@@ -74,7 +74,6 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
           direction="column"
           alignItems="flex-start"
           justify="center"
-          spacing={0}
         >
           <Grid item className="py0 px0">
             <EditableInput

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import EditableText from 'src/components/EditableText';
+import TableCell from 'src/components/TableCell';
+
+interface Props {
+  text?: string;
+  width?: string;
+}
+
+export const EditableTableRowLabel: React.FC<Props> = props => {
+  const { width } = props;
+  return (
+    <TableCell style={{ width: width || '20%' }}>
+      <EditableText
+        onEdit={() => Promise.resolve()}
+        onCancel={() => Promise.resolve()}
+        text="some text"
+        variant="standard"
+        typeVariant="any"
+      />
+    </TableCell>
+  );
+};
+
+export default EditableTableRowLabel;

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
@@ -3,20 +3,19 @@ import EditableText from 'src/components/EditableText';
 import TableCell from 'src/components/TableCell';
 
 interface Props {
-  text?: string;
+  text: string;
   width?: string;
 }
 
 export const EditableTableRowLabel: React.FC<Props> = props => {
-  const { width } = props;
+  const { text, width } = props;
   return (
     <TableCell style={{ width: width || '20%' }}>
       <EditableText
         onEdit={() => Promise.resolve()}
         onCancel={() => Promise.resolve()}
-        text="some text"
-        variant="standard"
-        typeVariant="any"
+        text={text}
+        typeVariant="table-cell"
       />
     </TableCell>
   );

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
@@ -17,16 +17,22 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface Props {
   text: string;
+  onEdit: (s: string) => Promise<any>;
   width?: string;
   iconVariant: Variant;
   subText?: string;
 }
 
 export const EditableTableRowLabel: React.FC<Props> = props => {
-  const { iconVariant, subText, text, width } = props;
+  const { iconVariant, subText, text, width, onEdit } = props;
   const [isEditing, toggleEditing] = React.useState<boolean>(false);
-  const [inputText, setInputText] = React.useState<string>('');
+  const [inputText, setInputText] = React.useState<string>(text);
   const classes = useStyles();
+
+  const onSubmit = () => {
+    onEdit(inputText)
+      .then(() => toggleEditing(false))
+  }
   return (
     <TableCell style={{ width: width || '30%' }}>
       <Grid
@@ -51,8 +57,8 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
         >
           <Grid item className="py0 px0">
             <EditableInput
-              onEdit={() => Promise.resolve()}
-              onCancel={() => Promise.resolve()}
+              onEdit={onSubmit}
+              onCancel={() => toggleEditing(false)}
               openForEdit={() => toggleEditing(true)}
               cancelEdit={() => toggleEditing(false)}
               onInputChange={(t: string) => setInputText(t)}

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
@@ -1,22 +1,77 @@
 import * as React from 'react';
-import EditableText from 'src/components/EditableText';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import EntityIcon, { Variant } from 'src/components/EntityIcon/EntityIcon';
+import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
+import EditableInput from './EditableInput';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  smallInput: {
+    height: '1em'
+  },
+  subText: {
+    fontSize: '0.8em'
+  }
+}));
 
 interface Props {
   text: string;
   width?: string;
+  iconVariant: Variant;
+  subText?: string;
 }
 
 export const EditableTableRowLabel: React.FC<Props> = props => {
-  const { text, width } = props;
+  const { iconVariant, subText, text, width } = props;
+  const [isEditing, toggleEditing] = React.useState<boolean>(false);
+  const [inputText, setInputText] = React.useState<string>('');
+  const classes = useStyles();
   return (
-    <TableCell style={{ width: width || '20%' }}>
-      <EditableText
-        onEdit={() => Promise.resolve()}
-        onCancel={() => Promise.resolve()}
-        text={text}
-        typeVariant="table-cell"
-      />
+    <TableCell style={{ width: width || '30%' }}>
+      <Grid
+        container
+        direction="row"
+        wrap="nowrap"
+        alignItems="center"
+        justify="flex-start"
+      >
+        {!isEditing && (
+          <Grid item xs={2}>
+            <EntityIcon variant={iconVariant} />
+          </Grid>
+        )}
+        <Grid
+          container
+          item
+          direction="column"
+          alignItems="flex-start"
+          justify="center"
+          spacing={0}
+        >
+          <Grid item className="py0 px0">
+            <EditableInput
+              onEdit={() => Promise.resolve()}
+              onCancel={() => Promise.resolve()}
+              openForEdit={() => toggleEditing(true)}
+              cancelEdit={() => toggleEditing(false)}
+              onInputChange={(t: string) => setInputText(t)}
+              text={text}
+              inputText={inputText}
+              isEditing={isEditing}
+              typeVariant="table-cell"
+              className={classes.smallInput}
+            />
+          </Grid>
+          {subText && !isEditing && (
+            <Grid item className="py0 px0">
+              <Typography variant="body2" className={classes.subText}>
+                {subText}
+              </Typography>
+            </Grid>
+          )}
+        </Grid>
+      </Grid>
     </TableCell>
   );
 };

--- a/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
+++ b/packages/manager/src/components/EditableTableRowLabel/EditableTableRowLabel.tsx
@@ -7,6 +7,9 @@ import TableCell from 'src/components/TableCell';
 import EditableInput from './EditableInput';
 
 const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    padding: theme.spacing(2)
+  },
   smallInput: {
     height: '1em'
   },
@@ -27,18 +30,32 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
   const { iconVariant, subText, text, width, onEdit } = props;
   const [isEditing, toggleEditing] = React.useState<boolean>(false);
   const [inputText, setInputText] = React.useState<string>(text);
+  const [error, setError] = React.useState<string | undefined>();
   const classes = useStyles();
 
   const onSubmit = () => {
+    setError(undefined);
     if (inputText !== text) {
-      onEdit(inputText).then(() => toggleEditing(false));
+      onEdit(inputText)
+        .then(() => toggleEditing(false))
+        .catch(e => setError(e)); // @todo have to make sure this is passed as a string
     } else {
       toggleEditing(false);
     }
   };
 
+  const handleClose = () => {
+    toggleEditing(false);
+    setError(undefined);
+  };
+
+  const handleOpen = () => {
+    setInputText(text);
+    toggleEditing(true);
+  };
+
   return (
-    <TableCell style={{ width: width || '30%' }}>
+    <TableCell  style={{ width: width || '30%', padding: '12px'}}>
       <Grid
         container
         direction="row"
@@ -47,7 +64,7 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
         justify="flex-start"
       >
         {!isEditing && (
-          <Grid item xs={2}>
+          <Grid item xs={1}>
             <EntityIcon variant={iconVariant} />
           </Grid>
         )}
@@ -61,9 +78,10 @@ export const EditableTableRowLabel: React.FC<Props> = props => {
         >
           <Grid item className="py0 px0">
             <EditableInput
+              errorText={error}
               onEdit={onSubmit}
-              openForEdit={() => toggleEditing(true)}
-              cancelEdit={() => toggleEditing(false)}
+              openForEdit={handleOpen}
+              cancelEdit={handleClose}
               onInputChange={(t: string) => setInputText(t)}
               text={text}
               inputText={inputText}

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -116,7 +116,7 @@ const styles = (theme: Theme) =>
     },
     input: {
       padding: '5px 8px',
-      ...theme.typography.body1
+      ...theme.typography.h1
     },
     headline: {
       ...theme.typography.h1
@@ -139,15 +139,13 @@ const styles = (theme: Theme) =>
     }
   });
 
-export type EditableTextVariant = 'h1' | 'h2' | 'table-cell';
-
 interface Props {
   onEdit: (text: string) => Promise<any>;
   onCancel: () => void;
   text: string;
   errorText?: string;
   labelLink?: string;
-  typeVariant: EditableTextVariant;
+  typeVariant: string;
   className?: string;
 }
 
@@ -238,11 +236,7 @@ export class EditableText extends React.Component<FinalProps, State> {
     const { isEditing, text } = this.state;
 
     const labelText = (
-      <Typography
-        className={classes.root}
-        variant={typeVariant === 'table-cell' ? 'body1' : 'h1'}
-        data-qa-editable-text
-      >
+      <Typography className={classes.root} variant="h1" data-qa-editable-text>
         {this.state.text}
       </Typography>
     );

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -116,7 +116,7 @@ const styles = (theme: Theme) =>
     },
     input: {
       padding: '5px 8px',
-      ...theme.typography.h1
+      ...theme.typography.body1
     },
     headline: {
       ...theme.typography.h1
@@ -139,13 +139,15 @@ const styles = (theme: Theme) =>
     }
   });
 
+export type EditableTextVariant = 'h1' | 'h2' | 'table-cell';
+
 interface Props {
   onEdit: (text: string) => Promise<any>;
   onCancel: () => void;
   text: string;
   errorText?: string;
   labelLink?: string;
-  typeVariant: string;
+  typeVariant: EditableTextVariant;
   className?: string;
 }
 
@@ -236,7 +238,11 @@ export class EditableText extends React.Component<FinalProps, State> {
     const { isEditing, text } = this.state;
 
     const labelText = (
-      <Typography className={classes.root} variant="h1" data-qa-editable-text>
+      <Typography
+        className={classes.root}
+        variant={typeVariant === 'table-cell' ? 'body1' : 'h1'}
+        data-qa-editable-text
+      >
         {this.state.text}
       </Typography>
     );

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -3,6 +3,8 @@ import * as classNames from 'classnames';
 import { clamp, equals } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
+import CircleProgress from 'src/components/CircleProgress';
+import InputAdornment from 'src/components/core/InputAdornment';
 import {
   createStyles,
   Theme,
@@ -112,6 +114,7 @@ interface BaseProps {
   max?: number;
   dataAttrs?: Record<string, any>;
   noMarginTop?: boolean;
+  loading?: boolean;
 }
 
 export type Props = BaseProps & TextFieldProps;
@@ -231,6 +234,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
       error,
       noMarginTop,
       label,
+      loading,
       ...textFieldProps
     } = this.props;
 
@@ -306,6 +310,11 @@ class LinodeTextField extends React.Component<CombinedProps> {
             }}
             InputProps={{
               disableUnderline: true,
+              endAdornment: loading && (
+                <InputAdornment position="end">
+                  <CircleProgress mini />
+                </InputAdornment>
+              ),
               className: classNames(
                 'input',
                 {

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -26,6 +26,7 @@ type ClassNames =
   | 'helpWrapperTextField'
   | 'expand'
   | 'errorText'
+  | 'editable'
   | 'helperTextTop'
   | 'small'
   | 'noTransform'
@@ -86,6 +87,16 @@ const styles = (theme: Theme) =>
     errorText: {
       color: theme.color.red
     },
+    editable: {
+      fontSize: '.75rem',
+      marginTop: theme.spacing(1) / 2,
+      position: 'absolute',
+      bottom: -5,
+      left: 6,
+      backgroundColor: theme.bg.white,
+      paddingLeft: 4,
+      paddingRight: 4
+    },
     helperTextTop: {
       marginBottom: theme.spacing(),
       marginTop: theme.spacing(2)
@@ -104,6 +115,7 @@ interface BaseProps {
   className?: any;
   expand?: boolean;
   small?: boolean;
+  editable?: boolean;
   // Currently only used for LKE node pool inputs
   tiny?: boolean;
   /**
@@ -211,6 +223,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
   render() {
     const {
       errorText,
+      editable,
       errorGroup,
       affirmative,
       classes,
@@ -363,7 +376,9 @@ class LinodeTextField extends React.Component<CombinedProps> {
           {tooltipText && <HelpIcon text={tooltipText} />}
           {errorText && (
             <FormHelperText
-              className={classes.errorText}
+              className={`${classes.errorText} ${
+                editable ? classes.editable : ''
+              }`}
               data-qa-textfield-error-text={this.props.label}
             >
               {errorText}


### PR DESCRIPTION
## Description

This includes a new table cell with an editable text field. Currently visible only in storybook (under EditableTableRowLabel).

## Note to Reviewers

This shares a lot of DNA with EditableText, but in this case the input needs to be a controlled component. EditableInput is an abstraction of just the markup of EditableText; if this approach is accepted, I can adjust the existing EditableText to use EditableInput internally to keep things consistent.

🔥 Styling for the error states is not yet complete.