### PR TITLE
M3-3624 Move events polling interval out of Redux

### DIFF
--- a/packages/manager/src/eventsPolling.ts
+++ b/packages/manager/src/eventsPolling.ts
@@ -1,0 +1,16 @@
+import { INTERVAL } from 'src/constants';
+
+let interval = 1;
+let deadline = Date.now();
+export const resetEventsPolling = (newInterval: number = 1) => {
+  deadline = Date.now() + INTERVAL * newInterval;
+  interval = newInterval;
+};
+
+export const setRequestDeadline = (newDeadline: number) =>
+  (deadline = newDeadline);
+export const setPollingInterval = (newInterval: number) =>
+  (interval = newInterval);
+
+export const getRequestDeadline = () => deadline;
+export const getPollingInterval = () => interval;

--- a/packages/manager/src/features/Images/ImagesDrawer.tsx
+++ b/packages/manager/src/features/Images/ImagesDrawer.tsx
@@ -17,7 +17,7 @@ import Drawer from 'src/components/Drawer';
 import Notice from 'src/components/Notice';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import TextField from 'src/components/TextField';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import DiskSelect from 'src/features/linodes/DiskSelect';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
 import { getAPIErrorOrDefault } from 'src/utilities/errorUtils';

--- a/packages/manager/src/features/Volumes/ListGroupedVolumes.tsx
+++ b/packages/manager/src/features/Volumes/ListGroupedVolumes.tsx
@@ -15,7 +15,7 @@ import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import RenderVolumeData, { RenderVolumeDataProps } from './RenderVolumeData';
-import { ExtendedVolume } from './VolumesLanding';
+import { ExtendedVolume } from './types';
 import TableWrapper from './VolumeTableWrapper';
 
 const DEFAULT_PAGE_SIZE = 25;
@@ -72,7 +72,7 @@ interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const ListGroupedDomains: React.FC<CombinedProps> = props => {
+const ListGroupedVolumes: React.FC<CombinedProps> = props => {
   const {
     data,
     order,
@@ -156,4 +156,4 @@ const ListGroupedDomains: React.FC<CombinedProps> = props => {
 
 const styled = withStyles(styles);
 
-export default styled(ListGroupedDomains);
+export default styled(ListGroupedVolumes);

--- a/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
+++ b/packages/manager/src/features/Volumes/VolumeAttachmentDrawer.tsx
@@ -17,7 +17,7 @@ import withVolumesRequests, {
   VolumesRequests
 } from 'src/containers/volumesRequests.container';
 import withLinodes from 'src/containers/withLinodes.container';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import LinodeSelect from 'src/features/linodes/LinodeSelect';
 import { isRestrictedUser } from 'src/features/Profile/permissionsHelpers';
 import { MapState } from 'src/store/types';

--- a/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/AttachVolumeToLinodeForm.tsx
@@ -8,7 +8,7 @@ import { compose } from 'recompose';
 import withVolumesRequests, {
   VolumesRequests
 } from 'src/containers/volumesRequests.container';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import { MapState } from 'src/store/types';
 import { openForCreating } from 'src/store/volumeForm';
 import {

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CloneVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CloneVolumeForm.tsx
@@ -6,7 +6,7 @@ import Typography from 'src/components/core/Typography';
 import withVolumesRequests, {
   VolumesRequests
 } from 'src/containers/volumesRequests.container';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import {
   handleFieldErrors,
   handleGeneralErrors

--- a/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/CreateVolumeForLinodeForm.tsx
@@ -19,7 +19,7 @@ import { MAX_VOLUME_SIZE } from 'src/constants';
 import withVolumesRequests, {
   VolumesRequests
 } from 'src/containers/volumesRequests.container';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import {
   hasGrant,
   isRestrictedUser

--- a/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumeForm.tsx
+++ b/packages/manager/src/features/Volumes/VolumeDrawer/ResizeVolumeForm.tsx
@@ -6,7 +6,7 @@ import Notice from 'src/components/Notice';
 import withVolumesRequests, {
   VolumesRequests
 } from 'src/containers/volumesRequests.container';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import {
   handleFieldErrors,
   handleGeneralErrors

--- a/packages/manager/src/features/Volumes/VolumeTableRow.tsx
+++ b/packages/manager/src/features/Volumes/VolumeTableRow.tsx
@@ -15,8 +15,8 @@ import Grid from 'src/components/Grid';
 import LinearProgress from 'src/components/LinearProgress';
 import TableCell from 'src/components/TableCell';
 import { formatRegion } from 'src/utilities';
+import { ExtendedVolume } from './types';
 import VolumesActionMenu from './VolumesActionMenu';
-import { ExtendedVolume } from './VolumesLanding';
 
 type ClassNames =
   | 'root'

--- a/packages/manager/src/features/Volumes/VolumesLanding.tsx
+++ b/packages/manager/src/features/Volumes/VolumesLanding.tsx
@@ -36,7 +36,7 @@ import withLinodes, {
   Props as WithLinodesProps
 } from 'src/containers/withLinodes.container';
 import { BlockStorage } from 'src/documentation';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import LinodePermissionsError from 'src/features/linodes/LinodesDetail/LinodePermissionsError';
 import {
   LinodeOptions,
@@ -62,6 +62,7 @@ import withRegions, {
   DefaultProps as RegionProps
 } from 'src/containers/regions.container';
 import { doesRegionSupportBlockStorage } from 'src/utilities/doesRegionSupportBlockStorage';
+import { ExtendedVolume } from './types';
 
 type ClassNames =
   | 'root'
@@ -139,11 +140,6 @@ const styles = (theme: Theme) =>
       minWidth: 250
     }
   });
-
-export interface ExtendedVolume extends Volume {
-  linodeLabel?: string;
-  linodeStatus?: string;
-}
 
 interface Props {
   linodeId?: number;

--- a/packages/manager/src/features/Volumes/types.ts
+++ b/packages/manager/src/features/Volumes/types.ts
@@ -1,0 +1,6 @@
+import { Volume } from 'linode-js-sdk/lib/volumes';
+
+export interface ExtendedVolume extends Volume {
+  linodeLabel?: string;
+  linodeStatus?: string;
+}

--- a/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
+++ b/packages/manager/src/features/linodes/CloneLanding/CloneLanding.tsx
@@ -32,7 +32,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import Grid from 'src/components/Grid';
 import TabLink from 'src/components/TabLink';
 import withLinodes from 'src/containers/withLinodes.container';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import { ApplicationState } from 'src/store';
 import { getAllLinodeDisks } from 'src/store/linodes/disk/disk.requests';
 import { getErrorMap } from 'src/utilities/errorUtils';

--- a/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/LinodeCreateContainer.tsx
@@ -58,7 +58,7 @@ import {
   WithTypesProps
 } from './types';
 
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import {
   baseApps,
   getOneClickApps

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeConfigs.tsx
@@ -23,7 +23,7 @@ import Grid from 'src/components/Grid';
 import PaginationFooter from 'src/components/PaginationFooter';
 import PanelErrorBoundary from 'src/components/PanelErrorBoundary';
 import Table from 'src/components/Table';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import {
   DeleteLinodeConfig,
   withLinodeDetailContext

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeAdvanced/LinodeDisks.tsx
@@ -24,7 +24,7 @@ import Grid from 'src/components/Grid';
 import Notice from 'src/components/Notice';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import ImagesDrawer, { modes } from 'src/features/Images/ImagesDrawer';
 import {
   CreateLinodeDisk,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeBackup/LinodeBackup.tsx
@@ -52,7 +52,8 @@ import PromiseLoader, {
 import Table from 'src/components/Table';
 import TableCell from 'src/components/TableCell';
 import TextField from 'src/components/TextField';
-import { events$, resetEventsPolling } from 'src/events';
+import { events$ } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import { linodeInTransition as isLinodeInTransition } from 'src/features/linodes/transitions';
 import {
   LinodeActionsProps,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromImage.tsx
@@ -23,7 +23,7 @@ import Grid from 'src/components/Grid';
 import ImageSelect from 'src/components/ImageSelect';
 import Notice from 'src/components/Notice';
 import withImages, { WithImages } from 'src/containers/withImages.container';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import userSSHKeyHoc, {
   UserSSHKeyProps
 } from 'src/features/linodes/userSSHKeyHoc';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRebuild/RebuildFromStackScript.tsx
@@ -25,7 +25,7 @@ import Grid from 'src/components/Grid';
 import ImageSelect from 'src/components/ImageSelect';
 import Notice from 'src/components/Notice';
 import withImages, { WithImages } from 'src/containers/withImages.container';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import userSSHKeyHoc, {
   UserSSHKeyProps
 } from 'src/features/linodes/userSSHKeyHoc';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeRescue/LinodeRescue.tsx
@@ -21,7 +21,7 @@ import { DocumentTitleSegment } from 'src/components/DocumentTitle';
 import ErrorState from 'src/components/ErrorState';
 import SectionErrorBoundary from 'src/components/SectionErrorBoundary';
 import withVolumes from 'src/containers/volumes.container';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
 import { MapState } from 'src/store/types';
 import createDevicesFromStrings, {

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeResize/LinodeResize.tsx
@@ -24,7 +24,7 @@ import {
 } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 import { DocumentTitleSegment } from 'src/components/DocumentTitle';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import SelectPlanPanel, {
   ExtendedType
 } from 'src/features/linodes/LinodesCreate/SelectPlanPanel';

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSettings/LinodeSettingsDeletePanel.tsx
@@ -9,7 +9,7 @@ import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
 import ExpansionPanel from 'src/components/ExpansionPanel';
 import PanelErrorBoundary from 'src/components/PanelErrorBoundary';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import { withLinodeDetailContext } from 'src/features/linodes/LinodesDetail/linodeDetailContext';
 import {
   LinodeActionsProps,

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodesDetailHeader/MutationNotification.tsx
@@ -18,7 +18,7 @@ import {
   WithStyles
 } from 'src/components/core/styles';
 import Notice from 'src/components/Notice';
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import { ApplicationState } from 'src/store';
 import { requestLinodeForStore } from 'src/store/linodes/linode.requests';
 import {

--- a/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
+++ b/packages/manager/src/features/linodes/MigrateLanding/MigrateLanding.tsx
@@ -28,7 +28,7 @@ import LinodeControls from '../LinodesDetail/LinodesDetailHeader/LinodeControls'
 import Notifications from '../LinodesDetail/LinodesDetailHeader/Notifications';
 import LinodeBusyStatus from '../LinodesDetail/LinodeSummary/LinodeBusyStatus';
 
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import { displayType } from 'src/features/linodes/presentation';
 import { ApplicationState } from 'src/store';
 import getLinodeDescription from 'src/utilities/getLinodeDescription';

--- a/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
+++ b/packages/manager/src/features/linodes/PowerActionsDialogOrDrawer.tsx
@@ -13,7 +13,7 @@ import Button from 'src/components/Button';
 import Dialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
 
-import { resetEventsPolling } from 'src/events';
+import { resetEventsPolling } from 'src/eventsPolling';
 import LinodeConfigDrawer from 'src/features/LinodeConfigSelectionDrawer';
 
 export type Action = 'Reboot' | 'Power Off' | 'Power On';

--- a/packages/manager/src/store/events/event.helpers.ts
+++ b/packages/manager/src/store/events/event.helpers.ts
@@ -6,27 +6,12 @@ import {
 } from 'linode-js-sdk/lib/account';
 import * as moment from 'moment';
 import { compose, equals, findIndex, omit, take, update } from 'ramda';
-import { ThunkDispatch } from 'redux-thunk';
-import { INTERVAL } from 'src/constants';
 import updateRight from 'src/utilities/updateRight';
 
-import { setPollingInterval, setRequestDeadline } from './event.actions';
 import { EntityEvent, ExtendedEvent } from './event.types';
 
 /** We use the epoch on our initial request to get all of the users events. */
 export const epoch = new Date(`1970-01-01T00:00:00.000`).getTime();
-
-export const resetEventsPolling = (
-  dispatch: ThunkDispatch<any, any, any>,
-  newInterval: number = 1
-) => {
-  // 16 is the max, so no sense dispatching these actions if we're already there.
-  if (newInterval >= 16) {
-    return;
-  }
-  dispatch(setRequestDeadline(Date.now() + INTERVAL * newInterval));
-  dispatch(setPollingInterval(newInterval));
-};
 
 /**
  * isRelevantDeletionEvent

--- a/packages/manager/src/store/middleware/combineEventsMiddleware.ts
+++ b/packages/manager/src/store/middleware/combineEventsMiddleware.ts
@@ -1,5 +1,6 @@
 import { compose, equals, uniqWith } from 'ramda';
 import { Middleware } from 'redux';
+import { resetEventsPolling } from 'src/eventsPolling';
 import {
   isEntityEvent,
   isInProgressEvent
@@ -7,7 +8,6 @@ import {
 import { EventHandler } from 'src/store/types';
 import { isType } from 'typescript-fsa';
 import { addEvents } from '../events/event.actions';
-import { resetEventsPolling } from '../events/event.helpers';
 import { ExtendedEvent } from '../events/event.types';
 
 const eventsMiddlewareFactory = (
@@ -54,7 +54,7 @@ const eventsMiddlewareFactory = (
        */
       if (isInProgressEvent(event)) {
         // If the event is in_progress, we poll more aggressively
-        resetEventsPolling(dispatch);
+        resetEventsPolling();
       }
     }
   }


### PR DESCRIPTION
## Description

- I previously moved setRequestDeadline, setPollingInterval and related
logic out of events.ts, because this had resulted in a circular dependency
(events imports the store which imports some of the methods above). Unfortunately,
this resulted in a bug where anything that subscribed to the events state in Redux
would render constantly as the polling interval was updated.

To try to avoid both issues, I created a new file at src/eventsPolling
that includes getters and setters for the variables in question.

- Resolved a circular dependency where ExtendedVolume was being imported
from child components.

- Fixed a typo in GroupedVolumes

## Note to Reviewers

Uncomment the console stuff in `src/eventsPolling.ts` to verify that the updating is happening as planned.