### PR TITLE
Fix: Styling regression on LV Disks tab

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
@@ -16,7 +16,7 @@ import { LongviewDisk } from '../../../request.types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
-    width: '250px',
+    width: 250,
     marginBottom: theme.spacing()
   }
 }));

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/OverviewGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/OverviewGraphs.tsx
@@ -16,10 +16,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     padding: theme.spacing(3) + 1,
     marginBottom: theme.spacing(1) + 3
   },
-  selectOuter: {
-    '& .time-range-select': {
-      width: 150
-    }
+  selectTimeRange: {
+    width: 150
   }
 }));
 
@@ -65,11 +63,12 @@ export const OverviewGraphs: React.FC<CombinedProps> = props => {
         <Grid item>
           <Typography variant="h2">Resource Allocation History</Typography>
         </Grid>
-        <Grid item className={classes.selectOuter}>
+        <Grid item>
           <TimeRangeSelect
             handleStatsChange={handleStatsChange}
             defaultValue={'Past 30 Minutes'}
             label="Select Time Range"
+            className={classes.selectTimeRange}
             hideLabel
           />
         </Grid>

--- a/packages/manager/src/features/Longview/shared/TimeRangeSelect.tsx
+++ b/packages/manager/src/features/Longview/shared/TimeRangeSelect.tsx
@@ -91,7 +91,6 @@ const TimeRangeSelect: React.FC<CombinedProps> = props => {
   return (
     <Select
       {...restOfSelectProps}
-      className={'time-range-select'}
       small
       onChange={handleChange}
       isClearable={false}


### PR DESCRIPTION
## Description

Removing className from the component level to allow features to dictate styling needs instead.

## Type of Change
- Bug fix ('fix')

If the any above types of change apply to this pull request, please ensure to include one of the listed keywords in the pull request title.

## Note to Reviewers

Please view the places `TimeRangeSelect` are in use to ensure there has not been a regression in their styling (mostly affecting placement + width)