### PR TITLE
[LV] Add errors to remaining graphs

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
@@ -23,6 +23,7 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
   } = props;
 
   const [data, setData] = React.useState<Partial<AllData>>({});
+  const [error, setError] = React.useState<string | undefined>();
   const request = () => {
     if (!start || !end) {
       return;
@@ -32,9 +33,12 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
       fields: ['cpu'],
       start,
       end
-    }).then(response => {
-      setData(response);
-    });
+    })
+      .then(response => {
+        setError(undefined);
+        setData(response);
+      })
+      .catch(_ => setError('Unable to retrieve CPU data'));
   };
 
   const cpuData = React.useMemo(() => {
@@ -56,6 +60,7 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
     <LongviewLineGraph
       title="CPU"
       subtitle="%"
+      error={error}
       showToday={isToday}
       timezone={timezone}
       data={[

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
@@ -19,6 +19,7 @@ export const LoadGraph: React.FC<CombinedProps> = props => {
   } = props;
 
   const [data, setData] = React.useState<Partial<AllData>>({});
+  const [error, setError] = React.useState<string | undefined>();
   const request = () => {
     if (!start || !end) {
       return;
@@ -27,9 +28,12 @@ export const LoadGraph: React.FC<CombinedProps> = props => {
       fields: ['load'],
       start,
       end
-    }).then(response => {
-      setData(response);
-    });
+    })
+      .then(response => {
+        setError(undefined);
+        setData(response);
+      })
+      .catch(_ => setError('Unable to retrieve load data.'));
   };
 
   React.useEffect(() => {
@@ -42,6 +46,7 @@ export const LoadGraph: React.FC<CombinedProps> = props => {
     <LongviewLineGraph
       title="Load"
       subtitle="Target < 1.00"
+      error={error}
       showToday={isToday}
       timezone={timezone}
       data={[

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -23,6 +23,7 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
   } = props;
 
   const [data, setData] = React.useState<Partial<AllData>>({});
+  const [error, setError] = React.useState<string | undefined>();
   const request = () => {
     if (!start || !end) {
       return;
@@ -31,9 +32,12 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
       fields: ['memory'],
       start,
       end
-    }).then(response => {
-      setData(response);
-    });
+    })
+      .then(response => {
+        setError(undefined);
+        setData(response);
+      })
+      .catch(_ => setError('Unable to retrieve memory usage data.'));
   };
 
   React.useEffect(() => {
@@ -65,6 +69,7 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
     <LongviewLineGraph
       title="Memory"
       subtitle={unit}
+      error={error}
       showToday={isToday}
       timezone={timezone}
       data={[

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -23,6 +23,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
   } = props;
 
   const [data, setData] = React.useState<Partial<AllData>>({});
+  const [error, setError] = React.useState<string | undefined>();
   const request = () => {
     if (!start || !end) {
       return;
@@ -32,9 +33,12 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
       fields: ['network'],
       start,
       end
-    }).then(response => {
-      setData(response);
-    });
+    })
+      .then(response => {
+        setError(undefined);
+        setData(response);
+      })
+      .catch(_ => setError('Unable to retrieve network data.'));
   };
 
   const networkData = React.useMemo(
@@ -76,6 +80,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
     <LongviewLineGraph
       title="Network"
       subtitle={maxUnit + '/s'}
+      error={error}
       showToday={isToday}
       timezone={timezone}
       data={[


### PR DESCRIPTION
Uses the pattern from #5880 to provide error states to the remaining overview graphs.