### PR TITLE
[OBJ] add display name for Philadelphia

### DIFF
--- a/packages/manager/src/constants.ts
+++ b/packages/manager/src/constants.ts
@@ -172,11 +172,12 @@ export const dcDisplayCountry = {
 };
 
 export const objectStorageClusterDisplay: Record<
-  ObjectStorageClusterID,
+  ObjectStorageClusterID | 'philadelphia',
   string
 > = {
   'us-east-1': 'Newark, NJ',
-  'us-east': 'Newark, NJ'
+  'us-east': 'Newark, NJ',
+  philadelphia: 'Philadelphia, PA'
 };
 
 export type ContinentKey = 'NA' | 'EU' | 'AS';

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -12,7 +12,7 @@ import EntityIcon from 'src/components/EntityIcon';
 import Grid from 'src/components/Grid';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
-import { formatRegion } from 'src/utilities/formatRegion';
+import { formatObjectStorageCluster } from 'src/utilities/formatRegion';
 import BucketActionMenu from './BucketActionMenu';
 
 type ClassNames = 'bucketNameWrapper' | 'bucketRow' | 'link';
@@ -78,7 +78,7 @@ export const BucketTableRow: React.StatelessComponent<
       </TableCell>
       <TableCell parentColumn="Region">
         <Typography variant="body2" data-qa-region>
-          {formatRegion(cluster)}
+          {formatObjectStorageCluster(cluster)}
         </Typography>
       </TableCell>
       <TableCell parentColumn="Created">

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/ClusterSelect.tsx
@@ -4,7 +4,7 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import clustersContainer, {
   StateProps
 } from 'src/containers/clusters.container';
-import { formatRegion } from 'src/utilities';
+import { formatObjectStorageCluster } from 'src/utilities/formatRegion';
 
 interface Props {
   selectedCluster: string;
@@ -28,7 +28,7 @@ export const ClusterSelect: React.StatelessComponent<CombinedProps> = props => {
 
   const options: Item<string>[] = clustersData.map(eachCluster => ({
     value: eachCluster.id,
-    label: formatRegion(eachCluster.region)
+    label: formatObjectStorageCluster(eachCluster.region)
   }));
 
   React.useEffect(() => {

--- a/packages/manager/src/utilities/formatRegion.ts
+++ b/packages/manager/src/utilities/formatRegion.ts
@@ -1,4 +1,3 @@
-import { ObjectStorageClusterID } from 'linode-js-sdk/lib/object-storage';
 import {
   /* dcDisplayCountry, */ dcDisplayNames,
   objectStorageClusterDisplay
@@ -48,5 +47,5 @@ export const getHumanReadableCountry = (regionSlug: string) => {
   return 'Other';
 };
 
-export const formatObjectStorageCluster = (clusterId: ObjectStorageClusterID) =>
-  objectStorageClusterDisplay[clusterId];
+export const formatObjectStorageCluster = (clusterId: string) =>
+  objectStorageClusterDisplay[clusterId] || '';


### PR DESCRIPTION
## Description

Add mapping for display name of test cluster. This will only ever be visible in dev.

- I cheated the typing a bit here, since I didn't want the `ObjectStorageClusterID` type to be polluted. 
- I changed instances of `formatRegion` in OBJ to the unused `formatObjectStorageCluster` because I didn't want to pollute the rest of the region types.

## Note to Reviewers

Please check that both prod and dev look OK.
