### PR TITLE
M3-3620 Update breadcrumb typography and alignment

### DIFF
--- a/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/Breadcrumb.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles({
   preContainer: {
     display: 'flex',
     flexWrap: 'wrap',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     marginTop: -3
   },
   editablePreContainer: {

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -10,7 +10,6 @@ import { EditableProps, LabelProps } from './types';
 const useStyles = makeStyles((theme: Theme) => ({
   crumb: {
     ...theme.typography.h1,
-    lineHeight: 1.2,
     textTransform: 'capitalize'
   },
   noCap: {


### PR DESCRIPTION
## M3-3620 Update breadcrumb typography and alignment

This fixes an issue with alignment shown in the screenshot and a responsive typography issue needed for a caker item.

<img width="797" alt="Screen Shot 2019-11-20 at 10 16 11 AM" src="https://user-images.githubusercontent.com/205353/69257649-6750e000-0b89-11ea-9cab-cf9b1a8ce632.png">

## Type of Change
- Non breaking change ('update')

