### PR TITLE
LKE-1064 endpoint

### DIFF
--- a/packages/linode-js-sdk/src/kubernetes/kubernetes.ts
+++ b/packages/linode-js-sdk/src/kubernetes/kubernetes.ts
@@ -12,6 +12,7 @@ import {
   CreateKubeClusterPayload,
   KubeConfigResponse,
   KubernetesCluster,
+  KubernetesEndpointResponse,
   KubernetesVersion
 } from './types';
 
@@ -112,4 +113,16 @@ export const getKubernetesVersion = (versionID: string) =>
   Request<KubernetesVersion>(
     setMethod('GET'),
     setURL(`${BETA_API_ROOT}/lke/versions/${versionID}`)
+  ).then(response => response.data);
+
+/** getKubernetesClusterEndpoint
+ *
+ * Returns the endpoint URL for a single Kubernetes cluster by ID.
+ *
+ */
+
+export const getKubernetesClusterEndpoint = (clusterID: number) =>
+  Request<KubernetesEndpointResponse>(
+    setMethod('GET'),
+    setURL(`${BETA_API_ROOT}/lke/clusters/${clusterID}/api-endpoint`)
   ).then(response => response.data);

--- a/packages/linode-js-sdk/src/kubernetes/types.ts
+++ b/packages/linode-js-sdk/src/kubernetes/types.ts
@@ -32,6 +32,10 @@ export interface KubernetesVersion {
   id: string;
 }
 
+export interface KubernetesEndpointResponse {
+  endpoint: string;
+}
+
 export interface CreateKubeClusterPayload {
   label?: string; // Label will be assigned by the API if not provided
   region?: string; // Will be caught by Yup if undefined

--- a/packages/linode-js-sdk/src/kubernetes/types.ts
+++ b/packages/linode-js-sdk/src/kubernetes/types.ts
@@ -33,7 +33,7 @@ export interface KubernetesVersion {
 }
 
 export interface KubernetesEndpointResponse {
-  endpoint: string;
+  endpoints: string[];
 }
 
 export interface CreateKubeClusterPayload {

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -36,14 +36,28 @@ interface Props {
   cluster: ExtendedCluster;
   endpoint: string | null;
   endpointError?: string;
+  endpointLoading: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
+const renderEndpoint = (
+  endpoint: string | null,
+  endpointLoading: boolean,
+  endpointError?: string
+) => {
+  if (endpointLoading) {
+    return 'Loading...';
+  } else if (endpointError) {
+    return endpointError;
+  }
+  return endpoint || ''; // Just leave it blank if endpoint === null (which should never happen)
+};
+
 export const KubeSummaryPanel: React.FunctionComponent<
   CombinedProps
 > = props => {
-  const { classes, cluster, endpoint, endpointError } = props;
+  const { classes, cluster, endpoint, endpointError, endpointLoading } = props;
   const region = dcDisplayNames[cluster.region] || 'Unknown region';
   return (
     <Paper className={classes.root}>
@@ -66,9 +80,9 @@ export const KubeSummaryPanel: React.FunctionComponent<
         <Typography className={classes.label}>
           Kubernetes API Endpoint
         </Typography>
-        {/** If one of these is defined, the other one should not be. */}
-        {endpoint && <Typography>{endpoint}</Typography>}
-        {endpointError && <Typography>{endpointError}</Typography>}
+        <Typography>
+          {renderEndpoint(endpoint, endpointLoading, endpointError)}
+        </Typography>
       </Paper>
       <Paper className={classes.item}>
         <Typography className={classes.label}>Region</Typography>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubeSummaryPanel.tsx
@@ -34,6 +34,8 @@ const styles = (theme: Theme) =>
 
 interface Props {
   cluster: ExtendedCluster;
+  endpoint: string | null;
+  endpointError?: string;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -41,7 +43,7 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 export const KubeSummaryPanel: React.FunctionComponent<
   CombinedProps
 > = props => {
-  const { classes, cluster } = props;
+  const { classes, cluster, endpoint, endpointError } = props;
   const region = dcDisplayNames[cluster.region] || 'Unknown region';
   return (
     <Paper className={classes.root}>
@@ -64,7 +66,9 @@ export const KubeSummaryPanel: React.FunctionComponent<
         <Typography className={classes.label}>
           Kubernetes API Endpoint
         </Typography>
-        <Typography>8.8.8.8</Typography>
+        {/** If one of these is defined, the other one should not be. */}
+        {endpoint && <Typography>{endpoint}</Typography>}
+        {endpointError && <Typography>{endpointError}</Typography>}
       </Paper>
       <Paper className={classes.item}>
         <Typography className={classes.label}>Region</Typography>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -152,6 +152,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
   const [endpointError, setEndpointError] = React.useState<string | undefined>(
     undefined
   );
+  const [endpointLoading, setEndpointLoading] = React.useState<boolean>(false);
 
   React.useEffect(() => {
     const clusterID = +props.match.params.clusterID;
@@ -159,12 +160,15 @@ export const KubernetesClusterDetail: React.FunctionComponent<
       props.requestClusterForStore(clusterID);
       // The cluster endpoint has its own API...uh, endpoint, so we need
       // to request it separately.
+      setEndpointLoading(true);
       getKubernetesClusterEndpoint(clusterID)
         .then(response => {
           setEndpointError(undefined);
           setEndpoint(response.endpoint);
+          setEndpointLoading(false);
         })
         .catch(error => {
+          setEndpointLoading(false);
           setEndpointError(
             getAPIErrorOrDefault(error, 'Cluster endpoint not available.')[0]
               .reason
@@ -464,6 +468,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
               cluster={cluster}
               endpoint={endpoint}
               endpointError={endpointError}
+              endpointLoading={endpointLoading}
             />
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -164,7 +164,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
       getKubernetesClusterEndpoint(clusterID)
         .then(response => {
           setEndpointError(undefined);
-          setEndpoint(response.endpoint);
+          setEndpoint(response.endpoints[0]); // @todo will there ever be multiple values here?
           setEndpointLoading(false);
         })
         .catch(error => {


### PR DESCRIPTION
## Description

We were using a hardcoded API endpoint for LKE clusters, until the
API had added that information. This is now requestable at
/lke/clusters/:clusterID/api-endpoint, so the hard-coding can be
removed.

- added a service method and types for the new endpoint
- added a request in useEffect in the cluster detail component,
along with error handling and simple loading state.

## Type of Change
- Non breaking change ('update', 'change')

## Note

LKE isn't working properly in dev, so the best way to test this is to point your stuff at staging