### PR TITLE
M3-3559 Update A/AAAA record drawer title

### DIFF
--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -766,7 +766,7 @@ const typeMap = {
   master: 'SOA',
   slave: 'SOA',
   A: 'A',
-  AAAA: 'AAAA',
+  AAAA: 'A/AAAA',
   CAA: 'CAA',
   CNAME: 'CNAME',
   MX: 'MX',


### PR DESCRIPTION
## Description

This was causing some confusion, so the title of the drawer has been updated.


<img width="241" alt="Screen Shot 2019-11-07 at 5 53 28 PM" src="https://user-images.githubusercontent.com/16911484/68434664-84e47980-0187-11ea-884f-afa0fedfd053.png">

## Type of Change
- Non breaking change ('update', 'change')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

The drawer title is dynamic. I changed `typeMap`, which isn't used anywhere else. Just poke around Domains and make sure nothing broke.
