### PR TITLE
M3-3456 RDNS drawer for IPv6 ranges

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
@@ -7,6 +7,7 @@ import FormHelperText from 'src/components/core/FormHelperText';
 import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import TextField from 'src/components/TextField';
+import { arePropsEqual } from 'src/utilities/arePropsEqual';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
@@ -56,12 +57,23 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
   };
 
   componentWillReceiveProps(nextProps: CombinedProps) {
-    this.setState({
-      rdns: nextProps.rdns,
-      address: nextProps.address,
-      ipv6Address: nextProps.range,
-      errors: undefined
-    });
+    // This is a hack fix. We need to refactor and replace all components with
+    // `componentWillReceiveProps`. @todo: do this.
+    // https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops
+    if (
+      !arePropsEqual<CombinedProps>(
+        ['rdns', 'address', 'range'],
+        this.props,
+        nextProps
+      )
+    ) {
+      this.setState({
+        rdns: nextProps.rdns,
+        address: nextProps.address,
+        ipv6Address: nextProps.range,
+        errors: undefined
+      });
+    }
   }
 
   showDelayText = () => {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -553,6 +553,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
               ? this.state.currentlySelectedIPRange.range
               : undefined
           }
+          ips={ipsWithRDNS}
         />
 
         <ViewRDNSDrawer

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -276,6 +276,13 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
     });
   };
 
+  handleOpenEditRDNSForRange = (range: IPRange) => {
+    this.setState({
+      editRDNSDrawerOpen: true,
+      currentlySelectedIPRange: range
+    });
+  };
+
   renderRangeRow(range: IPRange, type: IPTypes) {
     const { classes } = this.props;
 
@@ -303,6 +310,8 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
           <LinodeNetworkingActionMenu
             onView={this.displayRangeDrawer(range)}
             ipType={type}
+            ipAddress={range}
+            onEdit={() => this.handleOpenEditRDNSForRange(range)}
           />
         </TableCell>
       </TableRow>
@@ -398,7 +407,8 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
   closeEditRDNSDrawer = () => {
     this.setState({
       editRDNSDrawerOpen: false,
-      currentlySelectedIP: undefined
+      currentlySelectedIP: undefined,
+      currentlySelectedIPRange: undefined
     });
     this.refreshIPs();
   };
@@ -536,6 +546,11 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
           rdns={
             this.state.currentlySelectedIP
               ? this.state.currentlySelectedIP.rdns
+              : undefined
+          }
+          range={
+            this.state.currentlySelectedIPRange
+              ? this.state.currentlySelectedIPRange.range
               : undefined
           }
         />

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -1,4 +1,4 @@
-import { IPAddress } from 'linode-js-sdk/lib/networking';
+import { IPAddress, IPRange } from 'linode-js-sdk/lib/networking';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
@@ -6,10 +6,10 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
   onView: () => void;
-  onEdit?: (ip: IPAddress) => void;
-  onRemove?: (ip: IPAddress) => void;
+  onEdit?: (ip: IPAddress | IPRange) => void;
+  onRemove?: (ip: IPAddress | IPRange) => void;
   ipType: IPTypes;
-  ipAddress?: IPAddress;
+  ipAddress?: IPAddress | IPRange;
   readOnly?: boolean;
 }
 


### PR DESCRIPTION
## Description

⚠️ ~**TODO: Merge #5758 first, then rebase this branch**~ ⚠️ DONE

~_Note: There is a bug where the form resets every time we receive events. This is unrelated to the present work, so the fix is coming in a separate PR._~ 

Went ahead and fixed this ^^^ here. It's kind of a hack fix; I went ahead and created M3-3595 to remove all instances of componentWillReceiveProps since it is being deprecated in React 17.

This PR allows the Edit RDNS Drawer for IPv6 ranges. I reused the existing `<EditRDNSDrawer />` component for this.

 Now, if we're editing RDNS for a range, we display a new text field to allow the user to enter the specific IP address to set RDNS on. The text field is pre-populated with the range prefix.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

**To fully test**, you'll need to follow the steps listed at #5758 to set up your Domain and Linode.

**To test many addresses:**

- Add the following on line 20 of EditRDNSDrawer.tsx: 

```typescript
import { ipAddressFactory } from 'src/factories/networking';
```

- Add the following on line 174 of the same file:

```typescript
const ips = ipAddressFactory.buildList(100, { rdns: 'my-website.com' });
```

Don't worry about the Typescript warnings. 

Please test the Networking tab in general and other drawers, functionality, etc.
