### PR TITLE
Add routing skeleton for new LKE detail layout with tabs

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DetailNavigation.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DetailNavigation.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import {
+  matchPath,
+  Route,
+  RouteComponentProps,
+  Switch
+} from 'react-router-dom';
+import AppBar from 'src/components/core/AppBar';
+import Tab from 'src/components/core/Tab';
+import Tabs from 'src/components/core/Tabs';
+import DefaultLoader from 'src/components/DefaultLoader';
+import TabLink from 'src/components/TabLink';
+
+const Details = DefaultLoader({
+  loader: () => import('./Details')
+});
+
+const Resize = DefaultLoader({
+  loader: () => import('./ResizeCluster')
+});
+
+interface Props {}
+
+type CombinedProps = Props & RouteComponentProps<{}>;
+
+export const DetailNavigation: React.FC<CombinedProps> = props => {
+  const {
+    match: { url }
+  } = props;
+
+  const tabs = [
+    /* NB: These must correspond to the routes inside the Switch */
+    { routeName: `${url}/details`, title: 'Details' },
+    { routeName: `${url}/resize`, title: 'Resize' }
+  ];
+
+  const handleTabChange = (
+    event: React.ChangeEvent<HTMLDivElement>,
+    value: number
+  ) => {
+    const { history } = props;
+    const routeName = tabs[value].routeName;
+    history.push(`${routeName}`);
+  };
+
+  return (
+    <>
+      <AppBar position="static" color="default">
+        <Tabs
+          value={tabs.findIndex(tab => matches(tab.routeName))}
+          onChange={handleTabChange}
+          indicatorColor="primary"
+          textColor="primary"
+          variant="scrollable"
+          scrollButtons="on"
+        >
+          {tabs.map(tab => (
+            <Tab
+              key={tab.title}
+              label={tab.title}
+              data-qa-tab={tab.title}
+              component={React.forwardRef((tabProps, ref) => (
+                <TabLink
+                  to={tab.routeName}
+                  title={tab.title}
+                  {...tabProps}
+                  ref={ref}
+                />
+              ))}
+            />
+          ))}
+        </Tabs>
+      </AppBar>
+      <Switch>
+        <Route exact path={`${url}/details`} component={Details} />
+        <Route exact path={`${url}/resize`} component={Resize} />
+      </Switch>
+    </>
+  );
+};
+
+const matches = (p: string) => {
+  return Boolean(matchPath(p, { path: location.pathname }));
+};
+
+export default DetailNavigation;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DetailNavigation.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DetailNavigation.tsx
@@ -6,10 +6,17 @@ import {
   Switch
 } from 'react-router-dom';
 import AppBar from 'src/components/core/AppBar';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import DefaultLoader from 'src/components/DefaultLoader';
 import TabLink from 'src/components/TabLink';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  tabBar: {
+    marginTop: 0
+  }
+}));
 
 const Details = DefaultLoader({
   loader: () => import('./Details')
@@ -24,6 +31,7 @@ interface Props {}
 type CombinedProps = Props & RouteComponentProps<{}>;
 
 export const DetailNavigation: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
   const {
     match: { url }
   } = props;
@@ -53,6 +61,7 @@ export const DetailNavigation: React.FC<CombinedProps> = props => {
           textColor="primary"
           variant="scrollable"
           scrollButtons="on"
+          className={classes.tabBar}
         >
           {tabs.map(tab => (
             <Tab

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/Details.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/Details.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+export const Details: React.FC<{}> = props => {
+  return <h1>Hello world2</h1>;
+};
+
+export default Details;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -33,6 +33,8 @@ import KubernetesDialog from './KubernetesDialog';
 import KubeSummaryPanel from './KubeSummaryPanel';
 import NodePoolsDisplay from './NodePoolsDisplay';
 
+import Navigation from './DetailNavigation';
+
 type ClassNames =
   | 'root'
   | 'title'
@@ -128,7 +130,17 @@ export const KubernetesClusterDetail: React.FunctionComponent<
     nodePoolsLoading,
     typesData,
     typesError,
-    typesLoading
+    typesLoading,
+    requestClusterForStore,
+    requestKubernetesClusters,
+    requestNodePools,
+    updateCluster,
+    updateNodePool,
+    createNodePool,
+    deleteCluster,
+    deleteNodePool,
+    setKubernetesErrors,
+    ...routerProps
   } = props;
 
   const [editing, setEditing] = React.useState<boolean>(false);
@@ -480,7 +492,8 @@ export const KubernetesClusterDetail: React.FunctionComponent<
           md={9}
           className={classes.sectionMain}
         >
-          <Grid item xs={12}>
+          <Navigation location={location} {...routerProps} />
+          {/* <Grid item xs={12}>
             <NodePoolsDisplay
               submittingForm={submitting}
               submitForm={submitForm}
@@ -516,7 +529,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
                   : undefined
               }
             />
-          </Grid>
+          </Grid> */}
           <Grid item xs={12} className={classes.deleteSection}>
             <Button
               destructive

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeCluster.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+interface Props {
+  text?: string;
+}
+
+export type CombinedProps = Props;
+
+export const ResizeCluster: React.FC<Props> = props => {
+  return <h2>Hello world</h2>;
+};
+
+export default ResizeCluster;

--- a/packages/manager/src/features/Kubernetes/index.tsx
+++ b/packages/manager/src/features/Kubernetes/index.tsx
@@ -32,11 +32,7 @@ class Kubernetes extends React.Component<Props> {
     return (
       <Switch>
         <Route component={ClusterCreate} exact path={`${path}/create`} />
-        <Route
-          component={ClusterDetail}
-          exact
-          path={`${path}/clusters/:clusterID`}
-        />
+        <Route component={ClusterDetail} path={`${path}/clusters/:clusterID`} />
         <Route component={KubernetesLanding} exact path={path} />
         <Redirect to={'/kubernetes'} />
       </Switch>


### PR DESCRIPTION
## Description

Replaced LKE content with a tabbed layout with placeholders.

## Note to Reviewers

This is going to fail the linter since there's commented out code and variables that aren't used as a result.