### PR TITLE
Don't report LaunchDarkly errors to Sentry

### DIFF
--- a/packages/manager/src/exceptionReporting.ts
+++ b/packages/manager/src/exceptionReporting.ts
@@ -14,11 +14,11 @@ const promiseRejectionsToIgnore: string[] = [
 ];
 
 window.addEventListener('unhandledrejection', err => {
-  /**
-   * Don't report network errors from LaunchDarkly
-   */
-
   if (pathOr('', ['reason', 'stack'], err).match(/launchdarkly/i)) {
+    /**
+     * This doesn't affect error reporting, but avoids some console noise
+     * until we've cleaned up Sentry.
+     */
     return;
   }
 

--- a/packages/manager/src/exceptionReporting.ts
+++ b/packages/manager/src/exceptionReporting.ts
@@ -14,6 +14,14 @@ const promiseRejectionsToIgnore: string[] = [
 ];
 
 window.addEventListener('unhandledrejection', err => {
+  /**
+   * Don't report network errors from LaunchDarkly
+   */
+
+  if (pathOr('', ['reason', 'stack'], err).match(/launchdarkly/i)) {
+    return;
+  }
+
   const firstReason = pathOr('', [0, 'reason'], err.reason);
 
   /* 

--- a/packages/manager/src/initSentry.ts
+++ b/packages/manager/src/initSentry.ts
@@ -35,6 +35,7 @@ export const initSentry = () => {
         'MyApp_RemoveAllHighlights',
         'http://tt.epicplay.com',
         "Can't find variable: ZiteReader",
+        'LaunchDarklyFlagFetchError',
         'jigsaw is not defined',
         'ComboSearch is not defined',
         'http://loading.retry.widdit.com/',


### PR DESCRIPTION
To test: block all requests to LaunchDarkly and check your console. No output from the `reportException` logic should be present.

All of these errors are network errors, so it might be better to just not report any of those. This was more precise so I thought it was the safest choice.