### PR TITLE
M3-3700 Allow primary nav to set multiple active links

### DIFF
--- a/packages/manager/src/components/PrimaryNav/AdditionalMenuItems.tsx
+++ b/packages/manager/src/components/PrimaryNav/AdditionalMenuItems.tsx
@@ -17,36 +17,6 @@ type CombinedProps = Props;
 
 const AdditionalMenuItems: React.FC<CombinedProps> = props => {
   const { isCollapsed } = props;
-  // const [adaError, setAdaError] = React.useState<string>('');
-
-  // React.useEffect(() => {
-  //   /*
-  //    * Init Ada Chaperone chat app
-  //    * Script is included in index.html
-  //    */
-  //   if ('AdaChaperone' in window) {
-  //     ada = new (window as any).AdaChaperone('linode');
-  //   } else {
-  //     setAdaError(
-  //       'There was an issue loading the support bot. Please try again later.'
-  //     );
-  //   }
-  // });
-
-  // const handleAdaInit = () => {
-  //   /*
-  //    * Show the Ada chat
-  //    */
-
-  //   if (typeof ada === 'undefined') {
-  //     return;
-  //   }
-
-  //   setAdaError('');
-  //   sendAdaEvent();
-  //   ada.show();
-  // };
-
   const links: PrimaryLink[] = [
     {
       display: 'Get Help',
@@ -54,16 +24,7 @@ const AdditionalMenuItems: React.FC<CombinedProps> = props => {
       QAKey: 'help',
       icon: <Help className="small wBorder" />
     }
-    // {
-    //   display: 'Support Bot',
-    //   key: 'chat',
-    //   onClick: handleAdaInit,
-    //   isDisabled: () => adaError
-    // }
   ];
-
-  /** ada chat bot */
-  // let ada: any;
 
   return (
     <React.Fragment>

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -66,6 +66,7 @@ interface PrimaryLink {
   key: string;
   attr?: { [key: string]: any };
   icon?: JSX.Element;
+  activeLinks?: Array<string>;
   onClick?: (e: React.ChangeEvent<any>) => void;
 }
 
@@ -194,7 +195,12 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
           display: 'Account',
           href: '/account/billing',
           key: 'account',
-          icon: <Account className="small" />
+          icon: <Account className="small" />,
+          activeLinks: [
+            '/account/billing',
+            '/account/users',
+            '/account/settings'
+          ]
         }
       },
       {
@@ -329,7 +335,9 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
           {...primaryLink.attr}
           className={classNames({
             [classes.listItem]: true,
-            [classes.active]: linkIsActive(primaryLink.href),
+            [classes.active]: primaryLink.activeLinks
+              ? linkIsActive('', primaryLink.activeLinks)
+              : linkIsActive(primaryLink.href),
             listItemCollpased: isCollapsed
           })}
         >

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -150,6 +150,10 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
         link: {
           display: 'Object Storage',
           href: '/object-storage/buckets',
+          activeLinks: [
+            '/object-storage/buckets',
+            '/object-storage/access-keys'
+          ],
           key: 'object-storage',
           icon: <Storage />
         }
@@ -227,6 +231,7 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
       {
         display: 'Linodes',
         href: '/linodes',
+        activeLinks: ['/linodes', '/linodes/create'],
         key: 'linodes',
         icon: <Linode />
       },

--- a/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/packages/manager/src/components/PrimaryNav/PrimaryNav.tsx
@@ -340,9 +340,10 @@ export class PrimaryNav extends React.Component<CombinedProps, State> {
           {...primaryLink.attr}
           className={classNames({
             [classes.listItem]: true,
-            [classes.active]: primaryLink.activeLinks
-              ? linkIsActive('', primaryLink.activeLinks)
-              : linkIsActive(primaryLink.href),
+            [classes.active]: linkIsActive(
+              primaryLink.href,
+              primaryLink.activeLinks
+            ),
             listItemCollpased: isCollapsed
           })}
         >

--- a/packages/manager/src/components/PrimaryNav/utils.ts
+++ b/packages/manager/src/components/PrimaryNav/utils.ts
@@ -1,11 +1,11 @@
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
 
-export const linkIsActive = (href: string) => {
+export const linkIsActive = (href: string, activeLinks?: Array<string>) => {
   const currentlyOnCreateLinodeFlow = location.pathname.match(
     /linodes[/]create/gi
   );
   const currentlyOnOneClickTab = location.search.match(/one-click/gi);
-  const isOneClickTab = href.match(/one-click/gi);
+  const isOneClickTab = href && href.match(/one-click/gi);
 
   /**
    * mark as active if the tab is "one click" and we're on the one-click route
@@ -18,5 +18,7 @@ export const linkIsActive = (href: string) => {
     return false;
   }
 
-  return isPathOneOf([href], location.pathname);
+  return !activeLinks
+    ? href && isPathOneOf([href], location.pathname)
+    : isPathOneOf(activeLinks, location.pathname);
 };

--- a/packages/manager/src/components/PrimaryNav/utils.ts
+++ b/packages/manager/src/components/PrimaryNav/utils.ts
@@ -1,7 +1,16 @@
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
 
-export const linkIsActive = (href: string, activeLinks?: Array<string>) => {
-  return !activeLinks
-    ? href && isPathOneOf([href], location.pathname)
-    : isPathOneOf(activeLinks, location.pathname);
+export const linkIsActive = (href: string, activeLinks: Array<string> = []) => {
+  const currentlyOnOneClickTab = location.search.match(/one-click/gi);
+  const isOneClickTab = href.match(/one-click/gi);
+
+  /**
+   * mark as active if the tab is "one click"
+   * Other create tabs default back to Linodes active tabs
+   */
+  if (currentlyOnOneClickTab) {
+    return isOneClickTab;
+  }
+
+  return isPathOneOf([href, ...activeLinks], location.pathname);
 };

--- a/packages/manager/src/components/PrimaryNav/utils.ts
+++ b/packages/manager/src/components/PrimaryNav/utils.ts
@@ -1,23 +1,6 @@
 import isPathOneOf from 'src/utilities/routing/isPathOneOf';
 
 export const linkIsActive = (href: string, activeLinks?: Array<string>) => {
-  const currentlyOnCreateLinodeFlow = location.pathname.match(
-    /linodes[/]create/gi
-  );
-  const currentlyOnOneClickTab = location.search.match(/one-click/gi);
-  const isOneClickTab = href && href.match(/one-click/gi);
-
-  /**
-   * mark as active if the tab is "one click" and we're on the one-click route
-   * any other create flow tabs don't need an active nav element
-   */
-  if (currentlyOnCreateLinodeFlow) {
-    if (currentlyOnOneClickTab) {
-      return isOneClickTab;
-    }
-    return false;
-  }
-
   return !activeLinks
     ? href && isPathOneOf([href], location.pathname)
     : isPathOneOf(activeLinks, location.pathname);

--- a/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
+++ b/packages/manager/src/features/TopMenu/UserMenu/UserMenu.tsx
@@ -222,11 +222,11 @@ export class UserMenu extends React.Component<CombinedProps, State> {
             onClose={this.handleClose}
             className={classes.menu}
           >
-            <MenuItem
+            {/* <MenuItem
               key="placeholder"
               aria-hidden
               className={classes.hidden}
-            />
+            /> */}
             {menuLinks.map(menuLink => this.renderMenuLink(menuLink))}
           </Menu>
         </Hidden>


### PR DESCRIPTION
## M3-3700 Allow primary nav to set multiple active links

Sub tabs will break the active caret on primary nav. These PR allows to have multiple ones. I also did some cleanup on the function and files.

## Type of Change
- Non breaking change ('update', 'change')