### PR TITLE
M3-3643 Improve Buttons, selects and textfields accessibility

### DIFF
--- a/packages/manager/src/MainContent.tsx
+++ b/packages/manager/src/MainContent.tsx
@@ -292,7 +292,7 @@ const MainContent: React.FC<CombinedProps> = props => {
               toggleTheme={props.toggleTheme}
               toggleSpacing={props.toggleSpacing}
             />
-            <main
+            <div
               className={`
                 ${classes.content}
                 ${
@@ -309,7 +309,7 @@ const MainContent: React.FC<CombinedProps> = props => {
                 isLoggedInAsCustomer={props.isLoggedInAsCustomer}
                 username={props.username}
               />
-              <div className={classes.wrapper} id="main-content">
+              <main className={classes.wrapper} id="main-content" role="main">
                 <Grid container spacing={0} className={classes.grid}>
                   <Grid item className={classes.switchWrapper}>
                     <Switch>
@@ -363,8 +363,8 @@ const MainContent: React.FC<CombinedProps> = props => {
                     </Switch>
                   </Grid>
                 </Grid>
-              </div>
-            </main>
+              </main>
+            </div>
 
             <Footer desktopMenuIsOpen={desktopMenuIsOpen} />
             <ToastNotifications />

--- a/packages/manager/src/components/ActionMenu/ActionMenu.stories.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.stories.tsx
@@ -43,7 +43,9 @@ class StoryActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu createActions={this.createActions()} ariaLabel="label" />
+    );
   }
 }
 
@@ -77,7 +79,9 @@ class StoryActionMenuWithTooltip extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu createActions={this.createActions()} ariaLabel="label" />
+    );
   }
 }
 
@@ -93,7 +97,9 @@ class StoryActionMenuWithOneAction extends React.Component<CombinedProps> {
     ];
   };
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu createActions={this.createActions()} ariaLabel="label" />
+    );
   }
 }
 

--- a/packages/manager/src/components/ActionMenu/ActionMenu.test.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.test.tsx
@@ -20,7 +20,11 @@ describe('ActionMenu', () => {
 
   it.skip('should render a menu when provided many or one action(s).', () => {
     const result = mount(
-      <ActionMenu classes={classes} createActions={createActionsMany} />
+      <ActionMenu
+        classes={classes}
+        createActions={createActionsMany}
+        ariaLabel="label"
+      />
     );
     expect(result.find('WithStyles(ActionMenu)')).toHaveLength(1);
 

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -69,6 +69,9 @@ const styles = (theme: Theme) =>
 interface Props {
   createActions: (closeMenu: Function) => Action[];
   toggleOpenCallback?: () => void;
+  // we want to require using aria label for these buttons
+  // as they don't have text (just an icon)
+  ariaLabel: string;
 }
 
 interface State {
@@ -112,7 +115,7 @@ export class ActionMenu extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { classes } = this.props;
+    const { classes, ariaLabel } = this.props;
     const { actions, anchorEl } = this.state;
 
     if (typeof actions === 'undefined') {
@@ -128,6 +131,7 @@ export class ActionMenu extends React.Component<CombinedProps, State> {
           onClick={this.handleClick}
           className={classes.button}
           data-qa-action-menu
+          aria-label={ariaLabel}
         >
           <MoreHoriz type="primary" className="kebob" />
         </IconButton>

--- a/packages/manager/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
+++ b/packages/manager/src/components/DebouncedSearchTextField/DebouncedSearchTextField.tsx
@@ -21,6 +21,8 @@ interface Props extends TextFieldProps {
   isSearching?: boolean;
   className?: string;
   placeholder?: string;
+  label: string;
+  hideLabel?: boolean;
 }
 
 type CombinedProps = Props;
@@ -33,6 +35,8 @@ const DebouncedSearch: React.FC<CombinedProps> = props => {
     debounceTime,
     onSearch,
     placeholder,
+    label,
+    hideLabel,
     ...restOfTextFieldProps
   } = props;
   const [query, setQuery] = React.useState<string>('');
@@ -72,6 +76,8 @@ const DebouncedSearch: React.FC<CombinedProps> = props => {
       className={className}
       placeholder={placeholder || 'Filter by query'}
       onChange={_setQuery}
+      label={label}
+      hideLabel={hideLabel}
       InputProps={{
         startAdornment: (
           <InputAdornment position="end">

--- a/packages/manager/src/components/DebouncedSearchTextField/StoryComponents/TextFieldExample.tsx
+++ b/packages/manager/src/components/DebouncedSearchTextField/StoryComponents/TextFieldExample.tsx
@@ -50,6 +50,8 @@ class Example extends React.Component<Props, State> {
           debounceTime={400}
           onSearch={this.handleSearch}
           isSearching={this.state.isSearching}
+          label="Search for something"
+          hideLabel
         />
         <ul data-qa-listOfItems>
           {this.state.list.map((eachThing: string) => {

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
@@ -204,6 +204,7 @@ export const EditableInput: React.FC<FinalProps> = props => {
           className={classes.textField}
           type="text"
           label="Edit Label"
+          hideLabel
           onChange={(e: any) => onInputChange(e.target.value)}
           onKeyDown={handleKeyPress}
           value={inputText}

--- a/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableInput.tsx
@@ -203,6 +203,7 @@ export const EditableInput: React.FC<FinalProps> = props => {
           loading={loading}
           className={classes.textField}
           type="text"
+          label="Edit Label"
           onChange={(e: any) => onInputChange(e.target.value)}
           onKeyDown={handleKeyPress}
           value={inputText}

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -252,6 +252,8 @@ const EditableText: React.FC<FinalProps> = props => {
           {...rest}
           className={classes.textField}
           type="text"
+          label={`Edit ${text} Label`}
+          hideLabel
           onChange={onChange}
           onKeyDown={handleKeyPress}
           value={text}

--- a/packages/manager/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
+++ b/packages/manager/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
@@ -128,8 +128,7 @@ class Example extends React.Component<{}, State> {
           textFieldProps={{
             dataAttrs: {
               'data-qa-basic-select': true
-            },
-            label: 'Basic Select'
+            }
           }}
           value={valueSingle}
           placeholder="Choose one fruit"

--- a/packages/manager/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
+++ b/packages/manager/src/components/EnhancedSelect/EnhancedSelect.stories.tsx
@@ -128,7 +128,8 @@ class Example extends React.Component<{}, State> {
           textFieldProps={{
             dataAttrs: {
               'data-qa-basic-select': true
-            }
+            },
+            label: 'Basic Select'
           }}
           value={valueSingle}
           placeholder="Choose one fruit"

--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -71,7 +71,7 @@ export interface BaseSelectProps
    but we're using the MUI select element so any props that
    can be passed to the MUI TextField element can be passed here
   */
-  textFieldProps?: TextFieldProps;
+  textFieldProps?: Omit<TextFieldProps, 'label'>;
   /**
    * errorText and label both passed to textFieldProps
    * @todo consider just putting this under textFieldProps
@@ -186,7 +186,6 @@ class Select extends React.PureComponent<CombinedProps, {}> {
         inputId={inputId ? inputId : convertToKebabCase(label)}
         textFieldProps={{
           ...textFieldProps,
-          label,
           hideLabel,
           errorText,
           errorGroup,

--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -7,6 +7,7 @@ import CreatableSelect, {
 import { Props as SelectProps } from 'react-select/lib/Select';
 import { withStyles, WithStyles } from 'src/components/core/styles';
 import { Props as TextFieldProps } from 'src/components/TextField';
+import { convertToKebabCase } from 'src/utilities/convertToKebobCase';
 /* TODO will be refactoring enhanced select to be an abstraction.
 Styles added in this file and the below imports will be utilized for the abstraction. */
 import DropdownIndicator from './components/DropdownIndicator';
@@ -76,7 +77,7 @@ export interface BaseSelectProps
    * @todo consider just putting this under textFieldProps
    */
   errorText?: string;
-  label?: string;
+  label: string;
   /** alias for isDisabled */
   disabled?: boolean;
   variant?: 'creatable';
@@ -179,10 +180,11 @@ class Select extends React.PureComponent<CombinedProps, {}> {
           but we're using the MUI select element so any props that
           can be passed to the MUI TextField element can be passed here
          */
-        inputId={inputId}
+        inputId={inputId ? inputId : convertToKebabCase(label)}
         textFieldProps={{
           ...textFieldProps,
           label,
+          hideLabel,
           errorText,
           errorGroup,
           disabled,
@@ -193,8 +195,7 @@ class Select extends React.PureComponent<CombinedProps, {}> {
           className: classNames({
             [classes.medium]: medium,
             [classes.small]: small,
-            [classes.inline]: inline,
-            [classes.hideLabel]: hideLabel
+            [classes.inline]: inline
           })
         }}
         /**

--- a/packages/manager/src/components/EnhancedSelect/Select.tsx
+++ b/packages/manager/src/components/EnhancedSelect/Select.tsx
@@ -77,6 +77,9 @@ export interface BaseSelectProps
    * @todo consider just putting this under textFieldProps
    */
   errorText?: string;
+  /**
+   * We require label for accessibility purpose
+   */
   label: string;
   /** alias for isDisabled */
   disabled?: boolean;

--- a/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
+++ b/packages/manager/src/components/EnhancedSelect/variants/RegionSelect/RegionSelect.tsx
@@ -27,6 +27,7 @@ interface Props extends Omit<BaseSelectProps, 'onChange'> {
   regions: ExtendedRegion[];
   handleSelection: (id: string) => void;
   selectedID: string | null;
+  label: string;
 }
 
 export const flags = {
@@ -137,6 +138,7 @@ const sortRegions = (region1: RegionItem, region2: RegionItem) => {
 
 const SelectRegionPanel: React.FC<Props> = props => {
   const {
+    label,
     disabled,
     handleSelection,
     regions,
@@ -154,7 +156,7 @@ const SelectRegionPanel: React.FC<Props> = props => {
       <Select
         isClearable={false}
         value={getSelectedRegionById(selectedID || '', options)}
-        label="Select a region"
+        label={label}
         disabled={disabled}
         placeholder="Regions"
         options={options}

--- a/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
+++ b/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
@@ -90,6 +90,8 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
             options={options}
             defaultValue={defaultPagination}
             onChange={this.handleSizeChange}
+            label="Number of items to show"
+            hideLabel
             isClearable={false}
             noMarginTop
             menuPlacement="top"

--- a/packages/manager/src/components/PasswordInput/HideShowText.tsx
+++ b/packages/manager/src/components/PasswordInput/HideShowText.tsx
@@ -11,6 +11,7 @@ interface State {
 type Props = TextFieldProps & {
   required?: boolean;
   tooltipText?: string;
+  label: string;
 };
 
 class HideShowText extends React.Component<Props, State> {
@@ -24,6 +25,7 @@ class HideShowText extends React.Component<Props, State> {
 
   render() {
     const { hidden } = this.state;
+    const { label } = this.props;
 
     return (
       <TextField
@@ -31,6 +33,7 @@ class HideShowText extends React.Component<Props, State> {
         dataAttrs={{
           'data-qa-hide': hidden
         }}
+        label={label}
         type={hidden ? 'password' : 'text'}
         InputProps={{
           startAdornment: hidden ? (

--- a/packages/manager/src/components/PasswordInput/PasswordInput.stories.tsx
+++ b/packages/manager/src/components/PasswordInput/PasswordInput.stories.tsx
@@ -4,7 +4,7 @@ import PasswordInput from './PasswordInput';
 
 storiesOf('Password Input', module).add('Example', () => (
   <div>
-    <PasswordInput />
+    <PasswordInput label="Password" />
     <p>Some text underneath</p>
   </div>
 ));

--- a/packages/manager/src/components/PrimaryNav/NavItem.tsx
+++ b/packages/manager/src/components/PrimaryNav/NavItem.tsx
@@ -53,7 +53,6 @@ const NavItem: React.SFC<CombinedProps> = props => {
     <React.Fragment>
       {href ? (
         <Link
-          role="menuitem"
           to={href}
           onClick={closeMenu}
           data-qa-nav-item={QAKey}
@@ -77,7 +76,6 @@ const NavItem: React.SFC<CombinedProps> = props => {
         <React.Fragment>
           <Tooltip title={isDisabled ? isDisabled() : ''} placement="left-end">
             <ListItem
-              role="menuitem"
               onClick={e => {
                 props.closeMenu();
                 /* disregarding undefined is fine here because of the error handling thrown above */

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -318,7 +318,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
     return (
       <React.Fragment key={primaryLink.key}>
         <Link
-          role="menuitem"
           to={primaryLink.href}
           onClick={(e: React.ChangeEvent<any>) => {
             this.props.closeMenu();
@@ -367,7 +366,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
           wrap="nowrap"
           spacing={0}
           component="nav"
-          role="menu"
+          role="navigation"
         >
           <Grid item>
             <div
@@ -376,7 +375,11 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
                 [classes.logoCollapsed]: isCollapsed
               })}
             >
-              <Link to={`/dashboard`} onClick={() => this.props.closeMenu()}>
+              <Link
+                to={`/dashboard`}
+                onClick={() => this.props.closeMenu()}
+                title="Dashboard"
+              >
                 <Logo width={115} height={43} />
               </Link>
             </div>
@@ -410,7 +413,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
             <Hidden mdUp>
               <Divider className={classes.divider} />
               <Link
-                role="menuitem"
                 to="/profile/display"
                 onClick={this.props.closeMenu}
                 data-qa-nav-item="/profile/display"
@@ -430,7 +432,6 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
                 />
               </Link>
               <Link
-                role="menuitem"
                 to="/logout"
                 onClick={this.props.closeMenu}
                 data-qa-nav-item="/logout"
@@ -455,6 +456,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
                 [classes.settingsCollapsed]: isCollapsed,
                 [classes.activeSettings]: anchorEl
               })}
+              aria-label="User settings"
             >
               <Settings />
             </IconButton>

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -82,7 +82,7 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
           handleSelection={handleSelection}
           regions={regions}
           selectedID={selectedID || null}
-          label="Select a region"
+          label="Select a Region"
         />
       </Paper>
     </>

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -82,6 +82,7 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
           handleSelection={handleSelection}
           regions={regions}
           selectedID={selectedID || null}
+          label="Select a region"
         />
       </Paper>
     </>

--- a/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
+++ b/packages/manager/src/components/TabbedPanel/TabbedPanel.tsx
@@ -91,9 +91,11 @@ class TabbedPanel extends React.Component<CombinedProps> {
       <Paper className={`${classes.root} ${rootClass}`} data-qa-tp={header}>
         <div className={`${classes.inner} ${innerClass}`}>
           {error && <Notice text={error} error />}
-          <Typography variant="h2" data-qa-tp-title>
-            {header}
-          </Typography>
+          {header !== '' && (
+            <Typography variant="h2" data-qa-tp-title>
+              {header}
+            </Typography>
+          )}
           {copy && (
             <Typography
               component="div"

--- a/packages/manager/src/components/TableRow/TableRow.tsx
+++ b/packages/manager/src/components/TableRow/TableRow.tsx
@@ -162,6 +162,7 @@ class TableRow extends React.Component<CombinedProps> {
         }
         hover={rowLink !== undefined}
         role={role}
+        aria-label={rowLink ? `View Details` : undefined}
         className={classNames(className, {
           [classes.root]: true,
           [classes.selected]: selected,

--- a/packages/manager/src/components/TagsInput/TagsInput.tsx
+++ b/packages/manager/src/components/TagsInput/TagsInput.tsx
@@ -20,6 +20,7 @@ export interface State {
 
 export interface Props {
   label?: string;
+  hideLabel?: boolean;
   name?: string;
   tagError?: string;
   value: Item[];
@@ -87,6 +88,7 @@ class TagsInput extends React.Component<Props, State> {
       value,
       name,
       label,
+      hideLabel,
       disabled,
       menuPlacement
     } = this.props;
@@ -103,7 +105,8 @@ class TagsInput extends React.Component<Props, State> {
         name={name}
         variant="creatable"
         isMulti={true}
-        label={label}
+        label={label || 'Add Tags'}
+        hideLabel={hideLabel}
         options={accountTags}
         placeholder={'Type to choose or create a tag.'}
         errorText={error}

--- a/packages/manager/src/components/TagsPanel/TagsPanel.tsx
+++ b/packages/manager/src/components/TagsPanel/TagsPanel.tsx
@@ -395,6 +395,8 @@ class TagsPanel extends React.Component<CombinedProps, State> {
             variant="creatable"
             onBlur={this.toggleTagInput}
             placeholder="Create or Select a Tag"
+            label="Create or Select a Tag"
+            hideLabel
             value={tagInputValue}
             createOptionPosition="first"
             autoFocus

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -133,6 +133,7 @@ interface BaseProps {
   dataAttrs?: Record<string, any>;
   noMarginTop?: boolean;
   loading?: boolean;
+  hideLabel?: boolean;
 }
 
 export type Props = BaseProps & TextFieldProps;
@@ -252,6 +253,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
       value,
       dataAttrs,
       error,
+      hideLabel,
       noMarginTop,
       label,
       loading,
@@ -282,8 +284,14 @@ class LinodeTextField extends React.Component<CombinedProps> {
             data-qa-textfield-label={label}
             className={classNames({
               [classes.wrapper]: noMarginTop ? false : true,
-              [classes.noTransform]: true
+              [classes.noTransform]: true,
+              'visually-hidden': hideLabel
             })}
+            htmlFor={
+              this.props.label
+                ? convertToKebabCase(`${this.props.label}`)
+                : undefined
+            }
           >
             {maybeRequiredLabel || ''}
           </InputLabel>
@@ -326,6 +334,9 @@ class LinodeTextField extends React.Component<CombinedProps> {
             }}
             inputProps={{
               'data-testid': 'textfield-input',
+              id: this.props.label
+                ? convertToKebabCase(`${this.props.label}`)
+                : undefined,
               ...inputProps
             }}
             InputProps={{
@@ -372,11 +383,6 @@ class LinodeTextField extends React.Component<CombinedProps> {
               },
               className
             )}
-            id={
-              this.props.label
-                ? convertToKebabCase(`${this.props.label}`)
-                : undefined
-            }
           >
             {this.props.children}
           </TextField>

--- a/packages/manager/src/components/TextField.tsx
+++ b/packages/manager/src/components/TextField.tsx
@@ -136,7 +136,11 @@ interface BaseProps {
   hideLabel?: boolean;
 }
 
-export type Props = BaseProps & TextFieldProps;
+interface TextFieldPropsOverrides extends TextFieldProps {
+  label: string;
+}
+
+export type Props = BaseProps & TextFieldProps & TextFieldPropsOverrides;
 
 type CombinedProps = Props & WithTheme & WithStyles<ClassNames>;
 
@@ -166,6 +170,7 @@ class LinodeTextField extends React.Component<CombinedProps> {
       nextProps.helperText !== this.props.helperText ||
       nextProps.classes !== this.props.classes ||
       nextProps.loading !== this.props.loading ||
+      nextProps.label !== this.props.label ||
       Boolean(
         this.props.select && nextProps.children !== this.props.children
       ) ||

--- a/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/MakeAPaymentPanel/MakeAPaymentPanel.tsx
@@ -68,7 +68,8 @@ type ClassNames =
   | 'actionPanel'
   | 'paypalMask'
   | 'paypalButtonWrapper'
-  | 'PaypalHidden';
+  | 'PaypalHidden'
+  | 'cvvField';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -100,6 +101,9 @@ const styles = (theme: Theme) =>
     },
     PaypalHidden: {
       opacity: 0.3
+    },
+    cvvField: {
+      width: 100
     }
   });
 
@@ -436,7 +440,7 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
   };
 
   renderForm = () => {
-    const { lastFour } = this.props;
+    const { lastFour, classes } = this.props;
     const { errors, successMessage } = this.state;
 
     const hasErrorFor = getAPIErrorFor(
@@ -502,6 +506,8 @@ class MakeAPaymentPanel extends React.Component<CombinedProps, State> {
                   value={this.state.cvv}
                   type="text"
                   placeholder={`000`}
+                  inputProps={{ id: 'paymentCVV' }}
+                  className={classes.cvvField}
                 />
               )}
             </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -467,7 +467,8 @@ class UpdateContactInformationPanel extends React.Component<
             textFieldProps={{
               dataAttrs: {
                 'data-qa-contact-country': true
-              }
+              },
+              label: 'Country'
             }}
           />
         </Grid>

--- a/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/UpdateContactInformationPanel/UpdateContactInformationPanel.tsx
@@ -467,8 +467,7 @@ class UpdateContactInformationPanel extends React.Component<
             textFieldProps={{
               dataAttrs: {
                 'data-qa-contact-country': true
-              },
-              label: 'Country'
+              }
             }}
           />
         </Grid>

--- a/packages/manager/src/features/Domains/DomainActionMenu.tsx
+++ b/packages/manager/src/features/Domains/DomainActionMenu.tsx
@@ -125,7 +125,12 @@ export class DomainActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for Domain ${this.props.domain}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/Domains/DomainRecordActionMenu.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordActionMenu.tsx
@@ -28,6 +28,7 @@ interface Props {
   onEdit: (data: Domain | EditPayload) => void;
   deleteData?: DeleteData;
   editPayload: Domain | EditPayload;
+  label: string;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}>;
@@ -66,7 +67,12 @@ class DomainRecordActionMenu extends React.Component<CombinedProps> {
       })
     )([]);
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for Record ${this.props.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -277,8 +277,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         textFieldProps={{
           dataAttrs: {
             'data-qa-domain-select': 'Expire Rate'
-          },
-          label: 'Expire Rate'
+          }
         }}
       />
     );
@@ -329,8 +328,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         textFieldProps={{
           dataAttrs: {
             'data-qa-domain-select': label
-          },
-          label
+          }
         }}
       />
     );
@@ -365,8 +363,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         textFieldProps={{
           dataAttrs: {
             'data-qa-domain-select': 'Protocol'
-          },
-          label: 'Protocol'
+          }
         }}
       />
     );
@@ -398,8 +395,7 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         textFieldProps={{
           dataAttrs: {
             'data-qa-domain-select': 'caa tag'
-          },
-          label: 'Tag'
+          }
         }}
       />
     );

--- a/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordDrawer.tsx
@@ -277,7 +277,8 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         textFieldProps={{
           dataAttrs: {
             'data-qa-domain-select': 'Expire Rate'
-          }
+          },
+          label: 'Expire Rate'
         }}
       />
     );
@@ -328,7 +329,8 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         textFieldProps={{
           dataAttrs: {
             'data-qa-domain-select': label
-          }
+          },
+          label
         }}
       />
     );
@@ -363,7 +365,8 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         textFieldProps={{
           dataAttrs: {
             'data-qa-domain-select': 'Protocol'
-          }
+          },
+          label: 'Protocol'
         }}
       />
     );
@@ -395,7 +398,8 @@ class DomainRecordDrawer extends React.Component<CombinedProps, State> {
         textFieldProps={{
           dataAttrs: {
             'data-qa-domain-select': 'caa tag'
-          }
+          },
+          label: 'Tag'
         }}
       />
     );

--- a/packages/manager/src/features/Domains/DomainRecords.tsx
+++ b/packages/manager/src/features/Domains/DomainRecords.tsx
@@ -312,7 +312,11 @@ class DomainRecords extends React.Component<CombinedProps, State> {
           title: '',
           render: (d: Domain) => {
             return d.type === 'master' ? (
-              <ActionMenu editPayload={d} onEdit={this.handleOpenSOADrawer} />
+              <ActionMenu
+                editPayload={d}
+                onEdit={this.handleOpenSOADrawer}
+                label={this.props.domain.domain}
+              />
             ) : null;
           }
         }
@@ -359,6 +363,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                   target,
                   ttl_sec
                 }}
+                label={name}
                 onEdit={this.openForEditNSRecord}
                 deleteData={{
                   recordID: id,
@@ -406,6 +411,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                 target,
                 ttl_sec
               }}
+              label={name}
               deleteData={{
                 recordID: id,
                 onDelete: this.confirmDeletion
@@ -440,6 +446,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                 ttl_sec
               }}
               onEdit={this.openForEditARecord}
+              label={name}
               deleteData={{
                 recordID: id,
                 onDelete: this.confirmDeletion
@@ -471,6 +478,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                 target,
                 ttl_sec
               }}
+              label={name}
               onEdit={this.openForEditCNAMERecord}
               deleteData={{
                 recordID: id,
@@ -504,6 +512,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                 target,
                 ttl_sec
               }}
+              label={name}
               onEdit={this.openForEditTXTRecord}
               deleteData={{
                 recordID: id,
@@ -559,6 +568,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                 target,
                 weight
               }}
+              label={this.props.domain.domain}
               onEdit={this.openForEditSRVRecord}
               deleteData={{
                 recordID: id,
@@ -593,6 +603,7 @@ class DomainRecords extends React.Component<CombinedProps, State> {
                 target,
                 ttl_sec
               }}
+              label={name}
               onEdit={this.openForEditCAARecord}
               deleteData={{
                 recordID: id,

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -70,8 +70,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
           required: true,
           helperText: `Add one or more predefined rules to this firewall. You can edit the
           default parameters for these rules after you create the firewall.`,
-          helperTextPosition: 'top',
-          label: 'Rules'
+          helperTextPosition: 'top'
         }}
         onChange={() => null}
       />
@@ -107,8 +106,7 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
         textFieldProps={{
           helperTextPosition: 'top',
           helperText: `Assign one or more Linodes to this firewall. You can
-          add Linodes later if you want to customize your rules first.`,
-          label: 'Linodes'
+          add Linodes later if you want to customize your rules first.`
         }}
         hideSelectedOptions={true}
       />

--- a/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/AddFirewallDrawer.tsx
@@ -70,7 +70,8 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
           required: true,
           helperText: `Add one or more predefined rules to this firewall. You can edit the
           default parameters for these rules after you create the firewall.`,
-          helperTextPosition: 'top'
+          helperTextPosition: 'top',
+          label: 'Rules'
         }}
         onChange={() => null}
       />
@@ -106,7 +107,8 @@ const AddFirewallDrawer: React.FC<CombinedProps> = props => {
         textFieldProps={{
           helperTextPosition: 'top',
           helperText: `Assign one or more Linodes to this firewall. You can
-          add Linodes later if you want to customize your rules first.`
+          add Linodes later if you want to customize your rules first.`,
+          label: 'Linodes'
         }}
         hideSelectedOptions={true}
       />

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallActionMenu.tsx
@@ -61,7 +61,12 @@ const FirewallActionMenu: React.FC<CombinedProps> = props => {
     ];
   };
 
-  return <ActionMenu createActions={createActions()} />;
+  return (
+    <ActionMenu
+      createActions={createActions()}
+      ariaLabel={`Action menu for Firewall ${props.firewallLabel}`}
+    />
+  );
 };
 
 export default React.memo(FirewallActionMenu);

--- a/packages/manager/src/features/Footer/AdaLink.tsx
+++ b/packages/manager/src/features/Footer/AdaLink.tsx
@@ -10,6 +10,7 @@ import {
 import Tooltip from 'src/components/core/Tooltip';
 import IconButton from 'src/components/IconButton';
 import { sendAdaEvent } from 'src/utilities/ga';
+
 type ClassNames = 'root' | 'disabled';
 
 const styles = (theme: Theme) =>
@@ -62,11 +63,15 @@ const AdaLink: React.FC<CombinedProps> = props => {
   const { classes } = props;
 
   return adaError === '' ? (
-    <IconButton onClick={handleAdaInit} className={classes.root}>
+    <IconButton
+      onClick={handleAdaInit}
+      className={classes.root}
+      aria-label="Get help with ADA bot"
+    >
       <AdaIcon />
     </IconButton>
   ) : (
-    <Tooltip title={adaError} placement="top-end">
+    <Tooltip title={adaError} placement="top-end" aria-label={adaError}>
       <AdaIcon className={classes.disabled} />
     </Tooltip>
   );

--- a/packages/manager/src/features/Footer/Footer.tsx
+++ b/packages/manager/src/features/Footer/Footer.tsx
@@ -100,52 +100,54 @@ export class Footer extends React.PureComponent<CombinedProps> {
     const { classes, desktopMenuIsOpen } = this.props;
 
     return (
-      <Grid
-        container
-        spacing={4}
-        alignItems="center"
-        className={classNames({
-          [classes.container]: true,
-          [classes.desktopMenuIsOpen]: desktopMenuIsOpen
-        })}
-      >
-        <Grid item className={classes.version}>
-          {this.renderVersion(classes.link)}
-        </Grid>
+      <footer role="contentinfo">
         <Grid
-          item
+          container
+          spacing={4}
+          alignItems="center"
           className={classNames({
-            [classes.linkContainer]: true
+            [classes.container]: true,
+            [classes.desktopMenuIsOpen]: desktopMenuIsOpen
           })}
         >
-          <a
-            className={classes.link}
-            href="https://developers.linode.com"
-            target="_blank"
-            aria-describedby="external-site"
-            rel="noopener noreferrer"
+          <Grid item className={classes.version}>
+            {this.renderVersion(classes.link)}
+          </Grid>
+          <Grid
+            item
+            className={classNames({
+              [classes.linkContainer]: true
+            })}
           >
-            API Reference
-          </a>
-        </Grid>
-        <Grid
-          item
-          className={classNames({
-            [classes.linkContainer]: true,
-            [classes.feedbackLink]: true
-          })}
-        >
-          <a
-            className={classes.link}
-            href={createMailto(window.navigator.userAgent || '')}
+            <a
+              className={classes.link}
+              href="https://developers.linode.com"
+              target="_blank"
+              aria-describedby="external-site"
+              rel="noopener noreferrer"
+            >
+              API Reference
+            </a>
+          </Grid>
+          <Grid
+            item
+            className={classNames({
+              [classes.linkContainer]: true,
+              [classes.feedbackLink]: true
+            })}
           >
-            Provide Feedback
-          </a>
+            <a
+              className={classes.link}
+              href={createMailto(window.navigator.userAgent || '')}
+            >
+              Provide Feedback
+            </a>
+          </Grid>
+          <Grid item className={classes.adaLink}>
+            <AdaLink />
+          </Grid>
         </Grid>
-        <Grid item className={classes.adaLink}>
-          <AdaLink />
-        </Grid>
-      </Grid>
+      </footer>
     );
   }
 

--- a/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
+++ b/packages/manager/src/features/Help/Panels/AlgoliaSearchBar.tsx
@@ -211,6 +211,8 @@ class AlgoliaSearchBar extends React.Component<CombinedProps, State> {
             onChange={this.handleSelect}
             onInputChange={this.onInputValueChange}
             placeholder="Search for answers..."
+            label="Search for answers"
+            hideLabel
             className={classNames({
               [classes.enhancedSelectWrapper]: true,
               [classes.enhancedSelectWrapperCompact]: spacingMode === 'compact'

--- a/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
+++ b/packages/manager/src/features/Help/SupportSearchLanding/SupportSearchLanding.tsx
@@ -132,6 +132,8 @@ export class SupportSearchLanding extends React.Component<
             data-qa-search-landing-input
             className={classes.searchBoxInner}
             placeholder="Search Linode documentation and community questions"
+            label="Search Linode documentation and community questions"
+            hideLabel
             value={query}
             onChange={this.onInputChange}
             disabled={!Boolean(searchEnabled)}

--- a/packages/manager/src/features/Images/ImageSelect.test.tsx
+++ b/packages/manager/src/features/Images/ImageSelect.test.tsx
@@ -220,7 +220,7 @@ describe('ImageSelect', () => {
           <Select
             onChange={props.onSelect}
             errorText={'An error'}
-            label="Label"
+            label="Image"
           />
         )
       ).toBeTruthy();

--- a/packages/manager/src/features/Images/ImageSelect.test.tsx
+++ b/packages/manager/src/features/Images/ImageSelect.test.tsx
@@ -217,7 +217,11 @@ describe('ImageSelect', () => {
       component.setProps({ imageError: 'An error' });
       expect(
         component.containsMatchingElement(
-          <Select onChange={props.onSelect} errorText={'An error'} />
+          <Select
+            onChange={props.onSelect}
+            errorText={'An error'}
+            label="Label"
+          />
         )
       ).toBeTruthy();
     });

--- a/packages/manager/src/features/Images/ImageSelect.tsx
+++ b/packages/manager/src/features/Images/ImageSelect.tsx
@@ -112,8 +112,7 @@ export class ImageSelect extends React.Component<CombinedProps, State> {
               options={renderedImages as any}
               placeholder="Select an Image"
               textFieldProps={{
-                required,
-                label: this.props.label || 'Image'
+                required
               }}
               label={this.props.label || 'Image'}
             />

--- a/packages/manager/src/features/Images/ImageSelect.tsx
+++ b/packages/manager/src/features/Images/ImageSelect.tsx
@@ -112,7 +112,8 @@ export class ImageSelect extends React.Component<CombinedProps, State> {
               options={renderedImages as any}
               placeholder="Select an Image"
               textFieldProps={{
-                required
+                required,
+                label: this.props.label || 'Image'
               }}
               label={this.props.label || 'Image'}
             />

--- a/packages/manager/src/features/Images/ImagesActionMenu.tsx
+++ b/packages/manager/src/features/Images/ImagesActionMenu.tsx
@@ -59,7 +59,12 @@ class ImagesActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for Image ${this.props.image.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu.tsx
+++ b/packages/manager/src/features/Kubernetes/ClusterList/ClusterActionMenu.tsx
@@ -90,7 +90,12 @@ export const ClusterActionMenu: React.FunctionComponent<
       });
   };
 
-  return <ActionMenu createActions={createActions()} />;
+  return (
+    <ActionMenu
+      createActions={createActions()}
+      ariaLabel={`Action menu for Cluster ${props.clusterLabel}`}
+    />
+  );
 };
 
 const enhanced = compose<CombinedProps, Props>(

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolPanel.tsx
@@ -173,6 +173,8 @@ const Panel: React.FunctionComponent<CombinedProps> = props => {
           type="number"
           min={0}
           max={100}
+          label="Number of Linodes"
+          hideLabel
           value={nodeCount}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             updateNodeCount(Math.max(+e.target.value, 0))

--- a/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
+++ b/packages/manager/src/features/Kubernetes/CreateCluster/NodePoolRow.tsx
@@ -191,6 +191,8 @@ export const NodePoolRow: React.FunctionComponent<CombinedProps> = props => {
             max={100}
             errorText={errorMap.count}
             type="number"
+            label="Node Count"
+            hideLabel
             className={classes.editableCount}
             value={pool.count}
             onChange={e =>

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesDialog.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesDialog.tsx
@@ -92,14 +92,15 @@ const KubernetesDialog: React.FC<CombinedProps> = props => {
         permanent and can't be undone.
       </Typography>
       <Typography style={{ marginTop: '10px' }}>
-        To confirm deletion, type the name of the cluster ({clusterLabel}) in
-        the field below:
+        To confirm deletion, type the name of the cluster (<b>{clusterLabel}</b>
+        ) in the field below:
       </Typography>
       <TextField
         data-testid={'dialog-confirm-text-input'}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
           setConfirmText(e.target.value)
         }
+        label="Cluster Name"
         expand
       />
     </ConfirmationDialog>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
@@ -109,6 +109,8 @@ const Disks: React.FC<CombinedProps> = props => {
           className={classes.root}
           handleStatsChange={setStartAndEnd}
           defaultValue="Past 30 Minutes"
+          label="Select Time Range"
+          hideLabel
         />
       </Box>
       {renderContent()}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs.tsx
@@ -72,6 +72,8 @@ export const OverviewGraphs: React.FC<CombinedProps> = props => {
           <TimeRangeSelect
             handleStatsChange={handleStatsChange}
             defaultValue={'Past 30 Minutes'}
+            label="Select Time Range"
+            hideLabel
           />
         </Grid>
       </Grid>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesLanding.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Processes/ProcessesLanding.tsx
@@ -56,6 +56,8 @@ const ProcessesLanding: React.FC<Props> = props => {
               className={classes.filterInput}
               small
               placeholder="Filter by process or user..."
+              label="Filter by process or user"
+              hideLabel
             />
             {/* Doesn't work yet. */}
             <Select
@@ -63,6 +65,8 @@ const ProcessesLanding: React.FC<Props> = props => {
               small
               placeholder="Last 12 Hours"
               onChange={() => null}
+              label="Select Time Range"
+              hideLabel
             />
           </Box>
           <ProcessesTable

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewActionMenu.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewActionMenu.tsx
@@ -41,7 +41,12 @@ const LongviewActionMenu: React.FC<CombinedProps> = props => {
     ];
   };
 
-  return <ActionMenu createActions={createActions()} />;
+  return (
+    <ActionMenu
+      createActions={createActions()}
+      ariaLabel={`Action menu for Longview Client ${props.longviewClientLabel}`}
+    />
+  );
 };
 
 export default React.memo(LongviewActionMenu);

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -276,6 +276,8 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
             options={sortOptions}
             value={sortOptions.find(thisOption => thisOption.value === sortKey)}
             onChange={handleSortKeyChange}
+            label="Sort by"
+            hideLabel
           />
         </Grid>
         <Grid item className={`${classes.addNew} py0`}>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -263,6 +263,8 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
         <Grid item className={`py0 ${classes.searchbar}`}>
           <Search
             placeholder="Filter by client label or hostname"
+            label="Filter by client label or hostname"
+            hideLabel
             onSearch={handleSearch}
             debounceTime={250}
             small

--- a/packages/manager/src/features/Managed/Contacts/ContactsActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsActionMenu.tsx
@@ -4,6 +4,7 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 interface Props {
   contactId: number;
+  contactName: string;
   updateOrAdd: (contact: ManagedContact) => void;
   openDialog: (id: number) => void;
   openDrawer: (contactId: number) => void;
@@ -34,7 +35,12 @@ export const ContactsActionMenu: React.FC<CombinedProps> = props => {
     return actions;
   };
 
-  return <ActionMenu createActions={createActions} />;
+  return (
+    <ActionMenu
+      createActions={createActions}
+      ariaLabel={`Action menu for Contact ${props.contactName}`}
+    />
+  );
 };
 
 export default ContactsActionMenu;

--- a/packages/manager/src/features/Managed/Contacts/ContactsRow.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsRow.tsx
@@ -31,6 +31,7 @@ export const ContactsRow: React.FunctionComponent<Props> = props => {
           updateOrAdd={updateOrAdd}
           openDrawer={openDrawer}
           openDialog={openDialog}
+          contactName={contact.name}
         />
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/Managed/Credentials/CredentialActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialActionMenu.tsx
@@ -21,9 +21,9 @@ export class CredentialActionMenu extends React.Component<CombinedProps, {}> {
       const actions = [
         {
           title: 'Edit',
-          onClick: () => { 
+          onClick: () => {
             openForEdit(credentialID);
-            closeMenu()
+            closeMenu();
           }
         },
         {
@@ -39,7 +39,12 @@ export class CredentialActionMenu extends React.Component<CombinedProps, {}> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for Credential ${this.props.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/Managed/MonitorDrawer.tsx
+++ b/packages/manager/src/features/Managed/MonitorDrawer.tsx
@@ -178,8 +178,7 @@ const MonitorDrawer: React.FC<CombinedProps> = props => {
                 }
                 onBlur={handleBlur}
                 textFieldProps={{
-                  tooltipText: helperText.consultation_group,
-                  label: 'Contact Group'
+                  tooltipText: helperText.consultation_group
                 }}
               />
 
@@ -198,8 +197,7 @@ const MonitorDrawer: React.FC<CombinedProps> = props => {
                     }
                     onBlur={handleBlur}
                     textFieldProps={{
-                      required: mode === modes.CREATING,
-                      label: 'Monitor Type'
+                      required: mode === modes.CREATING
                     }}
                   />
                 </Grid>
@@ -272,8 +270,7 @@ const MonitorDrawer: React.FC<CombinedProps> = props => {
                 )}
                 errorText={errors.credentials}
                 textFieldProps={{
-                  tooltipText: helperText.credentials,
-                  label: 'Credentials'
+                  tooltipText: helperText.credentials
                 }}
                 onChange={(items: Item<number>[]) => {
                   setFieldValue(

--- a/packages/manager/src/features/Managed/MonitorDrawer.tsx
+++ b/packages/manager/src/features/Managed/MonitorDrawer.tsx
@@ -178,7 +178,8 @@ const MonitorDrawer: React.FC<CombinedProps> = props => {
                 }
                 onBlur={handleBlur}
                 textFieldProps={{
-                  tooltipText: helperText.consultation_group
+                  tooltipText: helperText.consultation_group,
+                  label: 'Contact Group'
                 }}
               />
 
@@ -197,7 +198,8 @@ const MonitorDrawer: React.FC<CombinedProps> = props => {
                     }
                     onBlur={handleBlur}
                     textFieldProps={{
-                      required: mode === modes.CREATING
+                      required: mode === modes.CREATING,
+                      label: 'Monitor Type'
                     }}
                   />
                 </Grid>
@@ -270,7 +272,8 @@ const MonitorDrawer: React.FC<CombinedProps> = props => {
                 )}
                 errorText={errors.credentials}
                 textFieldProps={{
-                  tooltipText: helperText.credentials
+                  tooltipText: helperText.credentials,
+                  label: 'Credentials'
                 }}
                 onChange={(items: Item<number>[]) => {
                   setFieldValue(

--- a/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorActionMenu.tsx
@@ -100,7 +100,12 @@ export class MonitorActionMenu extends React.Component<CombinedProps, {}> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for Monitor ${this.props.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.test.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.test.tsx
@@ -14,6 +14,7 @@ const props: CombinedProps = {
   linodeId: 1,
   isEnabled: true,
   updateOne: jest.fn(),
+  linodeLabel: 'label',
   openDrawer: mockOpenDrawer,
   enqueueSnackbar: jest.fn(),
   closeSnackbar: jest.fn()

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessActionMenu.tsx
@@ -11,6 +11,7 @@ import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';
 
 interface Props {
   linodeId: number;
+  linodeLabel: string;
   isEnabled: boolean;
   updateOne: (linodeSetting: ManagedLinodeSetting) => void;
   openDrawer: (linodeId: number) => void;
@@ -82,7 +83,14 @@ export const SSHAccessActionMenu: React.FC<CombinedProps> = props => {
     return actions;
   };
 
-  return <ActionMenu createActions={createActions} />;
+  return (
+    <ActionMenu
+      createActions={createActions}
+      ariaLabel={`Action menu for SSH Access key for Linode ${
+        props.linodeLabel
+      }`}
+    />
+  );
 };
 
 const enhanced = compose<CombinedProps, Props>(withSnackbar);

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessRow.tsx
@@ -42,6 +42,7 @@ export const SSHAccessRow: React.FunctionComponent<Props> = props => {
           isEnabled={isAccessEnabled}
           updateOne={updateOne}
           openDrawer={openDrawer}
+          linodeLabel={linodeSetting.label}
         />
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
+++ b/packages/manager/src/features/NodeBalancers/ConfigNodeIPSelect.tsx
@@ -29,7 +29,7 @@ interface Props {
   errorText?: string;
   nodeAddress?: string;
   workflow: 'create' | 'edit';
-  textfieldProps: TextFieldProps;
+  textfieldProps: Omit<TextFieldProps, 'label'>;
 }
 
 type CombinedProps = WithStyles<ClassNames> & Props;

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -408,8 +408,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 textFieldProps={{
                   dataAttrs: {
                     'data-qa-active-check-select': true
-                  },
-                  label: 'Type'
+                  }
                 }}
                 small
                 disabled={disabled}
@@ -742,8 +741,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   textFieldProps={{
                     dataAttrs: {
                       'data-qa-protocol-select': true
-                    },
-                    label: 'Protocol'
+                    }
                   }}
                   disabled={disabled}
                   noMarginTop
@@ -811,8 +809,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   textFieldProps={{
                     dataAttrs: {
                       'data-qa-algorithm-select': true
-                    },
-                    label: 'Algorithm'
+                    }
                   }}
                   small
                   disabled={disabled}
@@ -837,8 +834,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   textFieldProps={{
                     dataAttrs: {
                       'data-qa-session-stickiness-select': true
-                    },
-                    label: 'Session Stickiness'
+                    }
                   }}
                   small
                   disabled={disabled}
@@ -994,8 +990,7 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                   textfieldProps={{
                                     dataAttrs: {
                                       'data-qa-backend-ip-address': true
-                                    },
-                                    label: 'Select IP'
+                                    }
                                   }}
                                   handleChange={this.props.onNodeAddressChange}
                                   selectedRegion={this.props.nodeBalancerRegion}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerConfigPanel.tsx
@@ -408,7 +408,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                 textFieldProps={{
                   dataAttrs: {
                     'data-qa-active-check-select': true
-                  }
+                  },
+                  label: 'Type'
                 }}
                 small
                 disabled={disabled}
@@ -741,7 +742,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   textFieldProps={{
                     dataAttrs: {
                       'data-qa-protocol-select': true
-                    }
+                    },
+                    label: 'Protocol'
                   }}
                   disabled={disabled}
                   noMarginTop
@@ -809,7 +811,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   textFieldProps={{
                     dataAttrs: {
                       'data-qa-algorithm-select': true
-                    }
+                    },
+                    label: 'Algorithm'
                   }}
                   small
                   disabled={disabled}
@@ -834,7 +837,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                   textFieldProps={{
                     dataAttrs: {
                       'data-qa-session-stickiness-select': true
-                    }
+                    },
+                    label: 'Session Stickiness'
                   }}
                   small
                   disabled={disabled}
@@ -990,7 +994,8 @@ class NodeBalancerConfigPanel extends React.Component<CombinedProps> {
                                   textfieldProps={{
                                     dataAttrs: {
                                       'data-qa-backend-ip-address': true
-                                    }
+                                    },
+                                    label: 'Select IP'
                                   }}
                                   handleChange={this.props.onNodeAddressChange}
                                   selectedRegion={this.props.nodeBalancerRegion}

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerActionMenu.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancerActionMenu.tsx
@@ -55,7 +55,12 @@ class NodeBalancerActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createLinodeActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createLinodeActions()}
+        ariaLabel={`Action menu for NodeBalancer ${this.props.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyMenu.tsx
@@ -11,6 +11,7 @@ interface Props {
   // ObjectStorageKeys --> ObjectStorageKeyTable --> HERE
   openRevokeDialog: (key: ObjectStorageKey) => void;
   openDrawerForEditing: (key: ObjectStorageKey) => void;
+  label: string;
 }
 
 type CombinedProps = Props;
@@ -38,7 +39,12 @@ const AccessKeyMenu: React.StatelessComponent<CombinedProps> = props => {
       ];
     };
   };
-  return <ActionMenu createActions={createActions()} />;
+  return (
+    <ActionMenu
+      createActions={createActions()}
+      ariaLabel={`Action menu for Object Storage Key ${props.label}`}
+    />
+  );
 };
 
 export default AccessKeyMenu;

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
@@ -116,6 +116,7 @@ export const AccessKeyTable: React.StatelessComponent<
             objectStorageKey={eachKey}
             openRevokeDialog={openRevokeDialog}
             openDrawerForEditing={openDrawerForEditing}
+            label={eachKey.label}
           />
         </TableCell>
       </TableRow>

--- a/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketDetail/ObjectActionMenu.tsx
@@ -30,7 +30,12 @@ export const ObjectActionMenu: React.FC<Props> = props => {
     ];
   };
 
-  return <ActionMenu createActions={createActions()} />;
+  return (
+    <ActionMenu
+      createActions={createActions()}
+      ariaLabel={`Action menu for Object ${props.objectName}`}
+    />
+  );
 };
 
 export default ObjectActionMenu;

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu.test.tsx
@@ -16,14 +16,14 @@ afterAll(cleanup);
 describe('BucketActionMenu', () => {
   it('Includes a "Delete" option', () => {
     const { queryByText } = render(
-      wrapWithTheme(<BucketActionMenu {...props} />)
+      wrapWithTheme(<BucketActionMenu {...props} label="label" />)
     );
     expect(queryByText('Delete')).toBeInTheDocument();
   });
 
   it('executes the onRemove function when the "Delete" option is clicked', () => {
     const { getAllByText } = render(
-      wrapWithTheme(<BucketActionMenu {...props} />)
+      wrapWithTheme(<BucketActionMenu {...props} label="label" />)
     );
 
     fireEvent.click(getAllByText('Delete')[0]);

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketActionMenu.tsx
@@ -3,6 +3,7 @@ import ActionMenu, { Action } from 'src/components/ActionMenu/ActionMenu';
 
 export interface Props {
   onRemove: () => void;
+  label: string;
 }
 
 export const BucketActionMenu: React.StatelessComponent<Props> = props => {
@@ -19,7 +20,12 @@ export const BucketActionMenu: React.StatelessComponent<Props> = props => {
     ];
   };
 
-  return <ActionMenu createActions={createActions()} />;
+  return (
+    <ActionMenu
+      createActions={createActions()}
+      ariaLabel={`Action menu for Bucket ${props.label}`}
+    />
+  );
 };
 
 export default BucketActionMenu;

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -161,8 +161,8 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
         to force deletion.
       </Typography>
       <Typography className={classes.copy}>
-        To confirm deletion, type the name of the bucket ({bucketToRemove.label}
-        ) in the field below:
+        To confirm deletion, type the name of the bucket (
+        <b>{bucketToRemove.label}</b>) in the field below:
       </Typography>
     </React.Fragment>
   ) : null;
@@ -222,6 +222,7 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
             setConfirmBucketName(e.target.value)
           }
           expand
+          label="Bucket Name"
         />
       </ConfirmationDialog>
     </React.Fragment>

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -90,7 +90,11 @@ export const BucketTableRow: React.StatelessComponent<
         />
       </TableCell>
       <TableCell>
-        <BucketActionMenu onRemove={onRemove} data-qa-action-menu />
+        <BucketActionMenu
+          onRemove={onRemove}
+          label={label}
+          data-qa-action-menu
+        />
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/Profile/APITokens/APITokenMenu.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenMenu.tsx
@@ -71,7 +71,12 @@ class APITokenMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for API Token ${this.props.token.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
+++ b/packages/manager/src/features/Profile/AuthenticationSettings/TwoFactor/QRCodeForm.tsx
@@ -58,7 +58,12 @@ const QRCodeForm: React.StatelessComponent<CombinedProps> = props => {
       <Typography variant="h3" data-qa-copy className={classes.instructions}>
         If your TFA app does not have a scanner, you can use this secret key:
       </Typography>
-      <CopyableTextField className={classes.root} value={secret} />
+      <CopyableTextField
+        className={classes.root}
+        value={secret}
+        label="Secret Key"
+        hideLabel
+      />
     </React.Fragment>
   );
 };

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -175,13 +175,13 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
           <React.Fragment>
             <Select
               options={timezoneList}
-              placeholder={'Choose a timezone'}
+              placeholder={'Choose a Timezone'}
               errorText={timezoneError}
               onChange={this.handleTimezoneChange}
               data-qa-tz-select
               defaultValue={defaultTimeZone}
               isClearable={false}
-              label="Choose a timezone"
+              label="Choose a Timezone"
               hideLabel
             />
             <ActionsPanel>

--- a/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
+++ b/packages/manager/src/features/Profile/DisplaySettings/TimezoneForm.tsx
@@ -181,6 +181,8 @@ export class TimezoneForm extends React.Component<CombinedProps, State> {
               data-qa-tz-select
               defaultValue={defaultTimeZone}
               isClearable={false}
+              label="Choose a timezone"
+              hideLabel
             />
             <ActionsPanel>
               <Button

--- a/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
@@ -162,8 +162,7 @@ class LishSettings extends React.Component<CombinedProps, State> {
                   textFieldProps={{
                     dataAttrs: {
                       'data-qa-mode-select': true
-                    },
-                    label: 'Authentication Mode'
+                    }
                   }}
                   options={modeOptions}
                   name="mode-select"

--- a/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
+++ b/packages/manager/src/features/Profile/LishSettings/LishSettings.tsx
@@ -162,14 +162,15 @@ class LishSettings extends React.Component<CombinedProps, State> {
                   textFieldProps={{
                     dataAttrs: {
                       'data-qa-mode-select': true
-                    }
+                    },
+                    label: 'Authentication Mode'
                   }}
                   options={modeOptions}
                   name="mode-select"
                   id="mode-select"
+                  label="Authentication Mode"
                   defaultValue={defaultMode}
                   onChange={this.onListAuthMethodChange as any}
-                  label="Authentication Mode"
                   isClearable={false}
                   errorText={authMethodError}
                 />

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthClientActionMenu.tsx
@@ -51,7 +51,12 @@ class OAuthClientActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for OAuth Client ${this.props.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeyActionMenu.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeyActionMenu.tsx
@@ -31,7 +31,12 @@ class SSHKeyActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for SSH Key ${this.props.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -485,6 +485,8 @@ const withStackScriptBase = (isSelecting: boolean) => (
                   search term with "username:", "label:", or "description:"`
                       : ''
                   }
+                  label="Search by Label, Username, or Description"
+                  hideLabel
                 />
               </div>
               <Table

--- a/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptActionMenu.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptPanel/StackScriptActionMenu.tsx
@@ -112,7 +112,12 @@ const StackScriptActionMenu: React.StatelessComponent<
       return actions;
     };
   };
-  return <ActionMenu createActions={createActions()} />;
+  return (
+    <ActionMenu
+      createActions={createActions()}
+      ariaLabel={`Action menu for StackScript ${props.stackScriptLabel}`}
+    />
+  );
 };
 
 const enhanced = compose<CombinedProps, Props>(

--- a/packages/manager/src/features/Support/AttachFileListItem.tsx
+++ b/packages/manager/src/features/Support/AttachFileListItem.tsx
@@ -102,6 +102,9 @@ export const AttachFileListItem: React.StatelessComponent<
                 </InputAdornment>
               )
             }}
+            label="File attached"
+            aria-label="Disabled Text Field"
+            hideLabel
           />
         </Grid>
         {!inlineDisplay && (

--- a/packages/manager/src/features/Support/AttachFileListItem.tsx
+++ b/packages/manager/src/features/Support/AttachFileListItem.tsx
@@ -102,7 +102,7 @@ export const AttachFileListItem: React.StatelessComponent<
                 </InputAdornment>
               )
             }}
-            label="File attached"
+            label="File Attached"
             aria-label="Disabled Text Field"
             hideLabel
           />

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TicketReply.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/TicketReply.tsx
@@ -46,6 +46,8 @@ class TicketReply extends React.Component<CombinedProps> {
             handleChange(e.target.value)
           }
           errorText={error}
+          label="Enter your reply"
+          hideLabel
         />
       </React.Fragment>
     );

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -181,6 +181,9 @@ class SearchBar extends React.Component<CombinedProps, State> {
         `}
         >
           <Search className={classes.icon} data-qa-search-icon />
+          <label htmlFor="search-bar" className="visually-hidden">
+            Main search
+          </label>
           <EnhancedSelect
             inputId="search-bar"
             blurInputOnSelect

--- a/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
+++ b/packages/manager/src/features/TopMenu/SearchBar/SearchBar.tsx
@@ -181,11 +181,12 @@ class SearchBar extends React.Component<CombinedProps, State> {
         `}
         >
           <Search className={classes.icon} data-qa-search-icon />
-          <label htmlFor="search-bar" className="visually-hidden">
+          <label htmlFor="main-search" className="visually-hidden">
             Main search
           </label>
           <EnhancedSelect
-            inputId="search-bar"
+            label="Main search"
+            hideLabel
             blurInputOnSelect
             options={finalOptions}
             onChange={this.onSelect}

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsButton.tsx
@@ -83,6 +83,7 @@ interface Props {
   count?: number;
   disabled?: boolean;
   className?: string;
+  open?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -92,7 +93,8 @@ const UserEventsButton: React.StatelessComponent<CombinedProps> = ({
   count,
   onClick,
   disabled,
-  className
+  className,
+  open
 }) => {
   return (
     <IconButton
@@ -100,7 +102,6 @@ const UserEventsButton: React.StatelessComponent<CombinedProps> = ({
       className={`${classes.root} ${className}`}
       disabled={disabled}
       aria-label="User Events"
-      aria-owns={open ? 'menu-list-grow' : undefined}
       aria-haspopup="true"
       data-testid="ueb"
     >

--- a/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserEventsMenu/UserEventsMenu.tsx
@@ -91,6 +91,7 @@ export class UserEventsMenu extends React.Component<CombinedProps, State> {
           count={unseenCount}
           disabled={events.length === 0}
           className={anchorEl ? 'active' : ''}
+          aria-owns={anchorEl ? 'user-events-menu' : undefined}
         />
         <Popper open={Boolean(anchorEl)} anchorEl={anchorEl} disablePortal>
           {({ TransitionProps, placement }) => (
@@ -109,7 +110,7 @@ export class UserEventsMenu extends React.Component<CombinedProps, State> {
                     placement === 'bottom' ? 'center top' : 'center bottom'
                 }}
               >
-                <MenuList className={classes.dropDown}>
+                <MenuList className={classes.dropDown} id="user-events-menu">
                   <UserEventsList
                     events={filteredEvents}
                     closeMenu={(e: any) => this.closeMenu(e)}

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -104,9 +104,19 @@ const styles = (theme: Theme) =>
     setAll: {
       width: 300,
       marginTop: theme.spacing(1) / 2,
-      '& .react-select__menu': {
-        maxWidth: 153,
-        right: 0
+      '& > div': {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'flex-end'
+      },
+      '& .react-select__menu, & .input': {
+        width: 125,
+        right: 0,
+        marginLeft: theme.spacing(1),
+        textAlign: 'left'
+      },
+      '& .react-select__menu-list': {
+        width: '100%'
       }
     }
   });
@@ -747,6 +757,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               inline
               className={classes.setAll}
               noMarginTop
+              small
             />
           </Grid>
         </Grid>

--- a/packages/manager/src/features/Users/UserPermissions.tsx
+++ b/packages/manager/src/features/Users/UserPermissions.tsx
@@ -419,7 +419,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
       cancel_account: 'Can cancel the entire account'
     };
     return (
-      <React.Fragment key={perm}>
+      <Grid item key={perm} xs={12} sm={6} className="py0">
         <FormControlLabel
           className={classes.globalRow}
           label={permDescriptionMap[perm]}
@@ -432,7 +432,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
           }
         />
         <Divider />
-      </React.Fragment>
+      </Grid>
     );
   };
 
@@ -532,7 +532,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
             spacingTop={8}
           />
         )}
-        <div className={classes.section}>
+        <Grid container className={classes.section}>
           {grants &&
             grants.global &&
             this.globalBooleanPerms
@@ -545,7 +545,7 @@ class UserPermissions extends React.Component<CombinedProps, State> {
               .map(perm =>
                 this.renderGlobalPerm(perm, grants.global[perm] as boolean)
               )}
-        </div>
+        </Grid>
         {this.renderBillingPerm()}
         {this.renderActions(
           this.savePermsType('global'),

--- a/packages/manager/src/features/Users/UsersActionMenu.tsx
+++ b/packages/manager/src/features/Users/UsersActionMenu.tsx
@@ -59,7 +59,12 @@ class UsersActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for user ${this.props.profileUsername}`}
+      />
+    );
   }
 }
 interface StateProps {

--- a/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeCreate/CreateVolumeForm.tsx
@@ -263,6 +263,7 @@ const CreateVolumeForm: React.FC<CombinedProps> = props => {
                     selectedID={values.region}
                     handleSelection={value => setFieldValue('region', value)}
                     disabled={disabled}
+                    label={'Select a Region'}
                     styles={{
                       /** altering styles for mobile-view */
                       menuList: (base: any) => ({

--- a/packages/manager/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
@@ -190,8 +190,7 @@ export class LinodeSelect extends React.Component<CombinedProps, State> {
           textFieldProps={{
             dataAttrs: {
               'data-qa-select-linode': true
-            },
-            label: 'Select a Linode'
+            }
           }}
           hideLabel
           {...rest}

--- a/packages/manager/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/LinodeSelect.tsx
@@ -190,8 +190,10 @@ export class LinodeSelect extends React.Component<CombinedProps, State> {
           textFieldProps={{
             dataAttrs: {
               'data-qa-select-linode': true
-            }
+            },
+            label: 'Select a Linode'
           }}
+          hideLabel
           {...rest}
         />
         {!error && (

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumesInstruction.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumesInstruction.tsx
@@ -52,6 +52,8 @@ const ResizeVolumeInstructions: React.FC<CombinedProps> = props => {
           className={classes.copyField}
           value={`umount /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`}
           data-qa-umount
+          label="Make sure the volume is unmounted for safety"
+          hideLabel
         />
       </div>
 
@@ -64,11 +66,15 @@ const ResizeVolumeInstructions: React.FC<CombinedProps> = props => {
           className={classes.copyField}
           value={`e2fsck -f /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`}
           data-qa-check-filesystem
+          label="Run a file system check"
+          hideLabel
         />
         <CopyableTextField
           className={classes.copyField}
           value={`resize2fs /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel}`}
           data-qa-resize-filesystem
+          label="Resize file system to fill the new volume"
+          hideLabel
         />
       </div>
 
@@ -80,6 +86,8 @@ const ResizeVolumeInstructions: React.FC<CombinedProps> = props => {
           className={classes.copyField}
           value={`mount /dev/disk/by-id/scsi-0Linode_Volume_${volumeLabel} /mnt/${volumeLabel}`}
           data-qa-mount
+          label="Mount back onto the filesystem"
+          hideLabel
         />
       </div>
       <ActionsPanel>

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
@@ -49,6 +49,8 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = props => {
           className={classes.copyField}
           value={`mkfs.ext4 "${props.volumePath}"`}
           data-qa-make-filesystem
+          label="Create a Filesystem"
+          hideLabel
         />
       </div>
 
@@ -60,6 +62,8 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = props => {
           className={classes.copyField}
           value={`mkdir "/mnt/${props.volumeLabel}"`}
           data-qa-mountpoint
+          label="Create a mountpoint"
+          hideLabel
         />
       </div>
 
@@ -71,6 +75,8 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = props => {
           className={classes.copyField}
           value={`mount "${props.volumePath}" "/mnt/${props.volumeLabel}"`}
           data-qa-mount
+          label="Mount Volume"
+          hideLabel
         />
       </div>
 
@@ -86,6 +92,8 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = props => {
             props.volumeLabel
           } ext4 defaults,noatime,nofail 0 2`}
           data-qa-boot-mount
+          label="Mount every time your Linode boots"
+          hideLabel
         />
       </div>
       <ActionsPanel>

--- a/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/VolumeConfigForm.tsx
@@ -62,7 +62,7 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = props => {
           className={classes.copyField}
           value={`mkdir "/mnt/${props.volumeLabel}"`}
           data-qa-mountpoint
-          label="Create a mountpoint"
+          label="Create a Mountpoint"
           hideLabel
         />
       </div>
@@ -88,9 +88,7 @@ const VolumeConfigDrawer: React.FC<CombinedProps> = props => {
         </Typography>
         <CopyableTextField
           className={classes.copyField}
-          value={`${props.volumePath} /mnt/${
-            props.volumeLabel
-          } ext4 defaults,noatime,nofail 0 2`}
+          value={`${props.volumePath} /mnt/${props.volumeLabel} ext4 defaults,noatime,nofail 0 2`}
           data-qa-boot-mount
           label="Mount every time your Linode boots"
           hideLabel

--- a/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
+++ b/packages/manager/src/features/Volumes/VolumesActionMenu.tsx
@@ -152,7 +152,12 @@ export class VolumesActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for Volume ${this.props.volumeLabel}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/linodes/CloneLanding/Details.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/Details.tsx
@@ -255,8 +255,7 @@ export const Configs: React.FC<Props> = props => {
             : undefined
         }
         textFieldProps={{
-          error: !!linodeError,
-          label: 'Destination'
+          error: !!linodeError
         }}
         groupByRegion
         updateFor={[

--- a/packages/manager/src/features/linodes/CloneLanding/Details.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/Details.tsx
@@ -255,7 +255,8 @@ export const Configs: React.FC<Props> = props => {
             : undefined
         }
         textFieldProps={{
-          error: !!linodeError
+          error: !!linodeError,
+          label: 'Destination'
         }}
         groupByRegion
         updateFor={[

--- a/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
+++ b/packages/manager/src/features/linodes/LinodeSelect/LinodeSelect.tsx
@@ -29,7 +29,7 @@ interface Props {
   disabled?: boolean;
   region?: string;
   handleChange: (linode: Linode) => void;
-  textFieldProps?: TextFieldProps;
+  textFieldProps?: Omit<TextFieldProps, 'label'>;
   groupByRegion?: boolean;
   placeholder?: string;
   valueOverride?: Override;

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.test.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.test.tsx
@@ -14,7 +14,8 @@ describe('Select Plan Panel', () => {
         disabledRow: '',
         chip: '',
         currentPlanChipCell: '',
-        radioCell: ''
+        radioCell: '',
+        headingCellContainer: ''
       }}
       types={extendedTypes}
       currentPlanHeading="Linode 2GB"

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -39,6 +39,7 @@ type ClassNames =
   | 'copy'
   | 'disabledRow'
   | 'chip'
+  | 'headingCellContainer'
   | 'currentPlanChipCell'
   | 'radioCell';
 
@@ -55,6 +56,10 @@ const styles = (theme: Theme) =>
     disabledRow: {
       backgroundColor: theme.bg.tableHeader,
       cursor: 'not-allowed'
+    },
+    headingCellContainer: {
+      display: 'flex',
+      alignItems: 'center'
     },
     chip: {
       backgroundColor: theme.color.green,
@@ -147,17 +152,23 @@ export class SelectPlanPanel extends React.Component<
               )}
             </TableCell>
             <TableCell data-qa-plan-name>
-              {type.heading}{' '}
-              {isSamePlan && (
-                <Chip
-                  data-qa-current-plan
-                  label="Current Plan"
-                  className={classes.chip}
-                />
-              )}
-              {tooltip && (
-                <HelpIcon text={tooltip} tooltipPosition="right-end" />
-              )}
+              <div className={classes.headingCellContainer}>
+                {type.heading}{' '}
+                {isSamePlan && (
+                  <Chip
+                    data-qa-current-plan
+                    label="Current Plan"
+                    className={classes.chip}
+                  />
+                )}
+                {tooltip && (
+                  <HelpIcon
+                    text={tooltip}
+                    tooltipPosition="right-end"
+                    className="py0"
+                  />
+                )}
+              </div>
             </TableCell>
             <TableCell data-qa-monthly> ${type.price.monthly}</TableCell>
             <TableCell data-qa-hourly>

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -4,6 +4,7 @@ import { isEmpty, pathOr } from 'ramda';
 import * as React from 'react';
 import { compose } from 'recompose';
 import Chip from 'src/components/core/Chip';
+import FormControlLabel from 'src/components/core/FormControlLabel';
 import Hidden from 'src/components/core/Hidden';
 import {
   createStyles,
@@ -131,11 +132,17 @@ export class SelectPlanPanel extends React.Component<
           >
             <TableCell className={classes.radioCell}>
               {!isSamePlan && (
-                <Radio
-                  checked={!planTooSmall && type.id === String(selectedID)}
-                  onChange={this.onSelect(type.id)}
-                  disabled={planTooSmall || disabled}
-                  id={type.id}
+                <FormControlLabel
+                  label={type.heading}
+                  className={'label-visually-hidden'}
+                  control={
+                    <Radio
+                      checked={!planTooSmall && type.id === String(selectedID)}
+                      onChange={this.onSelect(type.id)}
+                      disabled={planTooSmall || disabled}
+                      id={type.id}
+                    />
+                  }
                 />
               )}
             </TableCell>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -316,6 +316,7 @@ class LinodeConfigs extends React.Component<CombinedProps, State> {
             onEdit={this.openForEditing}
             onDelete={this.confirmDelete}
             readOnly={this.props.readOnly}
+            label={config.label}
           />
         </TableCell>
       </TableRow>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
@@ -7,6 +7,7 @@ interface Props {
   linodeStatus: string;
   linodeId?: number;
   diskId?: number;
+  label?: string;
   readOnly?: boolean;
   onRename: () => void;
   onResize: () => void;
@@ -87,7 +88,12 @@ class DiskActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for Disk ${this.props.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDiskActionMenu.tsx
@@ -7,7 +7,7 @@ interface Props {
   linodeStatus: string;
   linodeId?: number;
   diskId?: number;
-  label?: string;
+  label: string;
   readOnly?: boolean;
   onRename: () => void;
   onResize: () => void;

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -261,6 +261,7 @@ class LinodeDisks extends React.Component<CombinedProps, State> {
             linodeStatus={status || 'offline'}
             linodeId={linodeId}
             diskId={disk.id}
+            label={disk.label}
             onRename={this.openDrawerForRename(disk)}
             onResize={this.openDrawerForResize(disk)}
             onImagize={this.openImagizeDrawer(disk)}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -515,9 +515,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
     const { history, linodeID } = this.props;
     history.push(
       '/linodes/create' +
-        `?type=My%20Images&subtype=Backups&backupID=${
-          backup.id
-        }&linodeID=${linodeID}`
+        `?type=My%20Images&subtype=Backups&backupID=${backup.id}&linodeID=${linodeID}`
     );
   };
 
@@ -739,8 +737,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
               textFieldProps={{
                 dataAttrs: {
                   'data-qa-time-select': true
-                },
-                label: 'Time of Day'
+                }
               }}
               options={timeSelection}
               onChange={this.handleSelectBackupWindow}
@@ -761,8 +758,7 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
               textFieldProps={{
                 dataAttrs: {
                   'data-qa-weekday-select': true
-                },
-                label: 'Day of Week'
+                }
               }}
               options={daySelection}
               defaultValue={defaultDaySelection}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -739,7 +739,8 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
               textFieldProps={{
                 dataAttrs: {
                   'data-qa-time-select': true
-                }
+                },
+                label: 'Time of Day'
               }}
               options={timeSelection}
               onChange={this.handleSelectBackupWindow}
@@ -760,7 +761,8 @@ class _LinodeBackup extends React.Component<CombinedProps, State> {
               textFieldProps={{
                 dataAttrs: {
                   'data-qa-weekday-select': true
-                }
+                },
+                label: 'Day of Week'
               }}
               options={daySelection}
               defaultValue={defaultDaySelection}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackupActionMenu.tsx
@@ -49,7 +49,12 @@ class LinodeBackupActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for Backup ${this.props.backup.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -184,6 +184,8 @@ export class RestoreToLinodeDrawer extends React.Component<
             errorText={linodeError}
             placeholder="Select a Linode"
             isClearable={false}
+            label="Select a Linode"
+            hideLabel
           />
           {selectError && (
             <FormHelperText error>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -176,8 +176,7 @@ export class RestoreToLinodeDrawer extends React.Component<
             textFieldProps={{
               dataAttrs: {
                 'data-qa-select-linode': true
-              },
-              label: 'Select a Linode'
+              }
             }}
             defaultValue={selectedLinode || ''}
             options={linodeList}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/RestoreToLinodeDrawer.tsx
@@ -176,7 +176,8 @@ export class RestoreToLinodeDrawer extends React.Component<
             textFieldProps={{
               dataAttrs: {
                 'data-qa-select-linode': true
-              }
+              },
+              label: 'Select a Linode'
             }}
             defaultValue={selectedLinode || ''}
             options={linodeList}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/EditRDNSDrawer.tsx
@@ -185,6 +185,8 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
             <div className={classes.ipv6Input}>
               <TextField
                 placeholder="Enter an IPv6 address"
+                label="Enter an IPv6 address"
+                hideLabel
                 value={ipv6Address || ''}
                 errorText={hasErrorFor('ipv6Address')}
                 onChange={this.handleChangeIPv6Address}
@@ -194,6 +196,8 @@ class ViewRangeDrawer extends React.Component<CombinedProps, State> {
           )}
           <TextField
             placeholder="Enter a domain name"
+            label="Enter a domain name"
+            hideLabel
             value={rdns || ''}
             errorText={hasErrorFor('rdns')}
             onChange={this.handleChangeDomain}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -254,6 +254,8 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
             disabled={readOnly}
             isClearable={false}
             placeholder="Select an IP"
+            label="Select an IP"
+            hideLabel
           />
         </Grid>
         <Grid item className={classes.removeCont}>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -255,8 +255,7 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
             textFieldProps={{
               dataAttrs: {
                 'data-qa-share-ip': true
-              },
-              label: 'Select an IP'
+              }
             }}
             disabled={readOnly}
             isClearable={false}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/IPSharingPanel.tsx
@@ -178,7 +178,13 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
           <Divider className={classes.containerDivider} />
         </Grid>
         <Grid item xs={12}>
-          <TextField disabled value={ip} className={classes.ipField} />
+          <TextField
+            disabled
+            value={ip}
+            className={classes.ipField}
+            label="IP Address"
+            hideLabel
+          />
         </Grid>
       </Grid>
     );
@@ -249,7 +255,8 @@ class IPSharingPanel extends React.Component<CombinedProps, State> {
             textFieldProps={{
               dataAttrs: {
                 'data-qa-share-ip': true
-              }
+              },
+              label: 'Select an IP'
             }}
             disabled={readOnly}
             isClearable={false}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworking.tsx
@@ -312,7 +312,7 @@ class LinodeNetworking extends React.Component<CombinedProps, State> {
         <TableCell parentColumn="Address">
           <React.Fragment>
             {range.range}
-            <span style={{ margin: '0 5px 0 5px' }}>/</span>
+            <span style={{ margin: '0 5px' }}>/</span>
             {range.prefix}
           </React.Fragment>
           {range.route_target && <span> routed to {range.route_target}</span>}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -9,7 +9,7 @@ interface Props {
   onEdit?: (ip: IPAddress | IPRange) => void;
   onRemove?: (ip: IPAddress | IPRange) => void;
   ipType: IPTypes;
-  ipAddress?: any;
+  ipAddress?: IPAddress | IPRange;
   readOnly?: boolean;
 }
 
@@ -93,13 +93,11 @@ class LinodeNetworkingActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
+    const { address } = this.props.ipAddress as any;
     return (
       <ActionMenu
         createActions={this.createActions()}
-        ariaLabel={`Action menu for Address ${this.props.ipAddress &&
-          (this.props.ipAddress.range
-            ? this.props.ipAddress.range
-            : this.props.ipAddress.gateway)}`}
+        ariaLabel={`Action menu for Address ${address}`}
       />
     );
   }

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingActionMenu.tsx
@@ -9,7 +9,7 @@ interface Props {
   onEdit?: (ip: IPAddress | IPRange) => void;
   onRemove?: (ip: IPAddress | IPRange) => void;
   ipType: IPTypes;
-  ipAddress?: IPAddress | IPRange;
+  ipAddress?: any;
   readOnly?: boolean;
 }
 
@@ -93,7 +93,15 @@ class LinodeNetworkingActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createActions()}
+        ariaLabel={`Action menu for Address ${this.props.ipAddress &&
+          (this.props.ipAddress.range
+            ? this.props.ipAddress.range
+            : this.props.ipAddress.gateway)}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -296,6 +296,8 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
             placeholder="Select Action"
             isClearable={false}
             noMarginTop
+            label="Select Action"
+            hideLabel
           />
         </Grid>
         {renderLinodeSelect && renderLinodeSelect(state as Move)}
@@ -329,6 +331,8 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
           onChange={this.onSelectedLinodeChange(sourceIP)}
           isClearable={false}
           noMarginTop
+          label="Select Linode"
+          hideLabel
         />
       </Grid>
     );
@@ -359,6 +363,8 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
           }}
           isClearable={false}
           noMarginTop
+          label="Select IP Address"
+          hideLabel
         />
       </Grid>
     );

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -294,8 +294,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
             textFieldProps={{
               dataAttrs: {
                 'data-qa-ip-transfer-action-menu': state.mode
-              },
-              label: 'Select Action'
+              }
             }}
             onChange={this.onModeChange(state.sourceIP)}
             disabled={readOnly}
@@ -330,8 +329,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
           textFieldProps={{
             dataAttrs: {
               'data-qa-linode-select': true
-            },
-            label: 'Select Linode'
+            }
           }}
           disabled={readOnly || this.state.linodes.length === 1}
           defaultValue={defaultLinode}
@@ -366,8 +364,7 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
           textFieldProps={{
             dataAttrs: {
               'data-qa-swap-ip-action-menu': true
-            },
-            label: 'Select IP Address'
+            }
           }}
           isClearable={false}
           noMarginTop

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeNetworking/LinodeNetworkingIPTransferPanel.tsx
@@ -274,7 +274,12 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
           <Divider className={classes.containerDivider} />
         </Grid>
         <Grid item className={classes.mobileFieldWrapper}>
-          <TextField value={state.sourceIP} className={classes.ipField} />
+          <TextField
+            value={state.sourceIP}
+            className={classes.ipField}
+            label="IP Adress"
+            hideLabel
+          />
         </Grid>
         <Grid item xs={12} className={classes.autoGridsm}>
           <Select
@@ -289,7 +294,8 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
             textFieldProps={{
               dataAttrs: {
                 'data-qa-ip-transfer-action-menu': state.mode
-              }
+              },
+              label: 'Select Action'
             }}
             onChange={this.onModeChange(state.sourceIP)}
             disabled={readOnly}
@@ -324,7 +330,8 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
           textFieldProps={{
             dataAttrs: {
               'data-qa-linode-select': true
-            }
+            },
+            label: 'Select Linode'
           }}
           disabled={readOnly || this.state.linodes.length === 1}
           defaultValue={defaultLinode}
@@ -359,7 +366,8 @@ class LinodeNetworkingIPTransferPanel extends React.Component<
           textFieldProps={{
             dataAttrs: {
               'data-qa-swap-ip-action-menu': true
-            }
+            },
+            label: 'Select IP Address'
           }}
           isClearable={false}
           noMarginTop

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/LinodeRebuild.tsx
@@ -64,7 +64,7 @@ const LinodeRebuild: React.StatelessComponent<CombinedProps> = props => {
         >
           Rebuild
         </Typography>
-        <Typography data-qa-rebuild-desc>
+        <Typography data-qa-rebuild-desc style={{ marginBottom: 16 }}>
           If you can't rescue an existing disk, it's time to rebuild your
           Linode. There are a couple of different ways you can do this: either
           restore from a backup or start over with a fresh Linux distribution.
@@ -76,6 +76,8 @@ const LinodeRebuild: React.StatelessComponent<CombinedProps> = props => {
           onChange={(selected: Item<MODES>) => setMode(selected.value)}
           isClearable={false}
           disabled={disabled}
+          label="From Image"
+          hideLabel
         />
       </Paper>
       {mode === 'fromImage' && <RebuildFromImage />}

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeConfigActionMenu.tsx
@@ -11,6 +11,7 @@ interface Props {
   config: Config;
   linodeId: number;
   readOnly?: boolean;
+  label: string;
 }
 
 type CombinedProps = Props & RouteComponentProps<{}>;
@@ -91,7 +92,12 @@ class ConfigActionMenu extends React.Component<CombinedProps> {
   };
 
   render() {
-    return <ActionMenu createActions={this.createConfigActions()} />;
+    return (
+      <ActionMenu
+        createActions={this.createConfigActions()}
+        ariaLabel={`Action menu for Linode Config ${this.props.label}`}
+      />
+    );
   }
 }
 

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -303,6 +303,7 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
       <ActionMenu
         toggleOpenCallback={this.toggleOpenActionMenu}
         createActions={this.createLinodeActions()}
+        ariaLabel={`Action menu for Linode ${this.props.linodeLabel}`}
       />
     );
   }

--- a/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/ConfigureForm.tsx
@@ -77,6 +77,7 @@ const ConfigureForm: React.FC<CombinedProps> = props => {
         styles={{
           menuList: (base: any) => ({ ...base, maxHeight: `30vh !important` })
         }}
+        label="Select a Region"
       />
     </Paper>
   );

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -119,7 +119,12 @@ body.searchOverlay #main-content {
   }
 }
 
-.visually-hidden {
+.label-visually-hidden {
+  margin-right: 0 !important;
+}
+
+.visually-hidden,
+.label-visually-hidden span:last-child {
   /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
   position: absolute !important;
   height: 1px;


### PR DESCRIPTION
## Improve Buttons, selects and textfields accessibility

There's been a lack of solid support for accessibility overall in the APP. This PR enforces practice for selects and textfields, as well as some buttons without context (action menu etc).
Sorry for the big PR but this needs to be done this way in order to test well.

The PR also contains minor edits to markup and aria-labels overall that are non-breaking/dangerous.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

One pattern that is less than desirable is to have to add two labels on Selects that have `textFieldProps` since selects and textFields now both require labels. If someone has a good idea on how to get around that feel free to commit or comment