### PR TITLE
Separate LKE Cluster Details and Resize into two nested tabs: Details Page

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/Details.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/Details.tsx
@@ -1,7 +1,117 @@
 import * as React from 'react';
 
-export const Details: React.FC<{}> = props => {
-  return <h1>Hello world2</h1>;
+import LibraryBook from 'src/assets/icons/guides.svg';
+import Grid from 'src/components/core/Grid';
+import Paper from 'src/components/core/Paper';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
+import ExternalLink from 'src/components/ExternalLink';
+import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
+import NodePoolsDisplay from './NodePoolsDisplay';
+
+import { ExtendedCluster, PoolNodeWithPrice } from '.././types';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  docsWrapper: {
+    padding: theme.spacing(3),
+    margin: `${theme.spacing(3)}px 0`
+  },
+  docsIcon: {
+    width: 24,
+    position: 'relative',
+    top: 2,
+    marginRight: 8,
+    color: theme.color.headline
+  },
+  docsHeaderWrapper: {
+    marginBottom: theme.spacing(2)
+  },
+  post: {
+    marginBottom: theme.spacing(1) / 2
+  }
+}));
+
+interface Props {
+  cluster: ExtendedCluster;
+  nodePoolsLoading: boolean;
+  typesData?: ExtendedType[];
+}
+
+export type CombinedProps = Props;
+
+export const Details: React.FC<Props> = props => {
+  const classes = useStyles();
+  const { cluster, nodePoolsLoading, typesData } = props;
+
+  if (!cluster) {
+    return null;
+  }
+
+  /** Holds the local state of the cluster's node pools when editing */
+  const [pools] = React.useState<PoolNodeWithPrice[]>(cluster.node_pools || []);
+
+  const links = [
+    {
+      href:
+        'https://www.linode.com/docs/applications/containers/kubernetes/how-to-deploy-a-cluster-with-lke/',
+      title: 'Deploying LKE',
+      idx: 1
+    },
+    {
+      href:
+        'https://www.linode.com/docs/applications/containers/kubernetes/troubleshooting-kubernetes/',
+      title: 'Troubleshooting Kubernetes',
+      idx: 2
+    },
+    {
+      href:
+        'https://www.linode.com/docs/applications/containers/kubernetes/beginners-guide-to-kubernetes/',
+      title: "Beginner's Guide to Kubernetes",
+      idx: 3
+    }
+  ];
+
+  return (
+    <>
+      <Grid item xs={12}>
+        <NodePoolsDisplay
+          editing={false}
+          pools={cluster.node_pools}
+          poolsForEdit={pools}
+          types={typesData || []}
+          loading={nodePoolsLoading}
+        />
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <Paper className={classes.docsWrapper}>
+          <Grid
+            container
+            item
+            direction="row"
+            justify="flex-start"
+            alignItems="center"
+            className={classes.docsHeaderWrapper}
+          >
+            <Grid item>
+              <LibraryBook className={classes.docsIcon} />
+            </Grid>
+            <Grid item>
+              <Typography variant="h3">Additional Guides</Typography>
+            </Grid>
+          </Grid>
+          <Grid item>
+            {links.map(link => (
+              <div key={link.idx}>
+                <Typography variant="body1" className={classes.post}>
+                  <ExternalLink link={link.href} text={link.title} />
+                </Typography>
+              </div>
+            ))}
+          </Grid>
+        </Paper>
+      </Grid>
+    </>
+  );
 };
 
 export default Details;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/Details.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/Details.tsx
@@ -9,7 +9,7 @@ import ExternalLink from 'src/components/ExternalLink';
 import { ExtendedType } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';
 import NodePoolsDisplay from './NodePoolsDisplay';
 
-import { ExtendedCluster, PoolNodeWithPrice } from '.././types';
+import { ExtendedCluster } from '.././types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   docsWrapper: {
@@ -47,9 +47,6 @@ export const Details: React.FC<Props> = props => {
     return null;
   }
 
-  /** Holds the local state of the cluster's node pools when editing */
-  const [pools] = React.useState<PoolNodeWithPrice[]>(cluster.node_pools || []);
-
   const links = [
     {
       href:
@@ -77,7 +74,7 @@ export const Details: React.FC<Props> = props => {
         <NodePoolsDisplay
           editing={false}
           pools={cluster.node_pools}
-          poolsForEdit={pools}
+          poolsForEdit={[]}
           types={typesData || []}
           loading={nodePoolsLoading}
         />

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -56,7 +56,9 @@ const styles = (theme: Theme) =>
       },
       padding: 0
     },
-    section: {},
+    section: {
+      alignItems: 'flex-start'
+    },
     panelItem: {},
     button: {
       marginBottom: theme.spacing(3),

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/NodePoolsDisplay/NodePoolsDisplay.tsx
@@ -85,18 +85,18 @@ const styles = (theme: Theme) =>
 
 interface Props {
   editing: boolean;
-  submittingForm: boolean;
-  submissionSuccess: boolean;
+  submittingForm?: boolean;
+  submissionSuccess?: boolean;
   submissionError?: APIError[];
   pools: PoolNodeWithPrice[];
   poolsForEdit: PoolNodeWithPrice[];
   types: ExtendedType[];
   loading: boolean;
   submitDisabled?: boolean;
-  updatePool: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
-  deletePool: (poolID: number) => void;
-  resetForm: () => void;
-  submitForm: () => void;
+  updatePool?: (poolIdx: number, updatedPool: PoolNodeWithPrice) => void;
+  deletePool?: (poolID: number) => void;
+  resetForm?: () => void;
+  submitForm?: () => void;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;


### PR DESCRIPTION
## Description

This PR focuses on the /details tab, which includes a modified "view only" version of node pools details and a documentation blurb. 

## Type of Change
- Non breaking change ('change')
