### PR TITLE
Fix Vuln remove direct devDep handlebars and bump…

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -211,7 +211,6 @@
     "file-loader": "^3.0.1",
     "fork-ts-checker-webpack-plugin": "^0.5.2",
     "fs-extra": "^8.0.1",
-    "handlebars": "^4.2.0",
     "html-webpack-plugin": "^4.0.0-beta.5",
     "inert": "^5.1.0",
     "inquirer": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10016,10 +10016,10 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.0.tgz#0e039695ff50c93fc288557d696f3c1dc6776754"
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
-handlebars@^4.1.2, handlebars@^4.2.0, handlebars@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.4.3.tgz#180bae52c1d0e9ec0c15d7e82a4362d662762f6e"
-  integrity sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==
+handlebars@^4.1.2, handlebars@^4.4.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION

## Description

Before handlebar was a direct dep in our package json/dev dependancies of manager.
We do not import handlebars in our code.
Lerna uses it though
![image](https://user-images.githubusercontent.com/27222128/70354979-07239480-183f-11ea-8023-de16f6c0ff5d.png)

Version has a reported vuln
![image](https://user-images.githubusercontent.com/27222128/70355019-1f93af00-183f-11ea-901a-447e31208278.png)

After the change, 8 less Vuln and bumped:
![image](https://user-images.githubusercontent.com/27222128/70355057-3508d900-183f-11ea-94f4-038f3e64c1dc.png)

Also we simplified the yarn.lock a little and package.json.

## Type of Change
- Bug fix ('fix', 'repair', 'bug')
