### PR TITLE
M3-3245 "Show All" on Linodes Landing

### DIFF
--- a/packages/manager/src/components/Paginate.ts
+++ b/packages/manager/src/components/Paginate.ts
@@ -11,6 +11,10 @@ const createDiplayPage = <T extends any>(page: number, pageSize: number) => (
     return list;
   }
 
+  if (pageSize === Infinity) {
+    return list;
+  }
+
   const pages = Math.ceil(count / pageSize);
   const currentPage = clamp(1, pages, page);
   const startIndex = (currentPage - 1) * pageSize;
@@ -37,12 +41,13 @@ interface Props {
   page?: number;
   pageSize?: number;
   scrollToRef?: React.RefObject<any>;
+  pageSizeSetter?: (v: number) => void;
 }
 
 export default class Paginate extends React.Component<Props, State> {
   state: State = {
     page: this.props.page || 1,
-    pageSize: storage.pageSize.get() || 25
+    pageSize: this.props.pageSize || storage.pageSize.get()
   };
 
   handlePageChange = (page: number) => {
@@ -53,7 +58,12 @@ export default class Paginate extends React.Component<Props, State> {
 
   handlePageSizeChange = (pageSize: number) => {
     this.setState({ pageSize });
-    storage.pageSize.set(pageSize);
+    // Use the custom setter if one has been supplied.
+    if (this.props.pageSizeSetter) {
+      this.props.pageSizeSetter(pageSize);
+    } else {
+      storage.pageSize.set(pageSize);
+    }
   };
 
   render() {

--- a/packages/manager/src/components/Paginate.ts
+++ b/packages/manager/src/components/Paginate.ts
@@ -47,7 +47,7 @@ interface Props {
 export default class Paginate extends React.Component<Props, State> {
   state: State = {
     page: this.props.page || 1,
-    pageSize: this.props.pageSize || storage.pageSize.get()
+    pageSize: this.props.pageSize || storage.pageSize.get() || 25
   };
 
   handlePageChange = (page: number) => {

--- a/packages/manager/src/components/Paginate.ts
+++ b/packages/manager/src/components/Paginate.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import scrollTo from 'src/utilities/scrollTo';
 import { storage } from 'src/utilities/storage';
 
-const createDiplayPage = <T extends any>(page: number, pageSize: number) => (
+const createDisplayPage = <T extends any>(page: number, pageSize: number) => (
   list: T[]
 ): T[] => {
   const count = list.length;
@@ -67,7 +67,7 @@ export default class Paginate extends React.Component<Props, State> {
   };
 
   render() {
-    const view = createDiplayPage(this.state.page, this.state.pageSize);
+    const view = createDisplayPage(this.state.page, this.state.pageSize);
 
     const props = {
       ...this.props,

--- a/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
+++ b/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
@@ -82,6 +82,10 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
       return eachOption.value === pageSize;
     });
 
+    const isShowingAll = defaultPagination
+      ? defaultPagination.label === 'Show All'
+      : false;
+
     return (
       <Grid
         container
@@ -93,13 +97,15 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
         })}
       >
         <Grid item>
-          <PaginationControls
-            onClickHandler={handlePageChange}
-            page={finalPage}
-            count={count}
-            pageSize={finalPageSize}
-            eventCategory={eventCategory}
-          />
+          {!isShowingAll && (
+            <PaginationControls
+              onClickHandler={handlePageChange}
+              page={finalPage}
+              count={count}
+              pageSize={finalPageSize}
+              eventCategory={eventCategory}
+            />
+          )}
         </Grid>
         <Grid item>
           <Select

--- a/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
+++ b/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
@@ -27,6 +27,7 @@ export interface PaginationProps {
   page: number;
   pageSize: number;
   eventCategory: string;
+  showAll?: boolean;
 }
 
 interface Props extends PaginationProps {
@@ -37,7 +38,7 @@ interface Props extends PaginationProps {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const options = [
+const baseOptions = [
   { label: 'Show 25', value: 25 },
   { label: 'Show 50', value: 50 },
   { label: 'Show 75', value: 75 },
@@ -55,14 +56,29 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
       pageSize,
       handlePageChange,
       padded,
-      eventCategory
+      eventCategory,
+      showAll
     } = this.props;
 
     if (count <= 25) {
       return null;
     }
 
-    const defaultPagination = options.find(eachOption => {
+    const finalOptions = [...baseOptions];
+    // Add "Show All" to the list of options if the consumer has so specified.
+    if (showAll) {
+      finalOptions.push({ label: 'Show All', value: Infinity });
+    }
+
+    // If the user has selected "Show All", the page size should be set to the
+    // total number of elements.
+    const finalPageSize = pageSize === Infinity ? count : pageSize;
+
+    // If the user has selected "Show All", the selected page should be `1`
+    // since there is only one page.
+    const finalPage = pageSize === Infinity ? 1 : page;
+
+    const defaultPagination = finalOptions.find(eachOption => {
       return eachOption.value === pageSize;
     });
 
@@ -79,15 +95,15 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
         <Grid item>
           <PaginationControls
             onClickHandler={handlePageChange}
-            page={page}
+            page={finalPage}
             count={count}
-            pageSize={pageSize}
+            pageSize={finalPageSize}
             eventCategory={eventCategory}
           />
         </Grid>
         <Grid item>
           <Select
-            options={options}
+            options={finalOptions}
             defaultValue={defaultPagination}
             onChange={this.handleSizeChange}
             isClearable={false}

--- a/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
+++ b/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
@@ -70,21 +70,12 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
       finalOptions.push({ label: 'Show All', value: Infinity });
     }
 
-    // If the user has selected "Show All", the page size should be set to the
-    // total number of elements.
-    const finalPageSize = pageSize === Infinity ? count : pageSize;
-
-    // If the user has selected "Show All", the selected page should be `1`
-    // since there is only one page.
-    const finalPage = pageSize === Infinity ? 1 : page;
-
     const defaultPagination = finalOptions.find(eachOption => {
       return eachOption.value === pageSize;
     });
 
-    const isShowingAll = defaultPagination
-      ? defaultPagination.label === 'Show All'
-      : false;
+    // If "Show All" is currently selected, pageSize is `Infinity`.
+    const isShowingAll = pageSize === Infinity;
 
     return (
       <Grid
@@ -100,9 +91,9 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
           {!isShowingAll && (
             <PaginationControls
               onClickHandler={handlePageChange}
-              page={finalPage}
+              page={page}
               count={count}
-              pageSize={finalPageSize}
+              pageSize={pageSize}
               eventCategory={eventCategory}
             />
           )}

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -19,6 +19,7 @@ import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import TableWrapper from './TableWrapper';
 
 import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
+import { storage } from 'src/utilities/storage';
 
 const DEFAULT_PAGE_SIZE = 25;
 
@@ -106,6 +107,8 @@ const DisplayGroupedLinodes: React.StatelessComponent<
     someLinodesHaveMaintenance: props.someLinodesHaveMaintenance
   };
 
+  const storedPageSize = React.useMemo(storage.linodePageSize.get, []);
+
   if (display === 'grid') {
     return (
       <>
@@ -129,7 +132,11 @@ const DisplayGroupedLinodes: React.StatelessComponent<
                   </div>
                 </Grid>
               </Grid>
-              <Paginate data={linodes} pageSize={DEFAULT_PAGE_SIZE}>
+              <Paginate
+                data={linodes}
+                pageSize={storedPageSize}
+                pageSizeSetter={storage.linodePageSize.set}
+              >
                 {({
                   data: paginatedData,
                   handlePageChange,
@@ -160,6 +167,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<
                           pageSize={pageSize}
                           page={page}
                           eventCategory={'linodes landing'}
+                          showAll
                         />
                       </Grid>
                     </React.Fragment>
@@ -179,7 +187,11 @@ const DisplayGroupedLinodes: React.StatelessComponent<
         {orderedGroupedLinodes.map(([tag, linodes]) => {
           return (
             <React.Fragment key={tag}>
-              <Paginate data={linodes} pageSize={DEFAULT_PAGE_SIZE}>
+              <Paginate
+                data={linodes}
+                pageSize={storedPageSize}
+                pageSizeSetter={storage.linodePageSize.set}
+              >
                 {({
                   data: paginatedData,
                   handlePageChange,
@@ -230,6 +242,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<
                                 pageSize={pageSize}
                                 page={page}
                                 eventCategory={'linodes landing'}
+                                showAll
                               />
                             </TableCell>
                           </TableRow>

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -8,6 +8,7 @@ import PaginationFooter from 'src/components/PaginationFooter';
 import TableWrapper from './TableWrapper';
 
 import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
+import { storage } from 'src/utilities/storage';
 
 interface Props {
   openDeleteDialog: (linodeID: number, linodeLabel: string) => void;
@@ -36,8 +37,14 @@ const DisplayLinodes: React.StatelessComponent<CombinedProps> = props => {
     ...rest
   } = props;
 
+  const storedPageSize = React.useMemo(storage.linodePageSize.get, []);
+
   return (
-    <Paginate data={data}>
+    <Paginate
+      data={data}
+      pageSize={storedPageSize}
+      pageSizeSetter={storage.linodePageSize.set}
+    >
       {({
         data: paginatedData,
         handlePageChange,
@@ -78,6 +85,7 @@ const DisplayLinodes: React.StatelessComponent<CombinedProps> = props => {
                   pageSize={pageSize}
                   page={page}
                   eventCategory={'linodes landing'}
+                  showAll
                 />
               }
             </Grid>

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -38,6 +38,7 @@ export const setStorage = (key: string, value: string) => {
 };
 
 const PAGE_SIZE = 'PAGE_SIZE';
+const LINODE_PAGE_SIZE = 'LINODE_PAGE_SIZE';
 const HIDE_DISPLAY_GROUPS_CTA = 'importDisplayGroupsCTA';
 const HAS_IMPORTED_GROUPS = 'hasImportedGroups';
 const BACKUPSCTA_DISMISSED = 'BackupsCtaDismissed';
@@ -61,6 +62,10 @@ export interface Storage {
     expire: AuthGetAndSet;
   };
   pageSize: {
+    get: () => PageSize;
+    set: (perPage: PageSize) => void;
+  };
+  linodePageSize: {
     get: () => PageSize;
     set: (perPage: PageSize) => void;
   };
@@ -102,6 +107,19 @@ export const storage: Storage = {
       return parseInt(getStorage(PAGE_SIZE, '25'), 10);
     },
     set: v => setStorage(PAGE_SIZE, `${v}`)
+  },
+  // Page Size of Linodes Landing page.
+  linodePageSize: {
+    get: () => {
+      // For backwards compatibility, we'll fall back to the value of PAGE_SIZE.
+      // If that doesn't exist, we use '25' as a second fallback.
+      const fallback = parseInt(getStorage(PAGE_SIZE, '25'), 10);
+
+      // I used Number() instead of parseInt() here because parseInt() does not
+      // parse the string "Infinity" as a Number.
+      return Number(getStorage(LINODE_PAGE_SIZE, fallback));
+    },
+    set: v => setStorage(LINODE_PAGE_SIZE, `${v}`)
   },
   hideGroupImportCTA: {
     get: () => getStorage(HIDE_DISPLAY_GROUPS_CTA),


### PR DESCRIPTION
## Description

This PR introduces a "Show All" option so it is possible to view more than 100 Linodes.

I'm marking this as a POC because there are severe performance penalties for trying to render too many Linode Rows to the screen. It's not a matter of handling re-renders... it's the initial render that takes longer than is acceptable.

We could explore using a virtualized window to solve this, but in my estimation that would be a huge effort, especially since there are several ways we display Linodes (Grouped, List, Grid). Similarly, we could explore an infinite scrolling mechanism so that not all Linodes are rendered to the DOM at once.

I'm open to thoughts from the gallery here. The original intent is to better enable CTRL-F searching, but maybe our search bar is enough and we should promote it more.

⚠️  **EDIT:** Using a proper build speeds things up considerably, so have a look at the PR build in addition to running locally before making up your mind.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

The handling of page size in local storage is inconsistent. The PAGE_SIZE attribute is used in many places. I wanted to avoid polluting this attribute with new functionality, so I created a new key, LINODE_PAGE_SIZE. If "Show All" is selected, this will have a value of `Infinity`, which the Paginate and PaginationFooter components now know how to handle.

Use prod test account 1 for an account with many Linodes. Please try different views (Grouped-List, Grouped-Grid, List, Grid).
