### PR TITLE
Change: Disable Add Client Button for Disabled Users

### DIFF
--- a/packages/manager/src/containers/profile.container.ts
+++ b/packages/manager/src/containers/profile.container.ts
@@ -22,7 +22,7 @@ export interface StateProps {
 
 type MapProps<ReduxStateProps, OwnProps> = (
   ownProps: OwnProps,
-  data: State
+  data: StateProps
 ) => ReduxStateProps & Partial<StateProps>;
 
 export type Props = DispatchProps & StateProps;
@@ -57,17 +57,14 @@ const connected: Connected = <ReduxState extends {}, OwnProps extends {}>(
         data: profileData
       } = state.__resources.profile;
 
-      /** @todo name the arguments profileLoading, profileError, etc */
-      if (mapStateToProps) {
-        return mapStateToProps(ownProps, state.__resources.profile);
-      }
-
-      return {
-        profileData,
+      const result = {
+        profileLoading,
         profileError,
-        profileLastUpdated,
-        profileLoading
+        profileData,
+        profileLastUpdated
       };
+
+      return !!mapStateToProps ? mapStateToProps(ownProps, result) : result;
     },
     (dispatch: ThunkDispatch) => ({
       getProfile: () => dispatch(requestProfile()),

--- a/packages/manager/src/features/Account/AccountLanding.tsx
+++ b/packages/manager/src/features/Account/AccountLanding.tsx
@@ -130,7 +130,7 @@ interface StateProps {
 }
 
 export default compose<Props, {}>(
-  withProfile<StateProps, {}>((ownProps, { data }) => ({
+  withProfile<StateProps, {}>((ownProps, { profileData: data }) => ({
     isRestrictedUser: pathOr(false, ['restricted'], data)
   }))
 )(AccountLanding);

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/SummaryPanel.tsx
@@ -102,12 +102,14 @@ const enhanced = compose<CombinedProps, Props>(
       account
     })
   ),
-  withProfile<Profile, {}>((ownProps, profile) => ({
-    username: path(['username'], profile.data),
-    profileError: path(['read'], profile.error),
-    profileLoading: profile.loading,
-    isRestricted: pathOr(false, ['restricted'], profile.data)
-  }))
+  withProfile<Profile, {}>(
+    (ownProps, { profileLoading, profileData, profileError }) => ({
+      username: path(['username'], profileData),
+      profileError: path(['read'], profileError),
+      profileLoading,
+      isRestricted: pathOr(false, ['restricted'], profileData)
+    })
+  )
 );
 
 export default enhanced(SummaryPanel) as React.ComponentType<Props>;

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.test.tsx
@@ -46,6 +46,7 @@ const props: CombinedProps = {
   updateAccountSettings: jest.fn(),
   updateAccountSettingsInStore: jest.fn(),
   requestAccountSettings: jest.fn(),
+  userCanCreateClient: true,
   ...reactRouterProps
 };
 

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -370,7 +370,7 @@ export default compose<CombinedProps, Props & RouteComponentProps>(
   connected,
   withProfile<GrantsProps, {}>((ownProps, { profileData }) => ({
     userCanCreateClient: pathOr<boolean>(
-      true,
+      false,
       ['grants', 'global', 'add_longview'],
       profileData
     )

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -286,7 +286,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
             disabledReason={
               userCanCreateClient
                 ? ''
-                : 'You do not have access to create Longview Clients. Please contact an account administrator.'
+                : 'You are not authorized to create Longview Clients. Please contact an account administrator.'
             }
           />
         </Grid>
@@ -301,6 +301,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
         openPackageDrawer={handleDrawerOpen}
         createLongviewClient={handleAddClient}
         loading={newClientLoading}
+        userCanCreateLongviewClient={userCanCreateClient}
       />
       {!isLongviewPro && (
         <Grid

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -369,13 +369,18 @@ interface GrantsProps {
 export default compose<CombinedProps, Props & RouteComponentProps>(
   React.memo,
   connected,
-  withProfile<GrantsProps, {}>((ownProps, { profileData }) => ({
-    userCanCreateClient: pathOr<boolean>(
+  withProfile<GrantsProps, {}>((ownProps, { profileData }) => {
+    const isRestrictedUser = (profileData || {}).restricted;
+    const hasAddLongviewGrant = pathOr<boolean>(
       false,
       ['grants', 'global', 'add_longview'],
       profileData
-    )
-  })),
+    );
+    return {
+      userCanCreateClient:
+        !isRestrictedUser || (hasAddLongviewGrant && isRestrictedUser)
+    };
+  }),
   withLongviewClients(),
   withSettings(),
   withSnackbar

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
@@ -53,6 +53,7 @@ interface Props {
     longviewClientID: number,
     longviewClientLabel: string
   ) => void;
+  userCanCreateLongviewClient: boolean;
 }
 
 type CombinedProps = Props & LongviewProps;
@@ -67,7 +68,8 @@ const LongviewList: React.FC<CombinedProps> = props => {
     longviewClientsLoading,
     longviewClientsResults,
     openPackageDrawer,
-    triggerDeleteLongviewClient
+    triggerDeleteLongviewClient,
+    userCanCreateLongviewClient
   } = props;
 
   const classes = useStyles();
@@ -103,10 +105,16 @@ const LongviewList: React.FC<CombinedProps> = props => {
     return (
       <Paper className={classes.empty}>
         <Typography variant="body1" className={classes.emptyText}>
-          You have no Longview clients configured.{' '}
-          <button className={classes.button} onClick={createLongviewClient}>
-            Click here to add one.
-          </button>
+          {userCanCreateLongviewClient ? (
+            <React.Fragment>
+              You have no Longview clients configured.{' '}
+              <button className={classes.button} onClick={createLongviewClient}>
+                Click here to add one.
+              </button>
+            </React.Fragment>
+          ) : (
+            'You have no Longview clients configured.'
+          )}
         </Typography>
       </Paper>
     );

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptActionMenu.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptActionMenu.tsx
@@ -117,7 +117,7 @@ const StackScriptActionMenu: React.StatelessComponent<
 
 const enhanced = compose<CombinedProps, Props>(
   withRouter,
-  withProfile<ProfileProps, Props>((ownProps, profile) => {
+  withProfile<ProfileProps, Props>((ownProps, { profileData: profile }) => {
     return {
       username: path(['data', 'username'], profile)
     };

--- a/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptsDetail.tsx
@@ -148,7 +148,7 @@ export class StackScriptsDetail extends React.Component<CombinedProps, {}> {
 
 export default compose<CombinedProps, {}>(
   setDocs([StackScriptsDocs]),
-  withProfile<ProfileProps, {}>((ownProps, profile) => {
+  withProfile((ownProps, { profileData: profile }) => {
     return {
       username: path(['data', 'username'], profile)
     };

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -231,9 +231,9 @@ export class RestoreToLinodeDrawer extends React.Component<
 }
 
 const enhanced = compose<CombinedProps, Props>(
-  withProfile<ProfileProps, Props>((ownProps, profile) => {
+  withProfile<ProfileProps, Props>((ownProps, { profileData: profile }) => {
     return {
-      profile: profile.data
+      profile
     };
   })
 );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/Notifications.tsx
@@ -104,11 +104,13 @@ const enhanced = compose<CombinedProps, {}>(
   withNotifications(undefined, ({ requestNotifications }) => ({
     requestNotifications
   })),
-  withProfile<ProfileProps, {}>((undefined, profile) => ({
-    userTimezone: path(['data', 'timezone'], profile),
-    userTimezoneError: path(['read'], profile.error),
-    userTimezoneLoading: profile.loading
-  }))
+  withProfile<ProfileProps, {}>(
+    (undefined, { profileData: profile, profileLoading, profileError }) => ({
+      userTimezone: path(['data', 'timezone'], profile),
+      userTimezoneError: path(['read'], profileError),
+      userTimezoneLoading: profileLoading
+    })
+  )
 );
 
 export default enhanced(Notifications);


### PR DESCRIPTION
## Description

Disables "add a client" button for restricted users

## Type of Change
- Non breaking change ('update', 'change')

## To Test

View the landing page as a user who has the `longview_add` global grant turned off