### PR TITLE
[LV] Use noCap option for Longview Detail breadcrumb

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -210,6 +210,7 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
           pathname={props.location.pathname}
           firstAndLastOnly
           labelTitle={client.label}
+          labelOptions={{ noCap: true }}
         />
         <DocumentationButton href={'https://google.com'} />
       </Box>


### PR DESCRIPTION
## Description

Previously the LV client title was capitalized in the title: 

<img width="361" alt="Screen Shot 2019-12-10 at 5 09 44 PM" src="https://user-images.githubusercontent.com/16911484/70573409-ebd2c500-1b6f-11ea-9cf3-b7c6790598e7.png">

This PR adds the `noCap` option as we have with other entity detail pages.