### PR TITLE
M3-3599 Longview e2e tests

### DIFF
--- a/packages/manager/e2e/config/custom-commands.js
+++ b/packages/manager/e2e/config/custom-commands.js
@@ -17,7 +17,10 @@ const {
   createVolume,
   getLinodeImage,
   createDomain,
-  createNodeBalancer
+  createNodeBalancer,
+  createLongviewClient,
+  deleteLongviewClient,
+  getLVClients
 } = require('../setup/setup');
 
 const {
@@ -84,6 +87,18 @@ exports.browserCommands = () => {
     )
       .then(res => res)
       .catch(err => err);
+  });
+
+  browser.addCommand('createLongviewClient', function async(token) {
+    return createLongviewClient(token).then(res => res);
+  });
+
+  browser.addCommand('getLVClients', function async(token) {
+    return getLVClients(token).then(res => res);
+  });
+
+  browser.addCommand('deleteLongviewClient', function async(token, lvClientId) {
+    return deleteLongviewClient(token, lvClientId).then(res => res);
   });
 
   browser.addCommand('removeAllLinodes', function async(token) {

--- a/packages/manager/e2e/config/wdio.conf.js
+++ b/packages/manager/e2e/config/wdio.conf.js
@@ -143,7 +143,7 @@ exports.config = {
   coloredLogs: true,
   //
   // Warns when a deprecated command is used
-  deprecationWarnings: false,
+  deprecationWarnings: true,
   //
   // If you only want to run your tests until a specific amount of tests have failed use
   // bail (default is 0 - don't bail, run all tests).

--- a/packages/manager/e2e/constants.js
+++ b/packages/manager/e2e/constants.js
@@ -25,7 +25,10 @@ exports.constants = {
     nodeBalancers: '/nodebalancers',
     domains: '/domains',
     managed: '/managed',
-    longview: '/longview',
+    longview: {
+      clients: '/longview/clients',
+      planDetails: 'longview/plan-details'
+    },
     stackscripts: '/stackscripts',
     createStackScript: '/stackscripts/create',
     images: '/images',

--- a/packages/manager/e2e/pageobjects/longview/longview-landing.page.js
+++ b/packages/manager/e2e/pageobjects/longview/longview-landing.page.js
@@ -4,7 +4,7 @@ import Page from '../page';
 
 class LongviewLanding extends Page {
   get title() {
-    return $('[data-qa-header]');
+    return $('h1');
   }
 
   get clientsTab() {
@@ -90,8 +90,10 @@ class LongviewLanding extends Page {
   addLVClient(clientCount) {
     for (let count = 0; count < clientCount; count++) {
       this.addClient.click();
-      $('[data-qa-editable-text="true"]').waitForDisplayed();
-      $('[data-testid="installation"]').waitForDisplayed();
+      $('[data-qa-editable-text="true"]').waitForDisplayed(
+        constants.wait.normal
+      );
+      $('[data-testid="installation"]').waitForDisplayed(constants.wait.normal);
     }
   }
 

--- a/packages/manager/e2e/pageobjects/longview/longview-landing.page.js
+++ b/packages/manager/e2e/pageobjects/longview/longview-landing.page.js
@@ -1,12 +1,9 @@
-/*eslint no-console: ["error", { allow: ["warn", "error"] }] */
-const { constants } = require('../../constants');
 const { assertLog } = require('../../utils/assertionLog');
-
 import Page from '../page';
 
 class LongviewLanding extends Page {
   get title() {
-    return $('h1');
+    return $('[data-qa-header]');
   }
 
   get clientsTab() {
@@ -131,6 +128,11 @@ class LongviewLanding extends Page {
   removeAllLVClients(token) {
     const clientCount = this.getLVClientsAPI(token);
     this.deleteLVClientsAPI(token, clientCount);
+  }
+
+  checkForManaged(token) {
+    const userSettings = browser.getGlobalSettings(token);
+    return userSettings.managed;
   }
 }
 export default new LongviewLanding();

--- a/packages/manager/e2e/pageobjects/longview/longview-landing.page.js
+++ b/packages/manager/e2e/pageobjects/longview/longview-landing.page.js
@@ -1,0 +1,136 @@
+/*eslint no-console: ["error", { allow: ["warn", "error"] }] */
+const { constants } = require('../../constants');
+const { assertLog } = require('../../utils/assertionLog');
+
+import Page from '../page';
+
+class LongviewLanding extends Page {
+  get title() {
+    return $('h1');
+  }
+
+  get clientsTab() {
+    return $('[data-qa-tab="Clients"]');
+  }
+
+  get planDetailsTab() {
+    return $('[data-qa-tab="Plan Details"]');
+  }
+
+  get apiKey() {
+    return $('[data-testid="api-key"]');
+  }
+
+  get addClient() {
+    return $('[data-qa-icon-text-link="Add a Client"]');
+  }
+
+  get longviewClient() {
+    return $('[data-testid="installation"]');
+  }
+
+  get longviewClients() {
+    return $$('[data-testid="installation"]');
+  }
+
+  get deleteClientKabob() {
+    return $('[data-testid="installation"] [data-qa-action-menu]');
+  }
+
+  get deleteButton() {
+    return $('[data-qa-action-menu-item="Delete"]');
+  }
+
+  get lvDelete() {
+    return $('[data-testid="delete-button"]');
+  }
+
+  get noLVClients() {
+    return $('[data-testid="no-client-list"]');
+  }
+
+  get maxClientDialog() {
+    return $('[data-qa-dialog-title="Maximum Clients Reached"]');
+  }
+
+  get upgradeText() {
+    return $('[data-testid="longview-upgrade"]');
+  }
+
+  get dialogAlert() {
+    return $('[data-qa-dialog-content]');
+  }
+
+  isMaxClientCount() {
+    return this.maxClientDialog.isDisplayed();
+  }
+
+  baseLongviewPage() {
+    this.title.waitForDisplayed();
+    this.addClient.waitForDisplayed();
+    $('.MuiPaper-rounded').waitForDisplayed();
+    expect(browser.getUrl())
+      .withContext(`wrong url path`)
+      .toContain('/longview/clients');
+    expect(this.title.getText())
+      .withContext(`Incorrect page title`)
+      .toBe('Longview');
+    expect(this.documentationLink.isDisplayed())
+      .withContext(`Documentation link ${assertLog.displayed}`)
+      .toBe(true);
+    expect(this.documentationLink.isEnabled())
+      .withContext(`Documentation link ${assertLog.enabled}`)
+      .toBe(true);
+    expect(this.addClient.isEnabled())
+      .withContext(`Add client button ${assertLog.enabled}`)
+      .toBe(true);
+    expect(this.clientsTab.isEnabled())
+      .withContext(`Should be on client tab`)
+      .toBe(true);
+  }
+
+  addLVClient(clientCount) {
+    for (let count = 0; count < clientCount; count++) {
+      this.addClient.click();
+      $('[data-qa-editable-text="true"]').waitForDisplayed();
+      $('[data-testid="installation"]').waitForDisplayed();
+    }
+  }
+
+  addLVClientsAPI(token, numClients) {
+    let clientList = [];
+
+    for (let count = 0; count < numClients; count++) {
+      clientList.push(browser.createLongviewClient(token));
+    }
+    return clientList;
+  }
+
+  deleteLVClientAPI(clientId) {
+    return browser.deleteLongviewClient(token, clientId);
+  }
+
+  getLVClientsAPI(token) {
+    return browser.getLVClients(token);
+  }
+
+  removeLVClient(clientId) {
+    $(`[data-testid="${clientId}"] [data-qa-action-menu]`).click();
+    this.deleteButton.click();
+    this.dialogAlert.waitForDisplayed();
+    this.lvDelete.click();
+    this.dialogAlert.waitForDisplayed(true);
+  }
+
+  deleteLVClientsAPI(token, lvClients) {
+    lvClients.forEach(id => {
+      browser.deleteLongviewClient(token, id.id);
+    });
+  }
+
+  removeAllLVClients(token) {
+    const clientCount = this.getLVClientsAPI(token);
+    this.deleteLVClientsAPI(token, clientCount);
+  }
+}
+export default new LongviewLanding();

--- a/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
+++ b/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
@@ -1,5 +1,6 @@
 const { constants } = require('../../constants');
 const { assertLog } = require('../../utils/assertionLog');
+import longviewLanding from '../longview/longview-landing.page';
 import Logger from '../../utils/Logger';
 const log = new Logger('plan-details');
 
@@ -7,7 +8,7 @@ import Page from '../page';
 
 class LongviewPlanDetails extends Page {
   get title() {
-    return $('h1');
+    return $('[data-qa-header]');
   }
 
   get clientsTab() {
@@ -53,7 +54,9 @@ class LongviewPlanDetails extends Page {
   }
 
   resetToFree() {
-    if (this.isCurrentPlan('free')) return;
+    if (this.isCurrentPlan('free')) {
+      return;
+    }
     this.changeLongviewPlan('free');
   }
 
@@ -67,7 +70,7 @@ class LongviewPlanDetails extends Page {
       this.lv100Plan
     ];
 
-    this.currentPlan.waitForDisplayed(constants.wait.normal);
+    this.currentPlan.waitForDisplayed(constants.wait.short);
     expect(browser.getUrl())
       .withContext(`wrong url path`)
       .toContain('/longview/plan-details');
@@ -129,12 +132,19 @@ class LongviewPlanDetails extends Page {
     browser.pause(1500);
     // below call is looking for the button to be disabled. Unfortunately, it is
     // disabled as soon as the loading animation occurs
-    this.changePlanButton.waitForEnabled(constants.wait.normal, true);
+    this.changePlanButton.waitForEnabled(constants.wait.short, true);
   }
+  //
+
   // simplified API call to reset the user account
   setPlanLVFree(token) {
-    const free = { longview_subscription: null };
-    return browser.updateGlobalSettings(token, free);
+    if (longviewLanding.checkForManaged(token)) {
+      log.error('cannot use a managed user account for longview plan changes');
+      return;
+    } else {
+      const free = { longview_subscription: null };
+      return browser.updateGlobalSettings(token, free);
+    }
   }
 }
 

--- a/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
+++ b/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
@@ -8,7 +8,7 @@ import Page from '../page';
 
 class LongviewPlanDetails extends Page {
   get title() {
-    return $('[data-qa-header]');
+    return $('h1');
   }
 
   get clientsTab() {

--- a/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
+++ b/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
@@ -1,0 +1,141 @@
+const { constants } = require('../../constants');
+const { assertLog } = require('../../utils/assertionLog');
+import Logger from '../../utils/Logger';
+const log = new Logger('plan-details');
+
+import Page from '../page';
+
+class LongviewPlanDetails extends Page {
+  get title() {
+    return $('h1');
+  }
+
+  get clientsTab() {
+    return $('[data-qa-tab=Clients]');
+  }
+
+  get planDetailsTab() {
+    return $('[data-qa-tab=Plan Details]');
+  }
+
+  get currentPlan() {
+    return $('[data-testid=current-plan]');
+  }
+
+  get changePlanButton() {
+    return $('[data-testid=submit-button]');
+  }
+
+  get lvFreePlan() {
+    return $(`[data-testid=lv-sub-table-row-longview-free]`);
+  }
+
+  get lv3Plan() {
+    return $(`[data-testid=lv-sub-table-row-longview-3]`);
+  }
+
+  get lv10Plan() {
+    return $(`[data-testid=lv-sub-table-row-longview-10]`);
+  }
+
+  get lv40Plan() {
+    return $(`[data-testid=lv-sub-table-row-longview-40]`);
+  }
+
+  get lv100Plan() {
+    return $(`[data-testid=lv-sub-table-row-longview-100]`);
+  }
+
+  isCurrentPlan(clientCount) {
+    return $(
+      `[data-testid=lv-sub-table-row-longview-${clientCount}] [data-testid=current-plan]`
+    ).isDisplayed();
+  }
+
+  resetToFree() {
+    if (this.isCurrentPlan('free')) return;
+    this.changeLongviewPlan('free');
+  }
+
+  // checks to verify we are on the longview plan details page
+  planDetailsDisplay() {
+    const planOptions = [
+      this.lvFreePlan,
+      this.lv3Plan,
+      this.lv10Plan,
+      this.lv40Plan,
+      this.lv100Plan
+    ];
+
+    this.currentPlan.waitForDisplayed(constants.wait.normal);
+    expect(browser.getUrl())
+      .withContext(`wrong url path`)
+      .toContain('/longview/plan-details');
+    planOptions.forEach(plan => {
+      expect(plan.isDisplayed())
+        .withContext(`Longview plan ${assertLog.displayed}`)
+        .toBe(true);
+      expect(plan.getText()).toContain('Longview');
+    });
+    expect(this.title.getText())
+      .withContext(`${assertLog.incorrectText}`)
+      .toBe('Longview');
+    expect(this.documentationLink.isDisplayed())
+      .withContext(`missing documentation link`)
+      .toBe(true);
+    expect(this.lvFreePlan.getText())
+      .withContext(`${assertLog.incorrectText}`)
+      .toContain('Longview Free');
+    expect(this.changePlanButton.isDisplayed())
+      .withContext(`${assertLog.displayed}`)
+      .toBe(true);
+    expect(this.changePlanButton.isEnabled())
+      .withContext(`Change Plan button ${assertLog.notEnabled}`)
+      .toBe(false);
+  }
+  // verifies that the correct plan is selected and active
+  verifyPlan(clientCount) {
+    const planRow = $(
+      `[data-testid="lv-sub-table-row-longview-${clientCount}"]`
+    );
+    expect(this.isCurrentPlan(clientCount))
+      .withContext(`should be current plan`)
+      .toBe(true);
+    expect(planRow.$('data-qa-radio=true]'))
+      .withContext(`Plan radio button ${assertLog.enabled}`)
+      .toBe(true);
+
+    expect(this.changePlanButton.isEnabled())
+      .withContext(`Change plan button ${assertLog.notEnabled}`)
+      .toBe(false);
+  }
+  // Used for selecting or using any longview plan row
+  selectLongviewPlan(clientCount) {
+    const planRow = $(
+      `[data-testid="lv-sub-table-row-longview-${clientCount}"]`
+    );
+    planRow.click();
+  }
+
+  // used to handle the Change Plan button.
+  // Figure out a better solution to the Change Plan button and it's
+  // loading state and use the loading state to wait
+  changeLongviewPlan(clientCount) {
+    if (this.isCurrentPlan(clientCount)) {
+      log.warn('current plan already selected');
+      return false;
+    }
+    this.changePlanButton.click();
+    browser.pause(1500);
+    // below call is looking for the button to be disabled. Unfortunately, it is
+    // disabled as soon as the loading animation occurs
+    this.changePlanButton.waitForEnabled(constants.wait.normal, true);
+  }
+  // simplified API call to reset the user account
+  setPlanLVFree(token) {
+    const free = { longview_subscription: null };
+    return browser.updateGlobalSettings(token, free);
+  }
+}
+
+export default new LongviewPlanDetails();

--- a/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
+++ b/packages/manager/e2e/pageobjects/longview/longview-plan-details.page.js
@@ -47,6 +47,14 @@ class LongviewPlanDetails extends Page {
     return $(`[data-testid=lv-sub-table-row-longview-100]`);
   }
 
+  get loading() {
+    return $('[data-qa-loading="true"]');
+  }
+
+  get notLoading() {
+    return $('[data-qa-loading="false"]');
+  }
+
   isCurrentPlan(clientCount) {
     return $(
       `[data-testid="lv-sub-table-row-longview-${clientCount}"] [data-testid="current-plan"]`
@@ -129,12 +137,9 @@ class LongviewPlanDetails extends Page {
       return false;
     }
     this.changePlanButton.click();
-    browser.pause(1500);
-    // below call is looking for the button to be disabled. Unfortunately, it is
-    // disabled as soon as the loading animation occurs
+    browser.waitUntil(() => this.notLoading.isDisplayed());
     this.changePlanButton.waitForEnabled(constants.wait.short, true);
   }
-  //
 
   // simplified API call to reset the user account
   setPlanLVFree(token) {

--- a/packages/manager/e2e/pageobjects/page.js
+++ b/packages/manager/e2e/pageobjects/page.js
@@ -186,6 +186,10 @@ export default class Page {
     return '\ue013';
   }
 
+  get documentationLink() {
+    return $('[data-qa-icon-text-link="Documentation"]');
+  }
+
   //Shared in create linode and rebuild flow
   get selectImageHeader() {
     return $('[data-qa-tp="Choose a Distribution"]');

--- a/packages/manager/e2e/setup/setup.js
+++ b/packages/manager/e2e/setup/setup.js
@@ -52,7 +52,7 @@ exports.deleteAll = (token, user) => {
           return res.data;
         })
         .catch(error => {
-          console.log('Error', error);
+          console.error('Error', error);
           return error;
         });
     };
@@ -270,7 +270,7 @@ exports.createNodeBalancer = (token, label, region, tags) => {
       .post(endpoint, data)
       .then(response => resolve(response.data))
       .catch(error => {
-        console.log(error.data);
+        console.error(error.data);
         reject(error);
       });
   });
@@ -305,7 +305,7 @@ exports.removeAllVolumes = token => {
             resolve(res);
           })
           .catch(error => {
-            console.log(error.data);
+            console.error(error.data);
             return error;
           });
       });
@@ -374,9 +374,7 @@ exports.getMyStackScripts = token => {
       .get(endpoint, {
         headers: {
           Authorization: `Bearer ${token}`,
-          'X-Filter': `{"username":"${
-            browser.options.testUser
-          }","+order_by":"deployments_total","+order":"desc"}`,
+          'X-Filter': `{"username":"${browser.options.testUser}","+order_by":"deployments_total","+order":"desc"}`,
           'User-Agent': 'WebdriverIO'
         }
       })
@@ -492,6 +490,48 @@ exports.deleteUser = (token, username) => {
     return getAxiosInstance(token)
       .delete(endpoint)
       .then(response => resolve(response.data))
+      .catch(error => {
+        console.error('Error', error);
+        reject(error);
+      });
+  });
+};
+
+exports.createLongviewClient = token => {
+  return new Promise((resolve, reject) => {
+    const endpoint = '/longview/clients';
+
+    return getAxiosInstance(token)
+      .post(endpoint)
+      .then(response => resolve(response.data))
+      .catch(error => {
+        console.error('Error', error);
+        reject(error);
+      });
+  });
+};
+
+exports.deleteLongviewClient = (token, lvClientId) => {
+  return new Promise((resolve, reject) => {
+    const endpoint = `/longview/clients/${lvClientId}`;
+
+    return getAxiosInstance(token)
+      .delete(endpoint)
+      .then(response => resolve(response.data))
+      .catch(error => {
+        console.error('Error', error);
+        reject(error);
+      });
+  });
+};
+
+exports.getLVClients = token => {
+  return new Promise((resolve, reject) => {
+    const endpoint = '/longview/clients';
+
+    return getAxiosInstance(token)
+      .get(endpoint)
+      .then(response => resolve(response.data.data))
       .catch(error => {
         console.error('Error', error);
         reject(error);

--- a/packages/manager/e2e/specs/longview/longview-plan-details.spec.js
+++ b/packages/manager/e2e/specs/longview/longview-plan-details.spec.js
@@ -101,10 +101,13 @@ describe('longview suite', () => {
       expect(LongviewPlan.isCurrentPlan('free'))
         .withContext(`free plan should be set`)
         .toBe(true);
-
       LongviewPlan.selectLongviewPlan('100');
       LongviewPlan.changeLongviewPlan('100');
       LongviewPlan.verifyPlan('100');
+
+      LongviewPlan.selectLongviewPlan('40');
+      LongviewPlan.changeLongviewPlan('40');
+      LongviewPlan.verifyPlan('40');
     });
 
     it('cannot set a plan that is lower than current longview clients ', () => {

--- a/packages/manager/e2e/specs/longview/longview-plan-details.spec.js
+++ b/packages/manager/e2e/specs/longview/longview-plan-details.spec.js
@@ -1,0 +1,115 @@
+const { constants } = require('../../constants');
+const { readToken } = require('../../utils/config-utils');
+import LongviewLanding from '../../pageobjects/longview/longview-landing.page';
+import LongviewPlan from '../../pageobjects/longview/longview-plan-details.page';
+import { assertLog } from '../../utils/assertionLog';
+import { longviewText } from './longviewText';
+
+describe('longview suite', () => {
+  describe('Longview client tests', () => {
+    let token;
+    beforeEach(() => {
+      token = readToken(browser.options.testUser);
+      // removing all longview clients
+      LongviewLanding.removeAllLVClients(token);
+      browser.url(constants.routes.longview.clients);
+      LongviewLanding.baseLongviewPage();
+    });
+
+    it('checks default page with no longview clients', () => {
+      expect(LongviewLanding.noLVClients.isDisplayed())
+        .withContext(`should not have longview clients`)
+        .toBe(true);
+      expect(LongviewLanding.noLVClients.$('p').getText())
+        .withContext(`${assertLog.incorrectText}`)
+        .toBe(`${longviewText.noClients}`);
+      expect(LongviewLanding.upgradeText.getText())
+        .withContext(`${assertLog.incorrectText} for longview upgrade`)
+        .toBe(`${longviewText.upgradeMessage}`);
+    });
+
+    it('can add a new client', () => {
+      LongviewLanding.addLVClient(1);
+      expect($('[data-qa-editable-text]').isDisplayed())
+        .withContext(`Longview client name ${assertLog.displayed}`)
+        .toBe(true);
+      expect($('[data-qa-editable-text]').getText())
+        .withContext(`longview client ${assertLog.incorrectText}`)
+        .toContain('longview');
+    });
+
+    it('checks for correct longview client information', () => {
+      // create a client via API and validate information
+      const client = LongviewLanding.addLVClientsAPI(token, 1);
+      const installCode = `${longviewText.installCmd}${client[0].install_code}${longviewText.installCmd2}`;
+      const clientId = client[0].id;
+      browser.refresh();
+      LongviewLanding.baseLongviewPage();
+      const clientRow = $(`[data-testid="${clientId}"]`);
+      clientRow.waitForDisplayed();
+
+      expect(clientRow.$('[data-qa-editable-text]').getText())
+        .withContext(`${assertLog.incorrectText} longview label`)
+        .toBe(client[0].label);
+      expect(LongviewLanding.longviewClient.$('pre').getText())
+        .withContext(`${assertLog.incorrectText} for install command`)
+        .toBe(`${installCode}`);
+      expect(LongviewLanding.apiKey.getText())
+        .withContext(`${assertLog.incorrectText} api install key`)
+        .toBe(`API Key: ${client[0].api_key}`);
+    });
+
+    it('can delete a client', () => {
+      const client = LongviewLanding.addLVClientsAPI(token, 1);
+      const clientId = client[0].id;
+      browser.refresh();
+      LongviewLanding.baseLongviewPage();
+
+      $(`[data-testid="${clientId}"] [data-qa-action-menu]`).waitForDisplayed();
+      LongviewLanding.removeLVClient(clientId);
+    });
+  });
+
+  describe('longview plan detail tests', () => {
+    const lvSetting = { longview_subscription: '' };
+
+    beforeEach(() => {
+      const token = readToken(browser.options.testUser);
+      LongviewPlan.setPlanLVFree(token, lvSetting);
+      browser.url(constants.routes.longview.planDetails);
+      LongviewPlan.planDetailsDisplay();
+    });
+    it('checks that longview plan can changed', () => {
+      // Changes a plan
+      expect(LongviewPlan.isCurrentPlan('free'))
+        .withContext(`free plan should be set`)
+        .toBe(true);
+
+      LongviewPlan.selectLongviewPlan('100');
+      LongviewPlan.changeLongviewPlan('100');
+      LongviewPlan.verifyPlan('100');
+    });
+
+    it('cannot set a plan that is lower than current longview clients ', () => {
+      // Create 4 longview clients
+      const token = readToken(browser.options.testUser);
+      const clients = LongviewLanding.addLVClientsAPI(token, 4);
+      const clientCount = LongviewLanding.getLVClientsAPI();
+      const lvError = `Too many active Longview clients (${clientCount.length}) for the subscription selected (3). Select a larger subscription or reduce the number of Longview clients.`;
+      LongviewPlan.lv3Plan.click();
+      LongviewPlan.changePlanButton.click();
+      $('[data-qa-notice').waitForDisplayed();
+      expect($('[data-qa-error="true"]').isDisplayed())
+        .withContext(`Client count error ${assertLog.displayed}`)
+        .toBe(true);
+      expect($('[data-qa-error="true"]').getText())
+        .withContext(`${assertLog.incorrectText} for client error`)
+        .toBe(lvError);
+      expect(LongviewPlan.changePlanButton.isEnabled())
+        .withContext(`Change Plan button ${assertLog.enabled}`)
+        .toBe(true);
+      // delete created longview clients
+      LongviewLanding.deleteLVClientsAPI(token, clients);
+    });
+  });
+});

--- a/packages/manager/e2e/specs/longview/longview-plan-details.spec.js
+++ b/packages/manager/e2e/specs/longview/longview-plan-details.spec.js
@@ -93,11 +93,11 @@ describe('longview suite', () => {
     });
 
     it('checks that longview plan can be changed', () => {
-      // // checks for managed account
+      // checks for managed account
       expect(LongviewLanding.checkForManaged(token))
         .withContext(`${managedAccount}`)
         .toBe(false);
-      // // Changes a plan
+      // changes a plan
       expect(LongviewPlan.isCurrentPlan('free'))
         .withContext(`free plan should be set`)
         .toBe(true);

--- a/packages/manager/e2e/specs/longview/longviewText.js
+++ b/packages/manager/e2e/specs/longview/longviewText.js
@@ -1,0 +1,7 @@
+export const longviewText = {
+  noClients: 'You have no Longview clients configured. Click here to add one.',
+  upgradeMessage:
+    'Upgrade to Longview Pro for more clients, longer data retention, and more frequent data updates.',
+  installCmd: `curl -s https://lv.linode.com/`,
+  installCmd2: ' | sudo bash'
+};

--- a/packages/manager/e2e/utils/Logger.js
+++ b/packages/manager/e2e/utils/Logger.js
@@ -1,0 +1,48 @@
+export default class Logger {
+  constructor(title) {
+    this.title = title;
+  }
+  // color options: Reset must be used with a color after the %s to reset the console color
+  // colors = {
+  //   Reset = "\x1b[0m",
+  //   Bright = "\x1b[1m",
+  //   Dim = "\x1b[2m",
+  //   Underscore = "\x1b[4m",
+  //   Blink = "\x1b[5m",
+  //   Reverse = "\x1b[7m",
+  //   Hidden = "\x1b[8m",
+
+  //   FgBlack = "\x1b[30m",
+  //   FgRed = "\x1b[31m",
+  //   FgGreen = "\x1b[32m",
+  //   FgYellow = "\x1b[33m",
+  //   FgBlue = "\x1b[34m",
+  //   FgMagenta = "\x1b[35m",
+  //   FgCyan = "\x1b[36m",
+  //   FgWhite = "\x1b[37m",
+
+  //   BgBlack = "\x1b[40m",
+  //   BgRed = "\x1b[41m",
+  //   BgGreen = "\x1b[42m",
+  //   BgYellow = "\x1b[43m",
+  //   BgBlue = "\x1b[44m",
+  //   BgMagenta = "\x1b[45m",
+  //   BgCyan = "\x1b[46m",
+  //   BgWhite = "\x1b[47m"
+  // }
+
+  info(message) {
+    // Using Cyan with reset
+    console.log('\x1b[36m%s\x1b[0m', `${this.title} | ${message}`);
+  }
+
+  warn(message) {
+    // Using Yellow with reset
+    console.log('\x1b[33m%s\x1b[0m', `${this.title} | ${message}`);
+  }
+
+  error(message) {
+    // Using Red with reset
+    console.log('\x1b[31m%s\x1b[0m', `${this.title} | ${message}`);
+  }
+}

--- a/packages/manager/e2e/utils/assertionLog.js
+++ b/packages/manager/e2e/utils/assertionLog.js
@@ -1,6 +1,8 @@
 export const assertLog = {
   displayed: 'should be displayed',
+  enabled: 'should be enabled',
   notDisplayed: 'should not be displayed',
+  notEnabled: 'should not be enabled',
   incorrectText: 'incorrect text found',
   incorrectRegExVal: 'incorrect value found for regex with',
   incorrectNum: 'incorrect number of items',

--- a/packages/manager/e2e/utils/common.js
+++ b/packages/manager/e2e/utils/common.js
@@ -20,7 +20,7 @@ import NodeBalancers from '../pageobjects/nodebalancers.page';
 import NodeBalancerDetail from '../pageobjects/nodebalancer-detail/details.page';
 
 export const generatePassword = () => {
-  return crypto.randomBytes(20).toString('hex');
+  return crypto.randomBytes(30).toString('hex');
 };
 
 export const timestamp = () => {
@@ -248,6 +248,12 @@ export const checkEnvironment = () => {
   if (environment.includes('dev') || environment.includes('testing')) {
     pending('Feature not available in Testing or Dev environment');
   }
+};
+
+export const createLongviewClient = () => {
+  const token = readToken(browser.options.testUser);
+  const lvClient = browser.createLongviewClients(token);
+  return lvClient;
 };
 
 export const createVolumes = (volumeObjArray, waitForToast) => {

--- a/packages/manager/e2e/utils/cred-store.js
+++ b/packages/manager/e2e/utils/cred-store.js
@@ -1,6 +1,6 @@
+/*eslint no-console: ["error", { allow: ["warn", "error"] }] */
 const { resetAccounts } = require('../setup/cleanup');
 const { constants } = require('../constants');
-
 class CredStore {
   // default browser object is a mock to support testing outside the context
   // of running the e2e tests.  when running under e2e browser is passed in via
@@ -11,8 +11,6 @@ class CredStore {
   }
 
   setBrowser(browser) {
-    // console.log("setting browser to:");
-    // console.log(browser);
     this.browser = browser;
   }
 
@@ -20,35 +18,37 @@ class CredStore {
   // let implementor know that child class must provide an impl for this
   // method.
   getAllCreds() {
-    throw 'CredStore.getAllCreds() needs to be implemented in child class';
+    try {
+      throw new Error(
+        'CredStore.getAllCreds() needs to be implemented in child class'
+      );
+    } catch (e) {
+      alert(e.message);
+    }
   }
 
   cleanupAccounts() {
     if (this.shouldCleanupUsingAPI) {
-      console.log('cleaning up user resources via API');
+      //console.log('cleaning up user resources via API');
       return this.getAllCreds().then(credCollection => {
-        console.log(credCollection);
+        //console.log(credCollection);
         return resetAccounts(credCollection);
       });
     } else {
-      console.log('not cleaning up resources via API');
+      //console.log('not cleaning up resources via API');
       return Promise.resolve(false);
     }
   }
 
   login(username, password, shouldStoreToken = false) {
-    console.log('logging in for user: ' + username);
-
     let browser = this.browser;
 
     browser.url(constants.routes.linodes);
-    console.log(`route to follow: ${constants.routes.linodes}`);
     try {
-      console.log(`attempting to enter username`);
       $('#username').waitForDisplayed(constants.wait.long);
     } catch (err) {
-      //console.log(`page source`)
-      console.log(browser.getPageSource());
+      //error(`page source`)
+      error(browser.getPageSource());
     }
 
     $('#password').waitForDisplayed(constants.wait.long);
@@ -70,7 +70,7 @@ class CredStore {
         $('.oauthauthorize-page').waitForDisplayed(1000);
         return true;
       } catch (err) {
-        console.log('Not on the Oauth Page, continuing');
+        console.error('Not on the Oauth Page, continuing');
         return false;
       }
     };
@@ -104,7 +104,7 @@ class CredStore {
     try {
       $('[data-qa-add-new-menu-button]').waitForExist(constants.wait.normal);
     } catch (err) {
-      console.log(
+      console.error(
         'Add an entity menu failed to exist',
         'Failed to login to the Manager for some reason.'
       );
@@ -112,16 +112,16 @@ class CredStore {
       console.error(`Page source: \n ${browser.getPageSource()}`);
     }
 
-    // Wait for the welcome modal to display, click it once it appears
-    if ($('[role="dialog"]').waitForDisplayed()) {
-      const letsGoButton = url.includes('dev')
-        ? '.btn#submit'
-        : '[data-qa-welcome-button]';
-      $(letsGoButton).click();
-      $('[role="dialog"]').waitForDisplayed(constants.wait.long, true);
-    }
+    // // Wait for the welcome modal to display, click it once it appears
+    // if ($('[role="dialog"]').waitForDisplayed()) {
+    //   const letsGoButton = url.includes('dev')
+    //     ? '.btn#submit'
+    //     : '[data-qa-welcome-button]';
+    //   $(letsGoButton).click();
+    //   $('[role="dialog"]').waitForDisplayed(constants.wait.long, true);
+    // }
 
-    $('[data-qa-add-new-menu-button]').waitForDisplayed(constants.wait.long);
+    // $('[data-qa-add-new-menu-button]').waitForDisplayed(constants.wait.long);
 
     // TODO fix storeToken implementation
     //if (shouldStoreToken) {

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -80,7 +80,7 @@ const FinalCrumb: React.FC<CombinedProps> = props => {
             [classes.crumb]: true,
             [classes.noCap]: labelOptions && labelOptions.noCap
           })}
-          data-qa-label-text
+          data-qa-label-text={crumb}
         />
         {labelOptions && labelOptions.subtitle && (
           <Typography variant="body1" data-qa-label-subtitle>

--- a/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
+++ b/packages/manager/src/components/Breadcrumb/FinalCrumb.tsx
@@ -80,7 +80,7 @@ const FinalCrumb: React.FC<CombinedProps> = props => {
             [classes.crumb]: true,
             [classes.noCap]: labelOptions && labelOptions.noCap
           })}
-          data-qa-label-text={crumb}
+          dataQaEl={crumb}
         />
         {labelOptions && labelOptions.subtitle && (
           <Typography variant="body1" data-qa-label-subtitle>

--- a/packages/manager/src/components/Button/Button.tsx
+++ b/packages/manager/src/components/Button/Button.tsx
@@ -183,11 +183,12 @@ const wrappedButton: React.StatelessComponent<CombinedProps> = props => {
           className={classNames({
             [classes.reg]: true
           })}
+          data-qa-loading={loading}
         >
           {loading ? (
             loadingText ? (
-              /* 
-                the recommendation here is to not use loadingText that 
+              /*
+                the recommendation here is to not use loadingText that
                 will create a large width for the button. Keep
                 your loading text strings short.
               */

--- a/packages/manager/src/components/H1Header/H1Header.tsx
+++ b/packages/manager/src/components/H1Header/H1Header.tsx
@@ -4,6 +4,7 @@ import Typography from 'src/components/core/Typography';
 interface Props {
   title: string;
   className?: string;
+  dataQaEl?: string;
 }
 
 // Accessibility Feature:
@@ -12,7 +13,7 @@ interface Props {
 // It should serve as the only source for all H1s
 const H1Header: React.FC<Props> = props => {
   const h1Header = React.useRef<HTMLDivElement>(null);
-  const { className, title } = props;
+  const { className, title, dataQaEl } = props;
 
   React.useEffect(() => {
     if (h1Header.current !== null) {
@@ -21,7 +22,13 @@ const H1Header: React.FC<Props> = props => {
   }, []);
 
   return (
-    <Typography variant="h1" className={className} ref={h1Header} tabIndex={-1}>
+    <Typography
+      variant="h1"
+      className={className}
+      ref={h1Header}
+      tabIndex={-1}
+      data-qa-header={dataQaEl ? dataQaEl : ''}
+    >
       {title}
     </Typography>
   );

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Installation.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Installation.tsx
@@ -24,6 +24,7 @@ const Installation: React.FC<CombinedProps> = props => {
 
   return (
     <Paper
+      data-testid="longview-clients"
       className={classes.root}
       id="tabpanel-installation"
       role="tabpanel"

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Installation.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Installation.tsx
@@ -30,6 +30,7 @@ const Installation: React.FC<CombinedProps> = props => {
       aria-labelledby="tab-installation"
     >
       <Instructions
+        data-qa-instructions
         APIKey={props.clientAPIKey}
         installationKey={props.clientInstallationKey}
       />

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientInstructions.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientInstructions.tsx
@@ -62,7 +62,7 @@ export const LongviewClientInstructions: React.FC<Props> = props => {
   };
 
   return (
-    <Paper className={classes.root}>
+    <Paper data-testid={clientID} className={classes.root}>
       <Grid
         container
         direction="row"
@@ -70,6 +70,7 @@ export const LongviewClientInstructions: React.FC<Props> = props => {
         alignItems="flex-start"
         spacing={2}
         aria-label="Installation instructions for the Longview agent"
+        data-testid="installation"
       >
         <Grid item xs={11}>
           <Grid container>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -93,7 +93,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
   }
 
   return (
-    <Paper className={classes.root}>
+    <Paper data-testid={clientID} className={classes.root}>
       <Grid
         container
         wrap="nowrap"

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClients.tsx
@@ -322,7 +322,7 @@ export const LongviewClients: React.FC<CombinedProps> = props => {
           alignItems="center"
           justify="center"
         >
-          <Typography>
+          <Typography data-testid="longview-upgrade">
             <Link to={'/longview/plan-details'}>Upgrade to Longview Pro</Link>
             {` `}for more clients, longer data retention, and more frequent data
             updates.

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewDeleteDialog.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewDeleteDialog.tsx
@@ -92,6 +92,7 @@ const Actions: React.FC<ActionsProps> = props => {
         loading={props.isDeleting}
         destructive
         buttonType="secondary"
+        data-testid="delete-button"
       >
         Delete
       </Button>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewList.tsx
@@ -103,7 +103,7 @@ const LongviewList: React.FC<CombinedProps> = props => {
   /** Empty state */
   if (longviewClientsLastUpdated !== 0 && longviewClientsResults === 0) {
     return (
-      <Paper className={classes.empty}>
+      <Paper data-testid="no-client-list" className={classes.empty}>
         <Typography variant="body1" className={classes.emptyText}>
           {userCanCreateLongviewClient ? (
             <React.Fragment>

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewPlans.tsx
@@ -443,7 +443,11 @@ export const LongviewSubscriptionRow: React.FC<
           />
           {plan}
           {currentSubscriptionOnAccount === id && (
-            <Chip label="Current Plan" className={styles.chip} />
+            <Chip
+              data-testid="current-plan"
+              label="Current Plan"
+              className={styles.chip}
+            />
           )}
         </div>
       </TableCell>

--- a/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
+++ b/packages/manager/src/features/Longview/shared/InstallationInstructions.tsx
@@ -47,9 +47,7 @@ type CombinedProps = Props;
 const InstallationInstructions: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
-  const command = `curl -s https://lv.linode.com/${
-    props.installationKey
-  } | sudo bash`;
+  const command = `curl -s https://lv.linode.com/${props.installationKey} | sudo bash`;
 
   return (
     <Grid container>
@@ -112,7 +110,7 @@ const InstallationInstructions: React.FC<CombinedProps> = props => {
             </Typography>
           </Grid>
           <Grid item className={classes.instruction}>
-            <Typography>
+            <Typography data-testid="api-key">
               API Key: <span className={classes.apiKey}>{props.APIKey}</span>
             </Typography>
           </Grid>


### PR DESCRIPTION
Longview UI tests

* Created test for the longview plan subscription and longview clients.
* All tests can be run individually or together. The beforeEach and API calls will set up the data for the tests to run and use the information
from the responses for verification.

**note** there is an ugly browser.pause(1500) in the changePlan function.
This is because once the button is selected it is set to a disabled mode
so the check for the button to not be enabled will not work. Need a better
way to wait for the loading state on the button.

When running tests remember to use a user that does NOT have longview
clients installed. The tests will clear out all longview clients to make
sure the tests run reliably.

Added in some needed selectors to allow for UI automation to work easier. We are now using the data-testid instead of data-qa for testing attribiutes.

Fixes for crumb/header changes
changed title selector from '[data-qa-dialog-title]' to 'h1'

## Type of Change
- Non breaking change ('update', 'change')

## Applicable E2E Tests

To run relevant E2E tests, run these commands in 3 separate terminals:

1. `yarn up`
2. `yarn selenium`
3. `yarn e2e --file longview/longview-plan-details.spec.js`

## Note to Reviewers

When running tests remember to use a user that does NOT have longview
clients installed. The tests will clear out all longview clients to make
sure the tests run reliably.
