### PR TITLE
LKE Fix: node pool deletion

### DIFF
--- a/packages/manager/src/containers/kubernetes.container.ts
+++ b/packages/manager/src/containers/kubernetes.container.ts
@@ -23,7 +23,6 @@ import {
 import {
   CreateNodePoolParams,
   DeleteNodePoolParams,
-  ExtendedNodePool,
   UpdateNodePoolParams
 } from 'src/store/kubernetes/nodePools.actions';
 import {
@@ -82,8 +81,7 @@ type MapProps<ReduxStateProps, OwnProps> = (
   lastUpdated: number,
   clustersError: EntityError,
   clusters: KubernetesCluster[],
-  nodePoolsLoading: boolean,
-  nodePoolsData: ExtendedNodePool[]
+  nodePoolsLoading: boolean
 ) => ReduxStateProps & Partial<KubernetesProps>;
 
 export type Props = DispatchProps & KubernetesProps;
@@ -120,7 +118,6 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
       const nodePoolsLoading =
         state.__resources.nodePools.loading &&
         state.__resources.nodePools.lastUpdated === 0;
-      const nodePoolsData = nodePools;
 
       if (mapKubernetesToProps) {
         return mapKubernetesToProps(
@@ -129,8 +126,7 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
           lastUpdated,
           clustersError,
           clusters,
-          nodePoolsLoading,
-          nodePoolsData
+          nodePoolsLoading
         );
       }
 
@@ -139,8 +135,7 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
         lastUpdated,
         clustersError,
         clusters,
-        nodePoolsLoading,
-        nodePoolsData
+        nodePoolsLoading
       };
     },
     mapDispatchToProps

--- a/packages/manager/src/containers/kubernetes.container.ts
+++ b/packages/manager/src/containers/kubernetes.container.ts
@@ -23,6 +23,7 @@ import {
 import {
   CreateNodePoolParams,
   DeleteNodePoolParams,
+  ExtendedNodePool,
   UpdateNodePoolParams
 } from 'src/store/kubernetes/nodePools.actions';
 import {
@@ -43,7 +44,7 @@ export interface KubernetesProps {
 
 export interface DispatchProps {
   requestKubernetesClusters: () => Promise<any>;
-  requestClusterForStore: (clusterID: number) => void;
+  requestClusterForStore: (clusterID: number) => Promise<any>;
   requestNodePools: (clusterID: number) => Promise<any>;
   updateCluster: (params: UpdateClusterParams) => Promise<KubernetesCluster>;
   createNodePool: (params: CreateNodePoolParams) => Promise<any>;
@@ -81,7 +82,8 @@ type MapProps<ReduxStateProps, OwnProps> = (
   lastUpdated: number,
   clustersError: EntityError,
   clusters: KubernetesCluster[],
-  nodePoolsLoading: boolean
+  nodePoolsLoading: boolean,
+  nodePoolsData: ExtendedNodePool[]
 ) => ReduxStateProps & Partial<KubernetesProps>;
 
 export type Props = DispatchProps & KubernetesProps;
@@ -117,7 +119,8 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
       const lastUpdated = state.__resources.kubernetes.lastUpdated;
       const nodePoolsLoading =
         state.__resources.nodePools.loading &&
-        state.__resources.nodePools.entities.length === 0;
+        state.__resources.nodePools.lastUpdated === 0;
+      const nodePoolsData = nodePools;
 
       if (mapKubernetesToProps) {
         return mapKubernetesToProps(
@@ -126,7 +129,8 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
           lastUpdated,
           clustersError,
           clusters,
-          nodePoolsLoading
+          nodePoolsLoading,
+          nodePoolsData
         );
       }
 
@@ -135,7 +139,8 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
         lastUpdated,
         clustersError,
         clusters,
-        nodePoolsLoading
+        nodePoolsLoading,
+        nodePoolsData
       };
     },
     mapDispatchToProps

--- a/packages/manager/src/containers/kubernetes.container.ts
+++ b/packages/manager/src/containers/kubernetes.container.ts
@@ -42,8 +42,8 @@ export interface KubernetesProps {
 }
 
 export interface DispatchProps {
-  requestKubernetesClusters: () => Promise<any>;
-  requestClusterForStore: (clusterID: number) => Promise<any>;
+  requestKubernetesClusters: () => Promise<KubernetesCluster[]>;
+  requestClusterForStore: (clusterID: number) => Promise<KubernetesCluster>;
   requestNodePools: (clusterID: number) => Promise<any>;
   updateCluster: (params: UpdateClusterParams) => Promise<KubernetesCluster>;
   createNodePool: (params: CreateNodePoolParams) => Promise<any>;

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -18,6 +18,8 @@ import ErrorState from 'src/components/ErrorState';
 import KubeContainer, {
   DispatchProps
 } from 'src/containers/kubernetes.container';
+import { ExtendedNodePool } from 'src/store/kubernetes/nodePools.actions';
+
 import withTypes, { WithTypesProps } from 'src/containers/types.container';
 
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
@@ -96,6 +98,7 @@ interface KubernetesContainerProps {
   clusterDeleteError?: APIError[];
   lastUpdated: number;
   nodePoolsLoading: boolean;
+  nodePoolsData: ExtendedNodePool[];
 }
 
 type CombinedProps = WithTypesProps &
@@ -126,7 +129,7 @@ export const KubernetesClusterDetail: React.FunctionComponent<
   React.useEffect(() => {
     const clusterID = +props.match.params.clusterID;
     if (clusterID) {
-      props.requestClusterForStore(clusterID);
+      props.requestClusterForStore(clusterID).catch(_ => null); // Handle in Redux
       // The cluster endpoint has its own API...uh, endpoint, so we need
       // to request it separately.
       setEndpointLoading(true);
@@ -265,7 +268,8 @@ const withCluster = KubeContainer<
     lastUpdated,
     clustersError,
     clustersData,
-    nodePoolsLoading
+    nodePoolsLoading,
+    nodePoolsData
   ) => {
     const cluster =
       clustersData.find(c => +c.id === +ownProps.match.params.clusterID) ||
@@ -277,7 +281,8 @@ const withCluster = KubeContainer<
       clustersLoading,
       clustersLoadError: clustersError.read,
       clusterDeleteError: clustersError.delete,
-      nodePoolsLoading
+      nodePoolsLoading,
+      nodePoolsData
     };
   }
 );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -18,7 +18,6 @@ import ErrorState from 'src/components/ErrorState';
 import KubeContainer, {
   DispatchProps
 } from 'src/containers/kubernetes.container';
-import { ExtendedNodePool } from 'src/store/kubernetes/nodePools.actions';
 
 import withTypes, { WithTypesProps } from 'src/containers/types.container';
 

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -98,7 +98,6 @@ interface KubernetesContainerProps {
   clusterDeleteError?: APIError[];
   lastUpdated: number;
   nodePoolsLoading: boolean;
-  nodePoolsData: ExtendedNodePool[];
 }
 
 type CombinedProps = WithTypesProps &
@@ -268,8 +267,7 @@ const withCluster = KubeContainer<
     lastUpdated,
     clustersError,
     clustersData,
-    nodePoolsLoading,
-    nodePoolsData
+    nodePoolsLoading
   ) => {
     const cluster =
       clustersData.find(c => +c.id === +ownProps.match.params.clusterID) ||
@@ -281,8 +279,7 @@ const withCluster = KubeContainer<
       clustersLoading,
       clustersLoadError: clustersError.read,
       clusterDeleteError: clustersError.delete,
-      nodePoolsLoading,
-      nodePoolsData
+      nodePoolsLoading
     };
   }
 );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeCluster.tsx
@@ -119,7 +119,7 @@ export const ResizeCluster: React.FC<ResizeProps> = props => {
 
   const handleDeleteSuccess = (pool: PoolNodeWithPrice) => {
     const poolIdx = pools.findIndex(thisPool => thisPool.id === pool.id);
-    if (poolIdx) {
+    if (poolIdx > -1) {
       updatePools(prevPools => {
         return remove(poolIdx, 1, prevPools);
       });

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/ResizeCluster.tsx
@@ -8,7 +8,6 @@ import Grid from 'src/components/core/Grid';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import { DispatchProps } from 'src/containers/kubernetes.container';
 import { WithTypesProps } from 'src/containers/types.container';
-import { ExtendedNodePool } from 'src/store/kubernetes/nodePools.actions';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import scrollTo from 'src/utilities/scrollTo';
 import { addPriceToNodePool, getMonthlyPrice } from '.././kubeUtils';
@@ -28,7 +27,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   cluster: ExtendedCluster;
   nodePoolsLoading: boolean;
-  nodePoolsData: ExtendedNodePool[];
   clusterDeleteError?: APIError[];
 }
 

--- a/packages/manager/src/features/Kubernetes/kubeUtils.ts
+++ b/packages/manager/src/features/Kubernetes/kubeUtils.ts
@@ -21,6 +21,14 @@ export const getTotalClusterPrice = (pools: PoolNodeWithPrice[]) =>
       : accumulator + node.totalMonthlyPrice;
   }, 0);
 
+export const addPriceToNodePool = (
+  pool: ExtendedPoolNode,
+  typesData: LinodeType[]
+) => ({
+  ...pool,
+  totalMonthlyPrice: getMonthlyPrice(pool.type, pool.count, typesData)
+});
+
 /**
  * Usually when displaying or editing clusters, we need access
  * to pricing information as well as statistics, which aren't
@@ -32,20 +40,10 @@ export const extendCluster = (
   types: LinodeType[]
 ): ExtendedCluster => {
   // Identify which pools belong to this cluster and add pricing information.
-  const _pools = pools.reduce((accumulator, thisPool) => {
+  const _pools = pools.reduce((accum, thisPool) => {
     return thisPool.clusterID === cluster.id
-      ? [
-          ...accumulator,
-          {
-            ...thisPool,
-            totalMonthlyPrice: getMonthlyPrice(
-              thisPool.type,
-              thisPool.count,
-              types
-            )
-          }
-        ]
-      : accumulator;
+      ? [...accum, addPriceToNodePool(thisPool, types)]
+      : accum;
   }, []);
   const { CPU, RAM } = getTotalClusterMemoryAndCPU(_pools, types);
   return {

--- a/packages/manager/src/store/kubernetes/kubernetes.reducer.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.reducer.ts
@@ -111,6 +111,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       draft.loading = false;
       draft.entities = entities;
       draft.results = entities.map(cluster => cluster.id);
+      draft.lastUpdated = Date.now();
     }
 
     if (isType(action, requestClusterActions.failed)) {

--- a/packages/manager/src/store/kubernetes/kubernetes.requests.ts
+++ b/packages/manager/src/store/kubernetes/kubernetes.requests.ts
@@ -44,20 +44,25 @@ export const requestKubernetesClusters: ThunkActionCreator<
     });
 };
 
-type RequestClusterForStoreThunk = ThunkActionCreator<void, number>;
+type RequestClusterForStoreThunk = ThunkActionCreator<
+  Promise<KubernetesCluster>,
+  number
+>;
 export const requestClusterForStore: RequestClusterForStoreThunk = clusterID => dispatch => {
   dispatch(requestClusterActions.started({ clusterID }));
-  getKubernetesCluster(clusterID)
+  return getKubernetesCluster(clusterID)
     .then(cluster => {
       dispatch(requestNodePoolsForCluster({ clusterID }));
-      return dispatch(
+      dispatch(
         requestClusterActions.done({ result: cluster, params: { clusterID } })
       );
+      return cluster;
     })
     .catch(err => {
       dispatch(
         requestClusterActions.failed({ error: err, params: { clusterID } })
       );
+      return Promise.reject(err);
     });
 };
 

--- a/packages/manager/src/store/kubernetes/nodePools.reducer.ts
+++ b/packages/manager/src/store/kubernetes/nodePools.reducer.ts
@@ -70,6 +70,7 @@ const reducer: Reducer<State> = (state = defaultState, action) => {
       draft.entities.push(result);
       draft.results.push(result.id);
       draft.error!.create = undefined;
+      draft.lastUpdated = Date.now();
     }
 
     if (isType(action, createNodePoolActions.failed)) {


### PR DESCRIPTION
## Description

Found a few cases where the node pools table wasn't accurately reflecting the new state of the cluster after submitting the form. Added a .then thingy that re-requests the node pools from the API after all the update/delete/create requests have finished. (This wasn't necessary in the previous iteration since after submission we exited "edit mode", so the table always had the updated state.)

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

Try a bunch of combinations of update/edit/delete on the node pools table, with and without some request blocking going on.