### PR TITLE
Longview: Enable sorting clients on LongviewLanding page

### DIFF
--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/CPU.tsx
@@ -14,6 +14,12 @@ import withClientStats, {
 
 type CombinedProps = Props & WithTheme & LVDataProps;
 
+export const getFinalUsedCPU = (data: LVDataProps['longviewClientData']) => {
+  const numberOfCores = pathOr(0, ['SysInfo', 'cpu', 'cores'], data);
+  const usedCPU = sumCPUUsage(data.CPU);
+  return normalizeValue(usedCPU, numberOfCores);
+};
+
 const CPUGauge: React.FC<CombinedProps> = props => {
   const {
     longviewClientDataLoading: loading,

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, waitForElement } from '@testing-library/react';
 import * as React from 'react';
 import { memory } from 'src/__data__/longview';
 import { renderWithTheme } from 'src/utilities/testHelpers';
-import RAM, { generateTotalMemory, generateUsedMemory } from './RAM';
+import RAM from './RAM';
 
 afterEach(cleanup);
 
@@ -40,20 +40,6 @@ const errorStore = {
     }
   }
 };
-
-describe('Utility Functions', () => {
-  it('should generate used memory correctly', () => {
-    expect(generateUsedMemory(400, 100, 100)).toBe(200);
-    expect(generateUsedMemory(0, 100, 100)).toBe(0);
-    expect(generateUsedMemory(1000, 100, 100)).toBe(800);
-  });
-
-  it('should generate total memory correctly', () => {
-    expect(generateTotalMemory(100, 400)).toBe(500);
-    expect(generateTotalMemory(500, 400)).toBe(900);
-    expect(generateTotalMemory(100, 900)).toBe(1000);
-  });
-});
 
 describe('Longview RAM Gauge UI', () => {
   it('should render a loading state initially', () => {

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/RAM.tsx
@@ -3,6 +3,10 @@ import * as React from 'react';
 import { WithTheme, withTheme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import GaugePercent from 'src/components/GaugePercent';
+import {
+  generateTotalMemory,
+  generateUsedMemory
+} from '../../shared/utilities';
 import { baseGaugeProps, BaseProps as Props } from './common';
 
 import { readableBytes } from 'src/utilities/unitConversions';
@@ -114,20 +118,6 @@ const RAMGauge: React.FC<commbinedProps> = props => {
     />
   );
 };
-
-export const generateUsedMemory = (
-  used: number,
-  buffers: number,
-  cache: number
-) => {
-  /**
-   * calculation comes from original implementation of Longview.JS
-   */
-  const result = used - (buffers + cache);
-  return result < 0 ? 0 : result;
-};
-
-export const generateTotalMemory = (used: number, free: number) => used + free;
 
 export default withClientData<Props>(ownProps => ownProps.clientID)(
   withTheme(RAMGauge)

--- a/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/Gauges/Storage.tsx
@@ -13,6 +13,11 @@ import { baseGaugeProps, BaseProps as Props } from './common';
 
 type CombinedProps = Props & LVDataProps & WithTheme;
 
+export const getUsedStorage = (data: LVDataProps['longviewClientData']) => {
+  const storageInBytes = sumStorage(data.Disk);
+  return storageInBytes ? storageInBytes.total - storageInBytes.free : 0;
+};
+
 const StorageGauge: React.FC<CombinedProps> = props => {
   const {
     longviewClientDataError: error,

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
@@ -7,7 +7,9 @@ import { longviewClientFactory } from 'src/factories/longviewClient';
 import { renderWithTheme } from 'src/utilities/testHelpers';
 import {
   filterLongviewClientsByQuery,
-  LongviewClients
+  LongviewClients,
+  sortClientsBy,
+  sortFunc
 } from './LongviewClients';
 
 afterEach(cleanup);
@@ -57,6 +59,40 @@ describe('Utility Functions', () => {
       expect(filterLongviewClientsByQuery('fdsafdsafsdf', clients, {})).toEqual(
         []
       );
+  });
+
+  describe('Sorting helpers', () => {
+    describe('sortFunc helper', () => {
+      it('should handle basic sorting logic', () => {
+        expect([4, 5, 3, 1, 2].sort(sortFunc)).toEqual([5, 4, 3, 2, 1]);
+        expect(['d', 'c', 'a', 'e', 'b'].sort(sortFunc)).toEqual([
+          'e',
+          'd',
+          'c',
+          'b',
+          'a'
+        ]);
+      });
+
+      it('should respect the optional order argument', () => {
+        expect([4, 3, 5, 1, 2].sort((a, b) => sortFunc(a, b, 'asc'))).toEqual([
+          1,
+          2,
+          3,
+          4,
+          5
+        ]);
+
+        expect(
+          ['d', 'c', 'a', 'e', 'b'].sort((a, b) => sortFunc(a, b, 'desc'))
+        ).toEqual(['e', 'd', 'c', 'b', 'a']);
+      });
+    });
+    describe('sortClientsBy', () => {
+      it('should sort correctly by CPU percentage', () => {
+        expect(sortClientsBy('CPU' as any, [], {})).toEqual([]);
+      });
+    });
   });
 });
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -23,6 +23,7 @@ import withLongviewClients, {
 import { State as StatsState } from 'src/store/longviewStats/longviewStats.reducer';
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
+import { sumUsedMemory } from '../shared/utilities';
 import { getFinalUsedCPU } from './Gauges/CPU';
 import { generateUsedNetworkAsBytes } from './Gauges/Network';
 import { getUsedStorage } from './Gauges/Storage';
@@ -370,7 +371,25 @@ export const sortClientsBy = (
         return sortFunc(aCPU, bCPU);
       });
     case 'ram':
-      return clients;
+      return clients.sort((a, b) => {
+        const aRam = sumUsedMemory(pathOr({}, [a.id, 'data'], clientData));
+        const bRam = sumUsedMemory(pathOr({}, [b.id, 'data'], clientData));
+        return sortFunc(aRam, bRam);
+      });
+    case 'swap':
+      return clients.sort((a, b) => {
+        const aSwap = pathOr<number>(
+          0,
+          [a.id, 'data', 'Memory', 'swap', 'used', 0, 'y'],
+          clientData
+        );
+        const bSwap = pathOr<number>(
+          0,
+          [b.id, 'data', 'Memory', 'swap', 'used', 0, 'y'],
+          clientData
+        );
+        return sortFunc(aSwap, bSwap);
+      });
     case 'load':
       return clients.sort((a, b) => {
         const aLoad = pathOr<number>(

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -364,8 +364,8 @@ export const sortClientsBy = (
       });
     case 'cpu':
       return clients.sort((a, b) => {
-        const aCPU = getFinalUsedCPU(clientData[a.id].data);
-        const bCPU = getFinalUsedCPU(clientData[b.id].data);
+        const aCPU = getFinalUsedCPU(pathOr(0, [a.id, 'data'], clientData));
+        const bCPU = getFinalUsedCPU(pathOr(0, [b.id, 'data'], clientData));
 
         return sortFunc(aCPU, bCPU);
       });
@@ -375,13 +375,13 @@ export const sortClientsBy = (
       return clients.sort((a, b) => {
         const aLoad = pathOr<number>(
           0,
-          ['Load', 0, 'y'],
-          clientData[a.id].data
+          [a.id, 'data', 'Load', 0, 'y'],
+          clientData
         );
         const bLoad = pathOr<number>(
           0,
-          ['Load', 0, 'y'],
-          clientData[b.id].data
+          [b.id, 'data', 'Load', 0, 'y'],
+          clientData
         );
         return sortFunc(aLoad, bLoad);
       });
@@ -397,8 +397,8 @@ export const sortClientsBy = (
       });
     case 'storage':
       return clients.sort((a, b) => {
-        const aStorage = getUsedStorage(clientData[a.id].data);
-        const bStorage = getUsedStorage(clientData[b.id].data);
+        const aStorage = getUsedStorage(pathOr(0, [a.id, 'data'], clientData));
+        const bStorage = getUsedStorage(pathOr(0, [b.id, 'data'], clientData));
         return sortFunc(aStorage, bStorage);
       });
     default:

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -337,6 +337,10 @@ export default compose<CombinedProps, Props & RouteComponentProps>(
   withSnackbar
 )(LongviewClients);
 
+/**
+ * Helper function for sortClientsBy,
+ * to reduce (a>b) {return -1 } boilerplate
+ */
 export const sortFunc = (
   a: string | number,
   b: string | number,
@@ -353,6 +357,14 @@ export const sortFunc = (
   return order === 'desc' ? result : -result;
 };
 
+/**
+ * Handle sorting by various metrics,
+ * since the calculations for each are
+ * specific to that metric.
+ *
+ * This could be extracted to ./utilities,
+ * but it's unlikely to be used anywhere else.
+ */
 export const sortClientsBy = (
   sortKey: SortKey,
   clients: LongviewClient[],

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -335,6 +335,22 @@ export default compose<CombinedProps, Props & RouteComponentProps>(
   withSnackbar
 )(LongviewClients);
 
+export const sortFunc = (
+  a: string | number,
+  b: string | number,
+  order: 'asc' | 'desc' = 'desc'
+) => {
+  let result: number;
+  if (a > b) {
+    result = -1;
+  } else if (a < b) {
+    result = 1;
+  } else {
+    result = 0;
+  }
+  return order === 'desc' ? result : -result;
+};
+
 export const sortClientsBy = (
   sortKey: SortKey,
   clients: LongviewClient[],
@@ -343,26 +359,14 @@ export const sortClientsBy = (
   switch (sortKey) {
     case 'name':
       return clients.sort((a, b) => {
-        if (a.label > b.label) {
-          return 1;
-        }
-        if (a.label < b.label) {
-          return -1;
-        }
-        return 0;
+        return sortFunc(a.label, b.label, 'asc');
       });
     case 'cpu':
       return clients.sort((a, b) => {
         const aCPU = getFinalUsedCPU(clientData[a.id].data);
         const bCPU = getFinalUsedCPU(clientData[b.id].data);
 
-        if (aCPU > bCPU) {
-          return -1;
-        }
-        if (aCPU < bCPU) {
-          return 1;
-        }
-        return 0;
+        return sortFunc(aCPU, bCPU);
       });
     case 'ram':
       return clients;
@@ -378,25 +382,13 @@ export const sortClientsBy = (
           ['Load', 0, 'y'],
           clientData[b.id].data
         );
-        if (aLoad > bLoad) {
-          return -1;
-        }
-        if (aLoad < bLoad) {
-          return 1;
-        }
-        return 0;
+        return sortFunc(aLoad, bLoad);
       });
     case 'storage':
       return clients.sort((a, b) => {
         const aStorage = getUsedStorage(clientData[a.id].data);
         const bStorage = getUsedStorage(clientData[b.id].data);
-        if (aStorage > bStorage) {
-          return -1;
-        }
-        if (aStorage < bStorage) {
-          return 1;
-        }
-        return 0;
+        return sortFunc(aStorage, bStorage);
       });
     default:
       return clients;

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -24,6 +24,7 @@ import { State as StatsState } from 'src/store/longviewStats/longviewStats.reduc
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getFinalUsedCPU } from './Gauges/CPU';
+import { generateUsedNetworkAsBytes } from './Gauges/Network';
 import { getUsedStorage } from './Gauges/Storage';
 import DeleteDialog from './LongviewDeleteDialog';
 import LongviewList from './LongviewList';
@@ -383,6 +384,16 @@ export const sortClientsBy = (
           clientData[b.id].data
         );
         return sortFunc(aLoad, bLoad);
+      });
+    case 'network':
+      return clients.sort((a, b) => {
+        const aNet = generateUsedNetworkAsBytes(
+          pathOr(0, [a.id, 'data', 'Network', 'Interface'], clientData)
+        );
+        const bNet = generateUsedNetworkAsBytes(
+          pathOr(0, [b.id, 'data', 'Network', 'Interface'], clientData)
+        );
+        return sortFunc(aNet, bNet);
       });
     case 'storage':
       return clients.sort((a, b) => {

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -75,7 +75,7 @@ type CombinedProps = Props &
   StateProps &
   SettingsProps;
 
-type SortKey = 'name' | 'cpu';
+type SortKey = 'name' | 'cpu' | 'ram' | 'swap' | 'load' | 'network' | 'storage';
 
 export const LongviewClients: React.FC<CombinedProps> = props => {
   const [newClientLoading, setNewClientLoading] = React.useState<boolean>(
@@ -359,6 +359,28 @@ export const sortClientsBy = (
           return -1;
         }
         if (aCPU < bCPU) {
+          return 1;
+        }
+        return 0;
+      });
+    case 'ram':
+      return clients;
+    case 'load':
+      return clients.sort((a, b) => {
+        const aLoad = pathOr<number>(
+          0,
+          ['Load', 0, 'y'],
+          clientData[a.id].data
+        );
+        const bLoad = pathOr<number>(
+          0,
+          ['Load', 0, 'y'],
+          clientData[b.id].data
+        );
+        if (aLoad > bLoad) {
+          return -1;
+        }
+        if (aLoad < bLoad) {
           return 1;
         }
         return 0;

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -24,6 +24,7 @@ import { State as StatsState } from 'src/store/longviewStats/longviewStats.reduc
 import { MapState } from 'src/store/types';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 import { getFinalUsedCPU } from './Gauges/CPU';
+import { getUsedStorage } from './Gauges/Storage';
 import DeleteDialog from './LongviewDeleteDialog';
 import LongviewList from './LongviewList';
 import SubscriptionDialog from './SubscriptionDialog';
@@ -381,6 +382,18 @@ export const sortClientsBy = (
           return -1;
         }
         if (aLoad < bLoad) {
+          return 1;
+        }
+        return 0;
+      });
+    case 'storage':
+      return clients.sort((a, b) => {
+        const aStorage = getUsedStorage(clientData[a.id].data);
+        const bStorage = getUsedStorage(clientData[b.id].data);
+        if (aStorage > bStorage) {
+          return -1;
+        }
+        if (aStorage < bStorage) {
           return 1;
         }
         return 0;

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
@@ -7,7 +7,6 @@ import Paper from 'src/components/core/Paper';
 import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import ErrorState from 'src/components/ErrorState';
-import OrderBy from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import { Props as LVProps } from 'src/containers/longview.container';
@@ -113,37 +112,33 @@ const LongviewList: React.FC<CombinedProps> = props => {
 
   return (
     <React.Fragment>
-      <OrderBy data={filteredData} orderBy={'label'} order={'asc'}>
-        {({ data: orderedData, handleOrderChange, order, orderBy }) => (
-          <Paginate data={orderedData}>
-            {({
-              data: paginatedAndOrderedData,
-              count,
-              handlePageChange,
-              handlePageSizeChange,
-              page,
-              pageSize
-            }) => (
-              <>
-                <Box flexDirection="column">
-                  <LongviewRows
-                    longviewClientsData={paginatedAndOrderedData}
-                    triggerDeleteLongviewClient={triggerDeleteLongviewClient}
-                  />
-                </Box>
-                <PaginationFooter
-                  count={count}
-                  handlePageChange={handlePageChange}
-                  handleSizeChange={handlePageSizeChange}
-                  page={page}
-                  pageSize={pageSize}
-                  eventCategory="Longview Table"
-                />
-              </>
-            )}
-          </Paginate>
+      <Paginate data={filteredData}>
+        {({
+          data: paginatedAndOrderedData,
+          count,
+          handlePageChange,
+          handlePageSizeChange,
+          page,
+          pageSize
+        }) => (
+          <>
+            <Box flexDirection="column">
+              <LongviewRows
+                longviewClientsData={paginatedAndOrderedData}
+                triggerDeleteLongviewClient={triggerDeleteLongviewClient}
+              />
+            </Box>
+            <PaginationFooter
+              count={count}
+              handlePageChange={handlePageChange}
+              handleSizeChange={handlePageSizeChange}
+              page={page}
+              pageSize={pageSize}
+              eventCategory="Longview Table"
+            />
+          </>
         )}
-      </OrderBy>
+      </Paginate>
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/Longview/shared/utilities.test.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.test.ts
@@ -1,0 +1,15 @@
+import { generateTotalMemory, generateUsedMemory } from './utilities';
+
+describe('Utility Functions', () => {
+  it('should generate used memory correctly', () => {
+    expect(generateUsedMemory(400, 100, 100)).toBe(200);
+    expect(generateUsedMemory(0, 100, 100)).toBe(0);
+    expect(generateUsedMemory(1000, 100, 100)).toBe(800);
+  });
+
+  it('should generate total memory correctly', () => {
+    expect(generateTotalMemory(100, 400)).toBe(500);
+    expect(generateTotalMemory(500, 400)).toBe(900);
+    expect(generateTotalMemory(100, 900)).toBe(1000);
+  });
+});

--- a/packages/manager/src/features/Longview/shared/utilities.ts
+++ b/packages/manager/src/features/Longview/shared/utilities.ts
@@ -1,4 +1,5 @@
 import { pathOr } from 'ramda';
+import { LVClientData } from 'src/containers/longview.stats.container';
 import { pluralize } from 'src/utilities/pluralize';
 import { readableBytes } from 'src/utilities/unitConversions';
 import { Disk, LongviewPackage } from '../request.types';
@@ -40,4 +41,29 @@ export const sumStorage = (DiskData: Record<string, Disk> = {}): Storage => {
     total += pathOr(0, ['fs', 'total', 0, 'y'], disk);
   });
   return { free, total };
+};
+
+export const generateUsedMemory = (
+  used: number,
+  buffers: number,
+  cache: number
+) => {
+  /**
+   * calculation comes from original implementation of Longview.JS
+   */
+  const result = used - (buffers + cache);
+  return result < 0 ? 0 : result;
+};
+
+export const generateTotalMemory = (used: number, free: number) => used + free;
+
+/**
+ * Used for calculating comparison values for sorting by RAM
+ */
+export const sumUsedMemory = (data: LVClientData) => {
+  const usedMemory = pathOr(0, ['Memory', 'real', 'used', 0, 'y'], data);
+  const buffers = pathOr(0, ['Memory', 'real', 'buffers', 0, 'y'], data);
+  const cache = pathOr(0, ['Memory', 'real', 'cache', 0, 'y'], data);
+
+  return generateUsedMemory(usedMemory, buffers, cache);
 };


### PR DESCRIPTION
## Description

Enables the "Sort by" select on the landing page. Each metric has its own idiosyncratic calculations, so the sorting function is long af.

I was a little fast and loose with how I handled the logic. I added a few things to Kayla's new shared/utilities file, and left others in place. I don't think any of this will be reused anywhere else so it shouldn't be a problem, but if I have time I can take a pass at cleaning it up for consistency (probably everything should live in the utilities file and the gauges should import it).

Todo:

- [ ] Unit test the sort function. Setting up the mock data for this is going to be a monster, so it'll take a while.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

You'll have to either mock data or set up your clients to get different values to sort on. A fun one to try is `stress`:

```
apt install stress
stress -c 1 --timeout 500
```