### PR TITLE
M3-3641 Accessibility: External links and new windows

### DIFF
--- a/packages/manager/src/App.tsx
+++ b/packages/manager/src/App.tsx
@@ -174,9 +174,17 @@ export class App extends React.Component<CombinedProps, State> {
 
     return (
       <React.Fragment>
-        <a href="#main-content" className="visually-hidden">
+        {/** Accessibility helpers */}
+        <a href="#main-content" hidden>
           Skip to main content
         </a>
+        <div hidden>
+          <span id="new-window">Opens in a new window</span>
+          <span id="external-site">Opens an external site</span>
+          <span id="external-site-new-window">
+            Opens an external site in a new window
+          </span>
+        </div>
         {/** Update the LD client with the user's id as soon as we know it */}
         <IdentifyUser
           userID={userId}

--- a/packages/manager/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/manager/src/components/ActionMenu/ActionMenu.tsx
@@ -15,6 +15,7 @@ export interface Action {
   disabled?: boolean;
   tooltip?: string;
   isLoading?: boolean;
+  ariaDescribedBy?: string;
   onClick: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
@@ -154,6 +155,7 @@ export class ActionMenu extends React.Component<CombinedProps, State> {
               disabled={a.disabled}
               tooltip={a.tooltip}
               isLoading={a.isLoading}
+              aria-describedby={a.ariaDescribedBy}
             >
               {a.title}
             </MenuItem>

--- a/packages/manager/src/components/CookieWarning.tsx
+++ b/packages/manager/src/components/CookieWarning.tsx
@@ -22,6 +22,7 @@ const CookieWarning: React.FC<{}> = () => {
       <a
         href="https://orteil.dashnet.org/cookieclicker/"
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         style={{
           position: 'absolute',

--- a/packages/manager/src/components/DocumentationButton/DocumentationButton.tsx
+++ b/packages/manager/src/components/DocumentationButton/DocumentationButton.tsx
@@ -39,6 +39,7 @@ export const DocumentationButton: React.FC<CombinedProps> = props => {
       text="Documentation"
       title="Documentation"
       onClick={() => window.open(href, '_blank', 'noopener')}
+      aria-describedby="external-site"
     >
       Documentation
     </IconTextLink>

--- a/packages/manager/src/components/ExternalLink/ExternalLink.tsx
+++ b/packages/manager/src/components/ExternalLink/ExternalLink.tsx
@@ -81,6 +81,7 @@ class ExternalLink extends React.Component<CombinedProps> {
     return (
       <a
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         href={link}
         className={classNames(

--- a/packages/manager/src/components/Link.tsx
+++ b/packages/manager/src/components/Link.tsx
@@ -9,7 +9,8 @@ export const Link: React.FC<LinkProps> = props => {
   return isExternal(props.to as string) ? (
     <a
       href={props.to as string}
-      target="_blank"
+      target={isExternal ? '_blank' : '_parent'}
+      aria-describedby={isExternal ? 'new-window' : undefined}
       rel="noopener noreferrer"
       onClick={props.onClick}
       className={props.className}

--- a/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/packages/manager/src/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -101,6 +101,7 @@ const MaintenanceBanner: React.FC<CombinedProps> = props => {
         Please see
         <a
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
           href="https://status.linode.com"
         >

--- a/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
+++ b/packages/manager/src/components/SelectRegionPanel/SelectRegionPanel.tsx
@@ -66,6 +66,7 @@ const SelectRegionPanel: React.FC<Props & WithStyles<ClassNames>> = props => {
             {` `}
             <a
               target="_blank"
+              aria-describedby="external-site"
               rel="noopener noreferrer"
               href="https://www.linode.com/speedtest"
             >

--- a/packages/manager/src/components/TaxBanner/TaxBanner.test.tsx
+++ b/packages/manager/src/components/TaxBanner/TaxBanner.test.tsx
@@ -51,7 +51,7 @@ describe('Utility Functions', () => {
 
     const container = queryByTestId('hello');
     expect(container).toContainHTML(
-      '<div data-testid="hello">Please see docs at <a href="https://linode.com" target="_blank" rel="noopener noreferrer">this location</a>. And change <a href="/account/billing">your account</a>.</div>'
+      '<div data-testid="hello">Please see docs at <a href="https://linode.com" target="_blank" aria-describedby="external-site" rel="noopener noreferrer">this location</a>. And change <a href="/account/billing">your account</a>.</div>'
     );
   });
 });

--- a/packages/manager/src/components/TaxBanner/TaxBanner.tsx
+++ b/packages/manager/src/components/TaxBanner/TaxBanner.tsx
@@ -60,6 +60,7 @@ const VATBanner: React.FC<Props> = props => {
                 <a
                   href="https://www.linode.com/docs/platform/billing-and-support/tax-information/"
                   target="_blank"
+                  aria-describedby="external-site"
                   rel="noopener noreferrer"
                 >
                   Tax Information Guide.

--- a/packages/manager/src/components/TaxBanner/utilities.tsx
+++ b/packages/manager/src/components/TaxBanner/utilities.tsx
@@ -62,7 +62,13 @@ export const wrapStringInLink = (
   const arrayWithLink = sentenceAsArray.map(eachWord => {
     if (eachWord.match(new RegExp(textToReplace, 'gmi'))) {
       return type === 'external' ? (
-        <a key={eachWord} href={link} target="_blank" rel="noopener noreferrer">
+        <a
+          key={eachWord}
+          href={link}
+          target="_blank"
+          aria-describedby="external-site"
+          rel="noopener noreferrer"
+        >
           {eachWord}
         </a>
       ) : (

--- a/packages/manager/src/components/ViewAllLink/ViewAllLink.tsx
+++ b/packages/manager/src/components/ViewAllLink/ViewAllLink.tsx
@@ -74,6 +74,7 @@ const ViewAllLink: React.StatelessComponent<CombinedProps> = props => {
           })}
           data-qa-view-all-link
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
         >
           {text}

--- a/packages/manager/src/features/Account/AutoBackups.tsx
+++ b/packages/manager/src/features/Account/AutoBackups.tsx
@@ -90,6 +90,7 @@ const AutoBackups: React.StatelessComponent<CombinedProps> = props => {
                 data-qa-backups-price
                 href="https://linode.com/backups"
                 target="_blank"
+                aria-describedby="external-site"
                 rel="noopener noreferrer"
               >
                 {` Backups pricing page`}

--- a/packages/manager/src/features/Backups/BackupsCTA.tsx
+++ b/packages/manager/src/features/Backups/BackupsCTA.tsx
@@ -77,6 +77,7 @@ const BackupsCTA: React.StatelessComponent<CombinedProps> = props => {
             and be sure to read our guide on Backups{` `}
             <a
               target="_blank"
+              aria-describedby="external-site"
               rel="noopener noreferrer"
               href={
                 'https://www.linode.com/docs/platform' +

--- a/packages/manager/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
+++ b/packages/manager/src/features/Dashboard/BlogDashboardCard/BlogDashboardCard.tsx
@@ -134,6 +134,7 @@ export class BlogDashboardCard extends React.Component<CombinedProps, State> {
             href={item.link}
             className="blue"
             target="_blank"
+            aria-describedby="external-site"
             rel="noopener noreferrer"
             data-qa-blog-post
           >

--- a/packages/manager/src/features/Domains/DomainsLanding.tsx
+++ b/packages/manager/src/features/Domains/DomainsLanding.tsx
@@ -477,6 +477,7 @@ const EmptyCopy = () => (
       <a
         href="https://www.linode.com/docs/platform/manager/dns-manager-new-manager/"
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         className="h-u"
       >
@@ -486,6 +487,7 @@ const EmptyCopy = () => (
       <a
         href="https://www.linode.com/docs/"
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         className="h-u"
       >

--- a/packages/manager/src/features/Footer/Footer.tsx
+++ b/packages/manager/src/features/Footer/Footer.tsx
@@ -122,6 +122,7 @@ export class Footer extends React.PureComponent<CombinedProps> {
             className={classes.link}
             href="https://developers.linode.com"
             target="_blank"
+            aria-describedby="external-site"
             rel="noopener noreferrer"
           >
             API Reference
@@ -159,6 +160,7 @@ export class Footer extends React.PureComponent<CombinedProps> {
         className={className}
         href={`https://github.com/linode/manager/releases/tag/v${VERSION}`}
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
       >
         v{VERSION}

--- a/packages/manager/src/features/Help/Panels/SearchItem.tsx
+++ b/packages/manager/src/features/Help/Panels/SearchItem.tsx
@@ -37,6 +37,7 @@ const SearchItem: React.StatelessComponent<Props> = props => {
         [classes.selectedMenuItem]: isFocused
       })}
       value={data.label}
+      aria-describedby={!isFinal ? 'external-site' : undefined}
       attrs={{ ['data-qa-search-result']: source }}
       {...props}
     >

--- a/packages/manager/src/features/Images/ImagesLanding.tsx
+++ b/packages/manager/src/features/Images/ImagesLanding.tsx
@@ -458,6 +458,7 @@ const EmptyCopy = () => (
       <a
         href="https://linode.com/docs/platform/disk-images/linode-images-new-manager/"
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         className="h-u"
       >
@@ -467,6 +468,7 @@ const EmptyCopy = () => (
       <a
         href="https://linode.com/docs/quick-answers/linode-platform/deploy-an-image-to-a-linode"
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         className="h-u"
       >

--- a/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesLanding/KubernetesLandingEmptyState.tsx
@@ -98,6 +98,7 @@ class ListLinodesEmptyState extends React.Component<PropsWithStyles> {
             <a
               href="https://www.linode.com/docs/applications/containers/kubernetes/how-to-deploy-a-cluster-with-lke/"
               target="_blank"
+              aria-describedby="external-site"
               rel="noopener noreferrer"
               className="h-u"
             >

--- a/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
+++ b/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
@@ -92,6 +92,7 @@ const InstallationInstructions: React.FC<CombinedProps> = props => {
               <a
                 href="https://www.linode.com/docs/platform/longview/longview/"
                 target="_blank"
+                aria-describedby="external-site"
                 rel="noopener noreferrer"
               >
                 Troubleshooting guide
@@ -103,6 +104,7 @@ const InstallationInstructions: React.FC<CombinedProps> = props => {
               <a
                 href="https://www.linode.com/docs/platform/longview/longview/#install-the-longview-client"
                 target="_blank"
+                aria-describedby="external-site"
                 rel="noopener noreferrer"
               >
                 Manual installation instructions

--- a/packages/manager/src/features/Managed/SSHAccess/LinodePubKey.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/LinodePubKey.tsx
@@ -147,7 +147,12 @@ const LinodePubKey: React.FC<{}> = props => {
             </Box>
             <Typography>
               You must{' '}
-              <a href={DOC_URL} target="_blank" rel="noopener noreferrer">
+              <a
+                href={DOC_URL}
+                target="_blank"
+                aria-describedby="external-site"
+                rel="noopener noreferrer"
+              >
                 install our public SSH key
               </a>{' '}
               on all managed Linodes so we can access them and diagnose issues.

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingEmptyState.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/NodeBalancersLandingEmptyState.tsx
@@ -36,6 +36,7 @@ const EmptyCopy = () => (
       <a
         href="https://www.linode.com/docs/platform/nodebalancer/getting-started-with-nodebalancers/"
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         className="h-u"
       >
@@ -45,6 +46,7 @@ const EmptyCopy = () => (
       <a
         href="https://www.linode.com/docs/"
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         className="h-u"
       >

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyDrawer.tsx
@@ -112,6 +112,7 @@ export const AccessKeyDrawer: React.StatelessComponent<
                   <a
                     href="https://linode.com/docs/platform/object-storage/how-to-use-object-storage/#object-storage-tools"
                     target="_blank"
+                    aria-describedby="external-site"
                     rel="noopener noreferrer"
                     className="h-u"
                   >

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -144,6 +144,7 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
         <a
           href="https://www.linode.com/docs/platform/object-storage/lifecycle-policies/"
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
         >
           delete all objects
@@ -152,6 +153,7 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
         <a
           href="https://www.linode.com/docs/platform/object-storage/how-to-use-object-storage/#object-storage-tools"
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
         >
           another tool
@@ -264,6 +266,7 @@ const EmptyCopy = () => (
       <a
         href="https://linode.com/docs/platform/object-storage"
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         className="h-u"
       >

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketTableRow.tsx
@@ -68,6 +68,7 @@ export const BucketTableRow: React.StatelessComponent<
               className={classes.link}
               href={`https://${hostname}`}
               target="_blank"
+              aria-describedby="external-site"
               rel="noopener noreferrer"
               data-qa-hostname
             >

--- a/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
+++ b/packages/manager/src/features/StackScripts/StackScriptBase/StackScriptBase.tsx
@@ -582,6 +582,7 @@ const withStackScriptBase = (isSelecting: boolean) => (
         <a
           href="https://linode.com/docs/platform/stackscripts-new-manager/"
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
           className="h-u"
         >
@@ -591,6 +592,7 @@ const withStackScriptBase = (isSelecting: boolean) => (
         <a
           href="https://www.linode.com/docs/"
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
           className="h-u"
         >

--- a/packages/manager/src/features/Support/Hively.tsx
+++ b/packages/manager/src/features/Support/Hively.tsx
@@ -73,6 +73,7 @@ export const Hively: React.FC<Props> = props => {
           className={classes.hivelyLink}
           href={href + '3'}
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
         >
           How did I do?
@@ -82,6 +83,7 @@ export const Hively: React.FC<Props> = props => {
         <a
           href={href + '3'}
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
           className={classes.hivelyLinkIcon}
         >
@@ -96,6 +98,7 @@ export const Hively: React.FC<Props> = props => {
         <a
           href={href + '2'}
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
           className={classes.hivelyLinkIcon}
         >
@@ -110,6 +113,7 @@ export const Hively: React.FC<Props> = props => {
         <a
           href={href + '1'}
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
           className={classes.hivelyLinkIcon}
         >

--- a/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/MarkdownReference.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/TabbedReply/MarkdownReference.tsx
@@ -40,6 +40,7 @@ const MarkdownReference: React.FC<CombinedProps> = props => {
         {props.isReply ? 'reply' : 'question'}. For more examples see this
         <a
           target="_blank"
+          aria-describedby="external-site"
           rel="noopener noreferrer"
           href="http://demo.showdownjs.com/"
         >

--- a/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
+++ b/packages/manager/src/features/Support/SupportTickets/SupportTicketDrawer.tsx
@@ -485,7 +485,15 @@ export class SupportTicketDrawer extends React.Component<CombinedProps, State> {
               {`We love our customers, and we're here to help if you need us.
           Please keep in mind that not all topics are within the scope of our support.
           For overall system status, please see `}
-              <a href="https://status.linode.com">status.linode.com</a>.
+              <a
+                href="https://status.linode.com"
+                target="_blank"
+                aria-describedby="external-site"
+                rel="noopener noreferrer"
+              >
+                status.linode.com
+              </a>
+              .
             </Typography>
 
             {this.props.hideProductSelection ? null : (

--- a/packages/manager/src/features/TopMenu/UserNotificationsMenu/UserNotificationsMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserNotificationsMenu/UserNotificationsMenu.tsx
@@ -77,6 +77,7 @@ const userAgentDetection = () => {
           <a
             href="https://www.microsoft.com/en-us/windows/microsoft-edge"
             target="_blank"
+            aria-describedby="external-site"
             rel="noopener noreferrer"
           >
             Microsoft Edge

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -628,6 +628,7 @@ const EmptyCopy = () => (
       <a
         href="https://linode.com/docs/platform/block-storage/how-to-use-block-storage-with-your-linode-new-manager/"
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         className="h-u"
       >
@@ -637,6 +638,7 @@ const EmptyCopy = () => (
       <a
         href="https://www.linode.com/docs/"
         target="_blank"
+        aria-describedby="external-site"
         rel="noopener noreferrer"
         className="h-u"
       >

--- a/packages/manager/src/features/linodes/CloneLanding/Details.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/Details.tsx
@@ -272,6 +272,7 @@ export const Configs: React.FC<Props> = props => {
           <a
             href={errorMessageLinks.shrink}
             target="_blank"
+            aria-describedby="external-site"
             rel="noopener noreferrer"
           >
             Shrink your existing disks
@@ -280,6 +281,7 @@ export const Configs: React.FC<Props> = props => {
           <a
             href={errorMessageLinks.resize}
             target="_blank"
+            aria-describedby="external-site"
             rel="noopener noreferrer"
           >
             resize your Linode to a larger plan.

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectPlanPanel.tsx
@@ -307,6 +307,7 @@ export class SelectPlanPanel extends React.Component<
           <a
             href="https://www.linode.com/docs/platform/linode-gpu/getting-started-with-gpu/"
             target="_blank"
+            aria-describedby="external-site"
             rel="noopener noreferrer"
           >
             {` `}Here is a guide

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/LinodeControls.tsx
@@ -140,6 +140,7 @@ const LinodeControls: React.StatelessComponent<CombinedProps> = props => {
           disableFocusRipple={true}
           disableRipple={true}
           disabled={disabled}
+          aria-describedby="new-window"
         >
           Launch Console
         </Button>

--- a/packages/manager/src/features/linodes/LinodesDetail/MutateDrawer/MutateDrawer.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/MutateDrawer/MutateDrawer.tsx
@@ -177,7 +177,12 @@ class MutateDrawer extends React.Component<CombinedProps, State> {
          */}
         <Typography style={{ display: 'none' }}>
           {`Need help? Refer to the `}
-          <a href="google.com" target="_blank" rel="noopener noreferrer">
+          <a
+            href="google.com"
+            target="_blank"
+            aria-describedby="external-site"
+            rel="noopener noreferrer"
+          >
             supporting documentation
           </a>
           .

--- a/packages/manager/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -136,7 +136,7 @@ export class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     return (
       <div className={`${classes.ipLink}`} data-qa-copy-ip>
         <CopyTooltip
-          text={ip}
+          text={`Copy IP Address ${ip} to clipboard`}
           className={`${classes.icon} ${showCopyOnHover ? classes.hide : ''}
             ${copyRight ? classes.right : classes.left} copy`}
         />

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeActionMenu.tsx
@@ -146,6 +146,7 @@ export class LinodeActionMenu extends React.Component<CombinedProps, State> {
             e.preventDefault();
             e.stopPropagation();
           },
+          ariaDescribedBy: 'new-window',
           ...readOnlyProps
         },
         {

--- a/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/LinodeCard.tsx
@@ -232,6 +232,7 @@ export class LinodeCard extends React.PureComponent<CombinedProps> {
             <Button
               className={`${classes.button} ${classes.consoleButton}`}
               onClick={this.handleConsoleButtonClick}
+              aria-describedby="new-window"
               data-qa-console
             >
               Launch Console

--- a/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/ListLinodesEmptyState.tsx
@@ -99,6 +99,7 @@ class ListLinodesEmptyState extends React.Component<PropsWithStyles> {
             <a
               href="https://linode.com/docs/getting-started-new-manager/"
               target="_blank"
+              aria-describedby="external-site"
               rel="noopener noreferrer"
               className="h-u"
             >
@@ -108,6 +109,7 @@ class ListLinodesEmptyState extends React.Component<PropsWithStyles> {
             <a
               href="https://www.linode.com/docs/"
               target="_blank"
+              aria-describedby="external-site"
               rel="noopener noreferrer"
               className="h-u"
             >

--- a/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/CautionNotice.tsx
@@ -70,6 +70,7 @@ const CautionNotice: React.FC<CombinedProps> = props => {
           <a
             href="https://linode.com/docs/networking/dns/configure-your-linode-for-reverse-dns/"
             target="_blank"
+            aria-describedby="external-site"
             rel="noopener noreferrer"
           >
             Configure Your Linode for Reverse DNS (rDNS).


### PR DESCRIPTION
M3-3641 Accessibility: Present users with friendly message for new window or external site

This PR helps users with screen readers know that they may be clicking on an external link and directed somewhere else, or that the focus is going to switch to a new window (ex: Lish)

## Type of Change
- Non breaking change ('update', 'change')