### PR TITLE
Removing focus from H1 component

### DIFF
--- a/packages/manager/src/components/H1Header/H1Header.tsx
+++ b/packages/manager/src/components/H1Header/H1Header.tsx
@@ -1,10 +1,20 @@
 import * as React from 'react';
+import { makeStyles } from 'src/components/core/styles';
 import Typography from 'src/components/core/Typography';
 
 interface Props {
   title: string;
   className?: string;
 }
+
+const useStyles = makeStyles({
+  root: {
+    '&:focus': {
+      outline: 'none',
+      border: '3px solid red'
+    }
+  }
+});
 
 // Accessibility Feature:
 // The role of this component is to implement focus to the main content when navigating the application
@@ -13,6 +23,7 @@ interface Props {
 const H1Header: React.FC<Props> = props => {
   const h1Header = React.useRef<HTMLDivElement>(null);
   const { className, title } = props;
+  const classes = useStyles();
 
   React.useEffect(() => {
     if (h1Header.current !== null) {
@@ -21,7 +32,12 @@ const H1Header: React.FC<Props> = props => {
   }, []);
 
   return (
-    <Typography variant="h1" className={className} ref={h1Header} tabIndex={-1}>
+    <Typography
+      variant="h1"
+      className={`${classes.root} ${className}`}
+      ref={h1Header}
+      tabIndex={-1}
+    >
       {title}
     </Typography>
   );


### PR DESCRIPTION
## Description

As discussed in review, we're removing the focus state on the h1 component. 

## Type of Change
- Non breaking change ('update')

## Note to Reviewers

I left a red border for now so one can see that the h1 still remains focused, and of course will remove that before I merge.
