### PR TITLE
Additions to readableBytes (needed for LV Processes)

### DIFF
--- a/packages/manager/src/utilities/unitConversions.test.ts
+++ b/packages/manager/src/utilities/unitConversions.test.ts
@@ -109,6 +109,9 @@ describe('readableBytes', () => {
     expect(readableBytes(0.5, { unit: 'MB' }).formatted).toBe('0 MB');
     expect(readableBytes(0.3, { round: 0 }).formatted).toBe('0 bytes');
     expect(readableBytes(0.5, { round: 0 }).formatted).toBe('1 bytes');
+    expect(readableBytes(0.5, { round: 1 }).formatted).toBe('0.5 bytes');
+    expect(readableBytes(0.05, { round: 1 }).formatted).toBe('0.1 bytes');
+    expect(readableBytes(0.05, { round: 2 }).formatted).toBe('0.05 bytes');
   });
 
   it('allows custom unit labels', () => {

--- a/packages/manager/src/utilities/unitConversions.test.ts
+++ b/packages/manager/src/utilities/unitConversions.test.ts
@@ -100,7 +100,7 @@ describe('readableBytes', () => {
   });
 
   it('handles inputs that are <= 1', () => {
-    expect(readableBytes(1).formatted).toBe('1 bytes');
+    expect(readableBytes(1).formatted).toBe('1 byte');
     expect(readableBytes(0.5).formatted).toBe('0.5 bytes');
     expect(readableBytes(-0.5).formatted).toBe('-0.5 bytes');
     expect(readableBytes(0.01, { maxUnit: 'bytes' }).formatted).toBe(
@@ -108,7 +108,7 @@ describe('readableBytes', () => {
     );
     expect(readableBytes(0.5, { unit: 'MB' }).formatted).toBe('0 MB');
     expect(readableBytes(0.3, { round: 0 }).formatted).toBe('0 bytes');
-    expect(readableBytes(0.5, { round: 0 }).formatted).toBe('1 bytes');
+    expect(readableBytes(0.5, { round: 0 }).formatted).toBe('1 byte');
     expect(readableBytes(0.5, { round: 1 }).formatted).toBe('0.5 bytes');
     expect(readableBytes(0.05, { round: 1 }).formatted).toBe('0.1 bytes');
     expect(readableBytes(0.05, { round: 2 }).formatted).toBe('0.05 bytes');
@@ -139,5 +139,14 @@ describe('readableBytes', () => {
     expect(readableBytes(1, { unitLabels }).unit).toBe('B');
     // Default unit label (not affected):
     expect(readableBytes(1024, { unitLabels }).unit).toBe('KB');
+  });
+
+  it('correctly pluralizes "bytes"', () => {
+    expect(readableBytes(1).unit).toBe('byte');
+    expect(readableBytes(1).formatted).toBe('1 byte');
+    expect(readableBytes(-1).unit).toBe('byte');
+    expect(readableBytes(-1).formatted).toBe('-1 byte');
+    expect(readableBytes(2).unit).toBe('bytes');
+    expect(readableBytes(2).formatted).toBe('2 bytes');
   });
 });

--- a/packages/manager/src/utilities/unitConversions.test.ts
+++ b/packages/manager/src/utilities/unitConversions.test.ts
@@ -1,4 +1,4 @@
-import { readableBytes } from './unitConversions';
+import { readableBytes, ReadableBytesOptions } from './unitConversions';
 
 describe('readableBytes', () => {
   it('should return "0 bytes" if bytes === 0', () => {
@@ -12,6 +12,9 @@ describe('readableBytes', () => {
     expect(readableBytes(-1048576).value).toBe(-1);
 
     expect(readableBytes(-1048576, { handleNegatives: false }).formatted).toBe(
+      '0 bytes'
+    );
+    expect(readableBytes(-0.5, { handleNegatives: false }).formatted).toBe(
       '0 bytes'
     );
   });
@@ -94,5 +97,44 @@ describe('readableBytes', () => {
     expect(
       readableBytes(1024 * 1024 * 1024 * 50, { unit: 'TB' }).formatted
     ).toBe('0.05 TB');
+  });
+
+  it('handles inputs that are <= 1', () => {
+    expect(readableBytes(1).formatted).toBe('1 bytes');
+    expect(readableBytes(0.5).formatted).toBe('0.5 bytes');
+    expect(readableBytes(-0.5).formatted).toBe('-0.5 bytes');
+    expect(readableBytes(0.01, { maxUnit: 'bytes' }).formatted).toBe(
+      '0.01 bytes'
+    );
+    expect(readableBytes(0.5, { unit: 'MB' }).formatted).toBe('0 MB');
+    expect(readableBytes(0.3, { round: 0 }).formatted).toBe('0 bytes');
+    expect(readableBytes(0.5, { round: 0 }).formatted).toBe('1 bytes');
+  });
+
+  it('allows custom unit labels', () => {
+    const unitLabels: ReadableBytesOptions['unitLabels'] = {
+      bytes: 'B',
+      KB: 'Kilobytes',
+      MB: 'Megabytes',
+      GB: 'Gigabytes',
+      TB: 'Terabytes'
+    };
+    expect(readableBytes(1, { unitLabels }).unit).toBe('B');
+    expect(readableBytes(1024, { unitLabels }).unit).toBe('Kilobytes');
+    expect(readableBytes(1048576, { unitLabels }).unit).toBe('Megabytes');
+    expect(readableBytes(1073741824, { unitLabels }).unit).toBe('Gigabytes');
+    expect(readableBytes(1073741824 * 10000, { unitLabels }).unit).toBe(
+      'Terabytes'
+    );
+  });
+
+  it('only affects values with custom labels that have been specified', () => {
+    const unitLabels: ReadableBytesOptions['unitLabels'] = {
+      bytes: 'B'
+    };
+    // Custom unit label:
+    expect(readableBytes(1, { unitLabels }).unit).toBe('B');
+    // Default unit label (not affected):
+    expect(readableBytes(1024, { unitLabels }).unit).toBe('KB');
   });
 });

--- a/packages/manager/src/utilities/unitConversions.ts
+++ b/packages/manager/src/utilities/unitConversions.ts
@@ -100,6 +100,15 @@ export const readableBytes = (
 
   const value = parseFloat(result.toFixed(decimalPlaces));
 
+  // Special case to account for pluralization.
+  if ((value === 1 || value === -1) && unit === 'bytes') {
+    return {
+      value: isNegative ? -value : value,
+      unit: 'byte',
+      formatted: (isNegative ? '-' : '') + value + ' byte'
+    };
+  }
+
   return {
     value: isNegative ? -value : value,
     unit,

--- a/packages/manager/src/utilities/unitConversions.ts
+++ b/packages/manager/src/utilities/unitConversions.ts
@@ -67,7 +67,7 @@ export const readableBytes = (
       const idx = storageUnits.indexOf(originalLabel as StorageSymbol);
       if (idx > -1) {
         // The TS compiler wasn't aware of the null check above, so I added
-        // the non-null assertion operator on options.unitLabels
+        // the non-null assertion operator on options.unitLabels.
         storageUnits[idx] = options.unitLabels![originalLabel];
       }
     });


### PR DESCRIPTION
## Description

Two changes made to readableBytes in this PR:

1. Added a `unitLabels` option, which allows you to substitute labels for units. Now we can do `readableBytes(1, { unitLabels: { bytes: 'B' } })` to get `1 B` instead of `1 bytes`. This matches Classic and the LV designs, and is a handy option to have for this utility function beyond LV.
2. Handled cases where the input is greater than 0 but less than 1. I don't really like this, as ideally you wouldn't use this function for inputs that are less than 1 byte. However, on the LV Processes Tab (in Classic) we often see values like "0.5 B/s", for Average IO. Thus this addition was necessary to get to parity.

## Note to Reviewers
**The new unitLabels option isn't used anywhere in the app yet.** But you can try it out yourself!

Have a look at the new unit tests, and try writing your own. Check out places where `readableBytes ` is used (LinodeNetSummary, LV Gauges, Object Storage).


