### PR TITLE
[OBJ] Add cancellation info to Enable Object Storage Modal

### DIFF
--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.test.tsx
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom/extend-expect';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import * as React from 'react';
+import { wrapWithTheme } from 'src/utilities/testHelpers';
+import { EnableObjectStorageModal, Props } from './EnableObjectStorageModal';
+
+afterEach(cleanup);
+
+const handleSubmit = jest.fn();
+const onClose = jest.fn();
+
+const props: Props = {
+  handleSubmit,
+  onClose,
+  open: true
+};
+
+describe('EnableObjectStorageModal', () => {
+  it('includes a header', () => {
+    const { getByText } = render(
+      wrapWithTheme(<EnableObjectStorageModal {...props} />)
+    );
+    getByText('Just to confirm...');
+  });
+
+  it('includes a link to Account Settings', () => {
+    const { getByText } = render(
+      wrapWithTheme(<EnableObjectStorageModal {...props} />)
+    );
+    const link = getByText('Account Settings');
+    expect(link.closest('a')).toHaveAttribute('href', '/account/settings');
+  });
+
+  it('calls the onClose prop/handler when the Cancel button is clicked', () => {
+    const { getByText } = render(
+      wrapWithTheme(<EnableObjectStorageModal {...props} />)
+    );
+    fireEvent.click(getByText('Cancel'));
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('calls the handleSubmit prop/handler when the Enable Object Storage button is clicked', () => {
+    const { getByText } = render(
+      wrapWithTheme(<EnableObjectStorageModal {...props} />)
+    );
+    fireEvent.click(getByText('Enable Object Storage'));
+    expect(props.handleSubmit).toHaveBeenCalled();
+  });
+});

--- a/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
+++ b/packages/manager/src/features/ObjectStorage/EnableObjectStorageModal.tsx
@@ -4,14 +4,15 @@ import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
 import Typography from 'src/components/core/Typography';
 import ExternalLink from 'src/components/ExternalLink';
+import { Link } from 'src/components/Link';
 
-interface Props {
+export interface Props {
   open: boolean;
   onClose: () => void;
   handleSubmit: () => void;
 }
 
-const EnableObjectStorageModal: React.FC<Props> = ({
+export const EnableObjectStorageModal: React.FC<Props> = ({
   open,
   onClose,
   handleSubmit
@@ -47,6 +48,10 @@ const EnableObjectStorageModal: React.FC<Props> = ({
           text="Learn more."
           link="https://www.linode.com/docs/platform/object-storage/pricing-and-limitations/"
         />
+      </Typography>
+      <Typography variant="subtitle1" style={{ marginTop: 8 }}>
+        To discontinue billing, you'll need to cancel Object Storage in your{' '}
+        <Link to="/account/settings">Account Settings</Link>.
       </Typography>
     </ConfirmationDialog>
   );


### PR DESCRIPTION
## Description

This more explicitly lets the user know that in order to cancel Object Storage billing, they'll need to do so in Account Settings.

## Type of Change
- Non breaking change ('update', 'change')


## Note to Reviewers

- I also added a few unit tests for EnableObjectStorageModal.
