### PR TITLE
M3-3699 [LV] Empty/Loading states for LV overview graphs

### DIFF
--- a/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.test.tsx
+++ b/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.test.tsx
@@ -1,0 +1,49 @@
+import { isDataEmpty } from './LongviewLineGraph';
+
+describe('isDataEmpty helper function', () => {
+  it('should return true for an empty data set', () => {
+    expect(
+      isDataEmpty([
+        {
+          label: 'Series 1',
+          data: [],
+          borderColor: 'blue'
+        }
+      ])
+    ).toBe(true);
+  });
+
+  it('should return true for an empty data set with multiple (empty) entries', () => {
+    expect(
+      isDataEmpty([
+        {
+          label: 'Series 1',
+          data: [],
+          borderColor: 'blue'
+        },
+        {
+          label: 'Series 2',
+          data: [],
+          borderColor: 'green'
+        }
+      ])
+    ).toBe(true);
+  });
+
+  it('should return false if the dataset is not empty', () => {
+    expect(
+      isDataEmpty([
+        {
+          label: 'Series 1',
+          data: [[1, 2], [2, 3]],
+          borderColor: 'blue'
+        },
+        {
+          label: 'Series 2',
+          data: [],
+          borderColor: 'green'
+        }
+      ])
+    ).toBe(false);
+  });
+});

--- a/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
+++ b/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
@@ -81,7 +81,11 @@ const LongviewLineGraph: React.FC<CombinedProps> = props => {
 };
 
 export const isDataEmpty = (data: DataSet[]) => {
-  return data.every(thisSeries => thisSeries.data.length === 0);
+  return data.every(
+    thisSeries =>
+      thisSeries.data.length === 0 ||
+      thisSeries.data.every(thisPoint => thisPoint[1] === null)
+  );
 };
 
 export default compose<CombinedProps, Props>(React.memo)(LongviewLineGraph);

--- a/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
+++ b/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
@@ -5,7 +5,10 @@ import { makeStyles, Theme } from 'src/components/core/styles';
 import Divider from 'src/components/core/Divider';
 import Typography from 'src/components/core/Typography';
 import ErrorState from 'src/components/ErrorState';
-import LineGraph, { Props as LineGraphProps } from 'src/components/LineGraph';
+import LineGraph, {
+  DataSet,
+  Props as LineGraphProps
+} from 'src/components/LineGraph';
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {},
@@ -21,6 +24,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     '& > span': {
       color: theme.palette.text.primary
     }
+  },
+  message: {
+    position: 'absolute',
+    left: '50%',
+    top: '45%',
+    transform: 'translate(-50%, -50%)'
   }
 }));
 
@@ -28,6 +37,7 @@ export interface Props extends LineGraphProps {
   title: string;
   subtitle?: string;
   error?: string;
+  loading?: boolean;
 }
 
 type CombinedProps = Props;
@@ -35,7 +45,15 @@ type CombinedProps = Props;
 const LongviewLineGraph: React.FC<CombinedProps> = props => {
   const classes = useStyles();
 
-  const { error, title, subtitle, ...rest } = props;
+  const { error, loading, title, subtitle, ...rest } = props;
+
+  const message = error // Error state is separate, don't want to put text on top of it
+    ? undefined
+    : loading // Loading takes precedence over empty data
+    ? 'Loading data...'
+    : isDataEmpty(props.data)
+    ? 'No data to display'
+    : undefined;
 
   return (
     <React.Fragment>
@@ -48,7 +66,7 @@ const LongviewLineGraph: React.FC<CombinedProps> = props => {
         )}
       </Typography>
       <Divider type="landingHeader" className={classes.divider} />
-      <div>
+      <div style={{ position: 'relative' }}>
         {error ? (
           <div style={{ height: props.chartHeight || '300px' }}>
             <ErrorState errorText={error} />
@@ -56,9 +74,14 @@ const LongviewLineGraph: React.FC<CombinedProps> = props => {
         ) : (
           <LineGraph {...rest} />
         )}
+        {message && <div className={classes.message}>{message}</div>}
       </div>
     </React.Fragment>
   );
+};
+
+export const isDataEmpty = (data: DataSet[]) => {
+  return data.every(thisSeries => thisSeries.data.length === 0);
 };
 
 export default compose<CombinedProps, Props>(React.memo)(LongviewLineGraph);

--- a/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
+++ b/packages/manager/src/components/LongviewLineGraph/LongviewLineGraph.tsx
@@ -84,6 +84,7 @@ export const isDataEmpty = (data: DataSet[]) => {
   return data.every(
     thisSeries =>
       thisSeries.data.length === 0 ||
+      // If we've padded the data, every y value will be null
       thisSeries.data.every(thisPoint => thisPoint[1] === null)
   );
 };

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { sumCPU } from 'src/features/Longview/shared/utilities';
-import { AllData, getValues } from '../../../request';
 import {
   convertData,
   pathMaybeAddDataInThePast
 } from '../../../shared/formatters';
 import { GraphProps } from './types';
+import { useGraphs } from './useGraphs';
 
 export type CombinedProps = GraphProps & WithTheme;
 
@@ -23,24 +23,12 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
     timezone
   } = props;
 
-  const [data, setData] = React.useState<Partial<AllData>>({});
-  const [error, setError] = React.useState<string | undefined>();
-  const request = () => {
-    if (!start || !end) {
-      return;
-    }
-
-    return getValues(clientAPIKey, {
-      fields: ['cpu'],
-      start,
-      end
-    })
-      .then(response => {
-        setError(undefined);
-        setData(response);
-      })
-      .catch(_ => setError('Unable to retrieve CPU data.'));
-  };
+  const { data, loading, error, request } = useGraphs(
+    ['cpu'],
+    clientAPIKey,
+    start,
+    end
+  );
 
   const cpuData = React.useMemo(() => {
     const summedCPUData = sumCPU(data.CPU);
@@ -62,6 +50,7 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
       title="CPU"
       subtitle="%"
       error={error}
+      loading={loading}
       showToday={isToday}
       timezone={timezone}
       data={[

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/CPUGraph.tsx
@@ -39,7 +39,7 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
         setError(undefined);
         setData(response);
       })
-      .catch(_ => setError('Unable to retrieve CPU data'));
+      .catch(_ => setError('Unable to retrieve CPU data.'));
   };
 
   const cpuData = React.useMemo(() => {
@@ -69,19 +69,19 @@ export const CPUGraph: React.FC<CombinedProps> = props => {
           label: 'System',
           borderColor: theme.graphs.deepBlueBorder,
           backgroundColor: theme.graphs.deepBlue,
-          data: _convertData(cpuData.system, start, formatCPU)
+          data: _convertData(cpuData.system, start, end, formatCPU)
         },
         {
           label: 'User',
           borderColor: theme.graphs.skyBlueBorder,
           backgroundColor: theme.graphs.skyBlue,
-          data: _convertData(cpuData.user, start, formatCPU)
+          data: _convertData(cpuData.user, start, end, formatCPU)
         },
         {
           label: 'Wait',
           borderColor: theme.graphs.lightBlueBorder,
           backgroundColor: theme.graphs.lightBlue,
-          data: _convertData(cpuData.wait, start, formatCPU)
+          data: _convertData(cpuData.wait, start, end, formatCPU)
         }
       ]}
     />

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { appendStats } from 'src/features/Longview/shared/utilities';
-import { AllData, getValues } from '../../../request';
 import { Disk, StatWithDummyPoint } from '../../../request.types';
 import { convertData } from '../../../shared/formatters';
 import { GraphProps } from './types';
+import { useGraphs } from './useGraphs';
 
 export type CombinedProps = GraphProps & WithTheme;
 
@@ -22,23 +22,12 @@ export const DiskGraph: React.FC<CombinedProps> = props => {
     timezone
   } = props;
 
-  const [data, setData] = React.useState<Partial<AllData>>({});
-  const [requestError, setError] = React.useState<string | undefined>();
-  const request = () => {
-    if (!start || !end) {
-      return;
-    }
-    return getValues(clientAPIKey, {
-      fields: ['disk', 'sysinfo'],
-      start,
-      end
-    })
-      .then(response => {
-        setError(undefined);
-        setData(response);
-      })
-      .catch(_ => setError('Unable to load Disk I/O data.'));
-  };
+  const { data, loading, error: requestError, request } = useGraphs(
+    ['disk', 'sysinfo'],
+    clientAPIKey,
+    start,
+    end
+  );
 
   React.useEffect(() => {
     request();
@@ -61,6 +50,7 @@ export const DiskGraph: React.FC<CombinedProps> = props => {
       // Only show an error state if we don't have any data,
       // or in the case of special errors returned by processDiskData
       error={(!data.Disk && requestError) || error}
+      loading={loading}
       subtitle={'ops/second'}
       showToday={isToday}
       timezone={timezone}

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/DiskGraph.tsx
@@ -69,19 +69,19 @@ export const DiskGraph: React.FC<CombinedProps> = props => {
           label: 'Swap',
           borderColor: theme.graphs.redBorder,
           backgroundColor: theme.graphs.red,
-          data: _convertData(swap, start, formatDisk)
+          data: _convertData(swap, start, end, formatDisk)
         },
         {
           label: 'Write',
           borderColor: theme.graphs.lightOrangeBorder,
           backgroundColor: theme.graphs.lightOrange,
-          data: _convertData(write, start, formatDisk)
+          data: _convertData(write, start, end, formatDisk)
         },
         {
           label: 'Read',
           borderColor: theme.graphs.lightYellowBorder,
           backgroundColor: theme.graphs.lightYellow,
-          data: _convertData(read, start, formatDisk)
+          data: _convertData(read, start, end, formatDisk)
         }
       ]}
     />

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
@@ -55,7 +55,7 @@ export const LoadGraph: React.FC<CombinedProps> = props => {
           label: 'Load',
           borderColor: theme.graphs.lightGoldBorder,
           backgroundColor: theme.graphs.lightGold,
-          data: _convertData(data.Load || [], start, formatLoad)
+          data: _convertData(data.Load || [], start, end, formatLoad)
         }
       ]}
     />

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/LoadGraph.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
-import { AllData, getValues } from '../../../request';
 import { convertData } from '../../../shared/formatters';
 import { GraphProps } from './types';
+import { useGraphs } from './useGraphs';
 
 export type CombinedProps = GraphProps & WithTheme;
 
@@ -19,23 +19,12 @@ export const LoadGraph: React.FC<CombinedProps> = props => {
     timezone
   } = props;
 
-  const [data, setData] = React.useState<Partial<AllData>>({});
-  const [error, setError] = React.useState<string | undefined>();
-  const request = () => {
-    if (!start || !end) {
-      return;
-    }
-    return getValues(clientAPIKey, {
-      fields: ['load'],
-      start,
-      end
-    })
-      .then(response => {
-        setError(undefined);
-        setData(response);
-      })
-      .catch(_ => setError('Unable to retrieve load data.'));
-  };
+  const { data, loading, error, request } = useGraphs(
+    ['load'],
+    clientAPIKey,
+    start,
+    end
+  );
 
   React.useEffect(() => {
     request();
@@ -48,6 +37,7 @@ export const LoadGraph: React.FC<CombinedProps> = props => {
       title="Load"
       subtitle="Target < 1.00"
       error={error}
+      loading={loading}
       showToday={isToday}
       timezone={timezone}
       data={[

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -3,11 +3,11 @@ import * as React from 'react';
 import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { readableBytes } from 'src/utilities/unitConversions';
-import { AllData, getValues } from '../../../request';
 import { Stat } from '../../../request.types';
 import { convertData } from '../../../shared/formatters';
 import { generateUsedMemory, statMax } from '../../../shared/utilities';
 import { GraphProps } from './types';
+import { useGraphs } from './useGraphs';
 
 export type CombinedProps = GraphProps & WithTheme;
 
@@ -23,31 +23,12 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
     timezone
   } = props;
 
-  const [data, setData] = React.useState<Partial<AllData>>({});
-  const [loading, setLoading] = React.useState<boolean>(false);
-  const [error, setError] = React.useState<string | undefined>();
-  const request = () => {
-    if (!start || !end) {
-      return;
-    }
-    setLoading(true);
-    /** Set placeholder data to fix the x-axis on the new time window */
-    setData({});
-    return getValues(clientAPIKey, {
-      fields: ['memory'],
-      start,
-      end
-    })
-      .then(response => {
-        setLoading(false);
-        setError(undefined);
-        setData(response);
-      })
-      .catch(_ => {
-        setLoading(false);
-        setError('Unable to retrieve memory usage data.');
-      });
-  };
+  const { data, loading, error, request } = useGraphs(
+    ['memory'],
+    clientAPIKey,
+    start,
+    end
+  );
 
   React.useEffect(() => {
     request();

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/MemoryGraph.tsx
@@ -24,21 +24,29 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
   } = props;
 
   const [data, setData] = React.useState<Partial<AllData>>({});
+  const [loading, setLoading] = React.useState<boolean>(false);
   const [error, setError] = React.useState<string | undefined>();
   const request = () => {
     if (!start || !end) {
       return;
     }
+    setLoading(true);
+    /** Set placeholder data to fix the x-axis on the new time window */
+    setData({});
     return getValues(clientAPIKey, {
       fields: ['memory'],
       start,
       end
     })
       .then(response => {
+        setLoading(false);
         setError(undefined);
         setData(response);
       })
-      .catch(_ => setError('Unable to retrieve memory usage data.'));
+      .catch(_ => {
+        setLoading(false);
+        setError('Unable to retrieve memory usage data.');
+      });
   };
 
   React.useEffect(() => {
@@ -71,6 +79,7 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
       title="Memory"
       subtitle={unit}
       error={error}
+      loading={loading}
       showToday={isToday}
       timezone={timezone}
       data={[
@@ -78,25 +87,25 @@ export const MemoryGraph: React.FC<CombinedProps> = props => {
           label: 'Swap',
           borderColor: theme.graphs.redBorder,
           backgroundColor: theme.graphs.red,
-          data: _convertData(swap, start, formatMemory)
+          data: _convertData(swap, start, end, formatMemory)
         },
         {
           label: 'Buffers',
           borderColor: theme.graphs.darkPurpleBorder,
           backgroundColor: theme.graphs.darkPurple,
-          data: _convertData(buffers, start, formatMemory)
+          data: _convertData(buffers, start, end, formatMemory)
         },
         {
           label: 'Cache',
           borderColor: theme.graphs.purpleBorder,
           backgroundColor: theme.graphs.purple,
-          data: _convertData(cache, start, formatMemory)
+          data: _convertData(cache, start, end, formatMemory)
         },
         {
           label: 'Used',
           borderColor: theme.graphs.lightPurpleBorder,
           backgroundColor: theme.graphs.lightPurple,
-          data: _convertData(used, start, formatMemory)
+          data: _convertData(used, start, end, formatMemory)
         }
       ]}
     />

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -90,13 +90,13 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
 
           borderColor: theme.graphs.emeraldGreenBorder,
           backgroundColor: theme.graphs.emeraldGreen,
-          data: _convertData(rx_bytes, start, formatNetwork)
+          data: _convertData(rx_bytes, start, end, formatNetwork)
         },
         {
           label: 'Outbound',
           borderColor: theme.graphs.forestGreenBorder,
           backgroundColor: theme.graphs.forestGreen,
-          data: _convertData(tx_bytes, start, formatNetwork)
+          data: _convertData(tx_bytes, start, end, formatNetwork)
         }
       ]}
     />

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/NetworkGraph.tsx
@@ -5,9 +5,9 @@ import { withTheme, WithTheme } from 'src/components/core/styles';
 import LongviewLineGraph from 'src/components/LongviewLineGraph';
 import { generateUnits } from 'src/features/Longview/LongviewLanding/Gauges/Network';
 import { statMax, sumNetwork } from 'src/features/Longview/shared/utilities';
-import { AllData, getValues } from '../../../request';
 import { convertData } from '../../../shared/formatters';
 import { GraphProps } from './types';
+import { useGraphs } from './useGraphs';
 
 export type CombinedProps = GraphProps & WithTheme;
 
@@ -23,24 +23,12 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
     timezone
   } = props;
 
-  const [data, setData] = React.useState<Partial<AllData>>({});
-  const [error, setError] = React.useState<string | undefined>();
-  const request = () => {
-    if (!start || !end) {
-      return;
-    }
-
-    return getValues(clientAPIKey, {
-      fields: ['network'],
-      start,
-      end
-    })
-      .then(response => {
-        setError(undefined);
-        setData(response);
-      })
-      .catch(_ => setError('Unable to retrieve network data.'));
-  };
+  const { data, loading, error, request } = useGraphs(
+    ['network'],
+    clientAPIKey,
+    start,
+    end
+  );
 
   const networkData = React.useMemo(
     () => sumNetwork(pathOr({}, ['Interface'], data.Network)),
@@ -82,6 +70,7 @@ export const NetworkGraph: React.FC<CombinedProps> = props => {
       title="Network"
       subtitle={maxUnit + '/s'}
       error={error}
+      loading={loading}
       showToday={isToday}
       timezone={timezone}
       data={[

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/useGraphs.ts
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/useGraphs.ts
@@ -15,6 +15,7 @@ export const useGraphs = (
       return;
     }
     setLoading(true);
+    setData({});
     return getValues(clientAPIKey, {
       fields: requestFields,
       start,
@@ -27,7 +28,7 @@ export const useGraphs = (
       })
       .catch(_ => {
         setLoading(false);
-        setError('Unable to retrieve CPU data.');
+        setError('Unable to retrieve data.');
       });
   };
 

--- a/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/useGraphs.ts
+++ b/packages/manager/src/features/Longview/LongviewDetail/DetailTabs/OverviewGraphs/useGraphs.ts
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { AllData, getValues, LongviewFieldName } from '../../../request';
+
+export const useGraphs = (
+  requestFields: LongviewFieldName[],
+  clientAPIKey: string,
+  start: number,
+  end: number
+) => {
+  const [data, setData] = React.useState<Partial<AllData>>({});
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [error, setError] = React.useState<string | undefined>();
+  const request = () => {
+    if (!start || !end) {
+      return;
+    }
+    setLoading(true);
+    return getValues(clientAPIKey, {
+      fields: requestFields,
+      start,
+      end
+    })
+      .then(response => {
+        setLoading(false);
+        setError(undefined);
+        setData(response);
+      })
+      .catch(_ => {
+        setLoading(false);
+        setError('Unable to retrieve CPU data.');
+      });
+  };
+
+  return { error, data, loading, request };
+};

--- a/packages/manager/src/features/Longview/shared/formatters.ts
+++ b/packages/manager/src/features/Longview/shared/formatters.ts
@@ -106,12 +106,28 @@ export const maybeAddPastData = (
 export const convertData = (
   d: StatWithDummyPoint[],
   startTime: number,
+  endTime: number,
   formatter?: (pt: number | null) => number | null
-) =>
-  maybeAddPastData(d, startTime).map(
+) => {
+  /**
+   * For any empty data series, instead of an empty array
+   * (which would trigger default values for x axis ticks)
+   * add dummy points at the start and end, so that the x axis
+   * is displayed according to the selected time range.
+   *
+   * This is helpful for empty and loading states.
+   */
+  if (d.length === 0) {
+    return [[startTime * 1000, null], [endTime * 1000, null]] as [
+      number,
+      number | null
+    ][];
+  }
+  return maybeAddPastData(d, startTime).map(
     thisPoint =>
       [
         thisPoint.x * 1000,
         formatter ? formatter(thisPoint.y) : thisPoint.y
       ] as [number, number | null]
   );
+};


### PR DESCRIPTION
## Description

Overlays some text on empty/loading graphs. Currently loading logic is only implemented in the MemoryGraph, as a demo.

Also did a thing to fix for when graph data was empty, 
the X axis ticks would use default values,
which didn't generally match the selected time scales. It should
be possible to add custom formatting through charts.js, but since
we're already using null padding in our data processing, I just
added some more logic to that.

If a data series is empty, we'll use `[[start, null], [end, null]]`
instead of an empty array. This sets the X axis ticks to the expected
values without populating any graph data.

This allows us to do things like clear the data when making a new request,
so that the loading state doesn't overlay on stale data.
