### PR TITLE
M3 Longview Landing Adjustments

### DIFF
--- a/packages/manager/src/components/EditableEntityLabel/EditableEntityLabel.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableEntityLabel.tsx
@@ -16,17 +16,15 @@ const useStyles = makeStyles((theme: Theme) => ({
     position: 'relative',
     paddingRight: 20,
     whiteSpace: 'pre-wrap',
-    wordBreak: 'break-all'
-  },
-  subText: {
-    fontSize: '0.8em'
+    wordBreak: 'break-all',
+    fontSize: 15
   }
 }));
 
 interface Props {
   text: string;
   onEdit: (s: string) => Promise<any>;
-  iconVariant: Variant;
+  iconVariant?: Variant;
   loading: boolean;
   subText?: string;
   status?: string;
@@ -69,7 +67,7 @@ export const EditableEntityLabel: React.FC<Props> = props => {
       justify="flex-start"
       className={`${classes.root} m0`}
     >
-      {!isEditing && (
+      {!isEditing && iconVariant && (
         <Grid item className="py0 px0">
           <EntityIcon
             variant={iconVariant}
@@ -97,9 +95,7 @@ export const EditableEntityLabel: React.FC<Props> = props => {
           </Grid>
           {subText && !isEditing && (
             <Grid item className="py0 px0">
-              <Typography variant="body2" className={classes.subText}>
-                {subText}
-              </Typography>
+              <Typography variant="body2">{subText}</Typography>
             </Grid>
           )}
         </Grid>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -50,7 +50,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     textAlign: 'left'
   },
   lastUpdatedOuter: {
-    marginTop: theme.spacing(1)
+    [theme.breakpoints.up('md')]: {
+      marginTop: theme.spacing(1)
+    }
   },
   lastUpdatedText: {
     fontSize: '0.75rem'
@@ -62,7 +64,7 @@ interface Props {
   clientLabel: string;
   lastUpdatedError?: APIError[];
   updateLongviewClient: DispatchProps['updateLongviewClient'];
-  longviewClientLastUpdated: number;
+  longviewClientLastUpdated?: number;
 }
 
 type CombinedProps = Props & DispatchProps & LVDataProps & WithTheme;
@@ -123,13 +125,13 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
   );
   const packagesToUpdate = getPackageNoticeText(packages);
 
-  const utcLastUpdatedTime = new Date(longviewClientLastUpdated).toUTCString();
+  const utcLastUpdatedTime = new Date(longviewClientLastUpdated!).toUTCString();
   const formattedlastUpdatedTime =
-    longviewClientLastUpdated !== null
+    longviewClientLastUpdated !== undefined
       ? `Last updated ${formatDate(utcLastUpdatedTime, {
           humanizeCutoff: 'never'
         })}`
-      : undefined;
+      : 'Latest update time not available';
 
   /**
    * The pathOrs ahead will default to 'not available' values if

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientHeader.tsx
@@ -3,6 +3,7 @@ import { pathOr } from 'ramda';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { compose } from 'recompose';
+import Button from 'src/components/Button';
 import { makeStyles, Theme, WithTheme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import EditableEntityLabel from 'src/components/EditableEntityLabel';
@@ -12,6 +13,7 @@ import withClientStats, {
   Props as LVDataProps
 } from 'src/containers/longview.stats.container';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { formatDate } from 'src/utilities/formatDate';
 import { formatUptime } from 'src/utilities/formatUptime';
 import { pluralize } from 'src/utilities/pluralize';
 import { LongviewPackage } from '../request.types';
@@ -41,6 +43,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.down('md')]: {
       top: -4
     }
+  },
+  packageButton: {
+    fontSize: '0.875rem',
+    padding: 0,
+    textAlign: 'left'
+  },
+  lastUpdatedOuter: {
+    marginTop: theme.spacing(1)
+  },
+  lastUpdatedText: {
+    fontSize: '0.75rem'
   }
 }));
 
@@ -49,6 +62,7 @@ interface Props {
   clientLabel: string;
   lastUpdatedError?: APIError[];
   updateLongviewClient: DispatchProps['updateLongviewClient'];
+  longviewClientLastUpdated: number;
 }
 
 type CombinedProps = Props & DispatchProps & LVDataProps & WithTheme;
@@ -60,7 +74,11 @@ const getPackageNoticeText = (packages: LongviewPackage[]) => {
   if (packages.length === 0) {
     return 'All packages up to date';
   }
-  return `${pluralize('package', 'packages', packages.length)} have updates`;
+  return `${pluralize(
+    'package update',
+    'package updates',
+    packages.length
+  )} available`;
 };
 
 export const LongviewClientHeader: React.FC<CombinedProps> = props => {
@@ -105,6 +123,14 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
   );
   const packagesToUpdate = getPackageNoticeText(packages);
 
+  const utcLastUpdatedTime = new Date(longviewClientLastUpdated).toUTCString();
+  const formattedlastUpdatedTime =
+    longviewClientLastUpdated !== null
+      ? `Last updated ${formatDate(utcLastUpdatedTime, {
+          humanizeCutoff: 'never'
+        })}`
+      : undefined;
+
   /**
    * The pathOrs ahead will default to 'not available' values if
    * there's an error, so the only case we need to handle is
@@ -121,9 +147,7 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
       <Grid item>
         <EditableEntityLabel
           text={clientLabel}
-          iconVariant="linode"
           subText={hostname}
-          status="running"
           onEdit={handleUpdateLabel}
           loading={updating}
         />
@@ -134,7 +158,17 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
         ) : (
           <>
             <Typography>{formattedUptime}</Typography>
-            <Typography>{packagesToUpdate}</Typography>
+            {packages && packages.length > 0 ? (
+              <Button
+                className={classes.packageButton}
+                title={packagesToUpdate}
+                onClick={() => window.open('#')}
+              >
+                {packagesToUpdate}
+              </Button>
+            ) : (
+              <Typography>{packagesToUpdate}</Typography>
+            )}
           </>
         )}
       </Grid>
@@ -142,6 +176,13 @@ export const LongviewClientHeader: React.FC<CombinedProps> = props => {
         <Link to={`/longview/clients/${clientID}`} className={classes.link}>
           View details
         </Link>
+        {!loading && (
+          <div className={classes.lastUpdatedOuter}>
+            <Typography variant="caption" className={classes.lastUpdatedText}>
+              {formattedlastUpdatedTime}
+            </Typography>
+          </div>
+        )}
       </Grid>
     </Grid>
   );

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientInstructions.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientInstructions.tsx
@@ -73,7 +73,6 @@ export const LongviewClientInstructions: React.FC<Props> = props => {
             <Grid item xs={12} md={3}>
               <EditableEntityLabel
                 text={clientLabel}
-                iconVariant="linode"
                 subText="Waiting for data..."
                 onEdit={handleUpdateLabel}
                 loading={updating}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -47,6 +47,7 @@ interface Props extends ActionHandlers {
   clientLabel: string;
   clientAPIKey: string;
   clientInstallKey: string;
+  longviewClientLastUpdated: number;
 }
 
 type CombinedProps = Props & LVDataProps & DispatchProps;
@@ -60,7 +61,8 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
     clientAPIKey,
     triggerDeleteLongviewClient,
     clientInstallKey,
-    updateLongviewClient
+    updateLongviewClient,
+    longviewClientLastUpdated
   } = props;
 
   const { lastUpdated, lastUpdatedError, authed } = useClientLastUpdated(
@@ -103,6 +105,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
                 clientLabel={clientLabel}
                 lastUpdatedError={lastUpdatedError}
                 updateLongviewClient={updateLongviewClient}
+                longviewClientLastUpdated={longviewClientLastUpdated}
               />
             </Grid>
             <Grid item xs={12} md={9}>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -47,7 +47,6 @@ interface Props extends ActionHandlers {
   clientLabel: string;
   clientAPIKey: string;
   clientInstallKey: string;
-  longviewClientLastUpdated: number;
 }
 
 type CombinedProps = Props & LVDataProps & DispatchProps;
@@ -61,8 +60,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
     clientAPIKey,
     triggerDeleteLongviewClient,
     clientInstallKey,
-    updateLongviewClient,
-    longviewClientLastUpdated
+    updateLongviewClient
   } = props;
 
   const { lastUpdated, lastUpdatedError, authed } = useClientLastUpdated(
@@ -105,7 +103,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
                 clientLabel={clientLabel}
                 lastUpdatedError={lastUpdatedError}
                 updateLongviewClient={updateLongviewClient}
-                longviewClientLastUpdated={longviewClientLastUpdated}
+                longviewClientLastUpdated={lastUpdated}
               />
             </Grid>
             <Grid item xs={12} md={9}>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -23,22 +23,24 @@ import withLongviewClients, {
 import { State as StatsState } from 'src/store/longviewStats/longviewStats.reducer';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
-import { formatDate } from 'src/utilities/formatDate';
 import DeleteDialog from './LongviewDeleteDialog';
 import LongviewList from './LongviewList';
 import SubscriptionDialog from './SubscriptionDialog';
 
 const useStyles = makeStyles((theme: Theme) => ({
   headingWrapper: {
-    marginTop: theme.spacing()
+    marginBottom: theme.spacing(1)
   },
   addNew: {
     marginLeft: 'auto'
   },
   searchbar: {
-    marginBottom: theme.spacing(2),
-    '& >div': {
-      width: '300px'
+    width: '100%',
+    [theme.breakpoints.up('md')]: {
+      width: 'auto',
+      '& >div': {
+        width: '300px'
+      }
     }
   },
   cta: {
@@ -48,11 +50,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(2)
   },
   sortSelect: {
-    marginBottom: theme.spacing(2),
-    width: '300px',
+    width: 210,
     display: 'flex',
     flexFlow: 'row nowrap',
-    alignItems: 'center'
+    alignItems: 'center',
+    [theme.breakpoints.up('md')]: {
+      width: 221
+    }
   },
   selectLabel: {
     minWidth: '65px'
@@ -76,15 +80,6 @@ type CombinedProps = Props &
  * was updated.
  *
  */
-export const getLastUpdated = (lvClientData: Record<string, StatsState>) => {
-  const updated = Object.values(lvClientData).reduce((accum, thisClient) => {
-    return thisClient.lastUpdated > accum ? thisClient.lastUpdated : accum;
-  }, 0) as number;
-  if (updated === 0) {
-    return 'Loading...';
-  }
-  return `Data last updated at ${formatDate(new Date(updated).toUTCString())}`;
-};
 
 export const LongviewClients: React.FC<CombinedProps> = props => {
   const [newClientLoading, setNewClientLoading] = React.useState<boolean>(
@@ -241,14 +236,10 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
     pathOr(false, ['longview_subscription'], accountSettings)
   );
 
-  const lastUpdated = React.useMemo(() => getLastUpdated(lvClientData), [
-    lvClientData
-  ]);
-
   return (
     <React.Fragment>
       <Grid container className={classes.headingWrapper} alignItems="center">
-        <Grid item className={`pt0 ${classes.searchbar}`}>
+        <Grid item className={`py0 ${classes.searchbar}`}>
           <Search
             placeholder="Filter by client label or hostname"
             onSearch={handleSearch}
@@ -256,7 +247,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
             small
           />
         </Grid>
-        <Grid item className={`pt0 ${classes.sortSelect}`}>
+        <Grid item className={`py0 ${classes.sortSelect}`}>
           <Typography className={classes.selectLabel}>Sort by: </Typography>
           <Select
             small
@@ -266,10 +257,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
             onChange={handleSortKeyChange}
           />
         </Grid>
-        <Grid item className={`pt0 ${classes.lastUpdated}`}>
-          <Typography>{lastUpdated}</Typography>
-        </Grid>
-        <Grid item className={`${classes.addNew} pt0`}>
+        <Grid item className={`${classes.addNew} py0`}>
           <AddNewLink
             onClick={handleAddClient}
             label={newClientLoading ? 'Loading...' : 'Add a Client'}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewListRows.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewListRows.tsx
@@ -28,6 +28,7 @@ const LongviewListRows: React.FC<CombinedProps> = props => {
             clientLabel={eachClient.label}
             clientAPIKey={eachClient.api_key}
             triggerDeleteLongviewClient={triggerDeleteLongviewClient}
+            longviewClientLastUpdated={Number(eachClient.updated)}
           />
         );
       })}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewListRows.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewListRows.tsx
@@ -28,7 +28,6 @@ const LongviewListRows: React.FC<CombinedProps> = props => {
             clientLabel={eachClient.label}
             clientAPIKey={eachClient.api_key}
             triggerDeleteLongviewClient={triggerDeleteLongviewClient}
-            longviewClientLastUpdated={Number(eachClient.updated)}
           />
         );
       })}

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
@@ -94,19 +94,29 @@ const useStyles = makeStyles((theme: Theme) => {
       marginLeft: theme.spacing(2)
     },
     planCell: {
-      width: '40%'
+      [theme.breakpoints.up('md')]: {
+        width: '40%'
+      }
     },
     clientCell: {
-      width: '10%'
+      [theme.breakpoints.up('md')]: {
+        width: '10%'
+      }
     },
     dataRetentionCell: {
-      width: '15%'
+      [theme.breakpoints.up('md')]: {
+        width: '15%'
+      }
     },
     dataResolutionCell: {
-      width: '15%'
+      [theme.breakpoints.up('md')]: {
+        width: '15%'
+      }
     },
     priceCell: {
-      width: '15%'
+      [theme.breakpoints.up('md')]: {
+        width: '15%'
+      }
     },
     submitButton: {
       alignSelf: 'flex-start',


### PR DESCRIPTION
## Description

This PR ended up being a bit of a mix of visual adjustments mostly to landing but also to plan details (mobile). Of note:

• Removed entity icon from client rows
• Updated location and styling for last updated timestamp (now displays for each client row)
• Packages link styling
• Mobile Landing header
• Mobile Plan Details fix

## Type of Change
- Non breaking change ('update')