### PR TITLE
Add: Ability to Automatically Add Gmail MX Records

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -73,10 +73,17 @@ export class App extends React.Component<CombinedProps, State> {
   }
 
   componentDidMount() {
+    const { history, location } = this.props;
+
+    /* 
+     clear state each time the app mounts 
+     so that we're not persisting error messages across refreshes
+    */
+    history.replace(location.pathname, {});
     /**
      * Send pageviews unless blacklisted.
      */
-    this.props.history.listen(({ pathname }) => {
+    history.listen(({ pathname }) => {
       if ((window as any).ga) {
         (window as any).ga('send', 'pageview', pathname);
       }

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -16,8 +16,8 @@ const styles = (theme: Theme) =>
     root: {
       paddingTop: theme.spacing(2),
       paddingBottom: theme.spacing(1),
-      '& > button': {
-        marginBottom: theme.spacing(1)
+      '& > *': {
+        marginTop: theme.spacing(1)
       },
       '& > :first-child': {
         marginRight: theme.spacing(1)

--- a/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
+++ b/packages/manager/src/components/ActionsPanel/ActionsPanel.tsx
@@ -16,8 +16,8 @@ const styles = (theme: Theme) =>
     root: {
       paddingTop: theme.spacing(2),
       paddingBottom: theme.spacing(1),
-      '& > *': {
-        marginTop: theme.spacing(1)
+      '& > button': {
+        marginBottom: theme.spacing(1)
       },
       '& > :first-child': {
         marginRight: theme.spacing(1)

--- a/packages/manager/src/components/CheckBox/CheckBox.tsx
+++ b/packages/manager/src/components/CheckBox/CheckBox.tsx
@@ -10,6 +10,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import HelpIcon from 'src/components/HelpIcon';
 
 type CSSClasses = 'root' | 'checked' | 'disabled' | 'warning' | 'error';
@@ -71,13 +72,14 @@ const styles = (theme: Theme) =>
 interface Props extends CheckboxProps {
   variant?: 'warning' | 'error';
   text?: string | JSX.Element;
+  subtext?: string | JSX.Element;
   toolTipText?: string;
 }
 
 type FinalProps = Props & WithStyles<CSSClasses>;
 
 const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
-  const { toolTipText, text, classes, ...rest } = props;
+  const { toolTipText, text, subtext, className, classes, ...rest } = props;
 
   const classnames = classNames({
     [classes.root]: true,
@@ -91,6 +93,7 @@ const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
     return (
       <React.Fragment>
         <FormControlLabel
+          className={className}
           control={
             <Checkbox
               color="primary"
@@ -104,6 +107,7 @@ const LinodeCheckBox: React.StatelessComponent<FinalProps> = props => {
           label={props.text}
         />
         {toolTipText && <HelpIcon text={toolTipText} />}
+        {subtext && <Typography>{subtext}</Typography>}
       </React.Fragment>
     );
   }

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -841,7 +841,9 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               });
           }
         }
-        return this.redirectToLandingOrDetail(type, domainData.id);
+        return this.redirectToLandingOrDetail(type, domainData.id, {
+          recordError: domainData.error
+        });
       })
       .catch(err => {
         if (!this.mounted) {
@@ -960,6 +962,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
   };
 
   submit = () => {
+    this.setState({ errors: [] });
     if (this.props.mode === CREATING) {
       this.create();
     } else if (this.props.mode === CLONING) {

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -82,8 +82,12 @@ const styles = (theme: Theme) =>
     },
     actionPanel: {
       display: 'flex',
-      flexFlow: 'row wrap',
-      alignItems: 'center'
+      flexFlow: 'row',
+      alignItems: 'center',
+      '& > span': {
+        margin: theme.spacing(),
+        wordBreak: 'break-word'
+      }
     }
   });
 
@@ -190,27 +194,27 @@ const generateDefaultDomainRecords = (
     /** ipv6 can be null so don't try to create domain records in that case */
     !!cleanedIPv6
       ? [
-        ...baseIPv4Requests,
-        createDomainRecord(domainID, {
-          type: 'AAAA',
-          target: cleanedIPv6
-        }),
-        createDomainRecord(domainID, {
-          type: 'AAAA',
-          target: cleanedIPv6,
-          name: 'www'
-        }),
-        createDomainRecord(domainID, {
-          type: 'AAAA',
-          target: cleanedIPv6,
-          name: 'mail'
-        }),
-        createDomainRecord(domainID, {
-          type: 'MX',
-          priority: 10,
-          target: `mail.${domain}`
-        })
-      ]
+          ...baseIPv4Requests,
+          createDomainRecord(domainID, {
+            type: 'AAAA',
+            target: cleanedIPv6
+          }),
+          createDomainRecord(domainID, {
+            type: 'AAAA',
+            target: cleanedIPv6,
+            name: 'www'
+          }),
+          createDomainRecord(domainID, {
+            type: 'AAAA',
+            target: cleanedIPv6,
+            name: 'mail'
+          }),
+          createDomainRecord(domainID, {
+            type: 'MX',
+            priority: 10,
+            target: `mail.${domain}`
+          })
+        ]
       : baseIPv4Requests
   );
 };
@@ -483,7 +487,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               {!errorMap.defaultLinode && (
                 <FormHelperText>
                   {this.state.selectedDefaultLinode &&
-                    !this.state.selectedDefaultLinode.ipv6
+                  !this.state.selectedDefaultLinode.ipv6
                     ? `We'll automatically create domains for the first IPv4 address on this
                     Linode.`
                     : `We'll automatically create domain records for both the first
@@ -507,7 +511,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               {!errorMap.defaultNodeBalancer && (
                 <FormHelperText>
                   {this.state.selectedDefaultNodeBalancer &&
-                    !this.state.selectedDefaultNodeBalancer.ipv6
+                  !this.state.selectedDefaultNodeBalancer.ipv6
                     ? `We'll automatically create domains for the first IPv4 address on this
                   NodeBalancer.`
                     : `We'll automatically create domain records for both the first
@@ -535,19 +539,20 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
           >
             {mode === EDITING ? 'Update' : 'Create'}
           </Button>
-          {!!submitting ? (
+          {submitting ? (
             <span>
+              {/* Creating fdsafdsafdsafdsafdsafdasfdssdafdsaasfdsaf42314324.com */}
               {this.state.loadingText ? this.state.loadingText : null}
             </span>
           ) : (
-              <Button
-                onClick={this.closeDrawer}
-                buttonType="cancel"
-                data-qa-cancel
-              >
-                Cancel
+            <Button
+              onClick={this.closeDrawer}
+              buttonType="cancel"
+              data-qa-cancel
+            >
+              Cancel
             </Button>
-            )}
+          )}
         </ActionsPanel>
       </Drawer>
     );
@@ -773,7 +778,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               .catch((e: APIError[]) => {
                 reportException(
                   `Default DNS Records couldn't be created from Linode: ${
-                  e[0].reason
+                    e[0].reason
                   }`,
                   {
                     selectedLinode: this.state.selectedDefaultLinode!.id,
@@ -813,7 +818,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
               .catch((e: APIError[]) => {
                 reportException(
                   `Default DNS Records couldn't be created from NodeBalancer: ${
-                  e[0].reason
+                    e[0].reason
                   }`,
                   {
                     selectedNodeBalancer: this.state
@@ -915,7 +920,7 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     const data =
       type === 'master'
         ? // not sending type for master. There is a bug on server and it returns an error that `master_ips` is required
-        { domain, tags, soa_email: soaEmail, domainId: id }
+          { domain, tags, soa_email: soaEmail, domainId: id }
         : { domain, type, tags, master_ips: finalMasterIPs, domainId: id };
 
     if (type === 'master' && !isValidSOAEmail(data.soa_email || '', domain)) {

--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -25,6 +25,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import Typography from 'src/components/core/Typography';
 import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import Radio from 'src/components/Radio';
@@ -66,7 +67,8 @@ type ClassNames =
   | 'masterIPErrorNotice'
   | 'addIP'
   | 'actionPanel'
-  | 'gmailCheck';
+  | 'gmailCheck'
+  | 'submitButton';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -84,11 +86,14 @@ const styles = (theme: Theme) =>
       display: 'flex',
       flexFlow: 'row',
       alignItems: 'center',
-      '& > span': {
-        margin: theme.spacing(),
-        wordBreak: 'break-word'
+      '& > p': {
+        wordBreak: 'break-all'
+      },
+      '& $submitButton': {
+        marginBottom: 0
       }
-    }
+    },
+    submitButton: {}
   });
 
 type DefaultRecordsType = 'none' | 'linode' | 'nodebalancer';
@@ -536,19 +541,20 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
             data-qa-submit
             loading={submitting}
             disabled={disabled}
+            className={classes.submitButton}
           >
             {mode === EDITING ? 'Update' : 'Create'}
           </Button>
           {submitting ? (
-            <span>
-              {/* Creating fdsafdsafdsafdsafdsafdasfdssdafdsaasfdsaf42314324.com */}
+            <Typography>
               {this.state.loadingText ? this.state.loadingText : null}
-            </span>
+            </Typography>
           ) : (
             <Button
               onClick={this.closeDrawer}
               buttonType="cancel"
               data-qa-cancel
+              className={classes.submitButton}
             >
               Cancel
             </Button>
@@ -1054,8 +1060,8 @@ const connected = connect(
 
 export default compose<CombinedProps, {}>(
   withDomainActions,
-  styled,
   connected,
   withRouter,
-  withSnackbar
+  withSnackbar,
+  styled
 )(DomainDrawer);

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -23,10 +23,7 @@ import Button, { ButtonProps } from 'src/components/Button';
 import Drawer from 'src/components/Drawer';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Notice from 'src/components/Notice';
-import {
-  default as _TextField,
-  Props as TextFieldProps
-} from 'src/components/TextField';
+import TextField, { Props as TextFieldProps } from 'src/components/TextField';
 import {
   DomainActionsProps,
   withDomainActions
@@ -39,10 +36,6 @@ import {
   isValidDomainRecord,
   isValidSOAEmail
 } from './domainUtils';
-
-const TextField: React.StatelessComponent<TextFieldProps> = props => (
-  <_TextField {...props} />
-);
 
 interface Props extends EditableRecordFields, EditableDomainFields {
   open: boolean;
@@ -96,11 +89,8 @@ interface State {
 type CombinedProps = Props & DomainActionsProps;
 
 /* tslint:disable-next-line */
-interface _TextFieldProps {
-  label: string;
+interface _TextFieldProps extends TextFieldProps {
   field: keyof EditableRecordFields | keyof EditableDomainFields;
-  min?: number;
-  max?: number;
 }
 
 interface NumberFieldProps extends _TextFieldProps {
@@ -178,8 +168,9 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
     this.updateField('axfr_ips')(transferIPs);
   };
 
-  TextField = ({ label, field }: _TextFieldProps) => (
+  TextField = ({ label, field, ...rest }: _TextFieldProps) => (
     <TextField
+      {...rest}
       label={label}
       errorText={getAPIErrorsFor(
         DomainRecordDrawer.errorFields,
@@ -220,7 +211,11 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
   );
 
   TargetField = ({ label }: { label: string }) => (
-    <this.TextField field="target" label={label} />
+    <this.TextField
+      field="target"
+      label={label}
+      helperText="Trailing periods are optional"
+    />
   );
 
   ServiceField = () => <this.TextField field="service" label="Service" />;

--- a/packages/manager/src/utilities/ga.ts
+++ b/packages/manager/src/utilities/ga.ts
@@ -330,3 +330,11 @@ export const sendObjectsQueuedForUploadEvent = (numObjects: number) => {
     label: `${numObjects} objects`
   });
 };
+
+export const createDomainEvent = (action: string, label?: string) => {
+  sendEvent({
+    category: 'Create Domain',
+    action,
+    label
+  });
+}


### PR DESCRIPTION
## Description

I had this branch sitting for a long while - finally putting it up for review

This allows someone to create Gmail MX records along with their new domain. Asked for by a customer a few months back.

[See here for Google documentation](https://support.google.com/a/answer/140034?hl=en)

## Type of Change
- Non breaking change ('update', 'change')

## To Test

1. Open the _add domain_ drawer
2. Toggle the "create Gmail MX records" checkbox

## Notes

This also adds loading text next to the button, so the user has a better idea of what is loading at that particular time