### PR TITLE
[for release] Upgrade react-dropzone

### DIFF
--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -61,7 +61,7 @@
     "react-csv": "^1.1.1",
     "react-currency-formatter": "^1.1.0",
     "react-dom": "~16.8.6",
-    "react-dropzone": "^10.2.1",
+    "react-dropzone": "~10.2.1",
     "react-ga": "^2.5.3",
     "react-loadable": "^5.3.1",
     "react-number-format": "^3.5.0",

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -61,7 +61,7 @@
     "react-csv": "^1.1.1",
     "react-currency-formatter": "^1.1.0",
     "react-dom": "~16.8.6",
-    "react-dropzone": "^10.1.8",
+    "react-dropzone": "^10.2.1",
     "react-ga": "^2.5.3",
     "react-loadable": "^5.3.1",
     "react-number-format": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15879,7 +15879,7 @@ react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-dropzone@^10.2.1:
+react-dropzone@~10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-10.2.1.tgz#b7520124c4a3b66f96d49f7879027c7a475eaa20"
   integrity sha512-Me5nOu8hK9/Xyg5easpdfJ6SajwUquqYR/2YTdMotsCUgJ1pHIIwNsv0n+qcIno0tWR2V2rVQtj2r/hXYs2TnQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15879,10 +15879,10 @@ react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-dropzone@^10.1.8:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-10.2.0.tgz#6b3df4866045e7c078ddabe795fb8789dbbc4598"
-  integrity sha512-VvJtg6GKtM1Xu+SsMcBNBcB2XcOi27xbNLBMDkrpqsk3cSILFiBVoCuW96FSOWkCK1IFeNg67FjKu/c/KuUhkg==
+react-dropzone@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-10.2.1.tgz#b7520124c4a3b66f96d49f7879027c7a475eaa20"
+  integrity sha512-Me5nOu8hK9/Xyg5easpdfJ6SajwUquqYR/2YTdMotsCUgJ1pHIIwNsv0n+qcIno0tWR2V2rVQtj2r/hXYs2TnQ==
   dependencies:
     attr-accept "^2.0.0"
     file-selector "^0.1.12"


### PR DESCRIPTION
## Description

A dependency of react-dropzone called attr-accept had been bumped to the newest version in our yarn.lock. This version included breaking changes. As a result, in the Object Storage file uploader files were not correctly being accepted. Bumping the version of react-dropzone fixes this problem.

## Note to Reviewers

**To see the regression:** check out develop and attempt to upload a file. The file uploader area will be red. 

**To see the fix:** check out this branch and to the same thing. Please test with multiple browsers, filetypes, etc.
