### PR TITLE
M3-3637: LV Styling adjustments for Firefox and Safari

### DIFF
--- a/packages/manager/src/components/EditableEntityLabel/EditableEntityLabel.tsx
+++ b/packages/manager/src/components/EditableEntityLabel/EditableEntityLabel.tsx
@@ -77,7 +77,7 @@ export const EditableEntityLabel: React.FC<Props> = props => {
         </Grid>
       )}
       <Grid item className="py0">
-        <Grid container direction="column">
+        <Grid container>
           <Grid item className="py0 px0">
             <EditableInput
               errorText={error}
@@ -94,7 +94,7 @@ export const EditableEntityLabel: React.FC<Props> = props => {
             />
           </Grid>
           {subText && !isEditing && (
-            <Grid item className="py0 px0">
+            <Grid item xs={12} className="py0 px0">
               <Typography variant="body2">{subText}</Typography>
             </Grid>
           )}

--- a/packages/manager/src/components/TableRow/TableRow.tsx
+++ b/packages/manager/src/components/TableRow/TableRow.tsx
@@ -21,6 +21,8 @@ type ClassNames = 'root' | 'selected' | 'withForcedIndex' | 'activeCaret';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
+      // Matching height of caret if selected for firefox
+      height: theme.spacing() === COMPACT_SPACING_UNIT ? 34 : 42,
       transition: theme.transitions.create(['background-color']),
       [theme.breakpoints.up('md')]: {
         '&:before': {
@@ -66,7 +68,8 @@ const styles = (theme: Theme) =>
       },
       '& td': {
         borderTopColor: theme.palette.primary.light,
-        borderBottomColor: theme.palette.primary.light
+        borderBottomColor: theme.palette.primary.light,
+        position: 'relative'
       }
     },
     activeCaret: {

--- a/packages/manager/src/components/TableRow/TableRow.tsx
+++ b/packages/manager/src/components/TableRow/TableRow.tsx
@@ -21,8 +21,6 @@ type ClassNames = 'root' | 'selected' | 'withForcedIndex' | 'activeCaret';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      // Matching height of caret if selected for firefox
-      height: theme.spacing() === COMPACT_SPACING_UNIT ? 34 : 42,
       transition: theme.transitions.create(['background-color']),
       [theme.breakpoints.up('md')]: {
         '&:before': {

--- a/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
+++ b/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
@@ -78,14 +78,14 @@ const InstallationInstructions: React.FC<CombinedProps> = props => {
           </Grid>
         </Grid>
       </Grid>
-      <Grid item>
+      <Grid item xs={12}>
         <Typography>
           This should work for most installations, but if you have issues,
           please consult our troubleshooting guide and manual installation
           instructions (API key required):
         </Typography>
       </Grid>
-      <Grid item>
+      <Grid item xs={12}>
         <Grid container>
           <Grid item className={classes.instruction}>
             <Typography>

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -1245,7 +1245,7 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
           backfaceVisibility: 'hidden',
           position: 'relative',
           zIndex: 1,
-          height: spacingUnit * 6,
+          height: spacingUnit * 5 + 1,
           '&:before': {
             borderLeftColor: 'white'
           },


### PR DESCRIPTION
## Description

There were a couple visual items in safari and firefox that weren't consistent with chrome- this PR updates the following items:

• Safari entity label wrap issue on LV landing
• Safari Installation instructions text wrap issue
• Firefox and Safari inconsistencies with selected table row + caret on Processes table

## Type of Change
- Bug fix ('fix')

## Note to Reviewers

Please test in multiple browsers, breakpoints, etc. and take a look around to make sure there aren't any other visual discrepancies or regressions. 
