### PR TITLE
[LV] Graphs error state

### DIFF
--- a/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
+++ b/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
@@ -44,7 +44,13 @@ const LongviewLineGraph: React.FC<CombinedProps> = props => {
       </Typography>
       <Divider type="landingHeader" className={classes.divider} />
       <div>
-        {error ? <ErrorState errorText={error} /> : <LineGraph {...rest} />}
+        {error ? (
+          <div style={{ height: props.chartHeight || '300px' }}>
+            <ErrorState errorText={error} />
+          </div>
+        ) : (
+          <LineGraph {...rest} />
+        )}
       </div>
     </React.Fragment>
   );

--- a/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
+++ b/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
@@ -4,6 +4,7 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 
 import Divider from 'src/components/core/Divider';
 import Typography from 'src/components/core/Typography';
+import ErrorState from 'src/components/ErrorState';
 import LineGraph, { Props as LineGraphProps } from 'src/components/LineGraph';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -26,6 +27,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export interface Props extends LineGraphProps {
   title: string;
   subtitle: string;
+  error?: string;
 }
 
 type CombinedProps = Props;
@@ -33,7 +35,7 @@ type CombinedProps = Props;
 const LongviewLineGraph: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
-  const { title, subtitle, ...rest } = props;
+  const { error, title, subtitle, ...rest } = props;
 
   return (
     <React.Fragment>
@@ -42,7 +44,7 @@ const LongviewLineGraph: React.FC<CombinedProps> = props => {
       </Typography>
       <Divider type="landingHeader" className={classes.divider} />
       <div>
-        <LineGraph {...rest} />
+        {error ? <ErrorState errorText={error} /> : <LineGraph {...rest} />}
       </div>
     </React.Fragment>
   );

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/LongviewDetailOverview.tsx
@@ -116,7 +116,11 @@ export const LongviewDetailOverview: React.FC<CombinedProps> = props => {
             </Grid>
           </Paper>
         </Grid>
-        <OverviewGraphs clientAPIKey={clientAPIKey} timezone={timezone} />
+        <OverviewGraphs
+          clientAPIKey={clientAPIKey}
+          timezone={timezone}
+          lastUpdatedError={!!lastUpdatedError}
+        />
         <Grid container justify="space-between" item spacing={0}>
           <ListeningServices
             services={pathOr([], ['Ports', 'listening'], listeningPortsData)}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
@@ -7,19 +7,20 @@ import {
   convertData,
   pathMaybeAddDataInThePast
 } from '../../../shared/formatters';
+import { GraphProps } from './types';
 
-interface Props {
-  clientAPIKey: string;
-  isToday: boolean;
-  timezone: string;
-  start: number;
-  end: number;
-}
-
-export type CombinedProps = Props & WithTheme;
+export type CombinedProps = GraphProps & WithTheme;
 
 export const CPUGraph: React.FC<CombinedProps> = props => {
-  const { clientAPIKey, end, isToday, start, theme, timezone } = props;
+  const {
+    clientAPIKey,
+    end,
+    isToday,
+    lastUpdatedError,
+    start,
+    theme,
+    timezone
+  } = props;
 
   const [data, setData] = React.useState<Partial<AllData>>({});
   const request = () => {
@@ -47,7 +48,7 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
 
   React.useEffect(() => {
     request();
-  }, [start, end, clientAPIKey]);
+  }, [start, end, clientAPIKey, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -54,14 +54,12 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
     [data.Disk]
   );
 
-  if (error) {
-    return <div>{error}</div>;
-  }
-
   return (
     <LongviewLineGraph
       title="Disk I/O"
-      error={requestError || error}
+      // Only show an error state if we don't have any data,
+      // or in the case of special errors returned by processDiskData
+      error={(!data.Disk && requestError) || error}
       subtitle={'ops/second'}
       showToday={isToday}
       timezone={timezone}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -56,6 +56,7 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
   return (
     <LongviewLineGraph
       title="Disk I/O"
+      error={'An error!'}
       subtitle={'ops/second'}
       showToday={isToday}
       timezone={timezone}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
@@ -3,19 +3,20 @@ import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { AllData, getValues } from '../../../request';
 import { convertData } from '../../../shared/formatters';
+import { GraphProps } from './types';
 
-interface Props {
-  clientAPIKey: string;
-  isToday: boolean;
-  timezone: string;
-  start: number;
-  end: number;
-}
-
-export type CombinedProps = Props & WithTheme;
+export type CombinedProps = GraphProps & WithTheme;
 
 export const LoadGraph: React.FC<CombinedProps> = props => {
-  const { clientAPIKey, end, isToday, start, theme, timezone } = props;
+  const {
+    clientAPIKey,
+    lastUpdatedError,
+    end,
+    isToday,
+    start,
+    theme,
+    timezone
+  } = props;
 
   const [data, setData] = React.useState<Partial<AllData>>({});
   const request = () => {
@@ -33,7 +34,7 @@ export const LoadGraph: React.FC<CombinedProps> = props => {
 
   React.useEffect(() => {
     request();
-  }, [start, end, clientAPIKey]);
+  }, [start, end, clientAPIKey, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -7,19 +7,20 @@ import { AllData, getValues } from '../../../request';
 import { Stat } from '../../../request.types';
 import { convertData } from '../../../shared/formatters';
 import { generateUsedMemory, statMax } from '../../../shared/utilities';
+import { GraphProps } from './types';
 
-interface Props {
-  clientAPIKey: string;
-  isToday: boolean;
-  timezone: string;
-  start: number;
-  end: number;
-}
-
-export type CombinedProps = Props & WithTheme;
+export type CombinedProps = GraphProps & WithTheme;
 
 export const MemoryGraph: React.FC<CombinedProps> = props => {
-  const { clientAPIKey, end, isToday, start, theme, timezone } = props;
+  const {
+    clientAPIKey,
+    end,
+    isToday,
+    lastUpdatedError,
+    start,
+    theme,
+    timezone
+  } = props;
 
   const [data, setData] = React.useState<Partial<AllData>>({});
   const request = () => {
@@ -37,7 +38,7 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
 
   React.useEffect(() => {
     request();
-  }, [start, end, clientAPIKey]);
+  }, [start, end, clientAPIKey, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -7,19 +7,20 @@ import { generateUnits } from 'src/features/Longview/LongviewLanding/Gauges/Netw
 import { statMax, sumNetwork } from 'src/features/Longview/shared/utilities';
 import { AllData, getValues } from '../../../request';
 import { convertData } from '../../../shared/formatters';
+import { GraphProps } from './types';
 
-interface Props {
-  clientAPIKey: string;
-  isToday: boolean;
-  timezone: string;
-  start: number;
-  end: number;
-}
-
-export type CombinedProps = Props & WithTheme;
+export type CombinedProps = GraphProps & WithTheme;
 
 export const NetworkGraph: React.FC<CombinedProps> = props => {
-  const { clientAPIKey, end, isToday, start, theme, timezone } = props;
+  const {
+    clientAPIKey,
+    end,
+    isToday,
+    lastUpdatedError,
+    start,
+    theme,
+    timezone
+  } = props;
 
   const [data, setData] = React.useState<Partial<AllData>>({});
   const request = () => {
@@ -43,7 +44,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
 
   React.useEffect(() => {
     request();
-  }, [start, end, clientAPIKey]);
+  }, [start, end, clientAPIKey, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 
@@ -74,7 +75,6 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   return (
     <LongviewLineGraph
       title="Network"
-      error={'Some error'}
       subtitle={maxUnit + '/s'}
       showToday={isToday}
       timezone={timezone}
@@ -97,7 +97,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   );
 };
 
-const enhanced = compose<CombinedProps, Props>(
+const enhanced = compose<CombinedProps, GraphProps>(
   React.memo,
   withTheme
 );

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -74,6 +74,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   return (
     <LongviewLineGraph
       title="Network"
+      error={'Some error'}
       subtitle={maxUnit + '/s'}
       showToday={isToday}
       timezone={timezone}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/OverviewGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/OverviewGraphs.tsx
@@ -10,6 +10,7 @@ import DiskGraph from './DiskGraph';
 import LoadGraph from './LoadGraph';
 import MemoryGraph from './MemoryGraph';
 import NetworkGraph from './NetworkGraph';
+import { GraphProps } from './types';
 
 const useStyles = makeStyles((theme: Theme) => ({
   paperSection: {
@@ -26,11 +27,12 @@ const useStyles = makeStyles((theme: Theme) => ({
 interface Props {
   clientAPIKey: string;
   timezone: string;
+  lastUpdatedError: boolean;
 }
 export type CombinedProps = Props;
 
 export const OverviewGraphs: React.FC<CombinedProps> = props => {
-  const { clientAPIKey, timezone } = props;
+  const { clientAPIKey, lastUpdatedError, timezone } = props;
   const classes = useStyles();
   const [time, setTimeBox] = React.useState<WithStartAndEnd>({
     start: 0,
@@ -43,12 +45,13 @@ export const OverviewGraphs: React.FC<CombinedProps> = props => {
 
   const isToday = time.end - time.start < 60 * 60 * 25;
 
-  const graphProps = {
+  const graphProps: GraphProps = {
     clientAPIKey,
     timezone,
     isToday,
     start: time.start,
-    end: time.end
+    end: time.end,
+    lastUpdatedError
   };
 
   return (

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/types.ts
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/types.ts
@@ -1,0 +1,8 @@
+export interface GraphProps {
+  clientAPIKey: string;
+  timezone: string;
+  lastUpdatedError: boolean;
+  start: number;
+  end: number;
+  isToday: boolean;
+}


### PR DESCRIPTION
## Description

- POC for an error state. Right now it's only used in DiskGraph; if the idea is approved I can add it to the rest. One potential problem: a red error state for a user who has a openvz Linode might be distracting, and it isn't really an error. We could possibly use the `message` prop I'm hoping to add later (see below!) for that case as well.

- All graph components now listen to lastUpdatedError and re-request data when it changes. This solves for when an initial error causes the graphs not to load, then subsequent requests should fill in the data (they don't, currently).

- Extracted GraphProps interface to overview/types.ts. It was the same set of props used in all of the overview graphs, so it made sense.

Holding off on loading and empty states for now, until after Alban's finished his work on the graphs components. I want to superimpose text on the charts themselves in this case, which would conflict with his work.