### PR TITLE
M3-3416 [LV] Plan Details – handling for restricted users

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.test.tsx
@@ -22,6 +22,8 @@ const props: CombinedProps = {
   requestAccountSettings: jest.fn(),
   updateAccountSettings: jest.fn(),
   updateAccountSettingsInStore: jest.fn(),
+  mayUserModifyLVSubscription: true,
+  mayUserViewAccountSettings: true,
   subscriptionRequestHook: {
     data: mockLongviewSubscriptions,
     lastUpdated: 0,
@@ -96,5 +98,12 @@ describe('LongviewPlans', () => {
     within(getByTestId(`lv-sub-table-row-${currentLVSub}`)).getByText(
       'Current Plan'
     );
+  });
+
+  it('displays a notice if the user does not have permissions to modify', () => {
+    const { getByText } = renderWithTheme(
+      <LongviewPlans {...props} mayUserModifyLVSubscription={false} />
+    );
+    getByText(/don't have permission/gi);
   });
 });


### PR DESCRIPTION
## Description

As a followup to https://github.com/linode/manager/pull/5703, this PR handles the Plan Details page for restricted users.

There are a few different states:

**With read/write permissions:**

<img width="1081" alt="Screen Shot 2019-11-07 at 5 29 45 PM" src="https://user-images.githubusercontent.com/16911484/68433423-76e12980-0184-11ea-81fc-b667300857c6.png">


**With readonly permissions:**

<img width="1086" alt="Screen Shot 2019-11-07 at 5 30 05 PM" src="https://user-images.githubusercontent.com/16911484/68433429-7ba5dd80-0184-11ea-9de1-42770952dbd6.png">


## Note to Reviewers

Please test several combinations between restricted, (read and read-write), Managed, unrestricted, etc.


