### PR TITLE
M3-3482 Kubeconfig View button overflow at 1280 width

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeConfigPanel.tsx
@@ -30,7 +30,7 @@ const styles = (theme: Theme) =>
     },
     item: {
       paddingBottom: theme.spacing(2),
-      [theme.breakpoints.up('lg')]: {
+      [theme.breakpoints.up('xl')]: {
         display: 'flex',
         flexFlow: 'row nowrap'
       }
@@ -41,14 +41,14 @@ const styles = (theme: Theme) =>
       fontSize: '0.9rem',
       marginRight: 12,
       minWidth: 124,
-      [theme.breakpoints.down('md')]: {
+      [theme.breakpoints.down('lg')]: {
         marginBottom: theme.spacing(2),
         marginRight: 0
       }
     },
     buttonSecondary: {
       minWidth: 88,
-      [theme.breakpoints.down('md')]: {
+      [theme.breakpoints.down('lg')]: {
         marginBottom: 0,
         marginRight: 0
       }


### PR DESCRIPTION
## Description

At 1280 screen width, the Kubeconfig buttons were overflowing their container. I bumped up the breakpoints so the buttons stay wrapped until the xl breakpoint. 

## Type of Change
- Non breaking change ('update')
