### PR TITLE
Add type checking in getAPIErrorFor 

### DIFF
--- a/packages/manager/src/utilities/getAPIErrorFor.ts
+++ b/packages/manager/src/utilities/getAPIErrorFor.ts
@@ -1,4 +1,5 @@
 import { APIError } from 'linode-js-sdk/lib/types';
+import { DEFAULT_ERROR_MESSAGE } from 'src/constants';
 
 export default (
   errorMap: { [index: string]: string },
@@ -14,7 +15,7 @@ export default (
   // response. This is an old error handling utility, but I wanted to add it
   // as a safeguard so that this particular bug wouldn't happen again.
   if (!Array.isArray(arr)) {
-    return;
+    return field === 'none' ? DEFAULT_ERROR_MESSAGE : undefined;
   }
 
   let err;

--- a/packages/manager/src/utilities/getAPIErrorFor.ts
+++ b/packages/manager/src/utilities/getAPIErrorFor.ts
@@ -4,6 +4,19 @@ export default (
   errorMap: { [index: string]: string },
   arr: APIError[] = []
 ) => (field: string): undefined | string => {
+  // One time during a sprint review I was showing off the new RDNS for routed
+  // ranges feature. When attempting to update the RDNS, the application
+  // crashed. Either something went wrong in then `.then()` handler (more
+  // likely), or we received an error response from the API we weren't prepared
+  // to handle (less likely). I was not able to reproduce this issue without
+  // manually throwing an error. Either way, this represents a chink in our
+  // armor, as we always assume `.catch()`s will be called with an API error
+  // response. This is an old error handling utility, but I wanted to add it
+  // as a safeguard so that this particular bug wouldn't happen again.
+  if (!Array.isArray(arr)) {
+    return;
+  }
+
   let err;
 
   if (field === 'none') {


### PR DESCRIPTION
## Description

Add type checking to this oldish utility function in case it gets something we're not expecting.

This is an attempt to fix a crashing bug noticed during review. I wasn't able to reproduce the bug, so this was my best shot. There may still be a bug in this PR: https://github.com/linode/manager/pull/5773 but if there is, I haven't been able to find it.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')

Please test places around the app that use this utility function.
