### PR TITLE
M3-3697 fix tag dropdown in domains

### DIFF
--- a/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
+++ b/packages/manager/src/features/Domains/DomainRecordsWrapper.tsx
@@ -29,6 +29,9 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.up('md')]: {
       marginTop: theme.spacing(1)
     }
+  },
+  tagPanel: {
+    maxWidth: 500
   }
 }));
 
@@ -64,7 +67,9 @@ const DomainRecordsWrapper: React.FC<CombinedProps> = props => {
           <Typography variant="h3" className={classes.title} data-qa-title>
             Tags
           </Typography>
-          <TagsPanel tags={domain.tags} updateTags={handleUpdateTags} />
+          <div className={hookClasses.tagPanel}>
+            <TagsPanel tags={domain.tags} updateTags={handleUpdateTags} />
+          </div>
         </Paper>
       </Grid>
     </Grid>


### PR DESCRIPTION
## M3-3697 fix tag dropdown in domains

<img width="1280" alt="Screen Shot 2019-12-13 at 11 32 52 AM" src="https://user-images.githubusercontent.com/205353/70823455-eebaf900-1dad-11ea-88b8-8adccbc9c99d.png">


## Type of Change
- Bug fix ('fix', 'repair', 'bug')

