### PR TITLE
M3-3543 Longview landing tabs (git redo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "root",
   "private": true,
   "devDependencies": {
+    "factory.ts": "^0.5.0",
     "husky": "^3.0.1",
     "lerna": "^3.16.4",
     "tslint": "^5.20.0",

--- a/packages/manager/src/factories/longviewClient.ts
+++ b/packages/manager/src/factories/longviewClient.ts
@@ -1,0 +1,18 @@
+import * as Factory from 'factory.ts';
+import { Apps, LongviewClient } from 'linode-js-sdk/lib/longview';
+
+export const longviewAppsFactory = Factory.Sync.makeFactory<Apps>({
+  nginx: false,
+  mysql: false,
+  apache: false
+});
+
+export const longviewClientFactory = Factory.Sync.makeFactory<LongviewClient>({
+  id: Factory.each(id => id),
+  created: new Date().toDateString(),
+  updated: new Date().toDateString(),
+  label: Factory.each(i => `longview-client-${i}`),
+  api_key: 'EXAMPLE_API_KEY',
+  apps: longviewAppsFactory.build(),
+  install_code: 'INSTALL_ME'
+});

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent } from '@testing-library/react';
+import { LongviewClient } from 'linode-js-sdk/lib/longview';
+import * as React from 'react';
+import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import { longviewClientFactory } from 'src/factories/longviewClient';
+import { renderWithTheme } from 'src/utilities/testHelpers';
+import { LongviewClients } from './LongviewClients';
+
+jest.genMockFromModule('../request');
+
+afterEach(cleanup);
+
+const clients = longviewClientFactory.buildList(5);
+
+const arrayToData = (data: any[]): Record<string, LongviewClient> => {
+  return data.reduce((accum, thisItem) => {
+    accum[thisItem.id] = thisItem;
+    return accum;
+  }, {});
+};
+
+const props = {
+  longviewClientsData: arrayToData(clients),
+  longviewClientsError: {},
+  longviewClientsLastUpdated: 0,
+  longviewClientsLoading: false,
+  longviewClientsResults: clients.length,
+  createLongviewClient: jest.fn().mockResolvedValue({}),
+  deleteLongviewClient: jest.fn(),
+  getLongviewClients: jest.fn().mockResolvedValue([]),
+  updateLongviewClient: jest.fn(),
+  enqueueSnackbar: jest.fn(),
+  closeSnackbar: jest.fn(),
+  ...reactRouterProps
+};
+
+describe('Longview clients list view', () => {
+  it('should request clients on load', () => {
+    renderWithTheme(<LongviewClients {...props} />);
+    expect(props.getLongviewClients).toHaveBeenCalledTimes(1);
+  });
+
+  it('should have an Add a Client button', () => {
+    const { queryByText } = renderWithTheme(<LongviewClients {...props} />);
+    expect(queryByText('Add a Client')).toBeInTheDocument();
+  });
+
+  it('should attempt to create a new client when the Add a Client button is clicked', () => {
+    const { getByText } = renderWithTheme(<LongviewClients {...props} />);
+    const button = getByText('Add a Client');
+    fireEvent.click(button);
+    expect(props.createLongviewClient).toHaveBeenCalledWith();
+  });
+
+  it('should render a row for each client', () => {
+    const { queryAllByText } = renderWithTheme(<LongviewClients {...props} />);
+    expect(queryAllByText(/waiting/i)).toHaveLength(clients.length);
+  });
+});

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -18,7 +18,7 @@ import UpdateDrawer from './UpdateClientDrawer';
 
 type CombinedProps = RouteComponentProps & LongviewProps & WithSnackbarProps;
 
-const LongviewContent: React.FC<CombinedProps> = props => {
+export const LongviewClients: React.FC<CombinedProps> = props => {
   const [newClientLoading, setNewClientLoading] = React.useState<boolean>(
     false
   );
@@ -128,4 +128,4 @@ export default compose<CombinedProps, RouteComponentProps>(
   React.memo,
   withLongviewClients(),
   withSnackbar
-)(LongviewContent);
+)(LongviewClients);

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -1,0 +1,131 @@
+import { withSnackbar, WithSnackbarProps } from 'notistack';
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import { compose } from 'recompose';
+
+import AddNewLink from 'src/components/AddNewLink';
+import Grid from 'src/components/Grid';
+
+import withLongviewClients, {
+  Props as LongviewProps
+} from 'src/containers/longview.container';
+
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+
+import DeleteDialog from './LongviewDeleteDialog';
+import LongviewTable from './LongviewTable';
+import UpdateDrawer from './UpdateClientDrawer';
+
+type CombinedProps = RouteComponentProps & LongviewProps & WithSnackbarProps;
+
+const LongviewContent: React.FC<CombinedProps> = props => {
+  const [newClientLoading, setNewClientLoading] = React.useState<boolean>(
+    false
+  );
+  const [editDrawerOpen, toggleEditDrawer] = React.useState<boolean>(false);
+  const [deleteDialogOpen, toggleDeleteDialog] = React.useState<boolean>(false);
+  const [selectedClientID, setClientID] = React.useState<number | undefined>(
+    undefined
+  );
+  const [selectedClientLabel, setClientLabel] = React.useState<string>('');
+
+  React.useEffect(() => {
+    props.getLongviewClients();
+  }, []);
+
+  const openDeleteDialog = (id: number, label: string) => {
+    toggleDeleteDialog(true);
+    setClientID(id);
+    setClientLabel(label);
+  };
+
+  const openEditDrawer = (id: number, label: string) => {
+    toggleEditDrawer(true);
+    setClientID(id);
+    setClientLabel(label);
+  };
+
+  const handleAddClient = () => {
+    setNewClientLoading(true);
+    createLongviewClient()
+      .then(_ => {
+        setNewClientLoading(false);
+      })
+      .catch(errorResponse => {
+        props.enqueueSnackbar(
+          getAPIErrorOrDefault(
+            errorResponse,
+            'Error creating Longview client.'
+          )[0].reason,
+          { variant: 'error' }
+        ),
+          setNewClientLoading(false);
+      });
+  };
+
+  const {
+    longviewClientsData,
+    longviewClientsError,
+    longviewClientsLastUpdated,
+    longviewClientsLoading,
+    longviewClientsResults,
+    createLongviewClient,
+    deleteLongviewClient,
+    updateLongviewClient
+  } = props;
+
+  return (
+    <React.Fragment>
+      <Grid
+        container
+        justify="flex-end"
+        alignItems="flex-end"
+        style={{ paddingBottom: 0 }}
+      >
+        <Grid item>
+          <Grid container alignItems="flex-end">
+            <Grid item className="pt0">
+              {/** @todo replace with actual loading state when design is ready */}
+              <AddNewLink
+                onClick={handleAddClient}
+                label={newClientLoading ? 'Loading...' : 'Add a Client'}
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+      <LongviewTable
+        longviewClientsData={longviewClientsData}
+        longviewClientsError={longviewClientsError}
+        longviewClientsLastUpdated={longviewClientsLastUpdated}
+        longviewClientsLoading={longviewClientsLoading}
+        longviewClientsResults={longviewClientsResults}
+        triggerDeleteLongviewClient={openDeleteDialog}
+        triggerEditLongviewClient={openEditDrawer}
+      />
+      <UpdateDrawer
+        title={`Rename Longview Client${
+          selectedClientLabel ? `: ${selectedClientLabel}` : ''
+        }`}
+        selectedID={selectedClientID}
+        selectedLabel={selectedClientLabel}
+        updateClient={updateLongviewClient}
+        open={editDrawerOpen}
+        onClose={() => toggleEditDrawer(false)}
+      />
+      <DeleteDialog
+        selectedLongviewClientID={selectedClientID}
+        selectedLongviewClientLabel={selectedClientLabel}
+        deleteClient={deleteLongviewClient}
+        open={deleteDialogOpen}
+        closeDialog={() => toggleDeleteDialog(false)}
+      />
+    </React.Fragment>
+  );
+};
+
+export default compose<CombinedProps, RouteComponentProps>(
+  React.memo,
+  withLongviewClients(),
+  withSnackbar
+)(LongviewContent);

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -1,150 +1,105 @@
-import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
-import { RouteComponentProps } from 'react-router-dom';
-import { compose } from 'recompose';
-import { makeStyles, Theme } from 'src/components/core/styles';
+import {
+  matchPath,
+  Redirect,
+  Route,
+  RouteComponentProps,
+  Switch
+} from 'react-router-dom';
 
-import AddNewLink from 'src/components/AddNewLink';
 import Breadcrumb from 'src/components/Breadcrumb';
+import AppBar from 'src/components/core/AppBar';
 import Box from 'src/components/core/Box';
-import Divider from 'src/components/core/Divider';
+import Tab from 'src/components/core/Tab';
+import Tabs from 'src/components/core/Tabs';
+import DefaultLoader from 'src/components/DefaultLoader';
 import DocumentationButton from 'src/components/DocumentationButton';
-import Grid from 'src/components/Grid';
+import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import TabLink from 'src/components/TabLink';
 
-import withLongviewClients, {
-  Props as LongviewProps
-} from 'src/containers/longview.container';
+import { requestClusters as _requestClusters } from 'src/store/clusters/clusters.actions';
 
-import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+const LongviewClients = DefaultLoader({
+  loader: () => import('./LongviewClients')
+});
 
-import DeleteDialog from './LongviewDeleteDialog';
-import LongviewTable from './LongviewTable';
-import UpdateDrawer from './UpdateClientDrawer';
+const LongviewPlans = DefaultLoader({
+  loader: () => import('./LongviewPlans')
+});
 
-const useStyles = makeStyles((theme: Theme) => ({
-  line: {
-    marginTop: theme.spacing(10),
-    marginBottom: theme.spacing(3)
-  }
-}));
+type CombinedProps = RouteComponentProps<{}>;
 
-type CombinedProps = RouteComponentProps & LongviewProps & WithSnackbarProps;
+export const LongviewLanding: React.FunctionComponent<
+  CombinedProps
+> = props => {
+  const tabs = [
+    /* NB: These must correspond to the routes inside the Switch */
+    { title: 'Clients', routeName: `${props.match.url}/clients` },
+    { title: 'Plan Details', routeName: `${props.match.url}/plan-details` }
+  ];
 
-const LongviewContent: React.FC<CombinedProps> = props => {
-  const classes = useStyles();
-
-  const [newClientLoading, setNewClientLoading] = React.useState<boolean>(
-    false
-  );
-  const [editDrawerOpen, toggleEditDrawer] = React.useState<boolean>(false);
-  const [deleteDialogOpen, toggleDeleteDialog] = React.useState<boolean>(false);
-  const [selectedClientID, setClientID] = React.useState<number | undefined>(
-    undefined
-  );
-  const [selectedClientLabel, setClientLabel] = React.useState<string>('');
-
-  React.useEffect(() => {
-    props.getLongviewClients();
-  }, []);
-
-  const openDeleteDialog = (id: number, label: string) => {
-    toggleDeleteDialog(true);
-    setClientID(id);
-    setClientLabel(label);
+  const handleTabChange = (
+    _: React.ChangeEvent<HTMLDivElement>,
+    value: number
+  ) => {
+    const routeName = tabs[value].routeName;
+    props.history.push(`${routeName}`);
   };
 
-  const openEditDrawer = (id: number, label: string) => {
-    toggleEditDrawer(true);
-    setClientID(id);
-    setClientLabel(label);
+  const url = props.match.url;
+  const matches = (p: string) => {
+    return Boolean(matchPath(p, { path: props.location.pathname }));
   };
-
-  const handleAddClient = () => {
-    setNewClientLoading(true);
-    createLongviewClient()
-      .then(_ => {
-        setNewClientLoading(false);
-      })
-      .catch(errorResponse => {
-        props.enqueueSnackbar(
-          getAPIErrorOrDefault(
-            errorResponse,
-            'Error creating Longview client.'
-          )[0].reason,
-          { variant: 'error' }
-        ),
-          setNewClientLoading(false);
-      });
-  };
-
-  const {
-    longviewClientsData,
-    longviewClientsError,
-    longviewClientsLastUpdated,
-    longviewClientsLoading,
-    longviewClientsResults,
-    createLongviewClient,
-    deleteLongviewClient,
-    updateLongviewClient
-  } = props;
 
   return (
     <React.Fragment>
+      <DocumentTitleSegment segment="Longview" />
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Breadcrumb pathname={props.location.pathname} labelTitle="Longview" />
         <DocumentationButton href={'https://google.com'} />
       </Box>
-      <Divider className={classes.line} type="landingHeader" />
-      <Grid
-        container
-        justify="flex-end"
-        alignItems="flex-end"
-        style={{ paddingBottom: 0 }}
-      >
-        <Grid item>
-          <Grid container alignItems="flex-end">
-            <Grid item className="pt0">
-              {/** @todo replace with actual loading state when design is ready */}
-              <AddNewLink
-                onClick={handleAddClient}
-                label={newClientLoading ? 'Loading...' : 'Add a Client'}
-              />
-            </Grid>
-          </Grid>
-        </Grid>
-      </Grid>
-      <LongviewTable
-        longviewClientsData={longviewClientsData}
-        longviewClientsError={longviewClientsError}
-        longviewClientsLastUpdated={longviewClientsLastUpdated}
-        longviewClientsLoading={longviewClientsLoading}
-        longviewClientsResults={longviewClientsResults}
-        triggerDeleteLongviewClient={openDeleteDialog}
-        triggerEditLongviewClient={openEditDrawer}
-      />
-      <UpdateDrawer
-        title={`Rename Longview Client${
-          selectedClientLabel ? `: ${selectedClientLabel}` : ''
-        }`}
-        selectedID={selectedClientID}
-        selectedLabel={selectedClientLabel}
-        updateClient={updateLongviewClient}
-        open={editDrawerOpen}
-        onClose={() => toggleEditDrawer(false)}
-      />
-      <DeleteDialog
-        selectedLongviewClientID={selectedClientID}
-        selectedLongviewClientLabel={selectedClientLabel}
-        deleteClient={deleteLongviewClient}
-        open={deleteDialogOpen}
-        closeDialog={() => toggleDeleteDialog(false)}
-      />
+      <AppBar position="static" color="default">
+        <Tabs
+          value={tabs.findIndex(tab => matches(tab.routeName))}
+          onChange={handleTabChange}
+          indicatorColor="primary"
+          textColor="primary"
+          variant="scrollable"
+          scrollButtons="on"
+        >
+          {tabs.map(tab => (
+            <Tab
+              key={tab.title}
+              data-qa-tab={tab.title}
+              component={React.forwardRef((forwardedProps, ref) => (
+                <TabLink
+                  to={tab.routeName}
+                  title={tab.title}
+                  {...forwardedProps}
+                  ref={ref}
+                />
+              ))}
+            />
+          ))}
+        </Tabs>
+      </AppBar>
+      <Switch>
+        <Route
+          exact
+          strict
+          path={`${url}/clients`}
+          render={() => <LongviewClients {...props} />}
+        />
+        <Route
+          exact
+          strict
+          path={`${url}/plan-details`}
+          render={() => <LongviewPlans />}
+        />
+        <Redirect to={`${url}/clients`} />
+      </Switch>
     </React.Fragment>
   );
 };
 
-export default compose<CombinedProps, RouteComponentProps>(
-  React.memo,
-  withLongviewClients(),
-  withSnackbar
-)(LongviewContent);
+export default LongviewLanding;

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -14,7 +14,6 @@ import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import DefaultLoader from 'src/components/DefaultLoader';
 import DocumentationButton from 'src/components/DocumentationButton';
-import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import TabLink from 'src/components/TabLink';
 
 const LongviewClients = DefaultLoader({
@@ -51,7 +50,6 @@ export const LongviewLanding: React.FunctionComponent<
 
   return (
     <React.Fragment>
-      <DocumentTitleSegment segment="Longview" />
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Breadcrumb
           pathname={props.location.pathname}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -17,8 +17,6 @@ import DocumentationButton from 'src/components/DocumentationButton';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import TabLink from 'src/components/TabLink';
 
-import { requestClusters as _requestClusters } from 'src/store/clusters/clusters.actions';
-
 const LongviewClients = DefaultLoader({
   loader: () => import('./LongviewClients')
 });

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -53,7 +53,11 @@ export const LongviewLanding: React.FunctionComponent<
     <React.Fragment>
       <DocumentTitleSegment segment="Longview" />
       <Box display="flex" flexDirection="row" justifyContent="space-between">
-        <Breadcrumb pathname={props.location.pathname} labelTitle="Longview" />
+        <Breadcrumb
+          pathname={props.location.pathname}
+          labelTitle="Longview"
+          removeCrumbX={1}
+        />
         <DocumentationButton href={'https://google.com'} />
       </Box>
       <AppBar position="static" color="default">

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const LongviewPlans: React.FC<{}> = props => {
+  return <div>Hello world</div>;
+};
+
+export default LongviewPlans;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,6 +1314,15 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+clone-deep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -1905,6 +1914,14 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
+
+factory.ts@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/factory.ts/-/factory.ts-0.5.0.tgz#7627ed3634e766e97a570771522c04d936505f50"
+  integrity sha512-A4XEgeVqs6lAnQkQeaPYTxUTs8HUSdyRM50mlmTwhfq4z7uUJsVw5LN+5g7Y0G+MX5NGTm2UyJmCBYcYLnzJJQ==
+  dependencies:
+    clone-deep "^4.0.1"
+    source-map-support "^0.5.9"
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"
@@ -4222,6 +4239,13 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+shallow-clone@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -4328,6 +4352,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
+  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -4338,7 +4370,7 @@ source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==


### PR DESCRIPTION
## Description

Tab layout and routing for Longview Landing. Involved moving the current LongviewLanding into LongviewClients.tsx and creating a placeholder for LongviewPlans.

## Type of Change
- Breaking change ('break', 'deprecate')


## Note to Reviewers

Missing: 
- [x] tests
