### PR TITLE
Change: Hydrate CPU Gauge from Redux

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -1,86 +1,54 @@
 import { APIError } from 'linode-js-sdk/lib/types';
-import { clamp, path, pathOr } from 'ramda';
+import { clamp, pathOr } from 'ramda';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
 import GaugePercent from 'src/components/GaugePercent';
 import { pluralize } from 'src/utilities/pluralize';
-import requestStats from '../../request';
 import { CPU } from '../../request.types';
 import { baseGaugeProps } from './common';
+
+import withClientStats, {
+  Props as LVDataProps
+} from 'src/containers/longview.stats.container';
 
 interface Props {
   clientAPIKey: string;
   lastUpdated?: number;
+  clientID: number;
 }
 
-const CPUGauge: React.FC<Props> = props => {
-  const { clientAPIKey, lastUpdated } = props;
+const CPUGauge: React.FC<Props & LVDataProps> = props => {
+  const {
+    longviewClientDataLoading: loading,
+    longviewClientDataError: error,
+    longviewClientData
+  } = props;
 
-  const [dataHasResolvedAtLeastOnce, setDataResolved] = React.useState<boolean>(
-    false
+  const numberOfCores = pathOr(
+    0,
+    ['SysInfo', 'cpu', 'cores'],
+    longviewClientData
   );
-  const [loading, setLoading] = React.useState<boolean>(true);
-  const [error, setError] = React.useState<APIError | undefined>();
-
-  const [usedCPU, setUsedCPU] = React.useState<number>(0);
-  const [numCores, setNumCores] = React.useState<number>(0);
-
-  React.useEffect(() => {
-    let mounted = true;
-
-    requestStats(clientAPIKey, 'getLatestValue', ['cpu', 'sysinfo'])
-      .then(data => {
-        if (mounted) {
-          setLoading(false);
-          setError(undefined);
-
-          const cores = path<number>(['SysInfo', 'cpu', 'cores'], data);
-
-          // If we don't have the number of cores, we can't determine the value.
-          if (!cores) {
-            return;
-          }
-
-          if (!dataHasResolvedAtLeastOnce) {
-            setDataResolved(true);
-          }
-
-          setNumCores(cores);
-
-          const used = sumCPUUsage(data.CPU);
-          const normalizedUsed = normalizeValue(used, cores);
-          setUsedCPU(normalizedUsed);
-        }
-      })
-      .catch(_ => {
-        if (mounted && !dataHasResolvedAtLeastOnce) {
-          setError({
-            reason: 'Error' // @todo: Error message?
-          });
-          setLoading(false);
-        }
-      });
-
-    return () => {
-      mounted = false;
-    };
-  }, [lastUpdated]);
+  const usedCPU = sumCPUUsage(longviewClientData.CPU);
+  const finalUsedCPU = normalizeValue(usedCPU, numberOfCores);
 
   return (
     <GaugePercent
       {...baseGaugeProps}
       // The MAX depends on the number of CPU cores. Default to 1 if cores
       // doesn't exist or is 0.
-      max={100 * numCores}
+      max={100 * numberOfCores}
       value={usedCPU}
-      innerText={innerText(usedCPU || 0, loading, error)}
+      innerText={innerText(finalUsedCPU || 0, loading, error)}
       subTitle={
         <>
           <Typography>
             <strong>CPU</strong>
           </Typography>
           {!error && !loading && (
-            <Typography>{pluralize('Core', 'Cores', numCores || 0)}</Typography>
+            <Typography>
+              {pluralize('Core', 'Cores', numberOfCores || 0)}
+            </Typography>
           )}
         </>
       }
@@ -88,7 +56,7 @@ const CPUGauge: React.FC<Props> = props => {
   );
 };
 
-export default CPUGauge;
+export default withClientStats<Props>(ownProps => ownProps.clientID)(CPUGauge);
 
 // UTILITIES
 export const sumCPUUsage = (CPUData: Record<string, CPU> = {}) => {
@@ -112,10 +80,10 @@ export const normalizeValue = (value: number, numCores: number) => {
 export const innerText = (
   value: number,
   loading: boolean,
-  error?: APIError
+  error?: APIError[]
 ) => {
   if (error) {
-    return error.reason;
+    return 'Error';
   }
 
   if (loading) {

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -12,8 +12,6 @@ import withClientStats, {
 } from 'src/containers/longview.stats.container';
 
 interface Props {
-  clientAPIKey: string;
-  lastUpdated?: number;
   clientID: number;
 }
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -157,11 +157,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
         <Grid item xs={2} className={classes.label}>
           <LongviewClientHeader />
         </Grid>
-        <CPUGauge
-          clientID={clientID}
-          clientAPIKey={clientAPIKey}
-          lastUpdated={lastUpdated}
-        />
+        <CPUGauge clientID={clientID} />
         <Grid item>
           <RAMGauge token={clientAPIKey} lastUpdated={lastUpdated} />
         </Grid>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -19,6 +19,10 @@ import SwapGauge from './Gauges/Swap';
 import LongviewClientHeader from './LongviewClientHeader';
 import LongviewClientInstructions from './LongviewClientInstructions';
 
+import withClientStats, {
+  Props as LVDataProps
+} from 'src/containers/longview.stats.container';
+
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
     marginBottom: theme.spacing(4),
@@ -50,7 +54,7 @@ interface Props extends ActionHandlers {
   clientAPIKey: string;
 }
 
-type CombinedProps = Props;
+type CombinedProps = Props & LVDataProps;
 
 const LongviewClientRow: React.FC<CombinedProps> = props => {
   const classes = useStyles();
@@ -84,6 +88,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
           (!lastUpdated || pathOr(0, ['updated'], response) > lastUpdated)
         ) {
           setLastUpdated(response.updated);
+          props.getClientStats(props.clientAPIKey);
         }
       })
       .catch(e => {
@@ -152,7 +157,11 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
         <Grid item xs={2} className={classes.label}>
           <LongviewClientHeader />
         </Grid>
-        <CPUGauge clientAPIKey={clientAPIKey} lastUpdated={lastUpdated} />
+        <CPUGauge
+          clientID={clientID}
+          clientAPIKey={clientAPIKey}
+          lastUpdated={lastUpdated}
+        />
         <Grid item>
           <RAMGauge token={clientAPIKey} lastUpdated={lastUpdated} />
         </Grid>
@@ -181,4 +190,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
   );
 };
 
-export default compose<CombinedProps, Props>(React.memo)(LongviewClientRow);
+export default compose<CombinedProps, Props>(
+  React.memo,
+  withClientStats<Props>(ownProps => ownProps.clientID)
+)(LongviewClientRow);


### PR DESCRIPTION
## Description

Uses the `longviewStats` redux to state to supply data for the CPU Gauge

## Type of Change
- Non breaking change ('update', 'change')