### PR TITLE
Add loading state and clear errors on form submission [Linode Backups]

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -486,6 +486,16 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
   };
 
   handleSnapshotDialogDisplay = () => {
+    // If there's no label, don't open the modal. Show an error in the form.
+    if (!this.state.snapshotForm.label) {
+      this.setState({
+        snapshotForm: {
+          ...this.state.snapshotForm,
+          errors: [{ field: 'label', reason: 'Label is required.' }]
+        }
+      });
+      return;
+    }
     this.setState({
       dialogOpen: true,
       dialogError: undefined

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -162,6 +162,7 @@ interface State {
     window: Window;
     day: Day;
     errors?: APIError[];
+    loading: boolean;
   };
   restoreDrawer: {
     open: boolean;
@@ -215,7 +216,8 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     },
     settingsForm: {
       window: this.props.backupsSchedule.window || 'Scheduling',
-      day: this.props.backupsSchedule.day || 'Scheduling'
+      day: this.props.backupsSchedule.day || 'Scheduling',
+      loading: false
     },
     restoreDrawer: {
       open: false,
@@ -410,6 +412,10 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     } = this.props;
     const { settingsForm } = this.state;
 
+    this.setState(state => ({
+      settingsForm: { ...state.settingsForm, loading: true, errors: undefined }
+    }));
+
     updateLinode({
       linodeId: linodeID,
       backups: {
@@ -421,18 +427,23 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
       }
     })
       .then(() => {
+        this.setState(state => ({
+          settingsForm: { ...state.settingsForm, loading: false }
+        }));
+
         enqueueSnackbar('Backup settings saved', {
           variant: 'success'
         });
       })
       .catch(err => {
         this.setState(
-          {
+          state => ({
             settingsForm: {
-              ...settingsForm,
+              ...state.settingsForm,
+              loading: false,
               errors: getAPIErrorOrDefault(err)
             }
-          },
+          }),
           () => {
             scrollErrorIntoView();
           }
@@ -754,6 +765,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
               buttonType="primary"
               onClick={this.saveSettings}
               disabled={isReadOnly(permissions)}
+              loading={this.state.settingsForm.loading}
               data-qa-schedule
             >
               Save Schedule


### PR DESCRIPTION
## Description

When testing https://github.com/linode/manager/pull/5776 I noticed that the Backup Settings form was using old patterns. Specifically, there was no loading state and the error states were not being cleared upon new submission. This PR addresses both of these items.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

**To Test**, navigate to Linode Detail > Backups. Scroll down to Settings and submit the form. Request block to simulate error states, and/or select “Choose a time” or “Choose a day”.
