### PR TITLE
A11y: Adding new prop for aria label

### DIFF
--- a/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
+++ b/packages/manager/src/components/CopyTooltip/CopyTooltip.tsx
@@ -13,6 +13,7 @@ interface Props {
   text: string;
   className?: string;
   standAlone?: boolean;
+  ariaLabel?: string;
 }
 
 interface State {
@@ -91,12 +92,12 @@ class CopyTooltip extends React.Component<CombinedProps, State> {
   };
 
   render() {
-    const { classes, text, className, standAlone } = this.props;
+    const { classes, text, className, standAlone, ariaLabel } = this.props;
     const { copied } = this.state;
 
     return (
       <button
-        aria-label={text}
+        aria-label={ariaLabel ? ariaLabel : text}
         name={text}
         type="button"
         onClick={this.clickIcon}

--- a/packages/manager/src/features/linodes/LinodesLanding/IPAddress.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/IPAddress.tsx
@@ -136,7 +136,8 @@ export class IPAddress extends React.Component<Props & WithStyles<CSSClasses>> {
     return (
       <div className={`${classes.ipLink}`} data-qa-copy-ip>
         <CopyTooltip
-          text={`Copy IP Address ${ip} to clipboard`}
+          text={ip}
+          ariaLabel={`Copy IP Address ${ip} to clipboard`}
           className={`${classes.icon} ${showCopyOnHover ? classes.hide : ''}
             ${copyRight ? classes.right : classes.left} copy`}
         />


### PR DESCRIPTION
## Description

I introduced a regression, this fixes it 😅 CopyTooltip now takes an optional prop for aria label, otherwise it'll default to `text` like before. In particular this aids the IP Address copy icon implementation and gives more context to screen reader users.

## Type of Change
- Bug fix ('fix')