### PR TITLE
M3-3290 Wait 20 seconds after a resize then request the Linode again

### DIFF
--- a/packages/manager/src/store/linodes/linodes.events.ts
+++ b/packages/manager/src/store/linodes/linodes.events.ts
@@ -116,6 +116,18 @@ const handleLinodeMigrate = (
       // Once the migration/resize is done, we request notifications in order
       // to clear the Migration Imminent notification
       dispatch(requestNotifications());
+      /**
+       * After resizing, a Linode is booted (if it was booted before);
+       * however, no boot event is sent. Additionally, the 'finished'
+       * resize event is sent before this is complete. As a result,
+       * the requestLinodeForStore below will often return a
+       * status of 'offline', which will then not be updated.
+       *
+       * We send a follow-on request here to make sure the status is accurate.
+       * 20 seconds is ridiculous but shorter timeouts still end up telling
+       * us the Linode is offline.
+       */
+      setTimeout(() => dispatch(requestLinodeForStore(id, true)), 20000);
       return dispatch(requestLinodeForStore(id));
     default:
       return;


### PR DESCRIPTION
## Description

After a Linode resize is completed, if the Linode was previously running, the API will attempt to boot it. There's no linode_boot event, though, so we show the Linode as offline forever until the user reloads the page. After talking with the API, the only way around this is to wait for 20 seconds after the resize finishes then request the Linode again.

Has to be ~20 seconds or the Linode is still offline when we request. This may not work for every size/shape of Linode, but 20 seconds is already a long time without any progress bar. We could do an interval that polls until it's online, but we don't really know if there is even a boot in progress, and "poll forever after a resize just in case" seems like overkill.