### PR TITLE
M3-3512 Longview: sort clients by values

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
@@ -38,6 +38,7 @@ const props = {
   accountSettingsLoading: false,
   accountSettingsError: {},
   accountSettingsLastUpdated: 0,
+  lvClientData: {},
   ...reactRouterProps
 };
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
@@ -39,6 +39,7 @@ const props = {
   accountSettingsError: {},
   accountSettingsLastUpdated: 0,
   lvClientData: {},
+  lvClientsLoading: false,
   ...reactRouterProps
 };
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -107,6 +107,26 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
     {
       label: 'CPU',
       value: 'cpu'
+    },
+    {
+      label: 'RAM',
+      value: 'ram'
+    },
+    {
+      label: 'Swap',
+      value: 'swap'
+    },
+    {
+      label: 'Load',
+      value: 'load'
+    },
+    {
+      label: 'Network',
+      value: 'network'
+    },
+    {
+      label: 'Storage',
+      value: 'storage'
     }
   ];
 
@@ -186,6 +206,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
     longviewClientsLoading,
     longviewClientsResults,
     lvClientData,
+    lvClientsLoading,
     accountSettings,
     subscriptionsData,
     createLongviewClient,
@@ -230,7 +251,14 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
         </Grid>
         <Grid item className={`pt0 ${classes.lastUpdated}`}>
           <Typography>
-            Data last updated at <DateTimeDisplay value={lastUpdated} />
+            {lvClientsLoading ? (
+              'Loading...'
+            ) : (
+              <>
+                Data last updated at{` `}
+                <DateTimeDisplay value={lastUpdated} />
+              </>
+            )}
           </Typography>
         </Grid>
         <Grid item className={`${classes.addNew} pt0`}>
@@ -294,11 +322,18 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
  */
 interface StateProps {
   lvClientData: Record<string, StatsState>;
+  lvClientsLoading: boolean;
 }
 
 const mapStateToProps: MapState<StateProps, Props> = (state, ownProps) => {
+  const lvClientData = pathOr({}, ['longviewStats'], state);
   return {
-    lvClientData: pathOr({}, ['longviewStats'], state)
+    lvClientData,
+    // @todo this should be a memoized selector
+    lvClientsLoading: Object.values(lvClientData).some(
+      (thisClient: StatsState) =>
+        thisClient.loading && thisClient.lastUpdated === 0
+    )
   };
 };
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -49,7 +49,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   sortSelect: {
     marginBottom: theme.spacing(2),
-    width: '200px'
+    width: '300px',
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center'
+  },
+  selectLabel: {
+    minWidth: '65px'
   }
 }));
 
@@ -214,6 +220,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
           <Search onSearch={handleSearch} debounceTime={250} />
         </Grid>
         <Grid item className={`pt0 ${classes.sortSelect}`}>
+          <Typography className={classes.selectLabel}>Sort by: </Typography>
           <Select
             isClearable={false}
             options={sortOptions}

--- a/packages/manager/src/store/longviewStats/longviewStats.reducer.test.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.reducer.test.ts
@@ -75,19 +75,13 @@ describe('Longview Client Stats Reducer', () => {
       })
     );
 
-    expect(newState).toEqual({
-      123: {
-        data: {}
-      },
-      999: {
-        loading: false,
-        error: undefined,
-        data: {
-          ...systemInfo,
-          ...memory,
-          ...longviewLoad
-        }
-      }
+    expect(newState[123]).toEqual({
+      data: {}
     });
+    expect(newState[999]).toHaveProperty('loading', false);
+    expect(newState[999]).toHaveProperty('error', undefined);
+    expect(newState[999].data).toHaveProperty('SysInfo', systemInfo.SysInfo);
+    expect(newState[999].data).toHaveProperty('Memory', memory.Memory);
+    expect(newState[999].data).toHaveProperty('Load', longviewLoad.Load);
   });
 });

--- a/packages/manager/src/store/longviewStats/longviewStats.reducer.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.reducer.ts
@@ -35,7 +35,8 @@ const reducer = reducerWithInitialState(defaultState)
       [params.clientID]: {
         data: result,
         loading: false,
-        error: undefined
+        error: undefined,
+        lastUpdated: Date.now()
       }
     })
   )


### PR DESCRIPTION
## Description

This includes the layout and live data logic for "Data last updated at..." display.
The select for sorting clients by different values is a static Select for now.

I'm hoping to show this at review to get feedback on design, whether or not we want a global "last time any client was updated" display, etc. The actual sorting logic is going to be a nightmare and there's no chance it'll be ready for the next release. Please let me know if you think merging in this state (pending PR review) is acceptable.
## Type of Change