### PR TITLE
M3-3962 Remove same-domain SOA email restriction (client-side validation)

### DIFF
--- a/packages/manager/src/features/Domains/DomainDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainDrawer.tsx
@@ -56,8 +56,6 @@ import NodeBalancerSelect from 'src/features/NodeBalancers/NodeBalancerSelect';
 import { getErrorMap } from 'src/utilities/errorUtils';
 import { sendCreateDomainEvent } from 'src/utilities/ga';
 
-import { isValidSOAEmail } from './domainUtils';
-
 type ClassNames = 'root' | 'masterIPErrorNotice' | 'addIP';
 
 const styles = (theme: Theme) =>
@@ -500,25 +498,6 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
     this.closeDrawer();
   };
 
-  handleEmailValidationErrors = () => {
-    const err = [
-      {
-        field: 'soa_email',
-        reason:
-          'Please choose an SOA email address that does not belong to the target Domain.'
-      }
-    ];
-    this.setState(
-      {
-        submitting: false,
-        errors: getAPIErrorOrDefault(err)
-      },
-      () => {
-        scrollErrorIntoView();
-      }
-    );
-  };
-
   create = () => {
     const {
       domain,
@@ -582,11 +561,6 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
       type === 'master'
         ? { domain, type, tags, soa_email: soaEmail }
         : { domain, type, tags, master_ips: finalMasterIPs };
-
-    if (type === 'master' && !isValidSOAEmail(data.soa_email || '', domain)) {
-      this.handleEmailValidationErrors();
-      return;
-    }
 
     this.setState({ submitting: true });
     domainActions
@@ -750,11 +724,6 @@ class DomainDrawer extends React.Component<CombinedProps, State> {
         ? // not sending type for master. There is a bug on server and it returns an error that `master_ips` is required
           { domain, tags, soa_email: soaEmail, domainId: id }
         : { domain, type, tags, master_ips: finalMasterIPs, domainId: id };
-
-    if (type === 'master' && !isValidSOAEmail(data.soa_email || '', domain)) {
-      this.handleEmailValidationErrors();
-      return;
-    }
 
     this.setState({ submitting: true });
     domainActions

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -34,11 +34,7 @@ import {
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import getAPIErrorsFor from 'src/utilities/getAPIErrorFor';
 import scrollErrorIntoView from 'src/utilities/scrollErrorIntoView';
-import {
-  isValidCNAME,
-  isValidDomainRecord,
-  isValidSOAEmail
-} from './domainUtils';
+import { isValidCNAME, isValidDomainRecord } from './domainUtils';
 
 const TextField: React.StatelessComponent<TextFieldProps> = props => (
   <_TextField {...props} />
@@ -439,28 +435,12 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
   };
 
   onDomainEdit = () => {
-    const { domain, domainId, type, domainActions } = this.props;
+    const { domainId, type, domainActions } = this.props;
     this.setState({ submitting: true, errors: undefined });
 
     const data = {
       ...this.filterDataByType(this.state.fields, type)
     } as Partial<EditableDomainFields>;
-
-    /**
-     * Prevent changing the soa_email to an
-     * email within this Domain. This isn't breaking,
-     * but is bad practice.
-     */
-
-    if (!isValidSOAEmail(data.soa_email || '', domain || '')) {
-      const error = {
-        field: 'soa_email',
-        reason:
-          'Please choose an SOA email address that does not belong to this Domain.'
-      };
-      this.handleSubmissionErrors([error]);
-      return;
-    }
 
     if (data.axfr_ips) {
       /**

--- a/packages/manager/src/features/Domains/domainUtils.test.ts
+++ b/packages/manager/src/features/Domains/domainUtils.test.ts
@@ -1,33 +1,7 @@
 import { domainRecords as records } from 'src/__data__/domains';
-import {
-  isValidCNAME,
-  isValidDomainRecord,
-  isValidSOAEmail
-} from './domainUtils';
+import { isValidCNAME, isValidDomainRecord } from './domainUtils';
 
 describe('Domain-related utilities', () => {
-  describe('Validating email addresses', () => {
-    it('should not allow an email address that belongs to the target domain', () => {
-      // If you're creating example.com, admin@example.com will break things.
-      expect(isValidSOAEmail('admin@example.com', 'example.com')).toBe(false);
-    });
-
-    it('should allow normal combinations', () => {
-      expect(isValidSOAEmail('example@stuff.com', 'example.com')).toBe(true);
-    });
-
-    it('should not concern itself with email address format validation', () => {
-      expect(isValidSOAEmail('email.example.com', 'example.com')).toBe(true);
-    });
-
-    it('should handle subdomains', () => {
-      expect(isValidSOAEmail('admin@example.com', 'www.example.com')).toBe(
-        false
-      );
-      expect(isValidSOAEmail('admin@example.com', 'www.google.com')).toBe(true);
-    });
-  });
-
   describe('Validating CNAME records', () => {
     it('should prevent users from creating a CNAME record that would create a conflict', () => {
       expect(isValidCNAME('host', records)).toBe(false);

--- a/packages/manager/src/features/Domains/domainUtils.ts
+++ b/packages/manager/src/features/Domains/domainUtils.ts
@@ -1,5 +1,4 @@
 import { DomainRecord } from 'linode-js-sdk/lib/domains';
-import { takeLast } from 'ramda';
 
 export const isValidDomainRecord = (
   hostname: string,
@@ -11,18 +10,7 @@ export const isValidDomainRecord = (
 /**
  * Validation
  *
- * Currently, the API does not check that the soaEmail
- * is not associated with the target hostname. If you're creating
- * example.com, using `marty@example.com` as your soaEmail is unwise
- * (though technically won't break anything).
  */
-export const isValidSOAEmail = (email: string, hostname: string) => {
-  // admin@example.com --> example.com
-  const emailDomain = email.substr(email.indexOf('@') + 1);
-  // mail.example.com --> example.com
-  const strippedHostname = takeLast(2, hostname.split('.')).join('.');
-  return strippedHostname !== emailDomain;
-};
 
 export const isUniqueHostname = (hostname: string, records: DomainRecord[]) => {
   return !records.some(


### PR DESCRIPTION
## Description

Removes validation we had in place for making sure that a Domain's SOA address was outside of the domain.


## Notes

Try creating a domain such as mydomain.com and set the SOA address to you@mydomain.com. In production this will trigger a client-side error, on this branch you should proceed successfully.

All additional client-side validation we do (making sure CNAME records are unique, mostly) should be unchanged.