### PR TITLE
M3-3588 Fix empty volumes create button path

### DIFF
--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -427,7 +427,13 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
   };
 
   renderEmpty = () => {
-    const { linodeConfigs, linodeRegion, readOnly, regionsData } = this.props;
+    const {
+      linodeConfigs,
+      linodeRegion,
+      readOnly,
+      regionsData,
+      fromLinodes
+    } = this.props;
 
     if (
       linodeRegion &&
@@ -474,9 +480,12 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           icon={VolumesIcon}
           buttonProps={[
             {
-              onClick: () => {
-                this.props.history.push('/volumes/create');
-              },
+              onClick: fromLinodes
+                ? this.openCreateVolumeDrawer
+                : () => {
+                    this.props.history.push('/volumes/create');
+                  },
+
               children: 'Add a Volume',
               disabled: readOnly
             }

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -474,7 +474,9 @@ class VolumesLanding extends React.Component<CombinedProps, State> {
           icon={VolumesIcon}
           buttonProps={[
             {
-              onClick: this.openCreateVolumeDrawer,
+              onClick: () => {
+                this.props.history.push('/volumes/create');
+              },
               children: 'Add a Volume',
               disabled: readOnly
             }


### PR DESCRIPTION
## Fix empty volumes create button path

The create a volume button should route to the volume creation page, not the drawer anymore. This is a regression from the workflow refactor.

## Type of Change
- Bug fix ('fix', 'bug')