### PR TITLE
M3-3596 fix: Events Badge Hides behind scrollbar

### DIFF
--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
@@ -32,7 +32,7 @@ const styles = (theme: Theme) =>
       },
       [theme.breakpoints.up('lg')]: {
         marginLeft: theme.spacing(1),
-        marginRight: -theme.spacing(2)
+        marginRight: -theme.spacing(1)
       },
       '&:hover': {
         '& $icon': {

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
@@ -28,11 +28,13 @@ const styles = (theme: Theme) =>
       opacity: 1,
       transition: theme.transitions.create(['opacity']),
       [theme.breakpoints.up('md')]: {
-        marginRight: 0
+        marginRight:
+          theme.spacing(1) === 8 ? theme.spacing(1) : theme.spacing(2)
       },
       [theme.breakpoints.up('lg')]: {
         marginLeft: theme.spacing(1),
-        marginRight: -theme.spacing(1)
+        marginRight:
+          theme.spacing(1) === 8 ? -theme.spacing(1) : theme.spacing(1)
       },
       '&:hover': {
         '& $icon': {
@@ -61,7 +63,7 @@ const styles = (theme: Theme) =>
       position: 'absolute',
       zIndex: 2,
       top: 0,
-      right: theme.spacing(1),
+      right: 2,
       display: 'flex',
       alignItems: 'center'
     },

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
@@ -61,7 +61,7 @@ const styles = (theme: Theme) =>
       position: 'absolute',
       zIndex: 2,
       top: 0,
-      right: 2,
+      right: theme.spacing(1),
       display: 'flex',
       alignItems: 'center'
     },


### PR DESCRIPTION
## M3-3596 fix: Events Badge Hides behind scrollbar

This bug is only true if you set your operating system to always show scrollbars.

<img width="93" alt="Screen Shot 2019-11-14 at 10 49 18 AM" src="https://user-images.githubusercontent.com/205353/68978373-8be33b80-07c8-11ea-9ccc-74d609220ce4.png">

## Type of Change
- Bug fix ('fix')
