### PR TITLE
M3-3179 preload disk assignments on rescue tab

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.test.tsx
@@ -5,7 +5,7 @@ import { disks } from 'src/__data__/disks';
 import { volumes } from 'src/__data__/volumes';
 
 import { ExtendedVolume } from './DeviceSelection';
-import { LinodeRescue } from './LinodeRescue';
+import { getDefaultDeviceMapAndCounter, LinodeRescue } from './LinodeRescue';
 
 describe('LinodeRescue', () => {
   describe('volumes', () => {
@@ -62,6 +62,35 @@ describe('LinodeRescue', () => {
         }
       });
       expect(volumeCanBeRescued).toBeTruthy();
+    });
+  });
+
+  describe('calculating initial device map and counter', () => {
+    const extendedDisks = disks.map((disk, idx) => {
+      return {
+        ...disk,
+        _id: `test-disk-${idx}`
+      };
+    });
+
+    it('should map a single disk + swap to sda and sdb', () => {
+      const [map, counter] = getDefaultDeviceMapAndCounter(extendedDisks);
+      expect(counter).toBe(2);
+      expect(map).toHaveProperty('sda', 'test-disk-0');
+      expect(map).toHaveProperty('sdb', 'test-disk-1');
+      expect(map).toHaveProperty('sdc', undefined);
+      expect(map).toHaveProperty('sdd', undefined);
+      expect(map).toHaveProperty('sde', undefined);
+      expect(map).toHaveProperty('sdf', undefined);
+      expect(map).toHaveProperty('sdg', undefined);
+      expect(map).toHaveProperty('sdh', undefined);
+    });
+
+    it('should handle an empty input', () => {
+      const [map, counter] = getDefaultDeviceMapAndCounter([]);
+      expect(counter).toBe(0);
+      expect(map).toHaveProperty('sda', undefined);
+      expect(map).toHaveProperty('sdb', undefined);
     });
   });
 });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -96,7 +96,6 @@ interface DeviceMap {
   sde?: string;
   sdf?: string;
   sdg?: string;
-  sdh?: string;
 }
 
 export const getDefaultDeviceMapAndCounter = (
@@ -124,8 +123,7 @@ export const getDefaultDeviceMapAndCounter = (
     sdd: defaultDisks[3],
     sde: defaultDisks[4],
     sdf: defaultDisks[5],
-    sdg: defaultDisks[6],
-    sdh: defaultDisks[7]
+    sdg: defaultDisks[6]
   };
   return [deviceMap, counter];
 };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -88,9 +88,54 @@ type CombinedProps = VolumesProps &
   WithStyles<ClassNames> &
   WithSnackbarProps;
 
+interface DeviceMap {
+  sda?: string;
+  sdb?: string;
+  sdc?: string;
+  sdd?: string;
+  sde?: string;
+  sdf?: string;
+  sdg?: string;
+  sdh?: string;
+}
+
+export const getDefaultDeviceMapAndCounter = (
+  disks: ExtendedDisk[]
+): [DeviceMap, number] => {
+  const defaultDisks = disks.map(thisDisk => thisDisk._id);
+  const counter = defaultDisks.reduce(
+    (c, thisDisk) => (!!thisDisk ? c + 1 : c),
+    0
+  );
+  /**
+   * This mimics the behavior of Classic:
+   * when you load the Rebuild tab, each
+   * device slot is filled with one of your
+   * disks, until you run out of either disks
+   * or slots. Note that defaultDisks[10000]
+   * will be `undefined`, which is the correct
+   * value for an empty slot, so this is a safe
+   * assignment.
+   */
+  const deviceMap = {
+    sda: defaultDisks[0],
+    sdb: defaultDisks[1],
+    sdc: defaultDisks[2],
+    sdd: defaultDisks[3],
+    sde: defaultDisks[4],
+    sdf: defaultDisks[5],
+    sdg: defaultDisks[6],
+    sdh: defaultDisks[7]
+  };
+  return [deviceMap, counter];
+};
+
 export class LinodeRescue extends React.Component<CombinedProps, State> {
   constructor(props: CombinedProps) {
     super(props);
+    const [deviceMap, initialCounter] = getDefaultDeviceMapAndCounter(
+      props.linodeDisks || []
+    );
     const filteredVolumes = props.volumesData
       ? props.volumesData.filter(volume => {
           // whether volume is not attached to any Linode
@@ -112,17 +157,8 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
         disks: props.linodeDisks || [],
         volumes: filteredVolumes || []
       },
-      counter: 1,
-      rescueDevices: {
-        sda: undefined,
-        sdb: undefined,
-        sdc: undefined,
-        sdd: undefined,
-        sde: undefined,
-        sdf: undefined,
-        sdg: undefined,
-        sdh: undefined
-      }
+      counter: initialCounter,
+      rescueDevices: deviceMap
     };
   }
 
@@ -131,19 +167,13 @@ export class LinodeRescue extends React.Component<CombinedProps, State> {
     const { rescueDevices } = this.state;
 
     rescueLinode(linodeId, createDevicesFromStrings(rescueDevices))
-      .then(response => {
+      .then(_ => {
+        const [diskMap, counter] = getDefaultDeviceMapAndCounter(
+          this.props.linodeDisks || []
+        );
         this.setState({
-          counter: 1,
-          rescueDevices: {
-            sda: undefined,
-            sdb: undefined,
-            sdc: undefined,
-            sdd: undefined,
-            sde: undefined,
-            sdf: undefined,
-            sdg: undefined,
-            sdh: undefined
-          }
+          counter,
+          rescueDevices: diskMap
         });
         enqueueSnackbar('Linode rescue started.', {
           variant: 'info'


### PR DESCRIPTION
## Description

Preloads disks into the device selects when visiting the Rescue tab. The ticket title implies that we should get the disks from the Linode's active Config, but it turns out that this isn't what Classic does. Classic's behavior is weirder: it maps all of your disks to the available slots until you run out of either disks or slots. Fortunately, this is much easier for us than figuring out which config profile was booted most recently, which would involve requesting events for this Linode and finding the most recent boot or reboot event.

## Type of Change
- Non breaking change ('update', 'change')
