### PR TITLE
[LV] Safely access Processes

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
@@ -245,7 +245,7 @@ export const LongviewDetailOverview: React.FC<CombinedProps> = props => {
                 {/* @todo: Replace with real component. */}
                 {topProcessesLoading && <div>Loading...</div>}
                 {(lastUpdatedError || topProcessesError) && <div>Error!</div>}
-                {Object.keys(topProcessesData.Processes).length > 0 && (
+                {Object.keys(topProcessesData.Processes || []).length > 0 && (
                   <pre>
                     {JSON.stringify(props.topProcessesData.Processes, null, 2)}
                   </pre>

--- a/packages/manager/src/features/Longview/request.types.ts
+++ b/packages/manager/src/features/Longview/request.types.ts
@@ -151,7 +151,7 @@ export interface LongviewSystemInfo {
 // Resulting shape of calling `/fetch` with an api_action of `getValues` or
 // `getLatestValues` (and asking for the "Processes.*" key).
 export interface LongviewProcesses {
-  Processes: Record<string, Process>;
+  Processes?: Record<string, Process>;
 }
 
 export type Process = { longname: string } & Record<string, ProcessStats>;
@@ -166,7 +166,7 @@ export interface ProcessStats {
 
 // Resulting shape of calling `/fetch` with an api_action of `getTopProcesses`.
 export interface LongviewTopProcesses {
-  Processes: Record<string, TopProcess>;
+  Processes?: Record<string, TopProcess>;
 }
 
 export type TopProcess = Record<string, TopProcessStat>;


### PR DESCRIPTION
## Description

This fixes a bug in develop where the app crashes if DATA.Processes doesn't exist (which is likely to happen if the Linode in question is powered off).

This is indirectly fixed in this PR: https://github.com/linode/manager/pull/5799, but I wanted to go ahead and address this to get develop working again. I wanted to make the typing change anyway, so it'll still be useful once 5799 is merged.