### PR TITLE
[LV] Fix useEffect bug in LongviewClientRow

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -65,7 +65,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
     triggerDeleteLongviewClient
   } = props;
 
-  /* 
+  /*
    lastUpdated _might_ come back from the endpoint as 0, so it's important
    that we differentiate between _0_ and _undefined_
    */
@@ -75,7 +75,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
   const requestAndSetLastUpdated = () => {
     return getLastUpdated(clientAPIKey)
       .then(response => {
-        /* 
+        /*
           only update _lastUpdated_ state if it hasn't already been set
           or the API response is in a time past what's already been set.
         */
@@ -121,7 +121,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
       mounted = false;
       clearInterval(requestInterval);
     };
-  });
+  }, []);
 
   /**
    * We want to show a "waiting for data" state

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -92,7 +92,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
          * return an authentication failed error.
          */
         const reason = pathOr('', [0, 'reason'], e);
-        if (reason.match(/authentication/i)) {
+        if (mounted && reason.match(/authentication/i)) {
           setAuthed(false);
         }
       });
@@ -100,22 +100,11 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
 
   /** request on first mount */
   React.useEffect(() => {
-    if (mounted) {
-      requestAndSetLastUpdated();
-    }
-
-    return () => {
-      mounted = false;
-    };
-  }, []);
-
-  /** then request on an interval of 10 seconds */
-  React.useEffect(() => {
-    if (mounted) {
+    requestAndSetLastUpdated().then(() => {
       requestInterval = setInterval(() => {
         requestAndSetLastUpdated();
       }, 10000);
-    }
+    });
 
     return () => {
       mounted = false;


### PR DESCRIPTION
## Description

This fixes a `React.useEffect()` bug noticed when reviewing https://github.com/linode/manager/pull/5712. 

An effect that set an interval was missing a dependency array, resulting in `mounted` being set to false on every render. This caused occasional race-condition issues where the data wasn’t always being populated on page load.
