### PR TITLE
Change: Loading State & Error Handling for TimeRangeSelect

### DIFF
--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/Disks/Disks.tsx
@@ -58,10 +58,12 @@ const Disks: React.FC<CombinedProps> = props => {
     );
   };
 
-  const request = (): Promise<
-    Partial<LongviewDisk<''> & LongviewSystemInfo>
-  > => {
-    if (start && end && clientLastUpdated) {
+  const request = (
+    _start: number,
+    _end: number,
+    cb?: Function
+  ): Promise<Partial<LongviewDisk<''> & LongviewSystemInfo>> => {
+    if (_start && _end && clientLastUpdated) {
       if (!diskStats) {
         setLoading(true);
       }
@@ -70,8 +72,8 @@ const Disks: React.FC<CombinedProps> = props => {
 
       return getStats(clientAPIKey, 'getValues', {
         fields: ['disk', 'sysinfo'],
-        start,
-        end
+        start: _start,
+        end: _end
       })
         .then(r => {
           if (mounted) {
@@ -105,6 +107,9 @@ const Disks: React.FC<CombinedProps> = props => {
             updateDiskStats(enhancedDisk);
             updateSysInfoType(pathOr('', ['SysInfo', 'type'], r));
           }
+          if (cb) {
+            cb();
+          }
           return r;
         })
         .catch(() => {
@@ -122,19 +127,20 @@ const Disks: React.FC<CombinedProps> = props => {
   };
 
   const setStartAndEnd = (_start: number, _end: number) => {
-    setStart(_start);
-    setEnd(_end);
-    return request();
+    return request(_start, _end, () => {
+      setStart(_start);
+      setEnd(_end);
+    });
   };
 
   React.useEffect(() => {
     mounted = true;
-    request();
+    request(start, end);
 
     return () => {
       mounted = false;
     };
-  }, [clientLastUpdated, start, end]);
+  }, [clientLastUpdated]);
 
   const renderContent = () => {
     if (fetchError || lastUpdatedError) {

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { sumCPU } from 'src/features/Longview/shared/utilities';
-import { AllData, getValues } from '../../../request';
+// import { AllData, getValues } from '../../../request';
 import {
   convertData,
   pathMaybeAddDataInThePast
@@ -13,34 +13,36 @@ export type CombinedProps = GraphProps & WithTheme;
 
 export const CPUGraph: React.FC<CombinedProps> = props => {
   const {
-    clientAPIKey,
+    // clientAPIKey,
     end,
     isToday,
-    lastUpdated,
-    lastUpdatedError,
+    // lastUpdated,
+    // lastUpdatedError,
     start,
+    error,
+    data,
     theme,
     timezone
   } = props;
 
-  const [data, setData] = React.useState<Partial<AllData>>({});
-  const [error, setError] = React.useState<string | undefined>();
-  const request = () => {
-    if (!start || !end) {
-      return;
-    }
+  // const [data, setData] = React.useState<Partial<AllData>>({});
+  // const [error, setError] = React.useState<string | undefined>();
+  // const request = () => {
+  //   if (!start || !end) {
+  //     return;
+  //   }
 
-    return getValues(clientAPIKey, {
-      fields: ['cpu'],
-      start,
-      end
-    })
-      .then(response => {
-        setError(undefined);
-        setData(response);
-      })
-      .catch(_ => setError('Unable to retrieve CPU data'));
-  };
+  //   return getValues(clientAPIKey, {
+  //     fields: ['cpu'],
+  //     start,
+  //     end
+  //   })
+  //     .then(response => {
+  //       setError(undefined);
+  //       setData(response);
+  //     })
+  //     .catch(_ => setError('Unable to retrieve CPU data'));
+  // };
 
   const cpuData = React.useMemo(() => {
     const summedCPUData = sumCPU(data.CPU);
@@ -51,9 +53,9 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
     ]);
   }, [data.CPU]);
 
-  React.useEffect(() => {
-    request();
-  }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
+  // React.useEffect(() => {
+  //   request();
+  // }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { sumCPU } from 'src/features/Longview/shared/utilities';
-// import { AllData, getValues } from '../../../request';
 import {
   convertData,
   pathMaybeAddDataInThePast
@@ -12,37 +11,7 @@ import { GraphProps } from './types';
 export type CombinedProps = GraphProps & WithTheme;
 
 export const CPUGraph: React.FC<CombinedProps> = props => {
-  const {
-    // clientAPIKey,
-    end,
-    isToday,
-    // lastUpdated,
-    // lastUpdatedError,
-    start,
-    error,
-    data,
-    theme,
-    timezone
-  } = props;
-
-  // const [data, setData] = React.useState<Partial<AllData>>({});
-  // const [error, setError] = React.useState<string | undefined>();
-  // const request = () => {
-  //   if (!start || !end) {
-  //     return;
-  //   }
-
-  //   return getValues(clientAPIKey, {
-  //     fields: ['cpu'],
-  //     start,
-  //     end
-  //   })
-  //     .then(response => {
-  //       setError(undefined);
-  //       setData(response);
-  //     })
-  //     .catch(_ => setError('Unable to retrieve CPU data'));
-  // };
+  const { end, isToday, start, error, data, theme, timezone } = props;
 
   const cpuData = React.useMemo(() => {
     const summedCPUData = sumCPU(data.CPU);
@@ -52,10 +21,6 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
       ['wait']
     ]);
   }, [data.CPU]);
-
-  // React.useEffect(() => {
-  //   request();
-  // }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { appendStats } from 'src/features/Longview/shared/utilities';
-// import { AllData, getValues } from '../../../request';
 import { Disk, StatWithDummyPoint } from '../../../request.types';
 import { convertData } from '../../../shared/formatters';
 import { GraphProps } from './types';
@@ -12,39 +11,14 @@ export type CombinedProps = GraphProps & WithTheme;
 
 export const DiskGraph: React.FC<CombinedProps> = props => {
   const {
-    // clientAPIKey,
     end,
     isToday,
-    // lastUpdated,
-    // lastUpdatedError,
     start,
     data,
     error: requestError,
     theme,
     timezone
   } = props;
-
-  // const [data, setData] = React.useState<Partial<AllData>>({});
-  // const [requestError, setError] = React.useState<string | undefined>();
-  // const request = () => {
-  //   if (!start || !end) {
-  //     return;
-  //   }
-  //   return getValues(clientAPIKey, {
-  //     fields: ['disk', 'sysinfo'],
-  //     start,
-  //     end
-  //   })
-  //     .then(response => {
-  //       setError(undefined);
-  //       setData(response);
-  //     })
-  //     .catch(_ => setError('Unable to load your Disk I/O data'));
-  // };
-
-  // React.useEffect(() => {
-  //   request();
-  // }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { appendStats } from 'src/features/Longview/shared/utilities';
-import { AllData, getValues } from '../../../request';
+// import { AllData, getValues } from '../../../request';
 import { Disk, StatWithDummyPoint } from '../../../request.types';
 import { convertData } from '../../../shared/formatters';
 import { GraphProps } from './types';
@@ -12,37 +12,39 @@ export type CombinedProps = GraphProps & WithTheme;
 
 export const DiskGraph: React.FC<CombinedProps> = props => {
   const {
-    clientAPIKey,
+    // clientAPIKey,
     end,
     isToday,
-    lastUpdated,
-    lastUpdatedError,
+    // lastUpdated,
+    // lastUpdatedError,
     start,
+    data,
+    error: requestError,
     theme,
     timezone
   } = props;
 
-  const [data, setData] = React.useState<Partial<AllData>>({});
-  const [requestError, setError] = React.useState<string | undefined>();
-  const request = () => {
-    if (!start || !end) {
-      return;
-    }
-    return getValues(clientAPIKey, {
-      fields: ['disk', 'sysinfo'],
-      start,
-      end
-    })
-      .then(response => {
-        setError(undefined);
-        setData(response);
-      })
-      .catch(_ => setError('Unable to load Disk I/O data.'));
-  };
+  // const [data, setData] = React.useState<Partial<AllData>>({});
+  // const [requestError, setError] = React.useState<string | undefined>();
+  // const request = () => {
+  //   if (!start || !end) {
+  //     return;
+  //   }
+  //   return getValues(clientAPIKey, {
+  //     fields: ['disk', 'sysinfo'],
+  //     start,
+  //     end
+  //   })
+  //     .then(response => {
+  //       setError(undefined);
+  //       setData(response);
+  //     })
+  //     .catch(_ => setError('Unable to load your Disk I/O data'));
+  // };
 
-  React.useEffect(() => {
-    request();
-  }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
+  // React.useEffect(() => {
+  //   request();
+  // }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
-import { AllData, getValues } from '../../../request';
+// import { AllData, getValues } from '../../../request';
 import { convertData } from '../../../shared/formatters';
 import { GraphProps } from './types';
 
@@ -9,37 +9,39 @@ export type CombinedProps = GraphProps & WithTheme;
 
 export const LoadGraph: React.FC<CombinedProps> = props => {
   const {
-    clientAPIKey,
-    lastUpdated,
-    lastUpdatedError,
+    // clientAPIKey,
+    // lastUpdated,
+    // lastUpdatedError,
     end,
     isToday,
+    data,
+    error,
     start,
     theme,
     timezone
   } = props;
 
-  const [data, setData] = React.useState<Partial<AllData>>({});
-  const [error, setError] = React.useState<string | undefined>();
-  const request = () => {
-    if (!start || !end) {
-      return;
-    }
-    return getValues(clientAPIKey, {
-      fields: ['load'],
-      start,
-      end
-    })
-      .then(response => {
-        setError(undefined);
-        setData(response);
-      })
-      .catch(_ => setError('Unable to retrieve load data.'));
-  };
+  // const [data, setData] = React.useState<Partial<AllData>>({});
+  // const [error, setError] = React.useState<string | undefined>();
+  // const request = () => {
+  //   if (!start || !end) {
+  //     return;
+  //   }
+  //   return getValues(clientAPIKey, {
+  //     fields: ['load'],
+  //     start,
+  //     end
+  //   })
+  //     .then(response => {
+  //       setError(undefined);
+  //       setData(response);
+  //     })
+  //     .catch(_ => setError('Unable to retrieve load data.'));
+  // };
 
-  React.useEffect(() => {
-    request();
-  }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
+  // React.useEffect(() => {
+  //   request();
+  // }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
@@ -1,47 +1,13 @@
 import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
-// import { AllData, getValues } from '../../../request';
 import { convertData } from '../../../shared/formatters';
 import { GraphProps } from './types';
 
 export type CombinedProps = GraphProps & WithTheme;
 
 export const LoadGraph: React.FC<CombinedProps> = props => {
-  const {
-    // clientAPIKey,
-    // lastUpdated,
-    // lastUpdatedError,
-    end,
-    isToday,
-    data,
-    error,
-    start,
-    theme,
-    timezone
-  } = props;
-
-  // const [data, setData] = React.useState<Partial<AllData>>({});
-  // const [error, setError] = React.useState<string | undefined>();
-  // const request = () => {
-  //   if (!start || !end) {
-  //     return;
-  //   }
-  //   return getValues(clientAPIKey, {
-  //     fields: ['load'],
-  //     start,
-  //     end
-  //   })
-  //     .then(response => {
-  //       setError(undefined);
-  //       setData(response);
-  //     })
-  //     .catch(_ => setError('Unable to retrieve load data.'));
-  // };
-
-  // React.useEffect(() => {
-  //   request();
-  // }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
+  const { end, isToday, data, error, start, theme, timezone } = props;
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { readableBytes } from 'src/utilities/unitConversions';
-import { AllData, getValues } from '../../../request';
+// import { AllData, getValues } from '../../../request';
 import { Stat } from '../../../request.types';
 import { convertData } from '../../../shared/formatters';
 import { generateUsedMemory, statMax } from '../../../shared/utilities';
@@ -13,37 +13,39 @@ export type CombinedProps = GraphProps & WithTheme;
 
 export const MemoryGraph: React.FC<CombinedProps> = props => {
   const {
-    clientAPIKey,
+    // clientAPIKey,
     end,
     isToday,
-    lastUpdated,
-    lastUpdatedError,
+    // lastUpdated,
+    // lastUpdatedError,
     start,
     theme,
+    data,
+    error,
     timezone
   } = props;
 
-  const [data, setData] = React.useState<Partial<AllData>>({});
-  const [error, setError] = React.useState<string | undefined>();
-  const request = () => {
-    if (!start || !end) {
-      return;
-    }
-    return getValues(clientAPIKey, {
-      fields: ['memory'],
-      start,
-      end
-    })
-      .then(response => {
-        setError(undefined);
-        setData(response);
-      })
-      .catch(_ => setError('Unable to retrieve memory usage data.'));
-  };
+  // const [data, setData] = React.useState<Partial<AllData>>({});
+  // const [error, setError] = React.useState<string | undefined>();
+  // const request = () => {
+  //   if (!start || !end) {
+  //     return;
+  //   }
+  //   return getValues(clientAPIKey, {
+  //     fields: ['memory'],
+  //     start,
+  //     end
+  //   })
+  //     .then(response => {
+  //       setError(undefined);
+  //       setData(response);
+  //     })
+  //     .catch(_ => setError('Unable to retrieve memory usage data.'));
+  // };
 
-  React.useEffect(() => {
-    request();
-  }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
+  // React.useEffect(() => {
+  //   request();
+  // }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { readableBytes } from 'src/utilities/unitConversions';
-// import { AllData, getValues } from '../../../request';
 import { Stat } from '../../../request.types';
 import { convertData } from '../../../shared/formatters';
 import { generateUsedMemory, statMax } from '../../../shared/utilities';
@@ -12,40 +11,7 @@ import { GraphProps } from './types';
 export type CombinedProps = GraphProps & WithTheme;
 
 export const MemoryGraph: React.FC<CombinedProps> = props => {
-  const {
-    // clientAPIKey,
-    end,
-    isToday,
-    // lastUpdated,
-    // lastUpdatedError,
-    start,
-    theme,
-    data,
-    error,
-    timezone
-  } = props;
-
-  // const [data, setData] = React.useState<Partial<AllData>>({});
-  // const [error, setError] = React.useState<string | undefined>();
-  // const request = () => {
-  //   if (!start || !end) {
-  //     return;
-  //   }
-  //   return getValues(clientAPIKey, {
-  //     fields: ['memory'],
-  //     start,
-  //     end
-  //   })
-  //     .then(response => {
-  //       setError(undefined);
-  //       setData(response);
-  //     })
-  //     .catch(_ => setError('Unable to retrieve memory usage data.'));
-  // };
-
-  // React.useEffect(() => {
-  //   request();
-  // }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
+  const { end, isToday, start, theme, data, error, timezone } = props;
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -5,53 +5,18 @@ import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { generateUnits } from 'src/features/Longview/LongviewLanding/Gauges/Network';
 import { statMax, sumNetwork } from 'src/features/Longview/shared/utilities';
-// import { AllData, getValues } from '../../../request';
 import { convertData } from '../../../shared/formatters';
 import { GraphProps } from './types';
 
 export type CombinedProps = GraphProps & WithTheme;
 
 export const NetworkGraph: React.FC<CombinedProps> = props => {
-  const {
-    // clientAPIKey,
-    end,
-    isToday,
-    // lastUpdated,
-    // lastUpdatedError,
-    start,
-    theme,
-    data,
-    error,
-    timezone
-  } = props;
-
-  // const [data, setData] = React.useState<Partial<AllData>>({});
-  // const [error, setError] = React.useState<string | undefined>();
-  // const request = () => {
-  //   if (!start || !end) {
-  //     return;
-  //   }
-
-  //   return getValues(clientAPIKey, {
-  //     fields: ['network'],
-  //     start,
-  //     end
-  //   })
-  //     .then(response => {
-  //       setError(undefined);
-  //       setData(response);
-  //     })
-  //     .catch(_ => setError('Unable to retrieve network data.'));
-  // };
+  const { end, isToday, start, theme, data, error, timezone } = props;
 
   const networkData = React.useMemo(
     () => sumNetwork(pathOr({}, ['Interface'], data.Network)),
     [data.Network]
   );
-
-  // React.useEffect(() => {
-  //   request();
-  // }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -5,7 +5,7 @@ import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { generateUnits } from 'src/features/Longview/LongviewLanding/Gauges/Network';
 import { statMax, sumNetwork } from 'src/features/Longview/shared/utilities';
-import { AllData, getValues } from '../../../request';
+// import { AllData, getValues } from '../../../request';
 import { convertData } from '../../../shared/formatters';
 import { GraphProps } from './types';
 
@@ -13,43 +13,45 @@ export type CombinedProps = GraphProps & WithTheme;
 
 export const NetworkGraph: React.FC<CombinedProps> = props => {
   const {
-    clientAPIKey,
+    // clientAPIKey,
     end,
     isToday,
-    lastUpdated,
-    lastUpdatedError,
+    // lastUpdated,
+    // lastUpdatedError,
     start,
     theme,
+    data,
+    error,
     timezone
   } = props;
 
-  const [data, setData] = React.useState<Partial<AllData>>({});
-  const [error, setError] = React.useState<string | undefined>();
-  const request = () => {
-    if (!start || !end) {
-      return;
-    }
+  // const [data, setData] = React.useState<Partial<AllData>>({});
+  // const [error, setError] = React.useState<string | undefined>();
+  // const request = () => {
+  //   if (!start || !end) {
+  //     return;
+  //   }
 
-    return getValues(clientAPIKey, {
-      fields: ['network'],
-      start,
-      end
-    })
-      .then(response => {
-        setError(undefined);
-        setData(response);
-      })
-      .catch(_ => setError('Unable to retrieve network data.'));
-  };
+  //   return getValues(clientAPIKey, {
+  //     fields: ['network'],
+  //     start,
+  //     end
+  //   })
+  //     .then(response => {
+  //       setError(undefined);
+  //       setData(response);
+  //     })
+  //     .catch(_ => setError('Unable to retrieve network data.'));
+  // };
 
   const networkData = React.useMemo(
     () => sumNetwork(pathOr({}, ['Interface'], data.Network)),
     [data.Network]
   );
 
-  React.useEffect(() => {
-    request();
-  }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
+  // React.useEffect(() => {
+  //   request();
+  // }, [start, end, clientAPIKey, lastUpdated, lastUpdatedError]);
 
   const _convertData = React.useCallback(convertData, [data, start, end]);
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/OverviewGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/OverviewGraphs.tsx
@@ -1,26 +1,26 @@
 import * as React from 'react';
-import Paper from 'src/components/core/Paper';
-import { makeStyles, Theme } from 'src/components/core/styles';
-import Typography from 'src/components/core/Typography';
+// import Paper from 'src/components/core/Paper';
+// import { makeStyles, Theme } from 'src/components/core/styles';
+// import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
-import { WithStartAndEnd } from '../../../request';
-import TimeRangeSelect from '../../../shared/TimeRangeSelect';
-import CPUGraph from './CPUGraph';
-import DiskGraph from './DiskGraph';
-import LoadGraph from './LoadGraph';
-import MemoryGraph from './MemoryGraph';
-import NetworkGraph from './NetworkGraph';
-import { GraphProps } from './types';
+// import { WithStartAndEnd } from '../../../request';
+// import TimeRangeSelect from '../../../shared/TimeRangeSelect';
+// import CPUGraph from './CPUGraph';
+// import DiskGraph from './DiskGraph';
+// import LoadGraph from './LoadGraph';
+// import MemoryGraph from './MemoryGraph';
+// import NetworkGraph from './NetworkGraph';
+// import { GraphProps } from './types';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  paperSection: {
-    padding: theme.spacing(3) + 1,
-    marginBottom: theme.spacing(1) + 3
-  },
-  selectTimeRange: {
-    width: 150
-  }
-}));
+// const useStyles = makeStyles((theme: Theme) => ({
+//   paperSection: {
+//     padding: theme.spacing(3) + 1,
+//     marginBottom: theme.spacing(1) + 3
+//   },
+//   selectTimeRange: {
+//     width: 150
+//   }
+// }));
 
 interface Props {
   clientAPIKey: string;
@@ -31,32 +31,32 @@ interface Props {
 export type CombinedProps = Props;
 
 export const OverviewGraphs: React.FC<CombinedProps> = props => {
-  const { clientAPIKey, lastUpdated, lastUpdatedError, timezone } = props;
-  const classes = useStyles();
-  const [time, setTimeBox] = React.useState<WithStartAndEnd>({
-    start: 0,
-    end: 0
-  });
+  // const { clientAPIKey, lastUpdated, lastUpdatedError, timezone } = props;
+  // const classes = useStyles();
+  // const [time, setTimeBox] = React.useState<WithStartAndEnd>({
+  //   start: 0,
+  //   end: 0
+  // });
 
-  const handleStatsChange = (start: number, end: number) => {
-    setTimeBox({ start, end });
-  };
+  // const handleStatsChange = (start: number, end: number) => {
+  //   setTimeBox({ start, end });
+  // };
 
-  const isToday = time.end - time.start < 60 * 60 * 25;
+  // const isToday = time.end - time.start < 60 * 60 * 25;
 
-  const graphProps: GraphProps = {
-    clientAPIKey,
-    timezone,
-    isToday,
-    start: time.start,
-    end: time.end,
-    lastUpdatedError,
-    lastUpdated
-  };
+  // const graphProps: GraphProps = {
+  //   clientAPIKey,
+  //   timezone,
+  //   isToday,
+  //   start: time.start,
+  //   end: time.end,
+  //   lastUpdatedError,
+  //   lastUpdated
+  // };
 
   return (
     <Grid container item spacing={0}>
-      <Grid
+      {/* <Grid
         container
         item
         direction="row"
@@ -105,7 +105,7 @@ export const OverviewGraphs: React.FC<CombinedProps> = props => {
             </Grid>
           </Grid>
         </Paper>
-      </Grid>
+      </Grid> */}
     </Grid>
   );
 };

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/OverviewGraphs.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/OverviewGraphs.tsx
@@ -1,4 +1,3 @@
-// import { APIError } from 'linode-js-sdk/lib/types'
 import { withSnackbar, WithSnackbarProps } from 'notistack';
 import * as React from 'react';
 import Paper from 'src/components/core/Paper';
@@ -34,7 +33,7 @@ interface Props {
 export type CombinedProps = Props & WithSnackbarProps;
 
 export const OverviewGraphs: React.FC<CombinedProps> = props => {
-  const { clientAPIKey, lastUpdatedError, timezone, lastUpdated } = props;
+  const { clientAPIKey, timezone, lastUpdated } = props;
   const classes = useStyles();
   const [time, setTimeBox] = React.useState<WithStartAndEnd>({
     start: 0,
@@ -86,13 +85,10 @@ export const OverviewGraphs: React.FC<CombinedProps> = props => {
   const isToday = time.end - time.start < 60 * 60 * 25;
 
   const graphProps: GraphProps = {
-    clientAPIKey,
     timezone,
     isToday,
     start: time.start,
     end: time.end,
-    lastUpdatedError,
-    lastUpdated,
     data: data || {},
     error: fetchError
   };

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/types.ts
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/types.ts
@@ -6,4 +6,6 @@ export interface GraphProps {
   start: number;
   end: number;
   isToday: boolean;
+  data: any;
+  error?: string;
 }

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/types.ts
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/types.ts
@@ -1,8 +1,5 @@
 export interface GraphProps {
-  clientAPIKey: string;
   timezone: string;
-  lastUpdated?: number;
-  lastUpdatedError: boolean;
   start: number;
   end: number;
   isToday: boolean;


### PR DESCRIPTION
## Description

Allows the `<TimeRangeSelect />` component to listen in on errors and report whether or not a successful Longview stats request happened.

## What's New?

* The `handleStatsChange` prop is now typed as a function that returns a Promise. a la `(start: number, end: number) => Promise<any>`
  * This will let it hook into the `.catch` and revert back to the original select option if the request fails
* New `handleFetchError` prop which is a function that returns an error. The parent component then can decide what it wants to do with it (show a toast, swallow the error, etc.)
* Select value is now `loading...` and disabled when the request is in-flight
* All stats are coming from 1 request once again 😢 

## Type of Change
- Non breaking change ('update', 'change')

## What's the Alternative To This Approach?

If we don't want to go with this option, the other approach would be just to add error handling to each graph and toast for any failed errors.

The drawback here is that the select value might not accurately reflect what data is being shown in the graphs, but we get more simplicity and no need to make one batch request as a pro - we can continue making individual requests per graph.