### PR TITLE
Change: Expose Gauges to Fetch LastUpdated Errors

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -13,13 +13,15 @@ import withClientStats, {
 
 interface Props {
   clientID: number;
+  lastUpdatedError?: APIError[];
 }
 
 const CPUGauge: React.FC<Props & LVDataProps> = props => {
   const {
     longviewClientDataLoading: loading,
     longviewClientDataError: error,
-    longviewClientData
+    longviewClientData,
+    lastUpdatedError
   } = props;
 
   const numberOfCores = pathOr(
@@ -37,7 +39,11 @@ const CPUGauge: React.FC<Props & LVDataProps> = props => {
       // doesn't exist or is 0.
       max={100 * numberOfCores}
       value={usedCPU}
-      innerText={innerText(finalUsedCPU || 0, loading, error)}
+      innerText={innerText(
+        finalUsedCPU || 0,
+        loading,
+        error || lastUpdatedError
+      )}
       subTitle={
         <>
           <Typography>

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -5,16 +5,11 @@ import Typography from 'src/components/core/Typography';
 import GaugePercent from 'src/components/GaugePercent';
 import { pluralize } from 'src/utilities/pluralize';
 import { CPU } from '../../request.types';
-import { baseGaugeProps } from './common';
+import { baseGaugeProps, BaseProps as Props } from './common';
 
 import withClientStats, {
   Props as LVDataProps
 } from 'src/containers/longview.stats.container';
-
-interface Props {
-  clientID: number;
-  lastUpdatedError?: APIError[];
-}
 
 const CPUGauge: React.FC<Props & LVDataProps> = props => {
   const {

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
@@ -9,13 +10,15 @@ import { baseGaugeProps } from './common';
 
 interface Props {
   clientID: number;
+  lastUpdatedError?: APIError[];
 }
 
 const LoadGauge: React.FC<Props & LVDataProps> = props => {
   const {
     longviewClientData,
     longviewClientDataLoading: loading,
-    longviewClientDataError: error
+    longviewClientDataError: error,
+    lastUpdatedError
   } = props;
 
   const load = pathOr<number>(0, ['Load', 0, 'y'], longviewClientData);
@@ -29,7 +32,7 @@ const LoadGauge: React.FC<Props & LVDataProps> = props => {
     innerText: string;
     subTitle: JSX.Element | null;
   } => {
-    if (error) {
+    if (error || lastUpdatedError) {
       return {
         innerText: 'Error',
         subTitle: (

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Load.tsx
@@ -1,4 +1,3 @@
-import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
@@ -6,12 +5,7 @@ import GaugePercent from 'src/components/GaugePercent';
 import withClientData, {
   Props as LVDataProps
 } from 'src/containers/longview.stats.container';
-import { baseGaugeProps } from './common';
-
-interface Props {
-  clientID: number;
-  lastUpdatedError?: APIError[];
-}
+import { baseGaugeProps, BaseProps as Props } from './common';
 
 const LoadGauge: React.FC<Props & LVDataProps> = props => {
   const {

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
@@ -1,4 +1,3 @@
-import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -9,12 +8,7 @@ import withClientStats, {
   Props as LVDataProps
 } from 'src/containers/longview.stats.container';
 import { LongviewNetwork } from '../../request.types';
-import { baseGaugeProps } from './common';
-
-interface Props {
-  clientID: number;
-  lastUpdatedError?: APIError[];
-}
+import { baseGaugeProps, BaseProps as Props } from './common';
 
 type CombinedProps = Props & LVDataProps;
 

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Network.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -12,6 +13,7 @@ import { baseGaugeProps } from './common';
 
 interface Props {
   clientID: number;
+  lastUpdatedError?: APIError[];
 }
 
 type CombinedProps = Props & LVDataProps;
@@ -20,7 +22,8 @@ const NetworkGauge: React.FC<CombinedProps> = props => {
   const {
     longviewClientDataLoading: loading,
     longviewClientDataError: error,
-    longviewClientData
+    longviewClientData,
+    lastUpdatedError
   } = props;
 
   const networkUsed = generateUsedNetworkAsBytes(
@@ -31,7 +34,7 @@ const NetworkGauge: React.FC<CombinedProps> = props => {
     innerText: string;
     subTitle: JSX.Element | null;
   } => {
-    if (error) {
+    if (error || lastUpdatedError) {
       return {
         innerText: 'Error',
         subTitle: (

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
@@ -12,13 +13,15 @@ import withClientData, {
 
 interface Props {
   clientID: number;
+  lastUpdatedError?: APIError[];
 }
 
 const RAMGauge: React.FC<Props & LVDataProps> = props => {
   const {
     longviewClientDataError: error,
     longviewClientDataLoading: loading,
-    longviewClientData
+    longviewClientData,
+    lastUpdatedError
   } = props;
 
   const usedMemory = pathOr(
@@ -49,9 +52,9 @@ const RAMGauge: React.FC<Props & LVDataProps> = props => {
     innerText: string;
     subTitle: string | JSX.Element;
   } => {
-    if (loading) {
+    if (error || lastUpdatedError) {
       return {
-        innerText: 'Loading',
+        innerText: 'Error',
         subTitle: (
           <Typography>
             <strong>RAM</strong>
@@ -60,9 +63,9 @@ const RAMGauge: React.FC<Props & LVDataProps> = props => {
       };
     }
 
-    if (error) {
+    if (loading) {
       return {
-        innerText: 'Error',
+        innerText: 'Loading',
         subTitle: (
           <Typography>
             <strong>RAM</strong>

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -1,20 +1,14 @@
-import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
 import GaugePercent from 'src/components/GaugePercent';
-import { baseGaugeProps } from './common';
+import { baseGaugeProps, BaseProps as Props } from './common';
 
 import { readableBytes } from 'src/utilities/unitConversions';
 
 import withClientData, {
   Props as LVDataProps
 } from 'src/containers/longview.stats.container';
-
-interface Props {
-  clientID: number;
-  lastUpdatedError?: APIError[];
-}
 
 const RAMGauge: React.FC<Props & LVDataProps> = props => {
   const {

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
@@ -12,13 +12,15 @@ import { baseGaugeProps } from './common';
 
 interface Props {
   clientID: number;
+  lastUpdatedError?: APIError[];
 }
 
 const StorageGauge: React.FC<Props & LVDataProps> = props => {
   const {
     longviewClientDataError: error,
     longviewClientDataLoading: loading,
-    longviewClientData
+    longviewClientData,
+    lastUpdatedError
   } = props;
 
   const storageInBytes = sumStorage(longviewClientData.Disk);
@@ -35,7 +37,7 @@ const StorageGauge: React.FC<Props & LVDataProps> = props => {
       innerText={innerText(
         readableBytes(usedStorage).formatted,
         loading,
-        error
+        error || lastUpdatedError
       )}
       filledInColor="#F4AC3D"
       subTitle={

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
@@ -8,12 +8,7 @@ import withClientStats, {
 } from 'src/containers/longview.stats.container';
 import { readableBytes } from 'src/utilities/unitConversions';
 import { Disk } from '../../request.types';
-import { baseGaugeProps } from './common';
-
-interface Props {
-  clientID: number;
-  lastUpdatedError?: APIError[];
-}
+import { baseGaugeProps, BaseProps as Props } from './common';
 
 const StorageGauge: React.FC<Props & LVDataProps> = props => {
   const {

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Swap.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Swap.tsx
@@ -1,4 +1,3 @@
-import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
@@ -7,12 +6,7 @@ import withClientData, {
   Props as LVDataProps
 } from 'src/containers/longview.stats.container';
 import { readableBytes } from 'src/utilities/unitConversions';
-import { baseGaugeProps } from './common';
-
-interface Props {
-  clientID: number;
-  lastUpdatedError?: APIError[];
-}
+import { baseGaugeProps, BaseProps as Props } from './common';
 
 const SwapGauge: React.FC<Props & LVDataProps> = props => {
   const {

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Swap.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Swap.tsx
@@ -1,3 +1,4 @@
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import Typography from 'src/components/core/Typography';
@@ -10,13 +11,15 @@ import { baseGaugeProps } from './common';
 
 interface Props {
   clientID: number;
+  lastUpdatedError?: APIError[];
 }
 
 const SwapGauge: React.FC<Props & LVDataProps> = props => {
   const {
     longviewClientDataError: error,
     longviewClientDataLoading: loading,
-    longviewClientData
+    longviewClientData,
+    lastUpdatedError
   } = props;
 
   const freeMemory = pathOr<number>(
@@ -36,9 +39,9 @@ const SwapGauge: React.FC<Props & LVDataProps> = props => {
     innerText: string;
     subTitle: string | JSX.Element;
   } => {
-    if (loading) {
+    if (error || lastUpdatedError) {
       return {
-        innerText: 'Loading',
+        innerText: 'Error',
         subTitle: (
           <Typography>
             <strong>Swap</strong>
@@ -47,9 +50,9 @@ const SwapGauge: React.FC<Props & LVDataProps> = props => {
       };
     }
 
-    if (error) {
+    if (loading) {
       return {
-        innerText: 'Error',
+        innerText: 'Loading',
         subTitle: (
           <Typography>
             <strong>Swap</strong>

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/common.ts
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/common.ts
@@ -1,4 +1,11 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+
 export const baseGaugeProps = {
   height: 110,
   width: '100%'
 };
+
+export interface BaseProps {
+  clientID: number;
+  lastUpdatedError?: APIError[];
+}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -1,4 +1,5 @@
 import Close from '@material-ui/icons/Close';
+import { APIError } from 'linode-js-sdk/lib/types';
 import { pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
@@ -73,9 +74,23 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
   const [lastUpdated, setLastUpdated] = React.useState<number | undefined>(
     undefined
   );
+  const currentLastUpdated = React.useRef(lastUpdated);
+  const [lastUpdatedError, setLastUpdatedError] = React.useState<
+    APIError[] | undefined
+  >();
   const [authed, setAuthed] = React.useState<boolean>(true);
 
   const requestAndSetLastUpdated = () => {
+    /*
+     get the current last updated value 
+
+     This function is called as a closure inside the onMount useEffect
+     so we need to use a ref to get the new value
+    */
+    const { current: newLastUpdated } = currentLastUpdated;
+
+    setLastUpdatedError(undefined);
+
     return getLastUpdated(clientAPIKey)
       .then(response => {
         /*
@@ -84,7 +99,8 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
         */
         if (
           mounted &&
-          (!lastUpdated || pathOr(0, ['updated'], response) > lastUpdated)
+          (typeof newLastUpdated === 'undefined' ||
+            pathOr(0, ['updated'], response) > newLastUpdated)
         ) {
           setLastUpdated(response.updated);
           props.getClientStats(props.clientAPIKey);
@@ -96,11 +112,36 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
          * return an authentication failed error.
          */
         const reason = pathOr('', [0, 'reason'], e);
-        if (mounted && reason.match(/authentication/i)) {
-          setAuthed(false);
+
+        if (mounted) {
+          if (reason.match(/authentication/i)) {
+            setAuthed(false);
+          }
+
+          /* only set lastUpdated error if we haven't already gotten data before */
+          if (typeof newLastUpdated === 'undefined') {
+            setLastUpdatedError(e);
+          }
         }
       });
   };
+
+  React.useEffect(() => {
+    /*
+     update the ref each time the lastUpdate state changes 
+
+     Why not just add lastUpdated as a dependency to the useEffect below?
+     Because we don't want to re-instatiate the setInterval() over and over again
+     but instead just do it once.
+
+     The closure inside the useEffect below needs to know when lastUpdated changes
+     but doesn't necessarily need to be re-defined again. useRef lets us accomplish this
+
+     See: https://github.com/facebook/react/issues/14010#issuecomment-433788147
+     
+    */
+    currentLastUpdated.current = lastUpdated;
+  }, [lastUpdated]);
 
   /** request on first mount */
   React.useEffect(() => {
@@ -152,22 +193,22 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
             <Grid item xs={12} md={9}>
               <Grid container>
                 <Grid item xs={4} sm={2} className={classes.gaugeContainer}>
-                  <CPUGauge clientID={clientID} />
+                  <CPUGauge clientID={clientID} lastUpdatedError={lastUpdatedError} />
                 </Grid>
                 <Grid item xs={4} sm={2} className={classes.gaugeContainer}>
-                  <RAMGauge clientID={clientID} />
+                  <RAMGauge clientID={clientID} lastUpdatedError={lastUpdatedError} />
                 </Grid>
                 <Grid item xs={4} sm={2} className={classes.gaugeContainer}>
-                  <SwapGauge clientID={clientID} />
+                  <SwapGauge clientID={clientID} lastUpdatedError={lastUpdatedError} />
                 </Grid>
                 <Grid item xs={4} sm={2} className={classes.gaugeContainer}>
-                  <LoadGauge clientID={clientID} />
+                  <LoadGauge clientID={clientID} lastUpdatedError={lastUpdatedError} />
                 </Grid>
                 <Grid item xs={4} sm={2} className={classes.gaugeContainer}>
-                  <NetworkGauge clientID={clientID} />
+                  <NetworkGauge clientID={clientID} lastUpdatedError={lastUpdatedError} />
                 </Grid>
                 <Grid item xs={4} sm={2} className={classes.gaugeContainer}>
-                  <StorageGauge clientID={clientID} />
+                  <StorageGauge clientID={clientID} lastUpdatedError={lastUpdatedError} />
                 </Grid>
               </Grid>
             </Grid>


### PR DESCRIPTION
## Description

Lets the Gauges know there was an error fetching `lastUpdated` and displays and error state for that.

Also fixes an issue where the `requestLastUpdated` closure wasn't getting the most up-to-date `lastUpdated` value because that's how closures work.

[The solution comes from a Facebook employee](https://github.com/facebook/react/issues/14010#issuecomment-433788147) - I'm just following instructions

## Type of Change
- Non breaking change ('update', 'change')