### PR TITLE
Fix LKE Routing

### DIFF
--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -343,7 +343,11 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
       {
         conditionToAdd: () => isKubernetesEnabled(accountCapabilities),
         insertAfter: 'Longview',
-        link: { display: 'Kubernetes', href: '/kubernetes', key: 'kubernetes' }
+        link: {
+          display: 'Kubernetes',
+          href: '/kubernetes/clusters',
+          key: 'kubernetes'
+        }
       },
       {
         conditionToAdd: () => flags.oneClickLocation === 'sidenav',

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DetailNavigation.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/DetailNavigation.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { matchPath, Route, Switch } from 'react-router-dom';
+import { matchPath, Redirect, Route, Switch } from 'react-router-dom';
 import AppBar from 'src/components/core/AppBar';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Tab from 'src/components/core/Tab';
@@ -83,6 +83,7 @@ export const DetailNavigation: React.FC<ResizeProps> = props => {
           path={`${url}/details`}
           render={() => <Details {...props} />}
         />
+        <Redirect to={`${url}/details`} />
       </Switch>
     </>
   );

--- a/packages/manager/src/features/Kubernetes/index.tsx
+++ b/packages/manager/src/features/Kubernetes/index.tsx
@@ -33,8 +33,8 @@ class Kubernetes extends React.Component<Props> {
       <Switch>
         <Route component={ClusterCreate} exact path={`${path}/create`} />
         <Route component={ClusterDetail} path={`${path}/clusters/:clusterID`} />
-        <Route component={KubernetesLanding} exact path={path} />
-        <Redirect to={'/kubernetes'} />
+        <Route component={KubernetesLanding} exact path={`${path}/clusters`} />
+        <Redirect to={'/kubernetes/clusters'} />
       </Switch>
     );
   }


### PR DESCRIPTION
## Description

- Add a Redirect to the new details navigation page, so that clicking
on a cluster from the list view will go to kubernetes/clusters/xxx/details,
rather than kubernetes/clusters/xxx/ with the details tab mysteriously active.

- Fix a longstanding issue where the clusters view was at /kubernetes with
the detail view at /kubernetes/clusters/xxx. Navigating to Kubernetes now
takes you straight to the list view at /kubernetes/clusters, which matches
Object Storage's pattern.
