### PR TITLE
M3-3523 Processes Tab (Layout & Table)

### DIFF
--- a/packages/manager/src/components/TableRow/TableRow.tsx
+++ b/packages/manager/src/components/TableRow/TableRow.tsx
@@ -11,7 +11,7 @@ import _TableRow, {
   TableRowProps as _TableRowProps
 } from 'src/components/core/TableRow';
 
-type ClassNames = 'root';
+type ClassNames = 'root' | 'selected';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -29,6 +29,10 @@ const styles = (theme: Theme) =>
           paddingLeft: 5
         }
       }
+    },
+    selected: {
+      backgroundColor: '#f0f7ff',
+      border: 'solid 1px #93bcec !important'
     }
   });
 
@@ -39,6 +43,7 @@ interface Props {
   className?: string;
   staticContext?: boolean;
   htmlFor?: string;
+  selected?: boolean;
 }
 
 type CombinedProps = Props &
@@ -81,7 +86,14 @@ class TableRow extends React.Component<CombinedProps> {
   };
 
   render() {
-    const { classes, className, rowLink, staticContext, ...rest } = this.props;
+    const {
+      classes,
+      className,
+      rowLink,
+      staticContext,
+      selected,
+      ...rest
+    } = this.props;
 
     let role;
     switch (typeof rowLink) {
@@ -104,7 +116,8 @@ class TableRow extends React.Component<CombinedProps> {
         hover={rowLink !== undefined}
         role={role}
         className={classNames(className, {
-          [classes.root]: true
+          [classes.root]: true,
+          [classes.selected]: selected
         })}
         {...rest}
         tabIndex={rowLink ? 0 : -1}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesGraphs.tsx
@@ -1,0 +1,34 @@
+import { APIError } from 'linode-js-sdk/lib/types';
+import * as React from 'react';
+import Paper from 'src/components/core/Paper';
+// import { makeStyles, Theme } from 'src/components/core/styles';
+import { ExtendedProcess } from './ProcessesTable';
+
+// const useStyles = makeStyles((theme: Theme) => ({
+//   root: {}
+// }));
+
+interface Props {
+  processesData: ExtendedProcess[];
+  processesLoading: boolean;
+  processesError?: APIError[];
+  selectedRow: string | null;
+}
+
+type CombinedProps = Props;
+
+const ProcessesGraphs: React.FC<CombinedProps> = props => {
+  // const classes = useStyles();
+
+  const { processesData, selectedRow } = props;
+
+  const selected = processesData.find(p => p.id === selectedRow);
+
+  return (
+    <>
+      <Paper>{selected && `${selected.name} ${selected.user}`} </Paper>
+    </>
+  );
+};
+
+export default ProcessesGraphs;

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesLanding.tsx
@@ -1,0 +1,62 @@
+import * as Factory from 'factory.ts';
+import * as React from 'react';
+import Grid from 'src/components/Grid';
+import ProcessesGraphs from './ProcessesGraphs';
+import ProcessesTable, { ExtendedProcess } from './ProcessesTable';
+
+// === MOCK DAtA ===
+const randomElement = (arr: any[]) =>
+  arr[Math.floor(Math.random() * arr.length)];
+const randNum = (min: number, max: number) => {
+  return Math.round(Math.random() * (max - min) + min);
+};
+const TEMPORARY_longviewProcessFactory = Factory.Sync.makeFactory<
+  ExtendedProcess
+>({
+  // In real life, `id` will be name + user concatenated.
+  id: Factory.each(() => `${randNum(0, 50000)}`),
+  name: Factory.each(() => randomElement(['bash', 'ssd', 'systemd'])),
+  user: Factory.each(() => randomElement(['root', 'user1'])),
+  maxCount: Factory.each(() => randNum(0, 4)),
+  averageIO: Factory.each(() => randNum(0, 500)),
+  averageCPU: Factory.each(() => randNum(0, 100)),
+  averageMem: Factory.each(() => randNum(0, 100))
+});
+const mockData = TEMPORARY_longviewProcessFactory.buildList(25);
+// =================
+
+const ProcessesLanding: React.FC<{}> = () => {
+  const [selectedRow, setSelectedRow] = React.useState<string | null>(null);
+
+  // === MOCK DAtA ===
+  const processesData = mockData;
+  const processesLoading = false;
+  const processesError = undefined;
+  // =================
+
+  return (
+    <>
+      <Grid container>
+        <Grid item xs={9}>
+          <ProcessesTable
+            processesData={processesData}
+            processesLoading={processesLoading}
+            processesError={processesError}
+            selectedRow={selectedRow}
+            setSelectedRow={setSelectedRow}
+          />
+        </Grid>
+        <Grid item xs={3}>
+          <ProcessesGraphs
+            processesData={processesData}
+            processesLoading={processesLoading}
+            processesError={processesError}
+            selectedRow={selectedRow}
+          />
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+export default React.memo(ProcessesLanding);

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
@@ -1,0 +1,245 @@
+// === TEMPORARY FACTORY ===
+
+import { APIError } from 'linode-js-sdk/lib/types';
+import * as React from 'react';
+import Box from 'src/components/core/Box';
+import { makeStyles, Theme } from 'src/components/core/styles';
+import TableBody from 'src/components/core/TableBody';
+import TableHead from 'src/components/core/TableHead';
+import Select from 'src/components/EnhancedSelect/Select';
+import OrderBy from 'src/components/OrderBy';
+import Table from 'src/components/Table';
+import TableCell from 'src/components/TableCell';
+import TableRow from 'src/components/TableRow';
+import TableRowEmptyState from 'src/components/TableRowEmptyState';
+import TableRowError from 'src/components/TableRowError';
+import TableRowLoading from 'src/components/TableRowLoading';
+import TableSortCell from 'src/components/TableSortCell';
+import TextField from 'src/components/TextField';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  filterInput: {
+    width: 300
+  },
+  timeSelect: {
+    width: 200
+  }
+}));
+
+interface Props {
+  processesData: ExtendedProcess[];
+  processesLoading: boolean;
+  processesError?: APIError[];
+  selectedRow: string | null;
+  setSelectedRow: (id: string) => void;
+}
+
+type CombinedProps = Props;
+
+const ProcessesTable: React.FC<CombinedProps> = props => {
+  const classes = useStyles();
+
+  const {
+    processesData,
+    processesLoading,
+    processesError,
+    selectedRow,
+    setSelectedRow
+  } = props;
+
+  const errorMessage = processesError
+    ? 'There was an error getting Processes'
+    : undefined;
+
+  return (
+    <>
+      <Box display="flex" justifyContent="space-between">
+        {/* Doesn't work yet. */}
+        <TextField
+          className={classes.filterInput}
+          small
+          placeholder="Filter by process or user..."
+        />
+        {/* Doesn't work yet. */}
+        <Select
+          className={classes.timeSelect}
+          small
+          placeholder="Last 12 Hours"
+          onChange={() => null}
+        />
+      </Box>
+      <OrderBy data={processesData} orderBy={'name'} order={'desc'}>
+        {({ data: orderedData, handleOrderChange, order, orderBy }) => (
+          <>
+            <Table spacingTop={16}>
+              <TableHead>
+                <TableRow>
+                  <TableSortCell
+                    data-qa-table-header="Process"
+                    active={orderBy === 'name'}
+                    label="name"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                    style={{ width: '25%' }}
+                  >
+                    Process
+                  </TableSortCell>
+                  <TableSortCell
+                    data-qa-table-header="User"
+                    active={orderBy === 'user'}
+                    label="user"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                    style={{ width: '25%' }}
+                  >
+                    User
+                  </TableSortCell>
+                  <TableSortCell
+                    data-qa-table-header="Max Count"
+                    active={orderBy === 'maxCount'}
+                    label="maxCount"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                    style={{ width: '15%' }}
+                  >
+                    Protocol
+                  </TableSortCell>
+                  <TableSortCell
+                    data-qa-table-header="Avg IO"
+                    active={orderBy === 'averageIO'}
+                    label="averageIO"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                    style={{ width: '10%' }}
+                  >
+                    Avg IO
+                  </TableSortCell>
+                  <TableSortCell
+                    data-qa-table-header="Avg CPU"
+                    active={orderBy === 'averageCPU'}
+                    label="averageCPU"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                    style={{ width: '10%' }}
+                  >
+                    Avg CPU
+                  </TableSortCell>
+                  <TableSortCell
+                    data-qa-table-header="Avg Mem"
+                    active={orderBy === 'averageMem'}
+                    label="averageMem"
+                    direction={order}
+                    handleClick={handleOrderChange}
+                    style={{ width: '25%' }}
+                  >
+                    Avg Mem
+                  </TableSortCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {renderLoadingErrorData(
+                  processesLoading,
+                  orderedData,
+                  selectedRow,
+                  setSelectedRow,
+                  errorMessage
+                )}
+              </TableBody>
+            </Table>
+          </>
+        )}
+      </OrderBy>
+    </>
+  );
+};
+
+const renderLoadingErrorData = (
+  loading: boolean,
+  data: ExtendedProcess[],
+  selectedRow: string | null,
+  setSelectedRow: (id: string) => void,
+  error?: string
+) => {
+  if (error && data.length === 0) {
+    return <TableRowError colSpan={12} message={error} />;
+  }
+  if (loading && data.length === 0) {
+    return <TableRowLoading colSpan={6} />;
+  }
+  if (data.length === 0) {
+    return <TableRowEmptyState colSpan={12} />;
+  }
+
+  return data.map((thisProcesses, idx) => (
+    <ProcessesTableRow
+      key={`process-${idx}`}
+      id={thisProcesses.id}
+      isSelected={selectedRow === thisProcesses.id}
+      setSelectedRow={setSelectedRow}
+      {...thisProcesses}
+    />
+  ));
+};
+
+export interface ProcessTableRowProps extends ExtendedProcess {
+  id: string;
+  isSelected: boolean;
+  setSelectedRow: (id: string) => void;
+}
+
+export const ProcessesTableRow: React.FC<ProcessTableRowProps> = React.memo(
+  props => {
+    const {
+      name,
+      user,
+      maxCount,
+      averageIO,
+      averageCPU,
+      averageMem,
+      id,
+      setSelectedRow,
+      isSelected
+    } = props;
+    return (
+      <TableRow
+        rowLink={() => setSelectedRow(id)}
+        selected={isSelected}
+        data-testid="longview-service-row"
+      >
+        <TableCell parentColumn="Process" data-qa-service-process>
+          {name}
+        </TableCell>
+        <TableCell parentColumn="User" data-qa-service-user>
+          {user}
+        </TableCell>
+        <TableCell parentColumn="Max Count" data-qa-service-protocol>
+          {maxCount}
+        </TableCell>
+        <TableCell parentColumn="Avg IO" data-qa-service-port>
+          {/* @todo: formatting */}
+          {averageIO} B/s
+        </TableCell>
+        <TableCell parentColumn="Avg CPU" data-qa-service-ip>
+          {/* @todo: formatting */}
+          {averageCPU}%
+        </TableCell>
+        <TableCell parentColumn="Avg Mem" data-qa-service-ip>
+          {/* @todo: formatting */}
+          {averageMem} MB
+        </TableCell>
+      </TableRow>
+    );
+  }
+);
+
+export interface ExtendedProcess {
+  id: string;
+  name: string;
+  user: string;
+  maxCount: number;
+  averageIO: number;
+  averageCPU: number;
+  averageMem: number;
+}
+
+export default React.memo(ProcessesTable);

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
@@ -100,7 +100,7 @@ const ProcessesTable: React.FC<CombinedProps> = props => {
                     handleClick={handleOrderChange}
                     style={{ width: '15%' }}
                   >
-                    Protocol
+                    Max Count
                   </TableSortCell>
                   <TableSortCell
                     data-qa-table-header="Avg IO"
@@ -200,28 +200,28 @@ export const ProcessesTableRow: React.FC<ProcessTableRowProps> = React.memo(
     } = props;
     return (
       <TableRow
-        rowLink={() => setSelectedRow(id)}
+        onClick={() => setSelectedRow(id)}
         selected={isSelected}
         data-testid="longview-service-row"
       >
-        <TableCell parentColumn="Process" data-qa-service-process>
+        <TableCell parentColumn="Process" data-qa-process-process>
           {name}
         </TableCell>
-        <TableCell parentColumn="User" data-qa-service-user>
+        <TableCell parentColumn="User" data-qa-process-user>
           {user}
         </TableCell>
-        <TableCell parentColumn="Max Count" data-qa-service-protocol>
+        <TableCell parentColumn="Max Count" data-qa-process-max-count>
           {maxCount}
         </TableCell>
-        <TableCell parentColumn="Avg IO" data-qa-service-port>
+        <TableCell parentColumn="Avg IO" data-qa-process-avg-io>
           {/* @todo: formatting */}
           {averageIO} B/s
         </TableCell>
-        <TableCell parentColumn="Avg CPU" data-qa-service-ip>
+        <TableCell parentColumn="Avg CPU" data-qa-process-avg-cpu>
           {/* @todo: formatting */}
           {averageCPU}%
         </TableCell>
-        <TableCell parentColumn="Avg Mem" data-qa-service-ip>
+        <TableCell parentColumn="Avg Mem" data-qa-process-avg-mem>
           {/* @todo: formatting */}
           {averageMem} MB
         </TableCell>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesTable.tsx
@@ -1,5 +1,3 @@
-// === TEMPORARY FACTORY ===
-
 import { APIError } from 'linode-js-sdk/lib/types';
 import * as React from 'react';
 import Box from 'src/components/core/Box';

--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -28,6 +28,7 @@ import { get } from 'src/features/Longview/request';
 import { LongviewTopProcesses } from 'src/features/Longview/request.types';
 import { useAPIRequest } from 'src/hooks/useAPIRequest';
 import { useClientLastUpdated } from '../shared/useClientLastUpdated';
+import ProcessesLanding from './DetailTabs/Processes/ProcessesLanding';
 
 const topProcessesEmptyDataSet: LongviewTopProcesses = { Processes: {} };
 
@@ -208,7 +209,7 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
           exact
           strict
           path={`${url}/processes`}
-          render={() => <h2>Processes</h2>}
+          render={() => <ProcessesLanding />}
         />
         <Route
           exact


### PR DESCRIPTION
## Description

Initial work on the layout for the Processes tab. 

<img width="1349" alt="Screen Shot 2019-11-22 at 11 31 51 AM" src="https://user-images.githubusercontent.com/16911484/69443067-b0389e00-0d1b-11ea-9ed4-19a7ec71c54e.png">

My thought is that if we merge this, @WilkinsKa1  can work on styles in a separate PR while I work on the data fetching and munging.

### New:

New `selected` prop on `<TableRow />`. Styling isn't complete here, and there are rough edges around hover/focus/click states. 


### Notes:
- Data is static.
- The Graphs sidebar component is currently a stub.
- Loading/Error states aren’t really a thing yet.
- Ditto with Mobile styling.

## Note to Reviewers

Things to look for:

- Please check that the general shape of the layout and code makes sense. 
- Table sorting should work.
