### PR TITLE
Fix: Use relative path for NewRelic script

### DIFF
--- a/packages/manager/public/index.html
+++ b/packages/manager/public/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <script type="text/javascript" src="newrelic.js"></script>
+  <script type="text/javascript" src="/newrelic.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="theme-color" content="#000000">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">


### PR DESCRIPTION
## Description

Without a leading slash, this script was being loaded relative to whatever path it was loaded from. Thus, if a user navigated directly to linodes/create, the script would fail to load.

## Note to Reviewers

**To test:**

To verify the bug (from **testing** branch):
1) Open dev tools (network tab)
2) Go to localhost:3000/linodes/create
3) Observe: newrelic.js has been loaded from localhost:3000/linodes/newrelic.js

To verify the fix (from **this branch**):
1) Open dev tools (network tab)
2) Go to localhost:3000/linodes/create
3) Observe: newrelic.js has been loaded from localhost:3000/newrelic.js
