### PR TITLE
add sonar reporter dep for sonar on jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ localStorage.json
 
 # Vim users
 *.swp
+
+#sonar
+.scannerwork
+.sonar

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ localStorage.json
 #sonar
 .scannerwork
 .sonar
+packages/manager/test-report.xml

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -255,6 +255,7 @@
     "yargs": "^11.0.0"
   },
   "jest": {
+    "testResultsProcessor": "jest-sonar-reporter",
     "roots": [
       "<rootDir>/src"
     ],

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -217,6 +217,7 @@
     "jest": "^24.9.0",
     "jest-axe": "^3.2.0",
     "jest-junit": "^9.0.0",
+    "jest-sonar-reporter": "^2.0.0",
     "js-yaml": "^3.13.1",
     "lint-staged": "^9.4.2",
     "madge": "^3.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11919,6 +11919,13 @@ jest-snapshot@^24.8.0:
     pretty-format "^24.8.0"
     semver "^5.5.0"
 
+jest-sonar-reporter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-sonar-reporter/-/jest-sonar-reporter-2.0.0.tgz#faa54a7d2af7198767ee246a82b78c576789cf08"
+  integrity sha512-ZervDCgEX5gdUbdtWsjdipLN3bKJwpxbvhkYNXTAYvAckCihobSLr9OT/IuyNIRT1EZMDDwR6DroWtrq+IL64w==
+  dependencies:
+    xml "^1.0.1"
+
 jest-specific-snapshot@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/jest-specific-snapshot/-/jest-specific-snapshot-2.0.0.tgz#425fe524b25df154aa39f97fa6fe9726faaac273"


### PR DESCRIPTION
## Description

Changes:
- adds sonar to .gitignore
- adds 1 npm devDependency for coverage reporting

To use it, in CICD you can build and use this script to send an analysis to sonarcloud directly.
Replace `XXXXXXX` with proper info
```
docker run --rm -v $(pwd):/usr/src/ -w /usr/src/ node:10-alpine yarn install:all
docker run --rm -v $(pwd):/usr/src/ -w /usr/src/ node:10-alpine yarn workspace linode-js-sdk build
docker run --rm -v $(pwd):/usr/src/ -w /usr/src/ node:10-alpine yarn test --coverage --coverageDirectory=output/coverage/jest

echo sonar.projectKey=XXXXXXX > sonar-scanner.properties
echo sonar.organization=XXXXXXX >> sonar-scanner.properties
echo sonar.ws.timeout=120 >> sonar-scanner.properties
echo sonar.sources=packages/manager/src/,packages/manager/e2e/,packages/linode-js-sdk/src/ >> sonar-scanner.properties
echo sonar.exclusions=**/public/**,**/*.patch >> sonar-scanner.properties
echo sonar.typescript.tsconfigPath=packages/manager/tsconfig.json >> sonar-scanner.properties
echo sonar.javascript.lcov.reportPaths=packages/manager/output/coverage/jest/lcov.info >> sonar-scanner.properties
echo sonar.coverage.exclusions=**/e2e/**,**/__data__/** >> sonar-scanner.properties
echo sonar.testExecutionReportPaths=packages/manager/test-report.xml >> sonar-scanner.properties
echo sonar.tests=packages/manager/ >> sonar-scanner.properties
echo sonar.test.inclusions=**/*.test.ts,**/src/**/*.test.tsx,**/*.stories.tsx >> sonar-scanner.properties
echo sonar.test.exclusions=**/e2e/**,**/*.spec.js >> sonar-scanner.properties
cat sonar-scanner.properties

docker run --rm --user="$(id -u):$(id -g)" -e SONAR_TOKEN=XXXXXXX -e SONAR_HOST_URL=https://sonarcloud.io -e SONAR_USER_HOME=/usr/src/.sonar -v $(pwd)/sonar-scanner.properties:/opt/sonar-scanner/conf/sonar-scanner.properties -v $(pwd):/usr/src sonarsource/sonar-scanner-cli -X
```
