### PR TITLE
Making Changes to the cloud dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-node_modules
+packages/**/node_modules
 dist
 build
 localStorage.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:10-alpine
 
 # Run commands as "node" user. We don't want to run these commands as root
 #
@@ -11,9 +11,7 @@ USER node
 RUN yarn global add lerna
 
 # Copy the root level package.json and run yarn if anything changes
-COPY --chown=node:node package.json .
-COPY --chown=node:node yarn.lock .
-COPY --chown=node:node tslint.json .
+COPY --chown=node:node package.json yarn.lock tslint.json ./
 RUN yarn
 
 # Copy lerna.json
@@ -21,13 +19,11 @@ COPY --chown=node:node lerna.json .
 COPY --chown=node:node scripts ./scripts/
 
 # Copy Cloud Manager deps
-COPY --chown=node:node packages/manager/package.json ./packages/manager/
-COPY --chown=node:node packages/manager/yarn.lock ./packages/manager/
+COPY --chown=node:node packages/manager/package.json packages/manager/yarn.lock ./packages/manager/
 COPY --chown=node:node packages/manager/patches ./packages/manager/patches/
 
 # Copy JS SDK deps
-COPY --chown=node:node packages/linode-js-sdk/package.json ./packages/linode-js-sdk/
-COPY --chown=node:node packages/linode-js-sdk/yarn.lock ./packages/linode-js-sdk/
+COPY --chown=node:node packages/linode-js-sdk/package.json packages/linode-js-sdk/yarn.lock ./packages/linode-js-sdk/
 
 # Runs "yarn install" for all child packages
 RUN npx lerna bootstrap

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "e2e:all": "lerna run e2e:all --stream --scope linode-manager -- --color",
     "e2e:modified": "lerna run e2e:modified --stream --scope linode-manager -- --color",
     "docker:e2e": "docker-compose -f integration-test.yml up --exit-code-from manager-e2e",
-    "docker:test": "docker build -f Dockerfile . -t 'manager' && docker run -it --rm -v $(pwd)/packages/manager/src:/home/node/app/packages/manager/src -v $(pwd)/packages/linode-js-sdk/src:/home/node/app/packages/linode-js-sdk/src manager test",
-    "docker:local": "docker build -f Dockerfile . -t 'manager' && docker run -it --rm -p 3000:3000 -v $(pwd)/packages/manager/src:/home/node/app/packages/manager/src -v $(pwd)/packages/linode-js-sdk/src:/home/node/app/packages/linode-js-sdk/src manager start:docker",
+    "docker:test": "docker build -f Dockerfile . -t 'manager' && docker run -it cloud --rm -v $(pwd)/packages/manager/src:/home/node/app/packages/manager/src -v $(pwd)/packages/linode-js-sdk/src:/home/node/app/packages/linode-js-sdk/src manager test",
+    "docker:local": "docker build -f Dockerfile . -t 'manager' -t 'dev' && docker run -it --rm -p 3000:3000 -v $(pwd)/packages/manager/src:/home/node/app/packages/manager/src -v $(pwd)/packages/linode-js-sdk/src:/home/node/app/packages/linode-js-sdk/src manager start:docker",
     "docker:storybook": "docker build -f Dockerfile . -t 'storybook' && docker run -it --rm -p 6006:6006 -v $(pwd)/packages/manager/src:/home/node/app/packages/manager/src -v $(pwd)/packages/linode-js-sdk/src:/home/node/app/packages/linode-js-sdk/src storybook storybook",
     "docker:storybook:test": "docker-compose -f packages/manager/storybook-test.yml up --build --exit-code-from storybook-test"
   },


### PR DESCRIPTION
* The two biggest changes to reduce the size and time right now:
 1. witched from node:10 to node:10-alpine. This reduced the image size down to 1.9 gigs
 2. add 'packages/**/node_modules' instead node_modules to the .dockerignore file. This reduced
image size down to 1.35 gigs.

* merged 2 sets of 3 COPY lines down to 2 COPY lines reducing layers needed

* tested that changes to code will be automatically updated/rebuilt as with running locally

* next goal is to see if using multi-staged builds will reduce size further and improve speed

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

It would be a good idea to remove any large images or unneeded images on your machine
1. `docker system df` will show you how much space you can reclaim
2. `docker system prune -a` will remove all unused containers etc
3. `yarn docker:local` The first run of this may take about 10 minutes, subsequent runs should be at least half as long. It can take a while to build the front-end