### PR TITLE
Separate LKE Cluster Details and Resize into two nested tabs: Details Page

### DIFF
--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -20,7 +20,6 @@ import TableRow from 'src/components/TableRow';
 import TextField from 'src/components/TextField';
 import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
 import { displayTypeForKubePoolNode } from 'src/features/linodes/presentation';
-import useFlags from 'src/hooks/useFlags';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import { PoolNodeWithPrice } from '.././types';
 
@@ -58,8 +57,7 @@ const styles = (theme: Theme) =>
       [theme.breakpoints.down('sm')]: {
         justifyContent: 'flex-end !important' as 'flex-end',
         padding: 0,
-        paddingRight: '0 !important' as '0',
-        width: '10%'
+        paddingRight: '0 !important' as '0'
       }
     },
     editableCount: {
@@ -72,11 +70,9 @@ const styles = (theme: Theme) =>
     },
     priceTableCell: {
       // prevents position shift as price grows/shrinks
-      minWidth: 130,
-      width: '20%'
+      minWidth: 130
     },
     regularCell: {
-      width: '25%',
       height: 70
     }
   });
@@ -152,7 +148,6 @@ export const getStatusString = (
 
 export const NodePoolRow: React.FunctionComponent<CombinedProps> = props => {
   const { classes, editable, pool, idx, deletePool, type, updatePool } = props;
-  const flags = useFlags();
 
   if (editable && !(updatePool && deletePool)) {
     // Checking for conditionally required props
@@ -213,7 +208,7 @@ export const NodePoolRow: React.FunctionComponent<CombinedProps> = props => {
         <Typography>{`${displayPrice(pool.totalMonthlyPrice)}/mo`}</Typography>
       </TableCell>
       <TableCell className={classes.removeButtonWrapper}>
-        {(!flags.lkeHideButtons || editable) && (
+        {editable && (
           <Button
             buttonType="remove"
             deleteText={pool.queuedForDeletion ? 'Undo Remove' : 'Remove'}
@@ -221,7 +216,6 @@ export const NodePoolRow: React.FunctionComponent<CombinedProps> = props => {
             onClick={() => handleDelete(idx)}
             className={classNames({
               [classes.link]: true,
-              [classes.disabled]: !editable,
               [classes.removeButton]: true
             })}
           />

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DetailNavigation.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DetailNavigation.tsx
@@ -1,16 +1,12 @@
 import * as React from 'react';
-import {
-  matchPath,
-  Route,
-  RouteComponentProps,
-  Switch
-} from 'react-router-dom';
+import { matchPath, Route, Switch } from 'react-router-dom';
 import AppBar from 'src/components/core/AppBar';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import DefaultLoader from 'src/components/DefaultLoader';
 import TabLink from 'src/components/TabLink';
+import { ResizeProps } from './ResizeCluster';
 
 const useStyles = makeStyles((theme: Theme) => ({
   tabBar: {
@@ -26,11 +22,7 @@ const Resize = DefaultLoader({
   loader: () => import('./ResizeCluster')
 });
 
-interface Props {}
-
-type CombinedProps = Props & RouteComponentProps<{}>;
-
-export const DetailNavigation: React.FC<CombinedProps> = props => {
+export const DetailNavigation: React.FC<ResizeProps> = props => {
   const classes = useStyles();
   const {
     match: { url }
@@ -81,8 +73,16 @@ export const DetailNavigation: React.FC<CombinedProps> = props => {
         </Tabs>
       </AppBar>
       <Switch>
-        <Route exact path={`${url}/details`} component={Details} />
-        <Route exact path={`${url}/resize`} component={Resize} />
+        <Route
+          exact
+          path={`${url}/resize`}
+          render={() => <Resize {...props} />}
+        />
+        <Route
+          exact
+          path={`${url}/details`}
+          render={() => <Details {...props} />}
+        />
       </Switch>
     </>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/Details.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/Details.tsx
@@ -1,7 +1,117 @@
 import * as React from 'react';
 
-export const Details: React.FC<{}> = props => {
-  return <h1>Hello world2</h1>;
+import LibraryBook from 'src/assets/icons/guides.svg';
+import Grid from 'src/components/core/Grid';
+import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import ExternalLink from 'src/components/ExternalLink';
+import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
+import NodePoolsDisplay from './NodePoolsDisplay';
+
+import { ExtendedCluster, PoolNodeWithPrice } from '.././types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  docsWrapper: {
+    padding: theme.spacing(3),
+    margin: `${theme.spacing(3)}px 0`
+  },
+  docsIcon: {
+    width: 24,
+    position: 'relative',
+    top: 2,
+    marginRight: 8,
+    color: theme.color.headline
+  },
+  docsHeaderWrapper: {
+    marginBottom: theme.spacing(2)
+  },
+  post: {
+    marginBottom: theme.spacing(1) / 2
+  }
+}));
+
+interface Props {
+  cluster: ExtendedCluster;
+  nodePoolsLoading: boolean;
+  typesData?: ExtendedType[];
+}
+
+export type CombinedProps = Props;
+
+export const Details: React.FC<Props> = props => {
+  const classes = useStyles();
+  const { cluster, nodePoolsLoading, typesData } = props;
+
+  if (!cluster) {
+    return null;
+  }
+
+  /** Holds the local state of the cluster's node pools when editing */
+  const [pools] = React.useState<PoolNodeWithPrice[]>(cluster.node_pools || []);
+
+  const links = [
+    {
+      href:
+        'https://www.linode.com/docs/applications/containers/kubernetes/how-to-deploy-a-cluster-with-lke/',
+      title: 'Deploying LKE',
+      idx: 1
+    },
+    {
+      href:
+        'https://www.linode.com/docs/applications/containers/kubernetes/troubleshooting-kubernetes/',
+      title: 'Troubleshooting Kubernetes',
+      idx: 2
+    },
+    {
+      href:
+        'https://www.linode.com/docs/applications/containers/kubernetes/beginners-guide-to-kubernetes/',
+      title: "Beginner's Guide to Kubernetes",
+      idx: 3
+    }
+  ];
+
+  return (
+    <>
+      <Grid item xs={12}>
+        <NodePoolsDisplay
+          editing={false}
+          pools={cluster.node_pools}
+          poolsForEdit={pools}
+          types={typesData || []}
+          loading={nodePoolsLoading}
+        />
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <Paper className={classes.docsWrapper}>
+          <Grid
+            container
+            item
+            direction="row"
+            justify="flex-start"
+            alignItems="center"
+            className={classes.docsHeaderWrapper}
+          >
+            <Grid item>
+              <LibraryBook className={classes.docsIcon} />
+            </Grid>
+            <Grid item>
+              <Typography variant="h3">Additional Guides</Typography>
+            </Grid>
+          </Grid>
+          <Grid item>
+            {links.map(link => (
+              <div key={link.idx}>
+                <Typography variant="body1" className={classes.post}>
+                  <ExternalLink link={link.href} text={link.title} />
+                </Typography>
+              </div>
+            ))}
+          </Grid>
+        </Paper>
+      </Grid>
+    </>
+  );
 };
 
 export default Details;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -1,13 +1,10 @@
-import * as Bluebird from 'bluebird';
 import { getKubernetesClusterEndpoint } from 'linode-js-sdk/lib/kubernetes';
 import { APIError } from 'linode-js-sdk/lib/types';
-import { contains, equals, path, pathOr, remove, update } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'recompose';
 
 import Breadcrumb from 'src/components/Breadcrumb';
-import Button from 'src/components/Button';
 import CircleProgress from 'src/components/CircleProgress';
 import Grid from 'src/components/core/Grid';
 import {
@@ -24,14 +21,9 @@ import KubeContainer, {
 import withTypes, { WithTypesProps } from 'src/containers/types.container';
 
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import scrollTo from 'src/utilities/scrollTo';
-import { getMonthlyPrice } from '.././kubeUtils';
-import { ExtendedCluster, PoolNodeWithPrice } from '.././types';
-import NodePoolPanel from '../CreateCluster/NodePoolPanel';
+import { ExtendedCluster } from '.././types';
 import KubeConfigPanel from './KubeConfigPanel';
-import KubernetesDialog from './KubernetesDialog';
 import KubeSummaryPanel from './KubeSummaryPanel';
-import NodePoolsDisplay from './NodePoolsDisplay';
 
 import Navigation from './DetailNavigation';
 
@@ -43,7 +35,6 @@ type ClassNames =
   | 'section'
   | 'panelItem'
   | 'button'
-  | 'deleteSection'
   | 'titleGridWrapper'
   | 'tagHeading'
   | 'sectionMain'
@@ -76,11 +67,6 @@ const styles = (theme: Theme) =>
         [theme.breakpoints.only('md')]: {
           padding: `${theme.spacing(2)}px ${theme.spacing(1)}px`
         }
-      }
-    },
-    deleteSection: {
-      [theme.breakpoints.up('md')]: {
-        marginLeft: theme.spacing(3)
       }
     },
     titleGridWrapper: {
@@ -122,44 +108,13 @@ export const KubernetesClusterDetail: React.FunctionComponent<
   const {
     classes,
     cluster,
-    clusterDeleteError,
     clustersLoadError,
     clustersLoading,
     lastUpdated,
     location,
-    nodePoolsLoading,
-    typesData,
-    typesError,
-    typesLoading,
-    requestClusterForStore,
-    requestKubernetesClusters,
-    requestNodePools,
-    updateCluster,
-    updateNodePool,
-    createNodePool,
-    deleteCluster,
-    deleteNodePool,
-    setKubernetesErrors,
-    ...routerProps
+    ...rest
   } = props;
 
-  const [editing, setEditing] = React.useState<boolean>(false);
-  /** Holds the local state of the cluster's node pools when editing */
-  const [pools, updatePools] = React.useState<PoolNodeWithPrice[]>([]);
-  /** When adding new pools in the NodePoolPanel component, use these variables. */
-  const [selectedType, setSelectedType] = React.useState<string | undefined>(
-    undefined
-  );
-  const [count, setCount] = React.useState<number>(1);
-  /** Form submission */
-  const [submitting, setSubmitting] = React.useState<boolean>(false);
-  const [generalError, setErrors] = React.useState<APIError[] | undefined>(
-    undefined
-  );
-  const [success, setSuccess] = React.useState<boolean>(false);
-  /** Deletion confirmation modal */
-  const [confirmationOpen, setConfirmation] = React.useState<boolean>(false);
-  const [deleting, setDeleting] = React.useState<boolean>(false);
   const [endpoint, setEndpoint] = React.useState<string | null>(null);
   const [endpointError, setEndpointError] = React.useState<string | undefined>(
     undefined
@@ -188,20 +143,6 @@ export const KubernetesClusterDetail: React.FunctionComponent<
         });
     }
 
-    /**
-     * If we're navigating from the action menu on the cluster list page,
-     * we want to start with editing mode active.
-     */
-    const isEditing = pathOr(
-      false,
-      ['history', 'location', 'state', 'editing'],
-      props
-    );
-
-    if (isEditing !== editing) {
-      toggleEditing();
-    }
-
     const interval = setInterval(
       () => props.requestNodePools(+props.match.params.clusterID),
       10000
@@ -222,8 +163,8 @@ export const KubernetesClusterDetail: React.FunctionComponent<
 
   if (
     (clustersLoading && lastUpdated === 0) ||
-    nodePoolsLoading ||
-    typesLoading
+    props.nodePoolsLoading ||
+    props.typesLoading
   ) {
     return <CircleProgress />;
   }
@@ -231,201 +172,6 @@ export const KubernetesClusterDetail: React.FunctionComponent<
   if (cluster === null) {
     return null;
   }
-
-  /**
-   * These three handlers update the local pools state in the event of an error. If an update
-   * is fully successful, we'll exit editing mode, the table will show
-   * the current Redux state of the cluster, and none of this will matter.
-   *
-   * If, however, some requests fail while others succeed, we want to show
-   * error messages for actions that failed while updating the local form
-   * state for actions that succeeded (so that e.g. a pending pool that has been added no longer has the
-   * "pending pool" styles).
-   */
-  const handleError = (pool: PoolNodeWithPrice, error: APIError[]) => {
-    const poolIdx = pools.findIndex(thisPool => thisPool.id === pool.id);
-    updatePool(poolIdx, { ...pool, _error: error });
-    return Promise.reject(error);
-  };
-
-  const handleAddSuccess = (pool: PoolNodeWithPrice) => {
-    const poolIdx = pools.findIndex(thisPool => thisPool.id === pool.id);
-    updatePool(poolIdx, {
-      ...pool,
-      queuedForAddition: false,
-      queuedForDeletion: false
-    });
-  };
-
-  const handleDeleteSuccess = (pool: PoolNodeWithPrice) => {
-    const poolIdx = pools.findIndex(thisPool => thisPool.id === pool.id);
-    if (poolIdx) {
-      updatePools(prevPools => {
-        return remove(poolIdx, 1, prevPools);
-      });
-    }
-  };
-
-  const submitForm = () => {
-    /** If the user hasn't made any input, there's nothing to submit. */
-    if (equals(pools, cluster.node_pools)) {
-      setEditing(false);
-      return;
-    }
-    /** Fasten your seat belts... */
-    setSubmitting(true);
-    setErrors(undefined);
-    setSuccess(false);
-    Bluebird.map(pools, thisPool => {
-      if (thisPool.queuedForAddition) {
-        // This pool doesn't exist and needs to be created through the API.
-        return props
-          .createNodePool({
-            clusterID: cluster.id,
-            count: thisPool.count,
-            type: thisPool.type
-          })
-          .then(() => handleAddSuccess(thisPool))
-          .catch(e => handleError(thisPool, e));
-      } else if (thisPool.queuedForDeletion) {
-        // Marked for deletion
-        return props
-          .deleteNodePool({
-            clusterID: cluster.id,
-            nodePoolID: thisPool.id
-          })
-          .then(() => handleDeleteSuccess(thisPool))
-          .catch(e => handleError(thisPool, e));
-      } else if (!contains(thisPool, cluster.node_pools)) {
-        /** @todo contains() is deprecated in the next version of Ramda (0.26+). Replace with includes() if we ever upgrade. */
-
-        // User has adjusted the count for this pool. Needs to be pushed through to the API.
-        return props
-          .updateNodePool({
-            clusterID: cluster.id,
-            nodePoolID: thisPool.id,
-            count: thisPool.count,
-            type: thisPool.type
-          })
-          .catch(e => handleError(thisPool, e));
-      } else {
-        // Nothing has changed about this node, so don't make any requests.
-        return;
-      }
-    })
-      .then(() => {
-        setSuccess(true);
-        setSubmitting(false);
-        setEditing(false);
-      })
-      .catch(err => {
-        setErrors(
-          getAPIErrorOrDefault(
-            err,
-            'Some actions could not be completed. Please try again.'
-          )
-        );
-        setSubmitting(false);
-      });
-  };
-
-  const updatePool = (poolIdx: number, updatedPool: PoolNodeWithPrice) => {
-    const updatedPoolWithPrice = {
-      ...updatedPool,
-      totalMonthlyPrice: getMonthlyPrice(
-        updatedPool.type,
-        updatedPool.count,
-        typesData || []
-      )
-    };
-    updatePools(prevPools => update(poolIdx, updatedPoolWithPrice, prevPools));
-  };
-
-  const resetFormState = () => {
-    updatePools(cluster.node_pools);
-  };
-
-  const toggleEditing = () => {
-    /**
-     * Regardless of whether we're going into or out of editing mode,
-     * reset everything.
-     */
-
-    updatePools(cluster.node_pools);
-    setEditing(!editing);
-    setSuccess(false);
-    setErrors(undefined);
-  };
-
-  const handleAddNodePool = (pool: PoolNodeWithPrice) => {
-    if (editing) {
-      /** We're already in editing mode, so the list of pool nodes should be accurate */
-      updatePools(prevPools => {
-        const newPools = [
-          ...prevPools,
-          {
-            ...pool,
-            queuedForAddition: true
-          }
-        ];
-        scrollTo();
-        return newPools;
-      });
-    } else {
-      /** From a static state, adding a node pool should trigger editing state */
-      scrollTo();
-      toggleEditing();
-      /** Make sure the list of node pools is correct */
-      updatePools([
-        ...cluster.node_pools,
-        {
-          ...pool,
-          queuedForAddition: true
-        }
-      ]);
-    }
-  };
-
-  const handleDeletePool = (poolIdx: number) => {
-    updatePools(prevPools => {
-      const poolToDelete = path<PoolNodeWithPrice>([poolIdx], prevPools);
-      if (poolToDelete) {
-        if (poolToDelete.queuedForAddition) {
-          /**
-           * This is a new pool in local state that doesn't exist as far as the API is concerned.
-           * It can be directly removed.
-           */
-          return remove(poolIdx, 1, prevPools);
-        } else {
-          /**
-           * This is a "real" node that we don't want users to accidentally delete. Mark it for deletion
-           * (it will be handled on form submission). If the user has already marked this for deletion
-           * and clicks on "Remove Delete", remove the queuedForDeletion tag.
-           */
-          const withMarker = {
-            ...poolToDelete,
-            queuedForDeletion: !Boolean(poolToDelete.queuedForDeletion)
-          };
-          return update(poolIdx, withMarker, prevPools);
-        }
-      } else {
-        return prevPools;
-      }
-    });
-  };
-
-  const handleDeleteCluster = () => {
-    setDeleting(true);
-    props
-      .deleteCluster({ clusterID: cluster.id })
-      .then(() => props.history.push('/kubernetes'))
-      .catch(_ => setDeleting(false)); // Handle errors through Redux
-  };
-
-  const openDeleteConfirmation = () => {
-    props.setKubernetesErrors({ delete: undefined });
-    setConfirmation(true);
-  };
 
   const handleLabelChange = async (newLabel: string) => {
     props.updateCluster({ clusterID: cluster.id, label: newLabel });
@@ -492,64 +238,15 @@ export const KubernetesClusterDetail: React.FunctionComponent<
           md={9}
           className={classes.sectionMain}
         >
-          <Navigation location={location} {...routerProps} />
-          {/* <Grid item xs={12}>
-            <NodePoolsDisplay
-              submittingForm={submitting}
-              submitForm={submitForm}
-              submissionSuccess={success}
-              submissionError={generalError}
-              editing={editing}
-              toggleEditing={toggleEditing}
-              updatePool={updatePool}
-              deletePool={handleDeletePool}
-              resetForm={resetFormState}
-              pools={cluster.node_pools}
-              poolsForEdit={pools}
-              types={typesData || []}
-              loading={nodePoolsLoading}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <NodePoolPanel
-              hideTable
-              selectedType={selectedType}
-              types={typesData || []}
-              nodeCount={count}
-              addNodePool={handleAddNodePool}
-              handleTypeSelect={newType => setSelectedType(newType)}
-              updateNodeCount={newCount => setCount(newCount)}
-              typesLoading={typesLoading}
-              typesError={
-                typesError
-                  ? getAPIErrorOrDefault(
-                      typesError,
-                      'Error loading Linode type information.'
-                    )[0].reason
-                  : undefined
-              }
-            />
-          </Grid> */}
-          <Grid item xs={12} className={classes.deleteSection}>
-            <Button
-              destructive
-              buttonType="secondary"
-              onClick={openDeleteConfirmation}
-            >
-              Delete Cluster
-            </Button>
-          </Grid>
+          <Navigation
+            location={location}
+            cluster={cluster}
+            updateCluster={props.updateCluster}
+            updateNodePool={props.updateNodePool}
+            {...rest}
+          />
         </Grid>
       </Grid>
-      <KubernetesDialog
-        open={confirmationOpen}
-        loading={deleting}
-        error={path([0, 'reason'], clusterDeleteError)}
-        clusterLabel={cluster.label}
-        clusterPools={cluster.node_pools}
-        onClose={() => setConfirmation(false)}
-        onDelete={handleDeleteCluster}
-      />
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -56,7 +56,9 @@ const styles = (theme: Theme) =>
       },
       padding: 0
     },
-    section: {},
+    section: {
+      alignItems: 'flex-start'
+    },
     panelItem: {},
     button: {
       marginBottom: theme.spacing(3),

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -85,18 +85,23 @@ const styles = (theme: Theme) =>
 
 interface Props {
   editing: boolean;
-  submittingForm: boolean;
-  submissionSuccess: boolean;
+  submittingForm?: boolean;
+  submissionSuccess?: boolean;
   submissionError?: APIError[];
   pools: PoolNodeWithPrice[];
   poolsForEdit: PoolNodeWithPrice[];
   types: ExtendedType[];
   loading: boolean;
   submitDisabled?: boolean;
-  updatePool: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
-  deletePool: (poolID: number) => void;
-  resetForm: () => void;
-  submitForm: () => void;
+  // updatePool: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
+  // deletePool: (poolID: number) => void;
+  // resetForm: () => void;
+  // submitForm: () => void;
+  toggleEditing?: () => void;
+  updatePool?: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
+  deletePool?: (poolID: number) => void;
+  resetForm?: () => void;
+  submitForm?: () => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -17,7 +17,6 @@ import HelpIcon from 'src/components/HelpIcon';
 import Notice from 'src/components/Notice';
 
 import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
-import useFlags from 'src/hooks/useFlags';
 import { getErrorMap } from 'src/utilities/errorUtils';
 
 import NodePoolDisplayTable from '../../CreateCluster/NodePoolDisplayTable';
@@ -93,7 +92,7 @@ interface Props {
   poolsForEdit: PoolNodeWithPrice[];
   types: ExtendedType[];
   loading: boolean;
-  toggleEditing: () => void;
+  submitDisabled?: boolean;
   updatePool: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
   deletePool: (poolID: number) => void;
   resetForm: () => void;
@@ -119,12 +118,10 @@ export const NodePoolsDisplay: React.FunctionComponent<
     submissionError,
     submissionSuccess,
     submittingForm,
-    toggleEditing,
+    submitDisabled,
     types,
     updatePool
   } = props;
-
-  const flags = useFlags();
 
   const TooltipText = () => {
     return (
@@ -162,11 +159,6 @@ export const NodePoolsDisplay: React.FunctionComponent<
               interactive
               classes={{ tooltip: classes.tooltipOuter }}
             />
-          </Grid>
-          <Grid item>
-            <Button buttonType="secondary" onClick={toggleEditing}>
-              {editing ? 'Cancel' : 'Edit'}
-            </Button>
           </Grid>
         </Grid>
         {submissionSuccess && (
@@ -209,12 +201,12 @@ export const NodePoolsDisplay: React.FunctionComponent<
               {`$${getTotalClusterPrice(poolsForEdit)}/month`}
             </Typography>
           )}
-          {(!flags.lkeHideButtons || editing) && (
+          {editing && (
             <Grid item container xs={12} className={classes.ctaOuter}>
               <Button
                 className={classes.button}
                 buttonType="primary"
-                disabled={!editing || submittingForm}
+                disabled={submitDisabled || submittingForm}
                 loading={submittingForm}
                 onClick={submitForm}
               >

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeCluster.tsx
@@ -1,13 +1,311 @@
+import * as Bluebird from 'bluebird';
+import { APIError } from 'linode-js-sdk/lib/types';
+import { contains, equals, path, remove, update } from 'ramda';
 import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import Button from 'src/components/Button';
+import Grid from 'src/components/core/Grid';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import { DispatchProps } from 'src/containers/kubernetes.container';
+import { WithTypesProps } from 'src/containers/types.container';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import scrollTo from 'src/utilities/scrollTo';
+import { getMonthlyPrice } from '.././kubeUtils';
+import { ExtendedCluster, PoolNodeWithPrice } from '.././types';
+import NodePoolPanel from '../CreateCluster/NodePoolPanel';
+import KubernetesDialog from './KubernetesDialog';
+import NodePoolsDisplay from './NodePoolsDisplay';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  deleteSection: {
+    [theme.breakpoints.up('md')]: {
+      marginLeft: theme.spacing(3)
+    }
+  }
+}));
 
 interface Props {
-  text?: string;
+  cluster: ExtendedCluster;
+  nodePoolsLoading: boolean;
+  clusterDeleteError?: APIError[];
 }
 
-export type CombinedProps = Props;
+export type ResizeProps = Props &
+  DispatchProps &
+  WithTypesProps &
+  RouteComponentProps<{}>;
 
-export const ResizeCluster: React.FC<Props> = props => {
-  return <h2>Hello world</h2>;
+export const ResizeCluster: React.FC<ResizeProps> = props => {
+  const {
+    cluster,
+    typesData,
+    typesError,
+    typesLoading,
+    nodePoolsLoading
+  } = props;
+
+  if (!cluster) {
+    return null;
+  }
+
+  const classes = useStyles();
+
+  /** Deletion confirmation modal */
+  const [confirmationOpen, setConfirmation] = React.useState<boolean>(false);
+  const [deleting, setDeleting] = React.useState<boolean>(false);
+
+  /** Holds the local state of the cluster's node pools when editing */
+  const [pools, updatePools] = React.useState<PoolNodeWithPrice[]>(
+    cluster.node_pools || []
+  );
+  /** When adding new pools in the NodePoolPanel component, use these variables. */
+  const [selectedType, setSelectedType] = React.useState<string | undefined>(
+    undefined
+  );
+  const [count, setCount] = React.useState<number>(1);
+  /** Form submission */
+  const [submitting, setSubmitting] = React.useState<boolean>(false);
+  const [generalError, setErrors] = React.useState<APIError[] | undefined>(
+    undefined
+  );
+  const [success, setSuccess] = React.useState<boolean>(false);
+
+  const [submitDisabled, setSubmitDisabled] = React.useState<boolean>(true);
+
+  React.useEffect(() => {
+    if (!equals(pools, cluster.node_pools)) {
+      setSubmitDisabled(false);
+    } else {
+      setSubmitDisabled(true);
+    }
+  }, [pools, cluster.node_pools]);
+
+  const handleDeleteCluster = () => {
+    setDeleting(true);
+    props
+      .deleteCluster({ clusterID: cluster.id })
+      .then(() => props.history.push('/kubernetes'))
+      .catch(_ => setDeleting(false)); // Handle errors through Redux
+  };
+
+  const openDeleteConfirmation = () => {
+    props.setKubernetesErrors({ delete: undefined });
+    setConfirmation(true);
+  };
+  /**
+   * These three handlers update the local pools state in the event of an error. If an update
+   * is fully successful, we'll exit editing mode, the table will show
+   * the current Redux state of the cluster, and none of this will matter.
+   *
+   * If, however, some requests fail while others succeed, we want to show
+   * error messages for actions that failed while updating the local form
+   * state for actions that succeeded (so that e.g. a pending pool that has been added no longer has the
+   * "pending pool" styles).
+   */
+  const handleError = (pool: PoolNodeWithPrice, error: APIError[]) => {
+    const poolIdx = pools.findIndex(thisPool => thisPool.id === pool.id);
+    updatePool(poolIdx, { ...pool, _error: error });
+    return Promise.reject(error);
+  };
+
+  const handleAddSuccess = (pool: PoolNodeWithPrice) => {
+    const poolIdx = pools.findIndex(thisPool => thisPool.id === pool.id);
+    updatePool(poolIdx, {
+      ...pool,
+      queuedForAddition: false,
+      queuedForDeletion: false
+    });
+  };
+
+  const handleDeleteSuccess = (pool: PoolNodeWithPrice) => {
+    const poolIdx = pools.findIndex(thisPool => thisPool.id === pool.id);
+    if (poolIdx) {
+      updatePools(prevPools => {
+        return remove(poolIdx, 1, prevPools);
+      });
+    }
+  };
+
+  const submitForm = () => {
+    /** If the user hasn't made any input, there's nothing to submit. */
+    if (equals(pools, cluster.node_pools)) {
+      return;
+    }
+    /** Fasten your seat belts... */
+    setSubmitting(true);
+    setErrors(undefined);
+    setSuccess(false);
+    Bluebird.map(pools, thisPool => {
+      if (thisPool.queuedForAddition) {
+        // This pool doesn't exist and needs to be created through the API.
+        return props
+          .createNodePool({
+            clusterID: cluster.id,
+            count: thisPool.count,
+            type: thisPool.type
+          })
+          .then(() => handleAddSuccess(thisPool))
+          .catch(e => handleError(thisPool, e));
+      } else if (thisPool.queuedForDeletion) {
+        // Marked for deletion
+        return props
+          .deleteNodePool({
+            clusterID: cluster.id,
+            nodePoolID: thisPool.id
+          })
+          .then(() => handleDeleteSuccess(thisPool))
+          .catch(e => handleError(thisPool, e));
+      } else if (!contains(thisPool, cluster.node_pools)) {
+        /** @todo contains() is deprecated in the next version of Ramda (0.26+). Replace with includes() if we ever upgrade. */
+
+        // User has adjusted the count for this pool. Needs to be pushed through to the API.
+        return props
+          .updateNodePool({
+            clusterID: cluster.id,
+            nodePoolID: thisPool.id,
+            count: thisPool.count,
+            type: thisPool.type
+          })
+          .catch(e => handleError(thisPool, e));
+      } else {
+        // Nothing has changed about this node, so don't make any requests.
+        return;
+      }
+    })
+      .then(() => {
+        setSuccess(true);
+        setSubmitting(false);
+        setSubmitDisabled(true);
+      })
+      .catch(err => {
+        setErrors(
+          getAPIErrorOrDefault(
+            err,
+            'Some actions could not be completed. Please try again.'
+          )
+        );
+        setSubmitting(false);
+      });
+  };
+
+  const handleAddNodePool = (pool: PoolNodeWithPrice) => {
+    updatePools(prevPools => {
+      const newPools = [
+        ...prevPools,
+        {
+          ...pool,
+          queuedForAddition: true
+        }
+      ];
+      scrollTo();
+      return newPools;
+    });
+  };
+
+  const handleDeletePool = (poolIdx: number) => {
+    updatePools(prevPools => {
+      const poolToDelete = path<PoolNodeWithPrice>([poolIdx], prevPools);
+      if (poolToDelete) {
+        if (poolToDelete.queuedForAddition) {
+          /**
+           * This is a new pool in local state that doesn't exist as far as the API is concerned.
+           * It can be directly removed.
+           */
+          return remove(poolIdx, 1, prevPools);
+        } else {
+          /**
+           * This is a "real" node that we don't want users to accidentally delete. Mark it for deletion
+           * (it will be handled on form submission). If the user has already marked this for deletion
+           * and clicks on "Remove Delete", remove the queuedForDeletion tag.
+           */
+          const withMarker = {
+            ...poolToDelete,
+            queuedForDeletion: !Boolean(poolToDelete.queuedForDeletion)
+          };
+          return update(poolIdx, withMarker, prevPools);
+        }
+      } else {
+        return prevPools;
+      }
+    });
+  };
+
+  const resetFormState = () => {
+    updatePools(cluster.node_pools);
+  };
+
+  const updatePool = (poolIdx: number, updatedPool: PoolNodeWithPrice) => {
+    const updatedPoolWithPrice = {
+      ...updatedPool,
+      totalMonthlyPrice: getMonthlyPrice(
+        updatedPool.type,
+        updatedPool.count,
+        typesData || []
+      )
+    };
+    updatePools(prevPools => update(poolIdx, updatedPoolWithPrice, prevPools));
+  };
+
+  return (
+    <>
+      <Grid item xs={12}>
+        <NodePoolsDisplay
+          submittingForm={submitting}
+          submitForm={submitForm}
+          submissionSuccess={success}
+          submissionError={generalError}
+          submitDisabled={submitDisabled}
+          editing={true}
+          updatePool={updatePool}
+          deletePool={handleDeletePool}
+          resetForm={resetFormState}
+          pools={cluster.node_pools}
+          poolsForEdit={pools}
+          types={typesData || []}
+          loading={nodePoolsLoading}
+        />
+      </Grid>
+      <Grid item xs={12}>
+        <NodePoolPanel
+          hideTable
+          selectedType={selectedType}
+          types={typesData || []}
+          nodeCount={count}
+          addNodePool={handleAddNodePool}
+          handleTypeSelect={newType => setSelectedType(newType)}
+          updateNodeCount={newCount => setCount(newCount)}
+          typesLoading={typesLoading}
+          typesError={
+            typesError
+              ? getAPIErrorOrDefault(
+                  typesError,
+                  'Error loading Linode type information.'
+                )[0].reason
+              : undefined
+          }
+        />
+        <Grid item xs={12} className={classes.deleteSection}>
+          <Button
+            destructive
+            buttonType="secondary"
+            onClick={openDeleteConfirmation}
+          >
+            Delete Cluster
+          </Button>
+        </Grid>
+      </Grid>
+
+      <KubernetesDialog
+        open={confirmationOpen}
+        loading={deleting}
+        error={path([0, 'reason'], props.clusterDeleteError)}
+        clusterLabel={cluster.label}
+        clusterPools={cluster.node_pools}
+        onClose={() => setConfirmation(false)}
+        onDelete={handleDeleteCluster}
+      />
+    </>
+  );
 };
 
 export default ResizeCluster;


### PR DESCRIPTION
## Description

Please note this includes work from this [PR](https://github.com/linode/manager/pull/5728) so that needs to be merged first. This PR focuses on the /details tab, which includes a modified "view only" version of node pools details and a documentation blurb. 

## Type of Change
- Non breaking change ('change')
