### PR TITLE
Update LKE landing empty state link to point to new LKE guide

### DIFF
--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
@@ -95,9 +95,8 @@ class ListLinodesEmptyState extends React.Component<PropsWithStyles> {
             Need help getting started?
           </Typography>
           <Typography variant="subtitle1">
-            {/* @todo update link once we have one for LKE */}
             <a
-              href="https://linode.com/docs/getting-started-new-manager/"
+              href="https://www.linode.com/docs/applications/containers/kubernetes/how-to-deploy-a-cluster-with-lke/"
               target="_blank"
               rel="noopener noreferrer"
               className="h-u"


### PR DESCRIPTION
## Description

This link is the same as the one in the new /details view, which means that it's 404'ing at the moment. It (the guide) will be fixed before the beta is public.
