### PR TITLE
M3-3671 Accessibility: Summary Sidebars

### DIFF
--- a/packages/manager/src/components/Tag/Tag.tsx
+++ b/packages/manager/src/components/Tag/Tag.tsx
@@ -146,7 +146,11 @@ class Tag extends React.Component<CombinedProps, {}> {
         })}
         deleteIcon={
           chipProps.onDelete ? (
-            <Button data-qa-delete-tag className={classes.deleteButton}>
+            <Button
+              data-qa-delete-tag
+              className={classes.deleteButton}
+              aria-label={`Delete Tag "${this.props.label}"`}
+            >
               <Close />
             </Button>
           ) : (
@@ -159,6 +163,7 @@ class Tag extends React.Component<CombinedProps, {}> {
         component="div"
         clickable
         role="button"
+        aria-label={`Search for Tag "${this.props.label}"`}
       />
     );
   }

--- a/packages/manager/src/features/Billing/BillingDetail.tsx
+++ b/packages/manager/src/features/Billing/BillingDetail.tsx
@@ -138,12 +138,6 @@ export class BillingDetail extends React.Component<CombinedProps, State> {
             Billing
           </Typography>
           <Grid container>
-            <Grid item xs={12} md={4} lg={3} className={classes.sidebar}>
-              <SummaryPanel
-                data-qa-summary-panel
-                history={this.props.history}
-              />
-            </Grid>
             <Grid item xs={12} md={8} lg={9} className={classes.main}>
               <UpdateContactInformationPanel />
               <UpdateCreditCardPanel />
@@ -151,6 +145,12 @@ export class BillingDetail extends React.Component<CombinedProps, State> {
               <PromotionsPanel />
               <RecentInvoicesPanel />
               <RecentPaymentsPanel />
+            </Grid>
+            <Grid item xs={12} md={4} lg={3} className={classes.sidebar}>
+              <SummaryPanel
+                data-qa-summary-panel
+                history={this.props.history}
+              />
             </Grid>
           </Grid>
         </AccountProvider>

--- a/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
+++ b/packages/manager/src/features/Billing/BillingPanels/SummaryPanel/PanelCards/ContactInformation.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
 import { compose } from 'recompose';
+import Button from 'src/components/Button';
 import { makeStyles, Theme } from 'src/components/core/styles';
 
 import Paper from 'src/components/core/Paper';
@@ -17,9 +18,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     wordBreak: 'break-all'
   },
   cancel: {
-    marginTop: theme.spacing(2),
-    color: theme.palette.primary.main,
-    cursor: 'pointer'
+    marginTop: theme.spacing(2)
   }
 }));
 
@@ -102,12 +101,12 @@ const ContactInformation: React.FC<CombinedProps> = props => {
           <DateTimeDisplay value={activeSince} format="D MMM YYYY" />
         </div>
         {!isRestrictedUser && (
-          <Typography
+          <Button
             onClick={() => toggleModal(true)}
-            className={classes.cancel}
+            className={`${classes.cancel} px0`}
           >
             <strong>Close Account</strong>
-          </Typography>
+          </Button>
         )}
       </Paper>
       <Dialog

--- a/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
@@ -47,6 +47,13 @@ const DomainRecordsWrapper: React.FC<CombinedProps> = props => {
 
   return (
     <Grid container className={hookClasses.root}>
+      <Grid item xs={12} md={9} className={hookClasses.main}>
+        <DomainRecords
+          domain={domain}
+          domainRecords={records}
+          updateRecords={updateRecords}
+        />
+      </Grid>
       <Grid
         item
         xs={12}
@@ -59,13 +66,6 @@ const DomainRecordsWrapper: React.FC<CombinedProps> = props => {
           </Typography>
           <TagsPanel tags={domain.tags} updateTags={handleUpdateTags} />
         </Paper>
-      </Grid>
-      <Grid item xs={12} md={9} className={hookClasses.main}>
-        <DomainRecords
-          domain={domain}
-          domainRecords={records}
-          updateRecords={updateRecords}
-        />
       </Grid>
     </Grid>
   );

--- a/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
+++ b/packages/manager/src/features/Kubernetes/KubernetesClusterDetail/KubernetesClusterDetail.tsx
@@ -77,17 +77,6 @@ const styles = (theme: Theme) =>
     },
     tagHeading: {
       marginBottom: theme.spacing(1) + 4
-    },
-    sectionMain: {
-      [theme.breakpoints.up('md')]: {
-        order: 1
-      }
-    },
-    sectionSideBar: {
-      [theme.breakpoints.up('md')]: {
-        order: 2,
-        display: 'inline-block'
-      }
     }
   });
 interface KubernetesContainerProps {
@@ -214,6 +203,22 @@ export const KubernetesClusterDetail: React.FunctionComponent<
           container
           item
           direction="row"
+          xs={12}
+          md={9}
+          className={classes.sectionMain}
+        >
+          <Navigation
+            location={location}
+            cluster={cluster}
+            updateCluster={props.updateCluster}
+            updateNodePool={props.updateNodePool}
+            {...rest}
+          />
+        </Grid>
+        <Grid
+          container
+          item
+          direction="row"
           className={classes.sectionSideBar}
           xs={12}
           md={3}
@@ -232,22 +237,6 @@ export const KubernetesClusterDetail: React.FunctionComponent<
               endpointLoading={endpointLoading}
             />
           </Grid>
-        </Grid>
-        <Grid
-          container
-          item
-          direction="row"
-          xs={12}
-          md={9}
-          className={classes.sectionMain}
-        >
-          <Navigation
-            location={location}
-            cluster={cluster}
-            updateCluster={props.updateCluster}
-            updateNodePool={props.updateNodePool}
-            {...rest}
-          />
         </Grid>
       </Grid>
     </React.Fragment>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancerDetail/NodeBalancerSummary/NodeBalancerSummary.tsx
@@ -45,11 +45,11 @@ const NodeBalancerSummary: React.StatelessComponent<CombinedProps> = props => {
       <DocumentTitleSegment segment={`${nodeBalancer.label} - Summary`} />
       <NodeBalancerCreationErrors errors={errorResponses} />
       <Grid container>
-        <Grid item xs={12} md={4} lg={3} className={classes.sidebar}>
-          <SummaryPanel nodeBalancer={nodeBalancer} />
-        </Grid>
         <Grid item xs={12} md={8} lg={9} className={classes.main}>
           <TablesPanel nodeBalancer={nodeBalancer} />
+        </Grid>
+        <Grid item xs={12} md={4} lg={3} className={classes.sidebar}>
+          <SummaryPanel nodeBalancer={nodeBalancer} />
         </Grid>
       </Grid>
     </React.Fragment>

--- a/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
+++ b/packages/manager/src/features/linodes/LinodesDetail/LinodeSummary/LinodeSummary.tsx
@@ -697,9 +697,6 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
         <DocumentTitleSegment segment={`${linode.label} - Summary`} />
 
         <Grid container>
-          <Grid item xs={12} md={4} lg={3} className={classes.sidebar}>
-            <SummaryPanel />
-          </Grid>
           <Grid item xs={12} md={8} lg={9} className={classes.main}>
             <Grid
               container
@@ -783,6 +780,9 @@ export class LinodeSummary extends React.Component<CombinedProps, State> {
               renderBody={this.renderDiskIOChart}
               {...chartProps}
             />
+          </Grid>
+          <Grid item xs={12} md={4} lg={3} className={classes.sidebar}>
+            <SummaryPanel />
           </Grid>
         </Grid>
       </React.Fragment>

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -345,7 +345,3 @@ button::-moz-focus-inner {
 .terminal {
   padding: 24px;
 }
-
-*:focus {
-  outline: 2px solid red !important;
-}

--- a/packages/manager/src/index.css
+++ b/packages/manager/src/index.css
@@ -345,3 +345,7 @@ button::-moz-focus-inner {
 .terminal {
   padding: 24px;
 }
+
+*:focus {
+  outline: 2px solid red !important;
+}


### PR DESCRIPTION
## M3-3671 Accessibility: Summary Sidebars

The way the sidebars (containing tags etc) are being ordered is wrong from a tabular POV. The come first in the markup order and we change the order with flex-box.

I also fixed a couple related sidebar content issues (cancel account button, tags buttons)

## Type of Change
- Non breaking change ('update', 'change')