### PR TITLE
[LV] Update documentation link

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -211,7 +211,9 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
           firstAndLastOnly
           labelTitle={client.label}
         />
-        <DocumentationButton href={'https://google.com'} />
+        <DocumentationButton
+          href={'https://www.linode.com/docs/platform/longview/longview/'}
+        />
       </Box>
       <AppBar position="static" color="default">
         <Tabs


### PR DESCRIPTION
## Description

This was previously a placeholder. The documentation hasn't been updated to reflect LV in Cloud Manager, but this is the best we can do right now. The new link takes you to https://www.linode.com/docs/platform/longview/longview/.