### PR TITLE
M3-3577 Add option to allow only first and last crumbs in breadcrumbs

### DIFF
--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -73,6 +73,13 @@ storiesOf('Breadcrumb', module)
       </div>
     </StaticRouter>
   ))
+  .add('Breadcrumb with only first and last crumbs', () => (
+    <StaticRouter location="/" context={{}}>
+      <div style={{ padding: 24 }}>
+        <Breadcrumb pathname={customCrumbs} firstAndLastOnly />
+      </div>
+    </StaticRouter>
+  ))
   .add('Breadcrumb with a crumb removed', () => (
     <StaticRouter location="/" context={{}}>
       <div style={{ padding: 24 }}>

--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
@@ -10,6 +10,7 @@ export interface Props {
   labelOptions?: LabelProps;
   onEditHandlers?: EditableProps;
   removeCrumbX?: number;
+  firstAndLastOnly?: boolean;
   crumbOverrides?: CrumbOverridesProps[];
   className?: string;
   pathname: string;
@@ -41,6 +42,7 @@ export const Breadcrumb: React.FC<CombinedProps> = props => {
     labelOptions,
     onEditHandlers,
     removeCrumbX,
+    firstAndLastOnly,
     crumbOverrides,
     className,
     pathname
@@ -67,6 +69,7 @@ export const Breadcrumb: React.FC<CombinedProps> = props => {
           crumbOverrides={crumbOverrides}
           labelTitle={labelTitle}
           labelOptions={labelOptions}
+          firstAndLastOnly={firstAndLastOnly}
         />
       </div>
     </div>

--- a/packages/manager/src/components/Breadcrumb/Crumbs.tsx
+++ b/packages/manager/src/components/Breadcrumb/Crumbs.tsx
@@ -71,7 +71,8 @@ const Crumbs: React.FC<CombinedProps> = props => {
   const allCrumbsButLast = pathMap.slice(0, -1);
   const firstCrumb = [pathMap[0]];
   const lastCrumb = pathMap.slice(-1)[0];
-  const finalCrumbs = firstAndLastOnly ? firstCrumb : allCrumbsButLast;
+  const finalCrumbs =
+    firstAndLastOnly && pathMap.length > 1 ? firstCrumb : allCrumbsButLast;
 
   return (
     <>

--- a/packages/manager/src/components/Breadcrumb/Crumbs.tsx
+++ b/packages/manager/src/components/Breadcrumb/Crumbs.tsx
@@ -48,6 +48,7 @@ export interface CrumbOverridesProps {
 interface Props {
   pathMap: string[];
   crumbOverrides?: CrumbOverridesProps[];
+  firstAndLastOnly?: boolean;
   labelTitle?: string;
   labelOptions?: LabelProps;
   onEditHandlers?: EditableProps;
@@ -61,17 +62,20 @@ const Crumbs: React.FC<CombinedProps> = props => {
   const {
     pathMap,
     crumbOverrides,
+    firstAndLastOnly,
     labelOptions,
     labelTitle,
     onEditHandlers
   } = props;
 
   const allCrumbsButLast = pathMap.slice(0, -1);
+  const firstCrumb = [pathMap[0]];
   const lastCrumb = pathMap.slice(-1)[0];
+  const finalCrumbs = firstAndLastOnly ? firstCrumb : allCrumbsButLast;
 
   return (
     <>
-      {allCrumbsButLast.map((crumb: string, key: number) => {
+      {finalCrumbs.map((crumb: string, key: number) => {
         const link =
           '/' + pathMap.slice(0, -(pathMap.length - (key + 1))).join('/');
         const override =


### PR DESCRIPTION
## Add option to allow only first and last crumbs in breadcrumbs

In order to make the breadcrumb component more versatile, we wanted to be able to only keep the first and last crumbs and keep the component as simple as possible for basic usage. Instead of enhancing the `removeCrumbX` prop with an array, doing it this way will satisfy most use cases.

This will not affect any existing crumb unless the `firstAndLastOnly` prop is set

## Type of Change
- Non breaking change ('update', 'change')

