### PR TITLE
Change: Add Longview Client Data to Redux State

### DIFF
--- a/packages/manager/src/containers/longview.stats.container.ts
+++ b/packages/manager/src/containers/longview.stats.container.ts
@@ -1,0 +1,71 @@
+import { pathOr } from 'ramda';
+import { connect } from 'react-redux';
+import { ApplicationState } from 'src/store';
+import { ReturnType } from 'src/store/longviewStats/longviewStats.actions';
+import { getClientStats } from 'src/store/longviewStats/longviewStats.requests';
+import { EntityError, ThunkDispatch } from 'src/store/types';
+
+export interface LVClientData {
+  longviewClientData: ReturnType;
+  longviewClientDataLoading: boolean;
+  longviewClientDataError: Partial<EntityError>;
+}
+
+export interface DispatchProps {
+  getClientStats: (api_key: string) => Promise<ReturnType>;
+}
+
+export type Props = DispatchProps & LVClientData;
+
+/**
+ *
+ * @param supplyClientID callback function that should return the Longview Client
+ * ID for the stats you'd like to work with
+ *
+ * @example
+ *
+ * import withLongviewStats, { Props as LVDataProps }
+ *
+ * interface Props {
+ *  clientID: number;
+ *  apiKey: string;
+ * }
+ *
+ * type CombinedProps = Props & LVDataProps;
+ *
+ * const MyComponent: React.FC<CombinedProps> = props => {
+ *   React.useEffect(() => {
+ *       props.getClientStats(props.apiKey)
+ *   }, [])
+ *
+ *   return (
+ *      <div>hello world</div>
+ *   )
+ * }
+ *
+ * export default withLongviewStats<Props>((ownProps) => ownProps.clientID)(MyComponent)
+ */
+const connected = <OwnProps extends {}>(
+  supplyClientID: (ownProps: OwnProps) => number
+) =>
+  connect<LVClientData, DispatchProps, OwnProps, ApplicationState>(
+    (state, ownProps) => {
+      const { longviewStats } = state;
+
+      const foundClient = longviewStats[supplyClientID(ownProps)];
+
+      return {
+        longviewClientData: pathOr({}, ['data'], foundClient),
+        longviewClientDataLoading: pathOr(true, ['loading'], foundClient),
+        longviewClientDataError: pathOr({}, ['error'], foundClient)
+      };
+    },
+    (dispatch: ThunkDispatch, ownProps: OwnProps) => ({
+      getClientStats: api_key =>
+        dispatch(
+          getClientStats({ clientID: supplyClientID(ownProps), api_key })
+        )
+    })
+  );
+
+export default connected;

--- a/packages/manager/src/containers/longview.stats.container.ts
+++ b/packages/manager/src/containers/longview.stats.container.ts
@@ -1,14 +1,15 @@
-import { pathOr } from 'ramda';
+import { APIError } from 'linode-js-sdk/lib/types';
+import { path, pathOr } from 'ramda';
 import { connect } from 'react-redux';
 import { ApplicationState } from 'src/store';
 import { ReturnType } from 'src/store/longviewStats/longviewStats.actions';
 import { getClientStats } from 'src/store/longviewStats/longviewStats.requests';
-import { EntityError, ThunkDispatch } from 'src/store/types';
+import { ThunkDispatch } from 'src/store/types';
 
 export interface LVClientData {
   longviewClientData: ReturnType;
   longviewClientDataLoading: boolean;
-  longviewClientDataError: Partial<EntityError>;
+  longviewClientDataError?: APIError[];
 }
 
 export interface DispatchProps {
@@ -57,7 +58,7 @@ const connected = <OwnProps extends {}>(
       return {
         longviewClientData: pathOr({}, ['data'], foundClient),
         longviewClientDataLoading: pathOr(true, ['loading'], foundClient),
-        longviewClientDataError: pathOr({}, ['error'], foundClient)
+        longviewClientDataError: path(['error'], foundClient)
       };
     },
     (dispatch: ThunkDispatch, ownProps: OwnProps) => ({

--- a/packages/manager/src/features/Longview/request.ts
+++ b/packages/manager/src/features/Longview/request.ts
@@ -91,6 +91,7 @@ interface Get {
   >;
   (token: string, action: 'getLatestValue', field: 'network'[]): Promise<
     Partial<LongviewNetwork>
+  >;
   (
     token: string,
     action: 'getLatestValue',

--- a/packages/manager/src/features/Longview/request.ts
+++ b/packages/manager/src/features/Longview/request.ts
@@ -86,14 +86,18 @@ interface Get {
   (token: string, action: 'getLatestValue', field: ('disk')[]): Promise<
     Partial<LongviewDisk>
   >;
-  (token: string, action: LongviewAction, field?: LongviewFieldName[]): Promise<
-    Partial<AllData>
-  >;
   (token: string, action: 'getLatestValue', field: 'memory'[]): Promise<
     Partial<LongviewMemory>
   >;
   (token: string, action: 'getLatestValue', field: 'network'[]): Promise<
     Partial<LongviewNetwork>
+  (
+    token: string,
+    action: 'getLatestValue',
+    field: ('cpu' | 'disk' | 'load' | 'memory' | 'network' | 'sysinfo')[]
+  ): Promise<Partial<Omit<AllData, 'updated'>>>;
+  (token: string, action: LongviewAction, field?: LongviewFieldName[]): Promise<
+    Partial<AllData>
   >;
 }
 

--- a/packages/manager/src/store/index.ts
+++ b/packages/manager/src/store/index.ts
@@ -90,6 +90,10 @@ import longview, {
   defaultState as defaultLongviewState,
   State as LongviewState
 } from 'src/store/longview/longview.reducer';
+import longviewStats, {
+  defaultState as defaultLongviewStatsState,
+  State as LongviewStatsState
+} from 'src/store/longviewStats/longviewStats.reducer';
 import managedIssues, {
   defaultState as defaultManagedIssuesState,
   State as ManagedIssuesState
@@ -219,6 +223,7 @@ export interface ApplicationState {
   firewalls: FirewallState;
   globalErrors: GlobalErrorState;
   longviewClients: LongviewState;
+  longviewStats: LongviewStatsState;
 }
 
 const defaultState: ApplicationState = {
@@ -237,7 +242,8 @@ const defaultState: ApplicationState = {
   initialLoad: initialLoadState,
   firewalls: defaultFirewallState,
   globalErrors: defaultGlobalErrorState,
-  longviewClients: defaultLongviewState
+  longviewClients: defaultLongviewState,
+  longviewStats: defaultLongviewStatsState
 };
 
 /**
@@ -282,7 +288,8 @@ const reducers = combineReducers<ApplicationState>({
   initialLoad,
   firewalls,
   globalErrors,
-  longviewClients: longview
+  longviewClients: longview,
+  longviewStats
 });
 
 const enhancers = compose(

--- a/packages/manager/src/store/longviewStats/longviewStats.actions.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.actions.ts
@@ -1,0 +1,38 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+import {
+  LongviewCPU,
+  LongviewDisk,
+  LongviewLoad,
+  LongviewMemory,
+  LongviewNetwork,
+  LongviewSystemInfo
+} from 'src/features/Longview/request.types.ts';
+
+import actionCreatorFactory from 'typescript-fsa';
+
+export const actionCreator = actionCreatorFactory(`@@manager/longview/stats`);
+
+export type ReturnType = Partial<
+  LongviewCPU &
+    LongviewDisk &
+    LongviewLoad &
+    LongviewMemory &
+    LongviewNetwork &
+    LongviewSystemInfo
+>;
+
+export const requestClientStats = actionCreator.async<
+  {
+    api_key: string;
+    clientID: number;
+  },
+  /**
+   * This is a partial because we can't make any assumptions on pieces
+   * of pieces of the API responses that are guaranteed to exist.
+   *
+   * There is no documentation on why/when keys are missing from the response
+   * so it's easier to just play it safe on the client.
+   */
+  ReturnType,
+  APIError[]
+>(`get`);

--- a/packages/manager/src/store/longviewStats/longviewStats.reducer.test.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.reducer.test.ts
@@ -44,9 +44,7 @@ describe('Longview Client Stats Reducer', () => {
     expect(state1).toEqual({
       123: {
         loading: false,
-        error: {
-          read: mockError
-        }
+        error: mockError
       }
     });
 
@@ -56,9 +54,7 @@ describe('Longview Client Stats Reducer', () => {
       },
       999: {
         loading: false,
-        error: {
-          read: mockError
-        }
+        error: mockError
       }
     });
   });
@@ -85,7 +81,7 @@ describe('Longview Client Stats Reducer', () => {
       },
       999: {
         loading: false,
-        error: {},
+        error: undefined,
         data: {
           ...systemInfo,
           ...memory,

--- a/packages/manager/src/store/longviewStats/longviewStats.reducer.test.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.reducer.test.ts
@@ -1,0 +1,97 @@
+import { longviewLoad, memory, systemInfo } from 'src/__data__/longview';
+import { requestClientStats } from './longviewStats.actions';
+import reducer, { defaultState } from './longviewStats.reducer';
+
+const mockError = [{ reason: 'no reason' }];
+
+describe('Longview Client Stats Reducer', () => {
+  it('should handle an initiated request for Client data', () => {
+    expect(
+      reducer(
+        defaultState,
+        requestClientStats.started({ api_key: '1234', clientID: 123 })
+      )
+    ).toEqual({
+      123: {
+        loading: true
+      }
+    });
+  });
+
+  it('should handle a failed GET request', () => {
+    const state1 = reducer(
+      { ...defaultState, 123: { loading: true } },
+      requestClientStats.failed({
+        params: {
+          api_key: '1234',
+          clientID: 123
+        },
+        error: mockError
+      })
+    );
+
+    const state2 = reducer(
+      { ...defaultState, 123: { data: {} } },
+      requestClientStats.failed({
+        params: {
+          api_key: '999999aaaaa',
+          clientID: 999
+        },
+        error: mockError
+      })
+    );
+
+    expect(state1).toEqual({
+      123: {
+        loading: false,
+        error: {
+          read: mockError
+        }
+      }
+    });
+
+    expect(state2).toEqual({
+      123: {
+        data: {}
+      },
+      999: {
+        loading: false,
+        error: {
+          read: mockError
+        }
+      }
+    });
+  });
+
+  it('should handle a successful GET request', () => {
+    const newState = reducer(
+      { ...defaultState, 123: { data: {} }, 999: { loading: true } },
+      requestClientStats.done({
+        params: {
+          clientID: 999,
+          api_key: '9999aaaabbbb'
+        },
+        result: {
+          ...systemInfo,
+          ...memory,
+          ...longviewLoad
+        }
+      })
+    );
+
+    expect(newState).toEqual({
+      123: {
+        data: {}
+      },
+      999: {
+        loading: false,
+        error: {},
+        data: {
+          ...systemInfo,
+          ...memory,
+          ...longviewLoad
+        }
+      }
+    });
+  });
+});

--- a/packages/manager/src/store/longviewStats/longviewStats.reducer.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.reducer.ts
@@ -1,0 +1,65 @@
+import { reducerWithInitialState } from 'typescript-fsa-reducers';
+import { RelationalDataSet } from '../types';
+import {
+  requestClientStats,
+  ReturnType as LVClientData
+} from './longviewStats.actions';
+
+export type State = RelationalDataSet<LVClientData>;
+
+export const defaultState: State = {};
+
+const reducer = reducerWithInitialState(defaultState)
+  /** START GET ACTIONS */
+  .caseWithAction(requestClientStats.started, (state, { payload }) => {
+    const statsAlreadyExist = !!state[payload.clientID];
+
+    /**
+     * only set a loading state if we haven't already gotten
+     * stats for this particular Longview Client
+     */
+    return statsAlreadyExist
+      ? state
+      : {
+          ...state,
+          [payload.clientID]: {
+            loading: true
+          }
+        };
+  })
+  .caseWithAction(
+    requestClientStats.done,
+    (state, { payload: { result, params } }) => ({
+      ...state,
+      [params.clientID]: {
+        data: result,
+        loading: false,
+        error: {}
+      }
+    })
+  )
+  .caseWithAction(
+    requestClientStats.failed,
+    (state, { payload: { error, params } }) => {
+      /**
+       * at this point, we are guaranteed to have state[params.clientID].loading
+       * but we only want to set an error if we don't already have data
+       */
+      const statsAlreadyExist = !!(state[params.clientID] || {}).data;
+
+      return statsAlreadyExist
+        ? state
+        : {
+            ...state,
+            [params.clientID]: {
+              loading: false,
+              error: {
+                read: error
+              }
+            }
+          };
+    }
+  )
+  .default(state => state);
+
+export default reducer;

--- a/packages/manager/src/store/longviewStats/longviewStats.reducer.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.reducer.ts
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
 import { RelationalDataSet } from '../types';
 import {
@@ -5,7 +6,7 @@ import {
   ReturnType as LVClientData
 } from './longviewStats.actions';
 
-export type State = RelationalDataSet<LVClientData>;
+export type State = RelationalDataSet<LVClientData, APIError[]>;
 
 export const defaultState: State = {};
 
@@ -34,7 +35,7 @@ const reducer = reducerWithInitialState(defaultState)
       [params.clientID]: {
         data: result,
         loading: false,
-        error: {}
+        error: undefined
       }
     })
   )
@@ -53,9 +54,7 @@ const reducer = reducerWithInitialState(defaultState)
             ...state,
             [params.clientID]: {
               loading: false,
-              error: {
-                read: error
-              }
+              error
             }
           };
     }

--- a/packages/manager/src/store/longviewStats/longviewStats.requests.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.requests.ts
@@ -1,0 +1,17 @@
+import { get } from 'src/features/Longview/request';
+import { createRequestThunk } from '../store.helpers';
+import { requestClientStats } from './longviewStats.actions';
+
+export const getClientStats = createRequestThunk(
+  requestClientStats,
+  ({ api_key }) => {
+    return get(api_key, 'getLatestValue', [
+      'cpu',
+      'disk',
+      'load',
+      'memory',
+      'network',
+      'sysinfo'
+    ]).then(response => response);
+  }
+);

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -91,15 +91,30 @@ export type EventHandler = (
 ) => void;
 
 export interface EntitiesAsObjectState<T> {
-  error: Partial<{
-    read: APIError[];
-    create: APIError[];
-    delete: APIError[];
-    update: APIError[];
-  }>;
+  error: Partial<EntityError>;
   data: Record<string, T>;
   results: number;
   lastUpdated: number;
   loading: boolean;
   listOfIDsInOriginalOrder: (string | number)[];
 }
+
+/**
+ * This is meant to be specifically for data sets that relate to some parent
+ * data set.
+ *
+ * Think NodeBalancer configs - the key here will be the NodeBalancer ID
+ * and the data contains the meta data for the NodeBalancer Config
+ *
+ * Or for Longview Client Stats - the key is the Longview Client
+ * and the data is the actual stats for the Client
+ */
+export type RelationalDataSet<T extends {}> = Record<
+  string,
+  Partial<{
+    data: T;
+    loading: boolean;
+    error: Partial<EntityError>;
+    lastUpdated: number;
+  }>
+>;

--- a/packages/manager/src/store/types.ts
+++ b/packages/manager/src/store/types.ts
@@ -109,12 +109,12 @@ export interface EntitiesAsObjectState<T> {
  * Or for Longview Client Stats - the key is the Longview Client
  * and the data is the actual stats for the Client
  */
-export type RelationalDataSet<T extends {}> = Record<
+export type RelationalDataSet<T extends {}, E = EntityError> = Record<
   string,
   Partial<{
     data: T;
     loading: boolean;
-    error: Partial<EntityError>;
+    error: E;
     lastUpdated: number;
   }>
 >;


### PR DESCRIPTION
## Description

Adds both Longview Client Data to Redux state and a container component

## Type of Change
- Non breaking change ('update', 'change')

## How to use

For this component to function, you'll need a client ID available as `ownProps`, so the usage looks like the following:

```js
 import withLongviewStats, { Props as LVDataProps }

 interface Props {
  clientID: number;
  apiKey: string;
 }

 type CombinedProps = Props & LVDataProps;

 const MyComponent: React.FC<CombinedProps> = props => {
   React.useEffect(() => {
       props.getClientStats(props.apiKey)
   }, [])

   return (
      <div>hello world</div>
  )
}
 
 export default withLongviewStats<Props>((ownProps) => ownProps.clientID)(MyComponent)
```