### PR TITLE
M3-3525 overview graphs phase 2

### DIFF
--- a/packages/linode-js-sdk/src/managed/types.ts
+++ b/packages/linode-js-sdk/src/managed/types.ts
@@ -106,7 +106,7 @@ export interface IssueEntity {
 
 export interface DataSeries {
   x: number;
-  y: number;
+  y: number | null;
 }
 
 export interface ManagedStatsData {

--- a/packages/manager/src/components/LineGraph/LineGraph.tsx
+++ b/packages/manager/src/components/LineGraph/LineGraph.tsx
@@ -15,7 +15,8 @@ export interface DataSet {
   // the first number will be a UTC data and the second will be the amount per second
   fill?: boolean | string;
   backgroundColor?: string;
-  data: [number, number][];
+  // Both x and y can be null, but in our use cases x never will be.
+  data: [number, number | null][];
 }
 
 export interface Props {

--- a/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedChartPanel.tsx
+++ b/packages/manager/src/features/Dashboard/ManagedDashboardCard/ManagedChartPanel.tsx
@@ -79,7 +79,7 @@ type CombinedProps = Props & WithTheme;
 
 const chartHeight = 300;
 
-const formatData = (value: DataSeries[]): [number, number][] =>
+const formatData = (value: DataSeries[]): [number, number | null][] =>
   value.map(thisPoint => [thisPoint.x, thisPoint.y]);
 
 const createTabs = (

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs.tsx
@@ -207,6 +207,25 @@ export const convertData = (start: number, d: Stat[]) => {
    * Using null as the y value makes the intervening section of the
    * graph blank, which is the behavior we need.
    *
+   * In order to determine whether or not we should add this dummy
+   * point, we calculate based on a 5 minute interval, since that
+   * is the interval at which Longview stats are returned (see below).
+   *
+   * EXAMPLE 1:
+   *
+   * I installed LV on my Linode 10 minutes ago. I ask for 30 minutes of data.
+   * The data series will look something like:
+   * [[<9 minutes ago>, Y], [<4 minutes ago>, Y]]
+   * So we add the [<30 minutes ago>, null] point at the beginning to
+   * force the X axis to start in the right place.
+   *
+   * EXAMPLE 2:
+   * My Linode has been turned on for 2 hours.
+   * If I request 30 minutes of data, I see a series like this:
+   * [[<27 minutes ago, Y], [<22 minutes ago, Y], [<17 minutes ago, Y], [<12 minutes ago, Y], [<7 minutes ago, Y], [<2 minutes ago, Y]]
+   * If I were to request an hour of data, I’d see that the next point is from 32 minutes ago.
+   * Without the check, we’d stick a null at 30 minutes ago, so it’d look like there was no data during that time.
+   *
    * NOTE: The calculation below is using 5 minutes as the increment,
    * since this seems to be the normal behavior, even when using
    * an account with a Longview Pro subscription. If this

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs.tsx
@@ -58,6 +58,8 @@ export const OverviewGraphs: React.FC<CombinedProps> = props => {
     request(start, end);
   };
 
+  const isToday = time.end - time.start < 60 * 60 * 25;
+
   return (
     <Grid container alignItems="flex-end" item xs={12} spacing={0}>
       <Grid
@@ -102,7 +104,7 @@ export const OverviewGraphs: React.FC<CombinedProps> = props => {
               <LongviewLineGraph
                 title="Memory"
                 subtitle="GB"
-                showToday={true}
+                showToday={isToday}
                 timezone="GMT"
                 data={[
                   {
@@ -166,7 +168,7 @@ export const OverviewGraphs: React.FC<CombinedProps> = props => {
               <LongviewLineGraph
                 title="Load"
                 subtitle="Target < 1.00"
-                showToday={true}
+                showToday={isToday}
                 timezone="GMT"
                 data={[
                   {

--- a/packages/manager/src/features/Longview/request.types.ts
+++ b/packages/manager/src/features/Longview/request.types.ts
@@ -1,6 +1,12 @@
 export interface Stat {
+  /**
+   * Technically both can be null,
+   * but in all of our graphs the x
+   * axis is time, which should never
+   * be null.
+   */
   x: number;
-  y: number;
+  y: number | null;
 }
 
 interface FS {


### PR DESCRIPTION
## Description

Longview graph data does not include forward padding for time intervals
longer than the available data range (if you ask for a start time
of 7 days ago but your Linode is new and only has 20 minutes of data,
you just get the 20 minutes). This causes our charts components to
set the X axis as 20 minutes. We can avoid this by adding a [startTime, null]
point to the beginning of the series.

This introduces some complications, though, when for example you're asking
for 30 minutes of data but the first point is 27 minutes ago. This should
be a smooth chart (there's probably a data point from ~32 minutes ago with
similar data) but our trick will add a gap to the start of the chart. To handle
this, we're checking if the difference between the indicated start time and
the first data point returned from the LV API is > 5 minutes. This may
not work for Longview Pro clients, although in my testing the resolution
is still 5 minutes.

Additionally, moved the data formatting function in OverviewGraphs
to a React.useCallback so that we can avoid calling it too often.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

I also tried manually setting the x axis ticks/scale etc. but the behavior didn't match this solution, which looks just like classic and responds as you'd expect.