### PR TITLE
[LV] Update Load graph color

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
@@ -46,8 +46,8 @@ export const LoadGraph: React.FC<CombinedProps> = props => {
       data={[
         {
           label: 'Load',
-          borderColor: theme.graphs.blueBorder,
-          backgroundColor: theme.graphs.blue,
+          borderColor: theme.graphs.lightGoldBorder,
+          backgroundColor: theme.graphs.lightGold,
           data: _convertData(data.Load || [], start, formatLoad)
         }
       ]}

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -255,7 +255,9 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
       emeraldGreen: '#74D97E',
       emeraldGreenBorder: '#31CC4D',
       forestGreen: '#6FC37C',
-      forestGreenBorder: '#32AE4E'
+      forestGreenBorder: '#32AE4E',
+      lightGold: 'rgba(255, 220, 77, 0.7)',
+      lightGoldBorder: 'rgba(255,210,26,1)'
     },
     font: {
       normal: primaryFonts.normal,


### PR DESCRIPTION
## Description

This changes the color to gold, as in the designs: 

<img width="649" alt="Screen Shot 2019-12-10 at 4 30 47 PM" src="https://user-images.githubusercontent.com/16911484/70570723-6e588600-1b6a-11ea-9b72-0acaf7c6587f.png">

