### PR TITLE
M3-3614 Improve TableRow Loading skeleton

### DIFF
--- a/packages/manager/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/manager/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,16 +1,67 @@
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import Skeleton from './Skeleton';
+
+import TableBody from 'src/components/core/TableBody';
+import TableCell from 'src/components/core/TableCell';
+import TableHead from 'src/components/core/TableHead';
+import TableRow from 'src/components/core/TableRow';
+import Table from 'src/components/Table';
+import TableRowLoading from 'src/components/TableRowLoading';
+
+const renderTableHead = (
+  w1?: number,
+  w2?: number,
+  w3?: number,
+  w4?: number
+) => (
+  <TableHead>
+    <TableRow>
+      <TableCell style={{ width: w1 ? `${w1}%` : '25%' }}>Label</TableCell>
+      <TableCell style={{ width: w2 ? `${w2}%` : '25%' }}>Status</TableCell>
+      <TableCell style={{ width: w3 ? `${w3}%` : '25%' }}>Date</TableCell>
+      <TableCell style={{ width: w4 ? `${w4}%` : '25%' }}>What up?</TableCell>
+    </TableRow>
+  </TableHead>
+);
 
 storiesOf('Skeleton', module)
-  .add('Default', () => <Skeleton />)
-  .add('Table', () => (
-    <Skeleton
-      variant="rect"
-      width="100%"
-      height="30px"
-      table
-      columns={5}
-      firstColWidth={30}
-    />
-  ));
+  .add('Default Table ', () => (
+    <Table>
+      {renderTableHead()}
+      <TableBody>
+        <TableRowLoading colSpan={4} />
+      </TableBody>
+    </Table>
+  ))
+  .add('Table with first col width defined', () => (
+    <Table>
+      {renderTableHead(40, 20, 20, 20)}
+      <TableBody>
+        <TableRowLoading colSpan={4} firstColWidth={40} />
+      </TableBody>
+    </Table>
+  ))
+  .add('Table with first col width defined, one line skeleton', () => (
+    <Table>
+      {renderTableHead(40, 20, 20, 20)}
+      <TableBody>
+        <TableRowLoading colSpan={4} firstColWidth={40} oneLine />
+      </TableBody>
+    </Table>
+  ))
+  .add(
+    'Table with first col width defined, one line skeleton and entity icon',
+    () => (
+      <Table>
+        {renderTableHead(40, 20, 20, 20)}
+        <TableBody>
+          <TableRowLoading
+            colSpan={4}
+            firstColWidth={40}
+            oneLine
+            hasEntityIcon
+          />
+        </TableBody>
+      </Table>
+    )
+  );

--- a/packages/manager/src/components/Skeleton/Skeleton.tsx
+++ b/packages/manager/src/components/Skeleton/Skeleton.tsx
@@ -1,3 +1,4 @@
+import * as classNames from 'classnames';
 import * as React from 'react';
 import Skeleton, { SkeletonProps } from 'src/components/core/Skeleton';
 import { makeStyles, Theme } from 'src/components/core/styles';
@@ -9,6 +10,13 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: theme.spacing(1),
     marginBottom: 10
   },
+  oneLine: {
+    marginBottom: 0
+  },
+  hasEntityIcon: {
+    position: 'relative',
+    paddingLeft: 54
+  },
   columnTitle: {
     marginBottom: theme.spacing(1)
   },
@@ -16,9 +24,14 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginTop: theme.spacing(1),
     marginBottom: 0
   },
+  skeletonIconContainer: {
+    position: 'absolute',
+    left: theme.spacing(1),
+    top: -10
+  },
   skeletonIcon: {
-    width: 40,
-    height: 40
+    width: 36,
+    height: 36
   }
 }));
 
@@ -70,19 +83,10 @@ const _Skeleton: React.FC<combinedProps> = props => {
           data-testid={'skeletonCol'}
           className={compact ? 'py0' : undefined}
         >
-          <Grid container alignItems="center">
-            {hasEntityIcon && (
-              <Grid item>
-                <Skeleton variant="circle" className={classes.skeletonIcon} />
-              </Grid>
-            )}
-            <Grid item style={{ flex: 1 }}>
-              <Skeleton
-                className={classes.columnTitle}
-                height={textHeight && variant === 'text' ? textHeight : 16}
-              />
-            </Grid>
-          </Grid>
+          <Skeleton
+            className={classes.columnTitle}
+            height={textHeight && variant === 'text' ? textHeight : 16}
+          />
           {!oneLine && (
             <Grid container>
               <Grid item xs={9} className="py0">
@@ -112,12 +116,20 @@ const _Skeleton: React.FC<combinedProps> = props => {
           {renderTableSkeleton(ifColumns)}
           <Grid
             container
-            className={classes.root}
-            style={oneLine ? { marginBottom: 0 } : undefined}
+            className={classNames({
+              [classes.root]: true,
+              [classes.oneLine]: oneLine,
+              [classes.hasEntityIcon]: hasEntityIcon
+            })}
             data-testid={'tableSkeleton'}
             aria-label="Table Content Loading"
             tabIndex={0}
           >
+            {hasEntityIcon && (
+              <Grid item className={classes.skeletonIconContainer}>
+                <Skeleton variant="circle" className={classes.skeletonIcon} />
+              </Grid>
+            )}
             {cols}
           </Grid>
         </>

--- a/packages/manager/src/components/Skeleton/Skeleton.tsx
+++ b/packages/manager/src/components/Skeleton/Skeleton.tsx
@@ -15,7 +15,9 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   hasEntityIcon: {
     position: 'relative',
-    paddingLeft: 54
+    '& > div:nth-of-type(2)': {
+      paddingLeft: 54
+    }
   },
   columnTitle: {
     marginBottom: theme.spacing(1)
@@ -26,7 +28,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   skeletonIconContainer: {
     position: 'absolute',
-    left: theme.spacing(1),
     top: -10
   },
   skeletonIcon: {

--- a/packages/manager/src/components/Skeleton/Skeleton.tsx
+++ b/packages/manager/src/components/Skeleton/Skeleton.tsx
@@ -6,6 +6,7 @@ import Grid from 'src/components/Grid';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
+    marginTop: theme.spacing(1),
     marginBottom: 10
   },
   columnTitle: {
@@ -23,6 +24,8 @@ interface Props {
   firstColWidth?: number;
   textHeight?: number;
   subtextHeight?: number;
+  oneLine?: boolean;
+  compact?: boolean;
 }
 
 export type combinedProps = SkeletonProps & Props;
@@ -35,7 +38,9 @@ const _Skeleton: React.FC<combinedProps> = props => {
     firstColWidth,
     variant,
     textHeight,
-    subtextHeight
+    subtextHeight,
+    oneLine,
+    compact
   } = props;
 
   const cols: JSX.Element[] = [];
@@ -54,28 +59,31 @@ const _Skeleton: React.FC<combinedProps> = props => {
       cols.push(
         <Grid
           item
-          style={{ width: `${calcColumns()}%` }}
+          style={{ flexBasis: `${calcColumns()}%` }}
           key={`ske-${colCount}`}
           data-testid={'skeletonCol'}
+          className={compact ? 'py0' : undefined}
         >
           <Skeleton
             className={classes.columnTitle}
             height={textHeight && variant === 'text' ? textHeight : 16}
           />
-          <Grid container>
-            <Grid item xs={9} className="py0">
-              <Skeleton
-                className={classes.columnText}
-                height={subtextHeight ? subtextHeight : 8}
-              />
+          {!oneLine && (
+            <Grid container>
+              <Grid item xs={9} className="py0">
+                <Skeleton
+                  className={classes.columnText}
+                  height={subtextHeight ? subtextHeight : 8}
+                />
+              </Grid>
+              <Grid item xs={6} className="py0">
+                <Skeleton
+                  className={classes.columnText}
+                  height={subtextHeight ? subtextHeight : 8}
+                />
+              </Grid>
             </Grid>
-            <Grid item xs={6} className="py0">
-              <Skeleton
-                className={classes.columnText}
-                height={subtextHeight ? subtextHeight : 8}
-              />
-            </Grid>
-          </Grid>
+          )}
         </Grid>
       );
     }
@@ -90,6 +98,7 @@ const _Skeleton: React.FC<combinedProps> = props => {
           <Grid
             container
             className={classes.root}
+            style={oneLine ? { marginBottom: 0 } : undefined}
             data-testid={'tableSkeleton'}
             aria-label="Table Content Loading"
             tabIndex={0}

--- a/packages/manager/src/components/Skeleton/Skeleton.tsx
+++ b/packages/manager/src/components/Skeleton/Skeleton.tsx
@@ -15,6 +15,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   columnText: {
     marginTop: theme.spacing(1),
     marginBottom: 0
+  },
+  skeletonIcon: {
+    width: 40,
+    height: 40
   }
 }));
 
@@ -25,6 +29,7 @@ interface Props {
   textHeight?: number;
   subtextHeight?: number;
   oneLine?: boolean;
+  hasEntityIcon?: boolean;
   compact?: boolean;
 }
 
@@ -40,6 +45,7 @@ const _Skeleton: React.FC<combinedProps> = props => {
     textHeight,
     subtextHeight,
     oneLine,
+    hasEntityIcon,
     compact
   } = props;
 
@@ -64,10 +70,19 @@ const _Skeleton: React.FC<combinedProps> = props => {
           data-testid={'skeletonCol'}
           className={compact ? 'py0' : undefined}
         >
-          <Skeleton
-            className={classes.columnTitle}
-            height={textHeight && variant === 'text' ? textHeight : 16}
-          />
+          <Grid container alignItems="center">
+            {hasEntityIcon && (
+              <Grid item>
+                <Skeleton variant="circle" className={classes.skeletonIcon} />
+              </Grid>
+            )}
+            <Grid item style={{ flex: 1 }}>
+              <Skeleton
+                className={classes.columnTitle}
+                height={textHeight && variant === 'text' ? textHeight : 16}
+              />
+            </Grid>
+          </Grid>
           {!oneLine && (
             <Grid container>
               <Grid item xs={9} className="py0">

--- a/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
+++ b/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
@@ -27,41 +27,68 @@ const styles = (theme: Theme) =>
 
 export interface Props {
   colSpan: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+  numberOfRows?: number;
   firstColWidth?: number;
   transparent?: any;
+  oneLine?: boolean;
+  compact?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
 
-class TableRowLoading extends React.Component<CombinedProps> {
-  render() {
-    const { classes, transparent, colSpan, firstColWidth } = this.props;
-    return (
-      <TableRow
-        className={classNames({
-          [classes.transparent]: transparent
-        })}
-        data-testid="table-row-loading"
-        aria-label="Table content is loading"
-      >
-        <TableCell
-          colSpan={colSpan}
+const tableRowLoading: React.FC<CombinedProps> = props => {
+  const {
+    classes,
+    transparent,
+    colSpan,
+    firstColWidth,
+    oneLine,
+    numberOfRows,
+    compact
+  } = props;
+
+  const rows: JSX.Element[] = [];
+  const ifRows = numberOfRows !== undefined ? numberOfRows : 1;
+  const rowBuilder = (rowCount: number) => {
+    for (rowCount = 0; rowCount <= ifRows - 1; rowCount++) {
+      rows.push(
+        <TableRow
           className={classNames({
-            [classes.tableCell]: true,
             [classes.transparent]: transparent
           })}
+          data-testid="table-row-loading"
+          aria-label="Table content is loading"
+          key={`table-row-loading-${rowCount}`}
+          style={compact ? { height: 'auto' } : undefined}
         >
-          <Skeleton
-            table
-            columns={colSpan ? colSpan : 8}
-            firstColWidth={firstColWidth ? firstColWidth : undefined}
-          />
-        </TableCell>
-      </TableRow>
-    );
-  }
-}
+          <TableCell
+            colSpan={colSpan}
+            className={classNames({
+              [classes.tableCell]: true,
+              [classes.transparent]: transparent
+            })}
+          >
+            <Skeleton
+              table
+              columns={colSpan ? colSpan : 8}
+              firstColWidth={firstColWidth ? firstColWidth : undefined}
+              oneLine={oneLine}
+              compact={compact}
+            />
+          </TableCell>
+        </TableRow>
+      );
+    }
+  };
+
+  return (
+    <>
+      {rowBuilder(ifRows)}
+      {rows}
+    </>
+  );
+};
 
 const styled = withStyles(styles);
 
-export default styled(TableRowLoading);
+export default styled(tableRowLoading);

--- a/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
+++ b/packages/manager/src/components/TableRowLoading/TableRowLoading.tsx
@@ -32,6 +32,7 @@ export interface Props {
   transparent?: any;
   oneLine?: boolean;
   compact?: boolean;
+  hasEntityIcon?: boolean;
 }
 
 type CombinedProps = Props & WithStyles<ClassNames>;
@@ -44,6 +45,7 @@ const tableRowLoading: React.FC<CombinedProps> = props => {
     firstColWidth,
     oneLine,
     numberOfRows,
+    hasEntityIcon,
     compact
   } = props;
 
@@ -74,6 +76,7 @@ const tableRowLoading: React.FC<CombinedProps> = props => {
               firstColWidth={firstColWidth ? firstColWidth : undefined}
               oneLine={oneLine}
               compact={compact}
+              hasEntityIcon={hasEntityIcon}
             />
           </TableCell>
         </TableRow>

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -343,7 +343,16 @@ export const renderTableBody = (
   const filteredEvents = removeBlacklistedEvents(events, ['profile_update']);
 
   if (loading) {
-    return <TableRowLoading colSpan={12} data-qa-events-table-loading />;
+    return (
+      <TableRowLoading
+        colSpan={3}
+        numberOfRows={2}
+        oneLine
+        data-qa-events-table-loading
+        firstColWidth={70}
+        compact
+      />
+    );
   } else if (error) {
     return (
       <TableRowError

--- a/packages/manager/src/features/Events/EventsLanding.tsx
+++ b/packages/manager/src/features/Events/EventsLanding.tsx
@@ -346,7 +346,7 @@ export const renderTableBody = (
     return (
       <TableRowLoading
         colSpan={3}
-        numberOfRows={2}
+        numberOfRows={10}
         oneLine
         data-qa-events-table-loading
         firstColWidth={70}

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallLanding.tsx
@@ -19,7 +19,7 @@ import FirewallTable from './FirewallTable';
 
 const useStyles = makeStyles((theme: Theme) => ({
   line: {
-    marginTop: theme.spacing(10),
+    marginTop: theme.spacing(4),
     marginBottom: theme.spacing(3)
   }
 }));

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTable.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { compose } from 'recompose';
-// import { makeStyles, Theme } from 'src/components/core/styles'
+import { makeStyles, Theme } from 'src/components/core/styles';
 import { Props as FireProps } from 'src/containers/firewalls.container';
 
 import Paper from 'src/components/core/Paper';
@@ -17,16 +17,27 @@ import TableSortCell from 'src/components/TableSortCell';
 import { ActionHandlers } from './FirewallActionMenu';
 import FirewallRows from './FirewallTableRows';
 
-// const useStyles = makeStyles((theme: Theme) => ({
-//   root: {}
-// }))
+const useStyles = makeStyles((theme: Theme) => ({
+  labelCell: {
+    width: '25%'
+  },
+  statusCell: {
+    width: '15%'
+  },
+  ruleCell: {
+    width: '25%'
+  },
+  linodeCell: {
+    width: '25%'
+  }
+}));
 
 type FirewallProps = Omit<FireProps, 'getFirewalls'> & ActionHandlers;
 
 type CombinedProps = FirewallProps;
 
 const FirewallTable: React.FC<CombinedProps> = props => {
-  // const classes = useStyles();
+  const classes = useStyles();
 
   const {
     data: firewalls,
@@ -61,6 +72,7 @@ const FirewallTable: React.FC<CombinedProps> = props => {
                           direction={order}
                           handleClick={handleOrderChange}
                           data-qa-firewall-label-header
+                          className={classes.labelCell}
                         >
                           Firewall
                         </TableSortCell>
@@ -70,13 +82,20 @@ const FirewallTable: React.FC<CombinedProps> = props => {
                           direction={order}
                           handleClick={handleOrderChange}
                           data-qa-firewall-status-header
+                          className={classes.statusCell}
                         >
                           Status
                         </TableSortCell>
-                        <TableCell data-qa-firewall-rules-header>
+                        <TableCell
+                          data-qa-firewall-rules-header
+                          className={classes.ruleCell}
+                        >
                           Rules
                         </TableCell>
-                        <TableCell data-qa-firewall-rules-header>
+                        <TableCell
+                          data-qa-firewall-rules-header
+                          className={classes.linodeCell}
+                        >
                           Linodes
                         </TableCell>
                         <TableCell />

--- a/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTableRows.tsx
+++ b/packages/manager/src/features/Firewalls/FirewallLanding/FirewallTableRows.tsx
@@ -28,7 +28,7 @@ const FirewallTableRows: React.FC<CombinedProps> = props => {
   } = props;
 
   if (firewallsLoading && firewallsLastUpdated === 0) {
-    return <TableRowLoading colSpan={6} />;
+    return <TableRowLoading colSpan={6} firstColWidth={25} oneLine />;
   }
 
   /**

--- a/packages/manager/src/features/Managed/Contacts/ContactsTableContent.tsx
+++ b/packages/manager/src/features/Managed/Contacts/ContactsTableContent.tsx
@@ -34,7 +34,7 @@ export const ContactsTableContent: React.FC<CombinedProps> = props => {
   } = props;
 
   if (loading && lastUpdated === 0) {
-    return <TableRowLoading colSpan={6} />;
+    return <TableRowLoading colSpan={6} firstColWidth={15} oneLine />;
   }
 
   if (error) {

--- a/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialList.tsx
@@ -41,6 +41,12 @@ const useStyles = makeStyles((theme: Theme) => ({
   subHeader: {
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(2)
+  },
+  credCell: {
+    width: '30%'
+  },
+  decryptCell: {
+    width: '60%'
   }
 }));
 
@@ -250,6 +256,7 @@ export const CredentialList: React.FC<CombinedProps> = props => {
                             direction={order}
                             handleClick={handleOrderChange}
                             data-qa-credential-label-header
+                            className={classes.credCell}
                           >
                             Credential
                           </TableSortCell>
@@ -259,6 +266,7 @@ export const CredentialList: React.FC<CombinedProps> = props => {
                             direction={order}
                             handleClick={handleOrderChange}
                             data-qa-credential-decrypted-header
+                            className={classes.decryptCell}
                           >
                             Last Decrypted
                           </TableSortCell>

--- a/packages/manager/src/features/Managed/Credentials/CredentialRow.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialRow.tsx
@@ -10,12 +10,6 @@ import ActionMenu from './CredentialActionMenu';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    label: {
-      width: '30%',
-      [theme.breakpoints.down('sm')]: {
-        width: '100%'
-      }
-    },
     credentialDescription: {
       paddingTop: theme.spacing(1) / 2
     },
@@ -46,11 +40,7 @@ export const CredentialRow: React.FunctionComponent<CombinedProps> = props => {
       data-testid={'credential-row'}
       className={classes.credentialRow}
     >
-      <TableCell
-        parentColumn="Credential"
-        className={classes.label}
-        data-qa-credential-label
-      >
+      <TableCell parentColumn="Credential" data-qa-credential-label>
         <Typography variant="h3">{credential.label}</Typography>
       </TableCell>
       <TableCell parentColumn="Last Decrypted" data-qa-credential-decrypted>

--- a/packages/manager/src/features/Managed/Credentials/CredentialTableContent.tsx
+++ b/packages/manager/src/features/Managed/Credentials/CredentialTableContent.tsx
@@ -20,7 +20,7 @@ export type CombinedProps = Props;
 export const CredentialTableContent: React.FC<CombinedProps> = props => {
   const { error, loading, credentials, openDialog, openForEdit } = props;
   if (loading) {
-    return <TableRowLoading colSpan={2} />;
+    return <TableRowLoading firstColWidth={35} colSpan={2} oneLine />;
   }
 
   if (error) {

--- a/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
@@ -31,7 +31,7 @@ export const MonitorTableContent: React.FC<CombinedProps> = props => {
     openHistoryDrawer,
     openMonitorDrawer
   } = props;
-  if (!loading) {
+  if (loading) {
     return (
       <TableRowLoading colSpan={3} firstColWidth={45} oneLine hasEntityIcon />
     );

--- a/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
@@ -31,8 +31,8 @@ export const MonitorTableContent: React.FC<CombinedProps> = props => {
     openHistoryDrawer,
     openMonitorDrawer
   } = props;
-  if (loading) {
-    return <TableRowLoading colSpan={4} />;
+  if (!loading) {
+    return <TableRowLoading colSpan={3} firstColWidth={45} />;
   }
 
   if (error) {

--- a/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
+++ b/packages/manager/src/features/Managed/Monitors/MonitorTableContent.tsx
@@ -32,7 +32,9 @@ export const MonitorTableContent: React.FC<CombinedProps> = props => {
     openMonitorDrawer
   } = props;
   if (!loading) {
-    return <TableRowLoading colSpan={3} firstColWidth={45} />;
+    return (
+      <TableRowLoading colSpan={3} firstColWidth={45} oneLine hasEntityIcon />
+    );
   }
 
   if (error) {

--- a/packages/manager/src/features/Managed/SSHAccess/SSHAccessTableContent.tsx
+++ b/packages/manager/src/features/Managed/SSHAccess/SSHAccessTableContent.tsx
@@ -29,7 +29,7 @@ export const SSHAccessTableContent: React.FC<CombinedProps> = props => {
   } = props;
 
   if (loading && lastUpdated === 0) {
-    return <TableRowLoading colSpan={6} firstColWidth={30} />;
+    return <TableRowLoading colSpan={6} firstColWidth={30} oneLine />;
   }
 
   if (error) {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.test.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.test.tsx
@@ -44,7 +44,7 @@ describe('ObjectStorageKeyTable', () => {
 
   it('returns a loading state when loading', () => {
     wrapper.setProps({ loading: true });
-    expect(wrapper.find('WithStyles(TableRowLoading)')).toHaveLength(1);
+    expect(wrapper.find('WithStyles(tableRowLoading)')).toHaveLength(1);
   });
 
   it('returns an error state when there is an error', () => {

--- a/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
+++ b/packages/manager/src/features/ObjectStorage/AccessKeyLanding/AccessKeyTable.tsx
@@ -34,7 +34,7 @@ const styles = (theme: Theme) =>
       marginBottom: theme.spacing(2)
     },
     labelCell: {
-      width: '40%'
+      width: '48%'
     },
     copyIcon: {
       '& svg': {
@@ -71,11 +71,11 @@ export const AccessKeyTable: React.StatelessComponent<
 
   const renderContent = () => {
     if (isRestrictedUser) {
-      return <TableRowEmptyState colSpan={6} />;
+      return <TableRowEmptyState colSpan={12} />;
     }
 
     if (loading) {
-      return <TableRowLoading colSpan={6} />;
+      return <TableRowLoading colSpan={3} firstColWidth={50} oneLine />;
     }
 
     if (error) {
@@ -90,7 +90,7 @@ export const AccessKeyTable: React.StatelessComponent<
     return data && data.length > 0 ? (
       renderRows(data)
     ) : (
-      <TableRowEmptyState colSpan={6} />
+      <TableRowEmptyState colSpan={12} />
     );
   };
 

--- a/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
+++ b/packages/manager/src/features/Profile/APITokens/APITokenTable.tsx
@@ -429,7 +429,7 @@ export class APITokenTable extends React.Component<CombinedProps, State> {
     const { error, loading, data } = this.props;
 
     if (loading) {
-      return <TableRowLoading colSpan={6} />;
+      return <TableRowLoading colSpan={6} oneLine />;
     }
 
     if (error) {

--- a/packages/manager/src/features/Profile/OAuthClients/OAuthClients.tsx
+++ b/packages/manager/src/features/Profile/OAuthClients/OAuthClients.tsx
@@ -296,7 +296,7 @@ export class OAuthClients extends React.Component<CombinedProps, State> {
     }
 
     if (loading) {
-      return <TableRowLoading colSpan={6} />;
+      return <TableRowLoading colSpan={6} oneLine />;
     }
 
     return data && data.length > 0 ? (

--- a/packages/manager/src/features/Profile/SSHKeys/SSHKeys.test.tsx
+++ b/packages/manager/src/features/Profile/SSHKeys/SSHKeys.test.tsx
@@ -58,7 +58,7 @@ describe('SSHKeys', () => {
       />
     );
 
-    expect(wrapper.find(`WithStyles(TableRowLoading)`).exists()).toBeTruthy();
+    expect(wrapper.find(`WithStyles(tableRowLoading)`).exists()).toBeTruthy();
   });
 
   it('should display TableRowError if error if state.error is set.', () => {

--- a/packages/manager/src/features/Users/UsersLanding.tsx
+++ b/packages/manager/src/features/Users/UsersLanding.tsx
@@ -36,7 +36,13 @@ import CreateUserDrawer from './CreateUserDrawer';
 import UserDeleteConfirmationDialog from './UserDeleteConfirmationDialog';
 import ActionMenu from './UsersActionMenu';
 
-type ClassNames = 'title' | 'avatar' | 'emptyImage';
+type ClassNames =
+  | 'title'
+  | 'avatar'
+  | 'emptyImage'
+  | 'userNameCell'
+  | 'emailNameCell'
+  | 'accountNameCell';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -71,6 +77,15 @@ const styles = (theme: Theme) =>
         width: 40,
         height: 40
       }
+    },
+    userNameCell: {
+      width: '32%'
+    },
+    emailNameCell: {
+      width: '32%'
+    },
+    accountNameCell: {
+      width: '32%'
     }
   });
 
@@ -191,7 +206,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
       >
         <TableCell parentColumn="Username" data-qa-username>
           <Grid container alignItems="center">
-            <Grid item>
+            <Grid item style={{ display: 'flex' }}>
               {user.gravatarUrl === undefined ? (
                 <div className={classes.emptyImage} />
               ) : user.gravatarUrl === 'not found' ? (
@@ -273,9 +288,22 @@ class UsersLanding extends React.Component<CombinedProps, State> {
             <Table aria-label="List of Users">
               <TableHead>
                 <TableRow>
-                  <TableCell data-qa-username-column>Username</TableCell>
-                  <TableCell data-qa-email-column>Email Address</TableCell>
-                  <TableCell data-qa-restriction-column>
+                  <TableCell
+                    className={classes.userNameCell}
+                    data-qa-username-column
+                  >
+                    Username
+                  </TableCell>
+                  <TableCell
+                    className={classes.emailNameCell}
+                    data-qa-email-column
+                  >
+                    Email Address
+                  </TableCell>
+                  <TableCell
+                    className={classes.accountNameCell}
+                    data-qa-restriction-column
+                  >
                     Account Access
                   </TableCell>
                   <TableCell />
@@ -316,7 +344,7 @@ class UsersLanding extends React.Component<CombinedProps, State> {
     data?: User[]
   ) => {
     if (loading) {
-      return <TableRowLoading colSpan={4} />;
+      return <TableRowLoading colSpan={4} oneLine hasEntityIcon />;
     }
 
     if (error) {

--- a/packages/manager/src/themeFactory.ts
+++ b/packages/manager/src/themeFactory.ts
@@ -1033,6 +1033,7 @@ const themeDefaults: ThemeDefaults = ({ spacingOverride: spacingUnit }) => {
       },
       MuiSkeleton: {
         text: {
+          marginTop: 0,
           borderRadius: 0
         }
       },


### PR DESCRIPTION
## M3-3614 Improve TableRow Loading skeleton

In order to make the pattern matching various table rows layout I added some props and styles in various tables. (`oneLine`, `hasEntityIcon`).

StoryBook was updated to show the different states

## Type of Change
- Non breaking change ('update', 'change')


