### PR TITLE
[LV] Hide "View Details" link behind feature flag

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.test.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.test.tsx
@@ -14,14 +14,33 @@ const props: Props = {
 
 describe('Top Processes', () => {
   describe('TopProcesses Component', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
     it('renders the title', () => {
       const { getByText } = render(wrapWithTheme(<TopProcesses {...props} />));
       getByText('Top Processes');
     });
 
-    it('renders a View Details link', () => {
-      const { getByText } = render(wrapWithTheme(<TopProcesses {...props} />));
-      getByText('View Details');
+    it('renders the View Details link when the feature flag is enabled', () => {
+      jest.mock('src/hooks/useFlags', () => ({
+        default: () => ({ longviewTabs: true })
+      }));
+      const { queryByText } = render(
+        wrapWithTheme(<TopProcesses {...props} />)
+      );
+      expect(queryByText('View Details')).toBeDefined();
+    });
+
+    it('does not render the View Details link when the feature flag is disabled', () => {
+      jest.mock('src/hooks/useFlags', () => ({
+        default: () => ({ longviewTabs: false })
+      }));
+      const { queryByText } = render(
+        wrapWithTheme(<TopProcesses {...props} />)
+      );
+      expect(queryByText('View Details')).toBeNull();
     });
 
     it('renders rows for each process', () => {

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/TopProcesses.tsx
@@ -19,6 +19,7 @@ import {
   LongviewTopProcesses,
   TopProcessStat
 } from 'src/features/Longview/request.types';
+import useFlags from 'src/hooks/useFlags';
 import { readableBytes } from 'src/utilities/unitConversions';
 import { formatCPU } from '../../shared/formatters';
 
@@ -47,6 +48,8 @@ export const TopProcesses: React.FC<Props> = props => {
     lastUpdatedError
   } = props;
 
+  const flags = useFlags();
+
   const errorMessage = Boolean(topProcessesError || lastUpdatedError)
     ? 'There was an error getting Top Processes.'
     : undefined;
@@ -55,9 +58,12 @@ export const TopProcesses: React.FC<Props> = props => {
     <Grid item xs={12} md={4} lg={3}>
       <Box display="flex" flexDirection="row" justifyContent="space-between">
         <Typography variant="h2">Top Processes</Typography>
-        <Link to="processes" className={classes.detailsLink}>
-          View Details
-        </Link>
+        {/* Hide the link to the Processes Tab if the feature isn't enabled. */}
+        {flags.longviewTabs && (
+          <Link to="processes" className={classes.detailsLink}>
+            View Details
+          </Link>
+        )}
       </Box>
       <OrderBy
         data={extendTopProcesses(topProcessesData)}


### PR DESCRIPTION
## Description

This PR hides the "View Details" link in the Top Processes table, since it leads to a tab that won't be included in the MVP.


## Note to Reviewers

There are a few new unit tests. Try running the app with and without the `longview-tabs` feature flag enabled.
