### PR TITLE
M3-3715 Reduce OCA tile spacing between Icon and Label

### DIFF
--- a/packages/manager/src/components/SelectionCard/CardBase.tsx
+++ b/packages/manager/src/components/SelectionCard/CardBase.tsx
@@ -122,7 +122,7 @@ export class CardBase extends React.Component<CombinedProps> {
         className={`${classes.innerGrid} innerGrid`}
       >
         {renderIcon && (
-          <Grid item className={classes.icon}>
+          <Grid item className={`${classes.icon} cardBaseIcon`}>
             {renderIcon()}
           </Grid>
         )}

--- a/packages/manager/src/components/SelectionCard/SelectionCard.tsx
+++ b/packages/manager/src/components/SelectionCard/SelectionCard.tsx
@@ -162,6 +162,7 @@ export interface Props {
   disabled?: boolean;
   tooltip?: string;
   variant?: 'check' | 'info';
+  className?: string;
 }
 
 interface WithTooltipProps {
@@ -214,7 +215,7 @@ class SelectionCard extends React.PureComponent<CombinedProps, {}> {
     switch (variant) {
       case 'info':
         return (
-          <Grid item className={`${classes.info}`} xs={2}>
+          <Grid item className={`${classes.info} cardBaseInfo`} xs={2}>
             <Info onClick={this.handleInfoClick} />
           </Grid>
         );
@@ -242,7 +243,14 @@ class SelectionCard extends React.PureComponent<CombinedProps, {}> {
   };
 
   render() {
-    const { checked, classes, disabled, onClick, tooltip } = this.props;
+    const {
+      checked,
+      classes,
+      disabled,
+      onClick,
+      tooltip,
+      className
+    } = this.props;
 
     const cardGrid = () => (
       <Grid
@@ -252,13 +260,16 @@ class SelectionCard extends React.PureComponent<CombinedProps, {}> {
         lg={4}
         xl={3}
         tabIndex={0}
-        className={classNames({
-          [classes.root]: true,
-          checked: checked === true,
-          [classes.disabled]: disabled === true,
-          [classes.showCursor]: onClick && !disabled,
-          selectionCard: true
-        })}
+        className={classNames(
+          {
+            [classes.root]: true,
+            checked: checked === true,
+            [classes.disabled]: disabled === true,
+            [classes.showCursor]: onClick && !disabled,
+            selectionCard: true
+          },
+          className
+        )}
         onClick={this.handleClick}
         onKeyPress={this.handleKeyPress}
         data-qa-selection-card

--- a/packages/manager/src/features/linodes/LinodesCreate/SelectAppPanel.tsx
+++ b/packages/manager/src/features/linodes/LinodesCreate/SelectAppPanel.tsx
@@ -16,7 +16,11 @@ import { getParamFromUrl } from 'src/utilities/queryParams';
 import Panel from './Panel';
 import { AppsData } from './types';
 
-type ClassNames = 'flatImagePanelSelections' | 'panel' | 'loading';
+type ClassNames =
+  | 'flatImagePanelSelections'
+  | 'panel'
+  | 'loading'
+  | 'selectionCard';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -30,6 +34,20 @@ const styles = (theme: Theme) =>
     loading: {
       marginTop: theme.spacing(2),
       marginBottom: theme.spacing(2)
+    },
+    selectionCard: {
+      '& .cardBaseIcon': {
+        width: 40,
+        paddingRight: 0,
+        justifyContent: 'flex-start'
+      },
+      '& .cardBaseInfo': {
+        paddingLeft: 0,
+        '& svg': {
+          width: 28,
+          height: 28
+        }
+      }
     }
   });
 
@@ -131,6 +149,7 @@ class SelectAppPanel extends React.PureComponent<CombinedProps> {
               disabled={disabled}
               id={eachApp.id}
               iconUrl={eachApp.logo_url || ''}
+              classes={classes}
             />
           ))}
         </Grid>
@@ -164,7 +183,9 @@ interface SelectionProps {
   checked: boolean;
 }
 
-class SelectionCardWrapper extends React.PureComponent<SelectionProps> {
+class SelectionCardWrapper extends React.PureComponent<
+  SelectionProps & WithStyles<ClassNames>
+> {
   handleSelectApp = (event: React.SyntheticEvent<HTMLElement, Event>) => {
     const { id, label, userDefinedFields, availableImages } = this.props;
 
@@ -183,7 +204,7 @@ class SelectionCardWrapper extends React.PureComponent<SelectionProps> {
   };
 
   render() {
-    const { iconUrl, id, checked, label, disabled } = this.props;
+    const { iconUrl, id, checked, label, disabled, classes } = this.props;
     /**
      * '' is the default value for a stackscript's logo_url;
      * display a fallback image in this case, to avoid broken image icons
@@ -206,6 +227,7 @@ class SelectionCardWrapper extends React.PureComponent<SelectionProps> {
         data-qa-selection-card
         disabled={disabled}
         variant="info"
+        className={classes.selectionCard}
       />
     );
   }


### PR DESCRIPTION
## M3-3715 Reduce OCA tile spacing between Icon and Label

<img width="313" alt="Screen Shot 2019-12-17 at 10 34 45 AM (1)" src="https://user-images.githubusercontent.com/205353/71018450-81b5a500-20c6-11ea-9c39-8a2b7b7dcf75.png">

## Type of Change
- Non breaking change ('update', 'change')

