### PR TITLE
Longview: Update documentation link URL

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewLanding.tsx
@@ -63,7 +63,10 @@ export const LongviewLanding: React.FunctionComponent<
           labelTitle="Longview"
           removeCrumbX={1}
         />
-        <DocumentationButton href={'https://google.com'} />
+        <DocumentationButton
+          /** This URL points to the old guide until the update is live */
+          href={'https://www.linode.com/docs/platform/longview/longview/'}
+        />
       </Box>
       <AppBar position="static" color="default">
         <Tabs


### PR DESCRIPTION
## Description

The link points to the current (old) version of the doc, but will be updated to the new doc when it's done.
