### PR TITLE
M3-3667 Fix regression with editable text

### DIFF
--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -169,12 +169,12 @@ const EditableText: React.FC<FinalProps> = props => {
   } = props;
 
   React.useEffect(() => {
-    onCancel();
-  }, [isEditing]);
+    setText(props.text);
+  }, [props.text]);
 
   React.useEffect(() => {
-    setText(props.text);
-  }, []);
+    onCancel();
+  }, [isEditing]);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setText(e.target.value);

--- a/packages/manager/src/components/EditableText/EditableText.tsx
+++ b/packages/manager/src/components/EditableText/EditableText.tsx
@@ -169,8 +169,12 @@ const EditableText: React.FC<FinalProps> = props => {
   } = props;
 
   React.useEffect(() => {
+    onCancel();
+  }, [isEditing]);
+
+  React.useEffect(() => {
     setText(props.text);
-  }, [props.text]);
+  }, []);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setText(e.target.value);


### PR DESCRIPTION
## M3-3667 Fix regression with editable text

Error text was not resetting properly after switching to a functional component (try cancelling after getting an error). Added a `useEffect` to fix that

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
