### PR TITLE
Enable searching LV clients by hostname

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
@@ -46,29 +46,17 @@ const props = {
 
 describe('Utility Functions', () => {
   it('should properly filter longview clients by query', () => {
-    const mockLongviewClients: Record<string, LongviewClient> = clients.reduce(
-      (acc, eachClient) => {
-        acc[eachClient.id] = eachClient;
-        return acc;
-      },
-      {}
-    );
-
-    expect(filterLongviewClientsByQuery('1', mockLongviewClients)).toEqual({
-      1: clients[1]
-    }),
-      expect(
-        filterLongviewClientsByQuery('client', mockLongviewClients)
-      ).toEqual(mockLongviewClients),
-      expect(filterLongviewClientsByQuery('(', mockLongviewClients)).toEqual(
-        {}
+    expect(filterLongviewClientsByQuery('client-1', clients, {})).toEqual([
+      clients[1]
+    ]),
+      expect(filterLongviewClientsByQuery('client', clients, {})).toEqual(
+        clients
       ),
-      expect(filterLongviewClientsByQuery(')', mockLongviewClients)).toEqual(
-        {}
-      ),
-      expect(
-        filterLongviewClientsByQuery('fdsafdsafsdf', mockLongviewClients)
-      ).toEqual({});
+      expect(filterLongviewClientsByQuery('(', clients, {})).toEqual([]),
+      expect(filterLongviewClientsByQuery(')', clients, {})).toEqual([]),
+      expect(filterLongviewClientsByQuery('fdsafdsafsdf', clients, {})).toEqual(
+        []
+      );
   });
 });
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -250,7 +250,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
       <Grid container className={classes.headingWrapper} alignItems="center">
         <Grid item className={`pt0 ${classes.searchbar}`}>
           <Search
-            placeholder="Filter by client label"
+            placeholder="Filter by client label or hostname"
             onSearch={handleSearch}
             debounceTime={250}
             small
@@ -377,7 +377,7 @@ export const filterLongviewClientsByQuery = (
 
     // If the label didn't match, check the hostname
     const hostname = pathOr<string>(
-      'localhost',
+      '',
       ['data', 'SysInfo', 'hostname'],
       clientData[thisClient.id]
     );

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -277,7 +277,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
         </Grid>
       </Grid>
       <LongviewList
-        longviewClientsData={
+        filteredData={
           !!filteredClientList
             ? filteredClientList
             : Object.values(longviewClientsData)

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -91,7 +91,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
     false
   );
   const [filteredClientList, filterClientList] = React.useState<
-    Record<string, LongviewClient> | undefined
+    LongviewClient[] | undefined
   >();
   const [deleteDialogOpen, toggleDeleteDialog] = React.useState<boolean>(false);
   const [selectedClientID, setClientID] = React.useState<number | undefined>(
@@ -217,7 +217,11 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
 
   const handleSearch = (query: string) => {
     return filterClientList(
-      filterLongviewClientsByQuery(query, longviewClientsData)
+      filterLongviewClientsByQuery(
+        query,
+        Object.values(longviewClientsData),
+        lvClientData
+      )
     );
   };
 
@@ -274,7 +278,9 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
       </Grid>
       <LongviewList
         longviewClientsData={
-          !!filteredClientList ? filteredClientList : longviewClientsData
+          !!filteredClientList
+            ? filteredClientList
+            : Object.values(longviewClientsData)
         }
         longviewClientsError={longviewClientsError}
         longviewClientsLastUpdated={longviewClientsLastUpdated}
@@ -347,7 +353,8 @@ export default compose<CombinedProps, Props & RouteComponentProps>(
 
 export const filterLongviewClientsByQuery = (
   query: string,
-  clientList: Record<string, LongviewClient>
+  clientList: LongviewClient[],
+  clientData: Record<string, StatsState>
 ) => {
   /** just return the original list if there's no query */
   if (!query.trim()) {
@@ -361,12 +368,23 @@ export const filterLongviewClientsByQuery = (
    * Invalid regular expression: Unmatched ')'
    */
   const cleanedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return Object.keys(clientList).reduce((acc, eachKey) => {
-    const thisClient = clientList[eachKey];
-    if (thisClient.label.match(new RegExp(`${cleanedQuery}`, 'gmi'))) {
-      acc[eachKey] = thisClient;
+  const queryRegex = new RegExp(`${cleanedQuery}`, 'gmi');
+
+  return clientList.filter(thisClient => {
+    if (thisClient.label.match(queryRegex)) {
+      return true;
     }
 
-    return acc;
-  }, {});
+    // If the label didn't match, check the hostname
+    const hostname = pathOr<string>(
+      'localhost',
+      ['data', 'SysInfo', 'hostname'],
+      clientData[thisClient.id]
+    );
+    if (hostname.match(queryRegex)) {
+      return true;
+    }
+
+    return false;
+  });
 };

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
@@ -47,7 +47,7 @@ type LongviewProps = Omit<
 
 interface Props {
   loading: boolean;
-  longviewClientsData: LongviewClient[];
+  filteredData: LongviewClient[];
   createLongviewClient: () => void;
   triggerDeleteLongviewClient: (
     longviewClientID: number,
@@ -61,7 +61,7 @@ const LongviewList: React.FC<CombinedProps> = props => {
   const {
     createLongviewClient,
     loading,
-    longviewClientsData,
+    filteredData,
     longviewClientsError,
     longviewClientsLastUpdated,
     longviewClientsLoading,
@@ -113,7 +113,7 @@ const LongviewList: React.FC<CombinedProps> = props => {
 
   return (
     <React.Fragment>
-      <OrderBy data={longviewClientsData} orderBy={'label'} order={'asc'}>
+      <OrderBy data={filteredData} orderBy={'label'} order={'asc'}>
         {({ data: orderedData, handleOrderChange, order, orderBy }) => (
           <Paginate data={orderedData}>
             {({

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
@@ -1,3 +1,4 @@
+import { LongviewClient } from 'linode-js-sdk/lib/longview/types';
 import * as React from 'react';
 import { compose } from 'recompose';
 import CircleProgress from 'src/components/CircleProgress';
@@ -37,6 +38,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 type LongviewProps = Omit<
   LVProps,
+  | 'longviewClientsData'
   | 'getLongviewClients'
   | 'createLongviewClient'
   | 'deleteLongviewClient'
@@ -45,6 +47,7 @@ type LongviewProps = Omit<
 
 interface Props {
   loading: boolean;
+  longviewClientsData: LongviewClient[];
   createLongviewClient: () => void;
   triggerDeleteLongviewClient: (
     longviewClientID: number,
@@ -110,11 +113,7 @@ const LongviewList: React.FC<CombinedProps> = props => {
 
   return (
     <React.Fragment>
-      <OrderBy
-        data={Object.values(longviewClientsData)}
-        orderBy={'label'}
-        order={'asc'}
-      >
+      <OrderBy data={longviewClientsData} orderBy={'label'} order={'asc'}>
         {({ data: orderedData, handleOrderChange, order, orderBy }) => (
           <Paginate data={orderedData}>
             {({


### PR DESCRIPTION
## Description

Search box now filters by hostname

- Added a 3rd argument to pass lvClientData to the filtering function
- Adjusted types/typings so we can .filter rather than .reduce (since
in this case we need an array ultimately anyway)
- Fixed tests to adjust to new pattern
- Refactored a few things
