### PR TITLE
M3-3597 POC to remove ZXCVBN from Cloud and use Regex

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -88,8 +88,7 @@
     "typescript-fsa-reducers": "^1.2.0",
     "xml2js": "^0.4.19",
     "xterm": "^4.2.0",
-    "yup": "^0.26.3",
-    "zxcvbn": "^4.4.2"
+    "yup": "^0.26.3"
   },
   "scripts": {
     "postinstall": "patch-package",
@@ -185,7 +184,6 @@
     "@types/uuid": "^3.4.3",
     "@types/xml2js": "^0.4.3",
     "@types/yup": "^0.24.9",
-    "@types/zxcvbn": "^4.4.0",
     "@wdio/cli": "^5.10.10",
     "@wdio/dot-reporter": "^5.9.3",
     "@wdio/jasmine-framework": "^5.10.8",

--- a/packages/manager/src/components/PasswordInput/PasswordInput.spec.js
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.spec.js
@@ -2,10 +2,7 @@ const { navigateToStory } = require('../../../e2e/utils/storybook');
 
 describe('Password Input Suite', () => {
   const component = 'Password Input';
-  const childStories = [
-    'Example',
-  ]
-  const strengthIndicator = '[data-qa-strength]';
+  const childStories = ['Example'];
   const passwordInput = '[data-qa-hide] input';
 
   function hideShow(show) {
@@ -31,30 +28,7 @@ describe('Password Input Suite', () => {
   }
 
   beforeAll(() => {
-      navigateToStory(component, childStories[0]);
-  });
-
-  it('should display password input with strength indicator', () => {
-    $(passwordInput).waitForDisplayed();
-
-    const input = $(passwordInput);
-
-    expect(input.isExisting())
-      .withContext(`Input field does not exist`).toBe(true);
-  });
-
-  it('should update the strength when complexity of password increases', () => {
-    const testPasswords = ['weak', 'stronger1233', 'Stronger123#!'];
-    testPasswords.forEach((pass, index) => {
-      $(passwordInput).setValue(pass);
-      const strengthDisplays = $(strengthIndicator).isDisplayed();
-      const strength = $(strengthIndicator).getAttribute('data-qa-strength');
-
-      expect(strengthDisplays)
-        .withContext(`Password strength should be displayed`).toBe(true);
-      expect(parseInt(strength))
-        .withContext(`Incorrect strength indicator value`).toBe(index + 1);
-    });
+    navigateToStory(component, childStories[0]);
   });
 
   it('should display password when click show', () => {

--- a/packages/manager/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.tsx
@@ -26,9 +26,16 @@ type Props = TextFieldProps & {
 interface State {
   strength: boolean;
   lengthRequirement: boolean;
+  active: boolean;
 }
 
-type ClassNames = 'container' | 'listItem' | 'reqList' | 'valid' | 'check';
+type ClassNames =
+  | 'container'
+  | 'listItem'
+  | 'reqList'
+  | 'valid'
+  | 'check'
+  | 'active';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -48,10 +55,13 @@ const styles = (theme: Theme) =>
       }
     },
     check: {
-      color: theme.color.red,
+      color: theme.color.grey1,
       marginRight: theme.spacing(1),
       position: 'relative',
-      top: -1,
+      top: -1
+    },
+    active: {
+      color: theme.color.red,
       '&$valid': {
         color: theme.color.green
       }
@@ -71,14 +81,16 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 class PasswordInput extends React.Component<CombinedProps, State> {
   state: State = {
     strength: false,
-    lengthRequirement: false
+    lengthRequirement: false,
+    active: false
   };
 
   componentWillReceiveProps(nextProps: CombinedProps) {
     const { value } = nextProps;
     this.setState({
       strength: maybeStrength(value),
-      lengthRequirement: value && value.length >= 6 ? true : false
+      lengthRequirement: value && value.length >= 6 ? true : false,
+      active: value && value.length !== 0 ? true : false
     });
   }
 
@@ -91,12 +103,21 @@ class PasswordInput extends React.Component<CombinedProps, State> {
 
     this.setState({
       strength: maybeStrength(value),
-      lengthRequirement: value.length >= 6 ? true : false
+      lengthRequirement: value.length >= 6 ? true : false,
+      active: true
+    });
+  };
+
+  onBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const value: string = e.currentTarget.value;
+
+    this.setState({
+      active: value.length !== 0 && true
     });
   };
 
   render() {
-    const { strength, lengthRequirement } = this.state;
+    const { strength, lengthRequirement, active } = this.state;
     const {
       classes,
       value,
@@ -105,6 +126,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
       hideStrengthLabel,
       hideHelperText,
       hideValidation,
+      onBlur,
       ...rest
     } = this.props;
 
@@ -119,12 +141,13 @@ class PasswordInput extends React.Component<CombinedProps, State> {
               onChange={this.onChange}
               fullWidth
               required={required}
+              onBlur={this.onBlur}
             />
           </Grid>
           {!hideHelperText && (
             <Grid item xs={12}>
               <ul className={classes.reqList}>
-                <Typography component={'span'}>Password must</Typography>
+                <Typography>Password must:</Typography>
                 <li
                   className={classes.listItem}
                   aria-label={
@@ -136,6 +159,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
                   <span
                     className={classNames({
                       [classes.check]: true,
+                      [classes.active]: active,
                       [classes.valid]: lengthRequirement
                     })}
                   >
@@ -156,6 +180,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
                   <span
                     className={classNames({
                       [classes.check]: true,
+                      [classes.active]: active,
                       [classes.valid]: strength
                     })}
                   >

--- a/packages/manager/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import { isEmpty } from 'ramda';
 import * as React from 'react';
 import {
@@ -10,6 +11,8 @@ import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { Props as TextFieldProps } from 'src/components/TextField';
 import HideShowText from './HideShowText';
+
+import Check from 'src/assets/icons/check.svg';
 
 type Props = TextFieldProps & {
   value?: string;
@@ -25,12 +28,7 @@ interface State {
   lengthRequirement: boolean;
 }
 
-type ClassNames =
-  | 'container'
-  | 'passWrapper'
-  | 'infoText'
-  | 'valid'
-  | 'invalid';
+type ClassNames = 'container' | 'listItem' | 'reqList' | 'valid' | 'check';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -38,26 +36,33 @@ const styles = (theme: Theme) =>
       position: 'relative',
       paddingBottom: theme.spacing(1) / 2
     },
-    passWrapper: {
-      minWidth: '100%',
-      [theme.breakpoints.up('sm')]: {
-        minWidth: `calc(415px + ${theme.spacing(2)}px)`
-      }
-    },
-    infoText: {
+    reqList: {
+      listStyleType: 'none',
+      margin: 0,
       width: '100%',
-      padding: theme.spacing(1),
+      padding: `${theme.spacing(1)}px ${theme.spacing(2) - 2}px `,
       backgroundColor: theme.bg.offWhite,
       border: `1px solid ${theme.palette.divider}`,
       [theme.breakpoints.up('sm')]: {
         width: 415
       }
     },
-    valid: {
-      color: theme.color.green
+    check: {
+      color: theme.color.red,
+      marginRight: theme.spacing(1),
+      position: 'relative',
+      top: -1,
+      '&$valid': {
+        color: theme.color.green
+      }
     },
-    invalid: {
-      color: theme.color.red
+    valid: {},
+    listItem: {
+      display: 'flex',
+      margin: `${theme.spacing(1)}px 0`,
+      '& > span': {
+        display: 'block'
+      }
     }
   });
 
@@ -106,7 +111,7 @@ class PasswordInput extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <Grid container alignItems="flex-end" className={classes.container}>
-          <Grid item className={classes.passWrapper}>
+          <Grid item xs={12}>
             <HideShowText
               {...rest}
               tooltipText={disabledReason}
@@ -117,23 +122,53 @@ class PasswordInput extends React.Component<CombinedProps, State> {
             />
           </Grid>
           {!hideHelperText && (
-            <Grid item>
-              <Typography variant="body1" className={classes.infoText}>
-                Password must be at least{' '}
-                <span
-                  className={
-                    lengthRequirement ? classes.valid : classes.invalid
+            <Grid item xs={12}>
+              <ul className={classes.reqList}>
+                <Typography component={'span'}>Password must</Typography>
+                <li
+                  className={classes.listItem}
+                  aria-label={
+                    lengthRequirement
+                      ? 'Password contains enough characters'
+                      : 'Password should be at least 6 chars'
                   }
                 >
-                  <strong>6 characters</strong>
-                </span>{' '}
-                and contain at least{' '}
-                <span className={strength ? classes.valid : classes.invalid}>
-                  <strong>two of the following character classes</strong>
-                </span>
-                : uppercase letters, lowercase letters, numbers, and
-                punctuation.
-              </Typography>
+                  <span
+                    className={classNames({
+                      [classes.check]: true,
+                      [classes.valid]: lengthRequirement
+                    })}
+                  >
+                    <Check />
+                  </span>{' '}
+                  <Typography component={'span'}>
+                    Be at least <strong>6 characters</strong>
+                  </Typography>
+                </li>
+                <li
+                  className={classes.listItem}
+                  aria-label={
+                    strength
+                      ? "Password's strength is valid"
+                      : "Increase password's strength by adding uppercase letters, lowercase letters, numbers, or punctuation"
+                  }
+                >
+                  <span
+                    className={classNames({
+                      [classes.check]: true,
+                      [classes.valid]: strength
+                    })}
+                  >
+                    <Check />
+                  </span>{' '}
+                  <Typography component={'span'}>
+                    Contain at least{' '}
+                    <strong>two of the following character classes</strong>:
+                    uppercase letters, lowercase letters, numbers, and
+                    punctuation.
+                  </Typography>
+                </li>
+              </ul>
             </Grid>
           )}
         </Grid>

--- a/packages/manager/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.tsx
@@ -118,8 +118,8 @@ class PasswordInput extends React.Component<CombinedProps, State> {
 
 const maybeStrength = (value?: string) => {
 
-  const strongRegex = /^(?=.{2,}[a-z])(?=.{2,}[A-Z])(?=.{2,}[0-9])(?=.{2,}[!@#\$%\^&\*])(?=.{10,})/;
-  const mediumRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})/;
+  const strongRegex = /^(?=.{2,}[a-z])(?=.{2,}[A-Z])(?=.{2,}[0-9])(?=.{2,}[!"#$%&'()*+,-.\/:;<=>?@\[\]^_`{|}~\\])(?=.{10,})/;
+  const mediumRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!"#$%&'()*+,-.\/:;<=>?@\[\]^_`{|}~\\])(?=.{8,})/;
   const weekRegex = /^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})/;
 
   if (!value || isEmpty(value)) {

--- a/packages/manager/src/components/PasswordInput/PasswordInput.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.tsx
@@ -9,7 +9,6 @@ import {
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { Props as TextFieldProps } from 'src/components/TextField';
-import * as zxcvbn from 'zxcvbn';
 import StrengthIndicator from '../PasswordInput/StrengthIndicator';
 import HideShowText from './HideShowText';
 
@@ -118,14 +117,23 @@ class PasswordInput extends React.Component<CombinedProps, State> {
 }
 
 const maybeStrength = (value?: string) => {
+
+  const strongRegex = /^(?=.{2,}[a-z])(?=.{2,}[A-Z])(?=.{2,}[0-9])(?=.{2,}[!@#\$%\^&\*])(?=.{10,})/;
+  const mediumRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})/;
+  const weekRegex = /^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})/;
+
   if (!value || isEmpty(value)) {
     return null;
   } else {
-    const score = zxcvbn(value).score;
-    if (score === 4) {
+    if(strongRegex.test(value)){
       return 3;
+    }else if(mediumRegex.test(value)){
+      return 2;
+    }else if(weekRegex.test(value)){
+      return 1;
+    }else{
+      return 0;
     }
-    return score;
   }
 };
 

--- a/packages/manager/yarn.lock
+++ b/packages/manager/yarn.lock
@@ -3039,11 +3039,6 @@
   resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.24.9.tgz#da98f4b38eec7ca72146e7042679c8c8628896fa"
   integrity sha512-PxWHuxuJgCuVenEJk8cW6z7F+JFMHAJMSbih3gyjUOU23tjSjz2/jDBmb17yp1CBbozozQKn3InIXtYH3RzJGg==
 
-"@types/zxcvbn@^4.4.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@types/zxcvbn/-/zxcvbn-4.4.0.tgz#fbc1d941cc6d9d37d18405c513ba6b294f89b609"
-  integrity sha512-GQLOT+SN20a+AI51y3fAimhyTF4Y0RG+YP3gf91OibIZ7CJmPFgoZi+ZR5a+vRbS01LbQosITWum4ATmJ1Z6Pg==
-
 "@wdio/cli@^5.10.10":
   version "5.11.11"
   resolved "https://registry.yarnpkg.com/@wdio/cli/-/cli-5.11.11.tgz#3ab56bc753c9af1ca381c6c4a75ca1ec791eccdf"
@@ -16877,8 +16872,3 @@ zip-stream@^2.1.0:
     archiver-utils "^2.1.0"
     compress-commons "^2.0.0"
     readable-stream "^3.4.0"
-
-zxcvbn@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/zxcvbn/-/zxcvbn-4.4.2.tgz#28ec17cf09743edcab056ddd8b1b06262cc73c30"
-  integrity sha1-KOwXzwl0PtyrBW3dixsGJizHPDA=


### PR DESCRIPTION
## Description
- by removing ZXCVBN we are cutting 900k dependency in prod
- The regex serves the same purpose as before, to inform the user of the (relative) strength of their password. We update two states similarly to errors returned from the API (length and character reqs)

## Type of Change
- Non breaking change ('update', 'change')

## Note to reviewers
- Not a new problem, but seems like we get an error with a 6 chars password
<img width="426" alt="Screen Shot 2019-11-22 at 3 19 00 PM" src="https://user-images.githubusercontent.com/205353/69457661-9313c780-0d3b-11ea-8201-cf1b96320374.png">

