### PR TITLE
M3-3656 Aria Polite loading pattern

### DIFF
--- a/packages/manager/src/components/CircleProgress/CircleProgress.tsx
+++ b/packages/manager/src/components/CircleProgress/CircleProgress.tsx
@@ -9,6 +9,7 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
+import { srSpeak } from 'src/utilities/accessibility';
 
 type CSSClasses =
   | 'root'
@@ -128,78 +129,82 @@ interface Props extends CircularProgressProps {
 
 type CombinedProps = Props & WithStyles<CSSClasses>;
 
-const circleProgressComponent: React.StatelessComponent<
-  CombinedProps
-> = props => {
-  const variant = typeof props.value === 'number' ? 'static' : 'indeterminate';
-  const value = typeof props.value === 'number' ? props.value : 0;
-  const {
-    children,
-    classes,
-    noTopMargin,
-    green,
-    mini,
-    tag,
-    sort,
-    noInner,
-    noPadding,
-    ...rest
-  } = props;
-
-  const outerClasses = {
-    [classes.root]: true,
-    [classes.noTopMargin]: noTopMargin,
-    [classes.hasValueInside]: children !== undefined,
-    [classes.green]: green,
-    [classes.noPadding]: noPadding
-  };
-
-  if (props.className) {
-    outerClasses[props.className] = true;
+class CircleProgressComponent extends React.Component<CombinedProps> {
+  componentWillUnmount() {
+    srSpeak('Content has loaded', 'polite');
   }
 
-  return !mini ? (
-    <div
-      className={classNames(
-        {
-          [classes.root]: true,
-          [classes.noTopMargin]: noTopMargin
-        },
-        outerClasses
-      )}
-    >
-      {children !== undefined && (
-        <div className={classes.valueInside}>{children}</div>
-      )}
-      {noInner !== true && (
-        <div className={classes.topWrapper}>
-          <div className={classes.top} />
-        </div>
-      )}
-      <CircularProgress
-        {...rest}
-        className={classes.progress}
-        size={green ? 128 : 124}
-        value={value}
-        variant={variant}
-        thickness={green ? 4 : 2}
-        data-qa-circle-progress={value}
-      />
-    </div>
-  ) : (
-    <CircularProgress
-      className={classNames({
-        [classes.mini]: true,
-        [classes.tag]: tag,
-        [classes.sort]: sort,
-        [classes.noPadding]: noPadding
-      })}
-      size={noPadding ? 22 : 40}
-      data-qa-circle-progress
-    />
-  );
-};
+  render() {
+    const variant =
+      typeof this.props.value === 'number' ? 'static' : 'indeterminate';
+    const value = typeof this.props.value === 'number' ? this.props.value : 0;
+    const {
+      children,
+      classes,
+      noTopMargin,
+      green,
+      mini,
+      tag,
+      sort,
+      noInner,
+      noPadding,
+      ...rest
+    } = this.props;
 
+    const outerClasses = {
+      [classes.root]: true,
+      [classes.noTopMargin]: noTopMargin,
+      [classes.hasValueInside]: children !== undefined,
+      [classes.green]: green,
+      [classes.noPadding]: noPadding
+    };
+
+    if (this.props.className) {
+      outerClasses[this.props.className] = true;
+    }
+
+    return !mini ? (
+      <div
+        className={classNames(
+          {
+            [classes.root]: true,
+            [classes.noTopMargin]: noTopMargin
+          },
+          outerClasses
+        )}
+      >
+        {children !== undefined && (
+          <div className={classes.valueInside}>{children}</div>
+        )}
+        {noInner !== true && (
+          <div className={classes.topWrapper}>
+            <div className={classes.top} />
+          </div>
+        )}
+        <CircularProgress
+          {...rest}
+          className={classes.progress}
+          size={green ? 128 : 124}
+          value={value}
+          variant={variant}
+          thickness={green ? 4 : 2}
+          data-qa-circle-progress={value}
+        />
+      </div>
+    ) : (
+      <CircularProgress
+        className={classNames({
+          [classes.mini]: true,
+          [classes.tag]: tag,
+          [classes.sort]: sort,
+          [classes.noPadding]: noPadding
+        })}
+        size={noPadding ? 22 : 40}
+        data-qa-circle-progress
+      />
+    );
+  }
+}
 const styled = withStyles(styles);
 
-export default styled(circleProgressComponent);
+export default styled(CircleProgressComponent);

--- a/packages/manager/src/components/CircleProgress/CircleProgress.tsx
+++ b/packages/manager/src/components/CircleProgress/CircleProgress.tsx
@@ -172,6 +172,7 @@ class CircleProgressComponent extends React.Component<CombinedProps> {
           },
           outerClasses
         )}
+        aria-label="Content is loading"
       >
         {children !== undefined && (
           <div className={classes.valueInside}>{children}</div>

--- a/packages/manager/src/components/CircleProgress/CircleProgress.tsx
+++ b/packages/manager/src/components/CircleProgress/CircleProgress.tsx
@@ -9,7 +9,6 @@ import {
   withStyles,
   WithStyles
 } from 'src/components/core/styles';
-import { srSpeak } from 'src/utilities/accessibility';
 
 type CSSClasses =
   | 'root'
@@ -130,10 +129,6 @@ interface Props extends CircularProgressProps {
 type CombinedProps = Props & WithStyles<CSSClasses>;
 
 class CircleProgressComponent extends React.Component<CombinedProps> {
-  componentWillUnmount() {
-    srSpeak('Content has loaded', 'polite');
-  }
-
   render() {
     const variant =
       typeof this.props.value === 'number' ? 'static' : 'indeterminate';
@@ -172,6 +167,7 @@ class CircleProgressComponent extends React.Component<CombinedProps> {
           },
           outerClasses
         )}
+        tabIndex={0}
         aria-label="Content is loading"
       >
         {children !== undefined && (
@@ -202,6 +198,8 @@ class CircleProgressComponent extends React.Component<CombinedProps> {
         })}
         size={noPadding ? 22 : 40}
         data-qa-circle-progress
+        aria-label="Content is loading"
+        tabIndex={0}
       />
     );
   }

--- a/packages/manager/src/components/DrawerContent/DrawerContent.test.tsx
+++ b/packages/manager/src/components/DrawerContent/DrawerContent.test.tsx
@@ -10,7 +10,7 @@ describe('DrawerContent', () => {
   );
 
   it('should show loading component while loading is in progress', () => {
-    expect(component.name()).toEqual('WithStyles(circleProgressComponent)');
+    expect(component.name()).toEqual('WithStyles(CircleProgressComponent)');
     expect(component.find('table')).toHaveLength(0);
   });
 

--- a/packages/manager/src/components/Skeleton/Skeleton.tsx
+++ b/packages/manager/src/components/Skeleton/Skeleton.tsx
@@ -91,6 +91,8 @@ const _Skeleton: React.FC<combinedProps> = props => {
             container
             className={classes.root}
             data-testid={'tableSkeleton'}
+            aria-label="Table Content Loading"
+            tabIndex={0}
           >
             {cols}
           </Grid>
@@ -100,6 +102,8 @@ const _Skeleton: React.FC<combinedProps> = props => {
           {...props}
           className={classes.root}
           data-testid={'basicSkeleton'}
+          aria-label="Table Content Loading"
+          tabIndex={0}
         />
       )}
     </>

--- a/packages/manager/src/components/SplashScreen/SplashScreen.tsx
+++ b/packages/manager/src/components/SplashScreen/SplashScreen.tsx
@@ -47,6 +47,7 @@ const SplashScreen: React.FC<CombinedProps> = props => {
         className={classNames({
           [classes.root]: true
         })}
+        aria-label="Loading Cloud Manager"
       >
         <div className={classes.logo}>
           <Logo />

--- a/packages/manager/src/components/SplashScreen/SplashScreen.tsx
+++ b/packages/manager/src/components/SplashScreen/SplashScreen.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { compose } from 'recompose';
 import { makeStyles } from 'src/components/core/styles';
 import { MapState } from 'src/store/types';
+import { srSpeak } from 'src/utilities/accessibility';
 
 import Logo from 'src/assets/logo/logo-animated.svg';
 import './keyframes.css';
@@ -35,6 +36,10 @@ type CombinedProps = StateProps;
 
 const SplashScreen: React.FC<CombinedProps> = props => {
   const classes = useStyles();
+
+  React.useEffect(() => {
+    srSpeak('Loading Linode Cloud Manager', 'polite');
+  }, []);
 
   return props.appIsLoading ? (
     <>

--- a/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
+++ b/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
@@ -47,6 +47,7 @@ class TableRowLoading extends React.Component<CombinedProps> {
           [classes.transparent]: transparent
         })}
         data-testid="table-row-loading"
+        aria-label="Table content is loading"
       >
         <TableCell
           colSpan={colSpan}

--- a/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
+++ b/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
@@ -9,6 +9,7 @@ import {
 import TableCell from 'src/components/core/TableCell';
 import TableRow from 'src/components/core/TableRow';
 import Skeleton from 'src/components/Skeleton';
+import { srSpeak } from 'src/utilities/accessibility';
 
 type ClassNames = 'root' | 'tableCell' | 'transparent';
 
@@ -33,32 +34,38 @@ export interface Props {
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-const tableRowLoading: React.StatelessComponent<CombinedProps> = props => {
-  const { classes, transparent, colSpan, firstColWidth } = props;
-  return (
-    <TableRow
-      className={classNames({
-        [classes.transparent]: transparent
-      })}
-      data-testid="table-row-loading"
-    >
-      <TableCell
-        colSpan={colSpan}
+class TableRowLoading extends React.Component<CombinedProps> {
+  componentWillUnmount() {
+    srSpeak('Table content has loaded', 'polite');
+  }
+
+  render() {
+    const { classes, transparent, colSpan, firstColWidth } = this.props;
+    return (
+      <TableRow
         className={classNames({
-          [classes.tableCell]: true,
           [classes.transparent]: transparent
         })}
+        data-testid="table-row-loading"
       >
-        <Skeleton
-          table
-          columns={colSpan ? colSpan : 8}
-          firstColWidth={firstColWidth ? firstColWidth : undefined}
-        />
-      </TableCell>
-    </TableRow>
-  );
-};
+        <TableCell
+          colSpan={colSpan}
+          className={classNames({
+            [classes.tableCell]: true,
+            [classes.transparent]: transparent
+          })}
+        >
+          <Skeleton
+            table
+            columns={colSpan ? colSpan : 8}
+            firstColWidth={firstColWidth ? firstColWidth : undefined}
+          />
+        </TableCell>
+      </TableRow>
+    );
+  }
+}
 
 const styled = withStyles(styles);
 
-export default styled(tableRowLoading);
+export default styled(TableRowLoading);

--- a/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
+++ b/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
@@ -9,7 +9,6 @@ import {
 import TableCell from 'src/components/core/TableCell';
 import TableRow from 'src/components/core/TableRow';
 import Skeleton from 'src/components/Skeleton';
-import { srSpeak } from 'src/utilities/accessibility';
 
 type ClassNames = 'root' | 'tableCell' | 'transparent';
 
@@ -35,10 +34,6 @@ export interface Props {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 class TableRowLoading extends React.Component<CombinedProps> {
-  componentWillUnmount() {
-    srSpeak('Table content has loaded', 'polite');
-  }
-
   render() {
     const { classes, transparent, colSpan, firstColWidth } = this.props;
     return (

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.test.tsx
@@ -44,7 +44,7 @@ describe('ObjectStorageKeyTable', () => {
 
   it('returns a loading state when loading', () => {
     wrapper.setProps({ loading: true });
-    expect(wrapper.find('WithStyles(tableRowLoading)')).toHaveLength(1);
+    expect(wrapper.find('WithStyles(TableRowLoading)')).toHaveLength(1);
   });
 
   it('returns an error state when there is an error', () => {

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeys.test.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeys.test.tsx
@@ -58,7 +58,7 @@ describe('SSHKeys', () => {
       />
     );
 
-    expect(wrapper.find(`WithStyles(tableRowLoading)`).exists()).toBeTruthy();
+    expect(wrapper.find(`WithStyles(TableRowLoading)`).exists()).toBeTruthy();
   });
 
   it('should display TableRowError if error if state.error is set.', () => {

--- a/packages/manager/src/features/Support/SupportTicketDetail/SupportTicketDetail.test.tsx
+++ b/packages/manager/src/features/Support/SupportTicketDetail/SupportTicketDetail.test.tsx
@@ -28,7 +28,7 @@ describe('Support Ticket Detail', () => {
   describe('render', () => {
     it('renders a CircleProgress component when loading', () => {
       wrapper.setState({ loading: true });
-      expect(wrapper.find('WithStyles(circleProgressComponent)')).toHaveLength(
+      expect(wrapper.find('WithStyles(CircleProgressComponent)')).toHaveLength(
         1
       );
     });

--- a/packages/manager/src/utilities/accessibility.ts
+++ b/packages/manager/src/utilities/accessibility.ts
@@ -2,22 +2,26 @@
 // Fo instance, when page is loading
 export const srSpeak = (text: string, priority: 'polite' | 'assertive') => {
   const el = document.createElement('div');
-  const id = 'speak-' + Date.now();
+  const id =
+    'speak-' +
+    Math.random()
+      .toString(36)
+      .substr(2, 9);
   el.setAttribute('id', id);
   el.setAttribute('aria-live', priority || 'polite');
   el.classList.add('sr-only');
   document.body.appendChild(el);
   const elementById: HTMLElement | null = document.getElementById(id);
 
-  window.setTimeout(() => {
-    if (elementById) {
+  if (elementById) {
+    window.setTimeout(() => {
       elementById.innerText = text;
-    }
-  }, 100);
+    }, 100);
+  }
 
-  window.setTimeout(() => {
-    if (elementById) {
+  if (elementById) {
+    window.setTimeout(() => {
       document.body.removeChild(elementById);
-    }
-  }, 1000);
+    }, 1000);
+  }
 };

--- a/packages/manager/src/utilities/accessibility.ts
+++ b/packages/manager/src/utilities/accessibility.ts
@@ -1,0 +1,23 @@
+// Function to send aria-live messages
+// Fo instance, when page is loading
+export const srSpeak = (text: string, priority: string) => {
+  const el = document.createElement('div');
+  const id = 'speak-' + Date.now();
+  el.setAttribute('id', id);
+  el.setAttribute('aria-live', priority || 'polite');
+  el.classList.add('sr-only');
+  document.body.appendChild(el);
+  const elementById: HTMLElement | null = document.getElementById(id);
+
+  window.setTimeout(() => {
+    if (elementById) {
+      elementById.innerHTML = text;
+    }
+  }, 100);
+
+  window.setTimeout(() => {
+    if (elementById) {
+      document.body.removeChild(elementById);
+    }
+  }, 1000);
+};

--- a/packages/manager/src/utilities/accessibility.ts
+++ b/packages/manager/src/utilities/accessibility.ts
@@ -1,6 +1,6 @@
 // Function to send aria-live messages
 // Fo instance, when page is loading
-export const srSpeak = (text: string, priority: string) => {
+export const srSpeak = (text: string, priority: 'polite' | 'assertive') => {
   const el = document.createElement('div');
   const id = 'speak-' + Date.now();
   el.setAttribute('id', id);
@@ -11,7 +11,7 @@ export const srSpeak = (text: string, priority: string) => {
 
   window.setTimeout(() => {
     if (elementById) {
-      elementById.innerHTML = text;
+      elementById.innerText = text;
     }
   }, 100);
 


### PR DESCRIPTION
## M3-3656 Aria Polite loading pattern

We should let visually impaired people know when content has loaded in case it takes a long time. My first initial effort was to make the user know both when content is loading and when content has loaded, but it ends up being too much verbiage, and sometimes the events trigger so fast that we only get the first one ('content is loading) and never that content has loaded, which is misleading. Instead, we just let the user know that content has loaded as needed, and if it takes a long time to do so, user will navigate to the row and find the loading container with aria-label showing loading state. Pattern was added to both circle progress and table row loading. Added also one for splash screen.

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

You can test with VoiceOver (which is less accurate sometimes than NVDA) or setup Windows with NVDA (which is a more current pattern for many users).

Note: if loading is very fast we sometimes get no message, which is fine. Feel free to test with a connection throttle.
