### PR TITLE
Add: Duration Time to Events Landing and Activity Feed

### DIFF
--- a/packages/linode-js-sdk/src/account/types.ts
+++ b/packages/linode-js-sdk/src/account/types.ts
@@ -248,6 +248,10 @@ export interface Event {
   action: EventAction;
   created: string;
   entity: Entity | null;
+  /* 
+    NOTE: events before the duration key was added will have a duration of 0 
+  */
+  duration: number | null;
   percent_complete: number | null;
   rate: string | null;
   read: boolean;

--- a/packages/manager/src/__data__/events.ts
+++ b/packages/manager/src/__data__/events.ts
@@ -19,7 +19,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11241778'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 18029767,
@@ -38,7 +39,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11241778'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 18029572,
@@ -57,7 +59,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11241778'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 18022171,
@@ -76,7 +79,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11642886'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 18022021,
@@ -95,7 +99,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11642886'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 18021942,
@@ -114,7 +119,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11241778'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17957943,
@@ -133,7 +139,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17957944,
@@ -152,7 +159,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17957718,
@@ -171,7 +179,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17957108,
@@ -190,7 +199,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17956743,
@@ -209,7 +219,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17956360,
@@ -228,7 +239,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17955994,
@@ -247,7 +259,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17955841,
@@ -266,7 +279,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17955781,
@@ -285,7 +299,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17955694,
@@ -304,7 +319,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17955636,
@@ -323,7 +339,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17955613,
@@ -342,7 +359,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17955464,
@@ -361,7 +379,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17954738,
@@ -380,7 +399,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17951319,
@@ -399,7 +419,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17951106,
@@ -418,7 +439,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17950945,
@@ -437,7 +459,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17950407,
@@ -456,7 +479,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17950183,
@@ -475,7 +499,8 @@ export const events: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   }
 ];
 
@@ -497,7 +522,8 @@ export const uniqueEvents: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   },
   {
     id: 17950407,
@@ -516,7 +542,8 @@ export const uniqueEvents: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   }
 ];
 
@@ -538,5 +565,6 @@ export const reduxEvent: ExtendedEvent = {
     type: 'linode',
     url: '/v4/linode/instances/11440645'
   },
-  status: 'finished'
+  status: 'finished',
+  duration: 0
 };

--- a/packages/manager/src/factories/events.ts
+++ b/packages/manager/src/factories/events.ts
@@ -20,5 +20,6 @@ export const eventFactory = Factory.Sync.makeFactory<Event>({
   read: false,
   action: 'linode_boot',
   percent_complete: 10,
-  time_remaining: 0
+  time_remaining: 0,
+  duration: 0
 });

--- a/packages/manager/src/features/Events/Event.helpers.test.ts
+++ b/packages/manager/src/features/Events/Event.helpers.test.ts
@@ -97,7 +97,7 @@ describe('Utility Functions', () => {
     it('it should return a message for an event without a username unchanged', () => {
       const message = 'a message';
       expect(
-        formatEventWithUsername('linode_boot' as EventAction, null, message)
+        formatEventWithUsername('linode_boot' as EventAction, null, message, 0)
       ).toEqual(message);
     });
 
@@ -107,7 +107,8 @@ describe('Utility Functions', () => {
         formatEventWithUsername(
           'linode_boot' as EventAction,
           'test-user-001',
-          message
+          message,
+          0
         )
       ).toEqual('a message by test-user-001.');
     });
@@ -118,7 +119,8 @@ describe('Utility Functions', () => {
         formatEventWithUsername(
           'lassie_reboot' as EventAction,
           'test-user-001',
-          message
+          message,
+          0
         )
       ).toEqual(message);
     });

--- a/packages/manager/src/features/Events/Event.helpers.test.ts
+++ b/packages/manager/src/features/Events/Event.helpers.test.ts
@@ -97,7 +97,7 @@ describe('Utility Functions', () => {
     it('it should return a message for an event without a username unchanged', () => {
       const message = 'a message';
       expect(
-        formatEventWithUsername('linode_boot' as EventAction, null, message, 0)
+        formatEventWithUsername('linode_boot' as EventAction, null, message)
       ).toEqual(message);
     });
 
@@ -107,8 +107,7 @@ describe('Utility Functions', () => {
         formatEventWithUsername(
           'linode_boot' as EventAction,
           'test-user-001',
-          message,
-          0
+          message
         )
       ).toEqual('a message by test-user-001.');
     });
@@ -119,8 +118,7 @@ describe('Utility Functions', () => {
         formatEventWithUsername(
           'lassie_reboot' as EventAction,
           'test-user-001',
-          message,
-          0
+          message
         )
       ).toEqual(message);
     });

--- a/packages/manager/src/features/Events/Event.helpers.ts
+++ b/packages/manager/src/features/Events/Event.helpers.ts
@@ -1,5 +1,4 @@
 import { Event, EventAction } from 'linode-js-sdk/lib/account';
-import * as moment from 'moment';
 import { equals } from 'ramda';
 
 /**
@@ -83,19 +82,13 @@ export const maybeRemoveTrailingPeriod = (string: string) => {
 export const formatEventWithUsername = (
   action: EventAction,
   username: string | null,
-  message: string,
-  eventDuration: Event['duration']
+  message: string
 ) => {
-  const baseMessage =
-    username && action !== 'lassie_reboot'
-      ? /**
-         * The event message for Lassie events already includes "by the Lassie Watchdog service",
-         * so we don't want to add "by Linode" after that.
-         */
-        `${maybeRemoveTrailingPeriod(message)} by ${username}.`
-      : message;
-
-  return !!eventDuration && eventDuration > 0
-    ? `(took ${moment.duration(eventDuration).humanize()}) ${baseMessage}`
-    : baseMessage;
+  return username && action !== 'lassie_reboot'
+    ? /*
+        The event message for Lassie events already includes "by the Lassie Watchdog service",
+        so we don't want to add "by Linode" after that.
+      */
+      `${maybeRemoveTrailingPeriod(message)} by ${username}.`
+    : message;
 };

--- a/packages/manager/src/features/Events/Event.helpers.ts
+++ b/packages/manager/src/features/Events/Event.helpers.ts
@@ -1,4 +1,5 @@
 import { Event, EventAction } from 'linode-js-sdk/lib/account';
+import * as moment from 'moment';
 import { equals } from 'ramda';
 
 /**
@@ -82,13 +83,19 @@ export const maybeRemoveTrailingPeriod = (string: string) => {
 export const formatEventWithUsername = (
   action: EventAction,
   username: string | null,
-  message: string
+  message: string,
+  eventDuration: Event['duration']
 ) => {
-  return username && action !== 'lassie_reboot'
-    ? /**
-       * The event message for Lassie events already includes "by the Lassie Watchdog service",
-       * so we don't want to add "by Linode" after that.
-       */
-      `${maybeRemoveTrailingPeriod(message)} by ${username}.`
-    : message;
+  const baseMessage =
+    username && action !== 'lassie_reboot'
+      ? /**
+         * The event message for Lassie events already includes "by the Lassie Watchdog service",
+         * so we don't want to add "by Linode" after that.
+         */
+        `${maybeRemoveTrailingPeriod(message)} by ${username}.`
+      : message;
+
+  return !!eventDuration && eventDuration > 0
+    ? `(took ${moment.duration(eventDuration).humanize()}) ${baseMessage}`
+    : baseMessage;
 };

--- a/packages/manager/src/features/Events/EventRow.test.tsx
+++ b/packages/manager/src/features/Events/EventRow.test.tsx
@@ -5,6 +5,7 @@ import { Row, RowProps } from './EventRow';
 const message = 'this is a message.';
 const props: RowProps = {
   action: 'linode_boot',
+  duration: 0,
   message,
   type: 'linode',
   created: '2018-01-01',

--- a/packages/manager/src/features/Events/EventRow.test.tsx
+++ b/packages/manager/src/features/Events/EventRow.test.tsx
@@ -12,7 +12,8 @@ const props: RowProps = {
   username: null,
   classes: {
     root: '',
-    message: ''
+    message: '',
+    occurredCell: ''
   },
   linkTarget: jest.fn()
 };

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -64,6 +64,7 @@ export const EventRow: React.StatelessComponent<CombinedProps> = props => {
     status: pathOr(undefined, ['status'], entity),
     type,
     entityId,
+    duration: event.duration,
     username: event.username,
     action: event.action,
     classes
@@ -81,6 +82,7 @@ export interface RowProps extends WithStyles<ClassNames> {
   action: EventAction;
   created: string;
   username: string | null;
+  duration: Event['duration'];
 }
 
 export const Row: React.StatelessComponent<RowProps> = props => {
@@ -93,7 +95,8 @@ export const Row: React.StatelessComponent<RowProps> = props => {
     status,
     type,
     created,
-    username
+    username,
+    duration
   } = props;
 
   /** Some event types may not be handled by our system (or new types
@@ -102,6 +105,21 @@ export const Row: React.StatelessComponent<RowProps> = props => {
   if (!message) {
     return null;
   }
+
+  const displayedMessage = formatEventWithUsername(
+    action,
+    username,
+    message,
+    duration
+  );
+
+  /*
+    gets the capturing groups for duration and the rest of the event message
+  */
+  const durationText = /^(\(took.*\))(.*)$/gim.exec(displayedMessage);
+
+  // @ts-ignore
+  const [_, timeTaken, restOfMessage] = durationText || [];
 
   return (
     <TableRow
@@ -129,7 +147,14 @@ export const Row: React.StatelessComponent<RowProps> = props => {
           data-qa-event-message
           variant="body1"
         >
-          {formatEventWithUsername(action, username, message)}
+          {durationText ? (
+            <React.Fragment>
+              <strong>{timeTaken}</strong>
+              {` ${restOfMessage}`}
+            </React.Fragment>
+          ) : (
+            displayedMessage
+          )}
         </Typography>
       </TableCell>
       <TableCell parentColumn={'Time'} data-qa-event-created-cell compact>

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -23,7 +23,9 @@ import getEventsActionLink from 'src/utilities/getEventsActionLink';
 
 import { formatEventWithUsername } from './Event.helpers';
 
-type ClassNames = 'root' | 'message';
+import { formatEventSeconds } from 'src/utilities/minute-conversion/minute-conversion';
+
+type ClassNames = 'root' | 'message' | 'occurredCell';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -106,20 +108,7 @@ export const Row: React.StatelessComponent<RowProps> = props => {
     return null;
   }
 
-  const displayedMessage = formatEventWithUsername(
-    action,
-    username,
-    message,
-    duration
-  );
-
-  /*
-    gets the capturing groups for duration and the rest of the event message
-  */
-  const durationText = /^(\(took.*\))(.*)$/gim.exec(displayedMessage);
-
-  // @ts-ignore
-  const [_, timeTaken, restOfMessage] = durationText || [];
+  const displayedMessage = formatEventWithUsername(action, username, message);
 
   return (
     <TableRow
@@ -147,18 +136,16 @@ export const Row: React.StatelessComponent<RowProps> = props => {
           data-qa-event-message
           variant="body1"
         >
-          {durationText ? (
-            <React.Fragment>
-              <strong>{timeTaken}</strong>
-              {` ${restOfMessage}`}
-            </React.Fragment>
-          ) : (
-            displayedMessage
-          )}
+          {displayedMessage}
         </Typography>
       </TableCell>
-      <TableCell parentColumn={'Time'} data-qa-event-created-cell compact>
-        <DateTimeDisplay value={created} humanizeCutoff={'month'} />
+      <TableCell parentColumn="Time Taken">
+        <Typography variant="body1">{`${formatEventSeconds(
+          duration
+        )}`}</Typography>
+      </TableCell>
+      <TableCell parentColumn={'Occurred'} data-qa-event-created-cell compact>
+        <DateTimeDisplay value={created} />
       </TableCell>
     </TableRow>
   );

--- a/packages/manager/src/features/Events/EventRow.tsx
+++ b/packages/manager/src/features/Events/EventRow.tsx
@@ -139,12 +139,12 @@ export const Row: React.StatelessComponent<RowProps> = props => {
           {displayedMessage}
         </Typography>
       </TableCell>
-      <TableCell parentColumn="Time Taken">
+      <TableCell parentColumn="Duration">
         <Typography variant="body1">{`${formatEventSeconds(
           duration
         )}`}</Typography>
       </TableCell>
-      <TableCell parentColumn={'Occurred'} data-qa-event-created-cell compact>
+      <TableCell parentColumn={'When'} data-qa-event-created-cell compact>
         <DateTimeDisplay value={created} />
       </TableCell>
     </TableRow>

--- a/packages/manager/src/features/Events/EventsLanding.test.ts
+++ b/packages/manager/src/features/Events/EventsLanding.test.ts
@@ -20,7 +20,8 @@ const someEvent: Event[] = [
       type: 'linode',
       url: '/v4/linode/instances/11440645'
     },
-    status: 'finished'
+    status: 'finished',
+    duration: 0
   }
 ];
 

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -48,12 +48,11 @@ const styles = (theme: Theme) =>
       textAlign: 'center'
     },
     labelCell: {
-      width: '69%',
+      width: '60%',
       minWidth: 200,
       paddingLeft: 10
     },
     timeCell: {
-      width: '30%',
       paddingLeft: theme.spacing(1) / 2
     }
   });
@@ -292,10 +291,16 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
                 Event
               </TableCell>
               <TableCell
+                data-qa-events-time-taken-header
+                className={classes.timeCell}
+              >
+                Time Taken
+              </TableCell>
+              <TableCell
                 data-qa-events-time-header
                 className={classes.timeCell}
               >
-                Time
+                Occurred
               </TableCell>
             </TableRow>
           </TableHead>

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -291,16 +291,16 @@ export const EventsLanding: React.StatelessComponent<CombinedProps> = props => {
                 Event
               </TableCell>
               <TableCell
-                data-qa-events-time-taken-header
+                data-qa-events-duration-header
                 className={classes.timeCell}
               >
-                Time Taken
+                Duration
               </TableCell>
               <TableCell
                 data-qa-events-time-header
                 className={classes.timeCell}
               >
-                Occurred
+                When
               </TableCell>
             </TableRow>
           </TableHead>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -39,6 +39,21 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
     return null;
   }
 
+  const displayedMessage = formatEventWithUsername(
+    event.action,
+    event.username,
+    message,
+    event.duration
+  );
+
+  /*
+    gets the capturing groups for duration and the rest of the message
+  */
+  const durationText = /^(\(took.*\))(.*)$/gim.exec(displayedMessage);
+
+  // @ts-ignore
+  const [_, timeTaken, restOfMessage] = durationText || [];
+
   return (
     <Grid
       className={classes.root}
@@ -50,7 +65,14 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
     >
       <Grid item>
         <Typography>
-          {formatEventWithUsername(event.action, event.username, message)}
+          {durationText ? (
+            <React.Fragment>
+              <strong>{timeTaken}</strong>
+              {` ${restOfMessage}`}
+            </React.Fragment>
+          ) : (
+            displayedMessage
+          )}
         </Typography>
       </Grid>
       <Grid item>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/ActivityRow.tsx
@@ -12,6 +12,8 @@ import Grid from 'src/components/Grid';
 import eventMessageGenerator from 'src/eventMessageGenerator';
 import { formatEventWithUsername } from 'src/features/Events/Event.helpers';
 
+import { formatEventSeconds } from 'src/utilities/minute-conversion/minute-conversion';
+
 type ClassNames = 'root';
 
 const styles = (theme: Theme) =>
@@ -42,17 +44,8 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
   const displayedMessage = formatEventWithUsername(
     event.action,
     event.username,
-    message,
-    event.duration
+    message
   );
-
-  /*
-    gets the capturing groups for duration and the rest of the message
-  */
-  const durationText = /^(\(took.*\))(.*)$/gim.exec(displayedMessage);
-
-  // @ts-ignore
-  const [_, timeTaken, restOfMessage] = durationText || [];
 
   return (
     <Grid
@@ -65,18 +58,11 @@ export const ActivityRow: React.StatelessComponent<CombinedProps> = props => {
     >
       <Grid item>
         <Typography>
-          {durationText ? (
-            <React.Fragment>
-              <strong>{timeTaken}</strong>
-              {` ${restOfMessage}`}
-            </React.Fragment>
-          ) : (
-            displayedMessage
-          )}
+          {displayedMessage} ({formatEventSeconds(event.duration)})
         </Typography>
       </Grid>
       <Grid item>
-        <DateTimeDisplay value={event.created} humanizeCutoff={'month'} />
+        <DateTimeDisplay value={event.created} />
       </Grid>
     </Grid>
   );

--- a/packages/manager/src/features/linodes/transitions.test.ts
+++ b/packages/manager/src/features/linodes/transitions.test.ts
@@ -15,7 +15,8 @@ describe('transitionText helper', () => {
         seen: true,
         status: 'started',
         time_remaining: null,
-        username: 'linode'
+        username: 'linode',
+        duration: 0
       })
     ).toEqual('Snapshot');
   });
@@ -38,7 +39,8 @@ describe('transitionText helper', () => {
         seen: true,
         status: 'started',
         time_remaining: null,
-        username: 'linode'
+        username: 'linode',
+        duration: 0
       })
     ).toEqual('Optimus');
   });

--- a/packages/manager/src/store/events/event.helpers.test.ts
+++ b/packages/manager/src/store/events/event.helpers.test.ts
@@ -112,7 +112,8 @@ describe('event.helpers', () => {
             type: 'linode',
             url: '/v4/linode/instances/11440645'
           },
-          status: 'finished'
+          status: 'finished',
+          duration: 0
         },
         {
           id: 17957108,
@@ -131,7 +132,8 @@ describe('event.helpers', () => {
             type: 'linode',
             url: '/v4/linode/instances/11440645'
           },
-          status: 'finished'
+          status: 'finished',
+          duration: 0
         }
       ];
 
@@ -154,7 +156,8 @@ describe('event.helpers', () => {
             url: '/v4/linode/instances/11440645'
           },
           status: 'finished',
-          _deleted: '2018-12-02T23:15:45'
+          _deleted: '2018-12-02T23:15:45',
+          duration: 0
         },
         {
           id: 17957108,
@@ -174,7 +177,8 @@ describe('event.helpers', () => {
             url: '/v4/linode/instances/11440645'
           },
           status: 'finished',
-          _deleted: '2018-12-02T23:15:45'
+          _deleted: '2018-12-02T23:15:45',
+          duration: 0
         }
       ];
 
@@ -198,7 +202,8 @@ describe('event.helpers', () => {
           username: 'test',
           rate: null,
           entity: null,
-          status: 'finished'
+          status: 'finished',
+          duration: 0
         },
         {
           id: 17957718,
@@ -212,7 +217,8 @@ describe('event.helpers', () => {
           username: 'test',
           rate: null,
           entity: null,
-          status: 'started'
+          status: 'started',
+          duration: 0
         },
         {
           id: 17957108,
@@ -226,7 +232,8 @@ describe('event.helpers', () => {
           username: 'test',
           rate: null,
           entity: null,
-          status: 'finished'
+          status: 'finished',
+          duration: 0
         }
       ];
       const events: Event[] = [
@@ -242,7 +249,8 @@ describe('event.helpers', () => {
           username: 'test',
           rate: null,
           entity: null,
-          status: 'started'
+          status: 'started',
+          duration: 0
         }
       ];
       const result = addToEvents(prevEvents, events);

--- a/packages/manager/src/store/events/event.helpers.test.ts
+++ b/packages/manager/src/store/events/event.helpers.test.ts
@@ -268,7 +268,8 @@ describe('event.helpers', () => {
           username: 'test',
           rate: null,
           entity: null,
-          status: 'finished'
+          status: 'finished',
+          duration: 0
         },
         {
           id: 17957718,
@@ -282,7 +283,8 @@ describe('event.helpers', () => {
           username: 'test',
           rate: null,
           entity: null,
-          status: 'started'
+          status: 'started',
+          duration: 0
         },
         {
           id: 17957108,
@@ -296,7 +298,8 @@ describe('event.helpers', () => {
           username: 'test',
           rate: null,
           entity: null,
-          status: 'finished'
+          status: 'finished',
+          duration: 0
         }
       ]);
     });

--- a/packages/manager/src/store/events/event.reducer.test.ts
+++ b/packages/manager/src/store/events/event.reducer.test.ts
@@ -33,7 +33,8 @@ describe('events.reducer', () => {
               type: 'linode',
               url: '/v4/linode/instances/11241778'
             },
-            status: 'finished'
+            status: 'finished',
+            duration: 0
           },
           {
             id: 18022171,
@@ -52,7 +53,8 @@ describe('events.reducer', () => {
               type: 'linode',
               url: '/v4/linode/instances/11642886'
             },
-            status: 'started'
+            status: 'started',
+            duration: 0
           }
         ];
         const action = addEvents(events);

--- a/packages/manager/src/utilities/minute-conversion/minute-conversion.test.ts
+++ b/packages/manager/src/utilities/minute-conversion/minute-conversion.test.ts
@@ -1,5 +1,6 @@
 import {
   convertMinutesTo,
+  formatEventSeconds,
   generateMigrationTimeString
 } from './minute-conversion';
 
@@ -35,5 +36,22 @@ describe('Human-Readable Minute Conversion', () => {
       `1 day, 23 hours, and 0 minutes`
     );
     expect(generateMigrationTimeString(2880)).toBe(`2 days and 0 minutes`);
+  });
+});
+
+describe('Event seconds conversion', () => {
+  it('should format event seconds correctly', () => {
+    expect(formatEventSeconds(null)).toBe('Unknown');
+    expect(formatEventSeconds(undefined as any)).toBe('Unknown');
+    expect(formatEventSeconds(0)).toBe('Unknown');
+
+    expect(formatEventSeconds(3600)).toBe('1 hour, 0 minutes');
+    expect(formatEventSeconds(3660)).toBe('1 hour, 1 minute');
+    expect(formatEventSeconds(7300)).toBe('2 hours, 1 minute');
+    expect(formatEventSeconds(7500)).toBe('2 hours, 5 minutes');
+
+    expect(formatEventSeconds(60)).toBe('1 minute, 0 seconds');
+    expect(formatEventSeconds(80)).toBe('1 minute, 20 seconds');
+    expect(formatEventSeconds(120)).toBe('2 minutes, 0 seconds');
   });
 });

--- a/packages/manager/src/utilities/minute-conversion/minute-conversion.test.ts
+++ b/packages/manager/src/utilities/minute-conversion/minute-conversion.test.ts
@@ -45,13 +45,13 @@ describe('Event seconds conversion', () => {
     expect(formatEventSeconds(undefined as any)).toBe('Unknown');
     expect(formatEventSeconds(0)).toBe('Unknown');
 
-    expect(formatEventSeconds(3600)).toBe('1 hour, 0 minutes');
+    expect(formatEventSeconds(3600)).toBe('1 hour');
     expect(formatEventSeconds(3660)).toBe('1 hour, 1 minute');
     expect(formatEventSeconds(7300)).toBe('2 hours, 1 minute');
     expect(formatEventSeconds(7500)).toBe('2 hours, 5 minutes');
 
-    expect(formatEventSeconds(60)).toBe('1 minute, 0 seconds');
+    expect(formatEventSeconds(60)).toBe('1 minute');
     expect(formatEventSeconds(80)).toBe('1 minute, 20 seconds');
-    expect(formatEventSeconds(120)).toBe('2 minutes, 0 seconds');
+    expect(formatEventSeconds(120)).toBe('2 minutes');
   });
 });

--- a/packages/manager/src/utilities/minute-conversion/minute-conversion.ts
+++ b/packages/manager/src/utilities/minute-conversion/minute-conversion.ts
@@ -86,3 +86,33 @@ export const generateMigrationTimeString = (migrationTimeInMins: number) => {
 
   return pluralize('minute', 'minutes', migrationTimeInMins);
 };
+
+export const formatEventSeconds = (seconds: number | null) => {
+  if (!seconds) {
+    return 'Unknown';
+  }
+
+  if (seconds >= 3600) {
+    const hours = Math.floor(seconds / 60 / 60);
+    const minutes = Math.floor((seconds % 3600) / 60);
+
+    return `${pluralize('hour', 'hours', hours)}, ${pluralize(
+      'minute',
+      'minutes',
+      minutes
+    )}`;
+  }
+
+  if (seconds >= 60) {
+    const minutes = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+
+    return `${pluralize('minute', 'minutes', minutes)}, ${pluralize(
+      'second',
+      'seconds',
+      secs
+    )}`;
+  }
+
+  return `${pluralize('second', 'seconds', seconds)}`;
+};

--- a/packages/manager/src/utilities/minute-conversion/minute-conversion.ts
+++ b/packages/manager/src/utilities/minute-conversion/minute-conversion.ts
@@ -96,22 +96,26 @@ export const formatEventSeconds = (seconds: number | null) => {
     const hours = Math.floor(seconds / 60 / 60);
     const minutes = Math.floor((seconds % 3600) / 60);
 
-    return `${pluralize('hour', 'hours', hours)}, ${pluralize(
-      'minute',
-      'minutes',
-      minutes
-    )}`;
+    return minutes === 0
+      ? `${pluralize('hour', 'hours', hours)}`
+      : `${pluralize('hour', 'hours', hours)}, ${pluralize(
+          'minute',
+          'minutes',
+          minutes
+        )}`;
   }
 
   if (seconds >= 60) {
     const minutes = Math.floor(seconds / 60);
     const secs = Math.floor(seconds % 60);
 
-    return `${pluralize('minute', 'minutes', minutes)}, ${pluralize(
-      'second',
-      'seconds',
-      secs
-    )}`;
+    return secs === 0
+      ? `${pluralize('minute', 'minutes', minutes)}`
+      : `${pluralize('minute', 'minutes', minutes)}, ${pluralize(
+          'second',
+          'seconds',
+          secs
+        )}`;
   }
 
   return `${pluralize('second', 'seconds', seconds)}`;

--- a/packages/manager/src/utilities/minute-conversion/minute-conversion.ts
+++ b/packages/manager/src/utilities/minute-conversion/minute-conversion.ts
@@ -105,7 +105,7 @@ export const formatEventSeconds = (seconds: number | null) => {
 
   if (seconds >= 60) {
     const minutes = Math.floor(seconds / 60);
-    const secs = seconds % 60;
+    const secs = Math.floor(seconds % 60);
 
     return `${pluralize('minute', 'minutes', minutes)}, ${pluralize(
       'second',


### PR DESCRIPTION
## Description

Adds duration column to activity feed and events landing.

`duration` can be `0`, `null`, or `number` (in seconds)

## Type of Change
- Non breaking change ('update', 'change')

## Note to Reviewers

https://regex101.com/r/mPDfuk/1/

There's no design for this - I was really just winging it.