### PR TITLE
M3-3640 Accessibility: Focus on content when navigating

### DIFF
--- a/packages/manager/src/App.css
+++ b/packages/manager/src/App.css
@@ -33,6 +33,10 @@ img {
 }
 
 @keyframes App-logo-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/packages/manager/src/components/Breadcrumb/Crumbs.tsx
+++ b/packages/manager/src/components/Breadcrumb/Crumbs.tsx
@@ -52,6 +52,7 @@ interface Props {
   labelTitle?: string;
   labelOptions?: LabelProps;
   onEditHandlers?: EditableProps;
+  staticText?: string;
 }
 
 type CombinedProps = Props;

--- a/packages/manager/src/components/Breadcrumb/Crumbs.tsx
+++ b/packages/manager/src/components/Breadcrumb/Crumbs.tsx
@@ -52,7 +52,6 @@ interface Props {
   labelTitle?: string;
   labelOptions?: LabelProps;
   onEditHandlers?: EditableProps;
-  staticText?: string;
 }
 
 type CombinedProps = Props;

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -54,8 +54,14 @@ type CombinedProps = Props;
 
 const FinalCrumb: React.FC<CombinedProps> = props => {
   const classes = useStyles();
-
+  const h1Header = React.useRef<HTMLDivElement>(null);
   const { crumb, labelOptions, onEditHandlers } = props;
+
+  React.useEffect(() => {
+    if (h1Header.current !== null) {
+      h1Header.current.focus();
+    }
+  });
 
   if (onEditHandlers) {
     return (
@@ -82,6 +88,8 @@ const FinalCrumb: React.FC<CombinedProps> = props => {
             [classes.noCap]: labelOptions && labelOptions.noCap
           })}
           data-qa-label-text
+          tabIndex={-1}
+          ref={h1Header}
         >
           {crumb}
         </Typography>

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -2,9 +2,9 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import { compose } from 'recompose';
 import { makeStyles, Theme } from 'src/components/core/styles';
-
 import Typography from 'src/components/core/Typography';
 import EditableText from 'src/components/EditableText';
+import H1Header from 'src/components/H1Header';
 import { EditableProps, LabelProps } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -54,14 +54,7 @@ type CombinedProps = Props;
 
 const FinalCrumb: React.FC<CombinedProps> = props => {
   const classes = useStyles();
-  const h1Header = React.useRef<HTMLDivElement>(null);
   const { crumb, labelOptions, onEditHandlers } = props;
-
-  React.useEffect(() => {
-    if (h1Header.current !== null) {
-      h1Header.current.focus();
-    }
-  }, []);
 
   if (onEditHandlers) {
     return (
@@ -81,18 +74,14 @@ const FinalCrumb: React.FC<CombinedProps> = props => {
   return (
     <React.Fragment>
       <div className={classes.labelWrapper}>
-        <Typography
-          variant="h1"
+        <H1Header
+          title={crumb}
           className={classNames({
             [classes.crumb]: true,
             [classes.noCap]: labelOptions && labelOptions.noCap
           })}
           data-qa-label-text
-          tabIndex={-1}
-          ref={h1Header}
-        >
-          {crumb}
-        </Typography>
+        />
         {labelOptions && labelOptions.subtitle && (
           <Typography variant="body1" data-qa-label-subtitle>
             {labelOptions.subtitle}

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -61,7 +61,7 @@ const FinalCrumb: React.FC<CombinedProps> = props => {
     if (h1Header.current !== null) {
       h1Header.current.focus();
     }
-  });
+  }, []);
 
   if (onEditHandlers) {
     return (

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -156,7 +156,6 @@ type FinalProps = PassThroughProps & WithStyles<ClassNames>;
 const EditableText: React.FC<FinalProps> = props => {
   const [isEditing, setIsEditing] = React.useState(Boolean(props.errorText));
   const [text, setText] = React.useState(props.text);
-  const h1Header = React.useRef<HTMLDivElement>(null);
   const {
     classes,
     labelLink,
@@ -168,12 +167,6 @@ const EditableText: React.FC<FinalProps> = props => {
     className,
     ...rest
   } = props;
-
-  React.useEffect(() => {
-    if (h1Header.current !== null) {
-      h1Header.current.focus();
-    }
-  }, []);
 
   React.useEffect(() => {
     setText(props.text);

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -154,7 +154,7 @@ type PassThroughProps = Props & TextFieldProps;
 type FinalProps = PassThroughProps & WithStyles<ClassNames>;
 
 const EditableText: React.FC<FinalProps> = props => {
-  const [isEditing, setisEditing] = React.useState(Boolean(props.errorText));
+  const [isEditing, setIsEditing] = React.useState(Boolean(props.errorText));
   const [text, setText] = React.useState(props.text);
   const h1Header = React.useRef<HTMLDivElement>(null);
   const {
@@ -184,7 +184,7 @@ const EditableText: React.FC<FinalProps> = props => {
   };
 
   const openEdit = () => {
-    setisEditing(true);
+    setIsEditing(true);
   };
 
   const finishEditing = () => {
@@ -198,17 +198,17 @@ const EditableText: React.FC<FinalProps> = props => {
       props
         .onEdit(text)
         .then(() => {
-          setisEditing(false);
+          setIsEditing(false);
         })
         .catch(e => e);
     } else {
       /** otherwise, we've just submitted the form with no value change */
-      setisEditing(false);
+      setIsEditing(false);
     }
   };
 
   const cancelEditing = () => {
-    setisEditing(false);
+    setIsEditing(false);
     setText(props.text);
   };
 

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -14,7 +14,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import { TextFieldProps } from 'src/components/core/TextField';
-import Typography from 'src/components/core/Typography';
+import H1Header from 'src/components/H1Header';
 import TextField from '../TextField';
 
 type ClassNames =
@@ -222,15 +222,7 @@ const EditableText: React.FC<FinalProps> = props => {
     }
   };
   const labelText = (
-    <Typography
-      className={classes.root}
-      ref={h1Header}
-      tabIndex={-1}
-      variant="h1"
-      data-qa-editable-text
-    >
-      {text}
-    </Typography>
+    <H1Header title={text} className={classes.root} data-qa-editable-text />
   );
 
   return !isEditing && !errorText ? (

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -173,7 +173,7 @@ const EditableText: React.FC<FinalProps> = props => {
     if (h1Header.current !== null) {
       h1Header.current.focus();
     }
-  });
+  }, []);
 
   React.useEffect(() => {
     setText(props.text);

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -149,168 +149,156 @@ interface Props {
   className?: string;
 }
 
-interface State {
-  text: string;
-  isEditing: Boolean;
-}
-
 type PassThroughProps = Props & TextFieldProps;
 
 type FinalProps = PassThroughProps & WithStyles<ClassNames>;
 
-export class EditableText extends React.Component<FinalProps, State> {
-  state: State = {
-    isEditing: Boolean(this.props.errorText),
-    text: this.props.text
-  };
+const EditableText: React.FC<FinalProps> = props => {
+  const [isEditing, setisEditing] = React.useState(Boolean(props.errorText));
+  const [text, setText] = React.useState(props.text);
+  const h1Header = React.useRef<HTMLDivElement>(null);
+  const {
+    classes,
+    labelLink,
+    errorText,
+    onEdit,
+    onCancel,
+    text: propText,
+    typeVariant,
+    className,
+    ...rest
+  } = props;
 
-  componentDidUpdate(prevProps: FinalProps, prevState: State) {
-    const { text } = this.props;
-    const { text: prevText } = prevProps;
-    if (text !== prevText) {
-      this.setState({
-        isEditing: false,
-        text
-      });
+  React.useEffect(() => {
+    if (h1Header.current !== null) {
+      h1Header.current.focus();
     }
-  }
+  });
 
-  onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ text: e.target.value });
+  React.useEffect(() => {
+    setText(props.text);
+  }, [props.text]);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
   };
 
-  openEdit = () => {
-    this.setState({ isEditing: true });
+  const openEdit = () => {
+    setisEditing(true);
   };
 
-  finishEditing = () => {
-    const { text } = this.state;
+  const finishEditing = () => {
     /**
      * if the entered text is different from the original text
      * provided, run the update callback
      *
      * only exit editing mode if promise resolved
      */
-    if (text !== this.props.text) {
-      this.props
+    if (text !== props.text) {
+      props
         .onEdit(text)
         .then(() => {
-          this.setState({ isEditing: false });
+          setisEditing(false);
         })
         .catch(e => e);
     } else {
       /** otherwise, we've just submitted the form with no value change */
-      this.setState({ isEditing: false });
+      setisEditing(false);
     }
   };
 
-  cancelEditing = () => {
-    /** cancel editing and invoke callback function and revert text to original */
-    this.setState({ isEditing: false, text: this.props.text }, () => {
-      this.props.onCancel();
-    });
+  const cancelEditing = () => {
+    setisEditing(false);
+    setText(props.text);
   };
 
   /** confirm or cancel edits if the enter or escape keys are pressed, respectively */
-  handleKeyPress = (e: React.KeyboardEvent) => {
+  const handleKeyPress = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      this.finishEditing();
+      finishEditing();
     }
     if (e.key === 'Escape' || e.key === 'Esc') {
-      this.cancelEditing();
+      cancelEditing();
     }
   };
+  const labelText = (
+    <Typography
+      className={classes.root}
+      ref={h1Header}
+      tabIndex={-1}
+      variant="h1"
+      data-qa-editable-text
+    >
+      {text}
+    </Typography>
+  );
 
-  render() {
-    const {
-      classes,
-      labelLink,
-      errorText,
-      onEdit,
-      onCancel,
-      text: propText,
-      typeVariant,
-      className,
-      ...rest
-    } = this.props;
-    const { isEditing, text } = this.state;
-
-    const labelText = (
-      <Typography className={classes.root} variant="h1" data-qa-editable-text>
-        {this.state.text}
-      </Typography>
-    );
-
-    return !isEditing && !errorText ? (
-      <div
-        className={`${classes.container} ${classes.initial} ${className}`}
-        data-testid={'editable-text'}
-      >
-        <React.Fragment>
-          {!!labelLink ? (
-            <Link to={labelLink!} className={classes.underlineOnHover}>
-              {labelText}
-            </Link>
-          ) : (
-            labelText
-          )}
-          {/** pencil icon */}
-          <Button
-            className={`${classes.button} ${classes.editIcon}`}
-            onClick={this.openEdit}
-            data-qa-edit-button
-            aria-label={`Edit ${labelText}`}
-          >
-            <Edit className={`${classes.icon} ${classes.edit}`} />
-          </Button>
-        </React.Fragment>
-      </div>
-    ) : (
-      <ClickAwayListener
-        onClickAway={this.cancelEditing}
-        mouseEvent="onMouseDown"
-      >
-        <div
-          className={`${classes.container} ${classes.edit} ${className}`}
-          data-qa-edit-field
+  return !isEditing && !errorText ? (
+    <div
+      className={`${classes.container} ${classes.initial} ${className}`}
+      data-testid={'editable-text'}
+    >
+      <React.Fragment>
+        {!!labelLink ? (
+          <Link to={labelLink!} className={classes.underlineOnHover}>
+            {labelText}
+          </Link>
+        ) : (
+          labelText
+        )}
+        {/** pencil icon */}
+        <Button
+          className={`${classes.button} ${classes.editIcon}`}
+          onClick={openEdit}
+          data-qa-edit-button
+          aria-label={`Edit ${labelText}`}
         >
-          <TextField
-            {...rest}
-            className={classes.textField}
-            type="text"
-            onChange={this.onChange}
-            onKeyDown={this.handleKeyPress}
-            value={text}
-            errorText={this.props.errorText}
-            InputProps={{ className: classes.inputRoot }}
-            inputProps={{
-              className: classnames({
-                [classes.headline]: typeVariant === 'h1',
-                [classes.title]: typeVariant === 'h2',
-                [classes.input]: true
-              })
-            }}
-            autoFocus={true}
-          />
-          <Button
-            className={classes.button}
-            onClick={this.finishEditing}
-            data-qa-save-edit
-          >
-            <Check className={`${classes.icon} ${classes.save}`} />
-          </Button>
-          <Button
-            className={classes.button}
-            onClick={this.cancelEditing}
-            data-qa-cancel-edit
-          >
-            <Close className={`${classes.icon} ${classes.close}`} />
-          </Button>
-        </div>
-      </ClickAwayListener>
-    );
-  }
-}
+          <Edit className={`${classes.icon} ${classes.edit}`} />
+        </Button>
+      </React.Fragment>
+    </div>
+  ) : (
+    <ClickAwayListener onClickAway={cancelEditing} mouseEvent="onMouseDown">
+      <div
+        className={`${classes.container} ${classes.edit} ${className}`}
+        data-qa-edit-field
+      >
+        <TextField
+          {...rest}
+          className={classes.textField}
+          type="text"
+          onChange={onChange}
+          onKeyDown={handleKeyPress}
+          value={text}
+          errorText={props.errorText}
+          InputProps={{ className: classes.inputRoot }}
+          inputProps={{
+            className: classnames({
+              [classes.headline]: typeVariant === 'h1',
+              [classes.title]: typeVariant === 'h2',
+              [classes.input]: true
+            })
+          }}
+          autoFocus={true}
+        />
+        <Button
+          className={classes.button}
+          onClick={finishEditing}
+          data-qa-save-edit
+        >
+          <Check className={`${classes.icon} ${classes.save}`} />
+        </Button>
+        <Button
+          className={classes.button}
+          onClick={cancelEditing}
+          data-qa-cancel-edit
+        >
+          <Close className={`${classes.icon} ${classes.close}`} />
+        </Button>
+      </div>
+    </ClickAwayListener>
+  );
+};
 
 const styled = withStyles(styles);
 

--- a/packages/manager/src/components/H1Header/H1Header.tsx
+++ b/packages/manager/src/components/H1Header/H1Header.tsx
@@ -8,6 +8,11 @@ interface Props {
   className?: string;
 }
 
+// Accessibility Feature:
+// The role of this component is to implement focus to the main content when navigating the application
+// Since it is a one page APP, we need to help users focus on the main content when switching views
+// It should serve as the only source for all H1s
+
 const H1Header: React.FC<Props> = props => {
   const h1Header = React.useRef<HTMLDivElement>(null);
   const { className, title } = props;

--- a/packages/manager/src/components/H1Header/H1Header.tsx
+++ b/packages/manager/src/components/H1Header/H1Header.tsx
@@ -1,0 +1,28 @@
+import { compose } from 'ramda';
+import * as React from 'react';
+import Typography from 'src/components/core/Typography';
+import RenderGuard from 'src/components/RenderGuard';
+
+interface Props {
+  title: string;
+  className?: string;
+}
+
+const H1Header: React.FC<Props> = props => {
+  const h1Header = React.useRef<HTMLDivElement>(null);
+  const { className, title } = props;
+
+  React.useEffect(() => {
+    if (h1Header.current !== null) {
+      h1Header.current.focus();
+    }
+  }, []);
+
+  return (
+    <Typography variant="h1" className={className} ref={h1Header} tabIndex={-1}>
+      {title}
+    </Typography>
+  );
+};
+
+export default compose<any, any>(RenderGuard)(H1Header);

--- a/packages/manager/src/components/H1Header/index.tsx
+++ b/packages/manager/src/components/H1Header/index.tsx
@@ -1,0 +1,2 @@
+import H1Header from './H1Header';
+export default H1Header;

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Button, { ButtonProps } from 'src/components/Button';
 import {
   createStyles,
@@ -116,13 +117,12 @@ const Placeholder: React.StatelessComponent<CombinedProps> = props => {
         {Icon && <Icon className={`${classes.icon} ${animate && 'animate'}`} />}
       </Grid>
       <Grid item xs={12}>
-        <Typography
+        <Breadcrumb
+          pathname=""
+          labelTitle={title}
           className={classes.title}
           data-qa-placeholder-title
-          variant="h1"
-        >
-          {title}
-        </Typography>
+        />
       </Grid>
       <Grid item xs={12} lg={10} className={classes.copy}>
         {typeof copy === 'string' ? (

--- a/packages/manager/src/components/Placeholder/Placeholder.tsx
+++ b/packages/manager/src/components/Placeholder/Placeholder.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
-import Breadcrumb from 'src/components/Breadcrumb';
 import Button, { ButtonProps } from 'src/components/Button';
 import {
   createStyles,
@@ -10,6 +9,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import H1Header from 'src/components/H1Header';
 
 type ClassNames = 'root' | 'title' | 'copy' | 'icon' | 'button';
 
@@ -117,9 +117,8 @@ const Placeholder: React.StatelessComponent<CombinedProps> = props => {
         {Icon && <Icon className={`${classes.icon} ${animate && 'animate'}`} />}
       </Grid>
       <Grid item xs={12}>
-        <Breadcrumb
-          pathname=""
-          labelTitle={title}
+        <H1Header
+          title={title}
           className={classes.title}
           data-qa-placeholder-title
         />

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -2,6 +2,7 @@ import { Image } from 'linode-js-sdk/lib/images';
 import { StackScript } from 'linode-js-sdk/lib/stackscripts';
 import * as React from 'react';
 import { compose } from 'recompose';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
 import {
@@ -121,9 +122,11 @@ export class _StackScript extends React.Component<CombinedProps> {
 
     return (
       <div className={classes.root}>
-        <Typography variant="h1" component="h2" data-qa-stack-title={label}>
-          {label}
-        </Typography>
+        <Breadcrumb
+          pathname={''}
+          labelTitle={label}
+          data-qa-stack-title={label}
+        />
         <Typography
           variant="h3"
           className={classes.author}

--- a/packages/manager/src/components/StackScript/StackScript.tsx
+++ b/packages/manager/src/components/StackScript/StackScript.tsx
@@ -2,7 +2,6 @@ import { Image } from 'linode-js-sdk/lib/images';
 import { StackScript } from 'linode-js-sdk/lib/stackscripts';
 import * as React from 'react';
 import { compose } from 'recompose';
-import Breadcrumb from 'src/components/Breadcrumb';
 import Chip from 'src/components/core/Chip';
 import Divider from 'src/components/core/Divider';
 import {
@@ -14,6 +13,7 @@ import {
 import Typography from 'src/components/core/Typography';
 import DateTimeDisplay from 'src/components/DateTimeDisplay';
 import ExternalLink from 'src/components/ExternalLink';
+import H1Header from 'src/components/H1Header';
 import ScriptCode from 'src/components/ScriptCode';
 import withImages from 'src/containers/withImages.container';
 
@@ -122,13 +122,9 @@ export class _StackScript extends React.Component<CombinedProps> {
 
     return (
       <div className={classes.root}>
-        <Breadcrumb
-          pathname={''}
-          labelTitle={label}
-          data-qa-stack-title={label}
-        />
+        <H1Header title={label} data-qa-stack-title={label} />
         <Typography
-          variant="h3"
+          variant="h2"
           className={classes.author}
           data-qa-stack-author={username}
         >

--- a/packages/manager/src/features/CancelLanding/CancelLanding.tsx
+++ b/packages/manager/src/features/CancelLanding/CancelLanding.tsx
@@ -2,12 +2,12 @@ import { path } from 'ramda';
 import * as React from 'react';
 import { Redirect, useLocation } from 'react-router-dom';
 import { compose } from 'recompose';
-import Breadcrumb from 'src/components/Breadcrumb';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
 import Logo from 'src/assets/logo/logo-footer.svg';
 import Button from 'src/components/Button';
 import Typography from 'src/components/core/Typography';
+import H1Header from 'src/components/H1Header';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -54,10 +54,7 @@ export const CancelLanding: React.FC<{}> = () => {
   return (
     <div className={classes.root} data-testid="body">
       <Logo className={classes.logo} />
-      <Breadcrumb
-        pathname={''}
-        labelTitle="It's been our pleasure to serve you."
-      />
+      <H1Header title="It's been our pleasure to serve you." />
       <Typography>
         Your account is closed. We hope you'll consider Linode for your future
         cloud hosting needs.

--- a/packages/manager/src/features/CancelLanding/CancelLanding.tsx
+++ b/packages/manager/src/features/CancelLanding/CancelLanding.tsx
@@ -2,6 +2,7 @@ import { path } from 'ramda';
 import * as React from 'react';
 import { Redirect, useLocation } from 'react-router-dom';
 import { compose } from 'recompose';
+import Breadcrumb from 'src/components/Breadcrumb';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
 import Logo from 'src/assets/logo/logo-footer.svg';
@@ -53,7 +54,10 @@ export const CancelLanding: React.FC<{}> = () => {
   return (
     <div className={classes.root} data-testid="body">
       <Logo className={classes.logo} />
-      <Typography variant="h1">It's been our pleasure to serve you.</Typography>
+      <Breadcrumb
+        pathname={''}
+        labelTitle="It's been our pleasure to serve you."
+      />
       <Typography>
         Your account is closed. We hope you'll consider Linode for your future
         cloud hosting needs.

--- a/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -85,7 +85,7 @@ export const BackupsDashboardCard: React.StatelessComponent<
   }
 
   return (
-    <DashboardCard>
+    <DashboardCard data-qa-backups-dashboard-card>
       <Paper
         className={classNames({
           [classes.section]: true,

--- a/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/BackupsDashboardCard/BackupsDashboardCard.tsx
@@ -34,7 +34,8 @@ const styles = (theme: Theme) =>
     },
     icon: {
       color: theme.color.blueDTwhite,
-      margin: theme.spacing(1),
+      marginRight: theme.spacing(1),
+      marginLeft: theme.spacing(2),
       fontSize: 32
     },
     itemTitle: {
@@ -53,7 +54,7 @@ const styles = (theme: Theme) =>
       display: 'flex',
       flexFlow: 'row nowrap',
       alignItems: 'center',
-      justifyContent: 'center',
+      justifyContent: 'flex-start',
       padding: `${theme.spacing(1)}px !important`
     },
     ctaLink: {
@@ -92,7 +93,7 @@ export const BackupsDashboardCard: React.StatelessComponent<
         })}
       >
         <Backup className={classes.icon} />
-        <Typography className={classes.header} variant="h1">
+        <Typography className={classes.header} variant="h2">
           Back Up Your Data and Keep it Safe
         </Typography>
       </Paper>
@@ -154,8 +155,8 @@ BackupsDashboardCard.displayName = 'BackupsDashboardCard';
 const styled = withStyles(styles);
 
 const enhanced = compose<CombinedProps, Props>(
-  styled,
-  withRouter
+  withRouter,
+  styled
 )(BackupsDashboardCard);
 
 export default enhanced;

--- a/packages/manager/src/features/Dashboard/Dashboard.test.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.test.tsx
@@ -30,13 +30,13 @@ describe('Dashboard view', () => {
   describe('Backups CTA card', () => {
     it('display for non-managed users', () => {
       expect(
-        component.find('WithStyles(withRouter(BackupsDashboardCard))')
+        component.find('withRouter(WithStyles(BackupsDashboardCard))')
       ).toHaveLength(1);
     });
     it('should never display for managed users', () => {
       component.setProps({ managed: true });
       expect(
-        component.find('WithStyles(withRouter(BackupsDashboardCard))')
+        component.find('withRouter(WithStyles(BackupsDashboardCard))')
       ).toHaveLength(0);
     });
   });

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -7,7 +7,6 @@ import { connect, MapDispatchToProps } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
-import Breadcrumb from 'src/components/Breadcrumb';
 import {
   createStyles,
   Theme,
@@ -17,6 +16,7 @@ import {
 } from 'src/components/core/styles';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
+import H1Header from 'src/components/H1Header';
 import MaintenanceBanner from 'src/components/MaintenanceBanner';
 import TaxBanner from 'src/components/TaxBanner';
 import TagImportDrawer from 'src/features/TagImport';
@@ -104,10 +104,7 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
         <TaxBanner location={location} marginBottom={8} />
         <DocumentTitleSegment segment="Dashboard" />
         <Grid item xs={12}>
-          <Breadcrumb
-            pathname={props.location.pathname}
-            data-qa-dashboard-header
-          />
+          <H1Header title="Dashboard" data-qa-dashboard-header />
         </Grid>
         {managed && (
           <Grid item xs={12}>
@@ -202,10 +199,16 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   };
 };
 
-const connected = connect(mapStateToProps, mapDispatchToProps);
+const connected = connect(
+  mapStateToProps,
+  mapDispatchToProps
+);
 
 const styled = withStyles(styles, { withTheme: true });
 
-const enhanced = compose<CombinedProps, {}>(styled, connected)(Dashboard);
+const enhanced = compose<CombinedProps, {}>(
+  styled,
+  connected
+)(Dashboard);
 
 export default enhanced;

--- a/packages/manager/src/features/Dashboard/Dashboard.tsx
+++ b/packages/manager/src/features/Dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import { connect, MapDispatchToProps } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import AbuseTicketBanner from 'src/components/AbuseTicketBanner';
+import Breadcrumb from 'src/components/Breadcrumb';
 import {
   createStyles,
   Theme,
@@ -14,7 +15,6 @@ import {
   WithStyles,
   WithTheme
 } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import MaintenanceBanner from 'src/components/MaintenanceBanner';
@@ -104,9 +104,10 @@ export const Dashboard: React.StatelessComponent<CombinedProps> = props => {
         <TaxBanner location={location} marginBottom={8} />
         <DocumentTitleSegment segment="Dashboard" />
         <Grid item xs={12}>
-          <Typography variant="h1" data-qa-dashboard-header>
-            Dashboard
-          </Typography>
+          <Breadcrumb
+            pathname={props.location.pathname}
+            data-qa-dashboard-header
+          />
         </Grid>
         {managed && (
           <Grid item xs={12}>

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import Waypoint from 'react-waypoint';
 import { compose } from 'recompose';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -278,9 +279,11 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
     <>
       {/* Only display this title on the main Events landing page */}
       {!entityId && (
-        <Typography variant="h1" className={classes.header}>
-          Events
-        </Typography>
+        <Breadcrumb
+          pathname={''}
+          className={classes.header}
+          labelTitle="Events"
+        />
       )}
       <Paper>
         <Table aria-label="List of Events">

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import Waypoint from 'react-waypoint';
 import { compose } from 'recompose';
-import Breadcrumb from 'src/components/Breadcrumb';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -17,6 +16,7 @@ import {
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import Typography from 'src/components/core/Typography';
+import H1Header from 'src/components/H1Header';
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
@@ -278,13 +278,7 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
   return (
     <>
       {/* Only display this title on the main Events landing page */}
-      {!entityId && (
-        <Breadcrumb
-          pathname={''}
-          className={classes.header}
-          labelTitle="Events"
-        />
-      )}
+      {!entityId && <H1Header title="Events" className={classes.header} />}
       <Paper>
         <Table aria-label="List of Events">
           <TableHead>

--- a/packages/manager/src/features/Help/Panels/SearchPanel.tsx
+++ b/packages/manager/src/features/Help/Panels/SearchPanel.tsx
@@ -1,6 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -9,7 +10,6 @@ import {
   WithStyles,
   WithTheme
 } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import { COMPACT_SPACING_UNIT } from 'src/themeFactory';
 import AlgoliaSearchBar from './AlgoliaSearchBar';
 
@@ -82,13 +82,12 @@ class SearchPanel extends React.Component<CombinedProps, {}> {
               [classes.bgIconCompact]: spacingMode === 'compact'
             })}
           />
-          <Typography
-            variant="h1"
+          <Breadcrumb
+            pathname={''}
+            labelTitle="What can we help you with?"
             className={classes.searchHeading}
             data-qa-search-heading
-          >
-            What can we help you with?
-          </Typography>
+          />
           <AlgoliaSearchBar />
         </Paper>
       </React.Fragment>

--- a/packages/manager/src/features/Help/Panels/SearchPanel.tsx
+++ b/packages/manager/src/features/Help/Panels/SearchPanel.tsx
@@ -1,7 +1,6 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 import LinodeIcon from 'src/assets/addnewmenu/linode.svg';
-import Breadcrumb from 'src/components/Breadcrumb';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -10,6 +9,7 @@ import {
   WithStyles,
   WithTheme
 } from 'src/components/core/styles';
+import H1Header from 'src/components/H1Header';
 import { COMPACT_SPACING_UNIT } from 'src/themeFactory';
 import AlgoliaSearchBar from './AlgoliaSearchBar';
 
@@ -82,9 +82,8 @@ class SearchPanel extends React.Component<CombinedProps, {}> {
               [classes.bgIconCompact]: spacingMode === 'compact'
             })}
           />
-          <Breadcrumb
-            pathname={''}
-            labelTitle="What can we help you with?"
+          <H1Header
+            title="What can we help you with?"
             className={classes.searchHeading}
             data-qa-search-heading
           />

--- a/packages/manager/src/features/Help/SupportSearchLanding/DocumentationResults.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/DocumentationResults.tsx
@@ -9,6 +9,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import ExternalLink from 'src/components/ExternalLink';
 
 type ClassNames =
   | 'root'
@@ -33,8 +34,6 @@ const styles = (theme: Theme) =>
       padding: `${theme.spacing(2)}px ${theme.spacing(3)}px`
     },
     moreResults: {
-      fontSize: '1rem',
-      fontWeight: 'bold',
       marginTop: theme.spacing(2)
     },
     icon: {
@@ -50,7 +49,8 @@ const styles = (theme: Theme) =>
       color: '#3683DC'
     },
     link: {
-      display: 'inline-block'
+      marginTop: theme.spacing(2),
+      fontFamily: theme.font.bold
     },
     searchItem: {
       position: 'initial',
@@ -113,7 +113,7 @@ const DocumentationResults: React.StatelessComponent<CombinedProps> = props => {
   return (
     <div className={classes.root}>
       <Typography
-        variant="h1"
+        variant="h2"
         className={classes.header}
         data-qa-results={sectionTitle}
       >
@@ -124,15 +124,12 @@ const DocumentationResults: React.StatelessComponent<CombinedProps> = props => {
           {results.length > 0 ? renderResults() : renderEmptyState()}
         </nav>
       </Paper>
-      <Typography variant="body2" className={classes.moreResults}>
-        <a
-          href={target}
-          className={classes.link}
-          data-qa-view-more={sectionTitle}
-        >
-          View more {sectionTitle}
-        </a>
-      </Typography>
+      <ExternalLink
+        link={target}
+        text={`View more ${sectionTitle}`}
+        data-qa-view-more={sectionTitle}
+        className={classes.link}
+      />
     </div>
   );
 };

--- a/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.test.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.test.tsx
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import { assocPath } from 'ramda';
 import * as React from 'react';
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import Breadcrumb from 'src/components/Breadcrumb';
+import H1Header from 'src/components/H1Header';
 import { CombinedProps, SupportSearchLanding } from './SupportSearchLanding';
 
 const classes = {
@@ -49,10 +49,8 @@ describe('Component', () => {
   it('should display the query text in the header', () => {
     expect(
       component.containsMatchingElement(
-        <Breadcrumb
-          pathname="/"
-          labelTitle='Search results for "search"'
-          removeCrumbX={2}
+        <H1Header
+          title='Search results for "search"'
           data-qa-support-search-landing-title={true}
         />
       )
@@ -62,20 +60,13 @@ describe('Component', () => {
     component.setState({ query: '' });
     expect(
       component.containsMatchingElement(
-        <Breadcrumb
-          pathname="/"
-          labelTitle="Search"
-          removeCrumbX={2}
-          data-qa-support-search-landing-title={true}
-        />
+        <H1Header title="Search" data-qa-support-search-landing-title={true} />
       )
     ).toBeTruthy();
     expect(
       component.containsMatchingElement(
-        <Breadcrumb
-          pathname="/"
-          labelTitle="Search results for"
-          removeCrumbX={2}
+        <H1Header
+          title="Search results for"
           data-qa-support-search-landing-title={true}
         />
       )

--- a/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.test.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.test.tsx
@@ -1,9 +1,8 @@
 import { shallow } from 'enzyme';
 import { assocPath } from 'ramda';
 import * as React from 'react';
-
 import { reactRouterProps } from 'src/__data__/reactRouterProps';
-import Typography from 'src/components/core/Typography';
+import Breadcrumb from 'src/components/Breadcrumb';
 import { CombinedProps, SupportSearchLanding } from './SupportSearchLanding';
 
 const classes = {
@@ -50,7 +49,12 @@ describe('Component', () => {
   it('should display the query text in the header', () => {
     expect(
       component.containsMatchingElement(
-        <Typography variant="h1">Search results for "search"</Typography>
+        <Breadcrumb
+          pathname="/"
+          labelTitle='Search results for "search"'
+          removeCrumbX={2}
+          data-qa-support-search-landing-title={true}
+        />
       )
     ).toBeTruthy();
   });
@@ -58,12 +62,22 @@ describe('Component', () => {
     component.setState({ query: '' });
     expect(
       component.containsMatchingElement(
-        <Typography variant="h1">Search</Typography>
+        <Breadcrumb
+          pathname="/"
+          labelTitle="Search"
+          removeCrumbX={2}
+          data-qa-support-search-landing-title={true}
+        />
       )
     ).toBeTruthy();
     expect(
       component.containsMatchingElement(
-        <Typography variant="h1">Search results for</Typography>
+        <Breadcrumb
+          pathname="/"
+          labelTitle="Search results for"
+          removeCrumbX={2}
+          data-qa-support-search-landing-title={true}
+        />
       )
     ).toBeFalsy();
   });

--- a/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -123,6 +123,7 @@ export class SupportSearchLanding extends React.Component<
                   query.length > 1 ? `Search results for "${query}"` : 'Search'
                 }
                 removeCrumbX={2}
+                data-qa-support-search-landing-title
               />
             </Grid>
           </Grid>

--- a/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -1,9 +1,8 @@
-import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import Search from '@material-ui/icons/Search';
 import { compose } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import IconButton from 'src/components/core/IconButton';
+import Breadcrumb from 'src/components/Breadcrumb';
 import InputAdornment from 'src/components/core/InputAdornment';
 import {
   createStyles,
@@ -11,7 +10,6 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
@@ -23,7 +21,6 @@ import HelpResources from './HelpResources';
 
 type ClassNames =
   | 'root'
-  | 'backButton'
   | 'searchBar'
   | 'searchBoxInner'
   | 'searchHeading'
@@ -38,13 +35,6 @@ const styles = (theme: Theme) =>
       alignItems: 'center',
       justifyContent: 'flex-start',
       position: 'relative'
-    },
-    backButton: {
-      margin: '2px 0 0 -16px',
-      '& svg': {
-        width: 34,
-        height: 34
-      }
     },
     searchBar: {
       maxWidth: '100%'
@@ -127,17 +117,13 @@ export class SupportSearchLanding extends React.Component<
         <Grid item>
           <Grid container alignItems="center">
             <Grid item>
-              <IconButton
-                onClick={this.onBackButtonClick}
-                className={classes.backButton}
-              >
-                <KeyboardArrowLeft />
-              </IconButton>
-            </Grid>
-            <Grid item>
-              <Typography variant="h1">
-                {query.length > 1 ? `Search results for "${query}"` : 'Search'}
-              </Typography>
+              <Breadcrumb
+                pathname={this.props.location.pathname}
+                labelTitle={
+                  query.length > 1 ? `Search results for "${query}"` : 'Search'
+                }
+                removeCrumbX={2}
+              />
             </Grid>
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -2,7 +2,6 @@ import Search from '@material-ui/icons/Search';
 import { compose } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import Breadcrumb from 'src/components/Breadcrumb';
 import InputAdornment from 'src/components/core/InputAdornment';
 import {
   createStyles,
@@ -11,6 +10,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
+import H1Header from 'src/components/H1Header';
 import Notice from 'src/components/Notice';
 import TextField from 'src/components/TextField';
 import { COMMUNITY_SEARCH_URL, DOCS_SEARCH_URL } from 'src/constants';
@@ -117,12 +117,10 @@ export class SupportSearchLanding extends React.Component<
         <Grid item>
           <Grid container alignItems="center">
             <Grid item>
-              <Breadcrumb
-                pathname={this.props.location.pathname}
-                labelTitle={
+              <H1Header
+                title={
                   query.length > 1 ? `Search results for "${query}"` : 'Search'
                 }
-                removeCrumbX={2}
                 data-qa-support-search-landing-title
               />
             </Grid>

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -5,7 +5,6 @@ import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import 'rxjs/add/operator/filter';
 import AddNewLink from 'src/components/AddNewLink';
-import Breadcrumb from 'src/components/Breadcrumb';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -18,6 +17,7 @@ import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
+import H1Header from 'src/components/H1Header';
 import OrderBy from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
@@ -130,10 +130,8 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
         style={{ paddingBottom: 0 }}
       >
         <Grid item>
-          <Breadcrumb
-            pathname={props.location.pathname}
-            labelTitle="Kubernetes Clusters"
-            removeCrumbX={1}
+          <H1Header
+            title="Kubernetes Clusters"
             className={classes.title}
             data-qa-title
           />

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -135,6 +135,7 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
             labelTitle="Kubernetes Clusters"
             removeCrumbX={1}
             className={classes.title}
+            data-qa-title
           />
         </Grid>
         <Grid item>

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterList.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
 import 'rxjs/add/operator/filter';
 import AddNewLink from 'src/components/AddNewLink';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Paper from 'src/components/core/Paper';
 import {
   createStyles,
@@ -15,7 +16,6 @@ import {
 import TableBody from 'src/components/core/TableBody';
 import TableHead from 'src/components/core/TableHead';
 import TableRow from 'src/components/core/TableRow';
-import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import OrderBy from 'src/components/OrderBy';
@@ -130,9 +130,12 @@ export const ClusterList: React.FunctionComponent<CombinedProps> = props => {
         style={{ paddingBottom: 0 }}
       >
         <Grid item>
-          <Typography variant="h1" data-qa-title className={classes.title}>
-            Kubernetes Clusters
-          </Typography>
+          <Breadcrumb
+            pathname={props.location.pathname}
+            labelTitle="Kubernetes Clusters"
+            removeCrumbX={1}
+            className={classes.title}
+          />
         </Grid>
         <Grid item>
           <Grid container alignItems="flex-end">

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -10,6 +10,7 @@ import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { StickyContainer } from 'react-sticky';
 import { compose } from 'recompose';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Grid from 'src/components/core/Grid';
 import Paper from 'src/components/core/Paper';
 import {
@@ -18,7 +19,6 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ErrorState from 'src/components/ErrorState';
@@ -44,7 +44,8 @@ const styles = (theme: Theme) =>
   createStyles({
     root: {},
     title: {
-      marginBottom: theme.spacing(1) + theme.spacing(1) / 2
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1)
     },
     sidebar: {
       [theme.breakpoints.up('md')]: {
@@ -248,9 +249,12 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
         <Grid container spacing={2}>
           <DocumentTitleSegment segment="Create a Kubernetes Cluster" />
           <Grid item className={`mlMain py0`}>
-            <Typography variant="h1" data-qa-title className={classes.title}>
-              Create a Kubernetes Cluster
-            </Typography>
+            <Breadcrumb
+              pathname={this.props.location.pathname}
+              data-qa-title
+              className={classes.title}
+              labelTitle="Create a Kubernetes Cluster"
+            />
             {errorMap.none && <Notice text={errorMap.none} error />}
             <SelectRegionPanel
               error={errorMap.region}

--- a/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/CreateCluster.tsx
@@ -10,7 +10,6 @@ import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { StickyContainer } from 'react-sticky';
 import { compose } from 'recompose';
-import Breadcrumb from 'src/components/Breadcrumb';
 import Grid from 'src/components/core/Grid';
 import Paper from 'src/components/core/Paper';
 import {
@@ -22,6 +21,7 @@ import {
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import ErrorState from 'src/components/ErrorState';
+import H1Header from 'src/components/H1Header';
 import Notice from 'src/components/Notice';
 import SelectRegionPanel from 'src/components/SelectRegionPanel';
 import TextField from 'src/components/TextField';
@@ -249,11 +249,10 @@ export class CreateCluster extends React.Component<CombinedProps, State> {
         <Grid container spacing={2}>
           <DocumentTitleSegment segment="Create a Kubernetes Cluster" />
           <Grid item className={`mlMain py0`}>
-            <Breadcrumb
-              pathname={this.props.location.pathname}
+            <H1Header
+              title="Create a Kubernetes Cluster"
               data-qa-title
               className={classes.title}
-              labelTitle="Create a Kubernetes Cluster"
             />
             {errorMap.none && <Notice text={errorMap.none} error />}
             <SelectRegionPanel

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
@@ -2,125 +2,44 @@ import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 import KubernetesSvg from 'src/assets/addnewmenu/kubernetes.svg';
-import Button from 'src/components/Button';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles
-} from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
-import Grid from 'src/components/Grid';
+import Placeholder from 'src/components/Placeholder';
 
-type CSSClasses = 'root' | 'copy' | 'icon' | 'title';
+type Props = RouteComponentProps<{}>;
 
-const styles = (theme: Theme) =>
-  createStyles({
-    '@keyframes scaleIn': {
-      from: {
-        transform: 'translateX( -10px ) rotateY( -180deg )'
-      },
-      to: {
-        transformOrigin: 'center center'
-      }
-    },
-    '@keyframes fadeIn': {
-      from: {
-        opacity: 0
-      },
-      to: {
-        opacity: 1
-      }
-    },
-    root: {
-      padding: `${theme.spacing(2)}px 0`,
-      [theme.breakpoints.up('md')]: {
-        padding: `${theme.spacing(10)}px 0`
-      }
-    },
-    copy: {
-      textAlign: 'center',
-      maxWidth: 800
-    },
-    icon: {
-      animation: '$scaleIn .5s ease-in-out',
-      width: 150,
-      height: 150,
-      '& use': {
-        fill: theme.bg.main
-      },
-      '& .outerCircle': {
-        fill: theme.color.absWhite,
-        stroke: theme.bg.offWhite
-      },
-      '& .insidePath path': {
-        opacity: 0,
-        animation: '$fadeIn .2s ease-in-out forwards .3s',
-        stroke: theme.palette.primary.main
-      }
-    },
-    title: {
-      fontFamily: theme.font.bold,
-      textAlign: 'center'
-    }
-  });
-
-type PropsWithStyles = WithStyles<CSSClasses> & RouteComponentProps<{}>;
-
-class ListLinodesEmptyState extends React.Component<PropsWithStyles> {
+class KubernetesEmptyState extends React.Component<Props> {
   render() {
-    const { classes } = this.props;
+    const SubtitleCopy = () => (
+      <>
+        <Typography variant="subtitle1">Need help getting started?</Typography>
+        <Typography variant="subtitle1">
+          <a
+            href="https://www.linode.com/docs/applications/containers/kubernetes/how-to-deploy-a-cluster-with-lke/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="h-u"
+          >
+            Learn more about getting started with LKE.
+          </a>
+        </Typography>
+      </>
+    );
 
     return (
-      <Grid
-        container
-        spacing={3}
-        alignItems="center"
-        direction="column"
-        justify="center"
-        className={classes.root}
-      >
-        <Grid item xs={12}>
-          <KubernetesSvg className={classes.icon} />
-        </Grid>
-        <Typography
-          variant="h4"
-          className={classes.title}
-          data-qa-placeholder-title
-        >
-          Add your first Kubernetes cluster!
-        </Typography>
-        <Grid item xs={12} lg={10} className={classes.copy}>
-          <Typography variant="subtitle1">
-            Need help getting started?
-          </Typography>
-          <Typography variant="subtitle1">
-            <a
-              href="https://www.linode.com/docs/applications/containers/kubernetes/how-to-deploy-a-cluster-with-lke/"
-              target="_blank"
-              aria-describedby="external-site"
-              rel="noopener noreferrer"
-              className="h-u"
-            >
-              Learn more about getting started with LKE.
-            </a>
-          </Typography>
-        </Grid>
-        <Grid item xs={12} lg={10} className={classes.copy}>
-          <Button
-            buttonType="primary"
-            onClick={() => this.props.history.push('/kubernetes/create')}
-          >
-            Create a Cluster
-          </Button>
-        </Grid>
-      </Grid>
+      <Placeholder
+        title="Add your first Kubernetes cluster!"
+        copy={<SubtitleCopy />}
+        icon={KubernetesSvg}
+        buttonProps={[
+          {
+            onClick: () => this.props.history.push('/kubernetes/create'),
+            children: 'Create a Cluster'
+          }
+        ]}
+      />
     );
   }
 }
-const enhanced = compose(
-  withRouter,
-  withStyles(styles)
-);
+const enhanced = compose(withRouter);
 
-export default enhanced(ListLinodesEmptyState);
+export default enhanced(KubernetesEmptyState);

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
@@ -44,8 +44,8 @@ const styles = (theme: Theme) =>
     },
     icon: {
       animation: '$scaleIn .5s ease-in-out',
-      width: 225,
-      height: 225,
+      width: 150,
+      height: 150,
       '& use': {
         fill: theme.bg.main
       },

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerCreate.tsx
@@ -17,6 +17,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Sticky, StickyContainer, StickyProps } from 'react-sticky';
 import { compose as recompose } from 'recompose';
 import ActionsPanel from 'src/components/ActionsPanel';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
 import CheckoutBar from 'src/components/CheckoutBar';
 import CircleProgress from 'src/components/CircleProgress';
@@ -30,6 +31,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import { ExtendedRegion } from 'src/components/EnhancedSelect/variants/RegionSelect';
 import Grid from 'src/components/Grid';
 import LabelAndTagsPanel from 'src/components/LabelAndTagsPanel';
 import Notice from 'src/components/Notice';
@@ -57,8 +59,6 @@ import {
   NodeBalancerConfigFieldsWithStatus,
   transformConfigsForRequest
 } from './utils';
-
-import { ExtendedRegion } from 'src/components/EnhancedSelect/variants/RegionSelect';
 
 type ClassNames = 'root' | 'main' | 'sidebar' | 'title';
 
@@ -459,10 +459,10 @@ class NodeBalancerCreate extends React.Component<CombinedProps, State> {
         <DocumentTitleSegment segment="Create a NodeBalancer" />
         <Grid container>
           <Grid item className={`${classes.main} mlMain`}>
-            <Typography variant="h1" data-qa-create-nodebalancer-header>
-              Create a NodeBalancer
-            </Typography>
-
+            <Breadcrumb
+              pathname={this.props.location.pathname}
+              data-qa-create-nodebalancer-header
+            />
             {generalError && !disabled && (
               <Notice spacingTop={8} error>
                 {generalError}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerConfigurations.tsx
@@ -1087,7 +1087,7 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
   );
 
   render() {
-    const { classes, nodeBalancerLabel } = this.props;
+    const { nodeBalancerLabel } = this.props;
     const {
       configs,
       configErrors,
@@ -1101,10 +1101,6 @@ class NodeBalancerConfigurations extends React.Component<CombinedProps, State> {
         <DocumentTitleSegment
           segment={`${nodeBalancerLabel} - Configurations`}
         />
-        <Typography variant="h1" data-qa-title className={classes.title}>
-          NodeBalancer Configurations
-        </Typography>
-
         {Array.isArray(configs) &&
           configs.map(
             this.renderConfig(panelMessages, configErrors, configSubmitting)

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSettings/NodeBalancerSettings.tsx
@@ -13,7 +13,6 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
@@ -143,9 +142,6 @@ class NodeBalancerSettings extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment={`${nodeBalancerLabel} - Settings`} />
-        <Typography variant="h1" className={classes.title}>
-          Settings
-        </Typography>
         <Paper className={classes.root}>
           <Grid item xs={12}>
             {generalError && <Notice error text={generalError} />}

--- a/packages/manager/src/features/Profile/Profile.tsx
+++ b/packages/manager/src/features/Profile/Profile.tsx
@@ -6,11 +6,11 @@ import {
   Switch,
   withRouter
 } from 'react-router-dom';
-import Breadcrumb from 'src/components/Breadcrumb';
 import AppBar from 'src/components/core/AppBar';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
+import H1Header from 'src/components/H1Header';
 import TabLink from 'src/components/TabLink';
 
 import DefaultLoader from 'src/components/DefaultLoader';
@@ -85,12 +85,7 @@ class Profile extends React.Component<Props> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="My Profile" />
-        <Breadcrumb
-          pathname={this.props.location.pathname}
-          labelTitle="My Profile"
-          removeCrumbX={1}
-          data-qa-profile-header
-        />
+        <H1Header title="My Profile" data-qa-profile-header />
         <AppBar position="static" color="default">
           <Tabs
             value={this.tabs.findIndex(tab => matches(tab.routeName))}

--- a/packages/manager/src/features/Profile/Profile.tsx
+++ b/packages/manager/src/features/Profile/Profile.tsx
@@ -6,10 +6,10 @@ import {
   Switch,
   withRouter
 } from 'react-router-dom';
+import Breadcrumb from 'src/components/Breadcrumb';
 import AppBar from 'src/components/core/AppBar';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
-import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import TabLink from 'src/components/TabLink';
 
@@ -85,9 +85,11 @@ class Profile extends React.Component<Props> {
     return (
       <React.Fragment>
         <DocumentTitleSegment segment="My Profile" />
-        <Typography variant="h1" data-qa-profile-header>
-          My Profile
-        </Typography>
+        <Breadcrumb
+          pathname={this.props.location.pathname}
+          labelTitle="My Profile"
+          removeCrumbX={1}
+        />
         <AppBar position="static" color="default">
           <Tabs
             value={this.tabs.findIndex(tab => matches(tab.routeName))}

--- a/packages/manager/src/features/Profile/Profile.tsx
+++ b/packages/manager/src/features/Profile/Profile.tsx
@@ -89,6 +89,7 @@ class Profile extends React.Component<Props> {
           pathname={this.props.location.pathname}
           labelTitle="My Profile"
           removeCrumbX={1}
+          data-qa-profile-header
         />
         <AppBar position="static" color="default">
           <Tabs

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -2,7 +2,6 @@ import { equals } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
-import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
 import {
   createStyles,
@@ -12,6 +11,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import H1Header from 'src/components/H1Header';
 import Notice from 'src/components/Notice';
 import reloadableWithRouter from 'src/features/linodes/LinodesDetail/reloadableWithRouter';
 import { ErrorObject } from 'src/store/selectors/entitiesErrors';
@@ -143,11 +143,9 @@ export class SearchLanding extends React.Component<CombinedProps, State> {
       <Grid container direction="column">
         <Grid item>
           {!resultsEmpty && !entitiesLoading && (
-            <Breadcrumb
-              pathname={this.props.location.pathname}
-              labelTitle={`Search Results ${query && `for "${query}"`}`}
+            <H1Header
+              title={`Search Results ${query && `for "${query}"`}`}
               className={classes.headline}
-              removeCrumbX={1}
             />
           )}
         </Grid>

--- a/packages/manager/src/features/Search/SearchLanding.tsx
+++ b/packages/manager/src/features/Search/SearchLanding.tsx
@@ -2,6 +2,7 @@ import { equals } from 'ramda';
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
+import Breadcrumb from 'src/components/Breadcrumb';
 import CircleProgress from 'src/components/CircleProgress';
 import {
   createStyles,
@@ -142,9 +143,12 @@ export class SearchLanding extends React.Component<CombinedProps, State> {
       <Grid container direction="column">
         <Grid item>
           {!resultsEmpty && !entitiesLoading && (
-            <Typography variant="h1" className={classes.headline}>
-              Search Results {query && `for "${query}"`}
-            </Typography>
+            <Breadcrumb
+              pathname={this.props.location.pathname}
+              labelTitle={`Search Results ${query && `for "${query}"`}`}
+              className={classes.headline}
+              removeCrumbX={1}
+            />
           )}
         </Grid>
         {errors.hasErrors && (

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -566,7 +566,7 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
         <Grid container spacing={0}>
           <Grid item xs={12}>
             <Breadcrumb
-              pathname={this.props.location.pathname}
+              pathname={'/linodes/create'}
               labelTitle="Create"
               data-qa-create-linode-header
             />

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -27,7 +27,7 @@ import {
   withLinodeActions
 } from 'src/store/linodes/linode.containers';
 
-import Typography from 'src/components/core/Typography';
+import Breadcrumb from 'src/components/Breadcrumb';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import { Tag } from 'src/components/TagsInput';
@@ -565,9 +565,11 @@ class LinodeCreateContainer extends React.PureComponent<CombinedProps, State> {
         <DocumentTitleSegment segment="Create a Linode" />
         <Grid container spacing={0}>
           <Grid item xs={12}>
-            <Typography variant="h1" data-qa-create-linode-header>
-              Create New Linode
-            </Typography>
+            <Breadcrumb
+              pathname={this.props.location.pathname}
+              labelTitle="Create"
+              data-qa-create-linode-header
+            />
           </Grid>
           <LinodeCreate
             regionDisplayInfo={this.getRegionInfo()}

--- a/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 import LinodeSvg from 'src/assets/addnewmenu/linode.svg';
+import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
 import {
   createStyles,
@@ -44,8 +45,8 @@ const styles = (theme: Theme) =>
     },
     icon: {
       animation: '$scaleIn .5s ease-in-out',
-      width: 225,
-      height: 225,
+      width: 150,
+      height: 150,
       '& use': {
         fill: theme.bg.main
       },
@@ -83,13 +84,12 @@ class ListLinodesEmptyState extends React.Component<PropsWithStyles> {
         <Grid item xs={12}>
           <LinodeSvg className={classes.icon} />
         </Grid>
-        <Typography
-          variant="h4"
+        <Breadcrumb
+          pathname={''}
+          labelTitle="Add your first Linode!"
           className={classes.title}
           data-qa-placeholder-title
-        >
-          Add your first Linode!
-        </Typography>
+        />
         <Grid item xs={12} lg={10} className={classes.copy}>
           <Typography variant="subtitle1">
             Choose a plan, select an image, and deploy within minutes. Need help

--- a/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { compose } from 'redux';
 import LinodeSvg from 'src/assets/addnewmenu/linode.svg';
-import Breadcrumb from 'src/components/Breadcrumb';
 import Button from 'src/components/Button';
 import {
   createStyles,
@@ -12,6 +11,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
+import H1Header from 'src/components/H1Header';
 
 type CSSClasses = 'root' | 'copy' | 'icon' | 'title';
 
@@ -84,9 +84,8 @@ class ListLinodesEmptyState extends React.Component<PropsWithStyles> {
         <Grid item xs={12}>
           <LinodeSvg className={classes.icon} />
         </Grid>
-        <Breadcrumb
-          pathname={''}
-          labelTitle="Add your first Linode!"
+        <H1Header
+          title="Add your first Linode!"
           className={classes.title}
           data-qa-placeholder-title
         />

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -342,5 +342,5 @@ button::-moz-focus-inner {
 }
 
 *:focus {
-  border: 2px red solid !important;
+  outline: 2px red solid !important;
 }

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -340,7 +340,3 @@ button::-moz-focus-inner {
 .terminal {
   padding: 24px;
 }
-
-*:focus {
-  outline: 2px red solid !important;
-}

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -340,3 +340,7 @@ button::-moz-focus-inner {
 .terminal {
   padding: 24px;
 }
+
+*:focus {
+  border: 2px red solid !important;
+}


### PR DESCRIPTION
## Accessibility: Focus on content when navigating

This PR improves accessibility by adding focus on the H1 when navigating to a new page. Since this is a one page app, our router does not do that automatically, so I implemented the focus() function in the breadcrumb (and editable text component since it also contains the H1) and replaced the breadcrumb wherever an isolated `<Typography variant="h1" />` was found. This should be the pattern to follow for ALL page titles from now on to preserve this enhancement.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

1. Please review EditableText component as i refactored it as a functional component with hooks
2. You'll notice the css for focus is a red outline. This is intentional for everyone to test, and will be removed once PR is approved
