### PR TITLE
M3-3604 Add static tables for listening services/active connections

### DIFF
--- a/packages/manager/src/factories/longviewService.ts
+++ b/packages/manager/src/factories/longviewService.ts
@@ -1,0 +1,29 @@
+import * as Factory from 'factory.ts';
+import {
+  LongviewPort,
+  LongviewPortsResponse,
+  LongviewService
+} from 'src/features/Longview/request.types';
+
+export const longviewPortFactory = Factory.Sync.makeFactory<LongviewPort>({
+  count: Factory.each(i => i),
+  user: Factory.each(i => `test-user-${i}`),
+  name: Factory.each(i => `test-name-${i}`)
+});
+
+export const longviewServiceFactory = Factory.Sync.makeFactory<LongviewService>(
+  {
+    user: Factory.each(i => `test-user-${i}`),
+    ip: '0.0.0.0',
+    port: 22,
+    type: 'tcp',
+    name: 'sshd'
+  }
+);
+
+export const longviewPortsResponseFactory = Factory.Sync.makeFactory<
+  LongviewPortsResponse
+>({
+  listening: longviewServiceFactory.buildList(2),
+  active: longviewPortFactory.buildList(2)
+});

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
@@ -124,11 +124,11 @@ const renderLoadingErrorData = (
   data: LongviewPort[],
   error?: string
 ) => {
-  if (loading) {
-    return <TableRowLoading colSpan={12} />;
-  }
   if (error) {
     return <TableRowError colSpan={12} message={error} />;
+  }
+  if (loading) {
+    return <TableRowLoading colSpan={4} />;
   }
   if (data.length === 0) {
     return <TableRowEmptyState colSpan={12} />;

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
@@ -13,29 +13,27 @@ import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
 import TableSortCell from 'src/components/TableSortCell';
-import { longviewServiceFactory } from 'src/factories/longviewService';
-import { LongviewService } from 'src/features/Longview/request.types';
-import LongviewServiceRow from './LongviewServiceRow';
+import { longviewPortFactory } from 'src/factories/longviewService';
+import { LongviewPort } from 'src/features/Longview/request.types';
+import ConnectionRow from './ConnectionRow';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  table: {
-    width: '750px'
-  }
+  table: {}
 }));
 
 export interface Props {}
 
-const mockServices = longviewServiceFactory.buildList(10);
+const mockServices = longviewPortFactory.buildList(5);
 
-export const ListeningServices: React.FC<Props> = props => {
+export const ActiveConnections: React.FC<Props> = props => {
   return (
-    <Grid item xs={8} md={8}>
-      <Typography variant="h2">Listening Services</Typography>
+    <Grid item xs={4} md={4}>
+      <Typography variant="h2">Active Connections</Typography>
       <Grid item>
-        <ServicesTable
-          services={mockServices}
-          servicesLoading={false}
-          servicesError={undefined}
+        <ConnectionsTable
+          connections={mockServices}
+          connectionsLoading={false}
+          connectionsError={undefined}
         />
       </Grid>
     </Grid>
@@ -43,17 +41,17 @@ export const ListeningServices: React.FC<Props> = props => {
 };
 
 export interface TableProps {
-  services: LongviewService[];
-  servicesLoading: boolean;
-  servicesError?: string;
+  connections: LongviewPort[];
+  connectionsLoading: boolean;
+  connectionsError?: string;
 }
 
-export const ServicesTable: React.FC<TableProps> = props => {
-  const { services, servicesError, servicesLoading } = props;
+export const ConnectionsTable: React.FC<TableProps> = props => {
+  const { connections, connectionsLoading, connectionsError } = props;
   const classes = useStyles();
 
   return (
-    <OrderBy data={services} orderBy={'process'} order={'asc'}>
+    <OrderBy data={connections} orderBy={'process'} order={'asc'}>
       {({ data: orderedData, handleOrderChange, order, orderBy }) => (
         <Paginate data={orderedData} pageSize={25}>
           {({
@@ -69,14 +67,13 @@ export const ServicesTable: React.FC<TableProps> = props => {
                 <TableHead>
                   <TableRow>
                     <TableSortCell
-                      data-qa-table-header="Process"
-                      active={orderBy === 'process'}
-                      label="process"
+                      data-qa-table-header="Name"
+                      active={orderBy === 'name'}
+                      label="name"
                       direction={order}
                       handleClick={handleOrderChange}
-                      style={{ width: '25%' }}
                     >
-                      Process
+                      Name
                     </TableSortCell>
                     <TableSortCell
                       data-qa-table-header="User"
@@ -84,47 +81,25 @@ export const ServicesTable: React.FC<TableProps> = props => {
                       label="user"
                       direction={order}
                       handleClick={handleOrderChange}
-                      style={{ width: '25%' }}
                     >
                       User
                     </TableSortCell>
                     <TableSortCell
-                      data-qa-table-header="Protocol"
-                      active={orderBy === 'protocol'}
-                      label="protocol"
+                      data-qa-table-header="Count"
+                      active={orderBy === 'count'}
+                      label="count"
                       direction={order}
                       handleClick={handleOrderChange}
-                      style={{ width: '15%' }}
                     >
-                      Protocol
-                    </TableSortCell>
-                    <TableSortCell
-                      data-qa-table-header="Port"
-                      active={orderBy === 'port'}
-                      label="port"
-                      direction={order}
-                      handleClick={handleOrderChange}
-                      style={{ width: '10%' }}
-                    >
-                      Port
-                    </TableSortCell>
-                    <TableSortCell
-                      data-qa-table-header="IP"
-                      active={orderBy === 'ip'}
-                      label="ip"
-                      direction={order}
-                      handleClick={handleOrderChange}
-                      style={{ width: '25%' }}
-                    >
-                      IP
+                      Count
                     </TableSortCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
                   {renderLoadingErrorData(
-                    servicesLoading,
+                    connectionsLoading,
                     paginatedData,
-                    servicesError
+                    connectionsError
                   )}
                 </TableBody>
               </Table>
@@ -134,7 +109,7 @@ export const ServicesTable: React.FC<TableProps> = props => {
                 pageSize={pageSize}
                 handlePageChange={handlePageChange}
                 handleSizeChange={handlePageSizeChange}
-                eventCategory="Longview active connections"
+                eventCategory="Longview listening services"
               />
             </>
           )}
@@ -146,7 +121,7 @@ export const ServicesTable: React.FC<TableProps> = props => {
 
 const renderLoadingErrorData = (
   loading: boolean,
-  data: LongviewService[],
+  data: LongviewPort[],
   error?: string
 ) => {
   if (loading) {
@@ -159,9 +134,12 @@ const renderLoadingErrorData = (
     return <TableRowEmptyState colSpan={12} />;
   }
 
-  return data.map((thisService, idx) => (
-    <LongviewServiceRow key={`longview-service-${idx}`} service={thisService} />
+  return data.map((thisConnection, idx) => (
+    <ConnectionRow
+      key={`longview-service-${idx}`}
+      connection={thisConnection}
+    />
   ));
 };
 
-export default ListeningServices;
+export default ActiveConnections;

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 export interface Props {}
 
-const mockServices = longviewPortFactory.buildList(5);
+const mockConnections = longviewPortFactory.buildList(5);
 
 export const ActiveConnections: React.FC<Props> = props => {
   return (
@@ -31,7 +31,7 @@ export const ActiveConnections: React.FC<Props> = props => {
       <Typography variant="h2">Active Connections</Typography>
       <Grid item>
         <ConnectionsTable
-          connections={mockServices}
+          connections={mockConnections}
           connectionsLoading={false}
           connectionsError={undefined}
         />
@@ -109,7 +109,7 @@ export const ConnectionsTable: React.FC<TableProps> = props => {
                 pageSize={pageSize}
                 handlePageChange={handlePageChange}
                 handleSizeChange={handlePageSizeChange}
-                eventCategory="Longview listening services"
+                eventCategory="Longview active connections"
               />
             </>
           )}
@@ -136,7 +136,7 @@ const renderLoadingErrorData = (
 
   return data.map((thisConnection, idx) => (
     <ConnectionRow
-      key={`longview-service-${idx}`}
+      key={`longview-active-connection-${idx}`}
       connection={thisConnection}
     />
   ));

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ActiveConnections.tsx
@@ -18,7 +18,26 @@ import { LongviewPort } from 'src/features/Longview/request.types';
 import ConnectionRow from './ConnectionRow';
 
 const useStyles = makeStyles((theme: Theme) => ({
-  table: {}
+  container: {
+    [theme.breakpoints.down('sm')]: {
+      marginTop: theme.spacing(3)
+    }
+  },
+  table: {
+    [theme.breakpoints.down('sm')]: {
+      '& tbody > tr > td:first-child .data': {
+        textAlign: 'right'
+      }
+    },
+    [theme.breakpoints.up('md')]: {
+      '& thead > tr > th:last-child': {
+        textAlign: 'right'
+      },
+      '& tbody > tr > td:last-child': {
+        textAlign: 'right'
+      }
+    }
+  }
 }));
 
 export interface Props {}
@@ -26,16 +45,15 @@ export interface Props {}
 const mockConnections = longviewPortFactory.buildList(5);
 
 export const ActiveConnections: React.FC<Props> = props => {
+  const classes = useStyles();
   return (
-    <Grid item xs={4} md={4}>
+    <Grid item xs={12} md={4} className={classes.container}>
       <Typography variant="h2">Active Connections</Typography>
-      <Grid item>
-        <ConnectionsTable
-          connections={mockConnections}
-          connectionsLoading={false}
-          connectionsError={undefined}
-        />
-      </Grid>
+      <ConnectionsTable
+        connections={mockConnections}
+        connectionsLoading={false}
+        connectionsError={undefined}
+      />
     </Grid>
   );
 };

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ConnectionRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ConnectionRow.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
+import { LongviewPort } from 'src/features/Longview/request.types';
+
+interface Props {
+  connection: LongviewPort;
+}
+
+export const ConnectionRow: React.FC<Props> = props => {
+  const { connection } = props;
+  return (
+    <TableRow data-testid="longview-connection-row">
+      <TableCell parentColumn="Name" data-qa-connection-name>
+        {connection.name}
+      </TableCell>
+      <TableCell parentColumn="User" data-qa-connection-user>
+        {connection.user}
+      </TableCell>
+      <TableCell parentColumn="Count" data-qa-connection-count>
+        {connection.count}
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default ConnectionRow;

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ConnectionRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/ConnectionRow.tsx
@@ -11,13 +11,13 @@ export const ConnectionRow: React.FC<Props> = props => {
   const { connection } = props;
   return (
     <TableRow data-testid="longview-connection-row">
-      <TableCell parentColumn="Name" data-qa-connection-name>
+      <TableCell parentColumn="Name" data-qa-active-connection-name>
         {connection.name}
       </TableCell>
-      <TableCell parentColumn="User" data-qa-connection-user>
+      <TableCell parentColumn="User" data-qa-active-connection-user>
         {connection.user}
       </TableCell>
-      <TableCell parentColumn="Count" data-qa-connection-count>
+      <TableCell parentColumn="Count" data-qa-active-connection-count>
         {connection.count}
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/index.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ActiveConnections/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ActiveConnections';

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
@@ -1,18 +1,31 @@
 import * as React from 'react';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import OrderBy from 'src/components/OrderBy';
+import Paginate from 'src/components/Paginate';
+import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
-import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableRowEmptyState from 'src/components/TableRowEmptyState';
 import TableRowError from 'src/components/TableRowError';
 import TableRowLoading from 'src/components/TableRowLoading';
+import TableSortCell from 'src/components/TableSortCell';
+import { longviewServiceFactory } from 'src/factories/longviewService';
 import { LongviewService } from 'src/features/Longview/request.types';
 import LongviewServiceRow from './LongviewServiceRow';
 
+const useStyles = makeStyles((theme: Theme) => ({
+  table: {
+    width: '750px'
+  }
+}));
+
 export interface Props {}
+
+const mockServices = longviewServiceFactory.buildList(10);
 
 export const ListeningServices: React.FC<Props> = props => {
   return (
@@ -20,7 +33,7 @@ export const ListeningServices: React.FC<Props> = props => {
       <Typography variant="h2">Listening Services</Typography>
       <Grid item>
         <ServicesTable
-          services={[]}
+          services={mockServices}
           servicesLoading={false}
           servicesError={undefined}
         />
@@ -37,22 +50,97 @@ export interface TableProps {
 
 export const ServicesTable: React.FC<TableProps> = props => {
   const { services, servicesError, servicesLoading } = props;
+  const classes = useStyles();
+
   return (
-    <Table spacingTop={16}>
-      <TableHead>
-        <TableRow>
-          <TableCell data-qa-table-header="Process">Process</TableCell>
-          <TableCell data-qa-table-header="User">User</TableCell>
-          <TableCell data-qa-table-header="Protocol">Protocol</TableCell>
-          <TableCell data-qa-table-header="Port">Port</TableCell>
-          <TableCell data-qa-table-header="IP">IP</TableCell>
-          <TableCell />
-        </TableRow>
-      </TableHead>
-      <TableBody>
-        {renderLoadingErrorData(servicesLoading, services, servicesError)}
-      </TableBody>
-    </Table>
+    <OrderBy data={services} orderBy={'process'} order={'asc'}>
+      {({ data: orderedData, handleOrderChange, order, orderBy }) => (
+        <Paginate data={orderedData} pageSize={25}>
+          {({
+            data: paginatedData,
+            count,
+            handlePageChange,
+            handlePageSizeChange,
+            page,
+            pageSize
+          }) => (
+            <>
+              <Table spacingTop={16} tableClass={classes.table}>
+                <TableHead>
+                  <TableRow>
+                    <TableSortCell
+                      data-qa-table-header="Process"
+                      active={orderBy === 'process'}
+                      label="process"
+                      direction={order}
+                      handleClick={handleOrderChange}
+                      style={{ width: '25%' }}
+                    >
+                      Process
+                    </TableSortCell>
+                    <TableSortCell
+                      data-qa-table-header="User"
+                      active={orderBy === 'user'}
+                      label="user"
+                      direction={order}
+                      handleClick={handleOrderChange}
+                      style={{ width: '25%' }}
+                    >
+                      User
+                    </TableSortCell>
+                    <TableSortCell
+                      data-qa-table-header="Protocol"
+                      active={orderBy === 'protocol'}
+                      label="protocol"
+                      direction={order}
+                      handleClick={handleOrderChange}
+                      style={{ width: '15%' }}
+                    >
+                      Protocol
+                    </TableSortCell>
+                    <TableSortCell
+                      data-qa-table-header="Port"
+                      active={orderBy === 'port'}
+                      label="port"
+                      direction={order}
+                      handleClick={handleOrderChange}
+                      style={{ width: '10%' }}
+                    >
+                      Port
+                    </TableSortCell>
+                    <TableSortCell
+                      data-qa-table-header="IP"
+                      active={orderBy === 'ip'}
+                      label="ip"
+                      direction={order}
+                      handleClick={handleOrderChange}
+                      style={{ width: '25%' }}
+                    >
+                      IP
+                    </TableSortCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {renderLoadingErrorData(
+                    servicesLoading,
+                    paginatedData,
+                    servicesError
+                  )}
+                </TableBody>
+              </Table>
+              <PaginationFooter
+                count={count}
+                page={page}
+                pageSize={pageSize}
+                handlePageChange={handlePageChange}
+                handleSizeChange={handlePageSizeChange}
+                eventCategory="Longview listening services"
+              />
+            </>
+          )}
+        </Paginate>
+      )}
+    </OrderBy>
   );
 };
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
@@ -149,11 +149,11 @@ const renderLoadingErrorData = (
   data: LongviewService[],
   error?: string
 ) => {
-  if (loading) {
-    return <TableRowLoading colSpan={12} />;
-  }
   if (error) {
     return <TableRowError colSpan={12} message={error} />;
+  }
+  if (loading) {
+    return <TableRowLoading colSpan={6} />;
   }
   if (data.length === 0) {
     return <TableRowEmptyState colSpan={12} />;

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import Typography from 'src/components/core/Typography';
+import Grid from 'src/components/Grid';
+import Table from 'src/components/Table';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
+import TableRowError from 'src/components/TableRowError';
+import TableRowLoading from 'src/components/TableRowLoading';
+import { LongviewService } from 'src/features/Longview/request.types';
+import LongviewServiceRow from './LongviewServiceRow';
+
+export interface Props {}
+
+export const ListeningServices: React.FC<Props> = props => {
+  return (
+    <Grid item xs={12} md={8}>
+      <Typography variant="h2">Listening Services</Typography>
+      <Grid item>
+        <ServicesTable
+          services={[]}
+          servicesLoading={false}
+          servicesError={undefined}
+        />
+      </Grid>
+    </Grid>
+  );
+};
+
+export interface TableProps {
+  services: LongviewService[];
+  servicesLoading: boolean;
+  servicesError?: string;
+}
+
+export const ServicesTable: React.FC<TableProps> = props => {
+  const { services, servicesError, servicesLoading } = props;
+  return (
+    <Table spacingTop={16}>
+      <TableHead>
+        <TableRow>
+          <TableCell data-qa-table-header="Process">Process</TableCell>
+          <TableCell data-qa-table-header="User">User</TableCell>
+          <TableCell data-qa-table-header="Protocol">Protocol</TableCell>
+          <TableCell data-qa-table-header="Port">Port</TableCell>
+          <TableCell data-qa-table-header="IP">IP</TableCell>
+          <TableCell />
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {renderLoadingErrorData(servicesLoading, services, servicesError)}
+      </TableBody>
+    </Table>
+  );
+};
+
+const renderLoadingErrorData = (
+  loading: boolean,
+  data: LongviewService[],
+  error?: string
+) => {
+  if (loading) {
+    return <TableRowLoading colSpan={12} />;
+  }
+  if (error) {
+    return <TableRowError colSpan={12} message={error} />;
+  }
+  if (data.length === 0) {
+    return <TableRowEmptyState colSpan={12} />;
+  }
+
+  return data.map((thisService, idx) => (
+    <LongviewServiceRow key={`longview-service-${idx}`} service={thisService} />
+  ));
+};
+
+export default ListeningServices;

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/ListeningServices.tsx
@@ -19,7 +19,19 @@ import LongviewServiceRow from './LongviewServiceRow';
 
 const useStyles = makeStyles((theme: Theme) => ({
   table: {
-    width: '750px'
+    [theme.breakpoints.down('sm')]: {
+      '& tbody > tr > td:first-child .data': {
+        textAlign: 'right'
+      }
+    },
+    [theme.breakpoints.up('md')]: {
+      '& thead > tr > th:last-child': {
+        textAlign: 'right'
+      },
+      '& tbody > tr > td:last-child': {
+        textAlign: 'right'
+      }
+    }
   }
 }));
 
@@ -29,15 +41,13 @@ const mockServices = longviewServiceFactory.buildList(10);
 
 export const ListeningServices: React.FC<Props> = props => {
   return (
-    <Grid item xs={8} md={8}>
+    <Grid item xs={12} md={8}>
       <Typography variant="h2">Listening Services</Typography>
-      <Grid item>
-        <ServicesTable
-          services={mockServices}
-          servicesLoading={false}
-          servicesError={undefined}
-        />
-      </Grid>
+      <ServicesTable
+        services={mockServices}
+        servicesLoading={false}
+        servicesError={undefined}
+      />
     </Grid>
   );
 };

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
+import { LongviewService } from 'src/features/Longview/request.types';
+
+interface Props {
+  service: LongviewService;
+}
+
+export const LongviewServiceRow: React.FC<Props> = props => {
+  const { service } = props;
+  return (
+    <TableRow data-testid="longview-service-row">
+      <TableCell parentColumn="Process" data-qa-service-process>
+        dhcclient
+      </TableCell>
+      <TableCell parentColumn="User" data-qa-service-user>
+        root
+      </TableCell>
+      <TableCell parentColumn="Protocol" data-qa-service-protocol>
+        UDP
+      </TableCell>
+      <TableCell parentColumn="Port" data-qa-service-port>
+        68
+      </TableCell>
+      <TableCell parentColumn="IP" data-qa-service-ip>
+        0.0.0.0
+      </TableCell>
+    </TableRow>
+  );
+};
+
+export default LongviewServiceRow;

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/LongviewServiceRow.tsx
@@ -12,19 +12,19 @@ export const LongviewServiceRow: React.FC<Props> = props => {
   return (
     <TableRow data-testid="longview-service-row">
       <TableCell parentColumn="Process" data-qa-service-process>
-        dhcclient
+        {service.name}
       </TableCell>
       <TableCell parentColumn="User" data-qa-service-user>
-        root
+        {service.user}
       </TableCell>
       <TableCell parentColumn="Protocol" data-qa-service-protocol>
-        UDP
+        {service.type}
       </TableCell>
       <TableCell parentColumn="Port" data-qa-service-port>
-        68
+        {service.port}
       </TableCell>
       <TableCell parentColumn="IP" data-qa-service-ip>
-        0.0.0.0
+        {service.ip}
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/index.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/ListeningServices/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './ListeningServices';

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
@@ -18,6 +18,7 @@ import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import HelpIcon from 'src/components/HelpIcon';
 
+import ActiveConnections from './ActiveConnections';
 import ListeningServices from './ListeningServices';
 
 import { systemInfo } from 'src/__data__/longview';
@@ -270,9 +271,7 @@ const LongviewDetailOverview: React.FC<CombinedProps> = props => {
         </Grid>
         <Grid container item xs={12}>
           <ListeningServices />
-          <Grid item xs={12} md={4}>
-            <Typography variant="h2">Active Connections</Typography>
-          </Grid>
+          <ActiveConnections />
         </Grid>
       </Grid>
     </React.Fragment>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
@@ -269,7 +269,7 @@ const LongviewDetailOverview: React.FC<CombinedProps> = props => {
         <Grid item xs={12}>
           <Paper className={classes.paperSection}>Graphs here</Paper>
         </Grid>
-        <Grid container item xs={12}>
+        <Grid container justify="space-between" item spacing={0}>
           <ListeningServices />
           <ActiveConnections />
         </Grid>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
@@ -18,6 +18,8 @@ import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import HelpIcon from 'src/components/HelpIcon';
 
+import ListeningServices from './ListeningServices';
+
 import { systemInfo } from 'src/__data__/longview';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -267,9 +269,7 @@ const LongviewDetailOverview: React.FC<CombinedProps> = props => {
           <Paper className={classes.paperSection}>Graphs here</Paper>
         </Grid>
         <Grid container item xs={12}>
-          <Grid item xs={12} md={8}>
-            <Typography variant="h2">Listening Services</Typography>
-          </Grid>
+          <ListeningServices />
           <Grid item xs={12} md={4}>
             <Typography variant="h2">Active Connections</Typography>
           </Grid>

--- a/packages/manager/src/features/Longview/request.types.ts
+++ b/packages/manager/src/features/Longview/request.types.ts
@@ -109,6 +109,23 @@ export interface LongviewPackages {
   Packages: LongviewPackage[];
 }
 
+export interface LongviewService {
+  user: string;
+  ip: string;
+  type: string;
+  port: number;
+}
+
+export interface LongviewPort {
+  count: number;
+  user: string;
+  name: string;
+}
+export interface LongviewPorts {
+  listening: LongviewService[];
+  active: LongviewPort[];
+}
+
 export interface LongviewSystemInfo {
   SysInfo: {
     arch: string;

--- a/packages/manager/src/features/Longview/request.types.ts
+++ b/packages/manager/src/features/Longview/request.types.ts
@@ -114,6 +114,7 @@ export interface LongviewService {
   ip: string;
   type: string;
   port: number;
+  name: string;
 }
 
 export interface LongviewPort {
@@ -121,7 +122,7 @@ export interface LongviewPort {
   user: string;
   name: string;
 }
-export interface LongviewPorts {
+export interface LongviewPortsResponse {
   listening: LongviewService[];
   active: LongviewPort[];
 }


### PR DESCRIPTION
## Description

Adds tables for services and connections. Static data only in this PR.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

These two responses are very similar, and it might be possible to do some conditional stuff and use a single table for both of them. I tried a few ways but there are small differences between them; this is mostly boilerplate so I'm ok with this approach.