### PR TITLE
Add extra request for resized Linode after time delay

### DIFF
--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -94,6 +94,19 @@ const handleLinodeRebuild = (
       // Get the new disks and update the store.
       dispatch(getAllLinodeDisks({ linodeId: id }));
       dispatch(getAllLinodeConfigs({ linodeId: id }));
+      /**
+       * After resizing, a Linode is booted (if it was booted before);
+       * however, no boot event is sent. Additionally, the 'finished'
+       * resize event is sent before this is complete. As a result,
+       * the requestLinodeForStore below will often return a
+       * status of 'offline', which will then not be updated.
+       *
+       * The best thing to do here would be to have the API send a boot
+       * event, or in the new events system push an update whenever a Linode's
+       * status changes. In the meantime, we can get around this by sending a follow-on
+       * request.
+       */
+      setTimeout(() => dispatch(requestLinodeForStore(id)), 10000);
       return dispatch(requestLinodeForStore(id));
     default:
       return;


### PR DESCRIPTION
## Description

Linode status is shown as "offline" after resize is complete, even after the Linode is back online. This is due to the fact that we use events to determine when to re-request a Linode and update its status, and the linode_resize event fires before the boot is complete.

Better solutions would involve having the API send a boot event, or a websocket push maybe. we could also consider polling on Linode detail. Since those are all larger conversations, we can get around this one edge case by sending out a final, delayed request for the resized Linode that should have the correct status.