### PR TITLE
[OBJ] Display billing notice when deleting last Bucket or Access Key

### DIFF
--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyLanding.tsx
@@ -70,7 +70,9 @@ type CombinedProps = Props &
   ReduxStateProps &
   DispatchProps;
 
-export const AccessKeyLanding: React.StatelessComponent<CombinedProps> = props => {
+export const AccessKeyLanding: React.StatelessComponent<
+  CombinedProps
+> = props => {
   const {
     classes,
     object_storage,
@@ -313,6 +315,7 @@ export const AccessKeyLanding: React.StatelessComponent<CombinedProps> = props =
         handleClose={closeRevokeDialog}
         handleSubmit={handleRevokeKeys}
         isLoading={isRevoking}
+        numAccessKeys={pathOr<number>(0, ['data', 'length'], paginationProps)}
         errors={revokeErrors}
       />
     </React.Fragment>
@@ -344,8 +347,15 @@ const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = (
   };
 };
 
-const connected = connect(mapStateToProps, mapDispatchToProps);
+const connected = connect(
+  mapStateToProps,
+  mapDispatchToProps
+);
 
-const enhanced = compose<CombinedProps, Props>(styled, paginated, connected);
+const enhanced = compose<CombinedProps, Props>(
+  styled,
+  paginated,
+  connected
+);
 
 export default enhanced(AccessKeyLanding);

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/RevokeAccessKeyDialog.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/RevokeAccessKeyDialog.tsx
@@ -3,7 +3,15 @@ import * as React from 'react';
 import ActionsPanel from 'src/components/ActionsPanel';
 import Button from 'src/components/Button';
 import ConfirmationDialog from 'src/components/ConfirmationDialog';
+import { makeStyles, Theme } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
+import CancelNotice from '../CancelNotice';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  cancelNotice: {
+    marginTop: theme.spacing(1)
+  }
+}));
 
 interface RevokeKeysDialogProps {
   label: string;
@@ -11,13 +19,24 @@ interface RevokeKeysDialogProps {
   isLoading: boolean;
   handleClose: () => void;
   handleSubmit: () => void;
+  numAccessKeys: number;
   errors?: APIError[];
 }
 
 export const RevokeAccessKeyDialog: React.StatelessComponent<
   RevokeKeysDialogProps
 > = props => {
-  const { label, isOpen, isLoading, handleClose, handleSubmit, errors } = props;
+  const {
+    label,
+    isOpen,
+    isLoading,
+    handleClose,
+    handleSubmit,
+    numAccessKeys,
+    errors
+  } = props;
+
+  const classes = useStyles();
 
   const actions = () => (
     <ActionsPanel>
@@ -44,6 +63,10 @@ export const RevokeAccessKeyDialog: React.StatelessComponent<
       error={(errors || []).map(e => e.reason).join(',')}
     >
       <Typography>Are you sure you want to revoke this Access Key?</Typography>
+      {/* If the user is attempting to revoke their last Access Key, remind them
+      that they will still be billed unless they cancel Object Storage in
+      Account Settings. */}
+      {numAccessKeys === 1 && <CancelNotice className={classes.cancelNotice} />}
     </ConfirmationDialog>
   );
 };

--- a/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
+++ b/packages/manager/src/features/ObjectStorage/BucketLanding/BucketLanding.tsx
@@ -33,6 +33,7 @@ import {
   sendDeleteBucketEvent,
   sendDeleteBucketFailedEvent
 } from 'src/utilities/ga';
+import CancelNotice from '../CancelNotice';
 import BucketTable from './BucketTable';
 
 type ClassNames = 'copy';
@@ -158,6 +159,10 @@ export const BucketLanding: React.StatelessComponent<CombinedProps> = props => {
         </a>{' '}
         to force deletion.
       </Typography>
+      {/* If the user is attempting to delete their last Bucket, remind them
+      that they will still be billed unless they cancel Object Storage in
+      Account Settings. */}
+      {bucketsData.length === 1 && <CancelNotice className={classes.copy} />}
       <Typography className={classes.copy}>
         To confirm deletion, type the name of the bucket ({bucketToRemove.label}
         ) in the field below:

--- a/packages/manager/src/features/ObjectStorage/CancelNotice.tsx
+++ b/packages/manager/src/features/ObjectStorage/CancelNotice.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import Typography from 'src/components/core/Typography';
+import { Link } from 'src/components/Link';
+
+interface Props {
+  className?: string;
+}
+
+const CancelNotice: React.FC<Props> = ({ className }) => {
+  return (
+    <Typography className={className}>
+      <strong>Please note:</strong> you will still be billed for Object Storage
+      unless you cancel it in your{' '}
+      <Link to="/account/settings">Account Settings.</Link>
+    </Typography>
+  );
+};
+
+export default React.memo(CancelNotice);


### PR DESCRIPTION
## Description

If a user is attempting to delete their last Bucket or last Access Key, display a warning that they will still be billed unless they cancel Object Storage in Account Settings.

## Type of Change
- Non breaking change ('update', 'change')
