### PR TITLE
[for release] Allow RDNS for IPv6 pools

### DIFF
--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.test.ts
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.test.ts
@@ -40,4 +40,14 @@ describe('listIPv6InRange utility function', () => {
       listIPv6InRange('2600:3c03:e000:3cb::', 64, [...ipv4List, outOfRangeIP])
     ).toHaveLength(0);
   });
+  it('allows pools', () => {
+    const ipv6Pool = ipAddressFactory.build({
+      type: 'ipv6/pool',
+      address: '2600:3c03::e1:5000',
+      rdns: 'my-site.com'
+    });
+    expect(
+      listIPv6InRange('2600:3c03::e1:5000', 64, [...ipv4List, ipv6Pool])
+    ).toHaveLength(1);
+  });
 });

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -847,9 +847,12 @@ export const listIPv6InRange = (
 ) => {
   return ips.filter(thisIP => {
     // Only keep addresses that:
-    // 1. are part of an IPv6 range
+    // 1. are part of an IPv6 range or pool
     // 2. have RDNS set
-    if (thisIP.type !== 'ipv6/range' || thisIP.rdns === null) {
+    if (
+      !['ipv6/range', 'ipv6/pool'].includes(thisIP.type) ||
+      thisIP.rdns === null
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Description

The previous logic in the `listIPv6InRange` utility function didn't account for /116 pools, which have a type of `ipv6/pool`. The logic has been adjusted so that RDNS entries for /116 pools will be displayed as well.


## Note to Reviewers

**To test,** have an assigned /116 pool and set RDNS on matching entries.
