### PR TITLE
Make search bar case-insensitive

### DIFF
--- a/packages/manager/src/features/Search/refinedSearch.test.ts
+++ b/packages/manager/src/features/Search/refinedSearch.test.ts
@@ -164,10 +164,6 @@ describe('Refined Search', () => {
       query = 'label:test-linode ORR';
       results = refinedSearch(query, data).map(entity => entity.value);
       expect(results).toEqual([]);
-
-      query = 'label:test-linode O';
-      results = refinedSearch(query, data).map(entity => entity.value);
-      expect(results).toEqual([]);
     });
   });
 });
@@ -343,6 +339,16 @@ describe('doesSearchTermMatchItemField', () => {
       false
     );
     expect(doesSearchTermMatchItemField('12', mockLinode, 'ips')).toBe(true);
+  });
+  it('is case-insensitive by default', () => {
+    expect(doesSearchTermMatchItemField('MY-APP', mockLinode, 'tags')).toBe(
+      true
+    );
+  });
+  it('is case-sensitive if specified', () => {
+    expect(
+      doesSearchTermMatchItemField('MY-APP', mockLinode, 'tags', true)
+    ).toBe(false);
   });
 });
 

--- a/packages/manager/src/features/Search/refinedSearch.ts
+++ b/packages/manager/src/features/Search/refinedSearch.ts
@@ -146,13 +146,18 @@ export const searchDefaultFields = (item: SearchableItem, query: string) => {
 export const doesSearchTermMatchItemField = (
   query: string,
   item: SearchableItem,
-  field: string
+  field: string,
+  caseSensitive = false
 ): boolean => {
   const flattenedItem = flattenSearchableItem(item);
 
   const fieldValue = ensureValueIsString(flattenedItem[field]);
 
-  return fieldValue.includes(query);
+  if (caseSensitive) {
+    return fieldValue.includes(query);
+  } else {
+    return fieldValue.toLowerCase().includes(query.toLowerCase());
+  }
 };
 
 // Flattens the "data" prop so we can access all fields on the item root


### PR DESCRIPTION
## Description

Taken from user feedback. It probably makes more sense for queries to be case-insensitive.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

- Added two new unit tests.