### PR TITLE
[For Release] LV Don't request/display stale data

### DIFF
--- a/packages/manager/src/containers/longview.stats.container.ts
+++ b/packages/manager/src/containers/longview.stats.container.ts
@@ -14,7 +14,10 @@ export interface LVClientData {
 }
 
 export interface DispatchProps {
-  getClientStats: (api_key: string) => Promise<ReturnType>;
+  getClientStats: (
+    api_key: string,
+    lastUpdated?: number
+  ) => Promise<ReturnType>;
 }
 
 export type Props = DispatchProps & LVClientData;
@@ -64,9 +67,13 @@ const connected = <OwnProps extends {}>(
       };
     },
     (dispatch: ThunkDispatch, ownProps: OwnProps) => ({
-      getClientStats: api_key =>
+      getClientStats: (api_key, lastUpdated) =>
         dispatch(
-          getClientStats({ clientID: supplyClientID(ownProps), api_key })
+          getClientStats({
+            clientID: supplyClientID(ownProps),
+            api_key,
+            lastUpdated
+          })
         )
     })
   );

--- a/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/LongviewDetail.tsx
@@ -89,7 +89,9 @@ export const LongviewDetail: React.FC<CombinedProps> = props => {
 
   const { lastUpdated, lastUpdatedError } = useClientLastUpdated(
     clientAPIKey,
-    clientAPIKey ? () => props.getClientStats(clientAPIKey) : undefined
+    clientAPIKey
+      ? _lastUpdated => props.getClientStats(clientAPIKey, _lastUpdated)
+      : undefined
   );
 
   const topProcesses = useAPIRequest<LongviewTopProcesses>(

--- a/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
+++ b/packages/manager/src/features/Longview/LongviewLanding/LongviewClientRow.tsx
@@ -71,7 +71,7 @@ const LongviewClientRow: React.FC<CombinedProps> = props => {
 
   const { lastUpdated, lastUpdatedError, authed } = useClientLastUpdated(
     clientAPIKey,
-    () => props.getClientStats(clientAPIKey)
+    _lastUpdated => props.getClientStats(clientAPIKey, _lastUpdated)
   );
 
   /**

--- a/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
+++ b/packages/manager/src/features/Longview/shared/useClientLastUpdated.ts
@@ -5,7 +5,7 @@ import { getLastUpdated } from '../request';
 
 export const useClientLastUpdated = (
   clientAPIKey?: string,
-  callback?: () => void
+  callback?: (lastUpdated?: number) => void
 ) => {
   let mounted = true;
   let requestInterval: NodeJS.Timeout;
@@ -46,9 +46,10 @@ export const useClientLastUpdated = (
           (typeof newLastUpdated === 'undefined' ||
             pathOr(0, ['updated'], response) > newLastUpdated)
         ) {
+          const _lastUpdated = pathOr(0, ['updated'], response);
           setLastUpdated(response.updated);
           if (callback) {
-            callback();
+            callback(_lastUpdated);
           }
         }
       })

--- a/packages/manager/src/store/longviewStats/longviewStats.actions.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.actions.ts
@@ -27,6 +27,7 @@ export const requestClientStats = actionCreator.async<
   {
     api_key: string;
     clientID: number;
+    lastUpdated?: number;
   },
   /**
    * This is a partial because we can't make any assumptions on pieces

--- a/packages/manager/src/store/longviewStats/longviewStats.requests.ts
+++ b/packages/manager/src/store/longviewStats/longviewStats.requests.ts
@@ -1,11 +1,11 @@
-import { get, getLastUpdated } from 'src/features/Longview/request';
+import { get } from 'src/features/Longview/request';
 import { LongviewPackage } from 'src/features/Longview/request.types';
 import { createRequestThunk } from '../store.helpers';
 import { requestClientStats } from './longviewStats.actions';
 
 export const getClientStats = createRequestThunk(
   requestClientStats,
-  async ({ api_key }) => {
+  async ({ api_key, lastUpdated }) => {
     /**
      * To calculate the number of packages in need
      * of updating, we need the full list of available
@@ -29,19 +29,10 @@ export const getClientStats = createRequestThunk(
      * returned data.
      *
      * Since we use this request to populate "live" data, we don't actually
-     * want to make this request if lastUpdated is more than ~30 minutes.
+     * want to make this request if lastUpdated is more than ~30 minutes ago.
      */
-    let lastUpdated = 0;
-    try {
-      lastUpdated = await getLastUpdated(api_key).then(
-        response => response.updated || 0
-      );
-    } catch {
-      return Promise.resolve({});
-    }
-
-    if (Date.now() / 1000 - lastUpdated > 60 * 30) {
-      return Promise.resolve({});
+    if (lastUpdated && Date.now() / 1000 - lastUpdated > 60 * 30) {
+      return Promise.resolve({ Packages: [...packages] });
     }
 
     return get(api_key, 'getLatestValue', {


### PR DESCRIPTION
## Description

Separate PR since I'm not sure about this. The issue is that `getLatestValue` always returns a value, and we're using those values to populate the gauges. If a client returned data a month ago, our "live" gauges will show that data, whereas Cloud will (correctly) not display it.