### PR TITLE
Hotfix: Safe access event.secondary_entity

### DIFF
--- a/packages/manager/src/eventMessageGenerator.test.ts
+++ b/packages/manager/src/eventMessageGenerator.test.ts
@@ -71,6 +71,13 @@ describe('Event message generation', () => {
           'booted'
         )
       ).toMatch('booted');
+      expect(
+        safeSecondaryEntityLabel(
+          mockEventWithoutSecondaryEntity,
+          'booted with',
+          'booted'
+        )
+      ).not.toMatch('booted with');
     });
   });
 });

--- a/packages/manager/src/eventMessageGenerator.test.ts
+++ b/packages/manager/src/eventMessageGenerator.test.ts
@@ -1,44 +1,76 @@
 import { Event } from 'linode-js-sdk/lib/account';
-import getEventMessage, { eventMessageCreators } from './eventMessageGenerator';
+import { entityFactory, eventFactory } from 'src/factories/events';
+import getEventMessage, {
+  eventMessageCreators,
+  safeSecondaryEntityLabel
+} from './eventMessageGenerator';
 
-describe('getEventMessage', () => {
-  it('should filter unknown events', () => {
-    const mockEvent = {
-      action: '__unknown__',
-      status: 'started'
-    };
-    const result = getEventMessage(mockEvent as Event);
+describe('Event message generation', () => {
+  describe('getEventMessage', () => {
+    it('should filter unknown events', () => {
+      const mockEvent = {
+        action: '__unknown__',
+        status: 'started'
+      };
+      const result = getEventMessage(mockEvent as Event);
 
-    expect(result).toBe('__unknown__');
+      expect(result).toBe('__unknown__');
+    });
+
+    it('should filter mangled events', () => {
+      const mockEvent = {
+        action: 'linode_reboot',
+        status: 'scheduled',
+        entity: null
+      };
+      const result = getEventMessage(mockEvent as Event);
+
+      expect(result).toBe('');
+    });
+
+    it('should call the message generator with the event', () => {
+      const mockEvent = {
+        action: 'linode_reboot',
+        status: 'scheduled',
+        entity: { label: 'test-linode-123' }
+      };
+
+      /** Mock the message creator */
+      eventMessageCreators.linode_reboot.scheduled = jest.fn();
+
+      /** Invoke the function. */
+      getEventMessage(mockEvent as Event);
+
+      /** Check that the mocked creator was called w/ the mock event. */
+      expect(eventMessageCreators.linode_reboot.scheduled).toHaveBeenCalledWith(
+        mockEvent
+      );
+    });
   });
 
-  it('should filter mangled events', () => {
-    const mockEvent = {
-      action: 'linode_reboot',
-      status: 'scheduled',
-      entity: null
-    };
-    const result = getEventMessage(mockEvent as Event);
+  describe('safeSecondaryEventLabel', () => {
+    it('should return a correct message if the secondary entity is present', () => {
+      const mockEventWithSecondaryEntity = eventFactory.build({
+        secondary_entity: entityFactory.build({ label: 'secondary-entity' })
+      });
+      expect(
+        safeSecondaryEntityLabel(
+          mockEventWithSecondaryEntity,
+          'booted with',
+          'booted'
+        )
+      ).toMatch('booted with secondary-entity');
+    });
 
-    expect(result).toBe('');
-  });
-
-  it('should call the message generator with the event', () => {
-    const mockEvent = {
-      action: 'linode_reboot',
-      status: 'scheduled',
-      entity: { label: 'test-linode-123' }
-    };
-
-    /** Mock the message creator */
-    eventMessageCreators.linode_reboot.scheduled = jest.fn();
-
-    /** Invoke the function. */
-    getEventMessage(mockEvent as Event);
-
-    /** Check that the mocked creator was called w/ the mock event. */
-    expect(eventMessageCreators.linode_reboot.scheduled).toHaveBeenCalledWith(
-      mockEvent
-    );
+    it('should return a safe default if the secondary entity is null', () => {
+      const mockEventWithoutSecondaryEntity = eventFactory.build();
+      expect(
+        safeSecondaryEntityLabel(
+          mockEventWithoutSecondaryEntity,
+          'booted with',
+          'booted'
+        )
+      ).toMatch('booted');
+    });
   });
 });

--- a/packages/manager/src/eventMessageGenerator.ts
+++ b/packages/manager/src/eventMessageGenerator.ts
@@ -13,6 +13,15 @@ interface CreatorsForStatus {
   notification?: EventMessageCreator;
 }
 
+export const safeSecondaryEntityLabel = (
+  e: Event,
+  text: string,
+  fallback: string = ''
+) => {
+  const label = path<string>(['secondary_entity', 'label'], e);
+  return label ? `${text} ${label}` : fallback;
+};
+
 /** @see https://leo.stcloudstate.edu/grammar/tenses.html */
 export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   account_update: {
@@ -136,21 +145,29 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   linode_boot: {
     scheduled: e =>
-      `Linode ${e.entity!.label} is scheduled to boot with config ${
-        e.secondary_entity!.label
-      }.`,
+      `Linode ${e.entity!.label} is scheduled to ${safeSecondaryEntityLabel(
+        e,
+        'boot with config',
+        'boot'
+      )}.`,
     started: e =>
-      `Linode ${e.entity!.label} is being booted with config ${
-        e.secondary_entity!.label
-      }.`,
+      `Linode ${e.entity!.label} is being ${safeSecondaryEntityLabel(
+        e,
+        'booted with config',
+        'booted'
+      )}.`,
     failed: e =>
-      `Linode ${e.entity!.label} could not be booted with config ${
-        e.secondary_entity!.label
-      }.`,
+      `Linode ${e.entity!.label} could not be ${safeSecondaryEntityLabel(
+        e,
+        'booted with config',
+        'booted'
+      )}.`,
     finished: e =>
-      `Linode ${e.entity!.label} has been booted with config ${
-        e.secondary_entity!.label
-      }.`
+      `Linode ${e.entity!.label} has been ${safeSecondaryEntityLabel(
+        e,
+        'booted with config',
+        'booted'
+      )}.`
   },
   lassie_reboot: {
     scheduled: e =>
@@ -180,7 +197,7 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
     failed: e =>
       `Linode ${e.entity!.label} could not be booted (Host initiated restart).`,
     finished: e =>
-      `Linode ${e.entity!.label} has booted (Host initiated restart).`
+      `Linode ${e.entity!.label} has been booted (Host initiated restart).`
   },
   ipaddress_update: {
     notification: e => `An IP address has been updated on your account.`
@@ -192,7 +209,8 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
       `Linode ${e.entity!.label} is being booted (Lish initiated boot).`,
     failed: e =>
       `Linode ${e.entity!.label} could not be booted (Lish initiated boot).`,
-    finished: e => `Linode ${e.entity!.label} has booted (Lish initiated boot).`
+    finished: e =>
+      `Linode ${e.entity!.label} has been booted (Lish initiated boot).`
   },
   linode_clone: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled to be cloned.`,
@@ -251,21 +269,29 @@ export const eventMessageCreators: { [index: string]: CreatorsForStatus } = {
   },
   linode_reboot: {
     scheduled: e =>
-      `Linode ${e.entity!.label} is scheduled for a reboot with config ${
-        e.secondary_entity!.label
-      }.`,
+      `Linode ${e.entity!.label} is scheduled ${safeSecondaryEntityLabel(
+        e,
+        'for a reboot with config',
+        'for a reboot'
+      )}.`,
     started: e =>
-      `Linode ${e.entity!.label} is being rebooted with config ${
-        e.secondary_entity!.label
-      }.`,
+      `Linode ${e.entity!.label} is being ${safeSecondaryEntityLabel(
+        e,
+        'rebooted with config',
+        'rebooted'
+      )}.`,
     failed: e =>
-      `Linode ${e.entity!.label} could not be rebooted with config ${
-        e.secondary_entity!.label
-      }.`,
+      `Linode ${e.entity!.label} could not be ${safeSecondaryEntityLabel(
+        e,
+        'rebooted with config',
+        'rebooted'
+      )}.`,
     finished: e =>
-      `Linode ${e.entity!.label} has been rebooted with config ${
-        e.secondary_entity!.label
-      }.`
+      `Linode ${e.entity!.label} has been ${safeSecondaryEntityLabel(
+        e,
+        'rebooted with config',
+        'rebooted'
+      )}.`
   },
   linode_rebuild: {
     scheduled: e => `Linode ${e.entity!.label} is scheduled for rebuild.`,

--- a/packages/manager/src/factories/events.ts
+++ b/packages/manager/src/factories/events.ts
@@ -1,0 +1,24 @@
+import * as Factory from 'factory.ts';
+import { Entity, Event } from 'linode-js-sdk/lib/account/types';
+
+export const entityFactory = Factory.Sync.makeFactory<Entity>({
+  id: Factory.each(id => id),
+  label: Factory.each(i => `event-entity-${i}`),
+  type: 'linode',
+  url: 'https://www.example.com'
+});
+
+export const eventFactory = Factory.Sync.makeFactory<Event>({
+  id: Factory.each(id => id),
+  created: new Date().toDateString(),
+  entity: null,
+  secondary_entity: null,
+  status: 'started',
+  rate: null,
+  username: 'prod-test-001',
+  seen: false,
+  read: false,
+  action: 'linode_boot',
+  percent_complete: 10,
+  time_remaining: 0
+});


### PR DESCRIPTION
## Description

I assumed that all events would come back with a secondary_entity,
but events created prior to this change were not updated. This caused
a lot of noise in Sentry (millions of reported exceptions) since we
weren't safe accessing the field.

Added a helper method, safeSecondaryEntityLabel, which handles this.

We should revisit this logic, since it gets pretty repetitive.