### PR TITLE
M3 Longview landing: cleanup

### DIFF
--- a/packages/manager/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
+++ b/packages/manager/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
@@ -20,6 +20,7 @@ interface Props extends TextFieldProps {
   debounceTime?: number;
   isSearching?: boolean;
   className?: string;
+  placeholder?: string;
 }
 
 type CombinedProps = Props;
@@ -31,6 +32,7 @@ const DebouncedSearch: React.FC<CombinedProps> = props => {
     InputProps,
     debounceTime,
     onSearch,
+    placeholder,
     ...restOfTextFieldProps
   } = props;
   const [query, setQuery] = React.useState<string>('');
@@ -67,7 +69,7 @@ const DebouncedSearch: React.FC<CombinedProps> = props => {
   return (
     <TextField
       className={className}
-      placeholder="Filter by query"
+      placeholder={placeholder || 'Filter by query'}
       onChange={_setQuery}
       InputProps={{
         startAdornment: (

--- a/packages/manager/src/components/EditableEntityLabel/EditableEntityLabel.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableEntityLabel.tsx
@@ -14,7 +14,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   smallInput: {
     position: 'relative',
-    paddingRight: 20
+    paddingRight: 20,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-all'
   },
   subText: {
     fontSize: '0.8em'

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
@@ -104,7 +104,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   editIcon: {
     position: 'absolute',
-    right: 0,
+    right: 10,
     [theme.breakpoints.up('sm')]: {
       opacity: 0,
       '&:focus': {

--- a/packages/manager/src/factories/accountSettings.ts
+++ b/packages/manager/src/factories/accountSettings.ts
@@ -1,0 +1,12 @@
+import * as Factory from 'factory.ts';
+import { AccountSettings } from 'linode-js-sdk/lib/account/types';
+
+export const accountSettingsFactory = Factory.Sync.makeFactory<AccountSettings>(
+  {
+    longview_subscription: null,
+    managed: false,
+    network_helper: false,
+    backups_enabled: false,
+    object_storage: 'active'
+  }
+);

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -11,6 +11,7 @@ import { DispatchProps } from 'src/containers/longview.container';
 import withClientStats, {
   Props as LVDataProps
 } from 'src/containers/longview.stats.container';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { formatUptime } from 'src/utilities/formatUptime';
 import { pluralize } from 'src/utilities/pluralize';
 import { LongviewPackage } from '../request.types';
@@ -81,7 +82,12 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
       .then(_ => {
         setUpdating(false);
       })
-      .catch(_ => setUpdating(false));
+      .catch(error => {
+        setUpdating(false);
+        return Promise.reject(
+          getAPIErrorOrDefault(error, 'Error updating label')[0].reason
+        );
+      });
   };
 
   const hostname = pathOr(

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -7,9 +7,7 @@ import { makeStyles, Theme, WithTheme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import EditableEntityLabel from 'src/components/EditableEntityLabel';
 import Grid from 'src/components/Grid';
-import withLongviewClients, {
-  DispatchProps
-} from 'src/containers/longview.container';
+import { DispatchProps } from 'src/containers/longview.container';
 import withClientStats, {
   Props as LVDataProps
 } from 'src/containers/longview.stats.container';
@@ -49,6 +47,7 @@ interface Props {
   clientID: number;
   clientLabel: string;
   lastUpdatedError?: APIError[];
+  updateLongviewClient: DispatchProps['updateLongviewClient'];
 }
 
 type CombinedProps = Props & DispatchProps & LVDataProps & WithTheme;
@@ -143,9 +142,7 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
 };
 
 const enhanced = compose<CombinedProps, Props>(
-  withClientStats((ownProps: Props) => ownProps.clientID),
-  /** We only need the update action here, easier than prop drilling through 4 components */
-  withLongviewClients(() => ({}))
+  withClientStats((ownProps: Props) => ownProps.clientID)
 );
 
 export default enhanced(LongviewClientHeader);

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientInstructions.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientInstructions.tsx
@@ -7,6 +7,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import EditableEntityLabel from 'src/components/EditableEntityLabel';
 import Grid from 'src/components/Grid';
 import { DispatchProps } from 'src/containers/longview.container';
+import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 import Instructions from '../shared/InstallationInstructions';
 
@@ -51,7 +52,12 @@ export const LongviewClientInstructions: React.FC<Props> = props => {
       .then(_ => {
         setUpdating(false);
       })
-      .catch(_ => setUpdating(false));
+      .catch(error => {
+        setUpdating(false);
+        return Promise.reject(
+          getAPIErrorOrDefault(error, 'Error updating label')[0].reason
+        );
+      });
   };
 
   return (

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientInstructions.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientInstructions.tsx
@@ -6,6 +6,7 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import EditableEntityLabel from 'src/components/EditableEntityLabel';
 import Grid from 'src/components/Grid';
+import { DispatchProps } from 'src/containers/longview.container';
 
 import Instructions from '../shared/InstallationInstructions';
 
@@ -28,6 +29,7 @@ interface Props {
   installCode: string;
   clientAPIKey: string;
   triggerDeleteLongviewClient: (id: number, label: string) => void;
+  updateLongviewClient: DispatchProps['updateLongviewClient'];
 }
 
 export const LongviewClientInstructions: React.FC<Props> = props => {
@@ -36,9 +38,22 @@ export const LongviewClientInstructions: React.FC<Props> = props => {
     clientLabel,
     installCode,
     triggerDeleteLongviewClient,
-    clientAPIKey
+    clientAPIKey,
+    updateLongviewClient
   } = props;
   const classes = useStyles();
+
+  const [updating, setUpdating] = React.useState<boolean>(false);
+
+  const handleUpdateLabel = (newLabel: string) => {
+    setUpdating(true);
+    return updateLongviewClient(clientID, newLabel)
+      .then(_ => {
+        setUpdating(false);
+      })
+      .catch(_ => setUpdating(false));
+  };
+
   return (
     <Paper className={classes.root}>
       <Grid
@@ -53,11 +68,11 @@ export const LongviewClientInstructions: React.FC<Props> = props => {
           <Grid container>
             <Grid item xs={12} md={3}>
               <EditableEntityLabel
-                text={'longview3347837'}
+                text={clientLabel}
                 iconVariant="linode"
                 subText="Waiting for data..."
-                onEdit={() => Promise.resolve(null)}
-                loading={false}
+                onEdit={handleUpdateLabel}
+                loading={updating}
               />
             </Grid>
             <Grid item xs={12} md={9}>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -19,6 +19,9 @@ import SwapGauge from './Gauges/Swap';
 import LongviewClientHeader from './LongviewClientHeader';
 import LongviewClientInstructions from './LongviewClientInstructions';
 
+import withLongviewClients, {
+  DispatchProps
+} from 'src/containers/longview.container';
 import withClientStats, {
   Props as LVDataProps
 } from 'src/containers/longview.stats.container';
@@ -53,7 +56,7 @@ interface Props {
   ) => void;
 }
 
-type CombinedProps = Props & LVDataProps;
+type CombinedProps = Props & LVDataProps & DispatchProps;
 
 const LongviewClientRow: React.FC<CombinedProps> = props => {
   const classes = useStyles();
@@ -66,7 +69,8 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
     clientLabel,
     clientAPIKey,
     triggerDeleteLongviewClient,
-    clientInstallKey
+    clientInstallKey,
+    updateLongviewClient
   } = props;
 
   /*
@@ -171,6 +175,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
         clientAPIKey={clientAPIKey}
         installCode={clientInstallKey}
         triggerDeleteLongviewClient={triggerDeleteLongviewClient}
+        updateLongviewClient={updateLongviewClient}
       />
     );
   }
@@ -192,6 +197,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
                 clientID={clientID}
                 clientLabel={clientLabel}
                 lastUpdatedError={lastUpdatedError}
+                updateLongviewClient={updateLongviewClient}
               />
             </Grid>
             <Grid item xs={12} md={9}>
@@ -257,5 +263,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
 
 export default compose<CombinedProps, Props>(
   React.memo,
-  withClientStats<Props>(ownProps => ownProps.clientID)
+  withClientStats<Props>(ownProps => ownProps.clientID),
+  /** We only need the update action here, easier than prop drilling through 4 components */
+  withLongviewClients(() => ({}))
 )(LongviewClientRow);

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent } from '@testing-library/react';
 import { LongviewClient } from 'linode-js-sdk/lib/longview';
 import * as React from 'react';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
+import { accountSettingsFactory } from 'src/factories/accountSettings';
 import { longviewClientFactory } from 'src/factories/longviewClient';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import {
@@ -94,5 +95,25 @@ describe('Longview clients list view', () => {
     expect(queryAllByTestId('longview-client-row')).toHaveLength(
       clients.length
     );
+  });
+
+  it('should render a CTA for non-Pro subscribers', () => {
+    const settings = accountSettingsFactory.build();
+    const { getByText } = renderWithTheme(
+      <LongviewClients {...props} accountSettings={settings} />
+    );
+
+    getByText(/upgrade to longview pro/i);
+  });
+
+  it('should not render a CTA for LV Pro subscribers', () => {
+    const settings = accountSettingsFactory.build({
+      longview_subscription: 'longview-100'
+    });
+    const { queryAllByText } = renderWithTheme(
+      <LongviewClients {...props} accountSettings={settings} />
+    );
+
+    expect(queryAllByText(/upgrade to longview pro/i)).toHaveLength(0);
   });
 });

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -159,6 +159,11 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
   );
 
   const isManaged = pathOr(false, ['managed'], accountSettings);
+  // If this value is defined they're not on the free plan
+  // and don't need to be CTA'd to upgrade.
+  const isLongviewPro = Boolean(
+    pathOr(false, ['longview_subscription'], accountSettings)
+  );
 
   return (
     <React.Fragment>
@@ -185,7 +190,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
         createLongviewClient={handleAddClient}
         loading={newClientLoading}
       />
-      {true && (
+      {!isLongviewPro && (
         <Grid
           className={classes.cta}
           container

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -169,7 +169,11 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
     <React.Fragment>
       <Grid container className={classes.headingWrapper}>
         <Grid item className={`pt0 ${classes.searchbar}`}>
-          <Search onSearch={handleSearch} debounceTime={250} />
+          <Search
+            placeholder="Filter by client label"
+            onSearch={handleSearch}
+            debounceTime={250}
+          />
         </Grid>
         <Grid item className={`${classes.addNew} pt0`}>
           <AddNewLink


### PR DESCRIPTION
## Description

Loose ends:

- Updating labels in LongviewClientInstructions
- Hide CTA if you're already LV Pro
- Add optional placeholder prop to DebouncedSearchTextfield
