### PR TITLE
Change: Stop Reporting OAuth and Not Found Errors To Sentry

### DIFF
--- a/packages/manager/src/events.ts
+++ b/packages/manager/src/events.ts
@@ -21,6 +21,7 @@ import {
 } from 'src/store/events/event.actions';
 import { resetEventsPolling as _resetEventsPolling } from 'src/store/events/event.helpers';
 import { getEvents } from 'src/store/events/event.request';
+import { ThunkDispatch } from 'src/store/types';
 
 export const events$ = new Subject<Event>();
 
@@ -32,18 +33,20 @@ export const resetEventsPolling = (newPollIteration = 1) => {
 
 export const requestEvents = () => {
   inProgress = true;
-  return store.dispatch(getEvents() as any).then((events: Event[]) => {
-    const reversed = events.reverse();
+  return (store.dispatch as ThunkDispatch)(getEvents())
+    .then((events: Event[]) => {
+      const reversed = events.reverse();
 
-    /**
-     * This feeds the stream for consumers of events$. We're simply pushing the events from the
-     * request response onto the stream one at a time.
-     */
-    reversed.forEach((linodeEvent: Event) => {
-      events$.next(linodeEvent);
-    });
-    inProgress = false;
-  });
+      /**
+       * This feeds the stream for consumers of events$. We're simply pushing the events from the
+       * request response onto the stream one at a time.
+       */
+      reversed.forEach((linodeEvent: Event) => {
+        events$.next(linodeEvent);
+      });
+      inProgress = false;
+    })
+    .catch(e => e);
 };
 
 export const startEventsInterval = () =>


### PR DESCRIPTION
## Description

Stops reporting some of the biggest offenders to Sentry
 
Ideally, we just need to buckle down and `.catch` all the promises in the events middleware, but there's just no time for that.

## Type of Change
- Non breaking change ('update', 'change')

## To Test

Use Charles to mock an API error and then remove a `catch` from some promise. I chose the `updateProfile` request in the `UpdateTimeZoneForm` component - in this example, you'll have to remove the `.catch` in both the component and the redux request.