### PR TITLE
[LV] Provide way back to Classic from MVP

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -16,9 +16,11 @@ import Box from 'src/components/core/Box';
 import Paper from 'src/components/core/Paper';
 import Tab from 'src/components/core/Tab';
 import Tabs from 'src/components/core/Tabs';
+import Typography from 'src/components/core/Typography';
 import DefaultLoader from 'src/components/DefaultLoader';
 import DocumentationButton from 'src/components/DocumentationButton';
 import ErrorState from 'src/components/ErrorState';
+import ExternalLink from 'src/components/ExternalLink';
 import NotFound from 'src/components/NotFound';
 import TabLink from 'src/components/TabLink';
 import withLongviewClients, {
@@ -236,6 +238,25 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
               ))}
             />
           ))}
+          {!showAllTabs && (
+            <Tab
+              component={() => (
+                <Typography
+                  variant="body1"
+                  style={{ alignSelf: 'center', color: '#abadaf' }}
+                >
+                  ...more coming soon!{' '}
+                  {
+                    <ExternalLink
+                      link="https://manager.linode.com/longview"
+                      text="Go to Classic Manager."
+                      hideIcon
+                    />
+                  }
+                </Typography>
+              )}
+            />
+          )}
         </Tabs>
       </AppBar>
       <Switch>


### PR DESCRIPTION
## Description

This is an attempt to provide a way back to Classic from the Longview MVP. Feedback on messaging/placement encouraged.

**To test:** change line 90 of LongviewDetail.tsx to:

```typescript
 const showAllTabs = false;
```


<img width="677" alt="Screen Shot 2019-12-10 at 5 04 22 PM" src="https://user-images.githubusercontent.com/16911484/70573223-81ba2000-1b6f-11ea-8d2d-6f6a4349c3c9.png">
