### PR TITLE
Include "Show All" on Volumes, Domains, NodeBalancers

### DIFF
--- a/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
+++ b/packages/manager/src/components/PaginationFooter/PaginationFooter.tsx
@@ -10,6 +10,8 @@ import Select, { Item } from 'src/components/EnhancedSelect/Select';
 import Grid from 'src/components/Grid';
 import PaginationControls from '../PaginationControls';
 
+export const MIN_PAGE_SIZE = 25;
+
 type ClassNames = 'root' | 'padded';
 
 const styles = (theme: Theme) =>
@@ -39,7 +41,7 @@ interface Props extends PaginationProps {
 type CombinedProps = Props & WithStyles<ClassNames>;
 
 const baseOptions = [
-  { label: 'Show 25', value: 25 },
+  { label: 'Show 25', value: MIN_PAGE_SIZE },
   { label: 'Show 50', value: 50 },
   { label: 'Show 75', value: 75 },
   { label: 'Show 100', value: 100 }
@@ -60,7 +62,7 @@ class PaginationFooter extends React.PureComponent<CombinedProps> {
       showAll
     } = this.props;
 
-    if (count <= 25) {
+    if (count <= MIN_PAGE_SIZE) {
       return null;
     }
 

--- a/packages/manager/src/components/PaginationFooter/index.ts
+++ b/packages/manager/src/components/PaginationFooter/index.ts
@@ -4,3 +4,4 @@ import PaginationFooter, {
 /* tslint:disable */
 export interface PaginationProps extends _PaginationProps {}
 export default PaginationFooter;
+export { MIN_PAGE_SIZE } from './PaginationFooter';

--- a/packages/manager/src/factories/nodebalancer.ts
+++ b/packages/manager/src/factories/nodebalancer.ts
@@ -1,0 +1,20 @@
+import * as Factory from 'factory.ts';
+import { NodeBalancer } from 'linode-js-sdk/lib/nodebalancers/types';
+
+export const nodeBalancerFactory = Factory.Sync.makeFactory<NodeBalancer>({
+  id: Factory.each(id => id),
+  label: Factory.each(i => `nodebalancer-id-${i}`),
+  hostname: 'example.com',
+  client_conn_throttle: 0,
+  region: 'us-east',
+  ipv4: '0.0.0.0',
+  ipv6: null,
+  created: '2019-12-12T00:00:00',
+  updated: '2019-12-13T00:00:00',
+  transfer: {
+    in: 0,
+    out: 0,
+    total: 0
+  },
+  tags: []
+});

--- a/packages/manager/src/features/Domains/ListDomains.tsx
+++ b/packages/manager/src/features/Domains/ListDomains.tsx
@@ -16,8 +16,8 @@ import TableCell from 'src/components/TableCell';
 import TableRow from 'src/components/TableRow';
 import TableSortCell from 'src/components/TableSortCell';
 import DomainTableRow from 'src/features/Domains/DomainTableRow';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { Handlers } from './DomainActionMenu';
-
 type ClassNames = 'root' | 'label';
 
 const styles = (theme: Theme) =>
@@ -39,8 +39,15 @@ type CombinedProps = Props & WithStyles<ClassNames>;
 
 const ListDomains: React.StatelessComponent<CombinedProps> = props => {
   const { data, orderBy, order, handleOrderChange, classes } = props;
+
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
+
   return (
-    <Paginate data={data} pageSize={25}>
+    <Paginate
+      data={data}
+      pageSize={infinitePageSize}
+      pageSizeSetter={setInfinitePageSize}
+    >
       {({
         data: paginatedData,
         count,
@@ -104,6 +111,7 @@ const ListDomains: React.StatelessComponent<CombinedProps> = props => {
             handlePageChange={handlePageChange}
             handleSizeChange={handlePageSizeChange}
             eventCategory="domains landing"
+            showAll
           />
         </React.Fragment>
       )}

--- a/packages/manager/src/features/Domains/ListGroupedDomains.tsx
+++ b/packages/manager/src/features/Domains/ListGroupedDomains.tsx
@@ -14,11 +14,10 @@ import Typography from 'src/components/core/Typography';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import DomainTableRow from 'src/features/Domains/DomainTableRow';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import { Handlers } from './DomainActionMenu';
 import TableWrapper from './DomainsTableWrapper';
-
-const DEFAULT_PAGE_SIZE = 25;
 
 type ClassNames =
   | 'root'
@@ -90,12 +89,18 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
   )(data);
   const tableWrapperProps = { handleOrderChange, order, orderBy };
 
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
+
   return (
     <TableWrapper {...tableWrapperProps}>
       {groupedDomains.map(([tag, domains]: [string, Domain[]]) => {
         return (
           <React.Fragment key={tag}>
-            <Paginate data={domains} pageSize={DEFAULT_PAGE_SIZE}>
+            <Paginate
+              data={domains}
+              pageSize={infinitePageSize}
+              pageSizeSetter={setInfinitePageSize}
+            >
               {({
                 data: paginatedData,
                 handlePageChange,
@@ -135,7 +140,7 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
                           onCheck={props.onCheck}
                         />
                       ))}
-                      {count > DEFAULT_PAGE_SIZE && (
+                      {count > infinitePageSize && (
                         <TableRow>
                           <TableCell
                             colSpan={7}

--- a/packages/manager/src/features/Domains/ListGroupedDomains.tsx
+++ b/packages/manager/src/features/Domains/ListGroupedDomains.tsx
@@ -12,7 +12,9 @@ import TableCell from 'src/components/core/TableCell';
 import TableRow from 'src/components/core/TableRow';
 import Typography from 'src/components/core/Typography';
 import Paginate from 'src/components/Paginate';
-import PaginationFooter from 'src/components/PaginationFooter';
+import PaginationFooter, {
+  MIN_PAGE_SIZE
+} from 'src/components/PaginationFooter';
 import DomainTableRow from 'src/features/Domains/DomainTableRow';
 import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
@@ -140,7 +142,7 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
                           onCheck={props.onCheck}
                         />
                       ))}
-                      {count > infinitePageSize && (
+                      {count > MIN_PAGE_SIZE && (
                         <TableRow>
                           <TableCell
                             colSpan={7}
@@ -153,6 +155,7 @@ const ListGroupedDomains: React.StatelessComponent<CombinedProps> = props => {
                               pageSize={pageSize}
                               page={page}
                               eventCategory={'domains landing'}
+                              showAll
                             />
                           </TableCell>
                         </TableRow>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
@@ -13,6 +13,7 @@ import TableRow from 'src/components/core/TableRow';
 import Typography from 'src/components/core/Typography';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import NodeBalancersLandingTableRows from './NodeBalancersLandingTableRows';
 import TableWrapper from './NodeBalancersTableWrapper';
@@ -99,12 +100,18 @@ const ListGroupedNodeBalancers: React.StatelessComponent<
   )(data);
   const tableWrapperProps = { handleOrderChange, order, orderBy };
 
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
+
   return (
     <TableWrapper {...tableWrapperProps}>
       {groupedNodeBalancers.map(([tag, nodeBalancers]) => {
         return (
           <React.Fragment key={tag}>
-            <Paginate data={nodeBalancers} pageSize={DEFAULT_PAGE_SIZE}>
+            <Paginate
+              data={nodeBalancers}
+              pageSize={infinitePageSize}
+              pageSizeSetter={setInfinitePageSize}
+            >
               {({
                 count,
                 data: paginatedData,

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
@@ -12,7 +12,9 @@ import TableCell from 'src/components/core/TableCell';
 import TableRow from 'src/components/core/TableRow';
 import Typography from 'src/components/core/Typography';
 import Paginate from 'src/components/Paginate';
-import PaginationFooter from 'src/components/PaginationFooter';
+import PaginationFooter, {
+  MIN_PAGE_SIZE
+} from 'src/components/PaginationFooter';
 import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import NodeBalancersLandingTableRows from './NodeBalancersLandingTableRows';
@@ -140,7 +142,7 @@ const ListGroupedNodeBalancers: React.StatelessComponent<
                         data={paginatedData}
                       />
                     </TableBody>
-                    {count > infinitePageSize && (
+                    {count > MIN_PAGE_SIZE && (
                       <TableRow>
                         <TableCell
                           colSpan={8}
@@ -153,6 +155,7 @@ const ListGroupedNodeBalancers: React.StatelessComponent<
                             handlePageChange={handlePageChange}
                             handleSizeChange={handlePageSizeChange}
                             eventCategory="nodebalancers landing"
+                            showAll
                           />
                         </TableCell>
                       </TableRow>

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListGroupedNodeBalancers.tsx
@@ -18,8 +18,6 @@ import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import NodeBalancersLandingTableRows from './NodeBalancersLandingTableRows';
 import TableWrapper from './NodeBalancersTableWrapper';
 
-const DEFAULT_PAGE_SIZE = 25;
-
 type ClassNames =
   | 'ip'
   | 'nameCell'
@@ -142,10 +140,10 @@ const ListGroupedNodeBalancers: React.StatelessComponent<
                         data={paginatedData}
                       />
                     </TableBody>
-                    {count > DEFAULT_PAGE_SIZE && (
+                    {count > infinitePageSize && (
                       <TableRow>
                         <TableCell
-                          colSpan={7}
+                          colSpan={8}
                           className={classes.paginationCell}
                         >
                           <PaginationFooter

--- a/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListNodeBalancers.tsx
+++ b/packages/manager/src/features/NodeBalancers/NodeBalancersLanding/ListNodeBalancers.tsx
@@ -10,6 +10,7 @@ import {
 import TableBody from 'src/components/core/TableBody';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import NodeBalancersLandingTableRows from './NodeBalancersLandingTableRows';
 import NodeBalancersTableWrapper from './NodeBalancersTableWrapper';
 
@@ -51,8 +52,14 @@ const ListNodeBalancers: React.StatelessComponent<CombinedProps> = props => {
   const { data, orderBy, order, handleOrderChange, toggleDialog } = props;
   const tableWrapperProps = { handleOrderChange, order, orderBy };
 
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
+
   return (
-    <Paginate data={data}>
+    <Paginate
+      data={data}
+      pageSize={infinitePageSize}
+      pageSizeSetter={setInfinitePageSize}
+    >
       {({
         count,
         data: paginatedData,
@@ -79,6 +86,7 @@ const ListNodeBalancers: React.StatelessComponent<CombinedProps> = props => {
             handlePageChange={handlePageChange}
             handleSizeChange={handlePageSizeChange}
             eventCategory="nodebalancers landing"
+            showAll
           />
         </>
       )}

--- a/packages/manager/src/features/Volumes/ListGroupedVolumes.tsx
+++ b/packages/manager/src/features/Volumes/ListGroupedVolumes.tsx
@@ -13,12 +13,11 @@ import TableRow from 'src/components/core/TableRow';
 import Typography from 'src/components/core/Typography';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import RenderVolumeData, { RenderVolumeDataProps } from './RenderVolumeData';
 import { ExtendedVolume } from './types';
 import TableWrapper from './VolumeTableWrapper';
-
-const DEFAULT_PAGE_SIZE = 25;
 
 type ClassNames =
   | 'root'
@@ -93,12 +92,18 @@ const ListGroupedVolumes: React.FC<CombinedProps> = props => {
     isVolumesLanding: renderProps.isVolumesLanding
   };
 
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
+
   return (
     <TableWrapper {...tableWrapperProps}>
       {groupedVolumes.map(([tag, volumes]: [string, Volume[]]) => {
         return (
           <React.Fragment key={tag}>
-            <Paginate data={volumes} pageSize={DEFAULT_PAGE_SIZE}>
+            <Paginate
+              data={volumes}
+              pageSize={infinitePageSize}
+              pageSizeSetter={setInfinitePageSize}
+            >
               {({
                 data: paginatedData,
                 handlePageChange,
@@ -125,7 +130,7 @@ const ListGroupedVolumes: React.FC<CombinedProps> = props => {
                         </TableCell>
                       </TableRow>
                       <RenderVolumeData data={paginatedData} {...renderProps} />
-                      {count > DEFAULT_PAGE_SIZE && (
+                      {count > infinitePageSize && (
                         <TableRow>
                           <TableCell
                             colSpan={7}

--- a/packages/manager/src/features/Volumes/ListGroupedVolumes.tsx
+++ b/packages/manager/src/features/Volumes/ListGroupedVolumes.tsx
@@ -12,7 +12,9 @@ import TableCell from 'src/components/core/TableCell';
 import TableRow from 'src/components/core/TableRow';
 import Typography from 'src/components/core/Typography';
 import Paginate from 'src/components/Paginate';
-import PaginationFooter from 'src/components/PaginationFooter';
+import PaginationFooter, {
+  MIN_PAGE_SIZE
+} from 'src/components/PaginationFooter';
 import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import RenderVolumeData, { RenderVolumeDataProps } from './RenderVolumeData';
@@ -130,7 +132,7 @@ const ListGroupedVolumes: React.FC<CombinedProps> = props => {
                         </TableCell>
                       </TableRow>
                       <RenderVolumeData data={paginatedData} {...renderProps} />
-                      {count > infinitePageSize && (
+                      {count > MIN_PAGE_SIZE && (
                         <TableRow>
                           <TableCell
                             colSpan={7}
@@ -143,6 +145,7 @@ const ListGroupedVolumes: React.FC<CombinedProps> = props => {
                               pageSize={pageSize}
                               page={page}
                               eventCategory={'volumes landing'}
+                              showAll
                             />
                           </TableCell>
                         </TableRow>

--- a/packages/manager/src/features/Volumes/ListVolumes.tsx
+++ b/packages/manager/src/features/Volumes/ListVolumes.tsx
@@ -5,6 +5,7 @@ import TableBody from 'src/components/core/TableBody';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
 import Table from 'src/components/Table';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import RenderVolumeData, { RenderVolumeDataProps } from './RenderVolumeData';
 import SortableVolumesTableHeader from './SortableVolumesTableHeader';
 
@@ -20,8 +21,15 @@ type CombinedProps = Props;
 
 const ListVolumes: React.FC<CombinedProps> = props => {
   const { orderBy, order, handleOrderChange, data, renderProps } = props;
+
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
+
   return (
-    <Paginate data={data} pageSize={25}>
+    <Paginate
+      data={data}
+      pageSize={infinitePageSize}
+      pageSizeSetter={setInfinitePageSize}
+    >
       {({
         data: paginatedData,
         count,
@@ -51,6 +59,7 @@ const ListVolumes: React.FC<CombinedProps> = props => {
             handlePageChange={handlePageChange}
             handleSizeChange={handlePageSizeChange}
             eventCategory="volumes landing"
+            showAll
           />
         </React.Fragment>
       )}

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -14,7 +14,9 @@ import Typography from 'src/components/core/Typography';
 import Grid from 'src/components/Grid';
 import { OrderByProps } from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
-import PaginationFooter from 'src/components/PaginationFooter';
+import PaginationFooter, {
+  MIN_PAGE_SIZE
+} from 'src/components/PaginationFooter';
 import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
 import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
@@ -225,7 +227,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<
                           </TableCell>
                         </TableRow>
                         <Component {...finalProps} />
-                        {count > infinitePageSize && (
+                        {count > MIN_PAGE_SIZE && (
                           <TableRow>
                             <TableCell
                               colSpan={7}

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -15,11 +15,10 @@ import Grid from 'src/components/Grid';
 import { OrderByProps } from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
+import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import TableWrapper from './TableWrapper';
-
-import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
-import { storage } from 'src/utilities/storage';
 
 const DEFAULT_PAGE_SIZE = 25;
 
@@ -107,8 +106,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<
     someLinodesHaveMaintenance: props.someLinodesHaveMaintenance
   };
 
-  const storedPageSize = React.useMemo(storage.linodePageSize.get, []);
-
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
   if (display === 'grid') {
     return (
       <>
@@ -134,8 +132,8 @@ const DisplayGroupedLinodes: React.StatelessComponent<
               </Grid>
               <Paginate
                 data={linodes}
-                pageSize={storedPageSize}
-                pageSizeSetter={storage.linodePageSize.set}
+                pageSize={infinitePageSize}
+                pageSizeSetter={setInfinitePageSize}
               >
                 {({
                   data: paginatedData,
@@ -189,8 +187,8 @@ const DisplayGroupedLinodes: React.StatelessComponent<
             <React.Fragment key={tag}>
               <Paginate
                 data={linodes}
-                pageSize={storedPageSize}
-                pageSizeSetter={storage.linodePageSize.set}
+                pageSize={infinitePageSize}
+                pageSizeSetter={setInfinitePageSize}
               >
                 {({
                   data: paginatedData,

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayGroupedLinodes.tsx
@@ -20,8 +20,6 @@ import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
 import { groupByTags, sortGroups } from 'src/utilities/groupByTags';
 import TableWrapper from './TableWrapper';
 
-const DEFAULT_PAGE_SIZE = 25;
-
 type ClassNames =
   | 'root'
   | 'tagGridRow'
@@ -227,7 +225,7 @@ const DisplayGroupedLinodes: React.StatelessComponent<
                           </TableCell>
                         </TableRow>
                         <Component {...finalProps} />
-                        {count > DEFAULT_PAGE_SIZE && (
+                        {count > infinitePageSize && (
                           <TableRow>
                             <TableCell
                               colSpan={7}

--- a/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
+++ b/packages/manager/src/features/linodes/LinodesLanding/DisplayLinodes.tsx
@@ -5,10 +5,9 @@ import Grid from 'src/components/Grid';
 import { OrderByProps } from 'src/components/OrderBy';
 import Paginate from 'src/components/Paginate';
 import PaginationFooter from 'src/components/PaginationFooter';
-import TableWrapper from './TableWrapper';
-
 import { Action } from 'src/features/linodes/PowerActionsDialogOrDrawer';
-import { storage } from 'src/utilities/storage';
+import { useInfinitePageSize } from 'src/hooks/useInfinitePageSize';
+import TableWrapper from './TableWrapper';
 
 interface Props {
   openDeleteDialog: (linodeID: number, linodeLabel: string) => void;
@@ -37,13 +36,13 @@ const DisplayLinodes: React.StatelessComponent<CombinedProps> = props => {
     ...rest
   } = props;
 
-  const storedPageSize = React.useMemo(storage.linodePageSize.get, []);
+  const { infinitePageSize, setInfinitePageSize } = useInfinitePageSize();
 
   return (
     <Paginate
       data={data}
-      pageSize={storedPageSize}
-      pageSizeSetter={storage.linodePageSize.set}
+      pageSize={infinitePageSize}
+      pageSizeSetter={setInfinitePageSize}
     >
       {({
         data: paginatedData,

--- a/packages/manager/src/hooks/useInfinitePageSize.ts
+++ b/packages/manager/src/hooks/useInfinitePageSize.ts
@@ -1,0 +1,9 @@
+import { useMemo } from 'react';
+import { storage } from 'src/utilities/storage';
+
+export const useInfinitePageSize = () => {
+  return {
+    infinitePageSize: useMemo(storage.infinitePageSize.get, []),
+    setInfinitePageSize: storage.infinitePageSize.set
+  };
+};

--- a/packages/manager/src/utilities/storage.ts
+++ b/packages/manager/src/utilities/storage.ts
@@ -38,7 +38,7 @@ export const setStorage = (key: string, value: string) => {
 };
 
 const PAGE_SIZE = 'PAGE_SIZE';
-const LINODE_PAGE_SIZE = 'LINODE_PAGE_SIZE';
+const INFINITE_PAGE_SIZE = 'INFINITE_PAGE_SIZE';
 const HIDE_DISPLAY_GROUPS_CTA = 'importDisplayGroupsCTA';
 const HAS_IMPORTED_GROUPS = 'hasImportedGroups';
 const BACKUPSCTA_DISMISSED = 'BackupsCtaDismissed';
@@ -65,7 +65,7 @@ export interface Storage {
     get: () => PageSize;
     set: (perPage: PageSize) => void;
   };
-  linodePageSize: {
+  infinitePageSize: {
     get: () => PageSize;
     set: (perPage: PageSize) => void;
   };
@@ -109,7 +109,7 @@ export const storage: Storage = {
     set: v => setStorage(PAGE_SIZE, `${v}`)
   },
   // Page Size of Linodes Landing page.
-  linodePageSize: {
+  infinitePageSize: {
     get: () => {
       // For backwards compatibility, we'll fall back to the value of PAGE_SIZE.
       // If that doesn't exist, we use '25' as a second fallback.
@@ -117,9 +117,9 @@ export const storage: Storage = {
 
       // I used Number() instead of parseInt() here because parseInt() does not
       // parse the string "Infinity" as a Number.
-      return Number(getStorage(LINODE_PAGE_SIZE, fallback));
+      return Number(getStorage(INFINITE_PAGE_SIZE, fallback));
     },
-    set: v => setStorage(LINODE_PAGE_SIZE, `${v}`)
+    set: v => setStorage(INFINITE_PAGE_SIZE, `${v}`)
   },
   hideGroupImportCTA: {
     get: () => getStorage(HIDE_DISPLAY_GROUPS_CTA),


### PR DESCRIPTION
## Description

Following the pattern done as a POC on LinodesLanding.

I added a NB factory to help test pagination here.

To test NB pagination, add this to line 236 of NodeBalancersLanding.tsx:

```typescript
    const factoryData = nodeBalancerFactory
      .buildList(150)
      .map(nb => ({ ...nb, configs: [] }));
```
And this on line 299: 

```typescript
<OrderBy data={factoryData} order={'desc'} orderBy={`label`}>
```
