### PR TITLE
[LV] Open packages drawer from LV overview tab

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/IconSection.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/IconSection.tsx
@@ -258,7 +258,7 @@ const IconSection: React.FC<Props> = props => {
               SideIcon={PackageIcon}
               text={packagesToUpdate}
               title={packagesToUpdate}
-              onClick={() => props.openPackageDrawer()}
+              onClick={props.openPackageDrawer}
             >
               {packagesToUpdate}
             </IconTextLink>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/IconSection.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/IconSection.tsx
@@ -55,6 +55,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   client: string;
   longviewClientData: LVDataProps['longviewClientData'];
+  openPackageDrawer: () => void;
 }
 
 const IconSection: React.FC<Props> = props => {
@@ -257,7 +258,7 @@ const IconSection: React.FC<Props> = props => {
               SideIcon={PackageIcon}
               text={packagesToUpdate}
               title={packagesToUpdate}
-              onClick={() => window.open('#')}
+              onClick={() => props.openPackageDrawer()}
             >
               {packagesToUpdate}
             </IconTextLink>

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
@@ -8,6 +8,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Grid from 'src/components/Grid';
 import { Props as LVDataProps } from 'src/containers/longview.stats.container';
 
+import LongviewPackageDrawer from '../../LongviewPackageDrawer';
 import ActiveConnections from './ActiveConnections';
 import GaugesSection from './GaugesSection';
 import IconSection from './IconSection';
@@ -62,6 +63,12 @@ export const LongviewDetailOverview: React.FC<CombinedProps> = props => {
   } = props;
 
   /**
+   * Package drawer open/close logic
+   */
+
+  const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
+
+  /**
    * Show an error for the services/connections
    * tables if the request errors, or if there is
    * a lastUpdated error (which will happen in the
@@ -88,6 +95,7 @@ export const LongviewDetailOverview: React.FC<CombinedProps> = props => {
               <IconSection
                 longviewClientData={longviewClientData}
                 client={client}
+                openPackageDrawer={() => setDrawerOpen(true)}
               />
               <GaugesSection
                 clientID={clientID}
@@ -116,6 +124,12 @@ export const LongviewDetailOverview: React.FC<CombinedProps> = props => {
           />
         </Grid>
       </Grid>
+      <LongviewPackageDrawer
+        clientLabel={client}
+        clientID={clientID}
+        isOpen={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+      />
     </React.Fragment>
   );
 };


### PR DESCRIPTION
## Description

You could already open the drawer from /longview/clients, now you can open it from the overview section too